### PR TITLE
ZJIT: Add codegen tests for fixnum mod

### DIFF
--- a/zjit/src/codegen_tests.rs
+++ b/zjit/src/codegen_tests.rs
@@ -2286,6 +2286,36 @@ fn test_fixnum_floor() {
 }
 
 #[test]
+fn test_fixnum_mod() {
+    eval("
+        def test(a, b) = a % b
+        test(13, 4) # profile opt_mod
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_mod);
+    assert_snapshot!(assert_compiles("[test(13, 4), test(13, 13), test(5, 7)]"), @"[1, 0, 5]");
+}
+
+#[test]
+fn test_fixnum_mod_negative() {
+    eval("
+        def test(a, b) = a % b
+        test(7, 3) # profile opt_mod
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_mod);
+    assert_snapshot!(assert_compiles("[test(-7, 3), test(7, -3), test(-7, -3)]"), @"[2, -2, -1]");
+}
+
+#[test]
+fn test_fixnum_mod_by_zero() {
+    eval("
+        def test(a, b) = a % b rescue :zero_div
+        test(13, 4) # profile opt_mod
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_mod);
+    assert_snapshot!(assert_compiles_allowing_exits("test(13, 0)"), @":zero_div");
+}
+
+#[test]
 fn test_opt_not() {
     eval("
         def test(obj) = !obj


### PR DESCRIPTION
It appears to be on lines [59 through 63 of `ruby/test/ruby/test_optimization.rb`](https://github.com/ruby/ruby/blob/f916141a2db972c39ad73ad584d505cc4dc63cb8/test/ruby/test_optimization.rb#L59-L63), 
but there are no test cases in `codegen_tests.rs`.
There do seem to be test cases for `plus`, `minus`, `div`, and others, though.

I added them, cover the basic case, negative operands, and division by zero.