### PR TITLE
Run macOS CI on `macos-26` by default

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -26,25 +26,29 @@ jobs:
       matrix:
         include:
           - test_task: check
-            os: macos-14
+            os: macos-26
           - test_task: check
-            os: macos-14
+            os: macos-26
             configure_args: '--with-gcc=gcc-14'
           - test_task: check
-            os: macos-14
+            os: macos-26
             configure_args: '--with-jemalloc --with-opt-dir=$(brew --prefix jemalloc)'
           - test_task: check
-            os: macos-14
+            os: macos-26
             configure_args: '--with-gmp'
           - test_task: test-all
             test_opts: --repeat-count=2
-            os: macos-14
+            os: macos-26
           - test_task: test-bundler-parallel
-            os: macos-14
+            os: macos-26
           - test_task: test-bundled-gems
-            os: macos-14
+            os: macos-26
           - test_task: check
             os: macos-15
+          - test_task: check
+            os: macos-15-intel
+          - test_task: check
+            os: macos-14
       fail-fast: false
 
     env:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -28,7 +28,7 @@ jobs:
           - test_task: check
             os: macos-26
           - test_task: check
-            os: macos-26
+            os: macos-15
             configure_args: '--with-gcc=gcc-14'
           - test_task: check
             os: macos-26

--- a/.github/workflows/modgc.yml
+++ b/.github/workflows/modgc.yml
@@ -28,7 +28,7 @@ jobs:
           - name: default
           - name: mmtk
             mmtk_build: release
-        os: [macos-latest, ubuntu-latest]
+        os: [macos-26, ubuntu-latest]
         include:
           - test_task: check
       fail-fast: false

--- a/.github/workflows/tarball-macos.yml
+++ b/.github/workflows/tarball-macos.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         test_task: [check, test-bundled-gems, test-bundler-parallel]
-        os: [macos-14, macos-15]
+        os: [macos-26, macos-15, macos-14]
         include:
           - os: macos-15-intel
             test_task: check

--- a/.github/workflows/yjit-macos.yml
+++ b/.github/workflows/yjit-macos.yml
@@ -30,7 +30,7 @@ jobs:
   cargo:
     name: cargo test
 
-    runs-on: macos-14
+    runs-on: macos-26
 
     if: >-
       ${{!(false
@@ -74,7 +74,7 @@ jobs:
       RUN_OPTS: ${{ matrix.yjit_opts }}
       SPECOPTS: ${{ matrix.specopts }}
 
-    runs-on: macos-14
+    runs-on: macos-26
 
     if: >-
       ${{!(false
@@ -134,7 +134,7 @@ jobs:
         id: launchable
         uses: ./.github/actions/launchable/setup
         with:
-          os: macos-14
+          os: macos-26
           test-opts: ${{ matrix.configure }}
           launchable-token: ${{ secrets.LAUNCHABLE_TOKEN }}
           builddir: build

--- a/.github/workflows/zjit-macos.yml
+++ b/.github/workflows/zjit-macos.yml
@@ -58,7 +58,7 @@ jobs:
       RUST_BACKTRACE: 1
       ZJIT_RB_BUG: 1
 
-    runs-on: macos-14
+    runs-on: macos-26
 
     if: >-
       ${{!(false
@@ -118,7 +118,7 @@ jobs:
         id: launchable
         uses: ./.github/actions/launchable/setup
         with:
-          os: macos-14
+          os: macos-26
           test-opts: ${{ matrix.configure }}
           launchable-token: ${{ secrets.LAUNCHABLE_TOKEN }}
           builddir: build
@@ -181,7 +181,7 @@ jobs:
             bench_opts: '--warmup=1 --bench=1 --excludes=shipit'
             configure: '--enable-zjit=dev_nodebug' # --enable-zjit=dev is too slow
 
-    runs-on: macos-14
+    runs-on: macos-26
 
     if: >-
       ${{!(false


### PR DESCRIPTION
`macos-26` will become the default macOS runner named `macos-latest` soon. We should use that by default.