### PR TITLE
Ensure DTrace probes capture all GC marking events

### DIFF
--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -5965,7 +5965,6 @@ gc_marks_start(rb_objspace_t *objspace, int full_mark)
 static bool
 gc_marks(rb_objspace_t *objspace, int full_mark)
 {
-    gc_prof_mark_timer_start(objspace);
     gc_marking_enter(objspace);
 
     bool marking_finished = false;
@@ -5986,7 +5985,6 @@ gc_marks(rb_objspace_t *objspace, int full_mark)
 #endif
 
     gc_marking_exit(objspace);
-    gc_prof_mark_timer_stop(objspace);
 
     return marking_finished;
 }
@@ -6882,6 +6880,8 @@ gc_marking_enter(rb_objspace_t *objspace)
 {
     GC_ASSERT(during_gc != 0);
 
+    gc_prof_mark_timer_start(objspace);
+
     if (MEASURE_GC) {
         gc_clock_start(&objspace->profile.marking_start_time);
     }
@@ -6897,6 +6897,8 @@ gc_marking_exit(rb_objspace_t *objspace)
     if (MEASURE_GC) {
         objspace->profile.marking_time_ns += gc_clock_end(&objspace->profile.marking_start_time);
     }
+
+    gc_prof_mark_timer_stop(objspace);
 }
 
 static void


### PR DESCRIPTION
`gc_prof_mark_timer_start` and `gc_prof_mark_timer_stop` include DTrace hooks for the `MARK_BEGIN` and `MARK_END` events, respectively. Previously, those probes are only triggered in `gc_marks`.  However, `gc_marks_continue` and `gc_rest` also contain marking activities, but are not captured by the probes.

We move the invocation of `gc_prof_mark_timer_start` and `gc_prof_mark_timer_stop` into `gc_marking_enter` and `gc_marking_exit` to ensure all marking activities are captured by the probes.

This change mainly affects tools that use those DTrace probes to trace GC events.  The following are screenshots of an eBPF-based tracing tool for CRuby which I am still developing.  It illustrates the GC events (`gc_enter` to `gc_exit`) and their marking and sweeping events (`gc_marking_enter` to `gc_marking_leave`, and `gc_sweeping_enter` and `gc_sweeping_leave`, respectively) on a timeline.

Before this change, the `MARK_BEGIN` and `MARK_END` probes only capture marking under `gc_start`, but marking events under `gc_continue` are lost.

<img width="1130" height="357" alt="Screenshot_20260601_164424" src="https://github.com/user-attachments/assets/ee893321-d9bf-4dec-8aa1-fd033238f6ff" />

After this change, we see the marking events under `gc_continue`, too.

<img width="1116" height="310" alt="Screenshot_20260601_164654" src="https://github.com/user-attachments/assets/365db220-115d-4fe1-a7f5-36eb3e70b850" />

