### PR TITLE
ZJIT: Add recompile support to GuardType

### DIFF
--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -4,7 +4,7 @@ use std::mem::take;
 use std::rc::Rc;
 use crate::bitset::BitSet;
 use crate::codegen::{local_size_and_idx_to_ep_offset, perf_symbol_range_start, perf_symbol_range_end};
-use crate::cruby::{vm_stack_canary, IseqPtr, YarvInsnIdx, RUBY_OFFSET_CFP_ISEQ, RUBY_OFFSET_CFP_JIT_RETURN, RUBY_OFFSET_CFP_PC, RUBY_OFFSET_CFP_SP, SIZEOF_VALUE_I32};
+use crate::cruby::{IseqPtr, RUBY_OFFSET_CFP_ISEQ, RUBY_OFFSET_CFP_JIT_RETURN, RUBY_OFFSET_CFP_PC, RUBY_OFFSET_CFP_SP, SIZEOF_VALUE_I32, vm_stack_canary, YarvInsnIdx };
 use crate::hir::{Invariant, SideExitReason};
 use crate::hir;
 use crate::options::{TraceExits, PerfMap, get_option};

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -4,12 +4,12 @@ use std::mem::take;
 use std::rc::Rc;
 use crate::bitset::BitSet;
 use crate::codegen::{local_size_and_idx_to_ep_offset, perf_symbol_range_start, perf_symbol_range_end};
-use crate::cruby::{IseqPtr, RUBY_OFFSET_CFP_ISEQ, RUBY_OFFSET_CFP_JIT_RETURN, RUBY_OFFSET_CFP_PC, RUBY_OFFSET_CFP_SP, SIZEOF_VALUE_I32, vm_stack_canary};
+use crate::cruby::{vm_stack_canary, IseqPtr, YarvInsnIdx, RUBY_OFFSET_CFP_ISEQ, RUBY_OFFSET_CFP_JIT_RETURN, RUBY_OFFSET_CFP_PC, RUBY_OFFSET_CFP_SP, SIZEOF_VALUE_I32};
 use crate::hir::{Invariant, SideExitReason};
 use crate::hir;
 use crate::options::{TraceExits, PerfMap, get_option};
 use crate::cruby::VALUE;
-use crate::payload::IseqVersionRef;
+use crate::payload::{IseqVersionRef, get_or_create_iseq_payload};
 use crate::stats::{exit_counter_ptr, exit_counter_ptr_for_opcode, side_exit_counter, CompileError};
 use crate::virtualmem::CodePtr;
 use crate::asm::{CodeBlock, Label};
@@ -2402,7 +2402,8 @@ impl Assembler
 
         fn compile_exit_recompile(asm: &mut Assembler, exit: &SideExit) {
             if let Some(recompile) = &exit.recompile {
-
+                let payload = get_or_create_iseq_payload(exit.iseq);
+                payload.reset_profiles_remaining(recompile.insn_idx as YarvInsnIdx);
                 use crate::codegen::exit_recompile;
                 asm_comment!(asm, "profile and maybe recompile");
                 asm_ccall!(asm, exit_recompile,

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -2576,25 +2576,6 @@ fn gen_guard_type(jit: &mut JITState, asm: &mut Assembler, val: lir::Opnd, val_t
 
         asm.cmp(klass, Opnd::Value(expected_class));
         asm.jne(jit, side_exit);
-    } else if guard_type.is_subtype(types::TData) {
-        let side = side_exit_with_recompile(jit, state, GuardType(guard_type), recompile);
-
-        // Check special constant
-        asm.test(val, Opnd::UImm(RUBY_IMMEDIATE_MASK as u64));
-        asm.jnz(jit, side.clone());
-
-        // Check false
-        asm.cmp(val, Qfalse.into());
-        asm.je(jit, side.clone());
-
-        // Check the T_DATA builtin type.
-        let val = asm.load_mem(val);
-        let flags = asm.load(Opnd::mem(VALUE_BITS, val, RUBY_OFFSET_RBASIC_FLAGS));
-        let mask     = RUBY_T_MASK.to_usize();
-        let expected = RUBY_T_DATA.to_usize();
-        let masked = asm.and(flags, mask.into());
-        asm.cmp(masked, expected.into());
-        asm.jne(jit, side);
     } else if let Some(builtin_type) = guard_type.builtin_type_equivalent() {
         let side = side_exit_with_recompile(jit, state, GuardType(guard_type), recompile);
 

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -699,9 +699,9 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
             let val_type = function.type_of(*val);
             gen_has_type(jit, asm, opnd!(val), val_type, *expected)
         }
-        Insn::GuardType { val, guard_type, state } => {
-            let val_type = function.type_of(*val);
-            gen_guard_type(jit, asm, opnd!(val), val_type, *guard_type, &function.frame_state(*state))
+        &Insn::GuardType { val, guard_type, state, recompile } => {
+            let val_type = function.type_of(val);
+            gen_guard_type(jit, asm, opnd!(val), val_type, guard_type, recompile, &function.frame_state(state))
         }
         &Insn::GuardBitEquals { val, expected, reason, state, recompile } => gen_guard_bit_equals(jit, asm, opnd!(val), expected, reason, recompile, &function.frame_state(state)),
         &Insn::GuardAnyBitSet { val, mask, reason, state, .. } => gen_guard_any_bit_set(jit, asm, opnd!(val), mask, reason, &function.frame_state(state)),
@@ -2523,33 +2523,33 @@ fn gen_has_type(jit: &mut JITState, asm: &mut Assembler, val: lir::Opnd, val_typ
 }
 
 /// Compile a type check with a side exit
-fn gen_guard_type(jit: &mut JITState, asm: &mut Assembler, val: lir::Opnd, val_type: Type, guard_type: Type, state: &FrameState) -> lir::Opnd {
+fn gen_guard_type(jit: &mut JITState, asm: &mut Assembler, val: lir::Opnd, val_type: Type, guard_type: Type, recompile: Option<Recompile>, state: &FrameState) -> lir::Opnd {
     let is_known_heap_basic_object = val_type.is_subtype(types::HeapBasicObject);
     gen_incr_counter(asm, Counter::guard_type_count);
     if guard_type.is_subtype(types::Fixnum) {
         asm.test(val, Opnd::UImm(RUBY_FIXNUM_FLAG as u64));
-        asm.jz(jit, side_exit(jit, state, GuardType(guard_type)));
+        asm.jz(jit, side_exit_with_recompile(jit, state, GuardType(guard_type), recompile));
     } else if guard_type.is_subtype(types::Flonum) {
         // Flonum: (val & RUBY_FLONUM_MASK) == RUBY_FLONUM_FLAG
         let masked = asm.and(val, Opnd::UImm(RUBY_FLONUM_MASK as u64));
         asm.cmp(masked, Opnd::UImm(RUBY_FLONUM_FLAG as u64));
-        asm.jne(jit, side_exit(jit, state, GuardType(guard_type)));
+        asm.jne(jit, side_exit_with_recompile(jit, state, GuardType(guard_type), recompile));
     } else if guard_type.is_subtype(types::StaticSymbol) {
         // Static symbols have (val & 0xff) == RUBY_SYMBOL_FLAG
         // Use 8-bit comparison like YJIT does.
         // If `val` is a constant (rare but possible), put it in a register to allow masking.
         let val = asm.load_imm(val);
         asm.cmp(val.with_num_bits(8), Opnd::UImm(RUBY_SYMBOL_FLAG as u64));
-        asm.jne(jit, side_exit(jit, state, GuardType(guard_type)));
+        asm.jne(jit, side_exit_with_recompile(jit, state, GuardType(guard_type), recompile));
     } else if guard_type.is_subtype(types::NilClass) {
         asm.cmp(val, Qnil.into());
-        asm.jne(jit, side_exit(jit, state, GuardType(guard_type)));
+        asm.jne(jit, side_exit_with_recompile(jit, state, GuardType(guard_type), recompile));
     } else if guard_type.is_subtype(types::TrueClass) {
         asm.cmp(val, Qtrue.into());
-        asm.jne(jit, side_exit(jit, state, GuardType(guard_type)));
+        asm.jne(jit, side_exit_with_recompile(jit, state, GuardType(guard_type), recompile));
     } else if guard_type.is_subtype(types::FalseClass) {
         asm.cmp(val, Qfalse.into());
-        asm.jne(jit, side_exit(jit, state, GuardType(guard_type)));
+        asm.jne(jit, side_exit_with_recompile(jit, state, GuardType(guard_type), recompile));
     } else if guard_type.is_immediate() {
         // All immediate types' guard should have been handled above
         panic!("unexpected immediate guard type: {guard_type}");
@@ -2560,7 +2560,7 @@ fn gen_guard_type(jit: &mut JITState, asm: &mut Assembler, val: lir::Opnd, val_t
         // TODO: Max thinks codegen should not care about the shapes of the operands except to create them. (Shopify/ruby#685)
         let val = asm.load_mem(val);
 
-        let side_exit = side_exit(jit, state, GuardType(guard_type));
+        let side_exit = side_exit_with_recompile(jit, state, GuardType(guard_type), recompile);
         if !is_known_heap_basic_object {
             // Check if it's a special constant
             asm.test(val, (RUBY_IMMEDIATE_MASK as u64).into());
@@ -2576,8 +2576,27 @@ fn gen_guard_type(jit: &mut JITState, asm: &mut Assembler, val: lir::Opnd, val_t
 
         asm.cmp(klass, Opnd::Value(expected_class));
         asm.jne(jit, side_exit);
+    } else if guard_type.is_subtype(types::TData) {
+        let side = side_exit_with_recompile(jit, state, GuardType(guard_type), recompile);
+
+        // Check special constant
+        asm.test(val, Opnd::UImm(RUBY_IMMEDIATE_MASK as u64));
+        asm.jnz(jit, side.clone());
+
+        // Check false
+        asm.cmp(val, Qfalse.into());
+        asm.je(jit, side.clone());
+
+        // Check the T_DATA builtin type.
+        let val = asm.load_mem(val);
+        let flags = asm.load(Opnd::mem(VALUE_BITS, val, RUBY_OFFSET_RBASIC_FLAGS));
+        let mask     = RUBY_T_MASK.to_usize();
+        let expected = RUBY_T_DATA.to_usize();
+        let masked = asm.and(flags, mask.into());
+        asm.cmp(masked, expected.into());
+        asm.jne(jit, side);
     } else if let Some(builtin_type) = guard_type.builtin_type_equivalent() {
-        let side = side_exit(jit, state, GuardType(guard_type));
+        let side = side_exit_with_recompile(jit, state, GuardType(guard_type), recompile);
 
         if !is_known_heap_basic_object {
             // Check special constant
@@ -2596,7 +2615,7 @@ fn gen_guard_type(jit: &mut JITState, asm: &mut Assembler, val: lir::Opnd, val_t
         asm.cmp(tag, Opnd::UImm(builtin_type as u64));
         asm.jne(jit, side);
     } else if guard_type.bit_equal(types::HeapBasicObject) {
-        let side_exit = side_exit(jit, state, GuardType(guard_type));
+        let side_exit = side_exit_with_recompile(jit, state, GuardType(guard_type), recompile);
         asm.cmp(val, Opnd::Value(Qfalse));
         asm.je(jit, side_exit.clone());
         asm.test(val, (RUBY_IMMEDIATE_MASK as u64).into());

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -2125,7 +2125,13 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
             Insn::IntOr      { left, right } => { write!(f, "IntOr {left}, {right}") },
             Insn::FixnumLShift { left, right, .. } => { write!(f, "FixnumLShift {left}, {right}") },
             Insn::FixnumRShift { left, right, .. } => { write!(f, "FixnumRShift {left}, {right}") },
-            Insn::GuardType { val, guard_type, .. } => { write!(f, "GuardType {val}, {}", guard_type.print(self.ptr_map)) },
+            Insn::GuardType { val, guard_type, recompile, .. } => {
+                write!(f, "GuardType {val}, {}", guard_type.print(self.ptr_map))?;
+                if recompile.is_some() {
+                    write!(f, " recompile")?;
+                }
+                return Ok(())
+            },
             Insn::RefineType { val, new_type, .. } => { write!(f, "RefineType {val}, {}", new_type.print(self.ptr_map)) },
             Insn::HasType { val, expected, .. } => { write!(f, "HasType {val}, {}", expected.print(self.ptr_map)) },
             Insn::GuardBitEquals { val, expected, recompile, .. } => {
@@ -3711,7 +3717,8 @@ impl Function {
 
                             // Add GuardType for profiled receiver
                             if let Some(profiled_type) = profiled_type {
-                                recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: None });
+                                let argc = unsafe { vm_ci_argc(ci) } as i32;
+                                recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: Some(Recompile::ProfileSend { argc }) });
                             }
 
                             let send_direct = self.push_insn(block, Insn::SendDirect { recv, cd, cme, iseq, args: processed_args, kw_bits, state: send_state, block: send_block });

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -1168,7 +1168,7 @@ pub enum Insn {
     HasType { val: InsnId, expected: Type },
 
     /// Side-exit if val doesn't have the expected type.
-    GuardType { val: InsnId, guard_type: Type, state: InsnId },
+    GuardType { val: InsnId, guard_type: Type, state: InsnId, recompile: Option<Recompile> },
     /// Side-exit if val is not the expected Const.
     GuardBitEquals { val: InsnId, expected: Const, reason: SideExitReason, state: InsnId, recompile: Option<Recompile> },
     /// Side-exit if (val & mask) == 0
@@ -3468,7 +3468,7 @@ impl Function {
 
     pub fn coerce_to(&mut self, block: BlockId, val: InsnId, guard_type: Type, state: InsnId) -> InsnId {
         if self.is_a(val, guard_type) { return val; }
-        self.push_insn(block, Insn::GuardType { val, guard_type, state })
+        self.push_insn(block, Insn::GuardType { val, guard_type, state , recompile: None})
     }
 
     fn count_complex_call_features(&mut self, block: BlockId, ci_flags: c_uint) {
@@ -3711,7 +3711,7 @@ impl Function {
 
                             // Add GuardType for profiled receiver
                             if let Some(profiled_type) = profiled_type {
-                                recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state });
+                                recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: None });
                             }
 
                             let send_direct = self.push_insn(block, Insn::SendDirect { recv, cd, cme, iseq, args: processed_args, kw_bits, state: send_state, block: send_block });
@@ -3754,7 +3754,7 @@ impl Function {
                             self.push_insn(block, Insn::PatchPoint { invariant: Invariant::MethodRedefined { klass, method: mid, cme }, state });
 
                             if let Some(profiled_type) = profiled_type {
-                                recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state });
+                                recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: None });
                             }
 
                             let send_direct = self.push_insn(block, Insn::SendDirect { recv, cd, cme, iseq, args: processed_args, kw_bits, state: send_state, block: None });
@@ -3774,7 +3774,7 @@ impl Function {
 
                             self.push_insn(block, Insn::PatchPoint { invariant: Invariant::MethodRedefined { klass, method: mid, cme }, state });
                             if let Some(profiled_type) = profiled_type {
-                                recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state });
+                                recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: None });
                             }
                             let id = unsafe { get_cme_def_body_attr_id(cme) };
 
@@ -3790,7 +3790,7 @@ impl Function {
 
                             self.push_insn(block, Insn::PatchPoint { invariant: Invariant::MethodRedefined { klass, method: mid, cme }, state });
                             if let Some(profiled_type) = profiled_type {
-                                recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state });
+                                recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: None });
                             }
                             let id = unsafe { get_cme_def_body_attr_id(cme) };
 
@@ -3812,7 +3812,7 @@ impl Function {
                                     }
                                     self.push_insn(block, Insn::PatchPoint { invariant: Invariant::MethodRedefined { klass, method: mid, cme }, state });
                                     if let Some(profiled_type) = profiled_type {
-                                        recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state });
+                                        recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: None });
                                     }
                                     let kw_splat = flags & VM_CALL_KW_SPLAT != 0;
                                     let invoke_proc = self.push_insn(block, Insn::InvokeProc { recv, args: args.clone(), state, kw_splat });
@@ -3850,7 +3850,7 @@ impl Function {
                                     }
                                     self.push_insn(block, Insn::PatchPoint { invariant: Invariant::MethodRedefined { klass, method: mid, cme }, state });
                                     if let Some(profiled_type) = profiled_type {
-                                        recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state });
+                                        recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: None });
                                     }
                                     // All structs from the same Struct class should have the same
                                     // length. So if our recv is embedded all runtime
@@ -3921,12 +3921,12 @@ impl Function {
 
                         if recv_type.is_string() {
                             self.push_insn(block, Insn::PatchPoint { invariant: Invariant::NoSingletonClass { klass: recv_type.class() }, state });
-                            let guard = self.push_insn(block, Insn::GuardType { val, guard_type: types::String, state });
+                            let guard = self.push_insn(block, Insn::GuardType { val, guard_type: types::String, state, recompile: None });
                             // Infer type so AnyToString can fold off this
                             self.insn_types[guard.0] = self.infer_type(guard);
                             self.make_equal_to(insn_id, guard);
                         } else {
-                            let recv = self.push_insn(block, Insn::GuardType { val, guard_type: Type::from_profiled_type(recv_type), state});
+                            let recv = self.push_insn(block, Insn::GuardType { val, guard_type: Type::from_profiled_type(recv_type), state, recompile: None });
                             let send_to_s = self.push_insn(block, Insn::Send { recv, cd, block: None, args: vec![], state, reason: ObjToStringNotString });
                             self.make_equal_to(insn_id, send_to_s);
                         }
@@ -4373,16 +4373,16 @@ impl Function {
     fn load_ivar_guard_type(&mut self, block: BlockId, recv: InsnId, recv_type: ProfiledType, state: InsnId) -> InsnId {
         if recv_type.flags().is_t_class() {
             // Check class first since `Class < Module`
-            self.push_insn(block, Insn::GuardType { val: recv, guard_type: types::Class, state })
+            self.push_insn(block, Insn::GuardType { val: recv, guard_type: types::Class, state , recompile: None})
         } else if recv_type.flags().is_t_module() {
-            self.push_insn(block, Insn::GuardType { val: recv, guard_type: types::Module, state })
+            self.push_insn(block, Insn::GuardType { val: recv, guard_type: types::Module, state , recompile: None})
         } else if recv_type.flags().is_t_data() {
-            self.push_insn(block, Insn::GuardType { val: recv, guard_type: types::TData, state })
+            self.push_insn(block, Insn::GuardType { val: recv, guard_type: types::TData, state , recompile: None})
         } else {
             // HeapBasicObject is wider than T_OBJECT, but shapes for T_OBJECTs are in a pool of
             // its own and are guaranteed to be different from shapes of any other T_* types. So
             // the shape check that follows already covers checking for T_OBJECT.
-            self.push_insn(block, Insn::GuardType { val: recv, guard_type: types::HeapBasicObject, state })
+            self.push_insn(block, Insn::GuardType { val: recv, guard_type: types::HeapBasicObject, state , recompile: None})
         }
     }
 
@@ -4769,7 +4769,7 @@ impl Function {
 
                     if let Some(profiled_type) = profiled_type {
                         // Guard receiver class
-                        recv = fun.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state });
+                        recv = fun.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: None });
                         fun.insn_types[recv.0] = fun.infer_type(recv);
                     }
 
@@ -4835,7 +4835,7 @@ impl Function {
 
                     if let Some(profiled_type) = profiled_type {
                         // Guard receiver class
-                        recv = fun.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state });
+                        recv = fun.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: None });
                         fun.insn_types[recv.0] = fun.infer_type(recv);
                     }
 
@@ -7093,9 +7093,9 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                     }
                     let ty = Type::from_profiled_type(summary.bucket(0));
                     let obj = if ty.is_subtype(types::NilClass) {
-                        fun.push_insn(block, Insn::GuardType { val: hash, guard_type: types::NilClass, state: exit_id })
+                        fun.push_insn(block, Insn::GuardType { val: hash, guard_type: types::NilClass, state: exit_id , recompile: None})
                     } else if ty.is_subtype(types::HashExact) {
-                        fun.push_insn(block, Insn::GuardType { val: hash, guard_type: types::HashExact, state: exit_id })
+                        fun.push_insn(block, Insn::GuardType { val: hash, guard_type: types::HashExact, state: exit_id , recompile: None})
                     } else {
                         fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::SplatKwNotNilOrHash, recompile: None });
                         break;  // End the block
@@ -7161,7 +7161,7 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                     let id = ID(get_arg(pc, 0).as_u64());
                     let pushval = get_arg(pc, 2);
                     if let Some(summary) = fun.polymorphic_summary(&profiles, self_param, exit_state.insn_idx) {
-                        self_param = fun.push_insn(block, Insn::GuardType { val: self_param, guard_type: types::HeapBasicObject, state: exit_id });
+                        self_param = fun.push_insn(block, Insn::GuardType { val: self_param, guard_type: types::HeapBasicObject, state: exit_id, recompile: None });
                         let rbasic_flags = fun.load_rbasic_flags(block, self_param);
                         let join_block = insn_idx_to_block.get(&insn_idx).copied().unwrap_or_else(|| fun.new_block(insn_idx));
                         let join_param = fun.push_insn(join_block, Insn::Param);
@@ -8332,7 +8332,7 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                         break;  // End the block
                     }
                     if let Some(summary) = fun.polymorphic_summary(&profiles, self_param, exit_state.insn_idx) {
-                        self_param = fun.push_insn(block, Insn::GuardType { val: self_param, guard_type: types::HeapBasicObject, state: exit_id });
+                        self_param = fun.push_insn(block, Insn::GuardType { val: self_param, guard_type: types::HeapBasicObject, state: exit_id, recompile: None });
                         let rbasic_flags = fun.load_rbasic_flags(block, self_param);
                         let join_block = insn_idx_to_block.get(&insn_idx).copied().unwrap_or_else(|| fun.new_block(insn_idx));
                         let join_param = fun.push_insn(join_block, Insn::Param);
@@ -8540,7 +8540,7 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                         break;  // End the block
                     }
                     let val = state.stack_pop()?;
-                    let array = fun.push_insn(block, Insn::GuardType { val, guard_type: types::ArrayExact, state: exit_id, });
+                    let array = fun.push_insn(block, Insn::GuardType { val, guard_type: types::ArrayExact, state: exit_id, recompile: None });
                     let length = fun.push_insn(block, Insn::ArrayLength { array });
                     let expected = fun.push_insn(block, Insn::Const { val: Const::CInt64(num as i64) });
                     fun.push_insn(block, Insn::GuardGreaterEq { left: length, right: expected, reason: SideExitReason::ExpandArray, state: exit_id });

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -3761,7 +3761,8 @@ impl Function {
                             self.push_insn(block, Insn::PatchPoint { invariant: Invariant::MethodRedefined { klass, method: mid, cme }, state });
 
                             if let Some(profiled_type) = profiled_type {
-                                recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: None });
+                                let argc = unsafe { vm_ci_argc(ci) } as i32;
+                                recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: Some(Recompile::ProfileSend{ argc }) });
                             }
 
                             let send_direct = self.push_insn(block, Insn::SendDirect { recv, cd, cme, iseq, args: processed_args, kw_bits, state: send_state, block: None });
@@ -3781,7 +3782,8 @@ impl Function {
 
                             self.push_insn(block, Insn::PatchPoint { invariant: Invariant::MethodRedefined { klass, method: mid, cme }, state });
                             if let Some(profiled_type) = profiled_type {
-                                recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: None });
+                                let argc = unsafe { vm_ci_argc(ci) } as i32;
+                                recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: Some(Recompile::ProfileSend{ argc }) });
                             }
                             let id = unsafe { get_cme_def_body_attr_id(cme) };
 
@@ -3797,7 +3799,8 @@ impl Function {
 
                             self.push_insn(block, Insn::PatchPoint { invariant: Invariant::MethodRedefined { klass, method: mid, cme }, state });
                             if let Some(profiled_type) = profiled_type {
-                                recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: None });
+                                let argc = unsafe { vm_ci_argc(ci) } as i32;
+                                recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: Some(Recompile::ProfileSend{ argc }) });
                             }
                             let id = unsafe { get_cme_def_body_attr_id(cme) };
 
@@ -3819,7 +3822,8 @@ impl Function {
                                     }
                                     self.push_insn(block, Insn::PatchPoint { invariant: Invariant::MethodRedefined { klass, method: mid, cme }, state });
                                     if let Some(profiled_type) = profiled_type {
-                                        recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: None });
+                                        let argc = unsafe { vm_ci_argc(ci) } as i32;
+                                        recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: Some(Recompile::ProfileSend{ argc }) });
                                     }
                                     let kw_splat = flags & VM_CALL_KW_SPLAT != 0;
                                     let invoke_proc = self.push_insn(block, Insn::InvokeProc { recv, args: args.clone(), state, kw_splat });
@@ -3857,7 +3861,8 @@ impl Function {
                                     }
                                     self.push_insn(block, Insn::PatchPoint { invariant: Invariant::MethodRedefined { klass, method: mid, cme }, state });
                                     if let Some(profiled_type) = profiled_type {
-                                        recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: None });
+                                        let argc = unsafe { vm_ci_argc(ci) } as i32;
+                                        recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: Some(Recompile::ProfileSend{ argc }) });
                                     }
                                     // All structs from the same Struct class should have the same
                                     // length. So if our recv is embedded all runtime
@@ -4776,7 +4781,8 @@ impl Function {
 
                     if let Some(profiled_type) = profiled_type {
                         // Guard receiver class
-                        recv = fun.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: None });
+                        let argc = unsafe { vm_ci_argc(call_info) } as i32;
+                        recv = fun.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: Some(Recompile::ProfileSend { argc }) });
                         fun.insn_types[recv.0] = fun.infer_type(recv);
                     }
 
@@ -4842,7 +4848,8 @@ impl Function {
 
                     if let Some(profiled_type) = profiled_type {
                         // Guard receiver class
-                        recv = fun.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: None });
+                        let argc = unsafe { vm_ci_argc(call_info) } as i32;
+                        recv = fun.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: Some(Recompile::ProfileSend { argc }) });
                         fun.insn_types[recv.0] = fun.infer_type(recv);
                     }
 

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -7100,9 +7100,9 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                     }
                     let ty = Type::from_profiled_type(summary.bucket(0));
                     let obj = if ty.is_subtype(types::NilClass) {
-                        fun.push_insn(block, Insn::GuardType { val: hash, guard_type: types::NilClass, state: exit_id , recompile: None})
+                        fun.push_insn(block, Insn::GuardType { val: hash, guard_type: types::NilClass, state: exit_id, recompile: None})
                     } else if ty.is_subtype(types::HashExact) {
-                        fun.push_insn(block, Insn::GuardType { val: hash, guard_type: types::HashExact, state: exit_id , recompile: None})
+                        fun.push_insn(block, Insn::GuardType { val: hash, guard_type: types::HashExact, state: exit_id, recompile: None})
                     } else {
                         fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::SplatKwNotNilOrHash, recompile: None });
                         break;  // End the block

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -3474,7 +3474,7 @@ impl Function {
 
     pub fn coerce_to(&mut self, block: BlockId, val: InsnId, guard_type: Type, state: InsnId) -> InsnId {
         if self.is_a(val, guard_type) { return val; }
-        self.push_insn(block, Insn::GuardType { val, guard_type, state, recompile: None})
+        self.push_insn(block, Insn::GuardType { val, guard_type, state, recompile: None })
     }
 
     fn count_complex_call_features(&mut self, block: BlockId, ci_flags: c_uint) {
@@ -4385,16 +4385,16 @@ impl Function {
     fn load_ivar_guard_type(&mut self, block: BlockId, recv: InsnId, recv_type: ProfiledType, state: InsnId) -> InsnId {
         if recv_type.flags().is_t_class() {
             // Check class first since `Class < Module`
-            self.push_insn(block, Insn::GuardType { val: recv, guard_type: types::Class, state, recompile: None})
+            self.push_insn(block, Insn::GuardType { val: recv, guard_type: types::Class, state, recompile: None })
         } else if recv_type.flags().is_t_module() {
-            self.push_insn(block, Insn::GuardType { val: recv, guard_type: types::Module, state, recompile: None})
+            self.push_insn(block, Insn::GuardType { val: recv, guard_type: types::Module, state, recompile: None })
         } else if recv_type.flags().is_t_data() {
-            self.push_insn(block, Insn::GuardType { val: recv, guard_type: types::TData, state, recompile: None})
+            self.push_insn(block, Insn::GuardType { val: recv, guard_type: types::TData, state, recompile: None })
         } else {
             // HeapBasicObject is wider than T_OBJECT, but shapes for T_OBJECTs are in a pool of
             // its own and are guaranteed to be different from shapes of any other T_* types. So
             // the shape check that follows already covers checking for T_OBJECT.
-            self.push_insn(block, Insn::GuardType { val: recv, guard_type: types::HeapBasicObject, state, recompile: None})
+            self.push_insn(block, Insn::GuardType { val: recv, guard_type: types::HeapBasicObject, state, recompile: None })
         }
     }
 
@@ -7107,9 +7107,9 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                     }
                     let ty = Type::from_profiled_type(summary.bucket(0));
                     let obj = if ty.is_subtype(types::NilClass) {
-                        fun.push_insn(block, Insn::GuardType { val: hash, guard_type: types::NilClass, state: exit_id, recompile: None})
+                        fun.push_insn(block, Insn::GuardType { val: hash, guard_type: types::NilClass, state: exit_id, recompile: None })
                     } else if ty.is_subtype(types::HashExact) {
-                        fun.push_insn(block, Insn::GuardType { val: hash, guard_type: types::HashExact, state: exit_id, recompile: None})
+                        fun.push_insn(block, Insn::GuardType { val: hash, guard_type: types::HashExact, state: exit_id, recompile: None })
                     } else {
                         fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::SplatKwNotNilOrHash, recompile: None });
                         break;  // End the block

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -3474,7 +3474,7 @@ impl Function {
 
     pub fn coerce_to(&mut self, block: BlockId, val: InsnId, guard_type: Type, state: InsnId) -> InsnId {
         if self.is_a(val, guard_type) { return val; }
-        self.push_insn(block, Insn::GuardType { val, guard_type, state , recompile: None})
+        self.push_insn(block, Insn::GuardType { val, guard_type, state, recompile: None})
     }
 
     fn count_complex_call_features(&mut self, block: BlockId, ci_flags: c_uint) {
@@ -4380,16 +4380,16 @@ impl Function {
     fn load_ivar_guard_type(&mut self, block: BlockId, recv: InsnId, recv_type: ProfiledType, state: InsnId) -> InsnId {
         if recv_type.flags().is_t_class() {
             // Check class first since `Class < Module`
-            self.push_insn(block, Insn::GuardType { val: recv, guard_type: types::Class, state , recompile: None})
+            self.push_insn(block, Insn::GuardType { val: recv, guard_type: types::Class, state, recompile: None})
         } else if recv_type.flags().is_t_module() {
-            self.push_insn(block, Insn::GuardType { val: recv, guard_type: types::Module, state , recompile: None})
+            self.push_insn(block, Insn::GuardType { val: recv, guard_type: types::Module, state, recompile: None})
         } else if recv_type.flags().is_t_data() {
-            self.push_insn(block, Insn::GuardType { val: recv, guard_type: types::TData, state , recompile: None})
+            self.push_insn(block, Insn::GuardType { val: recv, guard_type: types::TData, state, recompile: None})
         } else {
             // HeapBasicObject is wider than T_OBJECT, but shapes for T_OBJECTs are in a pool of
             // its own and are guaranteed to be different from shapes of any other T_* types. So
             // the shape check that follows already covers checking for T_OBJECT.
-            self.push_insn(block, Insn::GuardType { val: recv, guard_type: types::HeapBasicObject, state , recompile: None})
+            self.push_insn(block, Insn::GuardType { val: recv, guard_type: types::HeapBasicObject, state, recompile: None})
         }
     }
 

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -209,7 +209,7 @@ mod hir_opt_tests {
             end
             test 1; test 2
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -225,7 +225,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           v15:Fixnum[0] = Const Value(0)
           PatchPoint MethodRedefined(Integer@0x1008, -@0x1010, cme:0x1018)
-          v26:Fixnum = GuardType v10, Fixnum
+          v26:Fixnum = GuardType v10, Fixnum recompile
           CheckInterrupts
           Return v26
         ");
@@ -439,7 +439,7 @@ mod hir_opt_tests {
             end
             test 1; test 2
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -455,7 +455,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           v15:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Integer@0x1008, /@0x1010, cme:0x1018)
-          v26:Fixnum = GuardType v10, Fixnum
+          v26:Fixnum = GuardType v10, Fixnum recompile
           CheckInterrupts
           Return v26
         ");
@@ -1115,7 +1115,7 @@ mod hir_opt_tests {
             def test(arr) = arr[0]
             test([1,2,3])
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -1132,7 +1132,7 @@ mod hir_opt_tests {
           v15:Fixnum[0] = Const Value(0)
           PatchPoint NoSingletonClass(Array@0x1008)
           PatchPoint MethodRedefined(Array@0x1008, []@0x1010, cme:0x1018)
-          v27:ArrayExact = GuardType v10, ArrayExact
+          v27:ArrayExact = GuardType v10, ArrayExact recompile
           v35:CInt64[0] = Const CInt64(0)
           v29:CInt64 = ArrayLength v27
           v30:CInt64[0] = GuardLess v35, v29
@@ -1148,7 +1148,7 @@ mod hir_opt_tests {
             def test(arr) = arr[0]
             test([1,2,3])
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -1165,7 +1165,7 @@ mod hir_opt_tests {
           v15:Fixnum[0] = Const Value(0)
           PatchPoint NoSingletonClass(Array@0x1008)
           PatchPoint MethodRedefined(Array@0x1008, []@0x1010, cme:0x1018)
-          v27:ArrayExact = GuardType v10, ArrayExact
+          v27:ArrayExact = GuardType v10, ArrayExact recompile
           v35:CInt64[0] = Const CInt64(0)
           v29:CInt64 = ArrayLength v27
           v30:CInt64[0] = GuardLess v35, v29
@@ -1232,7 +1232,7 @@ mod hir_opt_tests {
             custom.count
         ");
         assert_eq!(VALUE::fixnum_from_usize(2), result);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:13:
         bb1():
           EntryPoint interpreter
@@ -1248,7 +1248,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint NoSingletonClass(CustomEq@0x1008)
           PatchPoint MethodRedefined(CustomEq@0x1008, !=@0x1010, cme:0x1018)
-          v30:ObjectSubclass[class_exact:CustomEq] = GuardType v10, ObjectSubclass[class_exact:CustomEq]
+          v30:ObjectSubclass[class_exact:CustomEq] = GuardType v10, ObjectSubclass[class_exact:CustomEq] recompile
           v31:BoolExact = CCallWithFrame v30, :BasicObject#!=@0x1040, v30
           v21:NilClass = Const Value(nil)
           CheckInterrupts
@@ -1264,7 +1264,7 @@ mod hir_opt_tests {
             end
             test(2); test(3)
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -1280,7 +1280,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           v15:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Integer@0x1008, +@0x1010, cme:0x1018)
-          v26:Fixnum = GuardType v10, Fixnum
+          v26:Fixnum = GuardType v10, Fixnum recompile
           v27:Fixnum = FixnumAdd v26, v15
           CheckInterrupts
           Return v27
@@ -1394,7 +1394,7 @@ mod hir_opt_tests {
             end
             test; test
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -1406,7 +1406,7 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
-          v18:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)]
+          v18:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           v19:BasicObject = SendDirect v18, 0x1038, :foo (0x1048)
           CheckInterrupts
           Return v19
@@ -1422,7 +1422,7 @@ mod hir_opt_tests {
             def test = baz
             test; test
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:5:
         bb1():
           EntryPoint interpreter
@@ -1434,7 +1434,7 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           PatchPoint MethodRedefined(Object@0x1000, baz@0x1008, cme:0x1010)
-          v18:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)]
+          v18:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           v20:Fixnum[1] = Const Value(1)
           CheckInterrupts
           Return v20
@@ -1449,7 +1449,7 @@ mod hir_opt_tests {
             def test = baz
             test; test
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -1461,7 +1461,7 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           PatchPoint MethodRedefined(Object@0x1000, baz@0x1008, cme:0x1010)
-          v19:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)]
+          v19:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           CheckInterrupts
           Return v19
         ");
@@ -1485,7 +1485,7 @@ mod hir_opt_tests {
             def test = foo(1)
             test; test
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:8:
         bb1():
           EntryPoint interpreter
@@ -1498,7 +1498,7 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           v11:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
-          v20:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)]
+          v20:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           v21:BasicObject = SendDirect v20, 0x1038, :foo (0x1048), v11
           CheckInterrupts
           Return v21
@@ -1514,7 +1514,7 @@ mod hir_opt_tests {
             def test(o) = o.fun_new_map {|e| e }
             test C.new; test C.new
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:5:
         bb1():
           EntryPoint interpreter
@@ -1530,7 +1530,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, fun_new_map@0x1010, cme:0x1018)
-          v27:ArraySubclass[class_exact:C] = GuardType v10, ArraySubclass[class_exact:C]
+          v27:ArraySubclass[class_exact:C] = GuardType v10, ArraySubclass[class_exact:C] recompile
           v28:BasicObject = SendDirect v27, 0x1040, :fun_new_map (0x1050)
           PatchPoint NoEPEscape(test)
           v18:CPtr = LoadSP
@@ -1551,7 +1551,7 @@ mod hir_opt_tests {
             def test(o) = o.bar { |x| x }
             test C.new; test C.new
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:7:
         bb1():
           EntryPoint interpreter
@@ -1567,7 +1567,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, bar@0x1010, cme:0x1018)
-          v28:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
+          v28:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C] recompile
           v29:BasicObject = CCallWithFrame v28, :Enumerable#bar@0x1040, block=0x1048
           PatchPoint NoEPEscape(test)
           v18:CPtr = LoadSP
@@ -1588,7 +1588,7 @@ mod hir_opt_tests {
             def test(a) = a.length
             test([1,2,3]); test([1,2,3])
         ", "{ specialized_instruction: false }");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -1604,7 +1604,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint NoSingletonClass(Array@0x1008)
           PatchPoint MethodRedefined(Array@0x1008, length@0x1010, cme:0x1018)
-          v24:ArrayExact = GuardType v10, ArrayExact
+          v24:ArrayExact = GuardType v10, ArrayExact recompile
           v25:CInt64 = ArrayLength v24
           v26:Fixnum = BoxFixnum v25
           CheckInterrupts
@@ -1650,7 +1650,7 @@ mod hir_opt_tests {
             end
             test; test
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:5:
         bb1():
           EntryPoint interpreter
@@ -1662,7 +1662,7 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
-          v18:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)]
+          v18:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           v19:BasicObject = SendDirect v18, 0x1038, :foo (0x1048)
           CheckInterrupts
           Return v19
@@ -1677,7 +1677,7 @@ mod hir_opt_tests {
             end
             test; test
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -1690,7 +1690,7 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           v11:Fixnum[3] = Const Value(3)
           PatchPoint MethodRedefined(Object@0x1000, Integer@0x1008, cme:0x1010)
-          v20:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)]
+          v20:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           v21:BasicObject = SendDirect v20, 0x1038, :Integer (0x1048), v11
           CheckInterrupts
           Return v21
@@ -1706,7 +1706,7 @@ mod hir_opt_tests {
             end
             test; test
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -1720,7 +1720,7 @@ mod hir_opt_tests {
           v11:Fixnum[1] = Const Value(1)
           v13:Fixnum[2] = Const Value(2)
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
-          v22:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)]
+          v22:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           v23:BasicObject = SendDirect v22, 0x1038, :foo (0x1048), v11, v13
           CheckInterrupts
           Return v23
@@ -1738,7 +1738,7 @@ mod hir_opt_tests {
             end
             test; test
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:5:
         bb1():
           EntryPoint interpreter
@@ -1750,7 +1750,7 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
-          v23:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)]
+          v23:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           v24:BasicObject = SendDirect v23, 0x1038, :foo (0x1048)
           PatchPoint MethodRedefined(Object@0x1000, bar@0x1050, cme:0x1058)
           v27:BasicObject = SendDirect v23, 0x1038, :bar (0x1048)
@@ -1766,7 +1766,7 @@ mod hir_opt_tests {
             def test = foo
             test
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -1778,7 +1778,7 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
-          v18:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)]
+          v18:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           v19:BasicObject = SendDirect v18, 0x1038, :foo (0x1048)
           CheckInterrupts
           Return v19
@@ -1792,7 +1792,7 @@ mod hir_opt_tests {
             def test = foo 3
             test
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -1805,7 +1805,7 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           v11:Fixnum[3] = Const Value(3)
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
-          v20:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)]
+          v20:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           v21:BasicObject = SendDirect v20, 0x1038, :foo (0x1048), v11
           CheckInterrupts
           Return v21
@@ -1819,7 +1819,7 @@ mod hir_opt_tests {
             def test = foo 3, 4
             test
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -1833,7 +1833,7 @@ mod hir_opt_tests {
           v11:Fixnum[3] = Const Value(3)
           v13:Fixnum[4] = Const Value(4)
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
-          v22:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)]
+          v22:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           v23:BasicObject = SendDirect v22, 0x1038, :foo (0x1048), v11, v13
           CheckInterrupts
           Return v23
@@ -1848,7 +1848,7 @@ mod hir_opt_tests {
             test
             test
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -1860,7 +1860,7 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           PatchPoint MethodRedefined(Object@0x1000, target@0x1008, cme:0x1010)
-          v44:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)]
+          v44:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           v45:BasicObject = SendDirect v44, 0x1038, :target (0x1048)
           v14:Fixnum[10] = Const Value(10)
           v16:Fixnum[20] = Const Value(20)
@@ -1887,7 +1887,7 @@ mod hir_opt_tests {
             end
             test; test
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -1901,7 +1901,7 @@ mod hir_opt_tests {
           v11:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
           v12:StringExact = StringCopy v11
           PatchPoint MethodRedefined(Object@0x1008, puts@0x1010, cme:0x1018)
-          v22:ObjectSubclass[class_exact*:Object@VALUE(0x1008)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1008)]
+          v22:ObjectSubclass[class_exact*:Object@VALUE(0x1008)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1008)] recompile
           v23:BasicObject = CCallVariadic v22, :Kernel#puts@0x1040, v12
           CheckInterrupts
           Return v23
@@ -1919,7 +1919,7 @@ mod hir_opt_tests {
             def test(a, b) = a + b
             test(1,2); test(3,4)
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:7:
         bb1():
           EntryPoint interpreter
@@ -1936,7 +1936,7 @@ mod hir_opt_tests {
           Jump bb3(v7, v8, v9)
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint MethodRedefined(Integer@0x1008, +@0x1010, cme:0x1018)
-          v27:Fixnum = GuardType v12, Fixnum
+          v27:Fixnum = GuardType v12, Fixnum recompile
           v29:Fixnum[100] = Const Value(100)
           CheckInterrupts
           Return v29
@@ -1949,7 +1949,7 @@ mod hir_opt_tests {
             def test(a, b) = a + b
             test(1,2); test(3,4)
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -1966,7 +1966,7 @@ mod hir_opt_tests {
           Jump bb3(v7, v8, v9)
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint MethodRedefined(Integer@0x1008, +@0x1010, cme:0x1018)
-          v28:Fixnum = GuardType v12, Fixnum
+          v28:Fixnum = GuardType v12, Fixnum recompile
           v29:Fixnum = GuardType v13, Fixnum
           v30:Fixnum = FixnumAdd v28, v29
           CheckInterrupts
@@ -1980,7 +1980,7 @@ mod hir_opt_tests {
             def test(a) = a + 1
             test(1); test(3)
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -1996,7 +1996,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           v15:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Integer@0x1008, +@0x1010, cme:0x1018)
-          v26:Fixnum = GuardType v10, Fixnum
+          v26:Fixnum = GuardType v10, Fixnum recompile
           v27:Fixnum = FixnumAdd v26, v15
           CheckInterrupts
           Return v27
@@ -2038,7 +2038,7 @@ mod hir_opt_tests {
             def test(a, b) = a[b]
             test(3, 4)
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -2055,7 +2055,7 @@ mod hir_opt_tests {
           Jump bb3(v7, v8, v9)
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint MethodRedefined(Integer@0x1008, []@0x1010, cme:0x1018)
-          v28:Fixnum = GuardType v12, Fixnum
+          v28:Fixnum = GuardType v12, Fixnum recompile
           v29:Fixnum = GuardType v13, Fixnum
           v30:Fixnum = FixnumAref v28, v29
           CheckInterrupts
@@ -2149,7 +2149,7 @@ mod hir_opt_tests {
             def test(a, b) = a < b
             test(1,2); test(3,4)
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -2166,7 +2166,7 @@ mod hir_opt_tests {
           Jump bb3(v7, v8, v9)
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint MethodRedefined(Integer@0x1008, <@0x1010, cme:0x1018)
-          v28:Fixnum = GuardType v12, Fixnum
+          v28:Fixnum = GuardType v12, Fixnum recompile
           v29:Fixnum = GuardType v13, Fixnum
           v30:BoolExact = FixnumLt v28, v29
           CheckInterrupts
@@ -2180,7 +2180,7 @@ mod hir_opt_tests {
             def test(a) = a < 1
             test(1); test(3)
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -2196,7 +2196,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           v15:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Integer@0x1008, <@0x1010, cme:0x1018)
-          v26:Fixnum = GuardType v10, Fixnum
+          v26:Fixnum = GuardType v10, Fixnum recompile
           v27:BoolExact = FixnumLt v26, v15
           CheckInterrupts
           Return v27
@@ -2467,7 +2467,7 @@ mod hir_opt_tests {
             def test(arr) = arr[0]
             test(arr)
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -2484,7 +2484,7 @@ mod hir_opt_tests {
           v15:Fixnum[0] = Const Value(0)
           PatchPoint NoSingletonClass(Array@0x1008)
           PatchPoint MethodRedefined(Array@0x1008, []@0x1010, cme:0x1018)
-          v27:ArrayExact = GuardType v10, ArrayExact
+          v27:ArrayExact = GuardType v10, ArrayExact recompile
           v35:CInt64[0] = Const CInt64(0)
           v29:CInt64 = ArrayLength v27
           v30:CInt64[0] = GuardLess v35, v29
@@ -2502,7 +2502,7 @@ mod hir_opt_tests {
             def test(arr) = arr[0]
             test(arr)
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -2519,7 +2519,7 @@ mod hir_opt_tests {
           v15:Fixnum[0] = Const Value(0)
           PatchPoint NoSingletonClass(Hash@0x1008)
           PatchPoint MethodRedefined(Hash@0x1008, []@0x1010, cme:0x1018)
-          v27:HashExact = GuardType v10, HashExact
+          v27:HashExact = GuardType v10, HashExact recompile
           v28:BasicObject = HashAref v27, v15
           CheckInterrupts
           Return v28
@@ -2813,7 +2813,7 @@ mod hir_opt_tests {
             end
             test(1, 2); test(3, 4)
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -2830,7 +2830,7 @@ mod hir_opt_tests {
           Jump bb3(v7, v8, v9)
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint MethodRedefined(Integer@0x1008, +@0x1010, cme:0x1018)
-          v32:Fixnum = GuardType v12, Fixnum
+          v32:Fixnum = GuardType v12, Fixnum recompile
           v33:Fixnum = GuardType v13, Fixnum
           v24:Fixnum[5] = Const Value(5)
           CheckInterrupts
@@ -2847,7 +2847,7 @@ mod hir_opt_tests {
             end
             test(1, 2); test(3, 4)
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -2864,7 +2864,7 @@ mod hir_opt_tests {
           Jump bb3(v7, v8, v9)
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint MethodRedefined(Integer@0x1008, -@0x1010, cme:0x1018)
-          v32:Fixnum = GuardType v12, Fixnum
+          v32:Fixnum = GuardType v12, Fixnum recompile
           v33:Fixnum = GuardType v13, Fixnum
           v24:Fixnum[5] = Const Value(5)
           CheckInterrupts
@@ -2881,7 +2881,7 @@ mod hir_opt_tests {
             end
             test(1, 2); test(3, 4)
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -2898,7 +2898,7 @@ mod hir_opt_tests {
           Jump bb3(v7, v8, v9)
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint MethodRedefined(Integer@0x1008, *@0x1010, cme:0x1018)
-          v32:Fixnum = GuardType v12, Fixnum
+          v32:Fixnum = GuardType v12, Fixnum recompile
           v33:Fixnum = GuardType v13, Fixnum
           v24:Fixnum[5] = Const Value(5)
           CheckInterrupts
@@ -2915,7 +2915,7 @@ mod hir_opt_tests {
             end
             test(1, 2); test(3, 4)
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -2932,7 +2932,7 @@ mod hir_opt_tests {
           Jump bb3(v7, v8, v9)
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint MethodRedefined(Integer@0x1008, /@0x1010, cme:0x1018)
-          v32:Fixnum = GuardType v12, Fixnum
+          v32:Fixnum = GuardType v12, Fixnum recompile
           v33:Fixnum = GuardType v13, Fixnum
           v34:Integer = FixnumDiv v32, v33
           v24:Fixnum[5] = Const Value(5)
@@ -2950,7 +2950,7 @@ mod hir_opt_tests {
             end
             test(1, 2); test(3, 4)
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -2967,7 +2967,7 @@ mod hir_opt_tests {
           Jump bb3(v7, v8, v9)
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint MethodRedefined(Integer@0x1008, %@0x1010, cme:0x1018)
-          v32:Fixnum = GuardType v12, Fixnum
+          v32:Fixnum = GuardType v12, Fixnum recompile
           v33:Fixnum = GuardType v13, Fixnum
           v34:Fixnum = FixnumMod v32, v33
           v24:Fixnum[5] = Const Value(5)
@@ -2985,7 +2985,7 @@ mod hir_opt_tests {
             end
             test(1, 2); test(3, 4)
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -3002,7 +3002,7 @@ mod hir_opt_tests {
           Jump bb3(v7, v8, v9)
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint MethodRedefined(Integer@0x1008, <@0x1010, cme:0x1018)
-          v32:Fixnum = GuardType v12, Fixnum
+          v32:Fixnum = GuardType v12, Fixnum recompile
           v33:Fixnum = GuardType v13, Fixnum
           v24:Fixnum[5] = Const Value(5)
           CheckInterrupts
@@ -3019,7 +3019,7 @@ mod hir_opt_tests {
             end
             test(1, 2); test(3, 4)
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -3036,7 +3036,7 @@ mod hir_opt_tests {
           Jump bb3(v7, v8, v9)
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint MethodRedefined(Integer@0x1008, <=@0x1010, cme:0x1018)
-          v32:Fixnum = GuardType v12, Fixnum
+          v32:Fixnum = GuardType v12, Fixnum recompile
           v33:Fixnum = GuardType v13, Fixnum
           v24:Fixnum[5] = Const Value(5)
           CheckInterrupts
@@ -3053,7 +3053,7 @@ mod hir_opt_tests {
             end
             test(1, 2); test(3, 4)
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -3070,7 +3070,7 @@ mod hir_opt_tests {
           Jump bb3(v7, v8, v9)
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint MethodRedefined(Integer@0x1008, >@0x1010, cme:0x1018)
-          v32:Fixnum = GuardType v12, Fixnum
+          v32:Fixnum = GuardType v12, Fixnum recompile
           v33:Fixnum = GuardType v13, Fixnum
           v24:Fixnum[5] = Const Value(5)
           CheckInterrupts
@@ -3087,7 +3087,7 @@ mod hir_opt_tests {
             end
             test(1, 2); test(3, 4)
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -3104,7 +3104,7 @@ mod hir_opt_tests {
           Jump bb3(v7, v8, v9)
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint MethodRedefined(Integer@0x1008, >=@0x1010, cme:0x1018)
-          v32:Fixnum = GuardType v12, Fixnum
+          v32:Fixnum = GuardType v12, Fixnum recompile
           v33:Fixnum = GuardType v13, Fixnum
           v24:Fixnum[5] = Const Value(5)
           CheckInterrupts
@@ -3121,7 +3121,7 @@ mod hir_opt_tests {
             end
             test(1, 2); test(3, 4)
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -3138,7 +3138,7 @@ mod hir_opt_tests {
           Jump bb3(v7, v8, v9)
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint MethodRedefined(Integer@0x1008, ==@0x1010, cme:0x1018)
-          v32:Fixnum = GuardType v12, Fixnum
+          v32:Fixnum = GuardType v12, Fixnum recompile
           v33:Fixnum = GuardType v13, Fixnum
           v24:Fixnum[5] = Const Value(5)
           CheckInterrupts
@@ -3155,7 +3155,7 @@ mod hir_opt_tests {
             end
             test(1, 2); test(3, 4)
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -3172,7 +3172,7 @@ mod hir_opt_tests {
           Jump bb3(v7, v8, v9)
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint MethodRedefined(Integer@0x1008, !=@0x1010, cme:0x1018)
-          v32:Fixnum = GuardType v12, Fixnum
+          v32:Fixnum = GuardType v12, Fixnum recompile
           PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_EQ)
           v34:Fixnum = GuardType v13, Fixnum
           v24:Fixnum[5] = Const Value(5)
@@ -3244,7 +3244,7 @@ mod hir_opt_tests {
             test(0) # profile
             test(1)
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -3259,7 +3259,7 @@ mod hir_opt_tests {
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint MethodRedefined(Integer@0x1008, itself@0x1010, cme:0x1018)
-          v23:Fixnum = GuardType v10, Fixnum
+          v23:Fixnum = GuardType v10, Fixnum recompile
           CheckInterrupts
           Return v23
         ");
@@ -3558,7 +3558,7 @@ mod hir_opt_tests {
             def test = block_given?
             test
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -3570,7 +3570,7 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           PatchPoint MethodRedefined(Object@0x1000, block_given?@0x1008, cme:0x1010)
-          v19:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)]
+          v19:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           v20:CPtr = GetEP 0
           v21:BoolExact = IsBlockGiven v20
           CheckInterrupts
@@ -3584,7 +3584,7 @@ mod hir_opt_tests {
             TEST = proc { block_given? }
             TEST.call
         ");
-        assert_snapshot!(hir_string_proc("TEST"), @"
+        assert_snapshot!(hir_string_proc("TEST"), @r"
         fn block in <compiled>@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -3596,7 +3596,7 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           PatchPoint MethodRedefined(Object@0x1000, block_given?@0x1008, cme:0x1010)
-          v19:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)]
+          v19:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           v20:FalseClass = Const Value(false)
           CheckInterrupts
           Return v20
@@ -3612,7 +3612,7 @@ mod hir_opt_tests {
             end
             test
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -3624,7 +3624,7 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           PatchPoint MethodRedefined(Object@0x1000, block_given?@0x1008, cme:0x1010)
-          v23:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)]
+          v23:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           v15:Fixnum[5] = Const Value(5)
           CheckInterrupts
           Return v15
@@ -3735,7 +3735,7 @@ mod hir_opt_tests {
             test c
         ");
 
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:6:
         bb1():
           EntryPoint interpreter
@@ -3751,7 +3751,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
-          v23:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
+          v23:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C] recompile
           v24:BasicObject = SendDirect v23, 0x1040, :foo (0x1050)
           CheckInterrupts
           Return v24
@@ -3767,7 +3767,7 @@ mod hir_opt_tests {
             test
         ");
         assert_eq!(VALUE::fixnum_from_usize(3), result);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -3781,7 +3781,7 @@ mod hir_opt_tests {
           v11:Fixnum[1] = Const Value(1)
           v13:Fixnum[2] = Const Value(2)
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
-          v22:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)]
+          v22:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           v23:BasicObject = SendDirect v22, 0x1038, :foo (0x1048), v11, v13
           CheckInterrupts
           Return v23
@@ -3800,7 +3800,7 @@ mod hir_opt_tests {
             test
             test
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -3815,7 +3815,7 @@ mod hir_opt_tests {
         bb3(v8:BasicObject, v9:NilClass):
           v13:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
-          v34:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v8, ObjectSubclass[class_exact*:Object@VALUE(0x1000)]
+          v34:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v8, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           v36:Fixnum[1] = Const Value(1)
           PatchPoint NoEPEscape(test)
           v21:CPtr = LoadSP
@@ -3838,7 +3838,7 @@ mod hir_opt_tests {
             test
             test
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -3854,7 +3854,7 @@ mod hir_opt_tests {
           v13:Fixnum[1] = Const Value(1)
           SetLocal :a, l0, EP@3, v13
           PatchPoint MethodRedefined(Object@0x1000, lambda@0x1008, cme:0x1010)
-          v45:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v8, ObjectSubclass[class_exact*:Object@VALUE(0x1000)]
+          v45:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v8, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           v46:BasicObject = CCallWithFrame v45, :Kernel#lambda@0x1038, block=0x1040
           v20:CPtr = GetEP 0
           v21:BasicObject = LoadField v20, :a@0x1048
@@ -3907,7 +3907,7 @@ mod hir_opt_tests {
             test
             test
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -3920,7 +3920,7 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           v11:Fixnum[10] = Const Value(10)
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
-          v20:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)]
+          v20:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           v21:BasicObject = SendDirect v20, 0x1038, :foo (0x1048), v11
           CheckInterrupts
           Return v21
@@ -3936,7 +3936,7 @@ mod hir_opt_tests {
             test
         ");
         assert_eq!(VALUE::fixnum_from_usize(110), result);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -3950,7 +3950,7 @@ mod hir_opt_tests {
           v11:Fixnum[10] = Const Value(10)
           v13:Fixnum[20] = Const Value(20)
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
-          v22:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)]
+          v22:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           v23:BasicObject = SendDirect v22, 0x1038, :foo (0x1048), v11, v13
           CheckInterrupts
           Return v23
@@ -3965,7 +3965,7 @@ mod hir_opt_tests {
             test
             test
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -3979,7 +3979,7 @@ mod hir_opt_tests {
           v11:Fixnum[1] = Const Value(1)
           v13:Fixnum[2] = Const Value(2)
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
-          v22:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)]
+          v22:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           v23:BasicObject = SendDirect v22, 0x1038, :foo (0x1048), v11, v13
           CheckInterrupts
           Return v23
@@ -3994,7 +3994,7 @@ mod hir_opt_tests {
             test
             test
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -4009,7 +4009,7 @@ mod hir_opt_tests {
           v13:Fixnum[1] = Const Value(1)
           v15:Fixnum[2] = Const Value(2)
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
-          v25:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)]
+          v25:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           v26:BasicObject = SendDirect v25, 0x1038, :foo (0x1048), v13, v15, v11
           CheckInterrupts
           Return v26
@@ -4024,7 +4024,7 @@ mod hir_opt_tests {
             test
             test
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -4039,7 +4039,7 @@ mod hir_opt_tests {
           v13:Fixnum[2] = Const Value(2)
           v15:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
-          v25:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)]
+          v25:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           v26:BasicObject = SendDirect v25, 0x1038, :foo (0x1048), v11, v15, v13
           CheckInterrupts
           Return v26
@@ -4054,7 +4054,7 @@ mod hir_opt_tests {
             test
             test
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -4068,7 +4068,7 @@ mod hir_opt_tests {
           v11:Fixnum[0] = Const Value(0)
           v13:Fixnum[2] = Const Value(2)
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
-          v22:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)]
+          v22:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           v23:BasicObject = SendDirect v22, 0x1038, :foo (0x1048), v11, v13
           CheckInterrupts
           Return v23
@@ -4083,7 +4083,7 @@ mod hir_opt_tests {
             test
             test
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -4098,7 +4098,7 @@ mod hir_opt_tests {
           v13:Fixnum[3] = Const Value(3)
           v15:Fixnum[4] = Const Value(4)
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
-          v37:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)]
+          v37:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           v38:BasicObject = SendDirect v37, 0x1038, :foo (0x1048), v11, v13, v15
           v20:Fixnum[1] = Const Value(1)
           v22:Fixnum[2] = Const Value(2)
@@ -4120,7 +4120,7 @@ mod hir_opt_tests {
             test
             test
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -4135,7 +4135,7 @@ mod hir_opt_tests {
           v13:Fixnum[3] = Const Value(3)
           v34:Fixnum[4] = Const Value(4)
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
-          v37:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)]
+          v37:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           v38:BasicObject = SendDirect v37, 0x1038, :foo (0x1048), v11, v13, v34
           v18:Fixnum[1] = Const Value(1)
           v20:Fixnum[2] = Const Value(2)
@@ -4157,7 +4157,7 @@ mod hir_opt_tests {
             test
             test
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -4170,7 +4170,7 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           v11:Fixnum[6] = Const Value(6)
           PatchPoint MethodRedefined(Object@0x1000, target@0x1008, cme:0x1010)
-          v48:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)]
+          v48:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           v49:BasicObject = SendDirect v48, 0x1038, :target (0x1048), v11
           v16:Fixnum[10] = Const Value(10)
           v18:Fixnum[20] = Const Value(20)
@@ -4199,7 +4199,7 @@ mod hir_opt_tests {
             test
             test
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -4212,7 +4212,7 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           v11:Fixnum[2] = Const Value(2)
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
-          v20:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)]
+          v20:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           v21:BasicObject = SendDirect v20, 0x1038, :foo (0x1048), v11
           CheckInterrupts
           Return v21
@@ -4314,7 +4314,7 @@ mod hir_opt_tests {
             test
             test
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -4327,7 +4327,7 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           v17:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
-          v20:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)]
+          v20:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           v21:BasicObject = SendDirect v20, 0x1038, :foo (0x1048), v17
           CheckInterrupts
           Return v21
@@ -4767,7 +4767,7 @@ mod hir_opt_tests {
             def test = Set.new
             test
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -4786,7 +4786,7 @@ mod hir_opt_tests {
           v17:HeapBasicObject = ObjectAlloc v43
           PatchPoint NoSingletonClass(Set@0x1008)
           PatchPoint MethodRedefined(Set@0x1008, initialize@0x1038, cme:0x1040)
-          v49:SetExact = GuardType v17, SetExact
+          v49:SetExact = GuardType v17, SetExact recompile
           v50:BasicObject = CCallVariadic v49, :Set#initialize@0x1068
           CheckInterrupts
           Return v49
@@ -5450,7 +5450,7 @@ mod hir_opt_tests {
             end
             test p
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -5467,7 +5467,7 @@ mod hir_opt_tests {
           v15:Fixnum[1] = Const Value(1)
           PatchPoint NoSingletonClass(Proc@0x1008)
           PatchPoint MethodRedefined(Proc@0x1008, call@0x1010, cme:0x1018)
-          v25:ObjectSubclass[class_exact:Proc] = GuardType v10, ObjectSubclass[class_exact:Proc]
+          v25:ObjectSubclass[class_exact:Proc] = GuardType v10, ObjectSubclass[class_exact:Proc] recompile
           v26:BasicObject = InvokeProc v25, v15
           CheckInterrupts
           Return v26
@@ -5483,7 +5483,7 @@ mod hir_opt_tests {
             end
             test p
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -5500,7 +5500,7 @@ mod hir_opt_tests {
           v15:Fixnum[2] = Const Value(2)
           PatchPoint NoSingletonClass(Proc@0x1008)
           PatchPoint MethodRedefined(Proc@0x1008, []@0x1010, cme:0x1018)
-          v26:ObjectSubclass[class_exact:Proc] = GuardType v10, ObjectSubclass[class_exact:Proc]
+          v26:ObjectSubclass[class_exact:Proc] = GuardType v10, ObjectSubclass[class_exact:Proc] recompile
           v27:BasicObject = InvokeProc v26, v15
           CheckInterrupts
           Return v27
@@ -5516,7 +5516,7 @@ mod hir_opt_tests {
             end
             test p
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -5533,7 +5533,7 @@ mod hir_opt_tests {
           v15:Fixnum[3] = Const Value(3)
           PatchPoint NoSingletonClass(Proc@0x1008)
           PatchPoint MethodRedefined(Proc@0x1008, yield@0x1010, cme:0x1018)
-          v25:ObjectSubclass[class_exact:Proc] = GuardType v10, ObjectSubclass[class_exact:Proc]
+          v25:ObjectSubclass[class_exact:Proc] = GuardType v10, ObjectSubclass[class_exact:Proc] recompile
           v26:BasicObject = InvokeProc v25, v15
           CheckInterrupts
           Return v26
@@ -5549,7 +5549,7 @@ mod hir_opt_tests {
             end
             test p
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -5566,7 +5566,7 @@ mod hir_opt_tests {
           v15:Fixnum[1] = Const Value(1)
           PatchPoint NoSingletonClass(Proc@0x1008)
           PatchPoint MethodRedefined(Proc@0x1008, ===@0x1010, cme:0x1018)
-          v25:ObjectSubclass[class_exact:Proc] = GuardType v10, ObjectSubclass[class_exact:Proc]
+          v25:ObjectSubclass[class_exact:Proc] = GuardType v10, ObjectSubclass[class_exact:Proc] recompile
           v26:BasicObject = InvokeProc v25, v15
           CheckInterrupts
           Return v26
@@ -7102,7 +7102,7 @@ mod hir_opt_tests {
             def test = one(zero)
             test
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:5:
         bb1():
           EntryPoint interpreter
@@ -7115,7 +7115,7 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint MethodRedefined(Object@0x1000, zero@0x1008, cme:0x1010)
-          v22:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)]
+          v22:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           v28:StaticSymbol[:b] = Const Value(VALUE(0x1038))
           PatchPoint MethodRedefined(Object@0x1000, one@0x1040, cme:0x1048)
           CheckInterrupts
@@ -7313,7 +7313,7 @@ mod hir_opt_tests {
 
             test(nil)
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -7328,7 +7328,7 @@ mod hir_opt_tests {
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint MethodRedefined(NilClass@0x1008, nil?@0x1010, cme:0x1018)
-          v24:NilClass = GuardType v10, NilClass
+          v24:NilClass = GuardType v10, NilClass recompile
           v25:TrueClass = Const Value(true)
           CheckInterrupts
           Return v25
@@ -7342,7 +7342,7 @@ mod hir_opt_tests {
 
             test(false)
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -7357,7 +7357,7 @@ mod hir_opt_tests {
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint MethodRedefined(FalseClass@0x1008, nil?@0x1010, cme:0x1018)
-          v24:FalseClass = GuardType v10, FalseClass
+          v24:FalseClass = GuardType v10, FalseClass recompile
           v25:FalseClass = Const Value(false)
           CheckInterrupts
           Return v25
@@ -7371,7 +7371,7 @@ mod hir_opt_tests {
 
             test(true)
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -7386,7 +7386,7 @@ mod hir_opt_tests {
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint MethodRedefined(TrueClass@0x1008, nil?@0x1010, cme:0x1018)
-          v24:TrueClass = GuardType v10, TrueClass
+          v24:TrueClass = GuardType v10, TrueClass recompile
           v25:FalseClass = Const Value(false)
           CheckInterrupts
           Return v25
@@ -7400,7 +7400,7 @@ mod hir_opt_tests {
 
             test(:foo)
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -7415,7 +7415,7 @@ mod hir_opt_tests {
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint MethodRedefined(Symbol@0x1008, nil?@0x1010, cme:0x1018)
-          v24:StaticSymbol = GuardType v10, StaticSymbol
+          v24:StaticSymbol = GuardType v10, StaticSymbol recompile
           v25:FalseClass = Const Value(false)
           CheckInterrupts
           Return v25
@@ -7429,7 +7429,7 @@ mod hir_opt_tests {
 
             test(1)
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -7444,7 +7444,7 @@ mod hir_opt_tests {
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint MethodRedefined(Integer@0x1008, nil?@0x1010, cme:0x1018)
-          v24:Fixnum = GuardType v10, Fixnum
+          v24:Fixnum = GuardType v10, Fixnum recompile
           v25:FalseClass = Const Value(false)
           CheckInterrupts
           Return v25
@@ -7458,7 +7458,7 @@ mod hir_opt_tests {
 
             test(1.0)
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -7473,7 +7473,7 @@ mod hir_opt_tests {
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint MethodRedefined(Float@0x1008, nil?@0x1010, cme:0x1018)
-          v24:Flonum = GuardType v10, Flonum
+          v24:Flonum = GuardType v10, Flonum recompile
           v25:FalseClass = Const Value(false)
           CheckInterrupts
           Return v25
@@ -7487,7 +7487,7 @@ mod hir_opt_tests {
 
             test('foo')
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -7503,7 +7503,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, nil?@0x1010, cme:0x1018)
-          v25:StringExact = GuardType v10, StringExact
+          v25:StringExact = GuardType v10, StringExact recompile
           v26:FalseClass = Const Value(false)
           CheckInterrupts
           Return v26
@@ -7517,7 +7517,7 @@ mod hir_opt_tests {
 
             test([])
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -7533,7 +7533,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint NoSingletonClass(Array@0x1008)
           PatchPoint MethodRedefined(Array@0x1008, !@0x1010, cme:0x1018)
-          v25:ArrayExact = GuardType v10, ArrayExact
+          v25:ArrayExact = GuardType v10, ArrayExact recompile
           v26:FalseClass = Const Value(false)
           CheckInterrupts
           Return v26
@@ -7547,7 +7547,7 @@ mod hir_opt_tests {
 
             test(false)
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -7562,7 +7562,7 @@ mod hir_opt_tests {
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint MethodRedefined(FalseClass@0x1008, !@0x1010, cme:0x1018)
-          v24:FalseClass = GuardType v10, FalseClass
+          v24:FalseClass = GuardType v10, FalseClass recompile
           v25:TrueClass = Const Value(true)
           CheckInterrupts
           Return v25
@@ -7576,7 +7576,7 @@ mod hir_opt_tests {
 
             test(nil)
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -7591,7 +7591,7 @@ mod hir_opt_tests {
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint MethodRedefined(NilClass@0x1008, !@0x1010, cme:0x1018)
-          v24:NilClass = GuardType v10, NilClass
+          v24:NilClass = GuardType v10, NilClass recompile
           v25:TrueClass = Const Value(true)
           CheckInterrupts
           Return v25
@@ -7608,7 +7608,7 @@ mod hir_opt_tests {
             test(false)
             test(true)
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -7635,11 +7635,25 @@ mod hir_opt_tests {
           v29:NilClass = Const Value(nil)
           Jump bb5(v25, v26, v29)
         bb5(v31:BasicObject, v32:BasicObject, v33:Falsy):
-          PatchPoint MethodRedefined(NilClass@0x1008, !@0x1010, cme:0x1018)
-          v45:NilClass = GuardType v33, NilClass
-          v46:TrueClass = Const Value(true)
+          v37:CBool = HasType v33, FalseClass
+          CondBranch v37, bb8(v31, v32, v33), bb9()
+        bb8(v38:BasicObject, v39:BasicObject, v40:Falsy):
+          PatchPoint MethodRedefined(FalseClass@0x1008, !@0x1010, cme:0x1018)
+          v68:TrueClass = Const Value(true)
+          Jump bb7(v38, v39, v68)
+        bb9():
+          v46:CBool = HasType v33, NilClass
+          CondBranch v46, bb10(v31, v32, v33), bb11()
+        bb10(v47:BasicObject, v48:BasicObject, v49:Falsy):
+          PatchPoint MethodRedefined(NilClass@0x1040, !@0x1010, cme:0x1018)
+          v71:TrueClass = Const Value(true)
+          Jump bb7(v47, v48, v71)
+        bb11():
+          v55:BasicObject = Send v33, :! # SendFallbackReason: SendWithoutBlock: polymorphic fallback
+          Jump bb7(v31, v32, v55)
+        bb7(v57:BasicObject, v58:BasicObject, v59:BasicObject):
           CheckInterrupts
-          Return v46
+          Return v59
         ");
     }
 
@@ -7650,7 +7664,7 @@ mod hir_opt_tests {
 
             test([])
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -7666,7 +7680,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint NoSingletonClass(Array@0x1008)
           PatchPoint MethodRedefined(Array@0x1008, empty?@0x1010, cme:0x1018)
-          v25:ArrayExact = GuardType v10, ArrayExact
+          v25:ArrayExact = GuardType v10, ArrayExact recompile
           v26:CInt64 = ArrayLength v25
           v27:CInt64[0] = Const CInt64(0)
           v28:CBool = IsBitEqual v26, v27
@@ -7683,7 +7697,7 @@ mod hir_opt_tests {
 
             test({})
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -7699,7 +7713,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint NoSingletonClass(Hash@0x1008)
           PatchPoint MethodRedefined(Hash@0x1008, empty?@0x1010, cme:0x1018)
-          v25:HashExact = GuardType v10, HashExact
+          v25:HashExact = GuardType v10, HashExact recompile
           v26:BoolExact = CCall v25, :Hash#empty?@0x1040
           CheckInterrupts
           Return v26
@@ -7714,7 +7728,7 @@ mod hir_opt_tests {
 
             test(C.new, C.new)
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -7732,7 +7746,7 @@ mod hir_opt_tests {
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, ==@0x1010, cme:0x1018)
-          v29:ObjectSubclass[class_exact:C] = GuardType v12, ObjectSubclass[class_exact:C]
+          v29:ObjectSubclass[class_exact:C] = GuardType v12, ObjectSubclass[class_exact:C] recompile
           v30:CBool = IsBitEqual v29, v13
           v31:BoolExact = BoxBool v30
           CheckInterrupts
@@ -7747,7 +7761,7 @@ mod hir_opt_tests {
 
             test(1, 2)
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -7764,7 +7778,7 @@ mod hir_opt_tests {
           Jump bb3(v7, v8, v9)
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint MethodRedefined(Integer@0x1008, &@0x1010, cme:0x1018)
-          v28:Fixnum = GuardType v12, Fixnum
+          v28:Fixnum = GuardType v12, Fixnum recompile
           v29:Fixnum = GuardType v13, Fixnum
           v30:Fixnum = FixnumAnd v28, v29
           CheckInterrupts
@@ -7779,7 +7793,7 @@ mod hir_opt_tests {
 
             test(1, 2)
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -7796,7 +7810,7 @@ mod hir_opt_tests {
           Jump bb3(v7, v8, v9)
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint MethodRedefined(Integer@0x1008, |@0x1010, cme:0x1018)
-          v28:Fixnum = GuardType v12, Fixnum
+          v28:Fixnum = GuardType v12, Fixnum recompile
           v29:Fixnum = GuardType v13, Fixnum
           v30:Fixnum = FixnumOr v28, v29
           CheckInterrupts
@@ -7813,7 +7827,7 @@ mod hir_opt_tests {
             test; test
         ");
 
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -7825,7 +7839,7 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
-          v18:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)]
+          v18:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           v20:NilClass = Const Value(nil)
           CheckInterrupts
           Return v20
@@ -7847,7 +7861,7 @@ mod hir_opt_tests {
             test O
             test O
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:10:
         bb1():
           EntryPoint interpreter
@@ -7863,7 +7877,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
-          v23:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
+          v23:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C] recompile
           v26:CShape = LoadField v23, :shape_id@0x1040
           v27:CShape[0x1041] = GuardBitEquals v26, CShape(0x1041) recompile
           v28:BasicObject = LoadField v23, :@foo@0x1042
@@ -7890,7 +7904,7 @@ mod hir_opt_tests {
             test O
             test O
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:13:
         bb1():
           EntryPoint interpreter
@@ -7906,7 +7920,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
-          v23:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
+          v23:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C] recompile
           v24:BasicObject = GetIvar v23, :@foo
           CheckInterrupts
           Return v24
@@ -8363,7 +8377,7 @@ mod hir_opt_tests {
             e = C.new(true)  # same class, different shape
             100.times { d.write(e) }  # shape guard exits, but no recompile
         ");
-        assert_snapshot!(hir_string_proc("D.new.method(:write)"), @"
+        assert_snapshot!(hir_string_proc("D.new.method(:write)"), @r"
         fn write@<compiled>:12:
         bb1():
           EntryPoint interpreter
@@ -8379,7 +8393,7 @@ mod hir_opt_tests {
         bb3(v9:HeapBasicObject, v10:BasicObject):
           v17:Fixnum[5] = Const Value(5)
           PatchPoint MethodRedefined(C@0x1008, foo=@0x1010, cme:0x1018)
-          v28:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
+          v28:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C] recompile
           v31:CShape = LoadField v28, :shape_id@0x1040
           v32:CShape[0x1041] = GuardBitEquals v31, CShape(0x1041)
           StoreField v28, :@foo@0x1042, v17
@@ -8706,7 +8720,7 @@ mod hir_opt_tests {
             O1.foo
             O2.foo
         "#);
-        assert_snapshot!(hir_string_proc("C.instance_method(:foo)"), @"
+        assert_snapshot!(hir_string_proc("C.instance_method(:foo)"), @r"
         fn foo@<compiled>:15:
         bb1():
           EntryPoint interpreter
@@ -8746,7 +8760,7 @@ mod hir_opt_tests {
         bb4(v13:BasicObject):
           v34:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Integer@0x1008, +@0x1010, cme:0x1018)
-          v45:Fixnum = GuardType v13, Fixnum
+          v45:Fixnum = GuardType v13, Fixnum recompile
           v46:Fixnum = FixnumAdd v45, v34
           CheckInterrupts
           Return v46
@@ -8785,7 +8799,7 @@ mod hir_opt_tests {
             O1.foo
             O2.foo
         "#);
-        assert_snapshot!(hir_string_proc("C.instance_method(:foo)"), @"
+        assert_snapshot!(hir_string_proc("C.instance_method(:foo)"), @r"
         fn foo@<compiled>:15:
         bb1():
           EntryPoint interpreter
@@ -8828,7 +8842,7 @@ mod hir_opt_tests {
         bb4(v13:BasicObject):
           v34:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Integer@0x1008, +@0x1010, cme:0x1018)
-          v50:Fixnum = GuardType v13, Fixnum
+          v50:Fixnum = GuardType v13, Fixnum recompile
           v51:Fixnum = FixnumAdd v50, v34
           CheckInterrupts
           Return v51
@@ -8859,7 +8873,7 @@ mod hir_opt_tests {
             O1.foo
             O2.foo
         "#);
-        assert_snapshot!(hir_string_proc("C.instance_method(:foo)"), @"
+        assert_snapshot!(hir_string_proc("C.instance_method(:foo)"), @r"
         fn foo@<compiled>:7:
         bb1():
           EntryPoint interpreter
@@ -8898,7 +8912,7 @@ mod hir_opt_tests {
         bb4(v13:BasicObject):
           v33:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Integer@0x1008, +@0x1010, cme:0x1018)
-          v44:Fixnum = GuardType v13, Fixnum
+          v44:Fixnum = GuardType v13, Fixnum recompile
           v45:Fixnum = FixnumAdd v44, v33
           CheckInterrupts
           Return v45
@@ -9045,7 +9059,7 @@ mod hir_opt_tests {
             def test(o) = o.foo
             test obj
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:12:
         bb1():
           EntryPoint interpreter
@@ -9061,7 +9075,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
-          v23:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
+          v23:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C] recompile
           v24:BasicObject = GetIvar v23, :@foo
           CheckInterrupts
           Return v24
@@ -9271,7 +9285,7 @@ mod hir_opt_tests {
             test; test
         "#);
         assert_eq!(VALUE::fixnum_from_usize(2), result);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:6:
         bb1():
           EntryPoint interpreter
@@ -9283,7 +9297,7 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
-          v18:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)]
+          v18:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           v19:BasicObject = SendDirect v18, 0x1038, :foo (0x1048)
           CheckInterrupts
           Return v19
@@ -9301,7 +9315,7 @@ mod hir_opt_tests {
             test
         ");
         assert_eq!(VALUE::fixnum_from_usize(42), result);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:5:
         bb1():
           EntryPoint interpreter
@@ -9313,7 +9327,7 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
-          v18:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)]
+          v18:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           v19:BasicObject = SendDirect v18, 0x1038, :foo (0x1048)
           CheckInterrupts
           Return v19
@@ -9331,7 +9345,7 @@ mod hir_opt_tests {
             test
         ");
         assert_eq!(VALUE::fixnum_from_usize(42), result);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:5:
         bb1():
           EntryPoint interpreter
@@ -9344,7 +9358,7 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
-          v19:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)]
+          v19:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           v20:BasicObject = SendDirect v19, 0x1038, :foo (0x1048)
           CheckInterrupts
           Return v20
@@ -9434,7 +9448,7 @@ mod hir_opt_tests {
             test C.new
             test C.new
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:6:
         bb1():
           EntryPoint interpreter
@@ -9450,7 +9464,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
-          v23:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
+          v23:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C] recompile
           v26:CShape = LoadField v23, :shape_id@0x1040
           v27:CShape[0x1041] = GuardBitEquals v26, CShape(0x1041) recompile
           v28:NilClass = Const Value(nil)
@@ -9470,7 +9484,7 @@ mod hir_opt_tests {
             test C.new
             test C.new
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:6:
         bb1():
           EntryPoint interpreter
@@ -9486,7 +9500,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
-          v23:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
+          v23:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C] recompile
           v26:CShape = LoadField v23, :shape_id@0x1040
           v27:CShape[0x1041] = GuardBitEquals v26, CShape(0x1041) recompile
           v28:NilClass = Const Value(nil)
@@ -9506,7 +9520,7 @@ mod hir_opt_tests {
             test C.new
             test C.new
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:6:
         bb1():
           EntryPoint interpreter
@@ -9522,7 +9536,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           v17:Fixnum[5] = Const Value(5)
           PatchPoint MethodRedefined(C@0x1008, foo=@0x1010, cme:0x1018)
-          v28:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
+          v28:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C] recompile
           v31:CShape = LoadField v28, :shape_id@0x1040
           v32:CShape[0x1041] = GuardBitEquals v31, CShape(0x1041)
           StoreField v28, :@foo@0x1042, v17
@@ -9545,7 +9559,7 @@ mod hir_opt_tests {
             test C.new
             test C.new
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:6:
         bb1():
           EntryPoint interpreter
@@ -9561,7 +9575,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           v17:Fixnum[5] = Const Value(5)
           PatchPoint MethodRedefined(C@0x1008, foo=@0x1010, cme:0x1018)
-          v28:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
+          v28:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C] recompile
           v31:CShape = LoadField v28, :shape_id@0x1040
           v32:CShape[0x1041] = GuardBitEquals v31, CShape(0x1041)
           StoreField v28, :@foo@0x1042, v17
@@ -9581,7 +9595,7 @@ mod hir_opt_tests {
             test C.new
             test C.new
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -9597,7 +9611,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
-          v23:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
+          v23:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C] recompile
           v24:BasicObject = LoadField v23, :foo@0x1040
           CheckInterrupts
           Return v24
@@ -9612,7 +9626,7 @@ mod hir_opt_tests {
             test C.new
             test C.new
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -9628,7 +9642,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
-          v23:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
+          v23:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C] recompile
           v24:CPtr = LoadField v23, :as_heap@0x1040
           v25:BasicObject = LoadField v24, :foo@0x1041
           CheckInterrupts
@@ -9647,7 +9661,7 @@ mod hir_opt_tests {
             test C.new
             test C.new
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -9663,7 +9677,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
-          v27:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
+          v27:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C] recompile
           v19:Fixnum[5] = Const Value(5)
           CheckInterrupts
           Return v19
@@ -9679,7 +9693,7 @@ mod hir_opt_tests {
             test C.new, value
             test C.new, value
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -9697,7 +9711,7 @@ mod hir_opt_tests {
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo=@0x1010, cme:0x1018)
-          v31:ObjectSubclass[class_exact:C] = GuardType v12, ObjectSubclass[class_exact:C]
+          v31:ObjectSubclass[class_exact:C] = GuardType v12, ObjectSubclass[class_exact:C] recompile
           v32:CUInt64 = LoadField v31, :RBASIC_FLAGS@0x1040
           v33:CUInt64 = GuardNoBitsSet v32, RUBY_FL_FREEZE=CUInt64(2048)
           StoreField v31, :foo=@0x1041, v13
@@ -9716,7 +9730,7 @@ mod hir_opt_tests {
             test C.new, value
             test C.new, value
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -9734,7 +9748,7 @@ mod hir_opt_tests {
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo=@0x1010, cme:0x1018)
-          v31:ObjectSubclass[class_exact:C] = GuardType v12, ObjectSubclass[class_exact:C]
+          v31:ObjectSubclass[class_exact:C] = GuardType v12, ObjectSubclass[class_exact:C] recompile
           v32:CUInt64 = LoadField v31, :RBASIC_FLAGS@0x1040
           v33:CUInt64 = GuardNoBitsSet v32, RUBY_FL_FREEZE=CUInt64(2048)
           v34:CPtr = LoadField v31, :as_heap@0x1041
@@ -9881,7 +9895,7 @@ mod hir_opt_tests {
             def test(o) = o.to_s
             test "foo"
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -9897,7 +9911,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, to_s@0x1010, cme:0x1018)
-          v24:StringExact = GuardType v10, StringExact
+          v24:StringExact = GuardType v10, StringExact recompile
           CheckInterrupts
           Return v24
         ");
@@ -9909,7 +9923,7 @@ mod hir_opt_tests {
             def test(x) = x.to_s
             test 5
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -9924,7 +9938,7 @@ mod hir_opt_tests {
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint MethodRedefined(Integer@0x1008, to_s@0x1010, cme:0x1018)
-          v23:Fixnum = GuardType v10, Fixnum
+          v23:Fixnum = GuardType v10, Fixnum recompile
           v24:StringExact = CCallVariadic v23, :Integer#to_s@0x1040
           CheckInterrupts
           Return v24
@@ -9937,7 +9951,7 @@ mod hir_opt_tests {
             def test(x) = x.to_s
             test (2**65)
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -9952,7 +9966,7 @@ mod hir_opt_tests {
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint MethodRedefined(Integer@0x1008, to_s@0x1010, cme:0x1018)
-          v23:Bignum = GuardType v10, Bignum
+          v23:Bignum = GuardType v10, Bignum recompile
           v24:StringExact = CCallVariadic v23, :Integer#to_s@0x1040
           CheckInterrupts
           Return v24
@@ -10032,7 +10046,7 @@ mod hir_opt_tests {
             end
             test([1, 2, 3], 0)
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -10050,7 +10064,7 @@ mod hir_opt_tests {
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint NoSingletonClass(Array@0x1008)
           PatchPoint MethodRedefined(Array@0x1008, []@0x1010, cme:0x1018)
-          v29:ArrayExact = GuardType v12, ArrayExact
+          v29:ArrayExact = GuardType v12, ArrayExact recompile
           v30:Fixnum = GuardType v13, Fixnum
           v31:CInt64 = UnboxFixnum v30
           v32:CInt64 = ArrayLength v29
@@ -10073,7 +10087,7 @@ mod hir_opt_tests {
             end
             test(C.new([1, 2, 3]), 0)
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -10091,7 +10105,7 @@ mod hir_opt_tests {
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, []@0x1010, cme:0x1018)
-          v29:ArraySubclass[class_exact:C] = GuardType v12, ArraySubclass[class_exact:C]
+          v29:ArraySubclass[class_exact:C] = GuardType v12, ArraySubclass[class_exact:C] recompile
           v30:Fixnum = GuardType v13, Fixnum
           v31:CInt64 = UnboxFixnum v30
           v32:CInt64 = ArrayLength v29
@@ -10145,7 +10159,7 @@ mod hir_opt_tests {
             end
             test({1 => 3}, 1)
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -10163,7 +10177,7 @@ mod hir_opt_tests {
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint NoSingletonClass(Hash@0x1008)
           PatchPoint MethodRedefined(Hash@0x1008, []@0x1010, cme:0x1018)
-          v29:HashExact = GuardType v12, HashExact
+          v29:HashExact = GuardType v12, HashExact recompile
           v30:BasicObject = HashAref v29, v13
           CheckInterrupts
           Return v30
@@ -10179,7 +10193,7 @@ mod hir_opt_tests {
             end
             test(C.new({0 => 3}), 0)
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -10197,7 +10211,7 @@ mod hir_opt_tests {
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, []@0x1010, cme:0x1018)
-          v29:HashSubclass[class_exact:C] = GuardType v12, HashSubclass[class_exact:C]
+          v29:HashSubclass[class_exact:C] = GuardType v12, HashSubclass[class_exact:C] recompile
           v30:BasicObject = CCallWithFrame v29, :Hash#[]@0x1040, v13
           CheckInterrupts
           Return v30
@@ -10275,7 +10289,7 @@ mod hir_opt_tests {
             end
             test({}, 0, 1)
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -10295,7 +10309,7 @@ mod hir_opt_tests {
         bb3(v13:BasicObject, v14:BasicObject, v15:BasicObject, v16:BasicObject):
           PatchPoint NoSingletonClass(Hash@0x1008)
           PatchPoint MethodRedefined(Hash@0x1008, []=@0x1010, cme:0x1018)
-          v37:HashExact = GuardType v14, HashExact
+          v37:HashExact = GuardType v14, HashExact recompile
           HashAset v37, v15, v16
           CheckInterrupts
           Return v16
@@ -10311,7 +10325,7 @@ mod hir_opt_tests {
             end
             test(C.new, 0, 1)
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -10331,7 +10345,7 @@ mod hir_opt_tests {
         bb3(v13:BasicObject, v14:BasicObject, v15:BasicObject, v16:BasicObject):
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, []=@0x1010, cme:0x1018)
-          v37:HashSubclass[class_exact:C] = GuardType v14, HashSubclass[class_exact:C]
+          v37:HashSubclass[class_exact:C] = GuardType v14, HashSubclass[class_exact:C] recompile
           v38:BasicObject = CCallWithFrame v37, :Hash#[]=@0x1040, v15, v16
           CheckInterrupts
           Return v16
@@ -10375,7 +10389,7 @@ mod hir_opt_tests {
             end
             test([])
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -10393,7 +10407,7 @@ mod hir_opt_tests {
           v19:Fixnum[10] = Const Value(10)
           PatchPoint NoSingletonClass(Array@0x1008)
           PatchPoint MethodRedefined(Array@0x1008, []=@0x1010, cme:0x1018)
-          v33:ArrayExact = GuardType v10, ArrayExact
+          v33:ArrayExact = GuardType v10, ArrayExact recompile
           v34:CUInt64 = LoadField v33, :RBASIC_FLAGS@0x1040
           v35:CUInt64 = GuardNoBitsSet v34, RUBY_FL_FREEZE=CUInt64(2048)
           v37:CUInt64 = GuardNoBitsSet v35, RUBY_ELTS_SHARED=CUInt64(4096)
@@ -10415,7 +10429,7 @@ mod hir_opt_tests {
             end
             test([], 0, 1)
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -10435,7 +10449,7 @@ mod hir_opt_tests {
         bb3(v13:BasicObject, v14:BasicObject, v15:BasicObject, v16:BasicObject):
           PatchPoint NoSingletonClass(Array@0x1008)
           PatchPoint MethodRedefined(Array@0x1008, []=@0x1010, cme:0x1018)
-          v37:ArrayExact = GuardType v14, ArrayExact
+          v37:ArrayExact = GuardType v14, ArrayExact recompile
           v38:Fixnum = GuardType v15, Fixnum
           v39:CUInt64 = LoadField v37, :RBASIC_FLAGS@0x1040
           v40:CUInt64 = GuardNoBitsSet v39, RUBY_FL_FREEZE=CUInt64(2048)
@@ -10463,7 +10477,7 @@ mod hir_opt_tests {
             a = MyArray.new
             test(a, 0, 1)
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -10483,7 +10497,7 @@ mod hir_opt_tests {
         bb3(v13:BasicObject, v14:BasicObject, v15:BasicObject, v16:BasicObject):
           PatchPoint NoSingletonClass(MyArray@0x1008)
           PatchPoint MethodRedefined(MyArray@0x1008, []=@0x1010, cme:0x1018)
-          v37:ArraySubclass[class_exact:MyArray] = GuardType v14, ArraySubclass[class_exact:MyArray]
+          v37:ArraySubclass[class_exact:MyArray] = GuardType v14, ArraySubclass[class_exact:MyArray] recompile
           v38:BasicObject = CCallVariadic v37, :Array#[]=@0x1040, v15, v16
           CheckInterrupts
           Return v16
@@ -10498,7 +10512,7 @@ mod hir_opt_tests {
             end
             test([])
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -10515,7 +10529,7 @@ mod hir_opt_tests {
           v15:Fixnum[1] = Const Value(1)
           PatchPoint NoSingletonClass(Array@0x1008)
           PatchPoint MethodRedefined(Array@0x1008, <<@0x1010, cme:0x1018)
-          v27:ArrayExact = GuardType v10, ArrayExact
+          v27:ArrayExact = GuardType v10, ArrayExact recompile
           v28:CUInt64 = LoadField v27, :RBASIC_FLAGS@0x1040
           v29:CUInt64 = GuardNoBitsSet v28, RUBY_FL_FREEZE=CUInt64(2048)
           ArrayPush v27, v15
@@ -10532,7 +10546,7 @@ mod hir_opt_tests {
             end
             test([])
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -10549,7 +10563,7 @@ mod hir_opt_tests {
           v15:Fixnum[1] = Const Value(1)
           PatchPoint NoSingletonClass(Array@0x1008)
           PatchPoint MethodRedefined(Array@0x1008, push@0x1010, cme:0x1018)
-          v26:ArrayExact = GuardType v10, ArrayExact
+          v26:ArrayExact = GuardType v10, ArrayExact recompile
           v27:CUInt64 = LoadField v26, :RBASIC_FLAGS@0x1040
           v28:CUInt64 = GuardNoBitsSet v27, RUBY_FL_FREEZE=CUInt64(2048)
           ArrayPush v26, v15
@@ -10566,7 +10580,7 @@ mod hir_opt_tests {
             end
             test([])
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -10585,7 +10599,7 @@ mod hir_opt_tests {
           v19:Fixnum[3] = Const Value(3)
           PatchPoint NoSingletonClass(Array@0x1008)
           PatchPoint MethodRedefined(Array@0x1008, push@0x1010, cme:0x1018)
-          v30:ArrayExact = GuardType v10, ArrayExact
+          v30:ArrayExact = GuardType v10, ArrayExact recompile
           v31:BasicObject = CCallVariadic v30, :Array#push@0x1040, v15, v17, v19
           CheckInterrupts
           Return v31
@@ -10751,7 +10765,7 @@ mod hir_opt_tests {
             test([])
         ");
         assert_contains_opcode("test", YARVINSN_opt_length);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -10767,7 +10781,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint NoSingletonClass(Array@0x1008)
           PatchPoint MethodRedefined(Array@0x1008, length@0x1010, cme:0x1018)
-          v25:ArrayExact = GuardType v10, ArrayExact
+          v25:ArrayExact = GuardType v10, ArrayExact recompile
           v26:CInt64 = ArrayLength v25
           v27:Fixnum = BoxFixnum v26
           CheckInterrupts
@@ -10782,7 +10796,7 @@ mod hir_opt_tests {
             test([])
         ");
         assert_contains_opcode("test", YARVINSN_opt_size);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -10798,7 +10812,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint NoSingletonClass(Array@0x1008)
           PatchPoint MethodRedefined(Array@0x1008, size@0x1010, cme:0x1018)
-          v25:ArrayExact = GuardType v10, ArrayExact
+          v25:ArrayExact = GuardType v10, ArrayExact recompile
           v26:CInt64 = ArrayLength v25
           v27:Fixnum = BoxFixnum v26
           CheckInterrupts
@@ -10813,7 +10827,7 @@ mod hir_opt_tests {
             test("foo")
         "#);
         assert_contains_opcode("test", YARVINSN_opt_regexpmatch2);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -10830,7 +10844,7 @@ mod hir_opt_tests {
           v15:RegexpExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           PatchPoint NoSingletonClass(String@0x1010)
           PatchPoint MethodRedefined(String@0x1010, =~@0x1018, cme:0x1020)
-          v27:StringExact = GuardType v10, StringExact
+          v27:StringExact = GuardType v10, StringExact recompile
           v28:BasicObject = CCallWithFrame v27, :String#=~@0x1048, v15
           CheckInterrupts
           Return v28
@@ -10843,7 +10857,7 @@ mod hir_opt_tests {
             def test(s, i) = s.getbyte(i)
             test("foo", 0)
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -10861,7 +10875,7 @@ mod hir_opt_tests {
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, getbyte@0x1010, cme:0x1018)
-          v28:StringExact = GuardType v12, StringExact
+          v28:StringExact = GuardType v12, StringExact recompile
           v29:Fixnum = GuardType v13, Fixnum
           v30:CInt64 = UnboxFixnum v29
           v31:CInt64 = LoadField v28, :len@0x1040
@@ -10884,7 +10898,7 @@ mod hir_opt_tests {
             end
             test("foo", 0)
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -10902,7 +10916,7 @@ mod hir_opt_tests {
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, getbyte@0x1010, cme:0x1018)
-          v32:StringExact = GuardType v12, StringExact
+          v32:StringExact = GuardType v12, StringExact recompile
           v33:Fixnum = GuardType v13, Fixnum
           v34:CInt64 = UnboxFixnum v33
           v35:CInt64 = LoadField v32, :len@0x1040
@@ -10924,7 +10938,7 @@ mod hir_opt_tests {
             end
             test("foo", 0, 127)
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -10944,7 +10958,7 @@ mod hir_opt_tests {
         bb3(v13:BasicObject, v14:BasicObject, v15:BasicObject, v16:BasicObject):
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, setbyte@0x1010, cme:0x1018)
-          v32:StringExact = GuardType v14, StringExact
+          v32:StringExact = GuardType v14, StringExact recompile
           v33:Fixnum = GuardType v15, Fixnum
           v34:Fixnum = GuardType v16, Fixnum
           v35:CInt64 = UnboxFixnum v33
@@ -10971,7 +10985,7 @@ mod hir_opt_tests {
             end
             test(MyString.new('foo'), 0, 127)
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:5:
         bb1():
           EntryPoint interpreter
@@ -10991,7 +11005,7 @@ mod hir_opt_tests {
         bb3(v13:BasicObject, v14:BasicObject, v15:BasicObject, v16:BasicObject):
           PatchPoint NoSingletonClass(MyString@0x1008)
           PatchPoint MethodRedefined(MyString@0x1008, setbyte@0x1010, cme:0x1018)
-          v32:StringSubclass[class_exact:MyString] = GuardType v14, StringSubclass[class_exact:MyString]
+          v32:StringSubclass[class_exact:MyString] = GuardType v14, StringSubclass[class_exact:MyString] recompile
           v33:Fixnum = GuardType v15, Fixnum
           v34:Fixnum = GuardType v16, Fixnum
           v35:CInt64 = UnboxFixnum v33
@@ -11016,7 +11030,7 @@ mod hir_opt_tests {
             end
             test("foo", 0, 3.14)
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -11036,7 +11050,7 @@ mod hir_opt_tests {
         bb3(v13:BasicObject, v14:BasicObject, v15:BasicObject, v16:BasicObject):
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, setbyte@0x1010, cme:0x1018)
-          v32:StringExact = GuardType v14, StringExact
+          v32:StringExact = GuardType v14, StringExact recompile
           v33:BasicObject = CCallWithFrame v32, :String#setbyte@0x1040, v15, v16
           CheckInterrupts
           Return v33
@@ -11051,7 +11065,7 @@ mod hir_opt_tests {
             end
             test("asdf")
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -11067,7 +11081,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, empty?@0x1010, cme:0x1018)
-          v25:StringExact = GuardType v10, StringExact
+          v25:StringExact = GuardType v10, StringExact recompile
           v26:CInt64 = LoadField v25, :len@0x1040
           v27:CInt64[0] = Const CInt64(0)
           v28:CBool = IsBitEqual v26, v27
@@ -11086,7 +11100,7 @@ mod hir_opt_tests {
             end
             test("this should get removed")
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -11102,7 +11116,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, empty?@0x1010, cme:0x1018)
-          v29:StringExact = GuardType v10, StringExact
+          v29:StringExact = GuardType v10, StringExact recompile
           v20:Fixnum[4] = Const Value(4)
           CheckInterrupts
           Return v20
@@ -11116,7 +11130,7 @@ mod hir_opt_tests {
             test(4)
         ");
         assert_contains_opcode("test", YARVINSN_opt_succ);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -11131,7 +11145,7 @@ mod hir_opt_tests {
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint MethodRedefined(Integer@0x1008, succ@0x1010, cme:0x1018)
-          v24:Fixnum = GuardType v10, Fixnum
+          v24:Fixnum = GuardType v10, Fixnum recompile
           v25:Fixnum[1] = Const Value(1)
           v26:Fixnum = FixnumAdd v24, v25
           CheckInterrupts
@@ -11146,7 +11160,7 @@ mod hir_opt_tests {
             test(4 << 70)
         ");
         assert_contains_opcode("test", YARVINSN_opt_succ);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -11161,7 +11175,7 @@ mod hir_opt_tests {
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint MethodRedefined(Integer@0x1008, succ@0x1010, cme:0x1018)
-          v24:Bignum = GuardType v10, Bignum
+          v24:Bignum = GuardType v10, Bignum recompile
           v25:BasicObject = CCallWithFrame v24, :Integer#succ@0x1040
           CheckInterrupts
           Return v25
@@ -11175,7 +11189,7 @@ mod hir_opt_tests {
             test(4)
         ");
         assert_contains_opcode("test", YARVINSN_opt_ltlt);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -11191,7 +11205,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           v15:Fixnum[5] = Const Value(5)
           PatchPoint MethodRedefined(Integer@0x1008, <<@0x1010, cme:0x1018)
-          v26:Fixnum = GuardType v10, Fixnum
+          v26:Fixnum = GuardType v10, Fixnum recompile
           v27:Fixnum = FixnumLShift v26, v15
           CheckInterrupts
           Return v27
@@ -11205,7 +11219,7 @@ mod hir_opt_tests {
             test(4)
         ");
         assert_contains_opcode("test", YARVINSN_opt_ltlt);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -11221,7 +11235,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           v15:Fixnum[-5] = Const Value(-5)
           PatchPoint MethodRedefined(Integer@0x1008, <<@0x1010, cme:0x1018)
-          v26:Fixnum = GuardType v10, Fixnum
+          v26:Fixnum = GuardType v10, Fixnum recompile
           v27:BasicObject = CCallWithFrame v26, :Integer#<<@0x1040, v15
           CheckInterrupts
           Return v27
@@ -11235,7 +11249,7 @@ mod hir_opt_tests {
             test(4)
         ");
         assert_contains_opcode("test", YARVINSN_opt_ltlt);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -11251,7 +11265,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           v15:Fixnum[64] = Const Value(64)
           PatchPoint MethodRedefined(Integer@0x1008, <<@0x1010, cme:0x1018)
-          v26:Fixnum = GuardType v10, Fixnum
+          v26:Fixnum = GuardType v10, Fixnum recompile
           v27:BasicObject = CCallWithFrame v26, :Integer#<<@0x1040, v15
           CheckInterrupts
           Return v27
@@ -11265,7 +11279,7 @@ mod hir_opt_tests {
             test(4, 5)
         ");
         assert_contains_opcode("test", YARVINSN_opt_ltlt);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -11282,7 +11296,7 @@ mod hir_opt_tests {
           Jump bb3(v7, v8, v9)
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint MethodRedefined(Integer@0x1008, <<@0x1010, cme:0x1018)
-          v28:Fixnum = GuardType v12, Fixnum
+          v28:Fixnum = GuardType v12, Fixnum recompile
           v29:BasicObject = CCallWithFrame v28, :Integer#<<@0x1040, v13
           CheckInterrupts
           Return v29
@@ -11295,7 +11309,7 @@ mod hir_opt_tests {
             def test(x) = x >> 5
             test(4)
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -11311,7 +11325,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           v15:Fixnum[5] = Const Value(5)
           PatchPoint MethodRedefined(Integer@0x1008, >>@0x1010, cme:0x1018)
-          v25:Fixnum = GuardType v10, Fixnum
+          v25:Fixnum = GuardType v10, Fixnum recompile
           v26:Fixnum = FixnumRShift v25, v15
           CheckInterrupts
           Return v26
@@ -11324,7 +11338,7 @@ mod hir_opt_tests {
             def test(x) = x >> -5
             test(4)
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -11340,7 +11354,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           v15:Fixnum[-5] = Const Value(-5)
           PatchPoint MethodRedefined(Integer@0x1008, >>@0x1010, cme:0x1018)
-          v25:Fixnum = GuardType v10, Fixnum
+          v25:Fixnum = GuardType v10, Fixnum recompile
           v26:BasicObject = CCallWithFrame v25, :Integer#>>@0x1040, v15
           CheckInterrupts
           Return v26
@@ -11353,7 +11367,7 @@ mod hir_opt_tests {
             def test(x) = x >> 64
             test(4)
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -11369,7 +11383,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           v15:Fixnum[64] = Const Value(64)
           PatchPoint MethodRedefined(Integer@0x1008, >>@0x1010, cme:0x1018)
-          v25:Fixnum = GuardType v10, Fixnum
+          v25:Fixnum = GuardType v10, Fixnum recompile
           v26:BasicObject = CCallWithFrame v25, :Integer#>>@0x1040, v15
           CheckInterrupts
           Return v26
@@ -11382,7 +11396,7 @@ mod hir_opt_tests {
             def test(x, y) = x >> y
             test(4, 5)
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -11399,7 +11413,7 @@ mod hir_opt_tests {
           Jump bb3(v7, v8, v9)
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint MethodRedefined(Integer@0x1008, >>@0x1010, cme:0x1018)
-          v27:Fixnum = GuardType v12, Fixnum
+          v27:Fixnum = GuardType v12, Fixnum recompile
           v28:BasicObject = CCallWithFrame v27, :Integer#>>@0x1040, v13
           CheckInterrupts
           Return v28
@@ -11412,7 +11426,7 @@ mod hir_opt_tests {
             def test(x, y) = x << y
             test("iron", "fish")
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -11430,7 +11444,7 @@ mod hir_opt_tests {
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, <<@0x1010, cme:0x1018)
-          v29:StringExact = GuardType v12, StringExact
+          v29:StringExact = GuardType v12, StringExact recompile
           v30:String = GuardType v13, String
           v31:StringExact = StringAppend v29, v30
           CheckInterrupts
@@ -11444,7 +11458,7 @@ mod hir_opt_tests {
             def test(x, y) = x << y
             test("iron", 4)
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -11462,7 +11476,7 @@ mod hir_opt_tests {
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, <<@0x1010, cme:0x1018)
-          v29:StringExact = GuardType v12, StringExact
+          v29:StringExact = GuardType v12, StringExact recompile
           v30:Fixnum = GuardType v13, Fixnum
           v31:StringExact = StringAppendCodepoint v29, v30
           CheckInterrupts
@@ -11478,7 +11492,7 @@ mod hir_opt_tests {
             def test(x, y) = x << y
             test("iron", MyString.new)
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -11496,7 +11510,7 @@ mod hir_opt_tests {
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, <<@0x1010, cme:0x1018)
-          v29:StringExact = GuardType v12, StringExact
+          v29:StringExact = GuardType v12, StringExact recompile
           v30:String = GuardType v13, String
           v31:StringExact = StringAppend v29, v30
           CheckInterrupts
@@ -11512,7 +11526,7 @@ mod hir_opt_tests {
             def test(x, y) = x << y
             test(MyString.new, "iron")
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -11530,7 +11544,7 @@ mod hir_opt_tests {
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint NoSingletonClass(MyString@0x1008)
           PatchPoint MethodRedefined(MyString@0x1008, <<@0x1010, cme:0x1018)
-          v29:StringSubclass[class_exact:MyString] = GuardType v12, StringSubclass[class_exact:MyString]
+          v29:StringSubclass[class_exact:MyString] = GuardType v12, StringSubclass[class_exact:MyString] recompile
           v30:BasicObject = CCallWithFrame v29, :String#<<@0x1040, v13
           CheckInterrupts
           Return v30
@@ -11597,7 +11611,7 @@ mod hir_opt_tests {
             def test(x) = x.ascii_only?
             test("iron")
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -11613,7 +11627,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, ascii_only?@0x1010, cme:0x1018)
-          v24:StringExact = GuardType v10, StringExact
+          v24:StringExact = GuardType v10, StringExact recompile
           v25:BoolExact = CCall v24, :String#ascii_only?@0x1040
           CheckInterrupts
           Return v25
@@ -11674,7 +11688,7 @@ mod hir_opt_tests {
             def test(x, y) = x ^ y
             test(1, 2)
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -11691,7 +11705,7 @@ mod hir_opt_tests {
           Jump bb3(v7, v8, v9)
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint MethodRedefined(Integer@0x1008, ^@0x1010, cme:0x1018)
-          v27:Fixnum = GuardType v12, Fixnum
+          v27:Fixnum = GuardType v12, Fixnum recompile
           v28:Fixnum = GuardType v13, Fixnum
           v29:Fixnum = FixnumXor v27, v28
           CheckInterrupts
@@ -11708,7 +11722,7 @@ mod hir_opt_tests {
             end
             test(1, 2)
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -11725,7 +11739,7 @@ mod hir_opt_tests {
           Jump bb3(v7, v8, v9)
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint MethodRedefined(Integer@0x1008, ^@0x1010, cme:0x1018)
-          v31:Fixnum = GuardType v12, Fixnum
+          v31:Fixnum = GuardType v12, Fixnum recompile
           v32:Fixnum = GuardType v13, Fixnum
           v23:Fixnum[42] = Const Value(42)
           CheckInterrupts
@@ -11739,7 +11753,7 @@ mod hir_opt_tests {
             def test(x, y) = x ^ y
             test(4 << 70, 1)
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -11756,7 +11770,7 @@ mod hir_opt_tests {
           Jump bb3(v7, v8, v9)
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint MethodRedefined(Integer@0x1008, ^@0x1010, cme:0x1018)
-          v27:Bignum = GuardType v12, Bignum
+          v27:Bignum = GuardType v12, Bignum recompile
           v28:BasicObject = CCallWithFrame v27, :Integer#^@0x1040, v13
           CheckInterrupts
           Return v28
@@ -11769,7 +11783,7 @@ mod hir_opt_tests {
             def test(x, y) = x ^ y
             test(1, 4 << 70)
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -11786,7 +11800,7 @@ mod hir_opt_tests {
           Jump bb3(v7, v8, v9)
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint MethodRedefined(Integer@0x1008, ^@0x1010, cme:0x1018)
-          v27:Fixnum = GuardType v12, Fixnum
+          v27:Fixnum = GuardType v12, Fixnum recompile
           v28:BasicObject = CCallWithFrame v27, :Integer#^@0x1040, v13
           CheckInterrupts
           Return v28
@@ -11799,7 +11813,7 @@ mod hir_opt_tests {
             def test(x, y) = x ^ y
             test(true, 0)
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -11816,7 +11830,7 @@ mod hir_opt_tests {
           Jump bb3(v7, v8, v9)
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint MethodRedefined(TrueClass@0x1008, ^@0x1010, cme:0x1018)
-          v27:TrueClass = GuardType v12, TrueClass
+          v27:TrueClass = GuardType v12, TrueClass recompile
           v28:BasicObject = CCallWithFrame v27, :TrueClass#^@0x1040, v13
           CheckInterrupts
           Return v28
@@ -11854,7 +11868,7 @@ mod hir_opt_tests {
             def test(hash) = hash.size
             test({foo: 3, bar: 1, baz: 4})
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -11870,7 +11884,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint NoSingletonClass(Hash@0x1008)
           PatchPoint MethodRedefined(Hash@0x1008, size@0x1010, cme:0x1018)
-          v25:HashExact = GuardType v10, HashExact
+          v25:HashExact = GuardType v10, HashExact recompile
           v26:Fixnum = CCall v25, :Hash#size@0x1040
           CheckInterrupts
           Return v26
@@ -11886,7 +11900,7 @@ mod hir_opt_tests {
             end
             test({foo: 3, bar: 1, baz: 4})
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -11902,7 +11916,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint NoSingletonClass(Hash@0x1008)
           PatchPoint MethodRedefined(Hash@0x1008, size@0x1010, cme:0x1018)
-          v29:HashExact = GuardType v10, HashExact
+          v29:HashExact = GuardType v10, HashExact recompile
           v20:Fixnum[5] = Const Value(5)
           CheckInterrupts
           Return v20
@@ -11918,7 +11932,7 @@ mod hir_opt_tests {
             def test(o) = o.respond_to?(:foo)
             test(C.new)
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:5:
         bb1():
           EntryPoint interpreter
@@ -11935,7 +11949,7 @@ mod hir_opt_tests {
           v15:StaticSymbol[:foo] = Const Value(VALUE(0x1008))
           PatchPoint NoSingletonClass(C@0x1010)
           PatchPoint MethodRedefined(C@0x1010, respond_to?@0x1018, cme:0x1020)
-          v26:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
+          v26:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C] recompile
           PatchPoint MethodRedefined(C@0x1010, foo@0x1048, cme:0x1050)
           v30:TrueClass = Const Value(true)
           CheckInterrupts
@@ -11951,7 +11965,7 @@ mod hir_opt_tests {
             def test(o) = o.respond_to?(:foo)
             test(C.new)
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -11968,7 +11982,7 @@ mod hir_opt_tests {
           v15:StaticSymbol[:foo] = Const Value(VALUE(0x1008))
           PatchPoint NoSingletonClass(C@0x1010)
           PatchPoint MethodRedefined(C@0x1010, respond_to?@0x1018, cme:0x1020)
-          v26:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
+          v26:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C] recompile
           PatchPoint MethodRedefined(C@0x1010, respond_to_missing?@0x1048, cme:0x1050)
           PatchPoint MethodRedefined(C@0x1010, foo@0x1078, cme:0x1080)
           v32:FalseClass = Const Value(false)
@@ -11987,7 +12001,7 @@ mod hir_opt_tests {
             def test(o) = o.respond_to?(:foo)
             test(C.new)
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:6:
         bb1():
           EntryPoint interpreter
@@ -12004,7 +12018,7 @@ mod hir_opt_tests {
           v15:StaticSymbol[:foo] = Const Value(VALUE(0x1008))
           PatchPoint NoSingletonClass(C@0x1010)
           PatchPoint MethodRedefined(C@0x1010, respond_to?@0x1018, cme:0x1020)
-          v26:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
+          v26:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C] recompile
           PatchPoint MethodRedefined(C@0x1010, foo@0x1048, cme:0x1050)
           v30:FalseClass = Const Value(false)
           CheckInterrupts
@@ -12022,7 +12036,7 @@ mod hir_opt_tests {
             def test(o) = o.respond_to?(:foo, false)
             test(C.new)
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:6:
         bb1():
           EntryPoint interpreter
@@ -12040,7 +12054,7 @@ mod hir_opt_tests {
           v17:FalseClass = Const Value(false)
           PatchPoint NoSingletonClass(C@0x1010)
           PatchPoint MethodRedefined(C@0x1010, respond_to?@0x1018, cme:0x1020)
-          v28:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
+          v28:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C] recompile
           PatchPoint MethodRedefined(C@0x1010, foo@0x1048, cme:0x1050)
           v32:FalseClass = Const Value(false)
           CheckInterrupts
@@ -12058,7 +12072,7 @@ mod hir_opt_tests {
             def test(o) = o.respond_to?(:foo, nil)
             test(C.new)
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:6:
         bb1():
           EntryPoint interpreter
@@ -12076,7 +12090,7 @@ mod hir_opt_tests {
           v17:NilClass = Const Value(nil)
           PatchPoint NoSingletonClass(C@0x1010)
           PatchPoint MethodRedefined(C@0x1010, respond_to?@0x1018, cme:0x1020)
-          v28:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
+          v28:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C] recompile
           PatchPoint MethodRedefined(C@0x1010, foo@0x1048, cme:0x1050)
           v32:FalseClass = Const Value(false)
           CheckInterrupts
@@ -12094,7 +12108,7 @@ mod hir_opt_tests {
             def test(o) = o.respond_to?(:foo, true)
             test(C.new)
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:6:
         bb1():
           EntryPoint interpreter
@@ -12112,7 +12126,7 @@ mod hir_opt_tests {
           v17:TrueClass = Const Value(true)
           PatchPoint NoSingletonClass(C@0x1010)
           PatchPoint MethodRedefined(C@0x1010, respond_to?@0x1018, cme:0x1020)
-          v28:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
+          v28:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C] recompile
           PatchPoint MethodRedefined(C@0x1010, foo@0x1048, cme:0x1050)
           v32:TrueClass = Const Value(true)
           CheckInterrupts
@@ -12129,7 +12143,7 @@ mod hir_opt_tests {
             def test(o) = o.respond_to?(:foo, 4)
             test(C.new)
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:5:
         bb1():
           EntryPoint interpreter
@@ -12147,7 +12161,7 @@ mod hir_opt_tests {
           v17:Fixnum[4] = Const Value(4)
           PatchPoint NoSingletonClass(C@0x1010)
           PatchPoint MethodRedefined(C@0x1010, respond_to?@0x1018, cme:0x1020)
-          v28:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
+          v28:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C] recompile
           PatchPoint MethodRedefined(C@0x1010, foo@0x1048, cme:0x1050)
           v32:TrueClass = Const Value(true)
           CheckInterrupts
@@ -12164,7 +12178,7 @@ mod hir_opt_tests {
             def test(o) = o.respond_to?(:foo, nil)
             test(C.new)
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:5:
         bb1():
           EntryPoint interpreter
@@ -12182,7 +12196,7 @@ mod hir_opt_tests {
           v17:NilClass = Const Value(nil)
           PatchPoint NoSingletonClass(C@0x1010)
           PatchPoint MethodRedefined(C@0x1010, respond_to?@0x1018, cme:0x1020)
-          v28:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
+          v28:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C] recompile
           PatchPoint MethodRedefined(C@0x1010, foo@0x1048, cme:0x1050)
           v32:TrueClass = Const Value(true)
           CheckInterrupts
@@ -12198,7 +12212,7 @@ mod hir_opt_tests {
             def test(o) = o.respond_to?(:foo)
             test(C.new)
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -12215,7 +12229,7 @@ mod hir_opt_tests {
           v15:StaticSymbol[:foo] = Const Value(VALUE(0x1008))
           PatchPoint NoSingletonClass(C@0x1010)
           PatchPoint MethodRedefined(C@0x1010, respond_to?@0x1018, cme:0x1020)
-          v26:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
+          v26:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C] recompile
           PatchPoint MethodRedefined(C@0x1010, respond_to_missing?@0x1048, cme:0x1050)
           PatchPoint MethodRedefined(C@0x1010, foo@0x1078, cme:0x1080)
           v32:FalseClass = Const Value(false)
@@ -12235,7 +12249,7 @@ mod hir_opt_tests {
             def test(o) = o.respond_to?(:foo)
             test(C.new)
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:7:
         bb1():
           EntryPoint interpreter
@@ -12252,7 +12266,7 @@ mod hir_opt_tests {
           v15:StaticSymbol[:foo] = Const Value(VALUE(0x1008))
           PatchPoint NoSingletonClass(C@0x1010)
           PatchPoint MethodRedefined(C@0x1010, respond_to?@0x1018, cme:0x1020)
-          v26:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
+          v26:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C] recompile
           v27:BasicObject = CCallVariadic v26, :Kernel#respond_to?@0x1048, v15
           CheckInterrupts
           Return v27
@@ -12266,7 +12280,7 @@ mod hir_opt_tests {
             def test = callee
             test
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -12278,7 +12292,7 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           PatchPoint MethodRedefined(Object@0x1000, callee@0x1008, cme:0x1010)
-          v18:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)]
+          v18:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           CheckInterrupts
           Return v18
         ");
@@ -12292,7 +12306,7 @@ mod hir_opt_tests {
             def test = callee
             test
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -12304,7 +12318,7 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           PatchPoint MethodRedefined(Object@0x1000, callee@0x1008, cme:0x1010)
-          v18:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)]
+          v18:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           v20:StringExact[VALUE(0x1038)] = Const Value(VALUE(0x1038))
           CheckInterrupts
           Return v20
@@ -12318,7 +12332,7 @@ mod hir_opt_tests {
             def test = callee
             test
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -12330,7 +12344,7 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           PatchPoint MethodRedefined(Object@0x1000, callee@0x1008, cme:0x1010)
-          v18:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)]
+          v18:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           v20:NilClass = Const Value(nil)
           CheckInterrupts
           Return v20
@@ -12344,7 +12358,7 @@ mod hir_opt_tests {
             def test = callee
             test
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -12356,7 +12370,7 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           PatchPoint MethodRedefined(Object@0x1000, callee@0x1008, cme:0x1010)
-          v18:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)]
+          v18:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           v20:TrueClass = Const Value(true)
           CheckInterrupts
           Return v20
@@ -12370,7 +12384,7 @@ mod hir_opt_tests {
             def test = callee
             test
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -12382,7 +12396,7 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           PatchPoint MethodRedefined(Object@0x1000, callee@0x1008, cme:0x1010)
-          v18:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)]
+          v18:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           v20:FalseClass = Const Value(false)
           CheckInterrupts
           Return v20
@@ -12396,7 +12410,7 @@ mod hir_opt_tests {
             def test = callee
             test
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -12408,7 +12422,7 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           PatchPoint MethodRedefined(Object@0x1000, callee@0x1008, cme:0x1010)
-          v18:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)]
+          v18:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           v20:Fixnum[0] = Const Value(0)
           CheckInterrupts
           Return v20
@@ -12422,7 +12436,7 @@ mod hir_opt_tests {
             def test = callee
             test
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -12434,7 +12448,7 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           PatchPoint MethodRedefined(Object@0x1000, callee@0x1008, cme:0x1010)
-          v18:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)]
+          v18:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           v20:Fixnum[1] = Const Value(1)
           CheckInterrupts
           Return v20
@@ -12448,7 +12462,7 @@ mod hir_opt_tests {
             def test = callee 3
             test
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -12461,7 +12475,7 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           v11:Fixnum[3] = Const Value(3)
           PatchPoint MethodRedefined(Object@0x1000, callee@0x1008, cme:0x1010)
-          v20:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)]
+          v20:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           CheckInterrupts
           Return v11
         ");
@@ -12474,7 +12488,7 @@ mod hir_opt_tests {
             def test = callee 1, 2, 3
             test
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -12489,7 +12503,7 @@ mod hir_opt_tests {
           v13:Fixnum[2] = Const Value(2)
           v15:Fixnum[3] = Const Value(3)
           PatchPoint MethodRedefined(Object@0x1000, callee@0x1008, cme:0x1010)
-          v24:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)]
+          v24:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           CheckInterrupts
           Return v15
         ");
@@ -12544,7 +12558,7 @@ mod hir_opt_tests {
             def test(o) = o.to_sym
             test :foo
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -12559,7 +12573,7 @@ mod hir_opt_tests {
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint MethodRedefined(Symbol@0x1008, to_sym@0x1010, cme:0x1018)
-          v22:StaticSymbol = GuardType v10, StaticSymbol
+          v22:StaticSymbol = GuardType v10, StaticSymbol recompile
           CheckInterrupts
           Return v22
         ");
@@ -12571,7 +12585,7 @@ mod hir_opt_tests {
             def test(o) = o.to_i
             test 5
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -12586,7 +12600,7 @@ mod hir_opt_tests {
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint MethodRedefined(Integer@0x1008, to_i@0x1010, cme:0x1018)
-          v22:Fixnum = GuardType v10, Fixnum
+          v22:Fixnum = GuardType v10, Fixnum recompile
           CheckInterrupts
           Return v22
         ");
@@ -12758,7 +12772,7 @@ mod hir_opt_tests {
             def test(l, r) = l == r
             test("a", "b")
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -12776,7 +12790,7 @@ mod hir_opt_tests {
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, ==@0x1010, cme:0x1018)
-          v29:StringExact = GuardType v12, StringExact
+          v29:StringExact = GuardType v12, StringExact recompile
           v30:String = GuardType v13, String
           v31:BoolExact = StringEqual v29, v30
           CheckInterrupts
@@ -12792,7 +12806,7 @@ mod hir_opt_tests {
             def test(l, r) = l == r
             test(C.new("a"), C.new("b"))
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -12810,7 +12824,7 @@ mod hir_opt_tests {
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, ==@0x1010, cme:0x1018)
-          v29:StringSubclass[class_exact:C] = GuardType v12, StringSubclass[class_exact:C]
+          v29:StringSubclass[class_exact:C] = GuardType v12, StringSubclass[class_exact:C] recompile
           v30:String = GuardType v13, String
           v31:BoolExact = StringEqual v29, v30
           CheckInterrupts
@@ -12826,7 +12840,7 @@ mod hir_opt_tests {
             def test(l, r) = l == r
             test("a", C.new("b"))
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -12844,7 +12858,7 @@ mod hir_opt_tests {
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, ==@0x1010, cme:0x1018)
-          v29:StringExact = GuardType v12, StringExact
+          v29:StringExact = GuardType v12, StringExact recompile
           v30:String = GuardType v13, String
           v31:BoolExact = StringEqual v29, v30
           CheckInterrupts
@@ -12858,7 +12872,7 @@ mod hir_opt_tests {
             def test(l, r) = l === r
             test("a", "b")
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -12876,7 +12890,7 @@ mod hir_opt_tests {
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, ===@0x1010, cme:0x1018)
-          v28:StringExact = GuardType v12, StringExact
+          v28:StringExact = GuardType v12, StringExact recompile
           v29:String = GuardType v13, String
           v30:BoolExact = StringEqual v28, v29
           CheckInterrupts
@@ -12892,7 +12906,7 @@ mod hir_opt_tests {
             def test(l, r) = l === r
             test(C.new("a"), C.new("b"))
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -12910,7 +12924,7 @@ mod hir_opt_tests {
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, ===@0x1010, cme:0x1018)
-          v28:StringSubclass[class_exact:C] = GuardType v12, StringSubclass[class_exact:C]
+          v28:StringSubclass[class_exact:C] = GuardType v12, StringSubclass[class_exact:C] recompile
           v29:String = GuardType v13, String
           v30:BoolExact = StringEqual v28, v29
           CheckInterrupts
@@ -12926,7 +12940,7 @@ mod hir_opt_tests {
             def test(l, r) = l === r
             test("a", C.new("b"))
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -12944,7 +12958,7 @@ mod hir_opt_tests {
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, ===@0x1010, cme:0x1018)
-          v28:StringExact = GuardType v12, StringExact
+          v28:StringExact = GuardType v12, StringExact recompile
           v29:String = GuardType v13, String
           v30:BoolExact = StringEqual v28, v29
           CheckInterrupts
@@ -12958,7 +12972,7 @@ mod hir_opt_tests {
             def test(s) = s == s
             test("x")
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -12974,7 +12988,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, ==@0x1010, cme:0x1018)
-          v26:StringExact = GuardType v10, StringExact
+          v26:StringExact = GuardType v10, StringExact recompile
           v29:TrueClass = Const Value(true)
           CheckInterrupts
           Return v29
@@ -12987,7 +13001,7 @@ mod hir_opt_tests {
             def test(s) = s === s
             test("x")
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -13003,7 +13017,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, ===@0x1010, cme:0x1018)
-          v25:StringExact = GuardType v10, StringExact
+          v25:StringExact = GuardType v10, StringExact recompile
           v28:TrueClass = Const Value(true)
           CheckInterrupts
           Return v28
@@ -13259,7 +13273,7 @@ mod hir_opt_tests {
             test("x", "x")
             test("x", "x")
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -13277,7 +13291,7 @@ mod hir_opt_tests {
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, ==@0x1010, cme:0x1018)
-          v29:StringExact = GuardType v12, StringExact
+          v29:StringExact = GuardType v12, StringExact recompile
           v30:String = GuardType v13, String
           v31:BoolExact = StringEqual v29, v30
           CheckInterrupts
@@ -13327,7 +13341,7 @@ mod hir_opt_tests {
             test("x")
             test("x")
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -13344,7 +13358,7 @@ mod hir_opt_tests {
           v15:NilClass = Const Value(nil)
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, !=@0x1010, cme:0x1018)
-          v27:StringExact = GuardType v10, StringExact
+          v27:StringExact = GuardType v10, StringExact recompile
           v28:BoolExact = CCallWithFrame v27, :BasicObject#!=@0x1040, v15
           CheckInterrupts
           Return v28
@@ -13359,7 +13373,7 @@ mod hir_opt_tests {
             test("x", "x")
         "#);
         assert_contains_opcode("test", YARVINSN_opt_neq);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -13377,7 +13391,7 @@ mod hir_opt_tests {
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, !=@0x1010, cme:0x1018)
-          v29:StringExact = GuardType v12, StringExact
+          v29:StringExact = GuardType v12, StringExact recompile
           PatchPoint MethodRedefined(String@0x1008, ==@0x1040, cme:0x1048)
           v33:String = GuardType v13, String
           v34:BoolExact = StringEqual v29, v33
@@ -13397,7 +13411,7 @@ mod hir_opt_tests {
             test("x")
         "#);
         assert_contains_opcode("test", YARVINSN_opt_neq);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -13413,7 +13427,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, !=@0x1010, cme:0x1018)
-          v26:StringExact = GuardType v10, StringExact
+          v26:StringExact = GuardType v10, StringExact recompile
           PatchPoint MethodRedefined(String@0x1008, ==@0x1040, cme:0x1048)
           v35:TrueClass = Const Value(true)
           v32:TrueClass = Const Value(true)
@@ -13432,7 +13446,7 @@ mod hir_opt_tests {
             end
             test("asdf")
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -13448,7 +13462,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, size@0x1010, cme:0x1018)
-          v25:StringExact = GuardType v10, StringExact
+          v25:StringExact = GuardType v10, StringExact recompile
           v26:Fixnum = CCall v25, :String#size@0x1040
           CheckInterrupts
           Return v26
@@ -13464,7 +13478,7 @@ mod hir_opt_tests {
             end
             test("asdf")
         "#);
-       assert_snapshot!(hir_string("test"), @"
+       assert_snapshot!(hir_string("test"), @r"
        fn test@<compiled>:3:
        bb1():
          EntryPoint interpreter
@@ -13480,7 +13494,7 @@ mod hir_opt_tests {
        bb3(v9:BasicObject, v10:BasicObject):
          PatchPoint NoSingletonClass(String@0x1008)
          PatchPoint MethodRedefined(String@0x1008, size@0x1010, cme:0x1018)
-         v29:StringExact = GuardType v10, StringExact
+         v29:StringExact = GuardType v10, StringExact recompile
          v20:Fixnum[5] = Const Value(5)
          CheckInterrupts
          Return v20
@@ -13495,7 +13509,7 @@ mod hir_opt_tests {
             end
             test("asdf")
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -13511,7 +13525,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, bytesize@0x1010, cme:0x1018)
-          v24:StringExact = GuardType v10, StringExact
+          v24:StringExact = GuardType v10, StringExact recompile
           v25:CInt64 = LoadField v24, :len@0x1040
           v26:Fixnum = BoxFixnum v25
           CheckInterrupts
@@ -13528,7 +13542,7 @@ mod hir_opt_tests {
             end
             test("asdf")
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -13544,7 +13558,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, bytesize@0x1010, cme:0x1018)
-          v28:StringExact = GuardType v10, StringExact
+          v28:StringExact = GuardType v10, StringExact recompile
           v19:Fixnum[5] = Const Value(5)
           CheckInterrupts
           Return v19
@@ -13559,7 +13573,7 @@ mod hir_opt_tests {
             end
             test("asdf")
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -13575,7 +13589,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, length@0x1010, cme:0x1018)
-          v25:StringExact = GuardType v10, StringExact
+          v25:StringExact = GuardType v10, StringExact recompile
           v26:Fixnum = CCall v25, :String#length@0x1040
           CheckInterrupts
           Return v26
@@ -13650,7 +13664,7 @@ mod hir_opt_tests {
             def test(o) = o.is_a?(String)
             test("asdf")
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -13669,7 +13683,7 @@ mod hir_opt_tests {
           v25:ClassSubclass[String@0x1010] = Const Value(VALUE(0x1010))
           PatchPoint NoSingletonClass(String@0x1010)
           PatchPoint MethodRedefined(String@0x1010, is_a?@0x1011, cme:0x1018)
-          v29:StringExact = GuardType v10, StringExact
+          v29:StringExact = GuardType v10, StringExact recompile
           v30:BoolExact = IsA v29, v25
           CheckInterrupts
           Return v30
@@ -13682,7 +13696,7 @@ mod hir_opt_tests {
             def test(o) = o.is_a?(Kernel)
             test("asdf")
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -13701,7 +13715,7 @@ mod hir_opt_tests {
           v25:ModuleSubclass[Kernel@0x1010] = Const Value(VALUE(0x1010))
           PatchPoint NoSingletonClass(String@0x1018)
           PatchPoint MethodRedefined(String@0x1018, is_a?@0x1020, cme:0x1028)
-          v29:StringExact = GuardType v10, StringExact
+          v29:StringExact = GuardType v10, StringExact recompile
           v30:BasicObject = CCallWithFrame v29, :Kernel#is_a?@0x1050, v25
           CheckInterrupts
           Return v30
@@ -13717,7 +13731,7 @@ mod hir_opt_tests {
             end
             test("asdf")
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -13736,7 +13750,7 @@ mod hir_opt_tests {
           v29:ClassSubclass[Integer@0x1010] = Const Value(VALUE(0x1010))
           PatchPoint NoSingletonClass(String@0x1018)
           PatchPoint MethodRedefined(String@0x1018, is_a?@0x1020, cme:0x1028)
-          v33:StringExact = GuardType v10, StringExact
+          v33:StringExact = GuardType v10, StringExact recompile
           v21:Fixnum[5] = Const Value(5)
           CheckInterrupts
           Return v21
@@ -13783,7 +13797,7 @@ mod hir_opt_tests {
             def test(o) = o.kind_of?(String)
             test("asdf")
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -13802,7 +13816,7 @@ mod hir_opt_tests {
           v25:ClassSubclass[String@0x1010] = Const Value(VALUE(0x1010))
           PatchPoint NoSingletonClass(String@0x1010)
           PatchPoint MethodRedefined(String@0x1010, kind_of?@0x1011, cme:0x1018)
-          v29:StringExact = GuardType v10, StringExact
+          v29:StringExact = GuardType v10, StringExact recompile
           v30:BoolExact = IsA v29, v25
           CheckInterrupts
           Return v30
@@ -13815,7 +13829,7 @@ mod hir_opt_tests {
             def test(o) = o.kind_of?(Kernel)
             test("asdf")
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -13834,7 +13848,7 @@ mod hir_opt_tests {
           v25:ModuleSubclass[Kernel@0x1010] = Const Value(VALUE(0x1010))
           PatchPoint NoSingletonClass(String@0x1018)
           PatchPoint MethodRedefined(String@0x1018, kind_of?@0x1020, cme:0x1028)
-          v29:StringExact = GuardType v10, StringExact
+          v29:StringExact = GuardType v10, StringExact recompile
           v30:BasicObject = CCallWithFrame v29, :Kernel#kind_of?@0x1050, v25
           CheckInterrupts
           Return v30
@@ -13850,7 +13864,7 @@ mod hir_opt_tests {
             end
             test("asdf")
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -13869,7 +13883,7 @@ mod hir_opt_tests {
           v29:ClassSubclass[Integer@0x1010] = Const Value(VALUE(0x1010))
           PatchPoint NoSingletonClass(String@0x1018)
           PatchPoint MethodRedefined(String@0x1018, kind_of?@0x1020, cme:0x1028)
-          v33:StringExact = GuardType v10, StringExact
+          v33:StringExact = GuardType v10, StringExact recompile
           v21:Fixnum[5] = Const Value(5)
           CheckInterrupts
           Return v21
@@ -14084,7 +14098,7 @@ mod hir_opt_tests {
             end
             test("this should get removed")
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -14100,7 +14114,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, length@0x1010, cme:0x1018)
-          v29:StringExact = GuardType v10, StringExact
+          v29:StringExact = GuardType v10, StringExact recompile
           v20:Fixnum[4] = Const Value(4)
           CheckInterrupts
           Return v20
@@ -14127,7 +14141,7 @@ mod hir_opt_tests {
             C.new  # warm up
             TEST = C.instance_method(:initialize)
         "#);
-        assert_snapshot!(hir_string_proc("TEST"), @"
+        assert_snapshot!(hir_string_proc("TEST"), @r"
         fn initialize@<compiled>:9:
         bb1():
           EntryPoint interpreter
@@ -14140,7 +14154,7 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint NoSingletonClass(C@0x1000)
           PatchPoint MethodRedefined(C@0x1000, class@0x1008, cme:0x1010)
-          v43:ObjectSubclass[class_exact:C] = GuardType v6, ObjectSubclass[class_exact:C]
+          v43:ObjectSubclass[class_exact:C] = GuardType v6, ObjectSubclass[class_exact:C] recompile
           v46:ClassSubclass[C@0x1000] = Const Value(VALUE(0x1000))
           v13:StaticSymbol[:_lex_actions] = Const Value(VALUE(0x1038))
           v15:TrueClass = Const Value(true)
@@ -14160,7 +14174,7 @@ mod hir_opt_tests {
             def test(o) = o.class.name
             test(C.new)
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -14176,7 +14190,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, class@0x1010, cme:0x1018)
-          v25:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
+          v25:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C] recompile
           v28:ClassSubclass[C@0x1008] = Const Value(VALUE(0x1008))
           PatchPoint MethodRedefined(Class@0x1040, name@0x1048, cme:0x1050)
           v32:StringExact|NilClass = CCall v28, :Module#name@0x1078
@@ -14192,7 +14206,7 @@ mod hir_opt_tests {
             def test(o) = o.class
             test(C.new)
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -14208,7 +14222,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, class@0x1010, cme:0x1018)
-          v23:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
+          v23:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C] recompile
           v26:ClassSubclass[C@0x1008] = Const Value(VALUE(0x1008))
           CheckInterrupts
           Return v26
@@ -14246,7 +14260,7 @@ mod hir_opt_tests {
             def test = self.class
             test
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -14258,7 +14272,7 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           PatchPoint MethodRedefined(Object@0x1000, class@0x1008, cme:0x1010)
-          v18:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)]
+          v18:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           v21:ClassSubclass[Object@0x1038] = Const Value(VALUE(0x1038))
           CheckInterrupts
           Return v21
@@ -14683,7 +14697,7 @@ mod hir_opt_tests {
             test o
             test o
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:9:
         bb1():
           EntryPoint interpreter
@@ -14699,7 +14713,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint NoSingletonClass(TestDynamic@0x1008)
           PatchPoint MethodRedefined(TestDynamic@0x1008, val@0x1010, cme:0x1018)
-          v23:ObjectSubclass[class_exact:TestDynamic] = GuardType v10, ObjectSubclass[class_exact:TestDynamic]
+          v23:ObjectSubclass[class_exact:TestDynamic] = GuardType v10, ObjectSubclass[class_exact:TestDynamic] recompile
           v26:CShape = LoadField v23, :shape_id@0x1040
           v27:CShape[0x1041] = GuardBitEquals v26, CShape(0x1041) recompile
           v28:BasicObject = LoadField v23, :@val@0x1042
@@ -14793,7 +14807,7 @@ mod hir_opt_tests {
             end
             C.new.callprivate
         "#);
-        assert_snapshot!(hir_string_proc("C.instance_method(:callprivate)"), @"
+        assert_snapshot!(hir_string_proc("C.instance_method(:callprivate)"), @r"
         fn callprivate@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -14806,7 +14820,7 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint NoSingletonClass(C@0x1000)
           PatchPoint MethodRedefined(C@0x1000, secret@0x1008, cme:0x1010)
-          v19:ObjectSubclass[class_exact:C] = GuardType v6, ObjectSubclass[class_exact:C]
+          v19:ObjectSubclass[class_exact:C] = GuardType v6, ObjectSubclass[class_exact:C] recompile
           v21:Fixnum[42] = Const Value(42)
           CheckInterrupts
           Return v21
@@ -14851,7 +14865,7 @@ mod hir_opt_tests {
             end
             Obj = BasicObject.new.callprivate
         "#);
-        assert_snapshot!(hir_string_proc("BasicObject.instance_method(:callprivate)"), @"
+        assert_snapshot!(hir_string_proc("BasicObject.instance_method(:callprivate)"), @r"
         fn callprivate@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -14864,7 +14878,7 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint NoSingletonClass(BasicObject@0x1000)
           PatchPoint MethodRedefined(BasicObject@0x1000, initialize@0x1008, cme:0x1010)
-          v21:BasicObjectExact = GuardType v6, BasicObjectExact
+          v21:BasicObjectExact = GuardType v6, BasicObjectExact recompile
           v22:NilClass = Const Value(nil)
           CheckInterrupts
           Return v22
@@ -14935,7 +14949,7 @@ mod hir_opt_tests {
             end
             C.new.callprotected
         "#);
-        assert_snapshot!(hir_string_proc("C.instance_method(:callprotected)"), @"
+        assert_snapshot!(hir_string_proc("C.instance_method(:callprotected)"), @r"
         fn callprotected@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -14948,7 +14962,7 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint NoSingletonClass(C@0x1000)
           PatchPoint MethodRedefined(C@0x1000, secret@0x1008, cme:0x1010)
-          v19:ObjectSubclass[class_exact:C] = GuardType v6, ObjectSubclass[class_exact:C]
+          v19:ObjectSubclass[class_exact:C] = GuardType v6, ObjectSubclass[class_exact:C] recompile
           v21:Fixnum[42] = Const Value(42)
           CheckInterrupts
           Return v21
@@ -15012,7 +15026,7 @@ mod hir_opt_tests {
         // fall back to SendWithoutBlock instead of the optimized CCall path.
         let hir = hir_string("test");
         assert!(! hir.contains("NoSingletonClass(String"), "{hir}");
-        assert_snapshot!(hir, @"
+        assert_snapshot!(hir, @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -15031,7 +15045,7 @@ mod hir_opt_tests {
           v19:BasicObject = Send v12, :length # SendFallbackReason: Singleton class previously created for receiver class
           PatchPoint NoSingletonClass(Proc@0x1008)
           PatchPoint MethodRedefined(Proc@0x1008, call@0x1010, cme:0x1018)
-          v40:ObjectSubclass[class_exact:Proc] = GuardType v13, ObjectSubclass[class_exact:Proc]
+          v40:ObjectSubclass[class_exact:Proc] = GuardType v13, ObjectSubclass[class_exact:Proc] recompile
           v41:BasicObject = InvokeProc v40
           PatchPoint NoEPEscape(test)
           v32:BasicObject = Send v12, :length # SendFallbackReason: Singleton class previously created for receiver class
@@ -15164,7 +15178,7 @@ mod hir_opt_tests {
         assert!(!hir.contains("InvokeSuper "), "InvokeSuper should optimize to SendDirect but got:\n{hir}");
         assert!(hir.contains("SendDirect"), "Should optimize to SendDirect for call without args or block:\n{hir}");
 
-        assert_snapshot!(hir, @"
+        assert_snapshot!(hir, @r"
         fn foo@<compiled>:10:
         bb1():
           EntryPoint interpreter
@@ -15187,7 +15201,7 @@ mod hir_opt_tests {
           v33:BasicObject = SendDirect v9, 0x1058, :foo (0x1068), v10
           v18:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Integer@0x1070, +@0x1078, cme:0x1080)
-          v36:Fixnum = GuardType v33, Fixnum
+          v36:Fixnum = GuardType v33, Fixnum recompile
           v37:Fixnum = FixnumAdd v36, v18
           CheckInterrupts
           Return v37
@@ -15430,7 +15444,7 @@ mod hir_opt_tests {
         assert!(hir.contains("InvokeSuper "), "Expected unoptimized InvokeSuper but got:\n{hir}");
         assert!(!hir.contains("SendDirect"), "Should not optimize to SendDirect for explicit blockarg:\n{hir}");
 
-        assert_snapshot!(hir, @"
+        assert_snapshot!(hir, @r"
         fn foo@<compiled>:10:
         bb1():
           EntryPoint interpreter
@@ -15448,7 +15462,7 @@ mod hir_opt_tests {
         bb3(v11:HeapBasicObject, v12:BasicObject, v13:NilClass):
           PatchPoint NoSingletonClass(B@0x1008)
           PatchPoint MethodRedefined(B@0x1008, proc@0x1010, cme:0x1018)
-          v39:ObjectSubclass[class_exact:B] = GuardType v11, ObjectSubclass[class_exact:B]
+          v39:ObjectSubclass[class_exact:B] = GuardType v11, ObjectSubclass[class_exact:B] recompile
           v40:BasicObject = CCallWithFrame v39, :Kernel#proc@0x1040, block=0x1048
           v19:CPtr = GetEP 0
           v20:BasicObject = LoadField v19, :blk@0x1050
@@ -15626,7 +15640,7 @@ mod hir_opt_tests {
 
         test C.new; test D.new; test C.new; test D.new
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:11:
         bb1():
           EntryPoint interpreter
@@ -15661,7 +15675,7 @@ mod hir_opt_tests {
         bb4(v35:BasicObject, v36:BasicObject, v37:BasicObject):
           v40:Fixnum[2] = Const Value(2)
           PatchPoint MethodRedefined(Integer@0x1070, +@0x1078, cme:0x1080)
-          v59:Fixnum = GuardType v37, Fixnum
+          v59:Fixnum = GuardType v37, Fixnum recompile
           v60:Fixnum = FixnumAdd v59, v40
           CheckInterrupts
           Return v60
@@ -16018,7 +16032,7 @@ mod hir_opt_tests {
                 test_ep_escape([1], lambda { }) { |x| }
             }
         ");
-        assert_snapshot!(hir_string("test_ep_escape"), @"
+        assert_snapshot!(hir_string("test_ep_escape"), @r"
         fn test_ep_escape@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -16078,7 +16092,7 @@ mod hir_opt_tests {
         bb11():
           v71:Falsy = RefineType v60, Falsy
           PatchPoint MethodRedefined(Object@0x1010, lambda@0x1018, cme:0x1020)
-          v118:ObjectSubclass[class_exact*:Object@VALUE(0x1010)] = GuardType v58, ObjectSubclass[class_exact*:Object@VALUE(0x1010)]
+          v118:ObjectSubclass[class_exact*:Object@VALUE(0x1010)] = GuardType v58, ObjectSubclass[class_exact*:Object@VALUE(0x1010)] recompile
           v119:BasicObject = CCallWithFrame v118, :Kernel#lambda@0x1048, block=0x1050
           v75:CPtr = GetEP 0
           v76:BasicObject = LoadField v75, :list@0x1001
@@ -16387,7 +16401,7 @@ mod hir_opt_tests {
           v19:Truthy = RefineType v10, Truthy
           v23:Fixnum[42] = Const Value(42)
           PatchPoint MethodRedefined(Object@0x1008, greet_recompile@0x1010, cme:0x1018)
-          v43:ObjectSubclass[class_exact*:Object@VALUE(0x1008)] = GuardType v9, ObjectSubclass[class_exact*:Object@VALUE(0x1008)]
+          v43:ObjectSubclass[class_exact*:Object@VALUE(0x1008)] = GuardType v9, ObjectSubclass[class_exact*:Object@VALUE(0x1008)] recompile
           v44:BasicObject = SendDirect v43, 0x1040, :greet_recompile (0x1050), v23
           CheckInterrupts
           Return v44
@@ -16525,7 +16539,7 @@ mod hir_opt_tests {
             end
             test 1; test 2
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -16541,7 +16555,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           v15:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Integer@0x1008, -@0x1010, cme:0x1018)
-          v35:Fixnum = GuardType v10, Fixnum
+          v35:Fixnum = GuardType v10, Fixnum recompile
           v36:Fixnum = FixnumSub v35, v15
           v21:Fixnum[2] = Const Value(2)
           v40:Fixnum = FixnumSub v35, v21
@@ -16716,7 +16730,7 @@ mod hir_opt_tests {
             def test(x) = x.nan?
             test(1.0)
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -16731,7 +16745,7 @@ mod hir_opt_tests {
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint MethodRedefined(Float@0x1008, nan?@0x1010, cme:0x1018)
-          v23:Flonum = GuardType v10, Flonum
+          v23:Flonum = GuardType v10, Flonum recompile
           v24:BoolExact = CCall v23, :Float#nan?@0x1040
           CheckInterrupts
           Return v24
@@ -16744,7 +16758,7 @@ mod hir_opt_tests {
             def test(x) = x.finite?
             test(1.0)
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -16759,7 +16773,7 @@ mod hir_opt_tests {
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint MethodRedefined(Float@0x1008, finite?@0x1010, cme:0x1018)
-          v23:Flonum = GuardType v10, Flonum
+          v23:Flonum = GuardType v10, Flonum recompile
           v24:BoolExact = CCall v23, :Float#finite?@0x1040
           CheckInterrupts
           Return v24
@@ -16772,7 +16786,7 @@ mod hir_opt_tests {
             def test(x) = x.infinite?
             test(1.0)
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -16787,7 +16801,7 @@ mod hir_opt_tests {
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint MethodRedefined(Float@0x1008, infinite?@0x1010, cme:0x1018)
-          v23:Flonum = GuardType v10, Flonum
+          v23:Flonum = GuardType v10, Flonum recompile
           v24:NilClass|Fixnum = CCall v23, :Float#infinite?@0x1040
           CheckInterrupts
           Return v24
@@ -16800,7 +16814,7 @@ mod hir_opt_tests {
             def test(x) = x.even?
             test(2)
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -16815,7 +16829,7 @@ mod hir_opt_tests {
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint MethodRedefined(Integer@0x1008, even?@0x1010, cme:0x1018)
-          v22:Fixnum = GuardType v10, Fixnum
+          v22:Fixnum = GuardType v10, Fixnum recompile
           v24:BoolExact = InvokeBuiltin leaf <inline_expr>, v22
           CheckInterrupts
           Return v24
@@ -16828,7 +16842,7 @@ mod hir_opt_tests {
             def test(x) = x.odd?
             test(3)
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -16843,7 +16857,7 @@ mod hir_opt_tests {
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint MethodRedefined(Integer@0x1008, odd?@0x1010, cme:0x1018)
-          v22:Fixnum = GuardType v10, Fixnum
+          v22:Fixnum = GuardType v10, Fixnum recompile
           v24:BoolExact = InvokeBuiltin leaf <inline_expr>, v22
           CheckInterrupts
           Return v24
@@ -16856,7 +16870,7 @@ mod hir_opt_tests {
             def test(x) = x.zero?
             test(1.0)
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -16871,7 +16885,7 @@ mod hir_opt_tests {
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint MethodRedefined(Float@0x1008, zero?@0x1010, cme:0x1018)
-          v22:Flonum = GuardType v10, Flonum
+          v22:Flonum = GuardType v10, Flonum recompile
           v24:BoolExact = InvokeBuiltin leaf <inline_expr>, v22
           CheckInterrupts
           Return v24
@@ -16884,7 +16898,7 @@ mod hir_opt_tests {
             def test(x) = x.positive?
             test(1.0)
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -16899,7 +16913,7 @@ mod hir_opt_tests {
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint MethodRedefined(Float@0x1008, positive?@0x1010, cme:0x1018)
-          v22:Flonum = GuardType v10, Flonum
+          v22:Flonum = GuardType v10, Flonum recompile
           v24:BoolExact = InvokeBuiltin leaf <inline_expr>, v22
           CheckInterrupts
           Return v24
@@ -16912,7 +16926,7 @@ mod hir_opt_tests {
             def test(x) = x.negative?
             test(-1.0)
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -16927,7 +16941,7 @@ mod hir_opt_tests {
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint MethodRedefined(Float@0x1008, negative?@0x1010, cme:0x1018)
-          v22:Flonum = GuardType v10, Flonum
+          v22:Flonum = GuardType v10, Flonum recompile
           v24:BoolExact = InvokeBuiltin leaf <inline_expr>, v22
           CheckInterrupts
           Return v24
@@ -16939,7 +16953,7 @@ mod hir_opt_tests {
             def test(a, b) = a + b
             test(1.0, 2.0)
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -16956,7 +16970,7 @@ mod hir_opt_tests {
           Jump bb3(v7, v8, v9)
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint MethodRedefined(Float@0x1008, +@0x1010, cme:0x1018)
-          v28:Flonum = GuardType v12, Flonum
+          v28:Flonum = GuardType v12, Flonum recompile
           v29:Flonum = GuardType v13, Flonum
           v30:Float = FloatAdd v28, v29
           CheckInterrupts
@@ -16970,7 +16984,7 @@ mod hir_opt_tests {
             def test(a, b) = a * b
             test(1.5, 2.5)
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -16987,7 +17001,7 @@ mod hir_opt_tests {
           Jump bb3(v7, v8, v9)
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint MethodRedefined(Float@0x1008, *@0x1010, cme:0x1018)
-          v28:Flonum = GuardType v12, Flonum
+          v28:Flonum = GuardType v12, Flonum recompile
           v29:Flonum = GuardType v13, Flonum
           v30:Float = FloatMul v28, v29
           CheckInterrupts
@@ -17001,7 +17015,7 @@ mod hir_opt_tests {
             def test(a, b) = a - b
             test(5.0, 3.0)
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -17018,7 +17032,7 @@ mod hir_opt_tests {
           Jump bb3(v7, v8, v9)
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint MethodRedefined(Float@0x1008, -@0x1010, cme:0x1018)
-          v28:Flonum = GuardType v12, Flonum
+          v28:Flonum = GuardType v12, Flonum recompile
           v29:Flonum = GuardType v13, Flonum
           v30:Float = FloatSub v28, v29
           CheckInterrupts
@@ -17032,7 +17046,7 @@ mod hir_opt_tests {
             def test(a, b) = a / b
             test(10.0, 3.0)
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -17049,7 +17063,7 @@ mod hir_opt_tests {
           Jump bb3(v7, v8, v9)
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint MethodRedefined(Float@0x1008, /@0x1010, cme:0x1018)
-          v28:Flonum = GuardType v12, Flonum
+          v28:Flonum = GuardType v12, Flonum recompile
           v29:Flonum = GuardType v13, Flonum
           v30:Float = FloatDiv v28, v29
           CheckInterrupts
@@ -17063,7 +17077,7 @@ mod hir_opt_tests {
             def test(a) = a.to_i
             test(3.7)
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -17078,7 +17092,7 @@ mod hir_opt_tests {
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint MethodRedefined(Float@0x1008, to_i@0x1010, cme:0x1018)
-          v23:Flonum = GuardType v10, Flonum
+          v23:Flonum = GuardType v10, Flonum recompile
           v24:Integer = FloatToInt v23
           CheckInterrupts
           Return v24
@@ -17091,7 +17105,7 @@ mod hir_opt_tests {
             def test(a, b) = a * b
             test(1.5, 3)
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -17108,7 +17122,7 @@ mod hir_opt_tests {
           Jump bb3(v7, v8, v9)
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint MethodRedefined(Float@0x1008, *@0x1010, cme:0x1018)
-          v28:Flonum = GuardType v12, Flonum
+          v28:Flonum = GuardType v12, Flonum recompile
           v29:Fixnum = GuardType v13, Fixnum
           v30:Float = FloatMul v28, v29
           CheckInterrupts
@@ -17136,7 +17150,7 @@ mod hir_opt_tests {
             end
             test(C.new(3))
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -17155,7 +17169,7 @@ mod hir_opt_tests {
           v17:Fixnum[0] = Const Value(0)
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, var@0x1010, cme:0x1018)
-          v138:ObjectSubclass[class_exact:C] = GuardType v12, ObjectSubclass[class_exact:C]
+          v138:ObjectSubclass[class_exact:C] = GuardType v12, ObjectSubclass[class_exact:C] recompile
           v139:BasicObject = LoadField v138, :var@0x1040
           PatchPoint MethodRedefined(Integer@0x1048, +@0x1050, cme:0x1058)
           v179:Fixnum = GuardType v139, Fixnum
@@ -17246,7 +17260,7 @@ mod hir_opt_tests {
             end
             test(:a, :b)
         "#);
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -17263,7 +17277,7 @@ mod hir_opt_tests {
           Jump bb3(v7, v8, v9)
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint MethodRedefined(Symbol@0x1008, ==@0x1010, cme:0x1018)
-          v48:StaticSymbol = GuardType v12, StaticSymbol
+          v48:StaticSymbol = GuardType v12, StaticSymbol recompile
           v49:CBool = IsBitEqual v48, v13
           v50:BoolExact = BoxBool v49
           CheckInterrupts

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -209,7 +209,7 @@ mod hir_opt_tests {
             end
             test 1; test 2
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -439,7 +439,7 @@ mod hir_opt_tests {
             end
             test 1; test 2
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -1115,7 +1115,7 @@ mod hir_opt_tests {
             def test(arr) = arr[0]
             test([1,2,3])
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -1148,7 +1148,7 @@ mod hir_opt_tests {
             def test(arr) = arr[0]
             test([1,2,3])
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -1232,7 +1232,7 @@ mod hir_opt_tests {
             custom.count
         ");
         assert_eq!(VALUE::fixnum_from_usize(2), result);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:13:
         bb1():
           EntryPoint interpreter
@@ -1264,7 +1264,7 @@ mod hir_opt_tests {
             end
             test(2); test(3)
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -1394,7 +1394,7 @@ mod hir_opt_tests {
             end
             test; test
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -1422,7 +1422,7 @@ mod hir_opt_tests {
             def test = baz
             test; test
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:5:
         bb1():
           EntryPoint interpreter
@@ -1449,7 +1449,7 @@ mod hir_opt_tests {
             def test = baz
             test; test
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -1485,7 +1485,7 @@ mod hir_opt_tests {
             def test = foo(1)
             test; test
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:8:
         bb1():
           EntryPoint interpreter
@@ -1514,7 +1514,7 @@ mod hir_opt_tests {
             def test(o) = o.fun_new_map {|e| e }
             test C.new; test C.new
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:5:
         bb1():
           EntryPoint interpreter
@@ -1551,7 +1551,7 @@ mod hir_opt_tests {
             def test(o) = o.bar { |x| x }
             test C.new; test C.new
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:7:
         bb1():
           EntryPoint interpreter
@@ -1588,7 +1588,7 @@ mod hir_opt_tests {
             def test(a) = a.length
             test([1,2,3]); test([1,2,3])
         ", "{ specialized_instruction: false }");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -1650,7 +1650,7 @@ mod hir_opt_tests {
             end
             test; test
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:5:
         bb1():
           EntryPoint interpreter
@@ -1677,7 +1677,7 @@ mod hir_opt_tests {
             end
             test; test
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -1706,7 +1706,7 @@ mod hir_opt_tests {
             end
             test; test
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -1738,7 +1738,7 @@ mod hir_opt_tests {
             end
             test; test
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:5:
         bb1():
           EntryPoint interpreter
@@ -1766,7 +1766,7 @@ mod hir_opt_tests {
             def test = foo
             test
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -1792,7 +1792,7 @@ mod hir_opt_tests {
             def test = foo 3
             test
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -1819,7 +1819,7 @@ mod hir_opt_tests {
             def test = foo 3, 4
             test
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -1848,7 +1848,7 @@ mod hir_opt_tests {
             test
             test
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -1887,7 +1887,7 @@ mod hir_opt_tests {
             end
             test; test
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -1919,7 +1919,7 @@ mod hir_opt_tests {
             def test(a, b) = a + b
             test(1,2); test(3,4)
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:7:
         bb1():
           EntryPoint interpreter
@@ -1949,7 +1949,7 @@ mod hir_opt_tests {
             def test(a, b) = a + b
             test(1,2); test(3,4)
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -1980,7 +1980,7 @@ mod hir_opt_tests {
             def test(a) = a + 1
             test(1); test(3)
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -2038,7 +2038,7 @@ mod hir_opt_tests {
             def test(a, b) = a[b]
             test(3, 4)
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -2149,7 +2149,7 @@ mod hir_opt_tests {
             def test(a, b) = a < b
             test(1,2); test(3,4)
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -2180,7 +2180,7 @@ mod hir_opt_tests {
             def test(a) = a < 1
             test(1); test(3)
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -2467,7 +2467,7 @@ mod hir_opt_tests {
             def test(arr) = arr[0]
             test(arr)
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -2502,7 +2502,7 @@ mod hir_opt_tests {
             def test(arr) = arr[0]
             test(arr)
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -2813,7 +2813,7 @@ mod hir_opt_tests {
             end
             test(1, 2); test(3, 4)
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -2847,7 +2847,7 @@ mod hir_opt_tests {
             end
             test(1, 2); test(3, 4)
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -2881,7 +2881,7 @@ mod hir_opt_tests {
             end
             test(1, 2); test(3, 4)
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -2915,7 +2915,7 @@ mod hir_opt_tests {
             end
             test(1, 2); test(3, 4)
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -2950,7 +2950,7 @@ mod hir_opt_tests {
             end
             test(1, 2); test(3, 4)
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -2985,7 +2985,7 @@ mod hir_opt_tests {
             end
             test(1, 2); test(3, 4)
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -3019,7 +3019,7 @@ mod hir_opt_tests {
             end
             test(1, 2); test(3, 4)
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -3053,7 +3053,7 @@ mod hir_opt_tests {
             end
             test(1, 2); test(3, 4)
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -3087,7 +3087,7 @@ mod hir_opt_tests {
             end
             test(1, 2); test(3, 4)
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -3121,7 +3121,7 @@ mod hir_opt_tests {
             end
             test(1, 2); test(3, 4)
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -3155,7 +3155,7 @@ mod hir_opt_tests {
             end
             test(1, 2); test(3, 4)
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -3244,7 +3244,7 @@ mod hir_opt_tests {
             test(0) # profile
             test(1)
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -3558,7 +3558,7 @@ mod hir_opt_tests {
             def test = block_given?
             test
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -3584,7 +3584,7 @@ mod hir_opt_tests {
             TEST = proc { block_given? }
             TEST.call
         ");
-        assert_snapshot!(hir_string_proc("TEST"), @r"
+        assert_snapshot!(hir_string_proc("TEST"), @"
         fn block in <compiled>@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -3612,7 +3612,7 @@ mod hir_opt_tests {
             end
             test
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -3735,7 +3735,7 @@ mod hir_opt_tests {
             test c
         ");
 
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:6:
         bb1():
           EntryPoint interpreter
@@ -3767,7 +3767,7 @@ mod hir_opt_tests {
             test
         ");
         assert_eq!(VALUE::fixnum_from_usize(3), result);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -3800,7 +3800,7 @@ mod hir_opt_tests {
             test
             test
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -3838,7 +3838,7 @@ mod hir_opt_tests {
             test
             test
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -3907,7 +3907,7 @@ mod hir_opt_tests {
             test
             test
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -3936,7 +3936,7 @@ mod hir_opt_tests {
             test
         ");
         assert_eq!(VALUE::fixnum_from_usize(110), result);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -3965,7 +3965,7 @@ mod hir_opt_tests {
             test
             test
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -3994,7 +3994,7 @@ mod hir_opt_tests {
             test
             test
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -4024,7 +4024,7 @@ mod hir_opt_tests {
             test
             test
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -4054,7 +4054,7 @@ mod hir_opt_tests {
             test
             test
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -4083,7 +4083,7 @@ mod hir_opt_tests {
             test
             test
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -4120,7 +4120,7 @@ mod hir_opt_tests {
             test
             test
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -4157,7 +4157,7 @@ mod hir_opt_tests {
             test
             test
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -4199,7 +4199,7 @@ mod hir_opt_tests {
             test
             test
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -4314,7 +4314,7 @@ mod hir_opt_tests {
             test
             test
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -4767,7 +4767,7 @@ mod hir_opt_tests {
             def test = Set.new
             test
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -5450,7 +5450,7 @@ mod hir_opt_tests {
             end
             test p
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -5483,7 +5483,7 @@ mod hir_opt_tests {
             end
             test p
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -5516,7 +5516,7 @@ mod hir_opt_tests {
             end
             test p
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -5549,7 +5549,7 @@ mod hir_opt_tests {
             end
             test p
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -7102,7 +7102,7 @@ mod hir_opt_tests {
             def test = one(zero)
             test
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:5:
         bb1():
           EntryPoint interpreter
@@ -7313,7 +7313,7 @@ mod hir_opt_tests {
 
             test(nil)
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -7342,7 +7342,7 @@ mod hir_opt_tests {
 
             test(false)
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -7371,7 +7371,7 @@ mod hir_opt_tests {
 
             test(true)
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -7400,7 +7400,7 @@ mod hir_opt_tests {
 
             test(:foo)
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -7429,7 +7429,7 @@ mod hir_opt_tests {
 
             test(1)
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -7458,7 +7458,7 @@ mod hir_opt_tests {
 
             test(1.0)
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -7487,7 +7487,7 @@ mod hir_opt_tests {
 
             test('foo')
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -7517,7 +7517,7 @@ mod hir_opt_tests {
 
             test([])
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -7547,7 +7547,7 @@ mod hir_opt_tests {
 
             test(false)
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -7576,7 +7576,7 @@ mod hir_opt_tests {
 
             test(nil)
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -7608,7 +7608,7 @@ mod hir_opt_tests {
             test(false)
             test(true)
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -7664,7 +7664,7 @@ mod hir_opt_tests {
 
             test([])
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -7697,7 +7697,7 @@ mod hir_opt_tests {
 
             test({})
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -7728,7 +7728,7 @@ mod hir_opt_tests {
 
             test(C.new, C.new)
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -7761,7 +7761,7 @@ mod hir_opt_tests {
 
             test(1, 2)
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -7793,7 +7793,7 @@ mod hir_opt_tests {
 
             test(1, 2)
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -7827,7 +7827,7 @@ mod hir_opt_tests {
             test; test
         ");
 
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -7861,7 +7861,7 @@ mod hir_opt_tests {
             test O
             test O
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:10:
         bb1():
           EntryPoint interpreter
@@ -7904,7 +7904,7 @@ mod hir_opt_tests {
             test O
             test O
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:13:
         bb1():
           EntryPoint interpreter
@@ -8377,7 +8377,7 @@ mod hir_opt_tests {
             e = C.new(true)  # same class, different shape
             100.times { d.write(e) }  # shape guard exits, but no recompile
         ");
-        assert_snapshot!(hir_string_proc("D.new.method(:write)"), @r"
+        assert_snapshot!(hir_string_proc("D.new.method(:write)"), @"
         fn write@<compiled>:12:
         bb1():
           EntryPoint interpreter
@@ -8720,7 +8720,7 @@ mod hir_opt_tests {
             O1.foo
             O2.foo
         "#);
-        assert_snapshot!(hir_string_proc("C.instance_method(:foo)"), @r"
+        assert_snapshot!(hir_string_proc("C.instance_method(:foo)"), @"
         fn foo@<compiled>:15:
         bb1():
           EntryPoint interpreter
@@ -8799,7 +8799,7 @@ mod hir_opt_tests {
             O1.foo
             O2.foo
         "#);
-        assert_snapshot!(hir_string_proc("C.instance_method(:foo)"), @r"
+        assert_snapshot!(hir_string_proc("C.instance_method(:foo)"), @"
         fn foo@<compiled>:15:
         bb1():
           EntryPoint interpreter
@@ -8873,7 +8873,7 @@ mod hir_opt_tests {
             O1.foo
             O2.foo
         "#);
-        assert_snapshot!(hir_string_proc("C.instance_method(:foo)"), @r"
+        assert_snapshot!(hir_string_proc("C.instance_method(:foo)"), @"
         fn foo@<compiled>:7:
         bb1():
           EntryPoint interpreter
@@ -9059,7 +9059,7 @@ mod hir_opt_tests {
             def test(o) = o.foo
             test obj
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:12:
         bb1():
           EntryPoint interpreter
@@ -9285,7 +9285,7 @@ mod hir_opt_tests {
             test; test
         "#);
         assert_eq!(VALUE::fixnum_from_usize(2), result);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:6:
         bb1():
           EntryPoint interpreter
@@ -9315,7 +9315,7 @@ mod hir_opt_tests {
             test
         ");
         assert_eq!(VALUE::fixnum_from_usize(42), result);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:5:
         bb1():
           EntryPoint interpreter
@@ -9345,7 +9345,7 @@ mod hir_opt_tests {
             test
         ");
         assert_eq!(VALUE::fixnum_from_usize(42), result);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:5:
         bb1():
           EntryPoint interpreter
@@ -9448,7 +9448,7 @@ mod hir_opt_tests {
             test C.new
             test C.new
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:6:
         bb1():
           EntryPoint interpreter
@@ -9484,7 +9484,7 @@ mod hir_opt_tests {
             test C.new
             test C.new
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:6:
         bb1():
           EntryPoint interpreter
@@ -9520,7 +9520,7 @@ mod hir_opt_tests {
             test C.new
             test C.new
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:6:
         bb1():
           EntryPoint interpreter
@@ -9559,7 +9559,7 @@ mod hir_opt_tests {
             test C.new
             test C.new
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:6:
         bb1():
           EntryPoint interpreter
@@ -9595,7 +9595,7 @@ mod hir_opt_tests {
             test C.new
             test C.new
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -9626,7 +9626,7 @@ mod hir_opt_tests {
             test C.new
             test C.new
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -9661,7 +9661,7 @@ mod hir_opt_tests {
             test C.new
             test C.new
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -9693,7 +9693,7 @@ mod hir_opt_tests {
             test C.new, value
             test C.new, value
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -9730,7 +9730,7 @@ mod hir_opt_tests {
             test C.new, value
             test C.new, value
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -9895,7 +9895,7 @@ mod hir_opt_tests {
             def test(o) = o.to_s
             test "foo"
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -9923,7 +9923,7 @@ mod hir_opt_tests {
             def test(x) = x.to_s
             test 5
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -9951,7 +9951,7 @@ mod hir_opt_tests {
             def test(x) = x.to_s
             test (2**65)
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -10046,7 +10046,7 @@ mod hir_opt_tests {
             end
             test([1, 2, 3], 0)
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -10087,7 +10087,7 @@ mod hir_opt_tests {
             end
             test(C.new([1, 2, 3]), 0)
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -10159,7 +10159,7 @@ mod hir_opt_tests {
             end
             test({1 => 3}, 1)
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -10193,7 +10193,7 @@ mod hir_opt_tests {
             end
             test(C.new({0 => 3}), 0)
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -10289,7 +10289,7 @@ mod hir_opt_tests {
             end
             test({}, 0, 1)
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -10325,7 +10325,7 @@ mod hir_opt_tests {
             end
             test(C.new, 0, 1)
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -10389,7 +10389,7 @@ mod hir_opt_tests {
             end
             test([])
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -10429,7 +10429,7 @@ mod hir_opt_tests {
             end
             test([], 0, 1)
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -10477,7 +10477,7 @@ mod hir_opt_tests {
             a = MyArray.new
             test(a, 0, 1)
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -10512,7 +10512,7 @@ mod hir_opt_tests {
             end
             test([])
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -10546,7 +10546,7 @@ mod hir_opt_tests {
             end
             test([])
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -10580,7 +10580,7 @@ mod hir_opt_tests {
             end
             test([])
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -10765,7 +10765,7 @@ mod hir_opt_tests {
             test([])
         ");
         assert_contains_opcode("test", YARVINSN_opt_length);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -10796,7 +10796,7 @@ mod hir_opt_tests {
             test([])
         ");
         assert_contains_opcode("test", YARVINSN_opt_size);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -10827,7 +10827,7 @@ mod hir_opt_tests {
             test("foo")
         "#);
         assert_contains_opcode("test", YARVINSN_opt_regexpmatch2);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -10857,7 +10857,7 @@ mod hir_opt_tests {
             def test(s, i) = s.getbyte(i)
             test("foo", 0)
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -10898,7 +10898,7 @@ mod hir_opt_tests {
             end
             test("foo", 0)
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -10938,7 +10938,7 @@ mod hir_opt_tests {
             end
             test("foo", 0, 127)
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -10985,7 +10985,7 @@ mod hir_opt_tests {
             end
             test(MyString.new('foo'), 0, 127)
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:5:
         bb1():
           EntryPoint interpreter
@@ -11030,7 +11030,7 @@ mod hir_opt_tests {
             end
             test("foo", 0, 3.14)
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -11065,7 +11065,7 @@ mod hir_opt_tests {
             end
             test("asdf")
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -11100,7 +11100,7 @@ mod hir_opt_tests {
             end
             test("this should get removed")
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -11130,7 +11130,7 @@ mod hir_opt_tests {
             test(4)
         ");
         assert_contains_opcode("test", YARVINSN_opt_succ);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -11160,7 +11160,7 @@ mod hir_opt_tests {
             test(4 << 70)
         ");
         assert_contains_opcode("test", YARVINSN_opt_succ);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -11189,7 +11189,7 @@ mod hir_opt_tests {
             test(4)
         ");
         assert_contains_opcode("test", YARVINSN_opt_ltlt);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -11219,7 +11219,7 @@ mod hir_opt_tests {
             test(4)
         ");
         assert_contains_opcode("test", YARVINSN_opt_ltlt);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -11249,7 +11249,7 @@ mod hir_opt_tests {
             test(4)
         ");
         assert_contains_opcode("test", YARVINSN_opt_ltlt);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -11279,7 +11279,7 @@ mod hir_opt_tests {
             test(4, 5)
         ");
         assert_contains_opcode("test", YARVINSN_opt_ltlt);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -11309,7 +11309,7 @@ mod hir_opt_tests {
             def test(x) = x >> 5
             test(4)
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -11338,7 +11338,7 @@ mod hir_opt_tests {
             def test(x) = x >> -5
             test(4)
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -11367,7 +11367,7 @@ mod hir_opt_tests {
             def test(x) = x >> 64
             test(4)
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -11396,7 +11396,7 @@ mod hir_opt_tests {
             def test(x, y) = x >> y
             test(4, 5)
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -11426,7 +11426,7 @@ mod hir_opt_tests {
             def test(x, y) = x << y
             test("iron", "fish")
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -11458,7 +11458,7 @@ mod hir_opt_tests {
             def test(x, y) = x << y
             test("iron", 4)
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -11492,7 +11492,7 @@ mod hir_opt_tests {
             def test(x, y) = x << y
             test("iron", MyString.new)
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -11526,7 +11526,7 @@ mod hir_opt_tests {
             def test(x, y) = x << y
             test(MyString.new, "iron")
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -11611,7 +11611,7 @@ mod hir_opt_tests {
             def test(x) = x.ascii_only?
             test("iron")
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -11688,7 +11688,7 @@ mod hir_opt_tests {
             def test(x, y) = x ^ y
             test(1, 2)
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -11722,7 +11722,7 @@ mod hir_opt_tests {
             end
             test(1, 2)
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -11753,7 +11753,7 @@ mod hir_opt_tests {
             def test(x, y) = x ^ y
             test(4 << 70, 1)
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -11783,7 +11783,7 @@ mod hir_opt_tests {
             def test(x, y) = x ^ y
             test(1, 4 << 70)
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -11813,7 +11813,7 @@ mod hir_opt_tests {
             def test(x, y) = x ^ y
             test(true, 0)
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -11868,7 +11868,7 @@ mod hir_opt_tests {
             def test(hash) = hash.size
             test({foo: 3, bar: 1, baz: 4})
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -11900,7 +11900,7 @@ mod hir_opt_tests {
             end
             test({foo: 3, bar: 1, baz: 4})
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -11932,7 +11932,7 @@ mod hir_opt_tests {
             def test(o) = o.respond_to?(:foo)
             test(C.new)
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:5:
         bb1():
           EntryPoint interpreter
@@ -11965,7 +11965,7 @@ mod hir_opt_tests {
             def test(o) = o.respond_to?(:foo)
             test(C.new)
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -12001,7 +12001,7 @@ mod hir_opt_tests {
             def test(o) = o.respond_to?(:foo)
             test(C.new)
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:6:
         bb1():
           EntryPoint interpreter
@@ -12036,7 +12036,7 @@ mod hir_opt_tests {
             def test(o) = o.respond_to?(:foo, false)
             test(C.new)
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:6:
         bb1():
           EntryPoint interpreter
@@ -12072,7 +12072,7 @@ mod hir_opt_tests {
             def test(o) = o.respond_to?(:foo, nil)
             test(C.new)
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:6:
         bb1():
           EntryPoint interpreter
@@ -12108,7 +12108,7 @@ mod hir_opt_tests {
             def test(o) = o.respond_to?(:foo, true)
             test(C.new)
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:6:
         bb1():
           EntryPoint interpreter
@@ -12143,7 +12143,7 @@ mod hir_opt_tests {
             def test(o) = o.respond_to?(:foo, 4)
             test(C.new)
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:5:
         bb1():
           EntryPoint interpreter
@@ -12178,7 +12178,7 @@ mod hir_opt_tests {
             def test(o) = o.respond_to?(:foo, nil)
             test(C.new)
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:5:
         bb1():
           EntryPoint interpreter
@@ -12212,7 +12212,7 @@ mod hir_opt_tests {
             def test(o) = o.respond_to?(:foo)
             test(C.new)
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -12249,7 +12249,7 @@ mod hir_opt_tests {
             def test(o) = o.respond_to?(:foo)
             test(C.new)
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:7:
         bb1():
           EntryPoint interpreter
@@ -12280,7 +12280,7 @@ mod hir_opt_tests {
             def test = callee
             test
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -12306,7 +12306,7 @@ mod hir_opt_tests {
             def test = callee
             test
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -12332,7 +12332,7 @@ mod hir_opt_tests {
             def test = callee
             test
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -12358,7 +12358,7 @@ mod hir_opt_tests {
             def test = callee
             test
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -12384,7 +12384,7 @@ mod hir_opt_tests {
             def test = callee
             test
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -12410,7 +12410,7 @@ mod hir_opt_tests {
             def test = callee
             test
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -12436,7 +12436,7 @@ mod hir_opt_tests {
             def test = callee
             test
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -12462,7 +12462,7 @@ mod hir_opt_tests {
             def test = callee 3
             test
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -12488,7 +12488,7 @@ mod hir_opt_tests {
             def test = callee 1, 2, 3
             test
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -12558,7 +12558,7 @@ mod hir_opt_tests {
             def test(o) = o.to_sym
             test :foo
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -12585,7 +12585,7 @@ mod hir_opt_tests {
             def test(o) = o.to_i
             test 5
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -12772,7 +12772,7 @@ mod hir_opt_tests {
             def test(l, r) = l == r
             test("a", "b")
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -12806,7 +12806,7 @@ mod hir_opt_tests {
             def test(l, r) = l == r
             test(C.new("a"), C.new("b"))
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -12840,7 +12840,7 @@ mod hir_opt_tests {
             def test(l, r) = l == r
             test("a", C.new("b"))
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -12872,7 +12872,7 @@ mod hir_opt_tests {
             def test(l, r) = l === r
             test("a", "b")
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -12906,7 +12906,7 @@ mod hir_opt_tests {
             def test(l, r) = l === r
             test(C.new("a"), C.new("b"))
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -12940,7 +12940,7 @@ mod hir_opt_tests {
             def test(l, r) = l === r
             test("a", C.new("b"))
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -12972,7 +12972,7 @@ mod hir_opt_tests {
             def test(s) = s == s
             test("x")
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -13001,7 +13001,7 @@ mod hir_opt_tests {
             def test(s) = s === s
             test("x")
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -13273,7 +13273,7 @@ mod hir_opt_tests {
             test("x", "x")
             test("x", "x")
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -13341,7 +13341,7 @@ mod hir_opt_tests {
             test("x")
             test("x")
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -13373,7 +13373,7 @@ mod hir_opt_tests {
             test("x", "x")
         "#);
         assert_contains_opcode("test", YARVINSN_opt_neq);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -13411,7 +13411,7 @@ mod hir_opt_tests {
             test("x")
         "#);
         assert_contains_opcode("test", YARVINSN_opt_neq);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -13446,7 +13446,7 @@ mod hir_opt_tests {
             end
             test("asdf")
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -13478,7 +13478,7 @@ mod hir_opt_tests {
             end
             test("asdf")
         "#);
-       assert_snapshot!(hir_string("test"), @r"
+       assert_snapshot!(hir_string("test"), @"
        fn test@<compiled>:3:
        bb1():
          EntryPoint interpreter
@@ -13509,7 +13509,7 @@ mod hir_opt_tests {
             end
             test("asdf")
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -13542,7 +13542,7 @@ mod hir_opt_tests {
             end
             test("asdf")
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -13573,7 +13573,7 @@ mod hir_opt_tests {
             end
             test("asdf")
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -13664,7 +13664,7 @@ mod hir_opt_tests {
             def test(o) = o.is_a?(String)
             test("asdf")
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -13696,7 +13696,7 @@ mod hir_opt_tests {
             def test(o) = o.is_a?(Kernel)
             test("asdf")
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -13731,7 +13731,7 @@ mod hir_opt_tests {
             end
             test("asdf")
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -13797,7 +13797,7 @@ mod hir_opt_tests {
             def test(o) = o.kind_of?(String)
             test("asdf")
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -13829,7 +13829,7 @@ mod hir_opt_tests {
             def test(o) = o.kind_of?(Kernel)
             test("asdf")
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -13864,7 +13864,7 @@ mod hir_opt_tests {
             end
             test("asdf")
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -14098,7 +14098,7 @@ mod hir_opt_tests {
             end
             test("this should get removed")
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -14141,7 +14141,7 @@ mod hir_opt_tests {
             C.new  # warm up
             TEST = C.instance_method(:initialize)
         "#);
-        assert_snapshot!(hir_string_proc("TEST"), @r"
+        assert_snapshot!(hir_string_proc("TEST"), @"
         fn initialize@<compiled>:9:
         bb1():
           EntryPoint interpreter
@@ -14174,7 +14174,7 @@ mod hir_opt_tests {
             def test(o) = o.class.name
             test(C.new)
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -14206,7 +14206,7 @@ mod hir_opt_tests {
             def test(o) = o.class
             test(C.new)
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -14260,7 +14260,7 @@ mod hir_opt_tests {
             def test = self.class
             test
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -14697,7 +14697,7 @@ mod hir_opt_tests {
             test o
             test o
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:9:
         bb1():
           EntryPoint interpreter
@@ -14807,7 +14807,7 @@ mod hir_opt_tests {
             end
             C.new.callprivate
         "#);
-        assert_snapshot!(hir_string_proc("C.instance_method(:callprivate)"), @r"
+        assert_snapshot!(hir_string_proc("C.instance_method(:callprivate)"), @"
         fn callprivate@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -14865,7 +14865,7 @@ mod hir_opt_tests {
             end
             Obj = BasicObject.new.callprivate
         "#);
-        assert_snapshot!(hir_string_proc("BasicObject.instance_method(:callprivate)"), @r"
+        assert_snapshot!(hir_string_proc("BasicObject.instance_method(:callprivate)"), @"
         fn callprivate@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -14949,7 +14949,7 @@ mod hir_opt_tests {
             end
             C.new.callprotected
         "#);
-        assert_snapshot!(hir_string_proc("C.instance_method(:callprotected)"), @r"
+        assert_snapshot!(hir_string_proc("C.instance_method(:callprotected)"), @"
         fn callprotected@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -15026,7 +15026,7 @@ mod hir_opt_tests {
         // fall back to SendWithoutBlock instead of the optimized CCall path.
         let hir = hir_string("test");
         assert!(! hir.contains("NoSingletonClass(String"), "{hir}");
-        assert_snapshot!(hir, @r"
+        assert_snapshot!(hir, @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -15178,7 +15178,7 @@ mod hir_opt_tests {
         assert!(!hir.contains("InvokeSuper "), "InvokeSuper should optimize to SendDirect but got:\n{hir}");
         assert!(hir.contains("SendDirect"), "Should optimize to SendDirect for call without args or block:\n{hir}");
 
-        assert_snapshot!(hir, @r"
+        assert_snapshot!(hir, @"
         fn foo@<compiled>:10:
         bb1():
           EntryPoint interpreter
@@ -15444,7 +15444,7 @@ mod hir_opt_tests {
         assert!(hir.contains("InvokeSuper "), "Expected unoptimized InvokeSuper but got:\n{hir}");
         assert!(!hir.contains("SendDirect"), "Should not optimize to SendDirect for explicit blockarg:\n{hir}");
 
-        assert_snapshot!(hir, @r"
+        assert_snapshot!(hir, @"
         fn foo@<compiled>:10:
         bb1():
           EntryPoint interpreter
@@ -15640,7 +15640,7 @@ mod hir_opt_tests {
 
         test C.new; test D.new; test C.new; test D.new
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:11:
         bb1():
           EntryPoint interpreter
@@ -16032,7 +16032,7 @@ mod hir_opt_tests {
                 test_ep_escape([1], lambda { }) { |x| }
             }
         ");
-        assert_snapshot!(hir_string("test_ep_escape"), @r"
+        assert_snapshot!(hir_string("test_ep_escape"), @"
         fn test_ep_escape@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -16379,7 +16379,7 @@ mod hir_opt_tests {
 
         // After profiling via the side exit, rebuilding HIR should now
         // have a SendDirect for greet_recompile instead of SideExit.
-        assert_snapshot!(hir_string("test_no_profile_recompile"), @r"
+        assert_snapshot!(hir_string("test_no_profile_recompile"), @"
         fn test_no_profile_recompile@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -16438,7 +16438,7 @@ mod hir_opt_tests {
         eval("3.times { test_final_version(false) }");
 
         // On the final version, greet_final should be a Send fallback, not a SideExit.
-        assert_snapshot!(hir_string("test_final_version"), @r"
+        assert_snapshot!(hir_string("test_final_version"), @"
         fn test_final_version@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -16539,7 +16539,7 @@ mod hir_opt_tests {
             end
             test 1; test 2
         ");
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter
@@ -16730,7 +16730,7 @@ mod hir_opt_tests {
             def test(x) = x.nan?
             test(1.0)
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -16758,7 +16758,7 @@ mod hir_opt_tests {
             def test(x) = x.finite?
             test(1.0)
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -16786,7 +16786,7 @@ mod hir_opt_tests {
             def test(x) = x.infinite?
             test(1.0)
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -16814,7 +16814,7 @@ mod hir_opt_tests {
             def test(x) = x.even?
             test(2)
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -16842,7 +16842,7 @@ mod hir_opt_tests {
             def test(x) = x.odd?
             test(3)
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -16870,7 +16870,7 @@ mod hir_opt_tests {
             def test(x) = x.zero?
             test(1.0)
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -16898,7 +16898,7 @@ mod hir_opt_tests {
             def test(x) = x.positive?
             test(1.0)
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -16926,7 +16926,7 @@ mod hir_opt_tests {
             def test(x) = x.negative?
             test(-1.0)
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -16953,7 +16953,7 @@ mod hir_opt_tests {
             def test(a, b) = a + b
             test(1.0, 2.0)
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -16984,7 +16984,7 @@ mod hir_opt_tests {
             def test(a, b) = a * b
             test(1.5, 2.5)
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -17015,7 +17015,7 @@ mod hir_opt_tests {
             def test(a, b) = a - b
             test(5.0, 3.0)
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -17046,7 +17046,7 @@ mod hir_opt_tests {
             def test(a, b) = a / b
             test(10.0, 3.0)
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -17077,7 +17077,7 @@ mod hir_opt_tests {
             def test(a) = a.to_i
             test(3.7)
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -17105,7 +17105,7 @@ mod hir_opt_tests {
             def test(a, b) = a * b
             test(1.5, 3)
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:2:
         bb1():
           EntryPoint interpreter
@@ -17150,7 +17150,7 @@ mod hir_opt_tests {
             end
             test(C.new(3))
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -17260,7 +17260,7 @@ mod hir_opt_tests {
             end
             test(:a, :b)
         "#);
-        assert_snapshot!(hir_string("test"), @r"
+        assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
           EntryPoint interpreter

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -16379,7 +16379,7 @@ mod hir_opt_tests {
 
         // After profiling via the side exit, rebuilding HIR should now
         // have a SendDirect for greet_recompile instead of SideExit.
-        assert_snapshot!(hir_string("test_no_profile_recompile"), @"
+        assert_snapshot!(hir_string("test_no_profile_recompile"), @r"
         fn test_no_profile_recompile@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -16438,7 +16438,7 @@ mod hir_opt_tests {
         eval("3.times { test_final_version(false) }");
 
         // On the final version, greet_final should be a Send fallback, not a SideExit.
-        assert_snapshot!(hir_string("test_final_version"), @"
+        assert_snapshot!(hir_string("test_final_version"), @r"
         fn test_final_version@<compiled>:4:
         bb1():
           EntryPoint interpreter

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -17292,4 +17292,44 @@ mod hir_opt_tests {
           Return v40
         ");
     }
+
+    #[test]
+    fn test_trigger_guard_type_recompilation() {
+        eval("
+            class C
+              def f(x)
+                @a = 1
+                y = x + 1
+                @a = y
+              end
+            end
+
+            # As of 06/04/2026, zjit/src/options.rs uses 5 as the default number of profiles
+            # Let's pick a number that is reasonably larger to ensure compilation, even if
+            # the default value changes a bit
+            num_to_compile = 30
+
+            c = C.new
+
+            # Repeatedly call an integer until this fast path gets JITed
+            num_to_compile.times { c.f(1) }
+
+        ");
+        assert_snapshot!(hir_string_proc("C.new.method(:f)"), @"
+        ");
+
+        let iseq = with_rubyvm(|| get_proc_iseq("C.new.method(:f)"));
+        assert_eq!(get_or_create_iseq_payload(iseq).versions.len(), 2,
+                  "expected a recompile to produce a second ISEQ version"
+        );
+
+        eval("
+            c = C.new
+            # Call this with a float in order to trigger a guard failure
+            # Do this enough times to cause a recompilation
+            num_to_compile.times { c.f(1.5) }
+        ");
+        assert_snapshot!(hir_string_proc("C.new.method(:f)"), @"
+        ");
+    }
 }

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -17315,7 +17315,21 @@ mod hir_opt_tests {
             num_to_compile.times { c.f(1) }
 
         ");
-        assert_snapshot!(hir_string_proc("C.new.method(:f)"), @"
+
+        let intermediate_hir = hir_string_proc("C.new.method(:f)");
+
+        eval("
+            # Supposed to be the same as the earlier Ruby method in this test
+            num_to_compile = 30
+            c = C.new
+            # Call this with a float in order to trigger a guard failure
+            # Do this enough times to cause a recompilation
+            num_to_compile.times { c.f(1.5) }
+        ");
+
+        let final_hir = hir_string_proc("C.new.method(:f)");
+
+        assert_snapshot!(format!("{intermediate_hir}\n{final_hir}"), @"
         fn f@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -17343,22 +17357,7 @@ mod hir_opt_tests {
           SetIvar v11, :@a, v47
           CheckInterrupts
           Return v47
-        ");
 
-        let iseq = with_rubyvm(|| get_proc_iseq("C.new.method(:f)"));
-        assert_eq!(get_or_create_iseq_payload(iseq).versions.len(), 2,
-                  "expected a recompile to produce a second ISEQ version"
-        );
-
-        eval("
-            # Supposed to be the same as the earlier Ruby method in this test
-            num_to_compile = 30
-            c = C.new
-            # Call this with a float in order to trigger a guard failure
-            # Do this enough times to cause a recompilation
-            num_to_compile.times { c.f(1.5) }
-        ");
-        assert_snapshot!(hir_string_proc("C.new.method(:f)"), @"
         fn f@<compiled>:4:
         bb1():
           EntryPoint interpreter

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -17316,6 +17316,33 @@ mod hir_opt_tests {
 
         ");
         assert_snapshot!(hir_string_proc("C.new.method(:f)"), @"
+        fn f@<compiled>:4:
+        bb1():
+          EntryPoint interpreter
+          v1:HeapBasicObject = LoadSelf
+          v2:CPtr = LoadSP
+          v3:BasicObject = LoadField v2, :x@0x1000
+          v4:NilClass = Const Value(nil)
+          Jump bb3(v1, v3, v4)
+        bb2():
+          EntryPoint JIT(0)
+          v7:HeapBasicObject = LoadArg :self@0
+          v8:BasicObject = LoadArg :x@1
+          v9:NilClass = Const Value(nil)
+          Jump bb3(v7, v8, v9)
+        bb3(v11:HeapBasicObject, v12:BasicObject, v13:NilClass):
+          v17:Fixnum[1] = Const Value(1)
+          PatchPoint SingleRactorMode
+          SetIvar v11, :@a, v17
+          PatchPoint NoEPEscape(f)
+          v27:Fixnum[1] = Const Value(1)
+          PatchPoint MethodRedefined(Integer@0x1008, +@0x1010, cme:0x1018)
+          v46:Fixnum = GuardType v12, Fixnum recompile
+          v47:Fixnum = FixnumAdd v46, v27
+          PatchPoint SingleRactorMode
+          SetIvar v11, :@a, v47
+          CheckInterrupts
+          Return v47
         ");
 
         let iseq = with_rubyvm(|| get_proc_iseq("C.new.method(:f)"));
@@ -17324,12 +17351,59 @@ mod hir_opt_tests {
         );
 
         eval("
+            # Supposed to be the same as the earlier Ruby method in this test
+            num_to_compile = 30
             c = C.new
             # Call this with a float in order to trigger a guard failure
             # Do this enough times to cause a recompilation
             num_to_compile.times { c.f(1.5) }
         ");
         assert_snapshot!(hir_string_proc("C.new.method(:f)"), @"
+        fn f@<compiled>:4:
+        bb1():
+          EntryPoint interpreter
+          v1:HeapBasicObject = LoadSelf
+          v2:CPtr = LoadSP
+          v3:BasicObject = LoadField v2, :x@0x1000
+          v4:NilClass = Const Value(nil)
+          Jump bb3(v1, v3, v4)
+        bb2():
+          EntryPoint JIT(0)
+          v7:HeapBasicObject = LoadArg :self@0
+          v8:BasicObject = LoadArg :x@1
+          v9:NilClass = Const Value(nil)
+          Jump bb3(v7, v8, v9)
+        bb3(v11:HeapBasicObject, v12:BasicObject, v13:NilClass):
+          v17:Fixnum[1] = Const Value(1)
+          PatchPoint SingleRactorMode
+          SetIvar v11, :@a, v17
+          PatchPoint NoEPEscape(f)
+          v27:Fixnum[1] = Const Value(1)
+          v30:CBool = HasType v12, Flonum
+          CondBranch v30, bb5(v11, v12, v13, v12, v27), bb6()
+        bb5(v31:HeapBasicObject, v32:BasicObject, v33:NilClass, v34:BasicObject, v35:Fixnum[1]):
+          v37:Flonum = RefineType v34, Flonum
+          PatchPoint MethodRedefined(Float@0x1008, +@0x1010, cme:0x1018)
+          v74:Float = FloatAdd v37, v35
+          Jump bb4(v31, v32, v33, v74)
+        bb6():
+          v41:CBool = HasType v12, Fixnum
+          CondBranch v41, bb7(v11, v12, v13, v12, v27), bb8()
+        bb7(v42:HeapBasicObject, v43:BasicObject, v44:NilClass, v45:BasicObject, v46:Fixnum[1]):
+          v48:Fixnum = RefineType v45, Fixnum
+          PatchPoint MethodRedefined(Integer@0x1040, +@0x1010, cme:0x1048)
+          v77:Fixnum = FixnumAdd v48, v46
+          Jump bb4(v42, v43, v44, v77)
+        bb8():
+          PatchPoint MethodRedefined(Float@0x1008, +@0x1010, cme:0x1018)
+          v80:Flonum = GuardType v12, Flonum recompile
+          v81:Float = FloatAdd v80, v27
+          Jump bb4(v11, v80, v13, v81)
+        bb4(v54:HeapBasicObject, v55:BasicObject, v56:NilClass, v57:Float|Fixnum):
+          PatchPoint SingleRactorMode
+          SetIvar v54, :@a, v57
+          CheckInterrupts
+          Return v57
         ");
     }
 }

--- a/zjit/src/hir/tests.rs
+++ b/zjit/src/hir/tests.rs
@@ -99,7 +99,7 @@ mod snapshot_tests {
             test
             test
         ");
-        assert_snapshot!(optimized_hir_string("test"), @r"
+        assert_snapshot!(optimized_hir_string("test"), @"
         fn test@<compiled>:3:
         bb0():
           Entries bb1, bb2
@@ -137,7 +137,7 @@ mod snapshot_tests {
             test
             test
         ");
-        assert_snapshot!(optimized_hir_string("test"), @r"
+        assert_snapshot!(optimized_hir_string("test"), @"
         fn test@<compiled>:3:
         bb0():
           Entries bb1, bb2

--- a/zjit/src/hir/tests.rs
+++ b/zjit/src/hir/tests.rs
@@ -99,7 +99,7 @@ mod snapshot_tests {
             test
             test
         ");
-        assert_snapshot!(optimized_hir_string("test"), @"
+        assert_snapshot!(optimized_hir_string("test"), @r"
         fn test@<compiled>:3:
         bb0():
           Entries bb1, bb2
@@ -120,7 +120,7 @@ mod snapshot_tests {
           v16:Any = Snapshot FrameState { pc: 0x1008, stack: [v6, v11, v13, v15], locals: [] }
           v23:Any = Snapshot FrameState { pc: 0x1008, stack: [v6, v13, v15, v11], locals: [] }
           PatchPoint MethodRedefined(Object@0x1010, foo@0x1018, cme:0x1020)
-          v25:ObjectSubclass[class_exact*:Object@VALUE(0x1010)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1010)]
+          v25:ObjectSubclass[class_exact*:Object@VALUE(0x1010)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1010)] recompile
           v26:BasicObject = SendDirect v25, 0x1048, :foo (0x1058), v13, v15, v11
           v18:Any = Snapshot FrameState { pc: 0x1060, stack: [v26], locals: [] }
           PatchPoint NoTracePoint
@@ -137,7 +137,7 @@ mod snapshot_tests {
             test
             test
         ");
-        assert_snapshot!(optimized_hir_string("test"), @"
+        assert_snapshot!(optimized_hir_string("test"), @r"
         fn test@<compiled>:3:
         bb0():
           Entries bb1, bb2
@@ -156,7 +156,7 @@ mod snapshot_tests {
           v13:Fixnum[2] = Const Value(2)
           v14:Any = Snapshot FrameState { pc: 0x1008, stack: [v6, v11, v13], locals: [] }
           PatchPoint MethodRedefined(Object@0x1010, foo@0x1018, cme:0x1020)
-          v22:ObjectSubclass[class_exact*:Object@VALUE(0x1010)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1010)]
+          v22:ObjectSubclass[class_exact*:Object@VALUE(0x1010)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1010)] recompile
           v23:BasicObject = SendDirect v22, 0x1048, :foo (0x1058), v11, v13
           v16:Any = Snapshot FrameState { pc: 0x1060, stack: [v23], locals: [] }
           PatchPoint NoTracePoint

--- a/zjit/src/payload.rs
+++ b/zjit/src/payload.rs
@@ -37,6 +37,9 @@ impl IseqPayload {
         }
     }
 
+    /// Profile counts are used for compilation policy.
+    /// When we deoptimize a method that can be recompiled, we need to update the count.
+    /// Otherwise, we will generate the same code that was just deoptimized.
     pub fn reset_profiles_remaining(&mut self, insn_idx: YarvInsnIdx) {
         let num_profiles = get_option!(num_profiles);
         self.profile.entry_mut(insn_idx).set_profiles_remaining(num_profiles);

--- a/zjit/src/payload.rs
+++ b/zjit/src/payload.rs
@@ -3,6 +3,7 @@ use std::ptr::NonNull;
 use crate::codegen::IseqCallRef;
 use crate::stats::CompileError;
 use crate::{cruby::*, profile::IseqProfile, virtualmem::CodePtr};
+use crate::options::get_option;
 
 pub use crate::jit_frame::JITFrame;
 
@@ -34,6 +35,11 @@ impl IseqPayload {
             was_invalidated_for_singleton_class_creation: false,
             self_is_heap_object: false,
         }
+    }
+
+    pub fn reset_profiles_remaining(&mut self, insn_idx: YarvInsnIdx) {
+        let num_profiles = get_option!(num_profiles);
+        self.profile.entry_mut(insn_idx).set_profiles_remaining(num_profiles);
     }
 }
 

--- a/zjit/src/payload.rs
+++ b/zjit/src/payload.rs
@@ -38,7 +38,7 @@ impl IseqPayload {
     }
 
     /// Profile counts are used for compilation policy.
-    /// When we deoptimize a method that can be recompiled, we need to update the count.
+    /// When we deoptimize a method that can be recompiled, we need to update the count to collect more profiles.
     /// Otherwise, we will generate the same code that was just deoptimized.
     pub fn reset_profiles_remaining(&mut self, insn_idx: YarvInsnIdx) {
         let num_profiles = get_option!(num_profiles);

--- a/zjit/src/profile.rs
+++ b/zjit/src/profile.rs
@@ -485,11 +485,6 @@ impl IseqProfile {
     pub fn profile_send_at(&mut self, iseq: IseqPtr, insn_idx: YarvInsnIdx, sp: *const VALUE, argc: usize) -> bool {
         let n = argc + 1; // args + receiver
         let entry = self.entry_mut(insn_idx);
-        // Reset profiling if the previous round already finished (stale YARV profiles).
-        // This ensures we collect num_profiles samples of the new shapes before recompiling.
-        if entry.profiles_remaining == 0 {
-            entry.profiles_remaining = get_option!(num_profiles);
-        }
         if entry.opnd_types.is_empty() {
             entry.opnd_types.resize(n, TypeDistribution::new());
         }

--- a/zjit/src/profile.rs
+++ b/zjit/src/profile.rs
@@ -417,13 +417,19 @@ impl ProfiledType {
 
 /// Per-instruction profile entry, stored sparsely in a sorted Vec.
 #[derive(Debug)]
-struct ProfileEntry {
+pub struct ProfileEntry {
     /// YARV instruction index
     insn_idx: u32,
     /// Type information of YARV instruction operands
     opnd_types: Vec<TypeDistribution>,
     /// Number of profiles remaining before recompilation. Counts down from --zjit-num-profiles.
     profiles_remaining: NumProfiles,
+}
+
+impl ProfileEntry {
+    pub fn set_profiles_remaining(&mut self, num_profiles: NumProfiles) {
+        self.profiles_remaining = num_profiles;
+    }
 }
 
 #[derive(Debug)]
@@ -445,7 +451,7 @@ impl IseqProfile {
     }
 
     /// Get or create a mutable profile entry for the given instruction index.
-    fn entry_mut(&mut self, insn_idx: YarvInsnIdx) -> &mut ProfileEntry {
+    pub fn entry_mut(&mut self, insn_idx: YarvInsnIdx) -> &mut ProfileEntry {
         let idx = insn_idx as u32;
         match self.entries.binary_search_by_key(&idx, |e| e.insn_idx) {
             Ok(i) => &mut self.entries[i],
@@ -479,6 +485,11 @@ impl IseqProfile {
     pub fn profile_send_at(&mut self, iseq: IseqPtr, insn_idx: YarvInsnIdx, sp: *const VALUE, argc: usize) -> bool {
         let n = argc + 1; // args + receiver
         let entry = self.entry_mut(insn_idx);
+        // Reset profiling if the previous round already finished (stale YARV profiles).
+        // This ensures we collect num_profiles samples of the new shapes before recompiling.
+        if entry.profiles_remaining == 0 {
+            entry.profiles_remaining = get_option!(num_profiles);
+        }
         if entry.opnd_types.is_empty() {
             entry.opnd_types.resize(n, TypeDistribution::new());
         }


### PR DESCRIPTION
This PR enables recompilation on `GuardType` Insns using a similar strategy to #16952.

It reduces the number of side exits due to `GuardType` failures substantially. Here are the following benchmarks from lobsters showing side exit reasons and below.

<details>
  <summary>Before</summary>

```
Top-18 side exit reasons (100.0% of total 7,015,988):
                   guard_type_failure: 6,219,567 (88.6%)
                   unhandled_hir_insn:   192,962 ( 2.8%)
                        compile_error:   159,044 ( 2.3%)
          patchpoint_method_redefined:   101,858 ( 1.5%)
      block_param_proxy_fallback_miss:    90,071 ( 1.3%)
                      no_profile_send:    75,510 ( 1.1%)
            block_param_proxy_not_nil:    62,195 ( 0.9%)
     patchpoint_stable_constant_names:    53,493 ( 0.8%)
        patchpoint_no_singleton_class:    17,646 ( 0.3%)
                  unhandled_block_arg:    11,616 ( 0.2%)
  block_param_proxy_not_iseq_or_ifunc:    10,734 ( 0.2%)
               fixnum_lshift_overflow:    10,165 ( 0.1%)
                   guard_less_failure:     8,658 ( 0.1%)
                  guard_shape_failure:     1,297 ( 0.0%)
             guard_greater_eq_failure:       791 ( 0.0%)
             guard_super_method_entry:       327 ( 0.0%)
               obj_to_string_fallback:        37 ( 0.0%)
                            interrupt:        17 ( 0.0%)
                             send_count: 152,679,023
                     dynamic_send_count:  18,533,868 (12.1%)
                   optimized_send_count: 134,145,155 (87.9%)
                  dynamic_setivar_count:   3,497,182 ( 2.3%)
                  dynamic_getivar_count:   9,519,425 ( 6.2%)
              dynamic_definedivar_count:   1,048,254 ( 0.7%)
              iseq_optimized_send_count:  45,486,354 (29.8%)
      inline_cfunc_optimized_send_count:  62,725,681 (41.1%)
       inline_iseq_optimized_send_count:   5,236,486 ( 3.4%)
non_variadic_cfunc_optimized_send_count:  11,531,825 ( 7.6%)
    variadic_cfunc_optimized_send_count:   9,164,809 ( 6.0%)
compiled_iseq_count:                                 6,160
compiled_side_exit_count:                           80,110
failed_iseq_count:                                       3
compile_time:                                      1,796ms
compile_side_exit_time:                               78ms
compile_side_exit_time_ratio:                         4.4%
compile_hir_time:                                    595ms
compile_hir_build_time:                              176ms
compile_hir_strength_reduce_time:                    241ms
compile_hir_canonicalize_time:                        36ms
compile_hir_fold_constants_time:                      28ms
compile_hir_clean_cfg_time:                           18ms
compile_hir_eliminate_dead_code_time:                 22ms
compile_lir_time:                                  1,097ms
profile_time:                                         33ms
gc_time:                                              24ms
invalidation_time:                                    10ms
vm_write_jit_frame_count:                      114,931,774
vm_write_sp_count:                             114,931,774
vm_write_locals_count:                         109,783,500
vm_write_stack_count:                          109,783,500
vm_write_to_parent_iseq_local_count:               596,276
guard_type_count:                              121,927,915
guard_type_exit_ratio:                                5.1%
guard_shape_count:                              31,103,377
guard_shape_exit_ratio:                               0.0%
load_field_count:                              176,019,606
store_field_count:                              13,251,392
side_exit_size:                                 13,811,608
code_region_bytes:                              33,685,504
side_exit_size_ratio:                                41.0%
zjit_alloc_bytes:                               22,020,613
total_mem_bytes:                                55,706,117
side_exit_count:                                 7,015,988
total_insn_count:                              828,871,310
vm_insn_count:                                  94,954,566
zjit_insn_count:                               733,916,744
ratio_in_zjit:                                       88.5%
```

</details>

<details>
  <summary>After</summary>

```
Top-19 side exit reasons (100.0% of total 1,103,972):
                   guard_type_failure: 369,400 (33.5%)
                      no_profile_send: 244,621 (22.2%)
                   unhandled_hir_insn: 196,133 (17.8%)
                        compile_error: 160,092 (14.5%)
            block_param_proxy_not_nil:  55,270 ( 5.0%)
      block_param_proxy_fallback_miss:  32,446 ( 2.9%)
                  unhandled_block_arg:  11,902 ( 1.1%)
  block_param_proxy_not_iseq_or_ifunc:  11,488 ( 1.0%)
               fixnum_lshift_overflow:  10,165 ( 0.9%)
                   guard_less_failure:   8,658 ( 0.8%)
                  guard_shape_failure:   2,215 ( 0.2%)
             guard_greater_eq_failure:     791 ( 0.1%)
             guard_super_method_entry:     327 ( 0.0%)
                  unhandled_yarv_insn:     270 ( 0.0%)
     patchpoint_stable_constant_names:     140 ( 0.0%)
                            interrupt:      25 ( 0.0%)
               obj_to_string_fallback:      22 ( 0.0%)
        patchpoint_no_singleton_class:       4 ( 0.0%)
          patchpoint_method_redefined:       3 ( 0.0%)
                             send_count: 171,152,020
                     dynamic_send_count:  24,812,242 (14.5%)
                   optimized_send_count: 146,339,778 (85.5%)
                  dynamic_setivar_count:   5,886,994 ( 3.4%)
                  dynamic_getivar_count:  12,749,260 ( 7.4%)
              dynamic_definedivar_count:   1,049,404 ( 0.6%)
              iseq_optimized_send_count:  50,757,633 (29.7%)
      inline_cfunc_optimized_send_count:  67,404,633 (39.4%)
       inline_iseq_optimized_send_count:   5,996,592 ( 3.5%)
non_variadic_cfunc_optimized_send_count:  13,338,259 ( 7.8%)
    variadic_cfunc_optimized_send_count:   8,842,661 ( 5.2%)
compiled_iseq_count:                                 7,950
compiled_side_exit_count:                          135,895
failed_iseq_count:                                       3
compile_time:                                      2,582ms
compile_side_exit_time:                              129ms
compile_side_exit_time_ratio:                         5.0%
compile_hir_time:                                    862ms
compile_hir_build_time:                              249ms
compile_hir_strength_reduce_time:                    366ms
compile_hir_canonicalize_time:                        52ms
compile_hir_fold_constants_time:                      38ms
compile_hir_clean_cfg_time:                           28ms
compile_hir_eliminate_dead_code_time:                 30ms
compile_lir_time:                                  1,562ms
profile_time:                                        136ms
gc_time:                                              28ms
invalidation_time:                                    14ms
vm_write_jit_frame_count:                      131,008,986
vm_write_sp_count:                             131,008,986
vm_write_locals_count:                         125,008,862
vm_write_stack_count:                          125,008,862
vm_write_to_parent_iseq_local_count:               640,568
guard_type_count:                               96,124,515
guard_type_exit_ratio:                                0.4%
guard_shape_count:                              34,187,111
guard_shape_exit_ratio:                               0.0%
load_field_count:                              182,145,766
store_field_count:                              15,920,134
side_exit_size:                                 24,348,644
code_region_bytes:                              53,510,144
side_exit_size_ratio:                                45.5%
zjit_alloc_bytes:                               24,855,989
total_mem_bytes:                                78,366,133
side_exit_count:                                 1,103,972
total_insn_count:                              825,147,793
vm_insn_count:                                  21,620,589
zjit_insn_count:                               803,527,204
ratio_in_zjit:                                       97.4%
```

</details>