### PR TITLE
ZJIT: Clean up specialized T_DATA path

### DIFF
--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -2551,25 +2551,6 @@ fn gen_guard_type(jit: &mut JITState, asm: &mut Assembler, val: lir::Opnd, guard
 
         asm.cmp(klass, Opnd::Value(expected_class));
         asm.jne(jit, side_exit);
-    } else if guard_type.is_subtype(types::TData) {
-        let side = side_exit(jit, state, GuardType(guard_type));
-
-        // Check special constant
-        asm.test(val, Opnd::UImm(RUBY_IMMEDIATE_MASK as u64));
-        asm.jnz(jit, side.clone());
-
-        // Check false
-        asm.cmp(val, Qfalse.into());
-        asm.je(jit, side.clone());
-
-        // Check the T_DATA builtin type.
-        let val = asm.load_mem(val);
-        let flags = asm.load(Opnd::mem(VALUE_BITS, val, RUBY_OFFSET_RBASIC_FLAGS));
-        let mask     = RUBY_T_MASK.to_usize();
-        let expected = RUBY_T_DATA.to_usize();
-        let masked = asm.and(flags, mask.into());
-        asm.cmp(masked, expected.into());
-        asm.jne(jit, side);
     } else if let Some(builtin_type) = guard_type.builtin_type_equivalent() {
         let side = side_exit(jit, state, GuardType(guard_type));
 

--- a/zjit/src/hir_type/mod.rs
+++ b/zjit/src/hir_type/mod.rs
@@ -444,8 +444,9 @@ impl Type {
             Some(cruby::RUBY_T_STRING)
         } else if self.bit_equal(types::Hash) {
             Some(cruby::RUBY_T_HASH)
+        } else if self.bit_equal(types::TData) {
+            Some(cruby::RUBY_T_DATA)
         } else {
-            // T_DATA uses a specialized guard, so not here.
             None
         }
     }


### PR DESCRIPTION
Data and TypedData now both are T_DATA so we can clean up this path and
make T_DATA look like the others: T_STRING, etc.

Thanks to @nobu for noticing and reporting here: https://github.com/ruby/ruby/pull/17114
