### PR TITLE
Fix mutex_free so it doesn't call into Ruby code during GC

### DIFF
--- a/thread_sync.c
+++ b/thread_sync.c
@@ -103,13 +103,14 @@ mutex_locked_p(rb_mutex_t *mutex)
     return mutex->ec_serial != 0;
 }
 
+static void thread_mutex_remove(rb_thread_t *thread, rb_mutex_t *mutex);
+
 static void
 mutex_free(void *ptr)
 {
     rb_mutex_t *mutex = ptr;
     if (mutex_locked_p(mutex)) {
-        const char *err = rb_mutex_unlock_th(mutex, mutex->th, 0);
-        if (err) rb_bug("%s", err);
+        thread_mutex_remove(mutex->th, mutex);
     }
     ruby_xfree(ptr);
 }


### PR DESCRIPTION
While freeing a locked mutex,  if there is a waiter for the mutex it could call `rb_fiber_scheduler_unblock` which calls into Ruby code.

The function `rb_mutex_unlock_th` was a footgun because it was used during normal Ruby code and also during GC. The fix is to not call this function during GC and simply remove the mutex from th->keeping_mutexes.