### PR TITLE
refactor: Centralize `ISASCII` early exit for search_nonascii

### DIFF
--- a/benchmark/string_coderange_scan.yml
+++ b/benchmark/string_coderange_scan.yml
@@ -1,0 +1,10 @@
+prelude: |
+  def unknown(s) = s.b.force_encoding("UTF-8")
+  multibyte   = unknown("\u{00e9}" * 16384)   # best case: every byte non-ASCII
+  alternating = unknown("\u{00e9}a" * 10922)  # worst case: non-ASCII then ASCII
+  ascii       = unknown("a" * 32768)          # baseline
+
+benchmark:
+  coderange_multibyte:   multibyte.dup.valid_encoding?
+  coderange_alternating: alternating.dup.valid_encoding?
+  coderange_ascii:       ascii.dup.valid_encoding?

--- a/string.c
+++ b/string.c
@@ -713,6 +713,10 @@ search_nonascii(const char *p, const char *e)
 {
     const char *s, *t;
 
+    if (p < e && !ISASCII(*p)) {
+        return p;
+    }
+
 #if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L)
 # if SIZEOF_UINTPTR_T == 8
 #  define NONASCII_MASK UINT64_C(0x8080808080808080)
@@ -2297,26 +2301,22 @@ enc_strlen(const char *p, const char *e, rb_encoding *enc, int cr)
         c = 0;
         if (ENC_CODERANGE_CLEAN_P(cr)) {
             while (p < e) {
-                if (ISASCII(*p)) {
-                    q = search_nonascii(p, e);
-                    if (!q)
-                        return c + (e - p);
-                    c += q - p;
-                    p = q;
-                }
+                q = search_nonascii(p, e);
+                if (!q)
+                    return c + (e - p);
+                c += q - p;
+                p = q;
                 p += rb_enc_fast_mbclen(p, e, enc);
                 c++;
             }
         }
         else {
             while (p < e) {
-                if (ISASCII(*p)) {
-                    q = search_nonascii(p, e);
-                    if (!q)
-                        return c + (e - p);
-                    c += q - p;
-                    p = q;
-                }
+                q = search_nonascii(p, e);
+                if (!q)
+                    return c + (e - p);
+                c += q - p;
+                p = q;
                 p += rb_enc_mbclen(p, e, enc);
                 c++;
             }
@@ -2354,15 +2354,13 @@ rb_enc_strlen_cr(const char *p, const char *e, rb_encoding *enc, int *cr)
     else if (rb_enc_asciicompat(enc)) {
         c = 0;
         while (p < e) {
-            if (ISASCII(*p)) {
-                q = search_nonascii(p, e);
-                if (!q) {
-                    if (!*cr) *cr = ENC_CODERANGE_7BIT;
-                    return c + (e - p);
-                }
-                c += q - p;
-                p = q;
+            q = search_nonascii(p, e);
+            if (!q) {
+                if (!*cr) *cr = ENC_CODERANGE_7BIT;
+                return c + (e - p);
             }
+            c += q - p;
+            p = q;
             ret = rb_enc_precise_mbclen(p, e, enc);
             if (MBCLEN_CHARFOUND_P(ret)) {
                 *cr |= ENC_CODERANGE_VALID;
@@ -3020,16 +3018,14 @@ str_nth_len(const char *p, const char *e, long *nthp, rb_encoding *enc)
                 *nthp = nth;
                 return (char *)e;
             }
-            if (ISASCII(*p)) {
-                p2 = search_nonascii(p, e2);
-                if (!p2) {
-                    nth -= e2 - p;
-                    *nthp = nth;
-                    return (char *)e2;
-                }
-                nth -= p2 - p;
-                p = p2;
+            p2 = search_nonascii(p, e2);
+            if (!p2) {
+                nth -= e2 - p;
+                *nthp = nth;
+                return (char *)e2;
             }
+            nth -= p2 - p;
+            p = p2;
             n = rb_enc_mbclen(p, e, enc);
             p += n;
             nth--;
@@ -11850,17 +11846,11 @@ enc_str_scrub(rb_encoding *enc, VALUE str, VALUE repl, int cr)
             else if (MBCLEN_CHARFOUND_P(ret)) {
                 cr = ENC_CODERANGE_VALID;
                 p += MBCLEN_CHARFOUND_LEN(ret);
-                /*
-                 * After a valid multibyte character, skip the following ASCII run.
-                 * If the next byte is already non-ASCII, search_nonascii would only
-                 * rediscover p after its word-at-a-time setup.
-                 */
-                if (p < e && ISASCII(*p)) {
-                    p = search_nonascii(p, e);
-                    if (!p) {
-                        p = e;
-                        break;
-                    }
+                /* After a multibyte character, fast-skip the following ASCII run. */
+                p = search_nonascii(p, e);
+                if (!p) {
+                    p = e;
+                    break;
                 }
             }
             else if (MBCLEN_INVALID_P(ret)) {


### PR DESCRIPTION
## Background

Follow-up to #16359.

Several callers of `search_nonascii` guard the call with an `ISASCII(*p)` check, to prevent doing the extra work in cases where the current byte is non-ASCII:

```c
# string.c:11851

if (p < e && ISASCII(*p)) {
  p = search_nonascii(p, e);
  if (!p) {
    p = e;
    break;
  }
}
```

This pattern is duplicated across `enc_strlen`, `rb_enc_strlen_cr`, `str_nth_len`, and `enc_str_scrub` — the last added in #16359.

The guard exists because, if `*p` is already non-ASCII, `search_nonascii` would only rediscover `p` after going through its word-at-a-time setup which can be expensive. In #16359 this took what would have been a slight regression in 2 benchmarks to a net-neutral.

## Proposal

Move the early exit into `search_nonascii` itself, so the setup is skipped when `*p` is already non-ASCII:

```diff
static inline const char *
search_nonascii(const char *p, const char *e)
{
    const char *s, *t;

+    if (p < e && !ISASCII(*p)) {
+        return p;
+    }
+
#if defined(__STDC_VERSION__) && ...
```

Then the call sites can call `search_nonascii` unconditionally and drop their `ISASCII` guards:

```diff
# string.c:11851

- if (p < e && ISASCII(*p)) {
  p = search_nonascii(p, e);
```

## Justification

This does not change any observable behaviour. The new early exit returns the exact same value; it just skips the setup. Moving this behaviour means that callers of `search_nonascii` don't need to be aware of the performance impact of word-at-a-time setup done by `search_nonascii` such as in #16359. 

The early exit now lives in one place instead of being repeated at every call site.

## Tradeoffs

Non-ASCII-heavy strings now always enter `search_nonascii` instead of skipping the call entirely. That means the early exit fires on every iteration rather than the call being skipped by the caller. However, since `search_nonascii` is `static inline` this should be free when it inlines which was true in the cases I observed.

We now add a branch to callers that previously did not guard the `search_nonascii` call such as `coderange_scan`. This is called once per entry meaning the likely worst case string would be something along the lines of `a🙂a🙂a🙂a🙂` where the impact would be `(cost to evaluate branch) - (time saved from word-at-a-time setup)`.

## Results

| Benchmark | Control | Experiment | Speedup |
| :--- | ---: | ---: | :--- |
| `coderange_multibyte` | 28,780 ns | 25,491 ns | 1.13x |
| `coderange_alternating` | 19,169 ns | 20,259 ns | 0.95x |
| `coderange_ascii` | 47 ns | 47 ns | 1.00x |

## Methodology

- Apple M4 Pro, macOS 26.3.1.
- Used built-in benchmark tooling
- Experiment: built ruby 4.1.0dev from this branch

#### Note
I updated an old comment from #16359.