### PR TITLE
Run FREEOBJ GC hooks as separate step before actual sweeping

### DIFF
--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -3688,10 +3688,6 @@ gc_sweep_plane(rb_objspace_t *objspace, rb_heap_t *heap, uintptr_t p, bits_t bit
 #endif
 
                 if (!rb_gc_obj_needs_cleanup_p(vp)) {
-                    if (RB_UNLIKELY(objspace->hook_events & RUBY_INTERNAL_EVENT_FREEOBJ)) {
-                        rb_gc_event_hook(vp, RUBY_INTERNAL_EVENT_FREEOBJ);
-                    }
-
                     (void)VALGRIND_MAKE_MEM_UNDEFINED((void*)p, slot_size);
                     heap_page_add_freeobj(objspace, sweep_page, vp);
                     gc_report(3, objspace, "page_sweep: %s (fast path) added to freelist\n", rb_obj_info(vp));
@@ -3699,8 +3695,6 @@ gc_sweep_plane(rb_objspace_t *objspace, rb_heap_t *heap, uintptr_t p, bits_t bit
                 }
                 else {
                     gc_report(2, objspace, "page_sweep: free %p\n", (void *)p);
-
-                    rb_gc_event_hook(vp, RUBY_INTERNAL_EVENT_FREEOBJ);
 
                     rb_gc_obj_free_vm_weak_references(vp);
                     if (rb_gc_obj_free(objspace, vp)) {
@@ -3921,10 +3915,70 @@ gc_ractor_newobj_cache_clear(void *c, void *data)
 }
 
 static void
+gc_sweep_freeobj_hooks_page(rb_objspace_t *objspace, struct heap_page *page)
+{
+    bits_t *bits = page->mark_bits;
+    uintptr_t p = (uintptr_t)page->start;
+    short slot_size = page->slot_size;
+    int total_slots = page->total_slots;
+    int bitmap_plane_count = CEILDIV(total_slots, BITS_BITLENGTH);
+
+    int out_of_range_bits = total_slots % BITS_BITLENGTH;
+    bits_t last_plane_mask = (out_of_range_bits != 0)
+        ? ~(((bits_t)1 << out_of_range_bits) - 1)
+        : 0;
+
+    for (int j = 0; j < bitmap_plane_count; j++) {
+        bits_t bitset = ~bits[j];
+        if (j == bitmap_plane_count - 1) {
+            bitset &= ~last_plane_mask;
+        }
+
+        uintptr_t pp = p;
+        while (bitset) {
+            if (bitset & 1) {
+                VALUE vp = (VALUE)pp;
+                asan_unpoisoning_object(vp) {
+                    switch (BUILTIN_TYPE(vp)) {
+                      case T_NONE:
+                      case T_ZOMBIE:
+                      case T_MOVED:
+                        break;
+                      default:
+                        rb_gc_event_hook(vp, RUBY_INTERNAL_EVENT_FREEOBJ);
+                        break;
+                    }
+                }
+            }
+            pp += slot_size;
+            bitset >>= 1;
+        }
+        p += BITS_BITLENGTH * slot_size;
+    }
+}
+
+static void
+gc_sweep_freeobj_hooks(rb_objspace_t *objspace)
+{
+    for (int i = 0; i < HEAP_COUNT; i++) {
+        rb_heap_t *heap = &heaps[i];
+        struct heap_page *page = NULL;
+
+        ccan_list_for_each(&heap->pages, page, page_node) {
+            gc_sweep_freeobj_hooks_page(objspace, page);
+        }
+    }
+}
+
+static void
 gc_sweep_start(rb_objspace_t *objspace)
 {
     gc_mode_transition(objspace, gc_mode_sweeping);
     objspace->rincgc.pooled_slots = 0;
+
+    if (RB_UNLIKELY(objspace->hook_events & RUBY_INTERNAL_EVENT_FREEOBJ)) {
+        gc_sweep_freeobj_hooks(objspace);
+    }
 
 #if GC_CAN_COMPILE_COMPACTION
     if (objspace->flags.during_compacting) {


### PR DESCRIPTION
Previously, when a `RUBY_INTERNAL_EVENT_FREEOBJ` hook was registered, we would run it immediately before we called the `obj_free` on an object. This PR changes this so that `FREEOBJ` is called on all objects which are to be freed in the GC cycle before doing any actual sweeping.

This should simplify `gc_sweep_plane` and make it easier for the compiler to inline and be slightly faster (though a predictable branch not taken is _basically_ free). More importantly this simplifies and paves the way for more advanced techniques like sweeping concurrently or avoiding examining each object (when cleanup/finalization isn't required).

This should have no negative effect on `ObjectSpace.trace_object_allocations_start`, the only blessed use of this API, which will work exactly the same. I also don't think it will impact other tools (profilers?) which listen to the semi-private event. The event will run _earlier_ but it would take some effort to observe a difference.

---

With this change `Object.allocate` seems very marginally faster (definitely in margin of error but seems consistent).

```
❯ ips --yjit --ruby ruby-base --ruby ruby-test -e 'Object.allocate'
ruby 4.1.0dev (2026-06-01T19:55:37Z master 9c62016982) +YJIT dev_nodebug +PRISM [arm64-darwin25]
     Object.allocate:   113.178M i/s (± 0.3%, GC 25.4%)

ruby 4.1.0dev (2026-06-02T19:01:00Z freeobj_hook_step 327e663cf6) +YJIT dev_nodebug +PRISM [arm64-darwin25]
     Object.allocate:   115.949M i/s (± 0.6%, GC 23.5%)


Summary
  ruby ruby-test ran
    1.02 ± 0.01 times faster than ruby ruby-base
```

With object tracing enabled (which is 20x slower, so I don't think should matter) there is no significant regression compared to master.

```ruby
require "objspace"
ObjectSpace.trace_object_allocations_start

IPS.ips do |x|
  x.report("Object.allocate")
end
```

```
❯ ips --yjit --ruby ruby-base --ruby ruby-test benchmark_trace_allocation.rb
ruby 4.1.0dev (2026-06-01T19:55:37Z master 9c62016982) +YJIT dev_nodebug +PRISM [arm64-darwin25]
     Object.allocate:     4.351M i/s (± 2.0%, GC 31.2%)

ruby 4.1.0dev (2026-06-02T19:01:00Z freeobj_hook_step 327e663cf6) +YJIT dev_nodebug +PRISM [arm64-darwin25]
     Object.allocate:     4.407M i/s (± 1.8%, GC 30.5%)


Summary
  ruby ruby-test ran
    1.01 ± 0.03 times faster than ruby ruby-base
```