### PR TITLE
Convert object_tracing to use weak references

### DIFF
--- a/ext/objspace/object_tracing.c
+++ b/ext/objspace/object_tracing.c
@@ -22,7 +22,6 @@ struct traceobj_arg {
     int running;
     int keep_remains;
     VALUE newobj_trace;
-    VALUE freeobj_trace;
     st_table *object_table; /* obj (VALUE) -> allocation_info */
     st_table *str_table;    /* cstr -> refcount */
     struct traceobj_arg *prev_traceobj_arg;
@@ -96,13 +95,11 @@ newobj_i(VALUE tpval, void *data)
     st_data_t v;
 
     if (st_lookup(arg->object_table, (st_data_t)obj, &v)) {
+        /* keep_remains kept this slot's entry after its object was freed. The
+         * allocator has now reused that address, so recycle the dead entry's
+         * info. A living entry here would mean two live objects at one address. */
         info = (struct allocation_info *)v;
-        if (arg->keep_remains) {
-            if (info->living) {
-                /* do nothing. there is possibility to keep living if FREEOBJ events while suppressing tracing */
-            }
-        }
-        /* reuse info */
+        assert(!info->living);
         delete_unique_str(arg->str_table, info->path);
         delete_unique_str(arg->str_table, info->class_path);
     }
@@ -119,37 +116,6 @@ newobj_i(VALUE tpval, void *data)
     info->class_path = class_path_cstr;
     info->generation = rb_gc_count();
     st_insert(arg->object_table, (st_data_t)obj, (st_data_t)info);
-}
-
-static void
-freeobj_i(VALUE tpval, void *data)
-{
-    struct traceobj_arg *arg = (struct traceobj_arg *)data;
-    rb_trace_arg_t *tparg = rb_tracearg_from_tracepoint(tpval);
-    st_data_t obj = (st_data_t)rb_tracearg_object(tparg);
-    st_data_t v;
-    struct allocation_info *info;
-
-    /* Modifying the st table can cause allocations, which can trigger GC.
-     * Since freeobj_i is called during GC, it must not trigger another GC. */
-    VALUE gc_disabled = rb_gc_disable_no_rest();
-
-    if (arg->keep_remains) {
-        if (st_lookup(arg->object_table, obj, &v)) {
-            info = (struct allocation_info *)v;
-            info->living = 0;
-        }
-    }
-    else {
-        if (st_delete(arg->object_table, &obj, &v)) {
-            info = (struct allocation_info *)v;
-            delete_unique_str(arg->str_table, info->path);
-            delete_unique_str(arg->str_table, info->class_path);
-            ruby_xfree(info);
-        }
-    }
-
-    if (gc_disabled == Qfalse) rb_gc_enable();
 }
 
 static int
@@ -171,7 +137,6 @@ allocation_info_tracer_mark(void *ptr)
 {
     struct traceobj_arg *trace_arg = (struct traceobj_arg *)ptr;
     rb_gc_mark(trace_arg->newobj_trace);
-    rb_gc_mark(trace_arg->freeobj_trace);
 }
 
 static void
@@ -198,14 +163,46 @@ allocation_info_tracer_memsize(const void *ptr)
 }
 
 static int
+allocation_info_tracer_weak_reference_i(st_data_t key, st_data_t value, st_data_t data)
+{
+    struct traceobj_arg *arg = (struct traceobj_arg *)data;
+    struct allocation_info *info = (struct allocation_info *)value;
+
+    if (rb_gc_handle_weak_references_alive_p((VALUE)key)) {
+        return ST_CONTINUE;
+    }
+
+    /* Object was collected. keep_remains keeps the dead entry for reporting. */
+    if (arg->keep_remains) {
+        info->living = 0;
+        return ST_CONTINUE;
+    }
+    else {
+        delete_unique_str(arg->str_table, info->path);
+        delete_unique_str(arg->str_table, info->class_path);
+        ruby_xfree(info);
+        return ST_DELETE;
+    }
+}
+
+static void
+allocation_info_tracer_weak_reference(void *ptr)
+{
+    struct traceobj_arg *arg = (struct traceobj_arg *)ptr;
+
+    st_foreach(arg->object_table, allocation_info_tracer_weak_reference_i, (st_data_t)arg);
+}
+
+static int
 allocation_info_tracer_compact_update_object_table_i(st_data_t key, st_data_t value, st_data_t data)
 {
     st_table *table = (st_table *)data;
+    struct allocation_info *info = (struct allocation_info *)value;
 
-    if (!rb_gc_pointer_to_heap_p(key)) {
-        struct allocation_info *info = (struct allocation_info *)value;
-        xfree(info);
-        return ST_DELETE;
+    /* In keep_remains mode the table keeps entries for freed objects. Their keys
+     * are dangling, so skip them instead of passing them to rb_gc_location. */
+    if (!info->living) {
+        return ST_CONTINUE;
     }
 
     if (key != rb_gc_location(key)) {
@@ -242,6 +239,7 @@ static const rb_data_type_t allocation_info_tracer_type = {
         allocation_info_tracer_free, /* Never called because global */
         allocation_info_tracer_memsize,
         allocation_info_tracer_compact,
+        allocation_info_tracer_weak_reference,
     },
     0, 0, RUBY_TYPED_FREE_IMMEDIATELY
 };
@@ -260,9 +258,10 @@ get_traceobj_arg(void)
         tmp_trace_arg->running = 0;
         tmp_trace_arg->keep_remains = tmp_keep_remains;
         tmp_trace_arg->newobj_trace = 0;
-        tmp_trace_arg->freeobj_trace = 0;
         tmp_trace_arg->object_table = st_init_numtable();
         tmp_trace_arg->str_table = st_init_strtable();
+
+        rb_gc_declare_weak_references(obj);
     }
     return tmp_trace_arg;
 }
@@ -284,10 +283,8 @@ trace_object_allocations_start(VALUE self)
     else {
         if (arg->newobj_trace == 0) {
             arg->newobj_trace = rb_tracepoint_new(0, RUBY_INTERNAL_EVENT_NEWOBJ, newobj_i, arg);
-            arg->freeobj_trace = rb_tracepoint_new(0, RUBY_INTERNAL_EVENT_FREEOBJ, freeobj_i, arg);
         }
         rb_tracepoint_enable(arg->newobj_trace);
-        rb_tracepoint_enable(arg->freeobj_trace);
     }
 
     return Qnil;
@@ -314,9 +311,6 @@ trace_object_allocations_stop(VALUE self)
     if (arg->running == 0) {
         if (arg->newobj_trace != 0) {
             rb_tracepoint_disable(arg->newobj_trace);
-        }
-        if (arg->freeobj_trace != 0) {
-            rb_tracepoint_disable(arg->freeobj_trace);
         }
     }
 

--- a/internal/gc.h
+++ b/internal/gc.h
@@ -210,9 +210,6 @@ size_t rb_gc_heap_id_for_size(size_t size);
 
 void rb_gc_mark_and_move(VALUE *ptr);
 
-void rb_gc_declare_weak_references(VALUE obj);
-bool rb_gc_handle_weak_references_alive_p(VALUE obj);
-
 void rb_gc_ref_update_table_values_only(st_table *tbl);
 
 void rb_gc_initial_stress_set(VALUE flag);
@@ -233,6 +230,8 @@ void rb_objspace_reachable_objects_from_root(void (func)(const char *category, V
 int rb_objspace_internal_object_p(VALUE obj);
 int rb_objspace_garbage_object_p(VALUE obj);
 bool rb_gc_pointer_to_heap_p(VALUE obj);
+void rb_gc_declare_weak_references(VALUE obj);
+bool rb_gc_handle_weak_references_alive_p(VALUE obj);
 
 void rb_objspace_each_objects(
     int (*callback)(void *start, void *end, size_t stride, void *data),

--- a/test/objspace/test_objspace.rb
+++ b/test/objspace/test_objspace.rb
@@ -350,6 +350,21 @@ class TestObjSpace < Test::Unit::TestCase
     RUBY
   end
 
+  def test_trace_object_allocations_does_not_reuse_freed_allocation_info
+    assert_separately(%w(-robjspace), <<~RUBY)
+      ObjectSpace.trace_object_allocations do
+        1_000_000.times.map { Object.new }
+      end
+
+      GC.start
+
+      objs = 1_000_000.times.map { Object.new }
+
+      leaked = objs.count { |obj| ObjectSpace.allocation_sourcefile(obj) }
+      assert_equal 0, leaked
+    RUBY
+  end
+
   def test_dump_flags
     # Ensure that the fstring is promoted to old generation
     4.times { GC.start }


### PR DESCRIPTION
Object tracing listens to the NEWOBJ hook to see all objects allocated while it is active. Previously it also enabled a FREEOBJ tracepoint to drop each object's record as the object was freed.

However the FREEOBJ tracepoint only fires while tracing is active. An object recorded during tracing can be freed after tracing stops, and that free was missed, leaving a stale record in object_table keyed by a freed object. These dangling keys are unsafe during compaction, which was previously mitigated with rb_gc_pointer_to_heap_p (which I'd like to stop using). These dangling keys could also become incorrectly associated with a new object allocated in its place.

Instead we can declare object_table's keys as weak references. The GC then invokes our weak reference callback on every collection, whether or not tracing is running, letting us reap the records of objects about to be freed. This callback runs before the FREEOBJ hook, which makes the FREEOBJ tracepoint unnecessary.