### PR TITLE
Backport RubyBox improvements: Jun 2026

### DIFF
--- a/box.c
+++ b/box.c
@@ -856,8 +856,7 @@ rb_box_load(int argc, VALUE *argv, VALUE box)
 
     rb_vm_frame_flag_set_box_require(GET_EC());
 
-    VALUE args = rb_ary_new_from_args(2, fname, wrap);
-    return rb_load_entrypoint(args);
+    return rb_load_entrypoint(fname, wrap);
 }
 
 static VALUE

--- a/box.c
+++ b/box.c
@@ -299,7 +299,7 @@ box_entry_free(void *ptr)
     cleanup_all_local_extensions(box->ruby_dln_libmap);
 
     free_box_st_tables(ptr);
-    SIZED_FREE(box);
+    xfree((void *)box);
 }
 
 static size_t
@@ -425,9 +425,6 @@ box_initialize(VALUE box_value)
             rb_load_gem_prelude((VALUE)box);
         }
     }
-
-    // Invalidate ZJIT code that assumes only the root box is active
-    rb_zjit_invalidate_root_box();
 
     return box_value;
 }

--- a/box.c
+++ b/box.c
@@ -230,7 +230,7 @@ rb_box_entry_mark(void *ptr)
     rb_gc_mark(box->ruby_dln_libmap);
     rb_gc_mark(box->gvar_tbl);
     if (box->classext_cow_classes) {
-        rb_mark_tbl(box->classext_cow_classes);
+        rb_mark_set(box->classext_cow_classes);
     }
 }
 
@@ -267,10 +267,10 @@ free_box_st_tables(void *ptr)
 }
 
 static int
-free_classext_for_box(st_data_t _key, st_data_t obj_value, st_data_t box_arg)
+free_classext_for_box(st_data_t key, st_data_t _value, st_data_t box_arg)
 {
     rb_classext_t *ext;
-    VALUE obj = (VALUE)obj_value;
+    VALUE obj = (VALUE)key;
     const rb_box_t *box = (const rb_box_t *)box_arg;
 
     if (RB_TYPE_P(obj, T_CLASS) || RB_TYPE_P(obj, T_MODULE)) {

--- a/box.c
+++ b/box.c
@@ -19,6 +19,8 @@
 #include "vm_core.h"
 #include "darray.h"
 
+#include "builtin.h"
+
 #include <stdio.h>
 
 #ifdef HAVE_SYS_SENDFILE_H
@@ -32,8 +34,12 @@ VALUE rb_cBox = 0;
 VALUE rb_cBoxEntry = 0;
 VALUE rb_mBoxLoader = 0;
 
-static rb_box_t root_box[1]; /* Initialize in initialize_root_box() */
+static rb_box_t master_box[1]; /* Initialize in initialize_master_box() */
+static rb_box_t *root_box;
 static rb_box_t *main_box;
+
+static rb_box_gem_flags_t box_gem_flags[1];
+
 static char *tmp_dir;
 static bool tmp_dir_has_dirsep;
 
@@ -58,14 +64,32 @@ static VALUE rb_box_inspect(VALUE obj);
 static void cleanup_all_local_extensions(VALUE libmap);
 
 void
+rb_box_set_gem_flags(rb_box_gem_flags_t *flags)
+{
+
+    box_gem_flags->gem = flags->gem;
+    box_gem_flags->error_highlight = flags->error_highlight;
+    box_gem_flags->did_you_mean    = flags->did_you_mean;
+    box_gem_flags->syntax_suggest  = flags->syntax_suggest;
+}
+
+void
 rb_box_init_done(void)
 {
     ruby_box_init_done = true;
 }
 
 const rb_box_t *
+rb_master_box(void)
+{
+    return master_box;
+}
+
+const rb_box_t *
 rb_root_box(void)
 {
+    if (!root_box) // The root box isn't initialized yet - The Ruby runtime is in setup.
+        return master_box;
     return root_box;
 }
 
@@ -79,12 +103,14 @@ const rb_box_t *
 rb_current_box(void)
 {
     /*
-     * If RUBY_BOX is not set, the root box is the only available one.
+     * If RUBY_BOX is not set, the master box is the only available one.
      *
-     * Until the main_box is not initialized, the root box is
+     * While the root/main boxes are not initialized, the master box is
      * the only valid box.
      * This early return is to avoid accessing EC before its setup.
      */
+    if (!root_box)
+        return master_box;
     if (!main_box)
         return root_box;
 
@@ -94,6 +120,8 @@ rb_current_box(void)
 const rb_box_t *
 rb_loading_box(void)
 {
+    if (!root_box)
+        return master_box;
     if (!main_box)
         return root_box;
 
@@ -129,7 +157,7 @@ box_main_to_s(VALUE obj)
 static void
 box_entry_initialize(rb_box_t *box)
 {
-    const rb_box_t *root = rb_root_box();
+    const rb_box_t *master = rb_master_box();
 
     // These will be updated immediately
     box->box_object = 0;
@@ -138,15 +166,15 @@ box_entry_initialize(rb_box_t *box)
     box->top_self = rb_obj_alloc(rb_cObject);
     rb_define_singleton_method(box->top_self, "to_s", box_main_to_s, 0);
     rb_define_alias(rb_singleton_class(box->top_self), "inspect", "to_s");
-    box->load_path = rb_ary_dup(root->load_path);
-    box->expanded_load_path = rb_ary_dup(root->expanded_load_path);
+    box->load_path = rb_ary_dup(master->load_path);
+    box->expanded_load_path = rb_ary_dup(master->expanded_load_path);
     box->load_path_snapshot = rb_ary_new();
     box->load_path_check_cache = 0;
-    box->loaded_features = rb_ary_dup(root->loaded_features);
+    box->loaded_features = rb_ary_dup(master->loaded_features);
     box->loaded_features_snapshot = rb_ary_new();
     box->loaded_features_index = st_init_numtable();
-    box->loaded_features_realpaths = rb_hash_dup(root->loaded_features_realpaths);
-    box->loaded_features_realpath_map = rb_hash_dup(root->loaded_features_realpath_map);
+    box->loaded_features_realpaths = rb_hash_dup(master->loaded_features_realpaths);
+    box->loaded_features_realpath_map = rb_hash_dup(master->loaded_features_realpath_map);
     box->loading_table = st_init_strtable();
     box->ruby_dln_libmap = rb_hash_new_with_size(0);
     box->gvar_tbl = rb_hash_new_with_size(0);
@@ -223,7 +251,7 @@ free_loaded_feature_index_i(st_data_t key, st_data_t value, st_data_t arg)
 }
 
 static void
-box_root_free(void *ptr)
+free_box_st_tables(void *ptr)
 {
     rb_box_t *box = (rb_box_t *)ptr;
     if (box->loading_table) {
@@ -270,8 +298,8 @@ box_entry_free(void *ptr)
 
     cleanup_all_local_extensions(box->ruby_dln_libmap);
 
-    box_root_free(ptr);
-    xfree(ptr);
+    free_box_st_tables(ptr);
+    SIZED_FREE(box);
 }
 
 static size_t
@@ -299,11 +327,11 @@ static const rb_data_type_t rb_box_data_type = {
     0, 0, RUBY_TYPED_FREE_IMMEDIATELY // TODO: enable RUBY_TYPED_WB_PROTECTED when inserting write barriers
 };
 
-static const rb_data_type_t rb_root_box_data_type = {
-    "Ruby::Box::Root",
+static const rb_data_type_t rb_master_box_data_type = {
+    "Ruby::Box::Master",
     {
         rb_box_entry_mark,
-        box_root_free,
+        free_box_st_tables,
         box_entry_memsize,
         rb_box_gc_update_references,
     },
@@ -336,7 +364,7 @@ rb_get_box_t(VALUE box)
     VM_ASSERT(box);
 
     if (NIL_P(box))
-        return root_box;
+        return (rb_box_t *)rb_root_box();
 
     VM_ASSERT(BOX_OBJ_P(box));
 
@@ -389,6 +417,17 @@ box_initialize(VALUE box_value)
     RCLASS_SET_CONST_TBL(box_value, RCLASSEXT_CONST_TBL(object_classext), true);
 
     rb_ivar_set(box_value, id_box_entry, entry);
+
+    if (ruby_box_init_done) {
+        if (box_gem_flags->gem) {
+            rb_vm_call_cfunc_in_box(Qnil, rb_define_gem_modules, (VALUE)box_gem_flags, Qnil,
+                                    rb_str_new_cstr("before_prelude.user.dummy"), (const rb_box_t *)box);
+            rb_load_gem_prelude((VALUE)box);
+        }
+    }
+
+    // Invalidate ZJIT code that assumes only the root box is active
+    rb_zjit_invalidate_root_box();
 
     return box_value;
 }
@@ -838,49 +877,52 @@ rb_box_require_relative(VALUE box, VALUE fname)
 }
 
 static void
-initialize_root_box(void)
+initialize_master_box(void)
 {
     rb_vm_t *vm = GET_VM();
-    rb_box_t *root = (rb_box_t *)rb_root_box();
+    rb_box_t *master = (rb_box_t *)rb_master_box();
 
-    root->load_path = rb_ary_new();
-    root->expanded_load_path = rb_ary_hidden_new(0);
-    root->load_path_snapshot = rb_ary_hidden_new(0);
-    root->load_path_check_cache = 0;
-    rb_define_singleton_method(root->load_path, "resolve_feature_path", rb_resolve_feature_path, 1);
+    master->load_path = rb_ary_new();
+    master->expanded_load_path = rb_ary_hidden_new(0);
+    master->load_path_snapshot = rb_ary_hidden_new(0);
+    master->load_path_check_cache = 0;
+    rb_define_singleton_method(master->load_path, "resolve_feature_path", rb_resolve_feature_path, 1);
 
-    root->loaded_features = rb_ary_new();
-    root->loaded_features_snapshot = rb_ary_hidden_new(0);
-    root->loaded_features_index = st_init_numtable();
-    root->loaded_features_realpaths = rb_hash_new();
-    rb_obj_hide(root->loaded_features_realpaths);
-    root->loaded_features_realpath_map = rb_hash_new();
-    rb_obj_hide(root->loaded_features_realpath_map);
+    master->loaded_features = rb_ary_new();
+    master->loaded_features_snapshot = rb_ary_hidden_new(0);
+    master->loaded_features_index = st_init_numtable();
+    master->loaded_features_realpaths = rb_hash_new();
+    rb_obj_hide(master->loaded_features_realpaths);
+    master->loaded_features_realpath_map = rb_hash_new();
+    rb_obj_hide(master->loaded_features_realpath_map);
 
-    root->ruby_dln_libmap = rb_hash_new_with_size(0);
-    root->gvar_tbl = rb_hash_new_with_size(0);
-    root->classext_cow_classes = NULL; // classext CoW never happen on the root box
+    master->ruby_dln_libmap = rb_hash_new_with_size(0);
+    master->gvar_tbl = rb_hash_new_with_size(0);
+    master->classext_cow_classes = NULL; // classext CoW never happen on the master box
 
-    vm->root_box = root;
+    vm->master_box = master;
 
     if (rb_box_available()) {
-        VALUE root_box, entry;
+        VALUE master_box, entry;
         ID id_box_entry;
         CONST_ID(id_box_entry, "__box_entry__");
 
-        root_box = rb_obj_alloc(rb_cBox);
-        RCLASS_SET_PRIME_CLASSEXT_WRITABLE(root_box, true);
-        RCLASS_SET_CONST_TBL(root_box, RCLASSEXT_CONST_TBL(RCLASS_EXT_PRIME(rb_cObject)), true);
+        master_box = rb_obj_alloc(rb_cBox);
+        RCLASS_SET_PRIME_CLASSEXT_WRITABLE(master_box, true);
+        RCLASS_SET_CONST_TBL(master_box, RCLASSEXT_CONST_TBL(RCLASS_EXT_PRIME(rb_cObject)), true);
 
-        root->box_id = box_generate_id();
-        root->box_object = root_box;
+        master->box_id = box_generate_id();
+        master->box_object = master_box;
 
-        entry = TypedData_Wrap_Struct(rb_cBoxEntry, &rb_root_box_data_type, root);
-        rb_ivar_set(root_box, id_box_entry, entry);
+        entry = TypedData_Wrap_Struct(rb_cBoxEntry, &rb_master_box_data_type, master);
+        rb_ivar_set(master_box, id_box_entry, entry);
+
+        rb_gc_register_mark_object(master_box);
+        rb_gc_register_mark_object(entry);
     }
     else {
-        root->box_id = 1;
-        root->box_object = Qnil;
+        master->box_id = 1;
+        master->box_object = Qnil;
     }
 }
 
@@ -904,11 +946,26 @@ static int box_experimental_warned = 0;
 
 RUBY_EXTERN const char ruby_api_version_name[];
 
-void
-rb_initialize_main_box(void)
+static VALUE
+box_value_initialize(bool root, bool user, bool optional)
 {
     rb_box_t *box;
-    VALUE main_box_value;
+    VALUE box_value = rb_class_new_instance(0, NULL, rb_cBox);
+
+    VM_ASSERT(BOX_OBJ_P(box_value));
+
+    box = rb_get_box_t(box_value);
+    box->box_object = box_value;
+    box->is_root = root;
+    box->is_user = user;
+    box->is_optional = optional;
+    return box_value;
+}
+
+void
+rb_initialize_mandatory_boxes(void)
+{
+    VALUE root_box_value, main_box_value;
     rb_vm_t *vm = GET_VM();
 
     VM_ASSERT(rb_box_available());
@@ -921,19 +978,18 @@ rb_initialize_main_box(void)
         box_experimental_warned = 1;
     }
 
-    main_box_value = rb_class_new_instance(0, NULL, rb_cBox);
-    VM_ASSERT(BOX_OBJ_P(main_box_value));
-    box = rb_get_box_t(main_box_value);
-    box->box_object = main_box_value;
-    box->is_user = true;
-    box->is_optional = false;
+    root_box_value = box_value_initialize(true, false, false);
+    main_box_value = box_value_initialize(false, true, false);
 
+    rb_const_set(rb_cBox, rb_intern("ROOT"), root_box_value);
     rb_const_set(rb_cBox, rb_intern("MAIN"), main_box_value);
 
-    vm->main_box = main_box = box;
+    vm->root_box = root_box = rb_get_box_t(root_box_value);
+    vm->main_box = main_box = rb_get_box_t(main_box_value);
 
     // create the writable classext of ::Object explicitly to finalize the set of visible top-level constants
-    RCLASS_EXT_WRITABLE_IN_BOX(rb_cObject, box);
+    RCLASS_EXT_WRITABLE_IN_BOX(rb_cObject, root_box);
+    RCLASS_EXT_WRITABLE_IN_BOX(rb_cObject, main_box);
 }
 
 static VALUE
@@ -942,12 +998,15 @@ rb_box_inspect(VALUE obj)
     rb_box_t *box;
     VALUE r;
     if (obj == Qfalse) {
-        r = rb_str_new_cstr("#<Ruby::Box:root>");
+        r = rb_str_new_cstr("#<Ruby::Box:master>");
         return r;
     }
     box = rb_get_box_t(obj);
     r = rb_str_new_cstr("#<Ruby::Box:");
     rb_str_concat(r, rb_funcall(LONG2NUM(box->box_id), rb_intern("to_s"), 0));
+    if (BOX_MASTER_P(box)) {
+        rb_str_cat_cstr(r, ",master");
+    }
     if (BOX_ROOT_P(box)) {
         rb_str_cat_cstr(r, ",root");
     }
@@ -979,9 +1038,9 @@ box_define_loader_method(const char *name)
 }
 
 void
-Init_root_box(void)
+Init_master_box(void)
 {
-    root_box->loading_table = st_init_strtable();
+    master_box->loading_table = st_init_strtable();
 }
 
 void
@@ -998,6 +1057,13 @@ Init_enable_box(void)
 
 /* :nodoc: */
 static VALUE
+rb_box_s_master(VALUE recv)
+{
+    return master_box->box_object;
+}
+
+/* :nodoc: */
+static VALUE
 rb_box_s_root(VALUE recv)
 {
     return root_box->box_object;
@@ -1008,6 +1074,14 @@ static VALUE
 rb_box_s_main(VALUE recv)
 {
     return main_box->box_object;
+}
+
+/* :nodoc: */
+static VALUE
+rb_box_master_p(VALUE box_value)
+{
+    const rb_box_t *box = (const rb_box_t *)rb_get_box_t(box_value);
+    return RBOOL(BOX_MASTER_P(box));
 }
 
 /* :nodoc: */
@@ -1144,7 +1218,7 @@ rb_f_dump_classext(VALUE recv, VALUE klass)
     box = RCLASSEXT_BOX(ext);
     snprintf(buf, 2048, "Prime classext box(%ld,%s), readable(%s), writable(%s)\n",
              box->box_id,
-             BOX_ROOT_P(box) ? "root" : (BOX_MAIN_P(box) ? "main" : "optional"),
+             BOX_MASTER_P(box) ? "master" : (BOX_ROOT_P(box) ? "root" : (BOX_MAIN_P(box) ? "main" : "optional")),
              RCLASS_PRIME_CLASSEXT_READABLE_P(klass) ? "t" : "f",
              RCLASS_PRIME_CLASSEXT_WRITABLE_P(klass) ? "t" : "f");
     rb_str_cat_cstr(res, buf);
@@ -1186,7 +1260,7 @@ Init_Box(void)
     rb_cBoxEntry = rb_define_class_under(rb_cBox, "Entry", rb_cObject);
     rb_define_alloc_func(rb_cBoxEntry, rb_box_entry_alloc);
 
-    initialize_root_box();
+    initialize_master_box();
 
     /* :nodoc: */
     rb_mBoxLoader = rb_define_module_under(rb_cBox, "Loader");
@@ -1197,8 +1271,10 @@ Init_Box(void)
     if (rb_box_available()) {
         rb_include_module(rb_cObject, rb_mBoxLoader);
 
+        rb_define_singleton_method(rb_cBox, "master", rb_box_s_master, 0);
         rb_define_singleton_method(rb_cBox, "root", rb_box_s_root, 0);
         rb_define_singleton_method(rb_cBox, "main", rb_box_s_main, 0);
+        rb_define_method(rb_cBox, "master?", rb_box_master_p, 0);
         rb_define_method(rb_cBox, "root?", rb_box_root_p, 0);
         rb_define_method(rb_cBox, "main?", rb_box_main_p, 0);
 

--- a/builtin.c
+++ b/builtin.c
@@ -1,4 +1,5 @@
 #include "internal.h"
+#include "internal/box.h"
 #include "vm_core.h"
 #include "iseq.h"
 #include "builtin.h"
@@ -56,7 +57,7 @@ builtin_lookup(const char *feature, size_t *psize)
 }
 
 static void
-load_with_builtin_functions(const char *feature_name, const struct rb_builtin_function *table)
+load_with_builtin_functions(const char *feature_name, const struct rb_builtin_function *table, const rb_box_t *target_box)
 {
     // search binary
     size_t size;
@@ -74,13 +75,40 @@ load_with_builtin_functions(const char *feature_name, const struct rb_builtin_fu
     vm->builtin_function_table = NULL;
 
     // exec
-    rb_iseq_eval(rb_iseq_check(iseq), rb_root_box()); // builtin functions are loaded in the root box
+    rb_iseq_eval(rb_iseq_check(iseq), target_box);
 }
 
 void
 rb_load_with_builtin_functions(const char *feature_name, const struct rb_builtin_function *table)
 {
-    load_with_builtin_functions(feature_name, table);
+    load_with_builtin_functions(feature_name, table, rb_root_box());
+}
+
+VALUE
+rb_define_gem_modules(VALUE flags_value, VALUE _)
+{
+    rb_box_gem_flags_t *flags = (rb_box_gem_flags_t *)flags_value;
+
+    if (flags->gem) {
+        rb_define_module("Gem");
+        if (flags->error_highlight) {
+            rb_define_module("ErrorHighlight");
+        }
+        if (flags->did_you_mean) {
+            rb_define_module("DidYouMean");
+        }
+        if (flags->syntax_suggest) {
+            rb_define_module("SyntaxSuggest");
+        }
+    }
+
+    return Qnil;
+}
+
+void
+rb_load_gem_prelude(VALUE box)
+{
+    load_with_builtin_functions("gem_prelude", NULL, (const rb_box_t *)box);
 }
 
 #endif
@@ -103,7 +131,9 @@ Init_builtin_features(void)
 
 #ifdef BUILTIN_BINARY_SIZE
 
-    load_with_builtin_functions("gem_prelude", NULL);
+    rb_load_gem_prelude((VALUE)rb_root_box());
+
+    rb_load_gem_prelude((VALUE)rb_main_box());
 
 #endif
 

--- a/builtin.c
+++ b/builtin.c
@@ -22,13 +22,36 @@ bin4feature(const struct builtin_binary *bb, const char *feature, size_t *psize)
 static const unsigned char*
 builtin_lookup(const char *feature, size_t *psize)
 {
-    static int index = 0;
-    const unsigned char *bin = bin4feature(&builtin_binary[index++], feature, psize);
+    static size_t index = 0;
+    const unsigned char *bin = NULL;
 
-    // usually, `builtin_binary` order is loading order at miniruby.
-    for (const struct builtin_binary *bb = &builtin_binary[0]; bb->feature &&! bin; bb++) {
-        bin = bin4feature(bb++, feature, psize);
+    /*
+     * Fast path:
+     * builtin_binary is usually arranged in the same order
+     * as features are looked up in miniruby, so try the next entry first.
+     */
+    if (builtin_binary[index].feature) {
+        bin = bin4feature(&builtin_binary[index], feature, psize);
+        index++;
     }
+    if (bin) {
+        return bin;
+    }
+
+    /*
+     * Fallback:
+     * In case the lookup order does not match the array order,
+     * scan the entire table to find the feature.
+     */
+    for (const struct builtin_binary *bb = &builtin_binary[0];
+         bb->feature;
+         bb++) {
+        bin = bin4feature(bb, feature, psize);
+        if (bin) {
+            break;
+        }
+    }
+
     return bin;
 }
 

--- a/builtin.h
+++ b/builtin.h
@@ -21,6 +21,8 @@ struct rb_builtin_function {
 }
 
 void rb_load_with_builtin_functions(const char *feature_name, const struct rb_builtin_function *table);
+VALUE rb_define_gem_modules(VALUE, VALUE);
+void rb_load_gem_prelude(VALUE box);
 
 #ifndef rb_execution_context_t
 typedef struct rb_execution_context_struct rb_execution_context_t;

--- a/class.c
+++ b/class.c
@@ -89,8 +89,7 @@ rb_class_unlink_classext(VALUE klass, const rb_box_t *box)
 {
     st_data_t ext;
     st_data_t key = (st_data_t)box->box_object;
-    VALUE obj_id = rb_obj_id(klass);
-    st_delete(box->classext_cow_classes, &obj_id, 0);
+    st_delete(box->classext_cow_classes, &klass, 0);
     st_delete(RCLASS_CLASSEXT_TBL(klass), &key, &ext);
     return (rb_classext_t *)ext;
 }
@@ -199,7 +198,7 @@ rb_class_set_box_classext(VALUE obj, const rb_box_t *box, rb_classext_t *ext)
     // (e.g. st_insert below) that could trigger GC.
     rb_gc_writebarrier_remember(obj);
 
-    st_insert(box->classext_cow_classes, (st_data_t)rb_obj_id(obj), obj);
+    st_insert(box->classext_cow_classes, (st_data_t)obj, 0);
 }
 
 RUBY_EXTERN rb_serial_t ruby_vm_global_cvar_state;

--- a/class.c
+++ b/class.c
@@ -190,7 +190,7 @@ rb_class_set_box_classext(VALUE obj, const rb_box_t *box, rb_classext_t *ext)
         .ext = ext,
     };
 
-    VM_ASSERT(BOX_USER_P(box));
+    VM_ASSERT(BOX_MUTABLE_P(box));
 
     st_update(RCLASS_CLASSEXT_TBL(obj), (st_data_t)box->box_object, set_box_classext_update, (st_data_t)&args);
 
@@ -697,7 +697,7 @@ class_alloc0(enum ruby_value_type type, VALUE klass, bool boxable)
 static VALUE
 class_alloc(enum ruby_value_type type, VALUE klass)
 {
-    bool boxable = rb_box_available() && BOX_ROOT_P(rb_current_box());
+    bool boxable = rb_box_available() && BOX_MASTER_P(rb_current_box());
     return class_alloc0(type, klass, boxable);
 }
 

--- a/depend
+++ b/depend
@@ -791,6 +791,7 @@ box.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
 box.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 box.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 box.$(OBJEXT): {$(VPATH)}box.c
+box.$(OBJEXT): {$(VPATH)}builtin.h
 box.$(OBJEXT): {$(VPATH)}config.h
 box.$(OBJEXT): {$(VPATH)}constant.h
 box.$(OBJEXT): {$(VPATH)}darray.h

--- a/doc/language/box.md
+++ b/doc/language/box.md
@@ -68,16 +68,35 @@ p s.x  # 1
 
 ### Ruby Box types
 
-There are two box types:
+There are three box types:
 
+* Master box
 * Root box
 * User boxes
 
-There is the root box, just a single box in a Ruby process. Ruby bootstrap runs in the root box, and all builtin classes/modules are defined in the root box. (See "Builtin classes and modules".)
+Ruby bootstrap runs in the root box, and a
 
-User boxes are to run user-written programs and libraries loaded from user programs. The user's main program (specified by the `ruby` command line argument) is executed in the "main" box, which is a user box automatically created at the end of Ruby's bootstrap, copied from the root box.
+There is the root box, just a single box in a Ruby process. All builtin classes/modules are defined and run in the root box. (See "Builtin classes and modules".)
 
-When `Ruby::Box.new` is called, an "optional" box (a user, non-main box) is created, copied from the root box. All user boxes are flat, copied from the root box.
+User boxes are to run user-written programs and libraries loaded from user programs. The user's main program (specified by the `ruby` command line argument) is executed in the "main" box, which is a user box automatically created at the end of Ruby's bootstrap. The files specified with `-r` command line option will be required in the main box.
+
+Calling `Ruby::Box.new` creates an "optional" box (a user, non-main box), technically equal to the main box.
+
+Ruby also has the master box. The master box is the "master copy" of all boxes. Boxes will be created as a copy of the master box. The master box is only for the source of box copies, and no code runs in the master box.
+
+
+```
+[master]
+ |
+ |----[root]
+ |
+ |----[main]
+ |
+ |----[user box 1]
+ |
+ |----[user box 2]
+ ...
+```
 
 ### Ruby Box class and instances
 
@@ -125,7 +144,7 @@ box::Foo.foo_is_blank? #=> false   (#blank? called in box)
 String::BLANK_PATTERN # NameError
 ```
 
-The main box and `box` are different boxes, so monkey patches in main are also invisible in `box`.
+The main box and `box` above are different boxes, so monkey patches in main are also invisible in `box`.
 
 ### Builtin classes and modules
 
@@ -133,9 +152,21 @@ In the box context, "builtin" classes and modules are classes and modules:
 
 * Accessible without any `require` calls in user scripts
 * Defined before any user program start running
-* Including classes/modules loaded by `prelude.rb` (including RubyGems `Gem`, for example)
 
 Hereafter, "builtin classes and modules" will be referred to as just "builtin classes".
+
+Builtin classes and modules are loaded in all boxes, and run in the root box.
+
+### Exceptional non-built-in classes/modules
+
+There are some exceptional classes/modules that are enabled in default, but aren't built-in classes. Those classes/modules are:
+
+* `RubyGems`
+* `ErrorHighlight`
+* `DidYouMean`
+* `SyntaxSuggest`
+
+Those classes/modules (part of default gems) are loaded in each boxes independently. If a user box's code calls RubyGems, it calls the RubyGems inside the box itself, instead of the root box's one.
 
 ### Builtin classes referred via box objects
 
@@ -316,41 +347,6 @@ This could potentially conflict with the user's expectations. We should find the
 #### Expose top level methods as a method of the box object
 
 Currently, top level methods in boxes are not accessible from outside of the box. But there might be a use case to call other box's top level methods.
-
-#### Split root and builtin box
-
-Currently, the single "root" box is the source of classext CoW. And also, the "root" box can load additional files after starting main script evaluation by calling methods which contain lines like `require "openssl"`.
-
-That means, user boxes can have different sets of definitions according to when it is created.
-
-```
-[root]
- |
- |----[main]
- |
- |(require "openssl" called in root)
- |
- |----[box1] having OpenSSL
- |
- |(remove_const called for OpenSSL in root)
- |
- |----[box2] without OpenSSL
-```
-
-This could cause unexpected behavior differences between user boxes. It should NOT be a problem because user scripts which refer to `OpenSSL` should call `require "openssl"` by themselves.
-But in the worst case, a script (without `require "openssl"`) runs well in `box1`, but doesn't run in `box2`. This situation looks like a "random failure" to users.
-
-An option possible to prevent this situation is to have "root" and "builtin" boxes.
-
-* root
-  * The box for the Ruby process bootstrap, then the source of CoW
-  * After starting the main box, no code runs in this box
-* builtin
-  * The box copied from the root box at the same time with "main"
-  * Methods and procs defined in the "root" box run in this box
-  * Classes and modules required will be loaded in this box
-
-This design realizes a consistent source of box CoW.
 
 #### Separate `cc_tbl` and `callable_m_tbl`, `cvc_tbl` for less classext CoW
 

--- a/eval.c
+++ b/eval.c
@@ -80,7 +80,7 @@ ruby_setup(void)
     rb_vm_encoded_insn_data_table_init();
     Init_enable_box();
     Init_vm_objects();
-    Init_root_box();
+    Init_master_box();
     Init_fstring_table();
 
     EC_PUSH_TAG(GET_EC());

--- a/eval.c
+++ b/eval.c
@@ -2216,6 +2216,9 @@ Init_eval(void)
     rb_gvar_ractor_local("$@");
     rb_gvar_ractor_local("$!");
 
+    rb_gvar_box_dynamic("$@");
+    rb_gvar_box_dynamic("$!");
+
     rb_define_global_function("raise", f_raise, -1);
     rb_define_global_function("fail", f_raise, -1);
 

--- a/internal/box.h
+++ b/internal/box.h
@@ -36,14 +36,25 @@ struct rb_box_struct {
     VALUE gvar_tbl;
     struct st_table *classext_cow_classes;
 
+    bool is_root;
     bool is_user;
     bool is_optional;
 };
 typedef struct rb_box_struct rb_box_t;
 
+struct rb_box_gem_flags {
+    bool gem;
+    bool error_highlight;
+    bool did_you_mean;
+    bool syntax_suggest;
+};
+typedef struct rb_box_gem_flags rb_box_gem_flags_t;
+
 #define BOX_OBJ_P(obj) (rb_obj_class(obj) == rb_cBox)
 
-#define BOX_ROOT_P(box) (box && !box->is_user)
+#define BOX_MASTER_P(box) (box && !box->is_root && !box->is_user)
+#define BOX_MUTABLE_P(box) (box && (box->is_root || box->is_user))
+#define BOX_ROOT_P(box) (box && box->is_root)
 #define BOX_USER_P(box) (box && box->is_user)
 #define BOX_OPTIONAL_P(box) (box && box->is_optional)
 #define BOX_MAIN_P(box) (box && box->is_user && !box->is_optional)
@@ -63,6 +74,7 @@ rb_box_available(void)
     return ruby_box_enabled;
 }
 
+const rb_box_t * rb_master_box(void);
 const rb_box_t * rb_root_box(void);
 const rb_box_t * rb_main_box(void);
 const rb_box_t * rb_current_box(void);
@@ -78,6 +90,7 @@ VALUE rb_get_box_object(rb_box_t *ns);
 VALUE rb_box_local_extension(VALUE box, VALUE fname, VALUE path, VALUE *cleanup);
 void rb_box_cleanup_local_extension(VALUE cleanup);
 
-void rb_initialize_main_box(void);
+void rb_initialize_mandatory_boxes(void);
 void rb_box_init_done(void);
+void rb_box_set_gem_flags(rb_box_gem_flags_t *);
 #endif /* INTERNAL_BOX_H */

--- a/internal/class.h
+++ b/internal/class.h
@@ -319,7 +319,7 @@ RCLASS_PRIME_CLASSEXT_WRITABLE_P(VALUE klass)
 {
     VM_ASSERT(klass != 0, "klass should be a valid object");
     VM_ASSERT_BOXABLE_TYPE(klass);
-    return FL_TEST(klass, RCLASS_PRIME_CLASSEXT_WRITABLE);
+    return FL_TEST_RAW(klass, RCLASS_PRIME_CLASSEXT_WRITABLE);
 }
 
 static inline void
@@ -328,10 +328,10 @@ RCLASS_SET_PRIME_CLASSEXT_WRITABLE(VALUE klass, bool writable)
     VM_ASSERT(klass != 0, "klass should be a valid object");
     VM_ASSERT_BOXABLE_TYPE(klass);
     if (writable) {
-        FL_SET(klass, RCLASS_PRIME_CLASSEXT_WRITABLE);
+        FL_SET_RAW(klass, RCLASS_PRIME_CLASSEXT_WRITABLE);
     }
     else {
-        FL_UNSET(klass, RCLASS_PRIME_CLASSEXT_WRITABLE);
+        FL_UNSET_RAW(klass, RCLASS_PRIME_CLASSEXT_WRITABLE);
     }
 }
 

--- a/internal/class.h
+++ b/internal/class.h
@@ -286,7 +286,7 @@ RCLASS_SET_BOX_CLASSEXT(VALUE obj, const rb_box_t *box, rb_classext_t *ext)
 {
     int first_set = 0;
     st_table *tbl = RCLASS_CLASSEXT_TBL(obj);
-    VM_ASSERT(BOX_USER_P(box)); // non-prime classext is only for user box, with box_object
+    VM_ASSERT(BOX_MUTABLE_P(box)); // Setting non-prime classext never happens on the master box
     VM_ASSERT(box->box_object);
     VM_ASSERT(RCLASSEXT_BOX(ext) == box);
     if (!tbl) {
@@ -361,7 +361,7 @@ RCLASS_EXT_READABLE_LOOKUP(VALUE obj, const rb_box_t *box)
 static inline rb_classext_t *
 RCLASS_EXT_READABLE_IN_BOX(VALUE obj, const rb_box_t *box)
 {
-    if (BOX_ROOT_P(box)
+    if (BOX_MASTER_P(box)
         || RCLASS_PRIME_CLASSEXT_READABLE_P(obj)) {
         return RCLASS_EXT_PRIME(obj);
     }
@@ -377,7 +377,7 @@ RCLASS_EXT_READABLE(VALUE obj)
     }
     // delay determining the current box to optimize for unmodified classes
     box = rb_current_box();
-    if (BOX_ROOT_P(box)) {
+    if (BOX_MASTER_P(box)) {
         return RCLASS_EXT_PRIME(obj);
     }
     return RCLASS_EXT_READABLE_LOOKUP(obj, box);
@@ -411,7 +411,7 @@ RCLASS_EXT_WRITABLE_LOOKUP(VALUE obj, const rb_box_t *box)
 static inline rb_classext_t *
 RCLASS_EXT_WRITABLE_IN_BOX(VALUE obj, const rb_box_t *box)
 {
-    if (BOX_ROOT_P(box)
+    if (BOX_MASTER_P(box)
         || RCLASS_PRIME_CLASSEXT_WRITABLE_P(obj)) {
         return RCLASS_EXT_PRIME(obj);
     }
@@ -427,7 +427,7 @@ RCLASS_EXT_WRITABLE(VALUE obj)
     }
     // delay determining the current box to optimize for unmodified classes
     box = rb_current_box();
-    if (BOX_ROOT_P(box)) {
+    if (BOX_MASTER_P(box)) {
         return RCLASS_EXT_PRIME(obj);
     }
     return RCLASS_EXT_WRITABLE_LOOKUP(obj, box);

--- a/internal/inits.h
+++ b/internal/inits.h
@@ -11,7 +11,7 @@
 
 /* box.c */
 void Init_enable_box(void);
-void Init_root_box(void);
+void Init_master_box(void);
 
 /* class.c */
 void Init_class_hierarchy(void);

--- a/internal/load.h
+++ b/internal/load.h
@@ -12,7 +12,7 @@
 
 /* load.c */
 VALUE rb_get_expanded_load_path(void);
-VALUE rb_load_entrypoint(VALUE args);
+VALUE rb_load_entrypoint(VALUE fname, VALUE wrap);
 VALUE rb_require_relative_entrypoint(VALUE fname);
 int rb_require_internal(VALUE fname);
 NORETURN(void rb_load_fail(VALUE, const char*));

--- a/load.c
+++ b/load.c
@@ -875,8 +875,8 @@ rb_load_protect(VALUE fname, int wrap, int *pstate)
     if (state != TAG_NONE) *pstate = state;
 }
 
-static VALUE
-load_entrypoint_internal(VALUE fname, VALUE wrap)
+VALUE
+rb_load_entrypoint(VALUE fname, VALUE wrap)
 {
     VALUE path, orig_fname;
 
@@ -895,18 +895,6 @@ load_entrypoint_internal(VALUE fname, VALUE wrap)
     RUBY_DTRACE_HOOK(LOAD_RETURN, RSTRING_PTR(orig_fname));
 
     return Qtrue;
-}
-
-VALUE
-rb_load_entrypoint(VALUE args)
-{
-    VALUE fname, wrap;
-    if (RARRAY_LEN(args) != 2) {
-        rb_bug("invalid arguments: %ld", RARRAY_LEN(args));
-    }
-    fname = rb_ary_entry(args, 0);
-    wrap = rb_ary_entry(args, 1);
-    return load_entrypoint_internal(fname, wrap);
 }
 
 /*
@@ -944,7 +932,7 @@ rb_f_load(int argc, VALUE *argv, VALUE _)
 {
     VALUE fname, wrap;
     rb_scan_args(argc, argv, "11", &fname, &wrap);
-    return load_entrypoint_internal(fname, wrap);
+    return rb_load_entrypoint(fname, wrap);
 }
 
 static char *

--- a/mini_builtin.c
+++ b/mini_builtin.c
@@ -102,3 +102,16 @@ rb_load_with_builtin_functions(const char *feature_name, const struct rb_builtin
     const rb_iseq_t *iseq = builtin_iseq_load(feature_name, table);
     rb_iseq_eval(iseq, rb_root_box());
 }
+
+VALUE
+rb_define_gem_modules(VALUE _a, VALUE _b)
+{
+    // do nothing - moniruby doesn't load gem_prelude.rb.
+    return Qnil;
+}
+
+void
+rb_load_gem_prelude(VALUE _)
+{
+    // do nothing - miniruby doesn't support loading RubyGems.
+}

--- a/ruby.c
+++ b/ruby.c
@@ -798,6 +798,25 @@ require_libraries(VALUE *req_list)
     *req_list = 0;
 }
 
+static void
+require_libraries_in_main_box(VALUE *req_list)
+{
+    const rb_box_t *main_box = rb_main_box();
+    VALUE list = *req_list;
+    ID require;
+    rb_encoding *extenc = rb_default_external_encoding();
+
+    CONST_ID(require, "require");
+    while (list && RARRAY_LEN(list) > 0) {
+        VALUE feature = rb_ary_shift(list);
+        rb_enc_associate(feature, extenc);
+        RBASIC_SET_CLASS_RAW(feature, rb_cString);
+        OBJ_FREEZE(feature);
+        rb_funcallv(main_box->box_object, require, 1, &feature);
+    }
+    *req_list = 0;
+}
+
 static const struct rb_block*
 toplevel_context(rb_binding_t *bind)
 {
@@ -1771,6 +1790,7 @@ proc_options(long argc, char **argv, ruby_cmdline_options_t *opt, int envopt)
     return argc0 - argc;
 }
 
+VALUE rb_define_gem_modules(VALUE, VALUE);
 void Init_builtin_features(void);
 
 static void
@@ -1798,26 +1818,6 @@ ruby_opt_init(ruby_cmdline_options_t *opt)
 
     if (opt->dump & dump_exit_bits) return;
 
-    if (FEATURE_SET_P(opt->features, gems)) {
-        rb_define_module("Gem");
-        if (opt->features.set & FEATURE_BIT(error_highlight)) {
-            rb_define_module("ErrorHighlight");
-        }
-        if (opt->features.set & FEATURE_BIT(did_you_mean)) {
-            rb_define_module("DidYouMean");
-        }
-        if (opt->features.set & FEATURE_BIT(syntax_suggest)) {
-            rb_define_module("SyntaxSuggest");
-        }
-    }
-
-    /* [Feature #19785] Warning for removed GC environment variable.
-     * Remove this in Ruby 3.4. */
-    if (getenv("RUBY_GC_HEAP_INIT_SLOTS")) {
-        rb_warn_deprecated("The environment variable RUBY_GC_HEAP_INIT_SLOTS",
-                           "environment variables RUBY_GC_HEAP_%d_INIT_SLOTS");
-    }
-
     Init_ext(); /* load statically linked extensions before rubygems */
     Init_extra_exts();
 
@@ -1826,15 +1826,52 @@ ruby_opt_init(ruby_cmdline_options_t *opt)
     GET_VM()->running = 1;
     memset(ruby_vm_redefined_flag, 0, sizeof(ruby_vm_redefined_flag));
 
-    ruby_init_prelude();
+    // Register JIT-optimized builtin CMEs before the prelude, which may
+    // redefine core methods (e.g. Kernel.prepend via bundler/setup).
+#if USE_YJIT
+    rb_yjit_init_builtin_cmes();
+#endif
+#if USE_ZJIT
+    extern void rb_zjit_init_builtin_cmes(void);
+    rb_zjit_init_builtin_cmes();
+#endif
 
-    /* Initialize the main box after loading libraries (including rubygems)
-     * to enable those in both root and main */
-    if (rb_box_available())
-        rb_initialize_main_box();
+    /**
+     * Initialize the root/main boxes before loading libraries to run them
+     * (including RubyGems, written in Ruby) in those boxes themselves
+     */
+    if (rb_box_available()) {
+        rb_initialize_mandatory_boxes();
+    }
+
     rb_box_init_done();
 
-    // Initialize JITs after ruby_init_prelude() because JITing prelude is typically not optimal.
+    if (FEATURE_SET_P(opt->features, gems)) {
+        rb_box_gem_flags_t gem_flags = {
+            .gem = FEATURE_SET_P(opt->features, gems),
+            .error_highlight = opt->features.set & FEATURE_BIT(error_highlight),
+            .did_you_mean    = opt->features.set & FEATURE_BIT(did_you_mean),
+            .syntax_suggest  = opt->features.set & FEATURE_BIT(syntax_suggest)
+        };
+
+        if (rb_box_available()) {
+            rb_vm_call_cfunc_in_box(Qnil, rb_define_gem_modules, (VALUE)&gem_flags, Qnil,
+                                    rb_str_new_cstr("before_prelude.root.dummy"), rb_root_box());
+            rb_vm_call_cfunc_in_box(Qnil, rb_define_gem_modules, (VALUE)&gem_flags, Qnil,
+                                    rb_str_new_cstr("before_prelude.main.dummy"), rb_main_box());
+
+            rb_box_set_gem_flags(&gem_flags);
+        }
+        else {
+            rb_define_gem_modules((VALUE)&gem_flags, Qnil);
+        }
+    }
+
+    // The root/main boxes load gem_prelude here.
+    // User boxes will load it in those #initialize instead.
+    ruby_init_prelude();
+
+    // Enable JITs after ruby_init_prelude() to avoid JITing prelude code.
 #if USE_YJIT
     rb_yjit_init(opt->yjit);
 #endif
@@ -1844,7 +1881,12 @@ ruby_opt_init(ruby_cmdline_options_t *opt)
 #endif
 
     ruby_set_script_name(opt->script_name);
-    require_libraries(&opt->req_list);
+    if (rb_box_available()) {
+        require_libraries_in_main_box(&opt->req_list);
+    }
+    else {
+        require_libraries(&opt->req_list);
+    }
 }
 
 static int

--- a/ruby.c
+++ b/ruby.c
@@ -1818,6 +1818,13 @@ ruby_opt_init(ruby_cmdline_options_t *opt)
 
     if (opt->dump & dump_exit_bits) return;
 
+    /* [Feature #19785] Warning for removed GC environment variable.
+     * Remove this in Ruby 3.4. */
+    if (getenv("RUBY_GC_HEAP_INIT_SLOTS")) {
+        rb_warn_deprecated("The environment variable RUBY_GC_HEAP_INIT_SLOTS",
+                           "environment variables RUBY_GC_HEAP_%d_INIT_SLOTS");
+    }
+
     Init_ext(); /* load statically linked extensions before rubygems */
     Init_extra_exts();
 

--- a/test/ruby/test_box.rb
+++ b/test/ruby/test_box.rb
@@ -1181,7 +1181,7 @@ class TestBox < Test::Unit::TestCase
     end;
   end
 
-  def test_method_invalidation_between_boxes
+  def test_method_invalidation_between_boxes_1
     assert_separately([ENV_ENABLE_BOX], __FILE__, __LINE__, "#{<<~"begin;"}\n#{<<~'end;'}", ignore_stderr: true)
     begin;
       b = Ruby::Box.new
@@ -1194,6 +1194,26 @@ class TestBox < Test::Unit::TestCase
 
       assert String === "x"
       assert b # to prevent GCing b
+    end;
+  end
+
+  def test_method_invalidation_between_boxes_2
+    assert_separately([ENV_ENABLE_BOX], __FILE__, __LINE__, "#{<<~"begin;"}\n#{<<~'end;'}", ignore_stderr: true)
+    begin;
+      PrepM = Module.new
+      Module.prepend(PrepM)
+      Module.new.include?(Module.new)
+
+      b = Ruby::Box.new
+      b.eval(<<~'RUBY')
+        Module.class_eval { def _test_method; end }
+
+        class C; end
+        class D < C; end
+        def C.include?(x) = true
+      RUBY
+
+      Module.new.include?(Module.new)
     end;
   end
 end

--- a/test/ruby/test_box.rb
+++ b/test/ruby/test_box.rb
@@ -625,6 +625,126 @@ class TestBox < Test::Unit::TestCase
     end;
   end
 
+  def test_errinfo_not_cached_in_box
+    assert_separately([ENV_ENABLE_BOX], __FILE__, __LINE__, "#{<<~"begin;"}\n#{<<~'end;'}", ignore_stderr: true)
+    begin;
+      first, second = Ruby::Box.new.eval(<<~'CODE')
+        a = begin; raise "first"; rescue RuntimeError; $!.message; end
+        b = begin; raise "second"; rescue RuntimeError; $!.message; end
+        [a, b]
+      CODE
+      assert_equal "first", first
+      assert_equal "second", second
+    end;
+  end
+
+  def test_errinfo_not_cached_in_nested_boxes
+    assert_separately([ENV_ENABLE_BOX], __FILE__, __LINE__, "#{<<~"begin;"}\n#{<<~'end;'}", ignore_stderr: true)
+    begin;
+      inner_msg, outer_msg = Ruby::Box.new.eval(<<~'CODE')
+        outer_a = begin; raise "outer1"; rescue RuntimeError; $!.message; end
+
+        inner_msg = Ruby::Box.new.eval(<<~'INNER')
+          begin; raise "inner1"; rescue RuntimeError; $!; end
+          begin; raise "inner2"; rescue RuntimeError; $!.message; end
+        INNER
+
+        outer_b = begin; raise "outer2"; rescue RuntimeError; $!.message; end
+        [inner_msg, outer_b]
+      CODE
+      assert_equal "inner2", inner_msg
+      assert_equal "outer2", outer_msg
+    end;
+  end
+
+  def test_backtrace_not_cached_in_box
+    assert_separately([ENV_ENABLE_BOX], __FILE__, __LINE__, "#{<<~"begin;"}\n#{<<~'end;'}", ignore_stderr: true)
+    begin;
+      a_actual, b_actual = Ruby::Box.new.eval(<<~'CODE')
+        a_actual = begin; raise "first"; rescue RuntimeError; $@.first[/:(\d+):/, 1].to_i; end
+        b_actual = begin; raise "second"; rescue RuntimeError; $@.first[/:(\d+):/, 1].to_i; end
+        [a_actual, b_actual]
+      CODE
+      assert_equal 1, a_actual
+      assert_equal 2, b_actual
+    end;
+  end
+
+  def test_backtrace_not_cached_in_nested_boxes
+    assert_separately([ENV_ENABLE_BOX], __FILE__, __LINE__, "#{<<~"begin;"}\n#{<<~'end;'}", ignore_stderr: true)
+    begin;
+      inner_actual, outer_actual = Ruby::Box.new.eval(<<~'CODE')
+        begin; raise "outer1"; rescue RuntimeError; $@; end
+        inner_actual = Ruby::Box.new.eval(<<~'INNER')
+          begin; raise "inner1"; rescue RuntimeError; $@; end
+          begin; raise "inner2"; rescue RuntimeError; $@.first[/:(\d+):/, 1].to_i; end
+        INNER
+        outer_actual = begin; raise "outer2"; rescue RuntimeError; $@.first[/:(\d+):/, 1].to_i; end
+        [inner_actual, outer_actual]
+      CODE
+      assert_equal 2, inner_actual
+      assert_equal 6, outer_actual
+    end;
+  end
+
+  def test_errinfo_isolated_between_boxes
+    assert_separately([ENV_ENABLE_BOX], __FILE__, __LINE__, "#{<<~"begin;"}\n#{<<~'end;'}", ignore_stderr: true)
+    begin;
+      box_a = Ruby::Box.new
+      box_b = Ruby::Box.new
+
+      a = box_a.eval('begin; raise "a"; rescue; $!.message; end')
+      b = box_b.eval('begin; raise "b"; rescue; $!.message; end')
+
+      assert_equal "a", a
+      assert_equal "b", b
+    end;
+  end
+
+  def test_backtrace_isolated_between_boxes
+    assert_separately([ENV_ENABLE_BOX], __FILE__, __LINE__, "#{<<~"begin;"}\n#{<<~'end;'}", ignore_stderr: true)
+    begin;
+      box_a = Ruby::Box.new
+      box_b = Ruby::Box.new
+
+      a_line = box_a.eval("\nbegin; raise; rescue; $@.first[/:(\\d+):/, 1].to_i; end")
+      b_line = box_b.eval('begin; raise; rescue; $@.first[/:(\d+):/, 1].to_i; end')
+
+      assert_equal 2, a_line
+      assert_equal 1, b_line
+    end;
+  end
+
+  def test_inner_box_rescue_does_not_disturb_outer_box_errinfo
+    assert_separately([ENV_ENABLE_BOX], __FILE__, __LINE__, "#{<<~"begin;"}\n#{<<~'end;'}", ignore_stderr: true)
+    begin;
+      box_a = Ruby::Box.new
+      errinfo_in_inner_rescue, errinfo_after_inner_rescue, errinfo_back_in_outer_rescue = box_a.eval(<<~'A')
+        errinfo_in_inner_rescue = errinfo_after_inner_rescue = errinfo_back_in_outer_rescue = nil
+        begin
+          raise "outer"
+        rescue
+          errinfo_in_inner_rescue, errinfo_after_inner_rescue = Ruby::Box.new.eval(<<~'B')
+            in_rescue = after_rescue = nil
+            begin
+              raise "inner"
+            rescue
+              in_rescue = $! && $!.message
+            end
+            after_rescue = $! && $!.message
+            [in_rescue, after_rescue]
+          B
+          errinfo_back_in_outer_rescue = $! && $!.message
+        end
+        [errinfo_in_inner_rescue, errinfo_after_inner_rescue, errinfo_back_in_outer_rescue]
+      A
+
+      assert_equal "inner", errinfo_in_inner_rescue
+      assert_equal "outer", errinfo_after_inner_rescue
+      assert_equal "outer", errinfo_back_in_outer_rescue
+    end;
+  end
+
   def test_load_path_and_loaded_features
     setup_box
 

--- a/test/ruby/test_box.rb
+++ b/test/ruby/test_box.rb
@@ -1180,4 +1180,20 @@ class TestBox < Test::Unit::TestCase
       assert_equal :box2, box2.eval("Class.new { include Math }.new.box2_test")
     end;
   end
+
+  def test_method_invalidation_between_boxes
+    assert_separately([ENV_ENABLE_BOX], __FILE__, __LINE__, "#{<<~"begin;"}\n#{<<~'end;'}", ignore_stderr: true)
+    begin;
+      b = Ruby::Box.new
+      b.eval(<<~'RUBY')
+      Module.prepend(Module.new)
+        class C; end
+        class D < C; end
+        def C.===(x) = true
+      RUBY
+
+      assert String === "x"
+      assert b # to prevent GCing b
+    end;
+  end
 end

--- a/test/ruby/test_box.rb
+++ b/test/ruby/test_box.rb
@@ -923,6 +923,8 @@ class TestBox < Test::Unit::TestCase
   end
 
   def test_boxes_have_different_rubygems
+    pend if /mswin|mingw/ =~ RUBY_PLATFORM # timeout on windows environments, only on the 4.0 branch
+
     # assert_separately w/ ENV_ENABLE_BOX and --enable=gems causes timeouts on CI @ Windows
     assert_in_out_err([ENV_ENABLE_BOX, "--enable=gems"], "#{<<-"begin;"}\n#{<<-'end;'}") do |output, error|
       begin;

--- a/test/ruby/test_box.rb
+++ b/test/ruby/test_box.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'test/unit'
+require 'rbconfig'
+require 'tempfile'
 
 class TestBox < Test::Unit::TestCase
   EXPERIMENTAL_WARNING_LINE_PATTERNS = [
@@ -154,8 +156,7 @@ class TestBox < Test::Unit::TestCase
     assert Ruby::Box.current.inspect.include?("main")
   end
 
-  def test_class_variables
-    # [Bug #21952]
+  def test_class_variables_in_root_are_invisible_in_other_boxes
     assert_separately([ENV_ENABLE_BOX], __FILE__, __LINE__, "here = '#{__dir__}'; #{<<~"begin;"}\n#{<<~'end;'}", ignore_stderr: true)
     begin;
       Ruby::Box.root.eval(<<~RUBY)
@@ -178,10 +179,9 @@ class TestBox < Test::Unit::TestCase
       REPRO
 
       b1 = Ruby::Box.new
-      assert_equal 2, b1.eval(code)
-
-      b2 = Ruby::Box.new
-      assert_equal 2, b2.eval(code)
+      assert_raise(NameError, "uninitialized class variable @@x in B") {
+        b1.eval(code)
+      }
     end;
   end
 
@@ -898,6 +898,72 @@ class TestBox < Test::Unit::TestCase
     end
   end
 
+  def test_calling_root_box_methods_does_not_change_user_boxes_newly_created
+    assert_separately([ENV_ENABLE_BOX], __FILE__, __LINE__, "#{<<~"begin;"}\n#{<<~'end;'}", ignore_stderr: true)
+    begin;
+      assert_not_include Object.constants.sort, :Find # required by Pathname#find
+      assert_not_include Ruby::Box.root.eval("Object.constants.sort"), :Find
+      b1 = Ruby::Box.new
+      assert_not_include b1.eval("Object.constants.sort"), :Find
+
+      require 'pathname'
+      Pathname.new('.').find{|path| path.directory?}
+      assert_include Object.constants.sort, :Find # required by Pathname#find
+
+      assert_not_include Ruby::Box.root.eval("Object.constants.sort"), :Find
+      assert_not_include b1.eval("Object.constants.sort"), :Find
+
+      Ruby::Box.root.eval("require 'pathname'; Pathname.new('.').find{|path| path.directory? }")
+      assert_include Ruby::Box.root.eval("Object.constants.sort"), :Find
+
+      assert_not_include b1.eval("Object.constants.sort"), :Find
+      b2 = Ruby::Box.new
+      assert_not_include b2.eval("Object.constants.sort"), :Find
+    end;
+  end
+
+  def test_boxes_have_different_rubygems
+    # assert_separately w/ ENV_ENABLE_BOX and --enable=gems causes timeouts on CI @ Windows
+    assert_in_out_err([ENV_ENABLE_BOX, "--enable=gems"], "#{<<-"begin;"}\n#{<<-'end;'}") do |output, error|
+      begin;
+        require "json"
+        h = {main: Gem.object_id, root: Ruby::Box.root.eval("Gem").object_id, box: Ruby::Box.new.eval("Gem").object_id}
+        puts h.to_json
+      end;
+      require "json"
+      result = JSON.parse(output.first, symbolize_names: true)
+      assert_not_equal result[:main], result[:root]
+      assert_not_equal result[:box], result[:root]
+      assert_not_equal result[:main], result[:box]
+    end
+  end
+
+  def test_require_list_loaded_only_in_main_box
+    Tempfile.create(["req_a", ".rb"]) do |t1|
+      Tempfile.create(["req_b", ".rb"]) do |t2|
+        t1.puts "module FooBarA; end"
+        t1.close
+        t2.puts "module FooBarB; end"
+        t2.close
+
+        opts = [ENV_ENABLE_BOX, "-r#{t1.path}", "-r#{t2.path}"]
+        assert_separately(opts, __FILE__, __LINE__, "#{<<~"begin;"}\n#{<<~'end;'}", ignore_stderr: true)
+        begin;
+          main_constants = Object.constants
+          assert_include main_constants, :FooBarA
+          assert_include main_constants, :FooBarB
+
+          root_constants = Ruby::Box.root.eval("Object.constants.sort")
+          master_constants = Ruby::Box.master.eval("Object.constants.sort")
+          assert_not_include root_constants, :FooBarA
+          assert_not_include root_constants, :FooBarB
+          assert_not_include master_constants, :FooBarA
+          assert_not_include master_constants, :FooBarB
+        end;
+      end
+    end
+  end
+
   def test_root_and_main_methods
     assert_separately([ENV_ENABLE_BOX], __FILE__, __LINE__, "#{<<~"begin;"}\n#{<<~'end;'}", ignore_stderr: true)
     begin;
@@ -993,6 +1059,18 @@ class TestBox < Test::Unit::TestCase
 
       assert_equal "Foo", box::FOO_NAME
       assert_equal "Foo", box::Foo.name
+    end;
+  end
+
+  def test_very_basic_method_calls_and_constants
+    assert_separately([ENV_ENABLE_BOX], __FILE__, __LINE__, "#{<<~"begin;"}\n#{<<~'end;'}", ignore_stderr: true)
+    begin;
+      code = <<~EOC
+      consts = Object.constants
+      [consts.include?(:String), consts.include?(:Array)]
+      EOC
+      assert_equal([true, true], Ruby::Box.current.eval(code))
+      assert_equal([true, true], Ruby::Box.root.eval(code))
     end;
   end
 

--- a/test/ruby/test_box.rb
+++ b/test/ruby/test_box.rb
@@ -899,7 +899,7 @@ class TestBox < Test::Unit::TestCase
   end
 
   def test_calling_root_box_methods_does_not_change_user_boxes_newly_created
-    assert_separately([ENV_ENABLE_BOX], __FILE__, __LINE__, "#{<<~"begin;"}\n#{<<~'end;'}", ignore_stderr: true)
+    assert_separately([ENV_ENABLE_BOX], __FILE__, __LINE__, "#{<<~"begin;"}\n#{<<~'end;'}", ignore_stderr: true, timeout: 60)
     begin;
       assert_not_include Object.constants.sort, :Find # required by Pathname#find
       assert_not_include Ruby::Box.root.eval("Object.constants.sort"), :Find

--- a/test/ruby/test_yjit.rb
+++ b/test/ruby/test_yjit.rb
@@ -1805,6 +1805,19 @@ class TestYJIT < Test::Unit::TestCase
     RUBY
   end
 
+  def test_yjit_prelude_bundler_setup
+    Tempfile.create do |f|
+      f.write(<<~'GEMFILE')
+        source "https://rubygems.org"
+        module C
+        end
+        Kernel.prepend(C)
+      GEMFILE
+      f.flush
+      assert_separately([{ "BUNDLER_SETUP" => "bundler/setup", "BUNDLE_GEMFILE" => f.path }, "--enable=gems", "--yjit"], "")
+    end
+  end
+
   private
 
   def code_gc_helpers

--- a/test/ruby/test_yjit.rb
+++ b/test/ruby/test_yjit.rb
@@ -1805,16 +1805,14 @@ class TestYJIT < Test::Unit::TestCase
     RUBY
   end
 
-  def test_yjit_prelude_bundler_setup
-    Tempfile.create do |f|
-      f.write(<<~'GEMFILE')
-        source "https://rubygems.org"
-        module C
-        end
-        Kernel.prepend(C)
-      GEMFILE
+  def test_yjit_prelude_kernel_prepend
+    # Simulate what bundler/setup can do: prepend a module to Kernel during
+    # the prelude via the BUNDLER_SETUP mechanism in rubygems.rb:
+    #   require ENV["BUNDLER_SETUP"] if ENV["BUNDLER_SETUP"] && !defined?(Bundler)
+    Tempfile.create(["kernel_prepend", ".rb"]) do |f|
+      f.write("Kernel.prepend(Module.new)\n")
       f.flush
-      assert_separately([{ "BUNDLER_SETUP" => "bundler/setup", "BUNDLE_GEMFILE" => f.path }, "--enable=gems", "--yjit"], "")
+      assert_separately([{ "BUNDLER_SETUP" => f.path }, "--enable=gems", "--yjit"], "", ignore_stderr: true)
     end
   end
 

--- a/test/ruby/test_zjit.rb
+++ b/test/ruby/test_zjit.rb
@@ -112,6 +112,17 @@ class TestZJIT < Test::Unit::TestCase
     RUBY
   end
 
+  def test_zjit_prelude_kernel_prepend
+    # Simulate what bundler/setup can do: prepend a module to Kernel during
+    # the prelude via the BUNDLER_SETUP mechanism in rubygems.rb:
+    #   require ENV["BUNDLER_SETUP"] if ENV["BUNDLER_SETUP"] && !defined?(Bundler)
+    Tempfile.create(["kernel_prepend", ".rb"]) do |f|
+      f.write("Kernel.prepend(Module.new)\n")
+      f.flush
+      assert_separately([{ "BUNDLER_SETUP" => f.path }, "--enable=gems", "--zjit"], "", ignore_stderr: true)
+    end
+  end
+
   def test_zjit_enable_respects_existing_options
     assert_separately(['--zjit-disable', '--zjit-stats-quiet'], <<~RUBY)
       refute_predicate RubyVM::ZJIT, :enabled?

--- a/vm.c
+++ b/vm.c
@@ -3189,7 +3189,7 @@ find_loader_control_frame(const rb_execution_context_t *ec, const rb_control_fra
     while (RUBY_VM_VALID_CONTROL_FRAME_P(cfp, end_cfp)) {
         if (!VM_ENV_FRAME_TYPE_P(cfp->ep, VM_FRAME_MAGIC_CFUNC))
             break;
-        if (!BOX_ROOT_P(current_box_on_cfp(ec, cfp)))
+        if (!BOX_MASTER_P(current_box_on_cfp(ec, cfp)))
             break;
         cfp = RUBY_VM_PREVIOUS_CONTROL_FRAME(cfp);
     }

--- a/vm_core.h
+++ b/vm_core.h
@@ -763,6 +763,7 @@ typedef struct rb_vm_struct {
     const VALUE special_exceptions[ruby_special_error_count];
 
     /* Ruby Box */
+    rb_box_t *master_box;
     rb_box_t *root_box;
     rb_box_t *main_box;
 

--- a/vm_dump.c
+++ b/vm_dump.c
@@ -89,6 +89,9 @@ control_frame_dump(const rb_execution_context_t *ec, const rb_control_frame_t *c
         break;
       case VM_FRAME_MAGIC_CFUNC:
         magic = "CFUNC";
+        if (me) {
+            box = me->def->box;
+        }
         break;
       case VM_FRAME_MAGIC_IFUNC:
         magic = "IFUNC";

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -2357,6 +2357,8 @@ vm_search_method_fastpath(VALUE cd_owner, struct rb_call_data *cd, VALUE klass)
 {
     const struct rb_callcache *cc = cd->cc;
 
+    VM_ASSERT_TYPE2(klass, T_CLASS, T_ICLASS);
+
 #if OPT_INLINE_METHOD_CACHE
     if (LIKELY(vm_cc_class_check(cc, klass))) {
         if (LIKELY(!METHOD_ENTRY_INVALIDATED(vm_cc_cme(cc)))) {

--- a/vm_method.c
+++ b/vm_method.c
@@ -407,6 +407,30 @@ invalidate_callable_method_entry_in_every_m_table_i(rb_classext_t *ext, bool is_
     }
 }
 
+struct collect_per_box_origins_arg {
+    VALUE owner;
+    VALUE klass_housing_cme;
+    VALUE origins; // Array of origins
+};
+
+static void
+collect_per_box_origins_i(rb_classext_t *ext, bool is_prime, VALUE box_value, void *data)
+{
+    struct collect_per_box_origins_arg *arg = (struct collect_per_box_origins_arg *)data;
+    VALUE origin = RCLASSEXT_ORIGIN(ext);
+
+    if (origin == arg->owner || origin == arg->klass_housing_cme) {
+        return;
+    }
+    long len = RARRAY_LEN(arg->origins);
+    for (long i = 0; i < len; i++) {
+        if (RARRAY_AREF(arg->origins, i) == origin) {
+            return;
+        }
+    }
+    rb_ary_push(arg->origins, origin);
+}
+
 static void
 invalidate_callable_method_entry_in_every_m_table(VALUE klass, ID mid, const rb_callable_method_entry_t *cme)
 {
@@ -493,6 +517,23 @@ clear_method_cache_by_id_in_class(VALUE klass, ID mid)
                         // (klass_housing_cme may be a non-boxable origin ICLASS that doesn't cover them)
                         if (klass_housing_cme != owner) {
                             invalidate_callable_method_entry_in_every_m_table(owner, mid, cme);
+                        }
+                        // Also update per-box origin ICLASSes. When ensure_origin is called in
+                        // one box's context, it creates a per-box origin ICLASS whose m_tbl is
+                        // a copy of owner's m_tbl at that time. The current execution box may
+                        // not see these origins via RCLASS_ORIGIN(owner), so we find them by
+                        // iterating all of owner's classexts and checking their origin_ fields.
+                        {
+                            VALUE origins = rb_ary_new();
+                            struct collect_per_box_origins_arg origins_arg = {
+                                .owner = owner,
+                                .klass_housing_cme = klass_housing_cme,
+                                .origins = origins,
+                            };
+                            rb_class_classext_foreach(owner, collect_per_box_origins_i, &origins_arg);
+                            for (long i = 0; i < RARRAY_LEN(origins); i++) {
+                                invalidate_callable_method_entry_in_every_m_table(RARRAY_AREF(origins, i), mid, cme);
+                            }
                         }
                     }
 

--- a/vm_method.c
+++ b/vm_method.c
@@ -489,6 +489,11 @@ clear_method_cache_by_id_in_class(VALUE klass, ID mid)
 
                         // replace the cme that will be invalid in the all classexts
                         invalidate_callable_method_entry_in_every_m_table(klass_housing_cme, mid, cme);
+                        // owner may be a boxable class with per-box classext copies of its m_tbl
+                        // (klass_housing_cme may be a non-boxable origin ICLASS that doesn't cover them)
+                        if (klass_housing_cme != owner) {
+                            invalidate_callable_method_entry_in_every_m_table(owner, mid, cme);
+                        }
                     }
 
                     vm_cme_invalidate((rb_callable_method_entry_t *)cme);

--- a/vm_method.c
+++ b/vm_method.c
@@ -524,7 +524,7 @@ clear_method_cache_by_id_in_class(VALUE klass, ID mid)
                         // not see these origins via RCLASS_ORIGIN(owner), so we find them by
                         // iterating all of owner's classexts and checking their origin_ fields.
                         {
-                            VALUE origins = rb_ary_new();
+                            VALUE origins = rb_ary_hidden_new(1);
                             struct collect_per_box_origins_arg origins_arg = {
                                 .owner = owner,
                                 .klass_housing_cme = klass_housing_cme,
@@ -534,6 +534,7 @@ clear_method_cache_by_id_in_class(VALUE klass, ID mid)
                             for (long i = 0; i < RARRAY_LEN(origins); i++) {
                                 invalidate_callable_method_entry_in_every_m_table(RARRAY_AREF(origins, i), mid, cme);
                             }
+                            RB_GC_GUARD(origins);
                         }
                     }
 

--- a/yjit.h
+++ b/yjit.h
@@ -35,6 +35,7 @@ void rb_yjit_cme_invalidate(rb_callable_method_entry_t *cme);
 void rb_yjit_collect_binding_alloc(void);
 void rb_yjit_collect_binding_set(void);
 void rb_yjit_compile_iseq(const rb_iseq_t *iseq, rb_execution_context_t *ec, bool jit_exception);
+void rb_yjit_init_builtin_cmes(void);
 void rb_yjit_init(bool yjit_enabled);
 void rb_yjit_free_at_exit(void);
 void rb_yjit_bop_redefined(int redefined_flag, enum ruby_basic_operators bop);
@@ -63,6 +64,7 @@ static inline void rb_yjit_cme_invalidate(rb_callable_method_entry_t *cme) {}
 static inline void rb_yjit_collect_binding_alloc(void) {}
 static inline void rb_yjit_collect_binding_set(void) {}
 static inline void rb_yjit_compile_iseq(const rb_iseq_t *iseq, rb_execution_context_t *ec, bool jit_exception) {}
+static inline void rb_yjit_init_builtin_cmes(void) {}
 static inline void rb_yjit_init(bool yjit_enabled) {}
 static inline void rb_yjit_bop_redefined(int redefined_flag, enum ruby_basic_operators bop) {}
 static inline void rb_yjit_constant_state_changed(ID id) {}

--- a/yjit/src/yjit.rs
+++ b/yjit/src/yjit.rs
@@ -37,12 +37,17 @@ pub fn yjit_enabled_p() -> bool {
     unsafe { rb_yjit_enabled_p }
 }
 
+/// Register specialized codegen for builtin C method entries.
+/// Must be called at boot before ruby_init_prelude() since the prelude
+/// could redefine core methods (e.g. Kernel.prepend via bundler).
+#[no_mangle]
+pub extern "C" fn rb_yjit_init_builtin_cmes() {
+    yjit_reg_method_codegen_fns();
+}
+
 /// This function is called from C code
 #[no_mangle]
 pub extern "C" fn rb_yjit_init(yjit_enabled: bool) {
-    // Register the method codegen functions. This must be done at boot.
-    yjit_reg_method_codegen_fns();
-
     // If --yjit-disable, yjit_init() will not be called until RubyVM::YJIT.enable.
     if yjit_enabled {
         yjit_init();


### PR DESCRIPTION
This change is to backport the changes below to 4.0

* https://github.com/ruby/ruby/pull/16863
* https://github.com/ruby/ruby/pull/16897
* https://github.com/ruby/ruby/pull/16911
* https://github.com/ruby/ruby/pull/16963
* https://github.com/ruby/ruby/pull/16970
* https://github.com/ruby/ruby/pull/16984
* https://github.com/ruby/ruby/pull/17119
* https://github.com/ruby/ruby/pull/17216
