### PR TITLE
Don't dump memory map in crash report when modular GC enabled

### DIFF
--- a/vm_dump.c
+++ b/vm_dump.c
@@ -1530,7 +1530,7 @@ rb_vm_bugreport(const void *ctx, FILE *errout)
     }
 
     {
-#ifndef RUBY_ASAN_ENABLED
+#if !defined(RUBY_ASAN_ENABLED) && !USE_MODULAR_GC
 # ifdef PROC_MAPS_NAME
         {
             FILE *fp = fopen(PROC_MAPS_NAME, "r");


### PR DESCRIPTION
MMTk reserves a large amount of memory, which can cause the memory maps to take a long time to generate and thus cause test timeouts.