### PR TITLE
Speed up Array#join with a byte-copy fast path [Feature #22094]

### DIFF
--- a/array.c
+++ b/array.c
@@ -23,6 +23,7 @@
 #include "internal/object.h"
 #include "internal/proc.h"
 #include "internal/rational.h"
+#include "internal/string.h"
 #include "internal/vm.h"
 #include "probes.h"
 #include "ruby/encoding.h"
@@ -3002,6 +3003,67 @@ ary_join_1(VALUE obj, VALUE ary, VALUE sep, long i, VALUE result, int *first)
     }
 }
 
+/* Fast path for Array#join: when every element is a String in one fast-path encoding
+ * (UTF-8 / US-ASCII / ASCII-8BIT) and the separator is byte-compatible, the result can
+ * be produced with a single memcpy pass instead of appending each element through
+ * rb_str_buf_append. Returns the joined String, or Qundef when any of those invariants
+ * does not hold -- the caller then uses the general path. No user code runs here, so
+ * the array cannot be mutated underneath us. */
+static VALUE
+ary_join_fast(VALUE ary, VALUE sep)
+{
+    long n = RARRAY_LEN(ary);
+    if (n == 0) return Qundef;
+
+    VALUE first = RARRAY_AREF(ary, 0);
+    if (!RB_TYPE_P(first, T_STRING)) return Qundef;
+    int encidx = ENCODING_GET(first);
+    if (!rb_str_encindex_fastpath(encidx)) return Qundef;
+
+    /* cr accumulates the result code range exactly as rb_str_buf_append would. */
+    enum ruby_coderange_type cr = ENC_CODERANGE_7BIT;
+    long sep_len = 0;
+    const char *sep_ptr = NULL;
+    if (!NIL_P(sep)) {
+        int sep_cr = rb_enc_str_coderange(sep);
+        /* The separator must share the element encoding, or be 7-bit (encidx is
+           ASCII-compatible, so a 7-bit separator concatenates without negotiation). */
+        if (ENCODING_GET(sep) != encidx && sep_cr != ENC_CODERANGE_7BIT) return Qundef;
+        sep_ptr = RSTRING_PTR(sep);
+        sep_len = RSTRING_LEN(sep);
+        if (n > 1) cr = ENC_CODERANGE_AND(cr, sep_cr);
+    }
+
+    /* One pass: confirm the shared encoding, measure the length, merge code ranges. */
+    long len = 1 + sep_len * (n - 1);
+    for (long i = 0; i < n; i++) {
+        VALUE s = RARRAY_AREF(ary, i);
+        if (!RB_TYPE_P(s, T_STRING) || ENCODING_GET(s) != encidx) return Qundef;
+        len += RSTRING_LEN(s);
+        cr = ENC_CODERANGE_AND(cr, rb_enc_str_coderange(s));
+    }
+
+    VALUE result = rb_str_buf_new(len);
+    rb_enc_associate_index(result, encidx);
+    char *const buf = RSTRING_PTR(result);
+    char *p = buf;
+    for (long i = 0; i < n; i++) {
+        VALUE s = RARRAY_AREF(ary, i);
+        long slen = RSTRING_LEN(s);
+        if (i > 0 && sep_len) {
+            memcpy(p, sep_ptr, sep_len);
+            p += sep_len;
+        }
+        memcpy(p, RSTRING_PTR(s), slen);
+        p += slen;
+    }
+
+    ENC_CODERANGE_CLEAR(result);  /* keep rb_str_set_len from rescanning the bytes */
+    rb_str_set_len(result, p - buf);
+    ENC_CODERANGE_SET(result, cr);
+    return result;
+}
+
 VALUE
 rb_ary_join(VALUE ary, VALUE sep)
 {
@@ -3010,8 +3072,12 @@ rb_ary_join(VALUE ary, VALUE sep)
 
     if (RARRAY_LEN(ary) == 0) return rb_usascii_str_new(0, 0);
 
+    if (!NIL_P(sep)) StringValue(sep);
+
+    result = ary_join_fast(ary, sep);
+    if (!UNDEF_P(result)) return result;
+
     if (!NIL_P(sep)) {
-        StringValue(sep);
         len += RSTRING_LEN(sep) * (RARRAY_LEN(ary) - 1);
     }
     long len_memo = RARRAY_LEN(ary);

--- a/benchmark/array_join.yml
+++ b/benchmark/array_join.yml
@@ -1,0 +1,34 @@
+prelude: |
+  # All elements are 7-bit ASCII Strings (the dominant real-world join case).
+  # Distinct objects so large-N cases exercise realistic heap/cache behavior.
+  a100_1    = Array.new(100)    { "a" * 1  }
+  a100_8    = Array.new(100)    { "a" * 8  }
+  a100_40   = Array.new(100)    { "a" * 40 }
+  a1k_1     = Array.new(1000)   { "a" * 1  }
+  a1k_8     = Array.new(1000)   { "a" * 8  }
+  a1k_40    = Array.new(1000)   { "a" * 40 }
+  a100k_1   = Array.new(100000) { "a" * 1  }
+  a100k_8   = Array.new(100000) { "a" * 8  }
+  a100k_40  = Array.new(100000) { "a" * 40 }
+
+benchmark:
+  # separator " " (space)
+  join_sp_n100_e1:    a100_1.join(" ")
+  join_sp_n100_e8:    a100_8.join(" ")
+  join_sp_n100_e40:   a100_40.join(" ")
+  join_sp_n1k_e1:     a1k_1.join(" ")
+  join_sp_n1k_e8:     a1k_8.join(" ")
+  join_sp_n1k_e40:    a1k_40.join(" ")
+  join_sp_n100k_e1:   a100k_1.join(" ")
+  join_sp_n100k_e8:   a100k_8.join(" ")
+  join_sp_n100k_e40:  a100k_40.join(" ")
+  # separator "\n" (newline)
+  join_nl_n100_e1:    a100_1.join("\n")
+  join_nl_n100_e8:    a100_8.join("\n")
+  join_nl_n100_e40:   a100_40.join("\n")
+  join_nl_n1k_e1:     a1k_1.join("\n")
+  join_nl_n1k_e8:     a1k_8.join("\n")
+  join_nl_n1k_e40:    a1k_40.join("\n")
+  join_nl_n100k_e1:   a100k_1.join("\n")
+  join_nl_n100k_e8:   a100k_8.join("\n")
+  join_nl_n100k_e40:  a100k_40.join("\n")

--- a/benchmark/array_join_regression.yml
+++ b/benchmark/array_join_regression.yml
@@ -1,0 +1,44 @@
+prelude: |
+  # --- must NOT take any fast path: prove added precompute-loop checks don't regress ---
+  # all multibyte UTF-8 (VALID coderange). 7-bit gate bails at elem 0; same-encoding gate TAKES it.
+  mb_utf8       = Array.new(1000) { "café" }
+  # ASCII except a trailing multibyte elem: WORST CASE for 7-bit gate (scans all, then falls back).
+  tail_mb       = Array.new(1000) { "a" * 8 }; tail_mb[-1] = "café"
+  # non-String elements -> ary_join_1 (to_s). Gate bails at type check before coderange.
+  nonstr_int    = Array.new(1000) { |i| i }
+  # ASCII strings except a trailing Integer: precompute scans strings, then mixed fallback.
+  mixed_tail    = (Array.new(999) { "a" * 8 } << 42)
+  # UTF-16LE: not ASCII-compatible. Both gates bail immediately.
+  utf16         = Array.new(1000) { "ab".encode("UTF-16LE") }
+  # nested arrays -> recursive fallback.
+  nested        = Array.new(500)  { [1, 2] }
+
+  # 7-bit ASCII elements but a multibyte separator (3-byte em dash). Both gates bail at sep check.
+  ascii_elems   = Array.new(1000) { "a" * 8 }
+  sep_mb        = "—"
+
+  # --- fast-path ELIGIBLE variants: confirm benefit generalizes beyond single chars / find crossover ---
+  # frozen ASCII elements (read-only path).
+  frozen_elems  = Array.new(1000) { ("a" * 8).freeze }
+  # large elements: where memcpy should dominate and the win decays toward 1x.
+  big_e256      = Array.new(1000) { "a" * 256  }
+  big_e1k       = Array.new(1000) { "a" * 1024 }
+  big_e4k       = Array.new(1000) { "a" * 4096 }
+
+benchmark:
+  # regression (fallback / gate worst-case) — all use a 1-byte ASCII separator unless noted
+  reg_multibyte_utf8:   mb_utf8.join(" ")
+  reg_tail_multibyte:   tail_mb.join(" ")
+  reg_nonstring_int:    nonstr_int.join(" ")
+  reg_mixed_tail_int:   mixed_tail.join(" ")
+  reg_utf16:            utf16.join(" ".encode("UTF-16LE"))
+  reg_nested:           nested.join(" ")
+  reg_multibyte_sep:    ascii_elems.join(sep_mb)
+
+  # fast-path eligible variants
+  fp_frozen:            frozen_elems.join(" ")
+  fp_nosep:             ascii_elems.join
+  fp_multichar_sep:     ascii_elems.join(", ")
+  fp_big_e256:          big_e256.join(" ")
+  fp_big_e1k:           big_e1k.join(" ")
+  fp_big_e4k:           big_e4k.join(" ")

--- a/depend
+++ b/depend
@@ -80,6 +80,7 @@ array.$(OBJEXT): $(top_srcdir)/internal/sanitizers.h
 array.$(OBJEXT): $(top_srcdir)/internal/serial.h
 array.$(OBJEXT): $(top_srcdir)/internal/set_table.h
 array.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
+array.$(OBJEXT): $(top_srcdir)/internal/string.h
 array.$(OBJEXT): $(top_srcdir)/internal/struct.h
 array.$(OBJEXT): $(top_srcdir)/internal/variable.h
 array.$(OBJEXT): $(top_srcdir)/internal/vm.h
@@ -102,6 +103,7 @@ array.$(OBJEXT): {$(VPATH)}config.h
 array.$(OBJEXT): {$(VPATH)}constant.h
 array.$(OBJEXT): {$(VPATH)}debug_counter.h
 array.$(OBJEXT): {$(VPATH)}defines.h
+array.$(OBJEXT): {$(VPATH)}encindex.h
 array.$(OBJEXT): {$(VPATH)}encoding.h
 array.$(OBJEXT): {$(VPATH)}id.h
 array.$(OBJEXT): {$(VPATH)}id_table.h

--- a/test/ruby/test_array.rb
+++ b/test/ruby/test_array.rb
@@ -2812,6 +2812,60 @@ class TestArray < Test::Unit::TestCase
     assert_equal("b", x.ary.join(""))
   end
 
+  def test_join_encoding
+    # Multibyte UTF-8 elements: result is UTF-8, valid, not ASCII-only.
+    r = @cls["caf\u00e9", "na\u00efve"].join(" ")
+    assert_equal("caf\u00e9 na\u00efve", r)
+    assert_equal(Encoding::UTF_8, r.encoding)
+    assert_equal(true, r.valid_encoding?)
+    assert_equal(false, r.ascii_only?)
+
+    # All 7-bit content stays ASCII-only.
+    r = @cls["abc", "def"].join(",")
+    assert_equal("abc,def", r)
+    assert_equal(true, r.ascii_only?)
+
+    # Multibyte separator (same encoding as the elements).
+    r = @cls["a", "b", "c"].join("\u2014")
+    assert_equal("a\u2014b\u2014c", r)
+    assert_equal(Encoding::UTF_8, r.encoding)
+    assert_equal(false, r.ascii_only?)
+    assert_equal(true, r.valid_encoding?)
+
+    # Mixed ASCII-compatible encodings, all 7-bit: result takes element 0's encoding.
+    r = @cls["abc".dup.force_encoding("US-ASCII"), "def".dup.force_encoding("UTF-8")].join(" ")
+    assert_equal("abc def", r)
+    assert_equal(Encoding::US_ASCII, r.encoding)
+    assert_equal(true, r.ascii_only?)
+
+    # 7-bit content in a non-ASCII encoding (Shift_JIS).
+    r = @cls["abc".encode("Shift_JIS"), "def".encode("Shift_JIS")].join(" ")
+    assert_equal(Encoding::Shift_JIS, r.encoding)
+    assert_equal("abc def".b, r.b)
+
+    # Same-encoding multibyte (Shift_JIS): byte-for-byte concatenation.
+    s = "\u65e5\u672c".encode("Shift_JIS")
+    sep = "/".encode("Shift_JIS")
+    r = @cls[s, s].join(sep)
+    assert_equal(Encoding::Shift_JIS, r.encoding)
+    assert_equal((s + sep + s).b, r.b)
+
+    # Broken bytes: result keeps them and reports invalid.
+    bad = "\xff\xfe".dup.force_encoding("UTF-8")
+    r = @cls[bad, bad].join(" ")
+    assert_equal((bad + " " + bad).b, r.b)
+    assert_equal(false, r.valid_encoding?)
+
+    # Incompatible element/separator encodings still raise.
+    assert_raise(Encoding::CompatibilityError) do
+      @cls["a".dup.force_encoding("UTF-8"), "b".encode("UTF-16LE")].join(" ")
+    end
+
+    # Bulk copy: large array, verified against a non-join oracle.
+    big = @cls.new(500) { "ab" }
+    assert_equal(("ab," * 500).chomp(","), big.join(","))
+  end
+
   def test_to_a2
     klass = Class.new(Array)
     a = klass.new.to_a


### PR DESCRIPTION
Duplicating from https://bugs.ruby-lang.org/issues/22094, please let me know if this is excessive.



## Original idea

What if we treat `Array#join(" ")`, `Array#join("\n")` and `Array#join(";")` as hot paths (as many, if not _most_ uses of `Array#join` in the wild), and see if there is anything to optimize for a single-character ASCII joiner?

## Detailed

`rb_ary_join` now works in three steps.

### 1. Measure (one pass)

Walk the array once to compute the total length (as before) and, at the same time,
track a single flag `ascii_only`—true while every element's code range is
`ENC_CODERANGE_7BIT` (and the separator is 7-bit). This is one extra flag read per
element.

If an element is not a `String`, fall back immediately to the existing
`ary_join_0` / `ary_join_1` append path (handles `to_str`, `to_s`, nested arrays,
etc.). Everything after this point knows all elements are Strings.

### 2. Decide if the result can be byte-copied

A raw copy is correct only when concatenating the bytes needs no encoding
negotiation. Two cases qualify:

- **All content is 7-bit ASCII** (`ascii_only`). 7-bit bytes are identical under any
  ASCII-compatible encoding, so the result is simply 7-bit in element 0's encoding.
  This also covers 7-bit strings in non-UTF-8 encodings such as Shift_JIS/EUC-JP.

- **Every element shares one fast-path encoding** (UTF-8 / US-ASCII / ASCII-8BIT —
  all ASCII-compatible with a 1-byte terminator) **and the separator is compatible**
  (same encoding, or 7-bit). This is checked in a short second pass that also merges
  the elements' code ranges. It is reached only when the array is *not* all-7-bit, so
  the common all-ASCII case never pays for it. This case covers all-UTF-8 text.

The merged result code range is: `7BIT` if every part is 7-bit, `VALID` if some part
is clean multibyte, or left `UNKNOWN` (recomputed lazily) if any part is itself
`UNKNOWN`/`BROKEN`. Same-encoding concatenation makes this merge exact.

Anything else—mixed encodings, multibyte Shift_JIS/EUC-JP, an incompatible
separator—is not copyable and uses the existing append path.

### 3. Copy

Allocate the result once, set its encoding to element 0's, then `memcpy` each
separator and element into the buffer through a single cursor. Set the length once
and stamp the precomputed code range (or leave it `UNKNOWN`).

The output is byte-, encoding-, and code-range-identical to the previous
implementation.

## Benchmarks

`benchmark/array_join.yml` and `benchmark/array_join_regression.yml`, run with
`benchmark-driver --repeat-count 4`; ratio = new i/s ÷ trunk i/s. MacBook Pro M1 (arm64), macOS.
`" "` and `"\n"` separators measured identically; one shown. YJIT on shows the same
ratios.

### All-String arrays (the target)

| array length \ element bytes | 1 | 8 | 40 |
|---|---|---|---|
| 100     | 2.77x | 2.41x | 1.98x |
| 1,000   | 2.91x | 2.52x | 2.21x |
| 100,000 | 2.94x | 2.57x | 2.20x |

### Other shapes

| case | ratio |
|---|---|
| no separator (`join`)             | 2.48x |
| multi-char separator (`", "`)     | 2.63x |
| frozen string elements            | 2.58x |
| all-UTF-8 multibyte text          | 2.07x |
| UTF-8 multibyte separator         | 2.18x |
| 7-bit Shift_JIS elements          | ~5x (trunk uses the slow negotiating path) |
| large elements, 256 B / 1 KB / 4 KB | 2.32x / 1.38x / 1.12x |

### Fallback cases (must not regress)

| case | ratio |
|---|---|
| non-String elements (`[1,2,3]`)        | 1.00x |
| UTF-16 elements                        | 0.99x |
| nested arrays                          | 1.00x |
| Strings then a trailing non-String     | 0.98x |

### YJIT on (spot check, all-String, separator `" "`)

| case | ratio |
|---|---|
| n=1,000, 1 B  | 2.93x |
| n=1,000, 8 B  | 2.54x |
| n=100,000, 8 B | 2.61x |


---

- Assisted-by: Opus 4.8.
