### PR TITLE
Clear interrupt_mask_stack on child thread after fork

### DIFF
--- a/test/ruby/test_thread.rb
+++ b/test/ruby/test_thread.rb
@@ -1694,4 +1694,22 @@ q.pop
       1000.times { Object.new }
     end;
   end
+
+  def test_thread_interrupt_mask_stack_cleared_after_fork_in_child
+    assert_separately([], "#{<<~"begin;"}\n#{<<~'end;'}", timeout: 60)
+    begin;
+      Thread.handle_interrupt(Object => :never) do
+        pid = fork do
+          th = Thread.new do
+            loop do
+            end
+          end
+          while th.status
+            th.kill
+          end
+        end
+        Process.waitpid(pid)
+      end
+    end;
+  end if Process.respond_to?(:fork)
 end

--- a/thread.c
+++ b/thread.c
@@ -4980,6 +4980,7 @@ rb_thread_atfork_internal(rb_thread_t *th, void (*atfork)(rb_thread_t *, const r
     vm->ractor.main_thread = th;
     r->threads.main = th;
     r->status_ = ractor_created;
+    rb_ary_clear(th->pending_interrupt_mask_stack);
 
     thread_sched_atfork(TH_SCHED(th));
     ubf_list_atfork();


### PR DESCRIPTION
Otherwise, we inherit a mask stack that can never be popped.