### PR TITLE
A fiber parked on a mutex m can be freed, then unlocking m crashes

### DIFF
--- a/test/fiber/test_mutex.rb
+++ b/test/fiber/test_mutex.rb
@@ -70,6 +70,113 @@ class TestFiberMutex < Test::Unit::TestCase
     thread.join
   end
 
+  # Regression test: a fiber parked in Fiber::Scheduler#block while waiting on a
+  # locked mutex links an on-stack waiter into the mutex's wait queue. That wait
+  # queue is not a GC root, and a scheduler is not required to retain the blocked
+  # fiber, so nothing else necessarily keeps it reachable -- the VM must root the
+  # parked fiber on its thread. Otherwise GC frees the fiber while it is parked,
+  # and unlocking the mutex walks a dangling waiter node and crashes.
+  def test_mutex_blocking_fiber_gc
+    assert_separately([], <<~'RUBY')
+      # A deliberately minimal scheduler: #block does not retain the blocked
+      # fiber and #fiber discards the fiber it resumes, so the only thing that
+      # can keep the parked fiber alive is the mutex marking its wait queue.
+      class MinScheduler
+        def block(blocker, timeout = nil)
+          Fiber.yield
+        end
+        def unblock(blocker, fiber)
+        end
+        def fiber(&block)
+          Fiber.new(blocking: false, &block).resume
+          nil
+        end
+        def fiber_interrupt(fiber, exception); end
+        def close; end
+        def kernel_sleep(*); end
+        def io_wait(*); end
+        def process_wait(*); end
+        def timeout_after(*); yield; end
+        def blocking_operation_wait(work); work.call; end
+      end
+
+      mutex = Thread::Mutex.new
+      mutex.lock
+
+      Fiber.set_scheduler(MinScheduler.new)
+      # Parks a fiber inside #block, linked into mutex's wait queue, then discards
+      # every Ruby-level reference to it.
+      Fiber.schedule do
+        mutex.lock
+        mutex.unlock
+      end
+
+      # If the mutex did not mark its wait queue, GC would free the parked fiber
+      # here and leave a dangling waiter in the mutex's wait queue.
+      5.times { GC.start }
+
+      # Walks the wait queue -- must not touch a freed fiber/waiter.
+      mutex.unlock
+      assert_equal(false, mutex.locked?)
+    RUBY
+  end
+
+  def test_mutex_blocking_fiber_gc_after_thread_kill
+    assert_separately([], <<~'RUBY')
+      # A worker thread parks a fiber in a mutex owned by the MAIN thread, then
+      # is killed while the fiber is still parked. Thread teardown only drains
+      # the dying thread's own keeping_mutexes, so the main thread's mutex keeps
+      # a waiter node pointing at the dead worker's fiber. The mutex must keep
+      # that fiber alive across GC (so the node never dangles), and unlocking it
+      # must tolerate the waiter's thread being THREAD_KILLED.
+      class MinScheduler
+        def block(blocker, timeout = nil)
+          Fiber.yield
+        end
+        def unblock(blocker, fiber); end
+        def fiber(&block)
+          Fiber.new(blocking: false, &block).resume
+          nil
+        end
+        def fiber_interrupt(fiber, exception); end
+        def close; end
+        def kernel_sleep(*); end
+        def io_wait(*); end
+        def process_wait(*); end
+        def timeout_after(*); yield; end
+        def blocking_operation_wait(work); work.call; end
+      end
+
+      mutex = Thread::Mutex.new
+      mutex.lock
+
+      worker = Thread.new do
+        Fiber.set_scheduler(MinScheduler.new)
+        # Parks a fiber in mutex's wait queue (mutex held by main thread), then
+        # discards every Ruby-level reference to it.
+        Fiber.schedule do
+          mutex.lock
+          mutex.unlock
+        end
+        Thread.stop
+      end
+
+      # Wait until the worker has parked its fiber in the wait queue.
+      Thread.pass until worker.stop?
+
+      worker.kill
+      worker.join
+
+      # If the mutex did not mark its wait queue, GC would free the dead
+      # worker's parked fiber here and leave a dangling waiter node.
+      5.times { GC.start }
+
+      # Walks the wait queue, whose only waiter belongs to the killed thread.
+      mutex.unlock
+      assert_equal(false, mutex.locked?)
+    RUBY
+  end
+
   def test_mutex_fiber_raise
     mutex = Thread::Mutex.new
     ran = false

--- a/thread.c
+++ b/thread.c
@@ -429,7 +429,7 @@ rb_threadptr_join_list_wakeup(rb_thread_t *thread)
         rb_thread_t *target_thread = join_list->thread;
 
         if (target_thread->scheduler != Qnil && join_list->fiber) {
-            rb_fiber_scheduler_unblock(target_thread->scheduler, target_thread->self, rb_fiberptr_self(join_list->fiber));
+            rb_fiber_scheduler_unblock(target_thread->scheduler, target_thread->self, join_list->fiber);
         }
         else {
             rb_threadptr_interrupt(target_thread);
@@ -1132,7 +1132,7 @@ thread_join(rb_thread_t *target_th, VALUE timeout, rb_hrtime_t *limit)
         struct rb_waiting_list waiter;
         waiter.next = target_th->join_list;
         waiter.thread = th;
-        waiter.fiber = rb_fiberptr_blocking(fiber) ? NULL : fiber;
+        waiter.fiber = nonblocking_fiber(fiber);
         target_th->join_list = &waiter;
 
         struct join_arg arg;

--- a/thread_sync.c
+++ b/thread_sync.c
@@ -16,18 +16,34 @@ typedef struct rb_mutex_struct {
 struct sync_waiter {
     VALUE self;
     rb_thread_t *th;
-    rb_fiber_t *fiber;
+    VALUE fiber;
     struct ccan_list_node node;
 };
 
-static inline rb_fiber_t*
+static inline VALUE
 nonblocking_fiber(rb_fiber_t *fiber)
 {
     if (rb_fiberptr_blocking(fiber)) {
-        return NULL;
+        return 0;
     }
 
-    return fiber;
+    return rb_fiberptr_self(fiber);
+}
+
+/* Keep fibers parked in this wait queue reachable across GC. A waiter lives on
+ * the blocked fiber's machine stack, so while it is parked nothing else
+ * necessarily roots the fiber. Threads in the waitq are rooted elsewhere (the
+ * VM living-threads list) */
+static void
+sync_waitq_mark_and_move(struct ccan_list_head *waitq)
+{
+    struct sync_waiter *cur = 0;
+
+    ccan_list_for_each(waitq, cur, node) {
+        if (cur->fiber) {
+            rb_gc_mark_and_move(&cur->fiber);
+        }
+    }
 }
 
 struct queue_sleep_arg {
@@ -50,7 +66,7 @@ sync_wakeup(struct ccan_list_head *head, long max)
 
         if (cur->th->status != THREAD_KILLED) {
             if (cur->th->scheduler != Qnil && cur->fiber) {
-                rb_fiber_scheduler_unblock(cur->th->scheduler, cur->self, rb_fiberptr_self(cur->fiber));
+                rb_fiber_scheduler_unblock(cur->th->scheduler, cur->self, cur->fiber);
             }
             else {
                 RUBY_DEBUG_LOG("target_th:%u", rb_th_serial(cur->th));
@@ -104,6 +120,13 @@ mutex_locked_p(rb_mutex_t *mutex)
 }
 
 static void
+mutex_mark_and_move(void *ptr)
+{
+    rb_mutex_t *mutex = ptr;
+    sync_waitq_mark_and_move(&mutex->waitq);
+}
+
+static void
 mutex_free(void *ptr)
 {
     rb_mutex_t *mutex = ptr;
@@ -122,7 +145,7 @@ mutex_memsize(const void *ptr)
 
 static const rb_data_type_t mutex_data_type = {
     "mutex",
-    {NULL, mutex_free, mutex_memsize,},
+    {mutex_mark_and_move, mutex_free, mutex_memsize, mutex_mark_and_move,},
     0, 0, RUBY_TYPED_FREE_IMMEDIATELY
 };
 
@@ -460,8 +483,15 @@ rb_mutex_unlock_th(rb_mutex_t *mutex, rb_thread_t *th, rb_serial_t ec_serial)
     ccan_list_for_each_safe(&mutex->waitq, cur, next, node) {
         ccan_list_del_init(&cur->node);
 
-        if (cur->th->scheduler != Qnil && cur->fiber) {
-            rb_fiber_scheduler_unblock(cur->th->scheduler, cur->self, rb_fiberptr_self(cur->fiber));
+        if (cur->th->status == THREAD_KILLED) {
+            /* The waiter's thread was killed while it was parked here (e.g. a
+             * fiber blocked under a Fiber::Scheduler that did not interrupt it
+             * during thread teardown). The waiter is dead; skip it and try to
+             * hand the mutex to the next waiter instead. */
+            continue;
+        }
+        else if (cur->th->scheduler != Qnil && cur->fiber) {
+            rb_fiber_scheduler_unblock(cur->th->scheduler, cur->self, cur->fiber);
             return NULL;
         }
         else {
@@ -474,8 +504,7 @@ rb_mutex_unlock_th(rb_mutex_t *mutex, rb_thread_t *th, rb_serial_t ec_serial)
               case THREAD_STOPPED: /* probably impossible */
                 rb_bug("unexpected THREAD_STOPPED");
               case THREAD_KILLED:
-                /* not sure about this, possible in exit GC? */
-                rb_bug("unexpected THREAD_KILLED");
+                /* handled above */
                 continue;
             }
         }
@@ -690,7 +719,9 @@ static void
 queue_mark_and_move(void *ptr)
 {
     struct rb_queue *q = ptr;
-    /* no need to mark threads in waitq, they are on stack */
+    /* A fiber parked here under a Fiber::Scheduler links an on-stack waiter
+     * into the waitq; it is not otherwise a GC root, so keep it reachable. */
+    sync_waitq_mark_and_move(&q->waitq);
     for (long index = 0; index < q->len; index++) {
         rb_gc_mark_and_move(&q->buffer[((q->offset + index) % q->capa)]);
     }
@@ -807,6 +838,8 @@ szqueue_mark_and_move(void *ptr)
     struct rb_szqueue *sq = ptr;
 
     queue_mark_and_move(&sq->q);
+    /* q.waitq is covered by queue_mark_and_move above; pushq is separate. */
+    sync_waitq_mark_and_move(szqueue_pushq(sq));
 }
 
 static void
@@ -1054,6 +1087,10 @@ queue_do_pop(rb_execution_context_t *ec, VALUE self, struct rb_queue *q, VALUE n
             ccan_list_add_tail(waitq, &queue_waiter.w.node);
             queue_waiter.as.q->num_waiting++;
 
+            if (queue_waiter.w.fiber) {
+                RB_OBJ_WRITTEN(self, Qundef, queue_waiter.w.fiber);
+            }
+
             struct queue_sleep_arg queue_sleep_arg = {
                 .self = self,
                 .timeout = timeout,
@@ -1130,6 +1167,10 @@ rb_szqueue_push(rb_execution_context_t *ec, VALUE self, VALUE object, VALUE non_
             ccan_list_add_tail(pushq, &queue_waiter.w.node);
             sq->num_waiting_push++;
 
+            if (queue_waiter.w.fiber) {
+                RB_OBJ_WRITTEN(self, Qundef, queue_waiter.w.fiber);
+            }
+
             struct queue_sleep_arg queue_sleep_arg = {
                 .self = self,
                 .timeout = timeout,
@@ -1170,9 +1211,16 @@ condvar_memsize(const void *ptr)
     return sizeof(struct rb_condvar);
 }
 
+static void
+condvar_mark_and_move(void *ptr)
+{
+    struct rb_condvar *cv = ptr;
+    sync_waitq_mark_and_move(&cv->waitq);
+}
+
 static const rb_data_type_t cv_data_type = {
     "condvar",
-    {0, RUBY_TYPED_DEFAULT_FREE, condvar_memsize,},
+    {condvar_mark_and_move, RUBY_TYPED_DEFAULT_FREE, condvar_memsize, condvar_mark_and_move,},
     0, 0, RUBY_TYPED_FREE_IMMEDIATELY|RUBY_TYPED_WB_PROTECTED
 };
 
@@ -1242,6 +1290,11 @@ rb_condvar_wait(rb_execution_context_t *ec, VALUE self, VALUE mutex, VALUE timeo
     };
 
     ccan_list_add_tail(&cv->waitq, &sync_waiter.node);
+
+    if (sync_waiter.fiber) {
+        RB_OBJ_WRITTEN(self, Qundef, sync_waiter.fiber);
+    }
+
     return rb_ec_ensure(ec, do_sleep, (VALUE)&args, delete_from_waitq, (VALUE)&sync_waiter);
 }
 

--- a/vm.c
+++ b/vm.c
@@ -3773,6 +3773,13 @@ thread_compact(void *ptr)
     rb_thread_t *th = ptr;
 
     th->self = rb_gc_location(th->self);
+
+    /* Update fibers blocked in Thread#join (see thread_mark). */
+    for (struct rb_waiting_list *join_list = th->join_list; join_list; join_list = join_list->next) {
+        if (join_list->fiber) {
+            rb_gc_mark_and_move(&join_list->fiber);
+        }
+    }
 }
 
 static void
@@ -3812,6 +3819,16 @@ thread_mark(void *ptr)
     RUBY_ASSERT(th->ec == NULL || th->ec == rb_fiberptr_get_ec(th->ec->fiber_ptr));
     rb_gc_mark(th->last_status);
     rb_gc_mark(th->locking_mutex);
+
+    /* A fiber blocked in Thread#join (under a Fiber::Scheduler) links an
+     * on-stack waiter into the joined thread's join_list. That waiter is not
+     * otherwise a GC root, so keep the blocked fiber reachable here. */
+    for (struct rb_waiting_list *join_list = th->join_list; join_list; join_list = join_list->next) {
+        if (join_list->fiber) {
+            rb_gc_mark_and_move(&join_list->fiber);
+        }
+    }
+
     rb_gc_mark(th->name);
 
     rb_gc_mark(th->scheduler);

--- a/vm_core.h
+++ b/vm_core.h
@@ -1039,7 +1039,7 @@ typedef struct rb_fiber_struct rb_fiber_t;
 struct rb_waiting_list {
     struct rb_waiting_list *next;
     struct rb_thread_struct *thread;
-    struct rb_fiber_struct *fiber;
+    VALUE fiber;
 };
 
 struct rb_execution_context_struct {


### PR DESCRIPTION
The fix is to use the Mutex waitq to mark the fibers. We could also root a waiting fiber on its owning thread, but that has the disadvantage that the fiber could become unrooted if the thread is killed. In that case, unlocking the mutex could still crash due to the freed fiber.

Alternative to https://github.com/ruby/ruby/pull/17207/