### PR TITLE
Robject: use IMEMO/fields as buffer when transitioning to extended

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -1383,8 +1383,7 @@ rb_gc_obj_needs_cleanup_p(VALUE obj)
 
     switch (flags & RUBY_T_MASK) {
       case T_OBJECT:
-        if (flags & ROBJECT_HEAP) return true;
-        return false;
+        return rb_shape_complex_p(shape_id);
 
       case T_DATA:
         {
@@ -1533,7 +1532,6 @@ rb_gc_obj_free(void *objspace, VALUE obj)
                 st_free_table(ROBJECT_FIELDS_HASH(obj));
             }
             else {
-                SIZED_FREE_N(ROBJECT(obj)->as.heap.fields, ROBJECT_FIELDS_CAPACITY(obj));
                 RB_DEBUG_COUNTER_INC(obj_obj_ptr);
             }
         }
@@ -2571,13 +2569,8 @@ rb_obj_memsize_of(VALUE obj)
 
     switch (BUILTIN_TYPE(obj)) {
       case T_OBJECT:
-        if (FL_TEST_RAW(obj, ROBJECT_HEAP)) {
-            if (rb_obj_shape_complex_p(obj)) {
-                size += rb_st_memsize(ROBJECT_FIELDS_HASH(obj));
-            }
-            else {
-                size += ROBJECT_FIELDS_CAPACITY(obj) * sizeof(VALUE);
-            }
+        if (rb_obj_shape_complex_p(obj)) {
+            size += rb_st_memsize(ROBJECT_FIELDS_HASH(obj));
         }
         break;
       case T_MODULE:
@@ -3498,6 +3491,9 @@ rb_gc_mark_children(void *objspace, VALUE obj)
             gc_mark_tbl_no_pin(ROBJECT_FIELDS_HASH(obj));
             len = ROBJECT_FIELDS_COUNT_COMPLEX(obj);
         }
+        else if (FL_TEST_RAW(obj, ROBJECT_HEAP)) {
+            rb_gc_mark_movable(ROBJECT(obj)->as.extended);
+        }
         else {
             const VALUE * const ptr = ROBJECT_FIELDS(obj);
 
@@ -3857,13 +3853,16 @@ gc_ref_update_object(void *objspace, VALUE v)
 
         size_t slot_size = rb_gc_obj_slot_size(v);
         size_t embed_size = rb_obj_embedded_size(ROBJECT_FIELDS_CAPACITY(v));
-        if (slot_size >= embed_size) {
-            // Object can be re-embedded
-            memcpy(ROBJECT(v)->as.ary, ptr, sizeof(VALUE) * ROBJECT_FIELDS_COUNT(v));
-            SIZED_FREE_N(ptr, ROBJECT_FIELDS_CAPACITY(v));
-            FL_UNSET_RAW(v, ROBJECT_HEAP);
-            ptr = ROBJECT(v)->as.ary;
+        if (slot_size < embed_size) {
+            UPDATE_IF_MOVED(objspace, ROBJECT(v)->as.extended);
+            return;
         }
+
+        // Object can be re-embedded
+        memcpy(ROBJECT(v)->as.ary, ptr, sizeof(VALUE) * ROBJECT_FIELDS_COUNT(v));
+        SIZED_FREE_N(ptr, ROBJECT_FIELDS_CAPACITY(v));
+        FL_UNSET_RAW(v, ROBJECT_HEAP);
+        ptr = ROBJECT(v)->as.ary;
     }
 
     for (uint32_t i = 0; i < ROBJECT_FIELDS_COUNT(v); i++) {

--- a/gc.c
+++ b/gc.c
@@ -3492,7 +3492,9 @@ rb_gc_mark_children(void *objspace, VALUE obj)
             len = ROBJECT_FIELDS_COUNT_COMPLEX(obj);
         }
         else if (FL_TEST_RAW(obj, ROBJECT_HEAP)) {
-            rb_gc_mark_movable(ROBJECT_EXTENDED_FIELDS(obj));
+            if (!rb_gc_checking_shareable()) {
+                rb_gc_mark_movable(ROBJECT_EXTENDED_FIELDS(obj));
+            }
         }
         else {
             const VALUE * const ptr = ROBJECT_FIELDS(obj);

--- a/gc.c
+++ b/gc.c
@@ -3492,7 +3492,7 @@ rb_gc_mark_children(void *objspace, VALUE obj)
             len = ROBJECT_FIELDS_COUNT_COMPLEX(obj);
         }
         else if (FL_TEST_RAW(obj, ROBJECT_HEAP)) {
-            rb_gc_mark_movable(ROBJECT(obj)->as.extended);
+            rb_gc_mark_movable(ROBJECT_EXTENDED_FIELDS(obj));
         }
         else {
             const VALUE * const ptr = ROBJECT_FIELDS(obj);

--- a/gc.c
+++ b/gc.c
@@ -3843,8 +3843,11 @@ gc_ref_update_array(void *objspace, VALUE v)
 static void
 gc_ref_update_object(void *objspace, VALUE v)
 {
-    VALUE *ptr = ROBJECT_FIELDS(v);
+    if (FL_TEST_RAW(v, ROBJECT_HEAP) && !rb_obj_shape_complex_p(v)) {
+        UPDATE_IF_MOVED(objspace, ROBJECT(v)->as.extended);
+    }
 
+    VALUE *ptr = ROBJECT_FIELDS(v);
     if (FL_TEST_RAW(v, ROBJECT_HEAP)) {
         if (rb_obj_shape_complex_p(v)) {
             gc_ref_update_table_values_only(ROBJECT_FIELDS_HASH(v));
@@ -3853,16 +3856,13 @@ gc_ref_update_object(void *objspace, VALUE v)
 
         size_t slot_size = rb_gc_obj_slot_size(v);
         size_t embed_size = rb_obj_embedded_size(ROBJECT_FIELDS_CAPACITY(v));
-        if (slot_size < embed_size) {
-            UPDATE_IF_MOVED(objspace, ROBJECT(v)->as.extended);
-            return;
+        if (slot_size >= embed_size) {
+            // Object can be re-embedded
+            memcpy(ROBJECT(v)->as.ary, ptr, sizeof(VALUE) * ROBJECT_FIELDS_COUNT(v));
+            SIZED_FREE_N(ptr, ROBJECT_FIELDS_CAPACITY(v));
+            FL_UNSET_RAW(v, ROBJECT_HEAP);
+            ptr = ROBJECT(v)->as.ary;
         }
-
-        // Object can be re-embedded
-        memcpy(ROBJECT(v)->as.ary, ptr, sizeof(VALUE) * ROBJECT_FIELDS_COUNT(v));
-        SIZED_FREE_N(ptr, ROBJECT_FIELDS_CAPACITY(v));
-        FL_UNSET_RAW(v, ROBJECT_HEAP);
-        ptr = ROBJECT(v)->as.ary;
     }
 
     for (uint32_t i = 0; i < ROBJECT_FIELDS_COUNT(v); i++) {

--- a/imemo.c
+++ b/imemo.c
@@ -141,7 +141,7 @@ rb_imemo_fields_new(VALUE owner, shape_id_t shape_id, bool shareable)
     size_t embedded_size = offsetof(struct rb_fields, as.embed) + capa * sizeof(VALUE);
     RUBY_ASSERT(rb_gc_size_allocatable_p(embedded_size));
     VALUE fields = rb_imemo_new(imemo_fields, owner, embedded_size, shareable);
-    RBASIC_SET_SHAPE_ID(fields, shape_id);
+    RBASIC_SET_SHAPE_ID(fields, rb_shape_transition_no_heap(shape_id));
     RUBY_ASSERT(IMEMO_TYPE_P(fields, imemo_fields));
     return fields;
 }
@@ -152,7 +152,7 @@ rb_imemo_fields_new_complex(VALUE owner, shape_id_t shape_id, size_t capa, bool 
     VALUE fields = rb_imemo_new(imemo_fields, owner, sizeof(struct rb_fields), shareable);
     IMEMO_OBJ_FIELDS(fields)->as.complex.table = st_init_numtable_with_size(capa);
     FL_SET_RAW(fields, OBJ_FIELD_HEAP);
-    RBASIC_SET_SHAPE_ID(fields, shape_id);
+    RBASIC_SET_SHAPE_ID(fields, rb_shape_transition_no_heap(shape_id));
     return fields;
 }
 

--- a/include/ruby/internal/core/robject.h
+++ b/include/ruby/internal/core/robject.h
@@ -90,14 +90,10 @@ struct RObject {
     /** Object's specific fields. */
     union {
 
-        /**
-         * Object that use  separated memory region for  instance variables use
-         * this pattern.
+        /* Reference to an IMEMO/fields that holds instance variables.
+         * For objects that overflowed.
          */
-        struct {
-            /** Pointer to a C array that holds instance variables. */
-            VALUE *fields;
-        } heap;
+        VALUE extended;
 
         /* When an object is too complex, it uses a st_table to store instance
          * variable name to value mappings.
@@ -115,33 +111,5 @@ struct RObject {
         VALUE ary[1];
     } as;
 };
-
-RBIMPL_ATTR_PURE_UNLESS_DEBUG()
-RBIMPL_ATTR_ARTIFICIAL()
-/**
- * Queries the instance variables.
- *
- * @param[in]  obj  Object in question.
- * @return     Its instance variables, in C array.
- * @pre        `obj` must be an instance of ::RObject.
- *
- * @internal
- *
- * @shyouhei finds no reason for this to be visible from extension libraries.
- */
-static inline VALUE *
-ROBJECT_FIELDS(VALUE obj)
-{
-    RBIMPL_ASSERT_TYPE(obj, RUBY_T_OBJECT);
-
-    struct RObject *const ptr = ROBJECT(obj);
-
-    if (RB_UNLIKELY(RB_FL_ANY_RAW(obj, ROBJECT_HEAP))) {
-        return ptr->as.heap.fields;
-    }
-    else {
-        return ptr->as.ary;
-    }
-}
 
 #endif /* RBIMPL_ROBJECT_H */

--- a/internal/imemo.h
+++ b/internal/imemo.h
@@ -317,10 +317,6 @@ rb_imemo_fields_complex_tbl(VALUE fields_obj)
     RUBY_ASSERT(IMEMO_TYPE_P(fields_obj, imemo_fields) || RB_TYPE_P(fields_obj, T_OBJECT));
     RUBY_ASSERT(FL_TEST_RAW(fields_obj, OBJ_FIELD_HEAP));
 
-    // Some codepaths unconditionally access the fields_ptr, and assume it can be used as st_table if the
-    // shape is complex.
-    RUBY_ASSERT((st_table *)rb_imemo_fields_ptr(fields_obj) == IMEMO_OBJ_FIELDS(fields_obj)->as.complex.table);
-
     return IMEMO_OBJ_FIELDS(fields_obj)->as.complex.table;
 }
 

--- a/internal/imemo.h
+++ b/internal/imemo.h
@@ -245,9 +245,6 @@ struct rb_fields {
             VALUE fields[1];
         } embed;
         struct {
-            VALUE *ptr;
-        } external;
-        struct {
             // Note: the st_table could be embedded, but complex T_CLASS should be rare to
             // non-existent, so not really worth the trouble.
             st_table *table;
@@ -260,8 +257,7 @@ struct rb_fields {
 #define OBJ_FIELD_HEAP ROBJECT_HEAP
 STATIC_ASSERT(imemo_fields_flags, OBJ_FIELD_HEAP == IMEMO_FL_USER0);
 STATIC_ASSERT(imemo_fields_embed_offset, offsetof(struct RObject, as.ary) == offsetof(struct rb_fields, as.embed.fields));
-STATIC_ASSERT(imemo_fields_external_offset, offsetof(struct RObject, as.heap.fields) == offsetof(struct rb_fields, as.external.ptr));
-STATIC_ASSERT(imemo_fields_complex_offset, offsetof(struct RObject, as.heap.fields) == offsetof(struct rb_fields, as.complex.table));
+STATIC_ASSERT(imemo_fields_complex_offset, offsetof(struct RObject, as.extended) == offsetof(struct rb_fields, as.complex.table));
 
 #define IMEMO_OBJ_FIELDS(fields) ((struct rb_fields *)fields)
 
@@ -308,12 +304,7 @@ rb_imemo_fields_ptr(VALUE fields_obj)
 
     RUBY_ASSERT(IMEMO_TYPE_P(fields_obj, imemo_fields) || RB_TYPE_P(fields_obj, T_OBJECT));
 
-    if (UNLIKELY(FL_TEST_RAW(fields_obj, OBJ_FIELD_HEAP))) {
-        return IMEMO_OBJ_FIELDS(fields_obj)->as.external.ptr;
-    }
-    else {
-        return IMEMO_OBJ_FIELDS(fields_obj)->as.embed.fields;
-    }
+    return IMEMO_OBJ_FIELDS(fields_obj)->as.embed.fields;
 }
 
 static inline st_table *

--- a/internal/object.h
+++ b/internal/object.h
@@ -9,6 +9,7 @@
  * @brief      Internal header for Object.
  */
 #include "ruby/ruby.h"          /* for VALUE */
+#include "imemo.h"
 
 /* object.c */
 
@@ -69,4 +70,20 @@ rb_obj_embedded_size(uint32_t fields_count)
     if (size < sizeof(struct RObject)) size = sizeof(struct RObject);
     return size;
 }
+
+RBIMPL_ATTR_PURE_UNLESS_DEBUG()
+RBIMPL_ATTR_ARTIFICIAL()
+static inline VALUE *
+ROBJECT_FIELDS(VALUE obj)
+{
+    RBIMPL_ASSERT_TYPE(obj, RUBY_T_OBJECT);
+
+    if (RB_UNLIKELY(RB_FL_ANY_RAW(obj, ROBJECT_HEAP))) {
+        return rb_imemo_fields_ptr(ROBJECT(obj)->as.extended);
+    }
+    else {
+        return ROBJECT(obj)->as.ary;
+    }
+}
+
 #endif /* INTERNAL_OBJECT_H */

--- a/internal/object.h
+++ b/internal/object.h
@@ -10,6 +10,7 @@
  */
 #include "ruby/ruby.h"          /* for VALUE */
 #include "imemo.h"
+#include "shape.h"
 
 /* object.c */
 
@@ -78,12 +79,7 @@ ROBJECT_FIELDS(VALUE obj)
 {
     RBIMPL_ASSERT_TYPE(obj, RUBY_T_OBJECT);
 
-    if (RB_UNLIKELY(RB_FL_ANY_RAW(obj, ROBJECT_HEAP))) {
-        return rb_imemo_fields_ptr(ROBJECT(obj)->as.extended);
-    }
-    else {
-        return ROBJECT(obj)->as.ary;
-    }
+    return rb_imemo_fields_ptr(ROBJECT_FIELDS_OBJ(obj));
 }
 
 #endif /* INTERNAL_OBJECT_H */

--- a/jit.c
+++ b/jit.c
@@ -28,7 +28,7 @@
 
 enum jit_bindgen_constants {
     // Field offsets for the RObject struct
-    ROBJECT_OFFSET_AS_HEAP_FIELDS = offsetof(struct RObject, as.heap.fields),
+    ROBJECT_OFFSET_AS_EXTENDED = offsetof(struct RObject, as.extended),
     ROBJECT_OFFSET_AS_ARY = offsetof(struct RObject, as.ary),
 
     // Field offset for prime classext's fields_obj from a class pointer

--- a/object.c
+++ b/object.c
@@ -362,12 +362,17 @@ rb_obj_copy_ivar(VALUE dest, VALUE obj)
     attr_index_t dest_capa = RSHAPE_CAPACITY(dest_shape_id);
 
     RUBY_ASSERT(src_num_ivs <= dest_capa);
+
+    VALUE dest_obj_fields = dest;
     if (initial_capa < dest_capa) {
-        rb_ensure_iv_list_size(dest, 0, dest_capa);
-        dest_buf = ROBJECT_FIELDS(dest);
+        dest_obj_fields = rb_imemo_fields_new(dest, dest_shape_id, false);
+        dest_buf = rb_imemo_fields_ptr(dest_obj_fields);
     }
 
-    rb_shape_copy_fields(dest, dest_buf, dest_shape_id, src_buf, src_shape_id);
+    rb_shape_copy_fields(dest_obj_fields, dest_buf, dest_shape_id, src_buf, src_shape_id);
+    if (dest != dest_obj_fields) {
+        RBASIC_SET_SHAPE_ID(dest_obj_fields, rb_shape_transition_no_heap(dest_shape_id));
+    }
     RBASIC_SET_SHAPE_ID(dest, dest_shape_id);
 }
 

--- a/object.c
+++ b/object.c
@@ -371,6 +371,8 @@ rb_obj_copy_ivar(VALUE dest, VALUE obj)
 
     rb_shape_copy_fields(dest_obj_fields, dest_buf, dest_shape_id, src_buf, src_shape_id);
     if (dest != dest_obj_fields) {
+        FL_SET_RAW(dest, ROBJECT_HEAP);
+        ROBJECT_SET_EXTENDED_FIELDS(dest, dest_obj_fields);
         RBASIC_SET_SHAPE_ID(dest_obj_fields, rb_shape_transition_no_heap(dest_shape_id));
     }
     RBASIC_SET_SHAPE_ID(dest, dest_shape_id);

--- a/shape.c
+++ b/shape.c
@@ -1297,11 +1297,13 @@ rb_shape_verify_consistency(VALUE obj, shape_id_t shape_id)
             shape_id_t fields_id = RBASIC_SHAPE_ID(fields_obj);
             if ((fields_id & ~SHAPE_ID_FL_FROZEN) != (rb_shape_transition_no_heap(shape_id) & ~SHAPE_ID_FL_FROZEN)) {
                 rb_bug(
-                    "T_OBJECT (%"PRIxVALUE") and its extended fields (%"PRIxVALUE") should have the same shape id obj=%u fields_obj=%u",
+                    "T_OBJECT (%"PRIxVALUE") and its extended fields (%"PRIxVALUE") should have the same shape id obj=%u (%s) fields_obj=%u (%s)",
                     obj,
                     fields_obj,
                     rb_shape_transition_no_heap(shape_id),
-                    RBASIC_SHAPE_ID(fields_obj)
+                    rb_id2name(RSHAPE_EDGE_NAME(shape_id)),
+                    RBASIC_SHAPE_ID(fields_obj),
+                    rb_id2name(RBASIC_SHAPE_ID(fields_obj))
                 );
             }
         }

--- a/shape.c
+++ b/shape.c
@@ -1291,6 +1291,20 @@ rb_shape_verify_consistency(VALUE obj, shape_id_t shape_id)
         if (shape_id_slot_size != actual_slot_size) {
             rb_bug("shape_id heap_index flags mismatch: shape_id_slot_size=%zu, gc_slot_size=%zu\n", shape_id_slot_size, actual_slot_size);
         }
+
+        if (FL_TEST_RAW(obj, ROBJECT_HEAP) && !rb_shape_complex_p(shape_id)) {
+            VALUE fields_obj = ROBJECT_FIELDS_OBJ(obj);
+            shape_id_t fields_id = RBASIC_SHAPE_ID(fields_obj);
+            if ((fields_id & ~SHAPE_ID_FL_FROZEN) != (rb_shape_transition_no_heap(shape_id) & ~SHAPE_ID_FL_FROZEN)) {
+                rb_bug(
+                    "T_OBJECT (%"PRIxVALUE") and its extended fields (%"PRIxVALUE") should have the same shape id obj=%u fields_obj=%u",
+                    obj,
+                    fields_obj,
+                    rb_shape_transition_no_heap(shape_id),
+                    RBASIC_SHAPE_ID(fields_obj)
+                );
+            }
+        }
     }
     else {
         if (flags_heap_index) {

--- a/shape.h
+++ b/shape.h
@@ -346,6 +346,39 @@ ROBJECT_SET_FIELDS_HASH(VALUE obj, st_table *tbl)
     ROBJECT(obj)->as.hash = tbl;
 }
 
+static inline VALUE
+ROBJECT_EXTENDED_FIELDS(VALUE obj)
+{
+    RBIMPL_ASSERT_TYPE(obj, RUBY_T_OBJECT);
+    RUBY_ASSERT(!rb_obj_shape_complex_p(obj));
+    RUBY_ASSERT(FL_TEST_RAW(obj, ROBJECT_HEAP));
+    RUBY_ASSERT(ROBJECT(obj)->as.extended);
+
+    return ROBJECT(obj)->as.extended;
+}
+
+static inline VALUE
+ROBJECT_FIELDS_OBJ(VALUE obj)
+{
+    RBIMPL_ASSERT_TYPE(obj, RUBY_T_OBJECT);
+
+    if (UNLIKELY(FL_TEST_RAW(obj, ROBJECT_HEAP) && !rb_obj_shape_complex_p(obj))) {
+        return ROBJECT_EXTENDED_FIELDS(obj);
+    }
+    return obj;
+}
+
+static inline void
+ROBJECT_SET_EXTENDED_FIELDS(VALUE obj, VALUE fields_obj)
+{
+    RBIMPL_ASSERT_TYPE(obj, RUBY_T_OBJECT);
+    RUBY_ASSERT(!rb_obj_shape_complex_p(obj));
+    RUBY_ASSERT(FL_TEST_RAW(obj, ROBJECT_HEAP));
+    RUBY_ASSERT(fields_obj);
+
+    RB_OBJ_WRITE(obj, &ROBJECT(obj)->as.extended, fields_obj);
+}
+
 static inline uint32_t
 ROBJECT_FIELDS_COUNT_COMPLEX(VALUE obj)
 {

--- a/shape.h
+++ b/shape.h
@@ -480,6 +480,12 @@ rb_shape_transition_heap(shape_id_t shape_id, size_t heap_index)
     return (shape_id & (~SHAPE_ID_HEAP_INDEX_MASK)) | rb_shape_root(heap_index);
 }
 
+static inline shape_id_t
+rb_shape_transition_no_heap(shape_id_t shape_id)
+{
+    return (shape_id & (~SHAPE_ID_HEAP_INDEX_MASK));
+}
+
 shape_id_t rb_shape_transition_object_id(shape_id_t shape_id);
 
 static inline shape_id_t

--- a/shape.h
+++ b/shape.h
@@ -368,6 +368,8 @@ ROBJECT_FIELDS_OBJ(VALUE obj)
     return obj;
 }
 
+static inline shape_id_t rb_shape_transition_no_heap(shape_id_t);
+
 static inline void
 ROBJECT_SET_EXTENDED_FIELDS(VALUE obj, VALUE fields_obj)
 {

--- a/tool/lib/test/unit.rb
+++ b/tool/lib/test/unit.rb
@@ -651,6 +651,7 @@ module Test
 
         # Require needed thing for parallel running
         require 'timeout'
+        p self
         @tasks = @order.group(@order.sort_by_string(@files)) # Array of filenames.
 
         @need_quit = false

--- a/variable.c
+++ b/variable.c
@@ -1421,8 +1421,8 @@ rb_obj_field_get(VALUE obj, shape_id_t target_shape_id)
         fields_obj = RCLASS_WRITABLE_FIELDS_OBJ(obj);
         break;
       case T_OBJECT:
-        if (FL_TEST_RAW(obj, ROBJECT_HEAP)) {
-            fields_obj = ROBJECT(obj)->as.extended;
+        if (!rb_shape_complex_p(target_shape_id) && FL_TEST_RAW(obj, ROBJECT_HEAP)) {
+            fields_obj = ROBJECT_EXTENDED_FIELDS(obj);
         }
         else {
             fields_obj = obj;
@@ -1454,6 +1454,7 @@ rb_ivar_lookup(VALUE obj, ID id, VALUE undef)
 {
     if (SPECIAL_CONST_P(obj)) return undef;
 
+    shape_id_t shape_id = RBASIC_SHAPE_ID(obj);
     VALUE fields_obj;
 
     switch (BUILTIN_TYPE(obj)) {
@@ -1477,8 +1478,8 @@ rb_ivar_lookup(VALUE obj, ID id, VALUE undef)
         fields_obj = obj;
         break;
       case T_OBJECT:
-        if (FL_TEST_RAW(obj, ROBJECT_HEAP)) {
-            fields_obj = ROBJECT(obj)->as.extended;
+        if (!rb_shape_complex_p(shape_id) && FL_TEST_RAW(obj, ROBJECT_HEAP)) {
+            fields_obj = ROBJECT_EXTENDED_FIELDS(obj);
         }
         else {
             fields_obj = obj;
@@ -1492,8 +1493,6 @@ rb_ivar_lookup(VALUE obj, ID id, VALUE undef)
     if (!fields_obj) {
         return undef;
     }
-
-    shape_id_t shape_id = RBASIC_SHAPE_ID(fields_obj);
 
     if (UNLIKELY(rb_shape_complex_p(shape_id))) {
         st_table *iv_table = rb_imemo_fields_complex_tbl(fields_obj);
@@ -1669,7 +1668,7 @@ rb_ivar_delete(VALUE obj, ID id, VALUE undef)
         break;
       case T_OBJECT:
         if (FL_TEST_RAW(obj, ROBJECT_HEAP)) {
-            fields_obj = ROBJECT(obj)->as.extended;
+            fields_obj = ROBJECT_EXTENDED_FIELDS(obj);
         }
         else {
             fields_obj = obj;
@@ -1986,21 +1985,21 @@ obj_field_set(VALUE obj, shape_id_t target_shape_id, ID field_name, VALUE val)
     else {
         attr_index_t index = RSHAPE_INDEX(target_shape_id);
 
-        VALUE fields_obj = obj;
-        VALUE *dest_buf = ROBJECT_FIELDS(obj);
+        VALUE fields_obj = ROBJECT_FIELDS_OBJ(obj);
+        VALUE *dest_buf = rb_imemo_fields_ptr(fields_obj);
 
         if (index >= RSHAPE_LEN(current_shape_id)) {
             if (UNLIKELY(index >= RSHAPE_CAPACITY(current_shape_id))) {
                 RUBY_ASSERT(!RB_OBJ_SHAREABLE_P(obj));
 
                 shape_id_t fields_shape_id = rb_shape_transition_no_heap(target_shape_id);
-                fields_obj = rb_imemo_fields_new(obj, fields_shape_id, false);
+                fields_obj = rb_imemo_fields_new(obj, fields_shape_id, RB_OBJ_SHAREABLE_P(obj));
                 dest_buf = rb_imemo_fields_ptr(fields_obj);
                 rb_shape_copy_fields(fields_obj, dest_buf, current_shape_id, ROBJECT_FIELDS(obj), current_shape_id);
 
                 RBASIC_SET_SHAPE_ID(fields_obj, fields_shape_id);
-                RB_OBJ_WRITE(obj, &ROBJECT(obj)->as.extended, fields_obj);
                 FL_SET_RAW(obj, ROBJECT_HEAP);
+                ROBJECT_SET_EXTENDED_FIELDS(obj, fields_obj);
             }
             RBASIC_SET_SHAPE_ID(obj, target_shape_id);
         }
@@ -2086,6 +2085,7 @@ rb_ivar_set(VALUE obj, ID id, VALUE val)
 {
     rb_check_frozen(obj);
     ivar_set(obj, id, val);
+    RUBY_ASSERT(rb_ivar_get(obj, id) == val);
     return val;
 }
 

--- a/variable.c
+++ b/variable.c
@@ -1421,12 +1421,7 @@ rb_obj_field_get(VALUE obj, shape_id_t target_shape_id)
         fields_obj = RCLASS_WRITABLE_FIELDS_OBJ(obj);
         break;
       case T_OBJECT:
-        if (!rb_shape_complex_p(target_shape_id) && FL_TEST_RAW(obj, ROBJECT_HEAP)) {
-            fields_obj = ROBJECT_EXTENDED_FIELDS(obj);
-        }
-        else {
-            fields_obj = obj;
-        }
+        fields_obj = ROBJECT_FIELDS_OBJ(obj);
         break;
       case T_IMEMO:
         RUBY_ASSERT(IMEMO_TYPE_P(obj, imemo_fields));
@@ -1613,6 +1608,8 @@ rb_evict_fields_to_hash(VALUE obj)
     shape_id_t new_shape_id = obj_transition_complex(obj, table);
 
     RUBY_ASSERT(rb_obj_shape_complex_p(obj));
+    RUBY_ASSERT(rb_imemo_fields_complex_tbl(obj) == table);
+    RUBY_ASSERT(ROBJECT_FIELDS_HASH(obj) == table);
     return new_shape_id;
 }
 
@@ -1651,12 +1648,7 @@ rb_ivar_delete(VALUE obj, ID id, VALUE undef)
         }
         break;
       case T_OBJECT:
-        if (FL_TEST_RAW(obj, ROBJECT_HEAP)) {
-            fields_obj = ROBJECT_EXTENDED_FIELDS(obj);
-        }
-        else {
-            fields_obj = obj;
-        }
+        fields_obj = ROBJECT_FIELDS_OBJ(obj);
         break;
       default: {
         fields_obj = rb_obj_fields(obj, id);
@@ -1679,15 +1671,18 @@ rb_ivar_delete(VALUE obj, ID id, VALUE undef)
 
     if (UNLIKELY(rb_shape_complex_p(next_shape_id))) {
         if (UNLIKELY(!rb_shape_complex_p(old_shape_id))) {
-            if (type == T_OBJECT) {
+            if (fields_obj == obj || RB_TYPE_P(obj, T_OBJECT)) {
                 rb_evict_fields_to_hash(obj);
+                fields_obj = obj;
+                RUBY_ASSERT(rb_imemo_fields_complex_tbl(fields_obj) == ROBJECT_FIELDS_HASH(obj));
             }
             else {
                 fields_obj = imemo_fields_complex_from_obj(obj, fields_obj, next_shape_id);
             }
         }
         st_data_t key = id;
-        if (!st_delete(rb_imemo_fields_complex_tbl(fields_obj), &key, (st_data_t *)&val)) {
+        st_table *table = rb_imemo_fields_complex_tbl(fields_obj);
+        if (!st_delete(table, &key, (st_data_t *)&val)) {
             val = undef;
         }
     }
@@ -1732,7 +1727,9 @@ rb_ivar_delete(VALUE obj, ID id, VALUE undef)
         }
     }
 
-    RBASIC_SET_SHAPE_ID(obj, next_shape_id);
+    // FIXME: rb_shape_transition_heap is hard to use.
+    RBASIC_SET_SHAPE_ID(obj, rb_shape_transition_heap(next_shape_id, rb_shape_heap_index(RBASIC_SHAPE_ID(obj)) - 1));
+
     if (fields_obj != original_fields_obj) {
         switch (type) {
           case T_OBJECT:

--- a/variable.c
+++ b/variable.c
@@ -1421,7 +1421,12 @@ rb_obj_field_get(VALUE obj, shape_id_t target_shape_id)
         fields_obj = RCLASS_WRITABLE_FIELDS_OBJ(obj);
         break;
       case T_OBJECT:
-        fields_obj = obj;
+        if (FL_TEST_RAW(obj, ROBJECT_HEAP)) {
+            fields_obj = ROBJECT(obj)->as.extended;
+        }
+        else {
+            fields_obj = obj;
+        }
         break;
       case T_IMEMO:
         RUBY_ASSERT(IMEMO_TYPE_P(obj, imemo_fields));
@@ -1472,7 +1477,12 @@ rb_ivar_lookup(VALUE obj, ID id, VALUE undef)
         fields_obj = obj;
         break;
       case T_OBJECT:
-        fields_obj = obj;
+        if (FL_TEST_RAW(obj, ROBJECT_HEAP)) {
+            fields_obj = ROBJECT(obj)->as.extended;
+        }
+        else {
+            fields_obj = obj;
+        }
         break;
       default:
         fields_obj = rb_obj_fields(obj, id);
@@ -1658,7 +1668,12 @@ rb_ivar_delete(VALUE obj, ID id, VALUE undef)
         }
         break;
       case T_OBJECT:
-        fields_obj = obj;
+        if (FL_TEST_RAW(obj, ROBJECT_HEAP)) {
+            fields_obj = ROBJECT(obj)->as.extended;
+        }
+        else {
+            fields_obj = obj;
+        }
         break;
       default: {
         fields_obj = rb_obj_fields(obj, id);
@@ -1721,9 +1736,11 @@ rb_ivar_delete(VALUE obj, ID id, VALUE undef)
                     MEMCPY(rb_imemo_fields_ptr(fields_obj), fields, VALUE, new_fields_count);
                     SIZED_FREE_N(fields, RSHAPE_CAPACITY(old_shape_id));
                 }
-                else if (RSHAPE_CAPACITY(old_shape_id) != RSHAPE_CAPACITY(next_shape_id)) {
-                    IMEMO_OBJ_FIELDS(fields_obj)->as.external.ptr = ruby_xrealloc_sized(fields, RSHAPE_CAPACITY(next_shape_id) * sizeof(VALUE), RSHAPE_CAPACITY(old_shape_id) * sizeof(VALUE));
-                }
+                // TODO: check but I think we don't need this.
+                // FIXME: actually we might for JITs.
+                // else if (RSHAPE_CAPACITY(old_shape_id) != RSHAPE_CAPACITY(next_shape_id)) {
+                //     IMEMO_OBJ_FIELDS(fields_obj)->as.external.ptr = ruby_xrealloc_sized(fields, RSHAPE_CAPACITY(next_shape_id) * sizeof(VALUE), RSHAPE_CAPACITY(old_shape_id) * sizeof(VALUE));
+                // }
             }
         }
         else {
@@ -1906,18 +1923,19 @@ generic_ivar_set(VALUE obj, ID id, VALUE val)
 void
 rb_ensure_iv_list_size(VALUE obj, uint32_t current_len, uint32_t new_capacity)
 {
-    RUBY_ASSERT(!rb_obj_shape_complex_p(obj));
-
-    if (FL_TEST_RAW(obj, ROBJECT_HEAP)) {
-        SIZED_REALLOC_N(ROBJECT(obj)->as.heap.fields, VALUE, new_capacity, current_len);
-    }
-    else {
-        VALUE *ptr = ROBJECT_FIELDS(obj);
-        VALUE *newptr = ALLOC_N(VALUE, new_capacity);
-        MEMCPY(newptr, ptr, VALUE, current_len);
-        FL_SET_RAW(obj, ROBJECT_HEAP);
-        ROBJECT(obj)->as.heap.fields = newptr;
-    }
+    rb_bug("Need to update JITs");
+//     RUBY_ASSERT(!rb_obj_shape_complex_p(obj));
+//
+//     if (FL_TEST_RAW(obj, ROBJECT_HEAP)) {
+//         SIZED_REALLOC_N(ROBJECT(obj)->as.heap.fields, VALUE, new_capacity, current_len);
+//     }
+//     else {
+//         VALUE *ptr = ROBJECT_FIELDS(obj);
+//         VALUE *newptr = ALLOC_N(VALUE, new_capacity);
+//         MEMCPY(newptr, ptr, VALUE, current_len);
+//         FL_SET_RAW(obj, ROBJECT_HEAP);
+//         ROBJECT(obj)->as.heap.fields = newptr;
+//     }
 }
 
 static int
@@ -1968,14 +1986,26 @@ obj_field_set(VALUE obj, shape_id_t target_shape_id, ID field_name, VALUE val)
     else {
         attr_index_t index = RSHAPE_INDEX(target_shape_id);
 
+        VALUE fields_obj = obj;
+        VALUE *dest_buf = ROBJECT_FIELDS(obj);
+
         if (index >= RSHAPE_LEN(current_shape_id)) {
             if (UNLIKELY(index >= RSHAPE_CAPACITY(current_shape_id))) {
-                rb_ensure_iv_list_size(obj, RSHAPE_CAPACITY(current_shape_id), RSHAPE_CAPACITY(target_shape_id));
+                RUBY_ASSERT(!RB_OBJ_SHAREABLE_P(obj));
+
+                shape_id_t fields_shape_id = rb_shape_transition_no_heap(target_shape_id);
+                fields_obj = rb_imemo_fields_new(obj, fields_shape_id, false);
+                dest_buf = rb_imemo_fields_ptr(fields_obj);
+                rb_shape_copy_fields(fields_obj, dest_buf, current_shape_id, ROBJECT_FIELDS(obj), current_shape_id);
+
+                RBASIC_SET_SHAPE_ID(fields_obj, fields_shape_id);
+                RB_OBJ_WRITE(obj, &ROBJECT(obj)->as.extended, fields_obj);
+                FL_SET_RAW(obj, ROBJECT_HEAP);
             }
             RBASIC_SET_SHAPE_ID(obj, target_shape_id);
         }
 
-        RB_OBJ_WRITE(obj, &ROBJECT_FIELDS(obj)[index], val);
+        RB_OBJ_WRITE(fields_obj, &dest_buf[index], val);
 
         return index;
     }

--- a/variable.c
+++ b/variable.c
@@ -1478,12 +1478,7 @@ rb_ivar_lookup(VALUE obj, ID id, VALUE undef)
         fields_obj = obj;
         break;
       case T_OBJECT:
-        if (!rb_shape_complex_p(shape_id) && FL_TEST_RAW(obj, ROBJECT_HEAP)) {
-            fields_obj = ROBJECT_EXTENDED_FIELDS(obj);
-        }
-        else {
-            fields_obj = obj;
-        }
+        fields_obj = ROBJECT_FIELDS_OBJ(obj);
         break;
       default:
         fields_obj = rb_obj_fields(obj, id);
@@ -1587,20 +1582,9 @@ obj_transition_complex(VALUE obj, st_table *table)
     switch (BUILTIN_TYPE(obj)) {
       case T_OBJECT:
         {
-            VALUE *old_fields = NULL;
-            uint32_t old_fields_len = 0;
-            if (FL_TEST_RAW(obj, ROBJECT_HEAP)) {
-                old_fields = ROBJECT_FIELDS(obj);
-                old_fields_len = ROBJECT_FIELDS_CAPACITY(obj);
-            }
-            else {
-                FL_SET_RAW(obj, ROBJECT_HEAP);
-            }
+            FL_SET_RAW(obj, ROBJECT_HEAP);
             RBASIC_SET_SHAPE_ID(obj, shape_id);
             ROBJECT_SET_FIELDS_HASH(obj, table);
-            if (old_fields) {
-                SIZED_FREE_N(old_fields, old_fields_len);
-            }
         }
         break;
       case T_CLASS:
@@ -1986,20 +1970,26 @@ obj_field_set(VALUE obj, shape_id_t target_shape_id, ID field_name, VALUE val)
         attr_index_t index = RSHAPE_INDEX(target_shape_id);
 
         VALUE fields_obj = ROBJECT_FIELDS_OBJ(obj);
+        const VALUE original_fields_obj = fields_obj;
         VALUE *dest_buf = rb_imemo_fields_ptr(fields_obj);
 
         if (index >= RSHAPE_LEN(current_shape_id)) {
+            shape_id_t fields_shape_id = rb_shape_transition_no_heap(target_shape_id);
+
             if (UNLIKELY(index >= RSHAPE_CAPACITY(current_shape_id))) {
                 RUBY_ASSERT(!RB_OBJ_SHAREABLE_P(obj));
 
-                shape_id_t fields_shape_id = rb_shape_transition_no_heap(target_shape_id);
                 fields_obj = rb_imemo_fields_new(obj, fields_shape_id, RB_OBJ_SHAREABLE_P(obj));
                 dest_buf = rb_imemo_fields_ptr(fields_obj);
                 rb_shape_copy_fields(fields_obj, dest_buf, current_shape_id, ROBJECT_FIELDS(obj), current_shape_id);
+            }
 
-                RBASIC_SET_SHAPE_ID(fields_obj, fields_shape_id);
+            if (fields_obj != original_fields_obj) {
                 FL_SET_RAW(obj, ROBJECT_HEAP);
                 ROBJECT_SET_EXTENDED_FIELDS(obj, fields_obj);
+            }
+            if (fields_obj != obj) {
+                RBASIC_SET_SHAPE_ID(fields_obj, fields_shape_id);
             }
             RBASIC_SET_SHAPE_ID(obj, target_shape_id);
         }

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1216,10 +1216,7 @@ vm_getivar(VALUE obj, ID id, const rb_iseq_t *iseq, IVC ic, const struct rb_call
 
     switch (BUILTIN_TYPE(obj)) {
       case T_OBJECT:
-        fields_obj = obj;
-        if (FL_TEST_RAW(obj, ROBJECT_HEAP) && !rb_obj_shape_complex_p(obj)) {
-            fields_obj = ROBJECT(obj)->as.extended;
-        }
+        fields_obj = ROBJECT_FIELDS_OBJ(obj);
         break;
       case T_CLASS:
       case T_MODULE:

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1460,9 +1460,13 @@ vm_setivar(VALUE obj, VALUE val, rb_setivar_cache cache)
                 break;
             }
 
-            RB_OBJ_WRITE(obj, &ROBJECT_FIELDS(obj)[cache.index], val);
+            VALUE fields_obj = ROBJECT_FIELDS_OBJ(obj);
+            RB_OBJ_WRITE(obj, &rb_imemo_fields_ptr(fields_obj)[cache.index], val);
             if (shape_id != dest_shape_id) {
                 RBASIC_SET_SHAPE_ID(obj, dest_shape_id);
+                if (obj != fields_obj) {
+                    RBASIC_SET_SHAPE_ID(fields_obj, rb_shape_transition_no_heap(dest_shape_id));
+                }
             }
 
             RB_DEBUG_COUNTER_INC(ivar_set_ic_hit);
@@ -3957,8 +3961,7 @@ vm_call_ivar(rb_execution_context_t *ec, rb_control_frame_t *cfp, struct rb_call
     const struct rb_callcache *cc = calling->cc;
     RB_DEBUG_COUNTER_INC(ccf_ivar);
     cfp->sp -= 1;
-    VALUE ivar = vm_getivar(calling->recv, vm_cc_cme(cc)->def->body.attr.id, NULL, NULL, cc, TRUE, Qnil);
-    return ivar;
+    return vm_getivar(calling->recv, vm_cc_cme(cc)->def->body.attr.id, NULL, NULL, cc, TRUE, Qnil);
 }
 
 static VALUE

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1296,10 +1296,9 @@ vm_getivar(VALUE obj, ID id, const rb_iseq_t *iseq, IVC ic, const struct rb_call
 #endif
 
         if (UNLIKELY(rb_shape_complex_p(shape_id))) {
-            st_table *table = (st_table *)ivar_list;
+            st_table *table = rb_imemo_fields_complex_tbl(fields_obj);
 
             RUBY_ASSERT(table);
-            RUBY_ASSERT(table == rb_imemo_fields_complex_tbl(fields_obj));
 
             if (!st_lookup(table, id, &val)) {
                 val = default_value;

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1217,6 +1217,9 @@ vm_getivar(VALUE obj, ID id, const rb_iseq_t *iseq, IVC ic, const struct rb_call
     switch (BUILTIN_TYPE(obj)) {
       case T_OBJECT:
         fields_obj = obj;
+        if (FL_TEST_RAW(obj, ROBJECT_HEAP) && !rb_obj_shape_complex_p(obj)) {
+            fields_obj = ROBJECT(obj)->as.extended;
+        }
         break;
       case T_CLASS:
       case T_MODULE:


### PR DESCRIPTION
This is very very WIP, opening it to share with other given some work is happening in this area: (https://github.com/ruby/ruby/pull/17139)

The idea is that RObject, when out of space, instead of allocating a raw buffer, would instead allocate an IMEMO/field like other types.

