### PR TITLE
test/ruby/test_io.rb: do not set RLIMIT_NPROC

### DIFF
--- a/test/ruby/test_io.rb
+++ b/test/ruby/test_io.rb
@@ -1393,10 +1393,6 @@ class TestIO < Test::Unit::TestCase
     args = ['-e', '$>.write($<.read)'] if args.empty?
     ruby = EnvUtil.rubybin
     opts = {}
-    if defined?(Process::RLIMIT_NPROC)
-      lim = Process.getrlimit(Process::RLIMIT_NPROC)[1]
-      opts[:rlimit_nproc] = [lim, 2048].min
-    end
     f = IO.popen([ruby] + args, 'r+', opts)
     pid = f.pid
     yield(f)


### PR DESCRIPTION
On my computer, setting RLIMIT_NPROC to the low value of 2048 prevents the forked process from creating any new native threads and it causes make test-all to hang forever.

Remove it, as it does not seem to serve any purpose here.