### PR TITLE
[4.0] Use stack callinfo/calldata for super dispatch

### DIFF
--- a/insns.def
+++ b/insns.def
@@ -1093,9 +1093,24 @@ invokesuper
 // attr rb_snum_t sp_inc = sp_inc_of_sendish(cd->ci);
 // attr rb_snum_t comptime_sp_inc = sp_inc_of_sendish(ci);
 {
-    VALUE bh = vm_caller_setup_arg_block(ec, GET_CFP(), cd->ci, blockiseq, true);
-    val = vm_sendish(ec, GET_CFP(), cd, bh, mexp_search_super);
+    struct rb_callinfo adjusted_ci = VM_CI_ON_STACK(vm_ci_mid(cd->ci),
+                                                   vm_ci_flag(cd->ci),
+                                                   vm_ci_argc(cd->ci),
+                                                   vm_ci_kwarg(cd->ci));
+    const struct rb_callcache *original_cc = rbimpl_atomic_ptr_load((void **)&cd->cc, RBIMPL_ATOMIC_ACQUIRE);
+    struct rb_call_data adjusted_cd = {
+        .ci = &adjusted_ci,
+        .cc = original_cc,
+    };
+
+    VALUE bh = vm_caller_setup_arg_block(ec, GET_CFP(), adjusted_cd.ci, blockiseq, true);
+    val = vm_sendish(ec, GET_CFP(), &adjusted_cd, bh, mexp_search_super);
     JIT_EXEC(ec, val);
+
+    if (original_cc != adjusted_cd.cc && vm_cc_markable(adjusted_cd.cc)) {
+        rbimpl_atomic_ptr_store((volatile void **)&cd->cc, (void *)adjusted_cd.cc, RBIMPL_ATOMIC_RELEASE);
+        RB_OBJ_WRITTEN(GET_ISEQ(), Qundef, adjusted_cd.cc);
+    }
 
     if (UNDEF_P(val)) {
         RESTORE_REGS();

--- a/test/ruby/test_ractor.rb
+++ b/test/ruby/test_ractor.rb
@@ -42,6 +42,59 @@ class TestRactor < Test::Unit::TestCase
 =end
   end
 
+  def test_shareable_proc_define_method_super_method_missing
+    assert_ractor(<<~'RUBY', timeout: 30)
+      iterations = 1_000_000
+
+      class SuperFromShareableProcMethodMissingBase
+        def method_missing(mid, *) = mid
+      end
+
+      class SuperFromShareableProcMethodMissingChild < SuperFromShareableProcMethodMissingBase
+        BODY = Ractor.shareable_proc { super() }
+        define_method(:foo, &BODY)
+        define_method(:bar, &BODY)
+      end
+
+      [:foo, :bar].map do |mid|
+        Ractor.new(mid, iterations) do |mid, iterations|
+          obj = SuperFromShareableProcMethodMissingChild.new
+          iterations.times do
+            got = obj.__send__(mid)
+            raise "#{mid} returned #{got.inspect}" unless got == mid
+          end
+        end
+      end.each(&:value)
+    RUBY
+  end
+
+  def test_shareable_proc_define_method_super_method_entry
+    assert_ractor(<<~'RUBY', timeout: 30)
+      iterations = 1_000_000
+
+      class SuperFromShareableProcBase
+        def foo = :foo
+        def bar = :bar
+      end
+
+      class SuperFromShareableProcChild < SuperFromShareableProcBase
+        BODY = Ractor.shareable_proc { super() }
+        define_method(:foo, &BODY)
+        define_method(:bar, &BODY)
+      end
+
+      [:foo, :bar].map do |mid|
+        Ractor.new(mid, iterations) do |mid, iterations|
+          obj = SuperFromShareableProcChild.new
+          iterations.times do
+            got = obj.__send__(mid)
+            raise "#{mid} returned #{got.inspect}" unless got == mid
+          end
+        end
+      end.each(&:value)
+    RUBY
+  end
+
   def test_shareability_error_uses_inspect
     x = (+"").instance_exec { method(:to_s) }
     def x.to_s

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -6178,8 +6178,23 @@ rb_vm_invokesuper(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, CALL_
 {
     stack_check(ec);
 
-    VALUE bh = vm_caller_setup_arg_block(ec, GET_CFP(), cd->ci, blockiseq, true);
-    VALUE val = vm_sendish(ec, GET_CFP(), cd, bh, mexp_search_super);
+    struct rb_callinfo adjusted_ci = VM_CI_ON_STACK(vm_ci_mid(cd->ci),
+                                                   vm_ci_flag(cd->ci),
+                                                   vm_ci_argc(cd->ci),
+                                                   vm_ci_kwarg(cd->ci));
+    const struct rb_callcache *original_cc = rbimpl_atomic_ptr_load((void **)&cd->cc, RBIMPL_ATOMIC_ACQUIRE);
+    struct rb_call_data adjusted_cd = {
+        .ci = &adjusted_ci,
+        .cc = original_cc,
+    };
+
+    VALUE bh = vm_caller_setup_arg_block(ec, GET_CFP(), adjusted_cd.ci, blockiseq, true);
+    VALUE val = vm_sendish(ec, GET_CFP(), &adjusted_cd, bh, mexp_search_super);
+
+    if (original_cc != adjusted_cd.cc && vm_cc_markable(adjusted_cd.cc)) {
+        rbimpl_atomic_ptr_store((volatile void **)&cd->cc, (void *)adjusted_cd.cc, RBIMPL_ATOMIC_RELEASE);
+        RB_OBJ_WRITTEN(GET_ISEQ(), Qundef, adjusted_cd.cc);
+    }
 
     VM_EXEC(ec, val);
     return val;

--- a/zjit/src/cruby.rs
+++ b/zjit/src/cruby.rs
@@ -784,6 +784,12 @@ impl ID {
     }
 }
 
+impl Display for ID {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.contents_lossy())
+    }
+}
+
 /// Produce a Ruby string from a Rust string slice
 pub fn rust_str_to_ruby(str: &str) -> VALUE {
     unsafe { rb_utf8_str_new(str.as_ptr() as *const _, str.len() as i64) }

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -1254,8 +1254,9 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
                 write!(f, " # SendFallbackReason: {reason}")?;
                 Ok(())
             }
-            Insn::SendWithoutBlockDirect { recv, cd, iseq, args, .. } => {
-                write!(f, "SendWithoutBlockDirect {recv}, :{} ({:?})", ruby_call_method_name(*cd), self.ptr_map.map_ptr(iseq))?;
+            Insn::SendWithoutBlockDirect { recv, cme, iseq, args, .. } => {
+                let method_name = unsafe { (**cme).called_id };
+                write!(f, "SendWithoutBlockDirect {recv}, :{} ({:?})", method_name, self.ptr_map.map_ptr(iseq))?;
                 for arg in args {
                     write!(f, ", {arg}")?;
                 }


### PR DESCRIPTION
Previously vm_search_super_method would allocate a new callinfo and write it back into the iseq's call data. Because iseqs can be shared between Ractors (e.g. via Ractor.shareable_proc + define_method), two Ractors invoking super through the same iseq could race on the ci/cc, producing wrong dispatch or crashes from torn callcache reads on weakly-ordered architectures.

Build the adjusted callinfo on the stack instead, mirroring sendforward/invokesuperforward. The callcache is also loaded and stored back with acquire/release atomics so it can be safely shared.

[Bug #22084]