### PR TITLE
Add a check in non-debug mode for calling a T_NONE class

### DIFF
--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -2178,6 +2178,18 @@ rb_vm_search_method_slowpath(const struct rb_callinfo *ci, VALUE klass)
 {
     const struct rb_callcache *cc;
 
+    VM_ASSERT(!SPECIAL_CONST_P(klass));
+
+    if (RB_BUILTIN_TYPE(klass) == T_NONE) {
+      // If we find a T_NONE here, it's most likely we called CLASS_OF(obj) on a
+      // garbage collected object (the freelist is stored in the class pointer),
+      // but it's possible that just the class was GC'd.
+      // This message intentionally tries to imply the former, but make an
+      // accurate statement for either case.
+      rb_bug("attempted to search method '%s' on a garbage collected object",
+             rb_id2name(vm_ci_mid(ci)));
+    }
+
     VM_ASSERT_TYPE2(klass, T_CLASS, T_ICLASS);
 
     cc = vm_search_cc(klass, ci);

--- a/vm_method.c
+++ b/vm_method.c
@@ -2007,6 +2007,18 @@ callable_method_entry_or_negative(VALUE klass, ID mid, VALUE *defined_class_ptr)
 {
     const rb_callable_method_entry_t *cme;
 
+    VM_ASSERT(!SPECIAL_CONST_P(klass));
+
+    if (RB_BUILTIN_TYPE(klass) == T_NONE) {
+      // If we find a T_NONE here, it's most likely we called CLASS_OF(obj) on a
+      // garbage collected object (the freelist is stored in the class pointer),
+      // but it's possible that just the class was GC'd.
+      // This message intentionally tries to imply the former, but make an
+      // accurate statement for either case.
+      rb_bug("attempted to search method '%s' on a garbage collected object",
+             rb_id2name(mid));
+    }
+
     VM_ASSERT_TYPE2(klass, T_CLASS, T_ICLASS);
 
     /* Fast path: lock-free read from cache */


### PR DESCRIPTION
Although a crash could occur anywhere, one of the most common symptoms we see from getting a reference to a garbage collected object is crashing while attempting to call a method on it.

These crashes usually occur when trying to perform an rb_id_table_lookup in the "class" cc_tbl, where the class is usually another garbage collected object, because the freelist is stored in the class pointer. This of course isn't guaranteed to happen, as it only works for `T_NONE`.

This commit aims to have a better error message in this case, in hopes of having a better grouping of errors and to give a better hint to those investigating and triaging crashes.

The cost of this is very low because it's only in the slow path. A memory read and branche reliably not taken is also very fast.

**Example output**:

``` ruby
ptr = Fiddle.dlwrap(Object.new)
GC.start
Fiddle.dlunwrap(ptr).to_s
```

```
./test.rb:9: [BUG] attempted to search method 'to_s' on a garbage collected object
ruby 3.5.0dev (2025-05-05T16:29:43Z call_t_none_assert.. 7b419c752b) +PRISM [arm64-darwin24]

-- Crash Report log information --------------------------------------------
```