### PR TITLE
ZJIT: Use shape id as cache key for object layout

### DIFF
--- a/zjit/src/cruby.rs
+++ b/zjit/src/cruby.rs
@@ -274,6 +274,14 @@ pub type YarvInsnIdx = usize;
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct ShapeId(pub u32);
 
+ #[derive(PartialEq, Eq)]
+pub enum ShapeLayout {
+    RObject,
+    RClass,
+    RData,
+    Other,
+}
+
 pub const INVALID_SHAPE_ID: ShapeId = ShapeId(rb_invalid_shape_id);
 
 impl ShapeId {
@@ -287,6 +295,16 @@ impl ShapeId {
 
     pub fn is_frozen(self) -> bool {
         (self.0 & SHAPE_ID_FL_FROZEN) != 0
+    }
+
+    pub fn layout(self) -> ShapeLayout {
+        match self.0 & SHAPE_ID_LAYOUT_MASK {
+            SHAPE_ID_LAYOUT_ROBJECT => ShapeLayout::RObject,
+            SHAPE_ID_LAYOUT_RCLASS => ShapeLayout::RClass,
+            SHAPE_ID_LAYOUT_RDATA => ShapeLayout::RData,
+            SHAPE_ID_LAYOUT_OTHER => ShapeLayout::Other,
+            layout => unreachable!("unknown shape layout bits: {layout:#x}"),
+        }
     }
 }
 

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -4402,7 +4402,6 @@ impl Function {
         // Too-complex shapes use hash tables; rb_shape_get_iv_index doesn't support them.
         // Callers must filter these out before calling load_ivar.
         assert!(!recv_type.shape().is_complex(), "load_ivar called with too-complex shape");
-
         let mut ivar_index: attr_index_t = 0;
         if ! unsafe { rb_shape_get_iv_index(recv_type.shape().0, id, &mut ivar_index) } {
             // If there is no IVAR index, then the ivar was undefined when we
@@ -4414,14 +4413,7 @@ impl Function {
         let layout = recv_type.shape().layout();
 
         match layout {
-            // If we have an rclass layout, we load it from the fields obj from
-            // the class ext.  When RUBY_BOX is enabled, boxable classes
-            // (classes like String which are defined at boot time), those classes
-            // will have the "other" layout, so we are free to rely on this check
-            // whether or not RUBY_BOX is enabled
             ShapeLayout::RClass | ShapeLayout::RData => {
-                // RClass and RData are very similar, but the fields object
-                // is stored at a different offset.
                 let offset = if layout == ShapeLayout::RClass {
                     RCLASS_OFFSET_PRIME_FIELDS_OBJ as i32
                 } else {
@@ -4478,16 +4470,9 @@ impl Function {
                             // need to wrap it again here.
                             self.push_insn_id(block, insn_id); continue;
                         }
-
-                        // Guard that the object is a heap object
                         let self_val = self.load_ivar_guard_type(block, self_val, recv_type, state);
-
-                        // Get the runtime shape value
                         let shape = self.load_shape(block, self_val);
-
-                        // Test that runtime shape is equal to the compile time shape
                         self.guard_shape(block, shape, recv_type.shape(), state, Some(Recompile::ProfileSelf));
-
                         let replacement = self.load_ivar(block, self_val, recv_type, id);
                         self.make_equal_to(insn_id, replacement);
                     }
@@ -7210,15 +7195,10 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                             if profiled_shape.is_complex() { continue; }
                             if seen_shape.contains(&profiled_shape) { continue; }
                             seen_shape.push(profiled_shape);
-
-                            // Load the runtime shape from the object, we know
-                            // it's OK to do this because we did GuardType above.
                             let runtime_shape = fun.load_shape(block, self_param);
-
                             // The expected shape can change over run, so we put it
                             // as a pointer to keep it stable in snapshot tests.
                             let expected_shape = fun.push_insn(block, Insn::Const { val: Const::CShape(profiled_shape) });
-
                             let has_shape = fun.push_insn(block, Insn::IsBitEqual { left: runtime_shape, right: expected_shape });
                             let iftrue_block = fun.new_block(insn_idx);
                             let target = BranchEdge { target: iftrue_block, args: vec![] };
@@ -8371,29 +8351,16 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                             if profiled_type.is_empty() { break; }
                             // Instance variable lookups on immediate values are always nil; don't bother
                             if profiled_type.flags().is_immediate() { continue; }
-
                             let profiled_shape = profiled_type.shape();
-
                             // Too-complex shapes use hash tables for ivars;
                             // rb_shape_get_iv_index doesn't work for them.
                             // Let the fallthrough GetIvar handle these.
                             if profiled_shape.is_complex() { continue; }
-
-                            // If we've generated code for this shape already,
-                            // then skip it
                             if seen_shape.contains(&profiled_shape) { continue; }
                             seen_shape.push(profiled_shape);
-
-                            // Load the runtime shape from the object, we know
-                            // it's OK to do this because we did GuardType above
                             let runtime_shape = fun.load_shape(block, self_param);
-
                             // Load the expected shape to a variable
                             let expected_shape = fun.push_insn(block, Insn::Const { val: Const::CShape(profiled_shape) });
-
-                            // If the expected is equal to the actual, then
-                            // we're good and can load the IV.  Otherwise jump
-                            // to the next block.
                             let has_shape = fun.push_insn(block, Insn::IsBitEqual { left: runtime_shape, right: expected_shape });
                             let iftrue_block = fun.new_block(insn_idx);
                             let target = BranchEdge { target: iftrue_block, args: vec![] };

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -4422,7 +4422,7 @@ impl Function {
 
                 let fields_obj = self.push_insn(block, Insn::LoadField {
                     recv: self_val, id: FieldName::fields_obj,
-                    offset: offset,
+                    offset,
                     return_type: types::RubyValue,
                 });
                 self.load_ivar_from_fields(block, fields_obj, recv_type.flags().is_fields_embedded(), id, ivar_index)

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -4398,10 +4398,11 @@ impl Function {
         }
     }
 
-    fn load_ivar(&mut self, block: BlockId, self_val: InsnId, recv_type: ProfiledType, id: ID, state: InsnId) -> InsnId {
+    fn load_ivar(&mut self, block: BlockId, self_val: InsnId, recv_type: ProfiledType, id: ID) -> InsnId {
         // Too-complex shapes use hash tables; rb_shape_get_iv_index doesn't support them.
         // Callers must filter these out before calling load_ivar.
         assert!(!recv_type.shape().is_complex(), "load_ivar called with too-complex shape");
+
         let mut ivar_index: attr_index_t = 0;
         if ! unsafe { rb_shape_get_iv_index(recv_type.shape().0, id, &mut ivar_index) } {
             // If there is no IVAR index, then the ivar was undefined when we
@@ -4409,37 +4410,41 @@ impl Function {
             // shape + iv name
             return self.push_insn(block, Insn::Const { val: Const::Value(Qnil) });
         }
-        if recv_type.flags().is_t_class() || recv_type.flags().is_t_module() {
-            // Class/module ivar: load from prime classext's fields_obj
-            if !self.assume_root_box(block, state) {
-                // Non-root box active: fall back to C call
+
+        let layout = recv_type.shape().layout();
+
+        match layout {
+            // If we have an rclass layout, we load it from the fields obj from
+            // the class ext.  When RUBY_BOX is enabled, boxable classes
+            // (classes like String which are defined at boot time), those classes
+            // will have the "other" layout, so we are free to rely on this check
+            // whether or not RUBY_BOX is enabled
+            ShapeLayout::RClass | ShapeLayout::RData => {
+                // RClass and RData are very similar, but the fields object
+                // is stored at a different offset.
+                let offset = if layout == ShapeLayout::RClass {
+                    RCLASS_OFFSET_PRIME_FIELDS_OBJ as i32
+                } else {
+                    TDATA_OFFSET_FIELDS_OBJ as i32
+                };
+
+                let fields_obj = self.push_insn(block, Insn::LoadField {
+                    recv: self_val, id: FieldName::fields_obj,
+                    offset: offset,
+                    return_type: types::RubyValue,
+                });
+                self.load_ivar_from_fields(block, fields_obj, recv_type.flags().is_fields_embedded(), id, ivar_index)
+            },
+            ShapeLayout::RObject => {
+                self.load_ivar_from_fields(block, self_val, recv_type.flags().is_embedded(), id, ivar_index)
+            },
+            ShapeLayout::Other => {
+                // Non-T_OBJECT, non-class/module, non-typed-data: fall back to C call
                 // NOTE: it's fine to use rb_ivar_get_at_no_ractor_check because
                 // getinstancevariable does assume_single_ractor_mode()
-                return self.load_ivar_c_call(block, self_val, ivar_index);
+                self.load_ivar_c_call(block, self_val, ivar_index)
             }
-            // Root box only: load directly from prime classext
-            let fields_obj = self.push_insn(block, Insn::LoadField {
-                recv: self_val, id: FieldName::fields_obj,
-                offset: RCLASS_OFFSET_PRIME_FIELDS_OBJ as i32,
-                return_type: types::RubyValue,
-            });
-            return self.load_ivar_from_fields(block, fields_obj, recv_type.flags().is_fields_embedded(), id, ivar_index);
         }
-        if recv_type.flags().is_t_data() {
-            let fields_obj = self.push_insn(block, Insn::LoadField {
-                recv: self_val, id: FieldName::fields_obj,
-                offset: TDATA_OFFSET_FIELDS_OBJ as i32,
-                return_type: types::RubyValue,
-            });
-            return self.load_ivar_from_fields(block, fields_obj, recv_type.flags().is_fields_embedded(), id, ivar_index);
-        }
-        if recv_type.flags().is_t_object() {
-            return self.load_ivar_from_fields(block, self_val, recv_type.flags().is_embedded(), id, ivar_index);
-        }
-        // Non-T_OBJECT, non-class/module, non-typed-data: fall back to C call
-        // NOTE: it's fine to use rb_ivar_get_at_no_ractor_check because
-        // getinstancevariable does assume_single_ractor_mode()
-        return self.load_ivar_c_call(block, self_val, ivar_index);
     }
 
     fn optimize_getivar(&mut self) {
@@ -4473,10 +4478,17 @@ impl Function {
                             // need to wrap it again here.
                             self.push_insn_id(block, insn_id); continue;
                         }
+
+                        // Guard that the object is a heap object
                         let self_val = self.load_ivar_guard_type(block, self_val, recv_type, state);
+
+                        // Get the runtime shape value
                         let shape = self.load_shape(block, self_val);
+
+                        // Test that runtime shape is equal to the compile time shape
                         self.guard_shape(block, shape, recv_type.shape(), state, Some(Recompile::ProfileSelf));
-                        let replacement = self.load_ivar(block, self_val, recv_type, id, state);
+
+                        let replacement = self.load_ivar(block, self_val, recv_type, id);
                         self.make_equal_to(insn_id, replacement);
                     }
                     Insn::DefinedIvar { self_val, id, pushval, state } => {
@@ -7176,12 +7188,11 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                     let pushval = get_arg(pc, 2);
                     if let Some(summary) = fun.polymorphic_summary(&profiles, self_param, exit_state.insn_idx) {
                         self_param = fun.push_insn(block, Insn::GuardType { val: self_param, guard_type: types::HeapBasicObject, state: exit_id, recompile: None });
-                        let rbasic_flags = fun.load_rbasic_flags(block, self_param);
                         let join_block = insn_idx_to_block.get(&insn_idx).copied().unwrap_or_else(|| fun.new_block(insn_idx));
                         let join_param = fun.push_insn(join_block, Insn::Param);
-                        // Dedup by expected shape and type so objects with different classes
-                        // but the same shape can share code.
-                        let mut seen_shape_and_flags = Vec::with_capacity(summary.buckets().len());
+                        // Dedup by expected shape so objects with different classes but the
+                        // same shape can share code.
+                        let mut seen_shape = Vec::with_capacity(summary.buckets().len());
                         for &profiled_type in summary.buckets() {
                             // End of the buckets
                             if profiled_type.is_empty() { break; }
@@ -7191,34 +7202,36 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                             // Class/module/T_DATA ivars use different storage rules.
                             // Let the fallthrough DefinedIvar handle these.
                             if !profiled_type.flags().is_t_object() { continue; }
-                            let expected_shape = profiled_type.shape();
-                            let (expected_rbasic_flags, rbasic_flags_mask) = profiled_type.rbasic_flags_and_mask();
-                            assert!(expected_shape.is_valid());
+                            let profiled_shape = profiled_type.shape();
+                            assert!(profiled_shape.is_valid());
                             // Too-complex shapes use hash tables for ivars;
                             // rb_shape_get_iv_index doesn't work for them.
                             // Let the fallthrough DefinedIvar handle these.
-                            if expected_shape.is_complex() { continue; }
-                            if seen_shape_and_flags.contains(&expected_rbasic_flags) { continue; }
-                            seen_shape_and_flags.push(expected_rbasic_flags);
-                            let rbasic_flags_mask = fun.push_insn(block, Insn::Const { val: Const::CUInt64(rbasic_flags_mask) });
+                            if profiled_shape.is_complex() { continue; }
+                            if seen_shape.contains(&profiled_shape) { continue; }
+                            seen_shape.push(profiled_shape);
+
+                            // Load the runtime shape from the object, we know
+                            // it's OK to do this because we did GuardType above.
+                            let runtime_shape = fun.load_shape(block, self_param);
+
                             // The expected shape can change over run, so we put it
                             // as a pointer to keep it stable in snapshot tests.
-                            let expected_rbasic_flags = fun.push_insn(block, Insn::Const { val: Const::CPtr(ptr::without_provenance(expected_rbasic_flags.to_usize())) });
-                            let expected_rbasic_flags = fun.push_insn(block, Insn::RefineType { val: expected_rbasic_flags, new_type: types::CUInt64 });
-                            let masked = fun.push_insn(block, Insn::IntAnd { left: rbasic_flags, right: rbasic_flags_mask});
-                            let has_shape_and_type = fun.push_insn(block, Insn::IsBitEqual { left: masked, right: expected_rbasic_flags });
+                            let expected_shape = fun.push_insn(block, Insn::Const { val: Const::CShape(profiled_shape) });
+
+                            let has_shape = fun.push_insn(block, Insn::IsBitEqual { left: expected_shape, right: runtime_shape });
                             let iftrue_block = fun.new_block(insn_idx);
                             let target = BranchEdge { target: iftrue_block, args: vec![] };
                             let fall_through = fun.new_block(insn_idx);
 
-                            fun.push_insn(block, Insn::CondBranch { val: has_shape_and_type,
+                            fun.push_insn(block, Insn::CondBranch { val: has_shape,
                                 if_true: target,
                                 if_false: BranchEdge { target: fall_through, args: vec![] }
                             });
 
                             block = fall_through;
                             let mut ivar_index: attr_index_t = 0;
-                            let result = if unsafe { rb_shape_get_iv_index(expected_shape.0, id, &mut ivar_index) } {
+                            let result = if unsafe { rb_shape_get_iv_index(profiled_shape.0, id, &mut ivar_index) } {
                                 fun.push_insn(iftrue_block, Insn::Const { val: Const::Value(pushval) })
                             } else {
                                 fun.push_insn(iftrue_block, Insn::Const { val: Const::Value(Qnil) })
@@ -8347,45 +8360,52 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                     }
                     if let Some(summary) = fun.polymorphic_summary(&profiles, self_param, exit_state.insn_idx) {
                         self_param = fun.push_insn(block, Insn::GuardType { val: self_param, guard_type: types::HeapBasicObject, state: exit_id, recompile: None });
-                        let rbasic_flags = fun.load_rbasic_flags(block, self_param);
                         let join_block = insn_idx_to_block.get(&insn_idx).copied().unwrap_or_else(|| fun.new_block(insn_idx));
                         let join_param = fun.push_insn(join_block, Insn::Param);
                         // Dedup by expected shape so objects with different classes but the same shape can share code
                         // TODO(max): De-duplicate further by checking ivar offsets to allow
                         // different shapes with the same ivar layout to share code
-                        let mut seen_shape_and_flags = Vec::with_capacity(summary.buckets().len());
+                        let mut seen_shape = Vec::with_capacity(summary.buckets().len());
                         for &profiled_type in summary.buckets() {
                             // End of the buckets
                             if profiled_type.is_empty() { break; }
                             // Instance variable lookups on immediate values are always nil; don't bother
                             if profiled_type.flags().is_immediate() { continue; }
-                            let expected_shape = profiled_type.shape();
-                            let (expected_rbasic_flags, rbasic_flags_mask) = profiled_type.rbasic_flags_and_mask();
-                            assert!(expected_shape.is_valid());
+
+                            let profiled_shape = profiled_type.shape();
+
                             // Too-complex shapes use hash tables for ivars;
                             // rb_shape_get_iv_index doesn't work for them.
                             // Let the fallthrough GetIvar handle these.
-                            if expected_shape.is_complex() { continue; }
-                            if seen_shape_and_flags.contains(&expected_rbasic_flags) { continue; }
-                            seen_shape_and_flags.push(expected_rbasic_flags);
-                            let rbasic_flags_mask = fun.push_insn(block, Insn::Const { val: Const::CUInt64(rbasic_flags_mask) });
-                            // The expected shape can change over run, so we put it
-                            // as a pointer to keep it stable in snapshot tests.
-                            let expected_rbasic_flags = fun.push_insn(block, Insn::Const { val: Const::CPtr(ptr::without_provenance(expected_rbasic_flags.to_usize())) });
-                            let expected_rbasic_flags = fun.push_insn(block, Insn::RefineType { val: expected_rbasic_flags, new_type: types::CUInt64 });
-                            let masked = fun.push_insn(block, Insn::IntAnd { left: rbasic_flags, right: rbasic_flags_mask});
-                            let has_shape_and_type = fun.push_insn(block, Insn::IsBitEqual { left: masked, right: expected_rbasic_flags });
+                            if profiled_shape.is_complex() { continue; }
+
+                            // If we've generated code for this shape already,
+                            // then skip it
+                            if seen_shape.contains(&profiled_shape) { continue; }
+                            seen_shape.push(profiled_shape);
+
+                            // Load the runtime shape from the object, we know
+                            // it's OK to do this because we did GuardType above
+                            let runtime_shape = fun.load_shape(block, self_param);
+
+                            // Load the expected shape to a variable
+                            let expected_shape = fun.push_insn(block, Insn::Const { val: Const::CShape(profiled_shape) });
+
+                            // If the expected is equal to the actual, then
+                            // we're good and can load the IV.  Otherwise jump
+                            // to the next block.
+                            let has_shape = fun.push_insn(block, Insn::IsBitEqual { left: expected_shape, right: runtime_shape });
                             let iftrue_block = fun.new_block(insn_idx);
                             let target = BranchEdge { target: iftrue_block, args: vec![] };
                             let fall_through = fun.new_block(insn_idx);
 
-                            fun.push_insn(block, Insn::CondBranch { val: has_shape_and_type,
+                            fun.push_insn(block, Insn::CondBranch { val: has_shape,
                                 if_true: target,
                                 if_false: BranchEdge { target: fall_through, args: vec![] }
                             });
 
                             block = fall_through;
-                            let result = fun.load_ivar(iftrue_block, self_param, profiled_type, id, exit_id);
+                            let result = fun.load_ivar(iftrue_block, self_param, profiled_type, id);
                             fun.push_insn(iftrue_block, Insn::Jump(BranchEdge { target: join_block, args: vec![result] }));
                         }
                         // In the fallthrough case, do a generic interpreter getivar and then join.

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -7195,11 +7195,11 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                             if profiled_shape.is_complex() { continue; }
                             if seen_shape.contains(&profiled_shape) { continue; }
                             seen_shape.push(profiled_shape);
-                            let runtime_shape = fun.load_shape(block, self_param);
+                            let actual_shape = fun.load_shape(block, self_param);
                             // The expected shape can change over run, so we put it
                             // as a pointer to keep it stable in snapshot tests.
                             let expected_shape = fun.push_insn(block, Insn::Const { val: Const::CShape(profiled_shape) });
-                            let has_shape = fun.push_insn(block, Insn::IsBitEqual { left: runtime_shape, right: expected_shape });
+                            let has_shape = fun.push_insn(block, Insn::IsBitEqual { left: actual_shape, right: expected_shape });
                             let iftrue_block = fun.new_block(insn_idx);
                             let target = BranchEdge { target: iftrue_block, args: vec![] };
                             let fall_through = fun.new_block(insn_idx);
@@ -8358,10 +8358,10 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                             if profiled_shape.is_complex() { continue; }
                             if seen_shape.contains(&profiled_shape) { continue; }
                             seen_shape.push(profiled_shape);
-                            let runtime_shape = fun.load_shape(block, self_param);
+                            let actual_shape = fun.load_shape(block, self_param);
                             // Load the expected shape to a variable
                             let expected_shape = fun.push_insn(block, Insn::Const { val: Const::CShape(profiled_shape) });
-                            let has_shape = fun.push_insn(block, Insn::IsBitEqual { left: runtime_shape, right: expected_shape });
+                            let has_shape = fun.push_insn(block, Insn::IsBitEqual { left: actual_shape, right: expected_shape });
                             let iftrue_block = fun.new_block(insn_idx);
                             let target = BranchEdge { target: iftrue_block, args: vec![] };
                             let fall_through = fun.new_block(insn_idx);

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -8352,6 +8352,7 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                             // Instance variable lookups on immediate values are always nil; don't bother
                             if profiled_type.flags().is_immediate() { continue; }
                             let profiled_shape = profiled_type.shape();
+                            assert!(profiled_shape.is_valid());
                             // Too-complex shapes use hash tables for ivars;
                             // rb_shape_get_iv_index doesn't work for them.
                             // Let the fallthrough GetIvar handle these.

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -7219,7 +7219,7 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                             // as a pointer to keep it stable in snapshot tests.
                             let expected_shape = fun.push_insn(block, Insn::Const { val: Const::CShape(profiled_shape) });
 
-                            let has_shape = fun.push_insn(block, Insn::IsBitEqual { left: expected_shape, right: runtime_shape });
+                            let has_shape = fun.push_insn(block, Insn::IsBitEqual { left: runtime_shape, right: expected_shape });
                             let iftrue_block = fun.new_block(insn_idx);
                             let target = BranchEdge { target: iftrue_block, args: vec![] };
                             let fall_through = fun.new_block(insn_idx);
@@ -8394,7 +8394,7 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                             // If the expected is equal to the actual, then
                             // we're good and can load the IV.  Otherwise jump
                             // to the next block.
-                            let has_shape = fun.push_insn(block, Insn::IsBitEqual { left: expected_shape, right: runtime_shape });
+                            let has_shape = fun.push_insn(block, Insn::IsBitEqual { left: runtime_shape, right: expected_shape });
                             let iftrue_block = fun.new_block(insn_idx);
                             let target = BranchEdge { target: iftrue_block, args: vec![] };
                             let fall_through = fun.new_block(insn_idx);

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -8052,32 +8052,27 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:HeapBasicObject):
           PatchPoint SingleRactorMode
-          v12:CUInt64 = LoadField v6, :RBASIC_FLAGS@0x1000
-          v14:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
-          v15:CPtr[CPtr(0x1001)] = Const CPtr(0x1001)
-          v16 = RefineType v15, CUInt64
-          v17:CInt64 = IntAnd v12, v14
-          v18:CBool = IsBitEqual v17, v16
-          CondBranch v18, bb5(), bb6()
+          v13:CShape = LoadField v6, :shape_id@0x1000
+          v14:CShape[0x1001] = Const CShape(0x1001)
+          v15:CBool = IsBitEqual v14, v13
+          CondBranch v15, bb5(), bb6()
         bb5():
-          v20:BasicObject = LoadField v6, :@foo@0x1002
-          Jump bb4(v20)
+          v17:BasicObject = LoadField v6, :@foo@0x1002
+          Jump bb4(v17)
         bb6():
-          v22:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
-          v23:CPtr[CPtr(0x1003)] = Const CPtr(0x1003)
-          v24 = RefineType v23, CUInt64
-          v25:CInt64 = IntAnd v12, v22
-          v26:CBool = IsBitEqual v25, v24
-          CondBranch v26, bb7(), bb8()
+          v19:CShape = LoadField v6, :shape_id@0x1000
+          v20:CShape[0x1003] = Const CShape(0x1003)
+          v21:CBool = IsBitEqual v20, v19
+          CondBranch v21, bb7(), bb8()
         bb7():
-          v28:BasicObject = LoadField v6, :@foo@0x1004
-          Jump bb4(v28)
+          v23:BasicObject = LoadField v6, :@foo@0x1004
+          Jump bb4(v23)
         bb8():
-          v30:BasicObject = GetIvar v6, :@foo
-          Jump bb4(v30)
-        bb4(v13:BasicObject):
+          v25:BasicObject = GetIvar v6, :@foo
+          Jump bb4(v25)
+        bb4(v12:BasicObject):
           CheckInterrupts
-          Return v13
+          Return v12
         ");
     }
 
@@ -8512,14 +8507,13 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
-          v17:Module = GuardType v6, Module
+          v17:HeapBasicObject = GuardType v6, HeapBasicObject
           v18:CShape = LoadField v17, :shape_id@0x1000
           v19:CShape[0x1001] = GuardBitEquals v18, CShape(0x1001) recompile
-          PatchPoint RootBoxOnly
-          v21:RubyValue = LoadField v17, :fields_obj@0x1002
-          v22:BasicObject = LoadField v21, :@foo@0x1003
+          v20:RubyValue = LoadField v17, :fields_obj@0x1002
+          v21:BasicObject = LoadField v20, :@foo@0x1003
           CheckInterrupts
-          Return v22
+          Return v21
         ");
     }
 
@@ -8584,14 +8578,13 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
-          v17:Class = GuardType v6, Class
+          v17:HeapBasicObject = GuardType v6, HeapBasicObject
           v18:CShape = LoadField v17, :shape_id@0x1000
           v19:CShape[0x1001] = GuardBitEquals v18, CShape(0x1001) recompile
-          PatchPoint RootBoxOnly
-          v21:RubyValue = LoadField v17, :fields_obj@0x1002
-          v22:BasicObject = LoadField v21, :@foo@0x1003
+          v20:RubyValue = LoadField v17, :fields_obj@0x1002
+          v21:BasicObject = LoadField v20, :@foo@0x1003
           CheckInterrupts
-          Return v22
+          Return v21
         ");
     }
 
@@ -8684,7 +8677,7 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
-          v17:TData = GuardType v6, TData
+          v17:HeapBasicObject = GuardType v6, HeapBasicObject
           v18:CShape = LoadField v17, :shape_id@0x1000
           v19:CShape[0x1001] = GuardBitEquals v18, CShape(0x1001) recompile
           v20:RubyValue = LoadField v17, :fields_obj@0x1002
@@ -8821,37 +8814,32 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           v11:HeapBasicObject = GuardType v6, HeapBasicObject
-          v12:CUInt64 = LoadField v11, :RBASIC_FLAGS@0x1000
-          v14:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
-          v15:CPtr[CPtr(0x1001)] = Const CPtr(0x1001)
-          v16 = RefineType v15, CUInt64
-          v17:CInt64 = IntAnd v12, v14
-          v18:CBool = IsBitEqual v17, v16
-          CondBranch v18, bb5(), bb6()
+          v13:CShape = LoadField v11, :shape_id@0x1000
+          v14:CShape[0x1001] = Const CShape(0x1001)
+          v15:CBool = IsBitEqual v14, v13
+          CondBranch v15, bb5(), bb6()
         bb5():
-          v20:BasicObject = LoadField v11, :@foo@0x1002
-          Jump bb4(v20)
+          v17:BasicObject = LoadField v11, :@foo@0x1002
+          Jump bb4(v17)
         bb6():
-          v22:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
-          v23:CPtr[CPtr(0x1003)] = Const CPtr(0x1003)
-          v24 = RefineType v23, CUInt64
-          v25:CInt64 = IntAnd v12, v22
-          v26:CBool = IsBitEqual v25, v24
-          CondBranch v26, bb7(), bb8()
+          v19:CShape = LoadField v11, :shape_id@0x1000
+          v20:CShape[0x1003] = Const CShape(0x1003)
+          v21:CBool = IsBitEqual v20, v19
+          CondBranch v21, bb7(), bb8()
         bb7():
-          v28:CPtr = LoadField v11, :as_heap@0x1004
-          v29:BasicObject = LoadField v28, :@foo@0x1000
-          Jump bb4(v29)
+          v23:CPtr = LoadField v11, :as_heap@0x1004
+          v24:BasicObject = LoadField v23, :@foo@0x1005
+          Jump bb4(v24)
         bb8():
-          v31:BasicObject = GetIvar v11, :@foo
-          Jump bb4(v31)
-        bb4(v13:BasicObject):
-          v34:Fixnum[1] = Const Value(1)
+          v26:BasicObject = GetIvar v11, :@foo
+          Jump bb4(v26)
+        bb4(v12:BasicObject):
+          v29:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Integer@0x1008, +@0x1010, cme:0x1018)
-          v45:Fixnum = GuardType v13, Fixnum recompile
-          v46:Fixnum = FixnumAdd v45, v34
+          v40:Fixnum = GuardType v12, Fixnum recompile
+          v41:Fixnum = FixnumAdd v40, v29
           CheckInterrupts
-          Return v46
+          Return v41
         ");
     }
 
@@ -8900,40 +8888,35 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           v11:HeapBasicObject = GuardType v6, HeapBasicObject
-          v12:CUInt64 = LoadField v11, :RBASIC_FLAGS@0x1000
-          v14:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
-          v15:CPtr[CPtr(0x1001)] = Const CPtr(0x1001)
-          v16 = RefineType v15, CUInt64
-          v17:CInt64 = IntAnd v12, v14
-          v18:CBool = IsBitEqual v17, v16
-          CondBranch v18, bb5(), bb6()
+          v13:CShape = LoadField v11, :shape_id@0x1000
+          v14:CShape[0x1001] = Const CShape(0x1001)
+          v15:CBool = IsBitEqual v14, v13
+          CondBranch v15, bb5(), bb6()
         bb5():
-          v20:CPtr = LoadField v11, :as_heap@0x1002
-          v21:BasicObject = LoadField v20, :@foo@0x1000
-          Jump bb4(v21)
+          v17:CPtr = LoadField v11, :as_heap@0x1002
+          v18:BasicObject = LoadField v17, :@foo@0x1003
+          Jump bb4(v18)
         bb6():
-          v23:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
-          v24:CPtr[CPtr(0x1003)] = Const CPtr(0x1003)
-          v25 = RefineType v24, CUInt64
-          v26:CInt64 = IntAnd v12, v23
-          v27:CBool = IsBitEqual v26, v25
-          CondBranch v27, bb7(), bb8()
+          v20:CShape = LoadField v11, :shape_id@0x1000
+          v21:CShape[0x1004] = Const CShape(0x1004)
+          v22:CBool = IsBitEqual v21, v20
+          CondBranch v22, bb7(), bb8()
         bb7():
-          v29:BasicObject = LoadField v11, :@foo@0x1004
-          Jump bb4(v29)
+          v24:BasicObject = LoadField v11, :@foo@0x1005
+          Jump bb4(v24)
         bb8():
-          v44:CShape = LoadField v11, :shape_id@0x1005
-          v45:CShape[0x1006] = GuardBitEquals v44, CShape(0x1006) recompile
-          v46:CPtr = LoadField v11, :as_heap@0x1002
-          v47:BasicObject = LoadField v46, :@foo@0x1000
-          Jump bb4(v47)
-        bb4(v13:BasicObject):
-          v34:Fixnum[1] = Const Value(1)
+          v39:CShape = LoadField v11, :shape_id@0x1000
+          v40:CShape[0x1001] = GuardBitEquals v39, CShape(0x1001) recompile
+          v41:CPtr = LoadField v11, :as_heap@0x1002
+          v42:BasicObject = LoadField v41, :@foo@0x1003
+          Jump bb4(v42)
+        bb4(v12:BasicObject):
+          v29:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Integer@0x1008, +@0x1010, cme:0x1018)
-          v50:Fixnum = GuardType v13, Fixnum recompile
-          v51:Fixnum = FixnumAdd v50, v34
+          v45:Fixnum = GuardType v12, Fixnum recompile
+          v46:Fixnum = FixnumAdd v45, v29
           CheckInterrupts
-          Return v51
+          Return v46
         ");
     }
 
@@ -8974,36 +8957,31 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           v11:HeapBasicObject = GuardType v6, HeapBasicObject
-          v12:CUInt64 = LoadField v11, :RBASIC_FLAGS@0x1000
-          v14:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
-          v15:CPtr[CPtr(0x1001)] = Const CPtr(0x1001)
-          v16 = RefineType v15, CUInt64
-          v17:CInt64 = IntAnd v12, v14
-          v18:CBool = IsBitEqual v17, v16
-          CondBranch v18, bb5(), bb6()
+          v13:CShape = LoadField v11, :shape_id@0x1000
+          v14:CShape[0x1001] = Const CShape(0x1001)
+          v15:CBool = IsBitEqual v14, v13
+          CondBranch v15, bb5(), bb6()
         bb5():
-          v20:BasicObject = LoadField v11, :@foo@0x1002
-          Jump bb4(v20)
+          v17:BasicObject = LoadField v11, :@foo@0x1002
+          Jump bb4(v17)
         bb6():
-          v22:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
-          v23:CPtr[CPtr(0x1003)] = Const CPtr(0x1003)
-          v24 = RefineType v23, CUInt64
-          v25:CInt64 = IntAnd v12, v22
-          v26:CBool = IsBitEqual v25, v24
-          CondBranch v26, bb7(), bb8()
+          v19:CShape = LoadField v11, :shape_id@0x1000
+          v20:CShape[0x1003] = Const CShape(0x1003)
+          v21:CBool = IsBitEqual v20, v19
+          CondBranch v21, bb7(), bb8()
         bb7():
-          v28:BasicObject = LoadField v11, :@foo@0x1002
-          Jump bb4(v28)
+          v23:BasicObject = LoadField v11, :@foo@0x1002
+          Jump bb4(v23)
         bb8():
-          v30:BasicObject = GetIvar v11, :@foo
-          Jump bb4(v30)
-        bb4(v13:BasicObject):
-          v33:Fixnum[1] = Const Value(1)
+          v25:BasicObject = GetIvar v11, :@foo
+          Jump bb4(v25)
+        bb4(v12:BasicObject):
+          v28:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Integer@0x1008, +@0x1010, cme:0x1018)
-          v44:Fixnum = GuardType v13, Fixnum recompile
-          v45:Fixnum = FixnumAdd v44, v33
+          v39:Fixnum = GuardType v12, Fixnum recompile
+          v40:Fixnum = FixnumAdd v39, v28
           CheckInterrupts
-          Return v45
+          Return v40
         ");
     }
 
@@ -9042,35 +9020,29 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           v11:HeapBasicObject = GuardType v6, HeapBasicObject
-          v12:CUInt64 = LoadField v11, :RBASIC_FLAGS@0x1000
-          v14:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
-          v15:CPtr[CPtr(0x1001)] = Const CPtr(0x1001)
-          v16 = RefineType v15, CUInt64
-          v17:CInt64 = IntAnd v12, v14
-          v18:CBool = IsBitEqual v17, v16
-          CondBranch v18, bb5(), bb6()
+          v13:CShape = LoadField v11, :shape_id@0x1000
+          v14:CShape[0x1001] = Const CShape(0x1001)
+          v15:CBool = IsBitEqual v14, v13
+          CondBranch v15, bb5(), bb6()
         bb5():
-          v20:RubyValue = LoadField v11, :fields_obj@0x1002
-          v21:BasicObject = LoadField v20, :@a@0x1002
-          Jump bb4(v21)
+          v17:RubyValue = LoadField v11, :fields_obj@0x1002
+          v18:BasicObject = LoadField v17, :@a@0x1002
+          Jump bb4(v18)
         bb6():
-          v23:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
-          v24:CPtr[CPtr(0x1003)] = Const CPtr(0x1003)
-          v25 = RefineType v24, CUInt64
-          v26:CInt64 = IntAnd v12, v23
-          v27:CBool = IsBitEqual v26, v25
-          CondBranch v27, bb7(), bb8()
+          v20:CShape = LoadField v11, :shape_id@0x1000
+          v21:CShape[0x1003] = Const CShape(0x1003)
+          v22:CBool = IsBitEqual v21, v20
+          CondBranch v22, bb7(), bb8()
         bb7():
-          PatchPoint RootBoxOnly
-          v30:RubyValue = LoadField v11, :fields_obj@0x1004
-          v31:BasicObject = LoadField v30, :@a@0x1002
-          Jump bb4(v31)
+          v24:RubyValue = LoadField v11, :fields_obj@0x1004
+          v25:BasicObject = LoadField v24, :@a@0x1002
+          Jump bb4(v25)
         bb8():
-          v33:BasicObject = GetIvar v11, :@a
-          Jump bb4(v33)
-        bb4(v13:BasicObject):
+          v27:BasicObject = GetIvar v11, :@a
+          Jump bb4(v27)
+        bb4(v12:BasicObject):
           CheckInterrupts
-          Return v13
+          Return v12
         ");
     }
 
@@ -16754,57 +16726,52 @@ mod hir_opt_tests {
         bb6(v19:HeapBasicObject, v20:Fixnum):
           v24:Fixnum[10] = Const Value(10)
           PatchPoint MethodRedefined(Integer@0x1000, <@0x1008, cme:0x1010)
-          v110:BoolExact = FixnumLt v20, v24
+          v105:BoolExact = FixnumLt v20, v24
           CheckInterrupts
-          v30:CBool = Test v110
+          v30:CBool = Test v105
           CondBranch v30, bb4(v19, v20), bb7()
         bb4(v40:HeapBasicObject, v41:Fixnum):
           PatchPoint SingleRactorMode
-          v47:CUInt64 = LoadField v40, :RBASIC_FLAGS@0x1038
-          v49:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
-          v50:CPtr[CPtr(0x1039)] = Const CPtr(0x1039)
-          v51 = RefineType v50, CUInt64
-          v52:CInt64 = IntAnd v47, v49
-          v53:CBool = IsBitEqual v52, v51
-          CondBranch v53, bb9(), bb10()
+          v48:CShape = LoadField v40, :shape_id@0x1038
+          v49:CShape[0x1039] = Const CShape(0x1039)
+          v50:CBool = IsBitEqual v49, v48
+          CondBranch v50, bb9(), bb10()
         bb9():
-          v55:BasicObject = LoadField v40, :@levar@0x103a
-          Jump bb8(v55)
+          v52:BasicObject = LoadField v40, :@levar@0x103a
+          Jump bb8(v52)
         bb10():
-          v57:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
-          v58:CPtr[CPtr(0x103b)] = Const CPtr(0x103b)
-          v59 = RefineType v58, CUInt64
-          v60:CInt64 = IntAnd v47, v57
-          v61:CBool = IsBitEqual v60, v59
-          CondBranch v61, bb11(), bb12()
+          v54:CShape = LoadField v40, :shape_id@0x1038
+          v55:CShape[0x103b] = Const CShape(0x103b)
+          v56:CBool = IsBitEqual v55, v54
+          CondBranch v56, bb11(), bb12()
         bb11():
-          v63:NilClass = Const Value(nil)
-          Jump bb8(v63)
+          v58:NilClass = Const Value(nil)
+          Jump bb8(v58)
         bb12():
-          v97:CShape = LoadField v40, :shape_id@0x103c
-          v98:CShape[0x103d] = GuardBitEquals v97, CShape(0x103d) recompile
-          v99:BasicObject = LoadField v40, :@levar@0x103a
-          Jump bb8(v99)
-        bb8(v48:BasicObject):
+          v92:CShape = LoadField v40, :shape_id@0x1038
+          v93:CShape[0x1039] = GuardBitEquals v92, CShape(0x1039) recompile
+          v94:BasicObject = LoadField v40, :@levar@0x103a
+          Jump bb8(v94)
+        bb8(v47:BasicObject):
           CheckInterrupts
-          v69:CBool = Test v48
-          CondBranch v69, bb5(v40, v41), bb13()
+          v64:CBool = Test v47
+          CondBranch v64, bb5(v40, v41), bb13()
         bb13():
           PatchPoint NoEPEscape(set_value_loop)
           PatchPoint SingleRactorMode
-          v101:CShape = LoadField v40, :shape_id@0x103c
-          v102:CShape[0x103e] = GuardBitEquals v101, CShape(0x103e) recompile
+          v96:CShape = LoadField v40, :shape_id@0x1038
+          v97:CShape[0x103b] = GuardBitEquals v96, CShape(0x103b) recompile
           StoreField v40, :@levar@0x103a, v41
           WriteBarrier v40, v41
-          v105:CShape[0x103d] = Const CShape(0x103d)
-          StoreField v40, :shape_id@0x103c, v105
+          v100:CShape[0x1039] = Const CShape(0x1039)
+          StoreField v40, :shape_id@0x1038, v100
           Jump bb5(v40, v41)
-        bb5(v81:HeapBasicObject, v82:Fixnum):
+        bb5(v76:HeapBasicObject, v77:Fixnum):
           PatchPoint NoEPEscape(set_value_loop)
-          v89:Fixnum[1] = Const Value(1)
-          PatchPoint MethodRedefined(Integer@0x1000, +@0x103f, cme:0x1040)
-          v114:Fixnum = FixnumAdd v82, v89
-          Jump bb6(v81, v114)
+          v84:Fixnum[1] = Const Value(1)
+          PatchPoint MethodRedefined(Integer@0x1000, +@0x103c, cme:0x1040)
+          v109:Fixnum = FixnumAdd v77, v84
+          Jump bb6(v76, v109)
         bb7():
           v35:NilClass = Const Value(nil)
           CheckInterrupts

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -5783,57 +5783,47 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           v10:HeapBasicObject = GuardType v6, HeapBasicObject
-          v11:CUInt64 = LoadField v10, :RBASIC_FLAGS@0x1000
-          v13:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
-          v14:CPtr[CPtr(0x1001)] = Const CPtr(0x1001)
-          v15 = RefineType v14, CUInt64
-          v16:CInt64 = IntAnd v11, v13
-          v17:CBool = IsBitEqual v16, v15
-          CondBranch v17, bb5(), bb6()
+          v12:CShape = LoadField v10, :shape_id@0x1000
+          v13:CShape[0x1001] = Const CShape(0x1001)
+          v14:CBool = IsBitEqual v12, v13
+          CondBranch v14, bb5(), bb6()
         bb5():
-          v19:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-          Jump bb4(v19)
+          v16:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          Jump bb4(v16)
         bb6():
-          v21:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
-          v22:CPtr[CPtr(0x1010)] = Const CPtr(0x1010)
-          v23 = RefineType v22, CUInt64
-          v24:CInt64 = IntAnd v11, v21
-          v25:CBool = IsBitEqual v24, v23
-          CondBranch v25, bb7(), bb8()
+          v18:CShape = LoadField v10, :shape_id@0x1000
+          v19:CShape[0x1010] = Const CShape(0x1010)
+          v20:CBool = IsBitEqual v18, v19
+          CondBranch v20, bb7(), bb8()
         bb7():
-          v27:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-          Jump bb4(v27)
+          v22:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          Jump bb4(v22)
         bb8():
-          v29:StringExact|NilClass = DefinedIvar v10, :@a
-          Jump bb4(v29)
-        bb4(v12:StringExact|NilClass):
-          v33:CUInt64 = LoadField v10, :RBASIC_FLAGS@0x1000
-          v35:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
-          v36:CPtr[CPtr(0x1001)] = Const CPtr(0x1001)
-          v37 = RefineType v36, CUInt64
-          v38:CInt64 = IntAnd v33, v35
-          v39:CBool = IsBitEqual v38, v37
-          CondBranch v39, bb10(), bb11()
+          v24:StringExact|NilClass = DefinedIvar v10, :@a
+          Jump bb4(v24)
+        bb4(v11:StringExact|NilClass):
+          v29:CShape = LoadField v10, :shape_id@0x1000
+          v30:CShape[0x1001] = Const CShape(0x1001)
+          v31:CBool = IsBitEqual v29, v30
+          CondBranch v31, bb10(), bb11()
         bb10():
-          v41:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-          Jump bb9(v41)
+          v33:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          Jump bb9(v33)
         bb11():
-          v43:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
-          v44:CPtr[CPtr(0x1010)] = Const CPtr(0x1010)
-          v45 = RefineType v44, CUInt64
-          v46:CInt64 = IntAnd v33, v43
-          v47:CBool = IsBitEqual v46, v45
-          CondBranch v47, bb12(), bb13()
+          v35:CShape = LoadField v10, :shape_id@0x1000
+          v36:CShape[0x1010] = Const CShape(0x1010)
+          v37:CBool = IsBitEqual v35, v36
+          CondBranch v37, bb12(), bb13()
         bb12():
-          v49:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-          Jump bb9(v49)
+          v39:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          Jump bb9(v39)
         bb13():
-          v51:StringExact|NilClass = DefinedIvar v10, :@b
-          Jump bb9(v51)
-        bb9(v34:StringExact|NilClass):
-          v54:ArrayExact = NewArray v12, v34
+          v41:StringExact|NilClass = DefinedIvar v10, :@b
+          Jump bb9(v41)
+        bb9(v28:StringExact|NilClass):
+          v44:ArrayExact = NewArray v11, v28
           CheckInterrupts
-          Return v54
+          Return v44
         ");
     }
 

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -5725,32 +5725,27 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           v10:HeapBasicObject = GuardType v6, HeapBasicObject
-          v11:CUInt64 = LoadField v10, :RBASIC_FLAGS@0x1000
-          v13:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
-          v14:CPtr[CPtr(0x1001)] = Const CPtr(0x1001)
-          v15 = RefineType v14, CUInt64
-          v16:CInt64 = IntAnd v11, v13
-          v17:CBool = IsBitEqual v16, v15
-          CondBranch v17, bb5(), bb6()
+          v12:CShape = LoadField v10, :shape_id@0x1000
+          v13:CShape[0x1001] = Const CShape(0x1001)
+          v14:CBool = IsBitEqual v12, v13
+          CondBranch v14, bb5(), bb6()
         bb5():
-          v19:NilClass = Const Value(nil)
-          Jump bb4(v19)
+          v16:NilClass = Const Value(nil)
+          Jump bb4(v16)
         bb6():
-          v21:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
-          v22:CPtr[CPtr(0x1002)] = Const CPtr(0x1002)
-          v23 = RefineType v22, CUInt64
-          v24:CInt64 = IntAnd v11, v21
-          v25:CBool = IsBitEqual v24, v23
-          CondBranch v25, bb7(), bb8()
+          v18:CShape = LoadField v10, :shape_id@0x1000
+          v19:CShape[0x1002] = Const CShape(0x1002)
+          v20:CBool = IsBitEqual v18, v19
+          CondBranch v20, bb7(), bb8()
         bb7():
-          v27:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-          Jump bb4(v27)
+          v22:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          Jump bb4(v22)
         bb8():
-          v29:StringExact|NilClass = DefinedIvar v10, :@a
-          Jump bb4(v29)
-        bb4(v12:StringExact|NilClass):
+          v24:StringExact|NilClass = DefinedIvar v10, :@a
+          Jump bb4(v24)
+        bb4(v11:StringExact|NilClass):
           CheckInterrupts
-          Return v12
+          Return v11
         ");
     }
 
@@ -5877,22 +5872,19 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           v10:HeapBasicObject = GuardType v6, HeapBasicObject
-          v11:CUInt64 = LoadField v10, :RBASIC_FLAGS@0x1000
-          v13:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
-          v14:CPtr[CPtr(0x1001)] = Const CPtr(0x1001)
-          v15 = RefineType v14, CUInt64
-          v16:CInt64 = IntAnd v11, v13
-          v17:CBool = IsBitEqual v16, v15
-          CondBranch v17, bb5(), bb6()
+          v12:CShape = LoadField v10, :shape_id@0x1000
+          v13:CShape[0x1001] = Const CShape(0x1001)
+          v14:CBool = IsBitEqual v12, v13
+          CondBranch v14, bb5(), bb6()
         bb5():
-          v19:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-          Jump bb4(v19)
+          v16:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          Jump bb4(v16)
         bb6():
-          v21:StringExact|NilClass = DefinedIvar v10, :@a
-          Jump bb4(v21)
-        bb4(v12:StringExact|NilClass):
+          v18:StringExact|NilClass = DefinedIvar v10, :@a
+          Jump bb4(v18)
+        bb4(v11:StringExact|NilClass):
           CheckInterrupts
-          Return v12
+          Return v11
         ");
     }
 
@@ -5934,22 +5926,19 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           v10:HeapBasicObject = GuardType v6, HeapBasicObject
-          v11:CUInt64 = LoadField v10, :RBASIC_FLAGS@0x1000
-          v13:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
-          v14:CPtr[CPtr(0x1001)] = Const CPtr(0x1001)
-          v15 = RefineType v14, CUInt64
-          v16:CInt64 = IntAnd v11, v13
-          v17:CBool = IsBitEqual v16, v15
-          CondBranch v17, bb5(), bb6()
+          v12:CShape = LoadField v10, :shape_id@0x1000
+          v13:CShape[0x1001] = Const CShape(0x1001)
+          v14:CBool = IsBitEqual v12, v13
+          CondBranch v14, bb5(), bb6()
         bb5():
-          v19:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-          Jump bb4(v19)
+          v16:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          Jump bb4(v16)
         bb6():
-          v21:StringExact|NilClass = DefinedIvar v10, :@a
-          Jump bb4(v21)
-        bb4(v12:StringExact|NilClass):
+          v18:StringExact|NilClass = DefinedIvar v10, :@a
+          Jump bb4(v18)
+        bb4(v11:StringExact|NilClass):
           CheckInterrupts
-          Return v12
+          Return v11
         ");
     }
 
@@ -5996,22 +5985,19 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           v10:HeapBasicObject = GuardType v6, HeapBasicObject
-          v11:CUInt64 = LoadField v10, :RBASIC_FLAGS@0x1000
-          v13:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
-          v14:CPtr[CPtr(0x1001)] = Const CPtr(0x1001)
-          v15 = RefineType v14, CUInt64
-          v16:CInt64 = IntAnd v11, v13
-          v17:CBool = IsBitEqual v16, v15
-          CondBranch v17, bb5(), bb6()
+          v12:CShape = LoadField v10, :shape_id@0x1000
+          v13:CShape[0x1001] = Const CShape(0x1001)
+          v14:CBool = IsBitEqual v12, v13
+          CondBranch v14, bb5(), bb6()
         bb5():
-          v19:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-          Jump bb4(v19)
+          v16:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          Jump bb4(v16)
         bb6():
-          v21:StringExact|NilClass = DefinedIvar v10, :@a
-          Jump bb4(v21)
-        bb4(v12:StringExact|NilClass):
+          v18:StringExact|NilClass = DefinedIvar v10, :@a
+          Jump bb4(v18)
+        bb4(v11:StringExact|NilClass):
           CheckInterrupts
-          Return v12
+          Return v11
         ");
     }
 
@@ -8054,7 +8040,7 @@ mod hir_opt_tests {
           PatchPoint SingleRactorMode
           v13:CShape = LoadField v6, :shape_id@0x1000
           v14:CShape[0x1001] = Const CShape(0x1001)
-          v15:CBool = IsBitEqual v14, v13
+          v15:CBool = IsBitEqual v13, v14
           CondBranch v15, bb5(), bb6()
         bb5():
           v17:BasicObject = LoadField v6, :@foo@0x1002
@@ -8062,7 +8048,7 @@ mod hir_opt_tests {
         bb6():
           v19:CShape = LoadField v6, :shape_id@0x1000
           v20:CShape[0x1003] = Const CShape(0x1003)
-          v21:CBool = IsBitEqual v20, v19
+          v21:CBool = IsBitEqual v19, v20
           CondBranch v21, bb7(), bb8()
         bb7():
           v23:BasicObject = LoadField v6, :@foo@0x1004
@@ -8365,32 +8351,27 @@ mod hir_opt_tests {
           v4:HeapBasicObject = LoadArg :self@0
           Jump bb3(v4)
         bb3(v6:HeapBasicObject):
-          v11:CUInt64 = LoadField v6, :RBASIC_FLAGS@0x1000
-          v13:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
-          v14:CPtr[CPtr(0x1001)] = Const CPtr(0x1001)
-          v15 = RefineType v14, CUInt64
-          v16:CInt64 = IntAnd v11, v13
-          v17:CBool = IsBitEqual v16, v15
-          CondBranch v17, bb5(), bb6()
+          v12:CShape = LoadField v6, :shape_id@0x1000
+          v13:CShape[0x1001] = Const CShape(0x1001)
+          v14:CBool = IsBitEqual v12, v13
+          CondBranch v14, bb5(), bb6()
         bb5():
-          v19:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-          Jump bb4(v19)
+          v16:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          Jump bb4(v16)
         bb6():
-          v21:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
-          v22:CPtr[CPtr(0x1010)] = Const CPtr(0x1010)
-          v23 = RefineType v22, CUInt64
-          v24:CInt64 = IntAnd v11, v21
-          v25:CBool = IsBitEqual v24, v23
-          CondBranch v25, bb7(), bb8()
+          v18:CShape = LoadField v6, :shape_id@0x1000
+          v19:CShape[0x1010] = Const CShape(0x1010)
+          v20:CBool = IsBitEqual v18, v19
+          CondBranch v20, bb7(), bb8()
         bb7():
-          v27:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-          Jump bb4(v27)
+          v22:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          Jump bb4(v22)
         bb8():
-          v29:StringExact|NilClass = DefinedIvar v6, :@foo
-          Jump bb4(v29)
-        bb4(v12:StringExact|NilClass):
+          v24:StringExact|NilClass = DefinedIvar v6, :@foo
+          Jump bb4(v24)
+        bb4(v11:StringExact|NilClass):
           CheckInterrupts
-          Return v12
+          Return v11
         ");
     }
 
@@ -8507,7 +8488,7 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
-          v17:HeapBasicObject = GuardType v6, HeapBasicObject
+          v17:Module = GuardType v6, Module
           v18:CShape = LoadField v17, :shape_id@0x1000
           v19:CShape[0x1001] = GuardBitEquals v18, CShape(0x1001) recompile
           v20:RubyValue = LoadField v17, :fields_obj@0x1002
@@ -8578,7 +8559,7 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
-          v17:HeapBasicObject = GuardType v6, HeapBasicObject
+          v17:Class = GuardType v6, Class
           v18:CShape = LoadField v17, :shape_id@0x1000
           v19:CShape[0x1001] = GuardBitEquals v18, CShape(0x1001) recompile
           v20:RubyValue = LoadField v17, :fields_obj@0x1002
@@ -8677,7 +8658,7 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
-          v17:HeapBasicObject = GuardType v6, HeapBasicObject
+          v17:TData = GuardType v6, TData
           v18:CShape = LoadField v17, :shape_id@0x1000
           v19:CShape[0x1001] = GuardBitEquals v18, CShape(0x1001) recompile
           v20:RubyValue = LoadField v17, :fields_obj@0x1002
@@ -8816,7 +8797,7 @@ mod hir_opt_tests {
           v11:HeapBasicObject = GuardType v6, HeapBasicObject
           v13:CShape = LoadField v11, :shape_id@0x1000
           v14:CShape[0x1001] = Const CShape(0x1001)
-          v15:CBool = IsBitEqual v14, v13
+          v15:CBool = IsBitEqual v13, v14
           CondBranch v15, bb5(), bb6()
         bb5():
           v17:BasicObject = LoadField v11, :@foo@0x1002
@@ -8824,7 +8805,7 @@ mod hir_opt_tests {
         bb6():
           v19:CShape = LoadField v11, :shape_id@0x1000
           v20:CShape[0x1003] = Const CShape(0x1003)
-          v21:CBool = IsBitEqual v20, v19
+          v21:CBool = IsBitEqual v19, v20
           CondBranch v21, bb7(), bb8()
         bb7():
           v23:CPtr = LoadField v11, :as_heap@0x1004
@@ -8890,7 +8871,7 @@ mod hir_opt_tests {
           v11:HeapBasicObject = GuardType v6, HeapBasicObject
           v13:CShape = LoadField v11, :shape_id@0x1000
           v14:CShape[0x1001] = Const CShape(0x1001)
-          v15:CBool = IsBitEqual v14, v13
+          v15:CBool = IsBitEqual v13, v14
           CondBranch v15, bb5(), bb6()
         bb5():
           v17:CPtr = LoadField v11, :as_heap@0x1002
@@ -8899,7 +8880,7 @@ mod hir_opt_tests {
         bb6():
           v20:CShape = LoadField v11, :shape_id@0x1000
           v21:CShape[0x1004] = Const CShape(0x1004)
-          v22:CBool = IsBitEqual v21, v20
+          v22:CBool = IsBitEqual v20, v21
           CondBranch v22, bb7(), bb8()
         bb7():
           v24:BasicObject = LoadField v11, :@foo@0x1005
@@ -8959,7 +8940,7 @@ mod hir_opt_tests {
           v11:HeapBasicObject = GuardType v6, HeapBasicObject
           v13:CShape = LoadField v11, :shape_id@0x1000
           v14:CShape[0x1001] = Const CShape(0x1001)
-          v15:CBool = IsBitEqual v14, v13
+          v15:CBool = IsBitEqual v13, v14
           CondBranch v15, bb5(), bb6()
         bb5():
           v17:BasicObject = LoadField v11, :@foo@0x1002
@@ -8967,7 +8948,7 @@ mod hir_opt_tests {
         bb6():
           v19:CShape = LoadField v11, :shape_id@0x1000
           v20:CShape[0x1003] = Const CShape(0x1003)
-          v21:CBool = IsBitEqual v20, v19
+          v21:CBool = IsBitEqual v19, v20
           CondBranch v21, bb7(), bb8()
         bb7():
           v23:BasicObject = LoadField v11, :@foo@0x1002
@@ -9022,7 +9003,7 @@ mod hir_opt_tests {
           v11:HeapBasicObject = GuardType v6, HeapBasicObject
           v13:CShape = LoadField v11, :shape_id@0x1000
           v14:CShape[0x1001] = Const CShape(0x1001)
-          v15:CBool = IsBitEqual v14, v13
+          v15:CBool = IsBitEqual v13, v14
           CondBranch v15, bb5(), bb6()
         bb5():
           v17:RubyValue = LoadField v11, :fields_obj@0x1002
@@ -9031,7 +9012,7 @@ mod hir_opt_tests {
         bb6():
           v20:CShape = LoadField v11, :shape_id@0x1000
           v21:CShape[0x1003] = Const CShape(0x1003)
-          v22:CBool = IsBitEqual v21, v20
+          v22:CBool = IsBitEqual v20, v21
           CondBranch v22, bb7(), bb8()
         bb7():
           v24:RubyValue = LoadField v11, :fields_obj@0x1004
@@ -16734,7 +16715,7 @@ mod hir_opt_tests {
           PatchPoint SingleRactorMode
           v48:CShape = LoadField v40, :shape_id@0x1038
           v49:CShape[0x1039] = Const CShape(0x1039)
-          v50:CBool = IsBitEqual v49, v48
+          v50:CBool = IsBitEqual v48, v49
           CondBranch v50, bb9(), bb10()
         bb9():
           v52:BasicObject = LoadField v40, :@levar@0x103a
@@ -16742,7 +16723,7 @@ mod hir_opt_tests {
         bb10():
           v54:CShape = LoadField v40, :shape_id@0x1038
           v55:CShape[0x103b] = Const CShape(0x103b)
-          v56:CBool = IsBitEqual v55, v54
+          v56:CBool = IsBitEqual v54, v55
           CondBranch v56, bb11(), bb12()
         bb11():
           v58:NilClass = Const Value(nil)

--- a/zjit/src/profile.rs
+++ b/zjit/src/profile.rs
@@ -351,28 +351,6 @@ impl ProfiledType {
         self.flags
     }
 
-    /// For ivar access, you need to know the index in the fields array (described by the shape)
-    /// and the way to get the fields array (described by the builtin type). Both pieces of
-    /// information are on the `RBasic::flags` field. This method returns expected masked flags
-    /// for guarding.
-    pub fn rbasic_flags_and_mask(&self) -> (u64, u64) {
-        let shape_flag_shift = u64::from(RB_SHAPE_FLAG_SHIFT);
-        let (shape, shape_mask) = (u64::from(self.shape().0) << shape_flag_shift, !0 << shape_flag_shift);
-        let (builtin_type, type_mask) = if self.flags().is_t_object() {
-            (RUBY_T_OBJECT, RUBY_T_MASK)
-        } else if self.flags().is_t_class() {
-            // Check class first since `Class < Module`
-            (RUBY_T_CLASS, RUBY_T_MASK)
-        } else if self.flags().is_t_module() {
-            (RUBY_T_MODULE, RUBY_T_MASK)
-        } else if self.flags().is_t_data() {
-            (RUBY_T_DATA, RUBY_T_MASK)
-        } else {
-            (0, 0)
-        };
-        (shape | u64::from(builtin_type), shape_mask | u64::from(type_mask))
-    }
-
     pub fn is_fixnum(&self) -> bool {
         self.class == unsafe { rb_cInteger } && self.flags.is_immediate()
     }


### PR DESCRIPTION
Since #17158, we can use the shape id as our cache key for determining object layout.  This patch changes ZJIT to use shape id instead of testing all bits.

Given this program:

```ruby
class Foo
  def initialize; @bar = 123; end
  def read; @bar; end
  def add; @baz = 123; end
end

foo = Foo.new
3.times {
  foo = Foo.new
  foo.read
  foo.add
  foo.read
}
```

We end up with a polymorphic read in the `read` method.  On master, the HIR looks like this:

```
Optimized HIR:
fn read@../test.rb:9:
bb1():
  EntryPoint interpreter
  v1:HeapBasicObject = LoadSelf
  Jump bb3(v1)
bb2():
  EntryPoint JIT(0)
  v4:HeapBasicObject = LoadArg :self@0
  Jump bb3(v4)
bb3(v6:HeapBasicObject):
  PatchPoint SingleRactorMode
  v12:CUInt64 = LoadField v6, :RBASIC_FLAGS@0x0
  v14:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
  v15:CPtr[CPtr(0x8000800000001)] = Const CPtr(0x8000800000001)
  v16 = RefineType v15, CUInt64
  v17:CInt64 = IntAnd v12, v14
  v18:CBool = IsBitEqual v17, v16
  CondBranch v18, bb5(), bb6()
bb5():
  v20:BasicObject = LoadField v6, :@bar@0x10
  Jump bb4(v20)
bb6():
  v22:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
  v23:CPtr[CPtr(0x8000900000001)] = Const CPtr(0x8000900000001)
  v24 = RefineType v23, CUInt64
  v25:CInt64 = IntAnd v12, v22
  v26:CBool = IsBitEqual v25, v24
  CondBranch v26, bb7(), bb8()
bb7():
  v28:BasicObject = LoadField v6, :@bar@0x10
  Jump bb4(v28)
bb8():
  v30:BasicObject = GetIvar v6, :@bar
  Jump bb4(v30)
bb4(v13:BasicObject):
  CheckInterrupts
  Return v13
```

On this branch, the HIR is like this:

```
Optimized HIR:
fn read@../test.rb:9:
bb1():
  EntryPoint interpreter
  v1:HeapBasicObject = LoadSelf
  Jump bb3(v1)
bb2():
  EntryPoint JIT(0)
  v4:HeapBasicObject = LoadArg :self@0
  Jump bb3(v4)
bb3(v6:HeapBasicObject):
  PatchPoint SingleRactorMode
  v13:CShape = LoadField v6, :shape_id@0x4
  v14:CShape[0x80008] = Const CShape(0x80008)
  v15:CBool = IsBitEqual v14, v13
  CondBranch v15, bb5(), bb6()
bb5():
  v17:BasicObject = LoadField v6, :@bar@0x10
  Jump bb4(v17)
bb6():
  v19:CShape = LoadField v6, :shape_id@0x4
  v20:CShape[0x80009] = Const CShape(0x80009)
  v21:CBool = IsBitEqual v20, v19
  CondBranch v21, bb7(), bb8()
bb7():
  v23:BasicObject = LoadField v6, :@bar@0x10
  Jump bb4(v23)
bb8():
  v25:BasicObject = GetIvar v6, :@bar
  Jump bb4(v25)
bb4(v12:BasicObject):
  CheckInterrupts
  Return v12
```

We're able to avoid loading all of the flags, applying a mask, and the testing.

The machine code for bb3 looks like this on master (I've removed the nop buffers for patch points):

```
  # Insn: v12 LoadField v6, :RBASIC_FLAGS@0x0
  # Load field id=RBASIC_FLAGS offset=0
  0x122c50124: ldur x1, [x0]
  # Insn: v14 Const CUInt64(0xffffffff0000001f)
  # Insn: v15 Const CPtr(0x8000800000001)
  # Insn: v16 RefineType v15, CUInt64
  # Insn: v17 IntAnd v12, v14
  0x122c50128: and x2, x1, #0xffffffff0000001f
  # Insn: v18 IsBitEqual v17, v16
  0x122c5012c: mov x3, #1
  0x122c50130: movk x3, #0, lsl #16
  0x122c50134: movk x3, #8, lsl #32
  0x122c50138: movk x3, #8, lsl #48
  0x122c5013c: cmp x2, x3
  0x122c50140: mov x2, #1
  0x122c50144: mov x3, #0
  0x122c50148: csel x2, x2, x3, eq
  0x122c5014c: tst x2, x2
  0x122c50150: b.ne #0x122c501e8
```

On this branch it looks like this:

```
  # Insn: v13 LoadField v6, :shape_id@0x4
  # Load field id=shape_id offset=4
  0x124dd0124: ldur w1, [x0, #4]
  # Insn: v14 Const CShape(0x80008)
  # Insn: v15 IsBitEqual v14, v13
  0x124dd0128: mov x2, #8
  0x124dd012c: movk x2, #8, lsl #16
  0x124dd0130: cmp x2, x1
  0x124dd0134: mov x1, #1
  0x124dd0138: mov x2, #0
  0x124dd013c: csel x1, x1, x2, eq
  0x124dd0140: tst x1, x1
  0x124dd0144: b.ne #0x124dd01d4
```

We've eliminated the `and` instruction and only need to do a 32 bit load for the shape.