### PR TITLE
ZJIT: Initialize JITFrame on method entry

### DIFF
--- a/zjit.h
+++ b/zjit.h
@@ -57,9 +57,6 @@ void rb_zjit_materialize_frames(const rb_execution_context_t *ec, rb_control_fra
 // instead of a heap-allocated JITFrame pointer.
 #define ZJIT_JIT_RETURN_C_FRAME 0x1
 
-// BADFrame. The high bit is set, so likely SEGV on linux and darwin if dereferenced.
-#define ZJIT_JIT_RETURN_POISON 0xbadfbadfbadfbadfULL
-
 static inline const zjit_jit_frame_t *
 CFP_ZJIT_FRAME(const rb_control_frame_t *cfp)
 {
@@ -67,9 +64,6 @@ CFP_ZJIT_FRAME(const rb_control_frame_t *cfp)
         return &rb_zjit_c_frame;
     }
     else {
-#if USE_ZJIT
-        RUBY_ASSERT((unsigned long long)((VALUE *)cfp->jit_return)[-1] != ZJIT_JIT_RETURN_POISON);
-#endif
         // Read JITFrame from the stack slot. gen_entry_point() writes an initial
         // frame describing the entry PC + iseq; subsequent gen_save_pc_for_gc()
         // calls update it with a more accurate PC before any non-leaf C call.

--- a/zjit/bindgen/src/main.rs
+++ b/zjit/bindgen/src/main.rs
@@ -315,7 +315,6 @@ fn main() {
         .allowlist_function("rb_zjit_insn_leaf")
         .allowlist_type("jit_bindgen_constants")
         .allowlist_type("zjit_struct_offsets")
-        .allowlist_var("ZJIT_JIT_RETURN_POISON")
         .allowlist_var("ZJIT_JIT_RETURN_C_FRAME")
         .allowlist_function("rb_assert_holding_vm_lock")
         .allowlist_function("rb_jit_shape_complex_p")

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -47,13 +47,6 @@ const PC_POISON: Option<*const VALUE> = if cfg!(feature = "runtime_checks") {
     None
 };
 
-/// Sentinel jit_return stored on ISEQ frame push when runtime checks are enabled.
-const JIT_RETURN_POISON: Option<usize> = if cfg!(feature = "runtime_checks") {
-    Some(ZJIT_JIT_RETURN_POISON as usize)
-} else {
-    None
-};
-
 /// Ephemeral code generation state
 struct JITState {
     /// ISEQ version that is being compiled, which will be used by PatchPoint
@@ -92,6 +85,11 @@ impl JITState {
     /// Retrieve the output of a given instruction that has been compiled
     fn get_opnd(&self, insn_id: InsnId) -> lir::Opnd {
         self.opnds[insn_id.0].unwrap_or_else(|| panic!("Failed to get_opnd({insn_id})"))
+    }
+
+    /// Get the ISEQ for the version currently being compiled.
+    fn iseq(&self) -> IseqPtr {
+        unsafe { self.version.as_ref().iseq }
     }
 
     /// Find or create a label for a given BlockId
@@ -2189,6 +2187,19 @@ fn gen_object_alloc_class(asm: &mut Assembler, class: VALUE, state: &FrameState)
     }
 }
 
+/// Map an entry point to the bytecode PC used by its initial JITFrame.
+/// JIT call entries use `opt_table[jit_entry_idx]`; the interpreter entry uses
+/// `opt_table.last()` for the fall-through path where all optionals are filled.
+fn entry_pc(iseq: IseqPtr, jit_entry_idx: Option<usize>) -> *const VALUE {
+    let params = unsafe { iseq.params() };
+    let opt_table = params.opt_table_slice();
+    let entry_idx = jit_entry_idx.unwrap_or_else(|| opt_table.len() - 1);
+    let entry_insn_idx = opt_table.get(entry_idx)
+        .unwrap_or_else(|| panic!("entry_pc: opt_table out of bounds. {params:#?}, entry_idx={entry_idx}"))
+        .as_u32();
+    unsafe { rb_iseq_pc_at_idx(iseq, entry_insn_idx) }
+}
+
 /// Compile a frame setup. If jit_entry_idx is Some, remember the address of it as a JIT entry.
 fn gen_entry_point(jit: &mut JITState, asm: &mut Assembler, jit_entry_idx: Option<usize>) {
     if let Some(jit_entry_idx) = jit_entry_idx {
@@ -2200,16 +2211,10 @@ fn gen_entry_point(jit: &mut JITState, asm: &mut Assembler, jit_entry_idx: Optio
     }
     asm.frame_setup(&[]);
 
-    // Publish the JITFrame slot's location via cfp->jit_return. The slot at
-    // [NATIVE_BASE_PTR - 8] is left uninitialized here; the JIT design relies on
-    // gen_save_pc_for_gc() to populate it before any C call, and on cross-ractor
-    // barriers ensuring that no other ractor scans this CFP before such a call.
+    // Publish a valid entry JITFrame before setting cfp->jit_return.
+    let jit_frame = JITFrame::new_iseq(entry_pc(jit.iseq(), jit_entry_idx), jit.iseq());
+    asm.mov(Opnd::mem(64, NATIVE_BASE_PTR, -SIZEOF_VALUE_I32), Opnd::const_ptr(jit_frame));
     asm.mov(Opnd::mem(64, CFP, RUBY_OFFSET_CFP_JIT_RETURN), NATIVE_BASE_PTR);
-
-    // Poison the JITFrame slot. It should be read only after gen_save_pc_for_gc().
-    if let Some(jit_return_poison) = JIT_RETURN_POISON {
-        asm.mov(Opnd::mem(64, NATIVE_BASE_PTR, -SIZEOF_VALUE_I32), jit_return_poison.into());
-    }
 }
 
 /// Compile code that exits from JIT code with a return value
@@ -2683,7 +2688,7 @@ fn gen_incr_send_fallback_counter(asm: &mut Assembler, reason: SendFallbackReaso
 /// (send, sendforward, invokesuper, invokesuperforward, invokeblock).
 /// These instructions call vm_caller_setup_arg_block which writes to cfp->block_code.
 #[allow(non_upper_case_globals)]
-fn iseq_may_write_block_code(iseq: IseqPtr) -> bool {
+pub(crate) fn iseq_may_write_block_code(iseq: IseqPtr) -> bool {
     let encoded_size = unsafe { rb_iseq_encoded_size(iseq) };
     let mut insn_idx: u32 = 0;
 
@@ -2715,7 +2720,7 @@ fn gen_save_pc_for_gc(asm: &mut Assembler, state: &FrameState) {
 
     gen_incr_counter(asm, Counter::vm_write_jit_frame_count);
     asm_comment!(asm, "save JITFrame to CFP");
-    let jit_frame = JITFrame::new_iseq(next_pc, state.iseq, !iseq_may_write_block_code(state.iseq));
+    let jit_frame = JITFrame::new_iseq(next_pc, state.iseq);
     asm.mov(Opnd::mem(64, NATIVE_BASE_PTR, -SIZEOF_VALUE_I32), Opnd::const_ptr(jit_frame));
 
     // CFP_PC for a live JIT frame routes through the JITFrame on the native

--- a/zjit/src/codegen_tests.rs
+++ b/zjit/src/codegen_tests.rs
@@ -4269,14 +4269,9 @@ fn test_getspecial_multiple_groups() {
     assert_snapshot!(assert_compiles(r#"test("123-456")"#), @r#""456""#);
 }
 
-// In a JIT-to-JIT call, gen_push_frame writes JIT_RETURN_POISON to the
-// callee's cfp->jit_return (runtime_checks builds). On the *first* such
-// call the function stub trampoline clears jit_return to NULL, so the
-// crash only manifests on the second JIT-to-JIT hit when the stub has
-// been patched to jump directly to the callee's JIT entry. Putting $& as
-// the first C call in the callee keeps the poison live until
-// gen_getspecial_symbol calls rb_backref_get → rb_vm_svar_lep → CFP_PC →
-// CFP_ZJIT_FRAME, which dereferences the poison without the prep fix.
+// In a JIT-to-JIT call, the callee's cfp->jit_return is published at entry.
+// Putting $& as the first C call in the callee exercises CFP_ZJIT_FRAME before
+// gen_save_pc_for_gc has a chance to update the entry JITFrame.
 #[test]
 fn test_getspecial_symbol_in_jit_to_jit_callee() {
     eval(r#"
@@ -4287,10 +4282,6 @@ fn test_getspecial_symbol_in_jit_to_jit_callee() {
         callee
         callee
 
-        # First call to caller_method profiles; second JITs caller_method
-        # and runs through the function-stub-hit path which clears
-        # jit_return. The third call goes through the patched stub with
-        # POISON intact, hitting the bug.
         caller_method
         caller_method
     "#);

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -235,7 +235,6 @@ pub const VM_ENV_DATA_INDEX_FLAGS: u32 = 0;
 pub const VM_BLOCK_HANDLER_NONE: u32 = 0;
 pub const SHAPE_ID_NUM_BITS: u32 = 32;
 pub const ZJIT_JIT_RETURN_C_FRAME: u32 = 1;
-pub const ZJIT_JIT_RETURN_POISON: i64 = -4981057192772781345;
 pub type rb_alloc_func_t = ::std::option::Option<unsafe extern "C" fn(klass: VALUE) -> VALUE>;
 pub const RUBY_Qfalse: ruby_special_consts = 0;
 pub const RUBY_Qnil: ruby_special_consts = 4;

--- a/zjit/src/jit_frame.rs
+++ b/zjit/src/jit_frame.rs
@@ -1,5 +1,6 @@
 use crate::cruby::{IseqPtr, VALUE, rb_gc_mark_movable, rb_gc_location};
 use crate::cruby::zjit_jit_frame;
+use crate::codegen::iseq_may_write_block_code;
 use crate::state::ZJITState;
 
 /// JITFrame struct is defined in zjit.h (the single source of truth) and
@@ -16,7 +17,8 @@ impl JITFrame {
     }
 
     /// Create a JITFrame for an ISEQ frame.
-    pub fn new_iseq(pc: *const VALUE, iseq: IseqPtr, materialize_block_code: bool) -> *const Self {
+    pub fn new_iseq(pc: *const VALUE, iseq: IseqPtr) -> *const Self {
+        let materialize_block_code = !iseq_may_write_block_code(iseq);
         Self::alloc(JITFrame { pc, iseq, materialize_block_code })
     }
 
@@ -121,11 +123,10 @@ mod tests {
         "#), @"100");
     }
 
-    // Side exit at the very start of a method, before any jit_return has been
-    // written by gen_save_pc_for_gc. The jit_return field should be 0 (from
-    // vm_push_frame), so materialization should be a no-op for that frame.
+    // Side exit at the very start of a method, before gen_save_pc_for_gc has
+    // updated the entry JITFrame.
     #[test]
-    fn test_side_exit_before_jit_return_write() {
+    fn test_side_exit_before_jit_frame_update() {
         assert_snapshot!(inspect("
             def entry(n) = n + 1
             entry(1)


### PR DESCRIPTION
This PR changes `gen_entry_point` to write a valid `JITFrame` into the native stack slot instead of leaving an uninitialized slot, which fixes flaky [CFP_ZJIT_FRAME != ZJIT_JIT_RETURN_POISON assertion failure on CI](https://github.com/ruby/ruby/actions/runs/26650569435/job/78547527485)".

Generally, an uninitialized `JITFrame` slot could be referenced when a signal handler walks the backtrace before JIT code reaches its first `gen_save_pc_for_gc` or side exit, e.g. `rb_profile_frames` from stackprof/vernier. To avoid returning information out of an uninitialized field, this PR initializes the slot on entry. See also: https://github.com/ruby/ruby/pull/16966#discussion_r3245254574

## Benchmark

On lobsters, it doesn't seem to have a significant impact on performance.

```
before: ruby 4.1.0dev (2026-06-02T21:25:30Z master ad8bf0e636) +ZJIT +PRISM [x86_64-linux]
after: ruby 4.1.0dev (2026-06-03T01:36:21Z zjit-entry-frame 3b32e2dfe2) +ZJIT +PRISM [x86_64-linux]

--------  ------------  ------------  -------------  ------------
bench      before (ms)    after (ms)  after 1st itr  before/after
lobsters  592.5 ± 1.1%  592.1 ± 1.1%          0.991         1.001
--------  ------------  ------------  -------------  ------------
```