### PR TITLE
[Feature #22097] Add Proc#refined

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -13713,8 +13713,9 @@ ibf_dump_iseq_each(struct ibf_dump *dump, const rb_iseq_t *iseq)
     const ibf_offset_t lvar_states_offset = ibf_dump_lvar_states(dump, iseq);
     const unsigned int catch_table_size =   body->catch_table ? body->catch_table->size : 0;
     const ibf_offset_t catch_table_offset = ibf_dump_catch_table(dump, iseq);
-    const int parent_iseq_index =           ibf_dump_iseq(dump, ISEQ_BODY(iseq)->parent_iseq);
-    const int local_iseq_index =            ibf_dump_iseq(dump, ISEQ_BODY(iseq)->local_iseq);
+    /* a NULL parent (persisted root) and references outside a Proc#refined subtree dump come out absent (-1) */
+    const int parent_iseq_index =           ibf_table_lookup(dump->iseq_table, (st_data_t)ISEQ_BODY(iseq)->parent_iseq);
+    const int local_iseq_index =            ibf_table_lookup(dump->iseq_table, (st_data_t)ISEQ_BODY(iseq)->local_iseq);
     const int mandatory_only_iseq_index =   ibf_dump_iseq(dump, ISEQ_BODY(iseq)->mandatory_only_iseq);
     const ibf_offset_t ci_entries_offset =  ibf_dump_ci_entries(dump, iseq);
     const ibf_offset_t outer_variables_offset = ibf_dump_outer_variables(dump, iseq);
@@ -14875,24 +14876,10 @@ ibf_dump_setup(struct ibf_dump *dump, VALUE dumper_obj)
     dump->current_buffer = &dump->global_buffer;
 }
 
-VALUE
-rb_iseq_ibf_dump(const rb_iseq_t *iseq, VALUE opt)
+static VALUE
+iseq_ibf_dump_0(struct ibf_dump *dump, const rb_iseq_t *iseq, VALUE opt)
 {
-    struct ibf_dump *dump;
     struct ibf_header header = {{0}};
-    VALUE dump_obj;
-    VALUE str;
-
-    if (ISEQ_BODY(iseq)->parent_iseq != NULL ||
-        ISEQ_BODY(iseq)->local_iseq != iseq) {
-        rb_raise(rb_eRuntimeError, "should be top of iseq");
-    }
-    if (RTEST(ISEQ_COVERAGE(iseq))) {
-        rb_raise(rb_eRuntimeError, "should not compile with coverage");
-    }
-
-    dump_obj = TypedData_Make_Struct(0, struct ibf_dump, &ibf_dump_type, dump);
-    ibf_dump_setup(dump, dump_obj);
 
     ibf_dump_write(dump, &header, sizeof(header));
     ibf_dump_iseq(dump, iseq);
@@ -14921,7 +14908,28 @@ rb_iseq_ibf_dump(const rb_iseq_t *iseq, VALUE opt)
 
     ibf_dump_overwrite(dump, &header, sizeof(header), 0);
 
-    str = dump->global_buffer.str;
+    return dump->global_buffer.str;
+}
+
+VALUE
+rb_iseq_ibf_dump(const rb_iseq_t *iseq, VALUE opt)
+{
+    struct ibf_dump *dump;
+    VALUE dump_obj;
+    VALUE str;
+
+    if (ISEQ_BODY(iseq)->parent_iseq != NULL ||
+        ISEQ_BODY(iseq)->local_iseq != iseq) {
+        rb_raise(rb_eRuntimeError, "should be top of iseq");
+    }
+    if (RTEST(ISEQ_COVERAGE(iseq))) {
+        rb_raise(rb_eRuntimeError, "should not compile with coverage");
+    }
+
+    dump_obj = TypedData_Make_Struct(0, struct ibf_dump, &ibf_dump_type, dump);
+    ibf_dump_setup(dump, dump_obj);
+
+    str = iseq_ibf_dump_0(dump, iseq, opt);
     RB_GC_GUARD(dump_obj);
     return str;
 }
@@ -15125,6 +15133,91 @@ rb_iseq_ibf_load_bytes(const char *bytes, size_t size)
 
     RB_GC_GUARD(loader_obj);
     return iseq;
+}
+
+/* collect the iseq table into an array indexed by iseq-list index */
+static int
+ibf_dump_iseq_table_collect_i(st_data_t key, st_data_t val, st_data_t arg)
+{
+    const rb_iseq_t **srcs = (const rb_iseq_t **)arg;
+    srcs[(int)val] = (const rb_iseq_t *)key;
+    return ST_CONTINUE;
+}
+
+/* pc2branchindex (branch coverage) is per-iseq, so pair each copy with its
+ * source by list index */
+static void
+iseq_subtree_copy_pc2branchindex(const struct ibf_dump *dump, const struct ibf_load *load)
+{
+    unsigned int iseq_count = (unsigned int)dump->iseq_table->num_entries;
+    VALUE srcs_buf;
+    const rb_iseq_t **srcs = ALLOCV_N(const rb_iseq_t *, srcs_buf, iseq_count);
+    st_foreach(dump->iseq_table, ibf_dump_iseq_table_collect_i, (st_data_t)srcs);
+
+    for (unsigned int i = 0; i < iseq_count; i++) {
+        rb_iseq_t *copy = ibf_load_iseq(load, (const rb_iseq_t *)(VALUE)i);
+        VALUE pc2branchindex = ISEQ_PC2BRANCHINDEX(srcs[i]);
+        if (pc2branchindex != Qnil) {
+            ISEQ_PC2BRANCHINDEX_SET(copy, pc2branchindex);
+        }
+    }
+
+    ALLOCV_END(srcs_buf);
+}
+
+/* Deep-copy an iseq subtree with independent inline caches for Proc#refined */
+const rb_iseq_t *
+rb_iseq_dup_with_independent_caches(const rb_iseq_t *src_root)
+{
+    struct ibf_dump *dump;
+    VALUE dump_obj;
+    VALUE str;
+
+    /* --- dump the subtree --- */
+    dump_obj = TypedData_Make_Struct(0, struct ibf_dump, &ibf_dump_type, dump);
+    ibf_dump_setup(dump, dump_obj);
+
+    str = iseq_ibf_dump_0(dump, src_root, Qnil);
+
+    /* --- load it back --- */
+    struct ibf_load *load;
+    VALUE loader_obj = TypedData_Make_Struct(0, struct ibf_load, &ibf_load_type, load);
+    ibf_load_setup(load, loader_obj, str);
+
+    /* What the loader could not reconstruct is the same for every iseq in
+     * the subtree: the only absent parent is the top's, every absent
+     * local_iseq is the source's local root (runtime walks compare it
+     * against the original frames, so a copy must not stand in), and
+     * pathobj/script_lines/coverage are per-file values. */
+    const struct rb_iseq_constant_body *sb = ISEQ_BODY(src_root);
+    unsigned int iseq_count = (unsigned int)dump->iseq_table->num_entries;
+    const rb_iseq_t *result = NULL;
+    for (unsigned int i = 0; i < iseq_count; i++) {
+        rb_iseq_t *copy = ibf_load_iseq(load, (const rb_iseq_t *)(VALUE)i);
+        /* force completion even under USE_LAZY_LOAD */
+        if (FL_TEST((VALUE)copy, ISEQ_NOT_LOADED_YET)) {
+            rb_ibf_load_iseq_complete(copy);
+        }
+
+        struct rb_iseq_constant_body *cb = ISEQ_BODY(copy);
+        if (!cb->local_iseq) RB_OBJ_WRITE(copy, &cb->local_iseq, sb->local_iseq);
+        RB_OBJ_WRITE(copy, &cb->location.pathobj, sb->location.pathobj);
+        RB_OBJ_WRITE(copy, &cb->variable.script_lines, sb->variable.script_lines);
+        ISEQ_COVERAGE_SET(copy, ISEQ_COVERAGE(src_root));
+
+        if (i == 0) {
+            RB_OBJ_WRITE(copy, &cb->parent_iseq, sb->parent_iseq);
+            result = copy;
+        }
+    }
+
+    if (ISEQ_PC2BRANCHINDEX(src_root) != Qnil) {
+        iseq_subtree_copy_pc2branchindex(dump, load);
+    }
+
+    RB_GC_GUARD(dump_obj);
+    RB_GC_GUARD(loader_obj);
+    return result;
 }
 
 VALUE

--- a/cont.c
+++ b/cont.c
@@ -2659,7 +2659,8 @@ rb_fiber_start(rb_fiber_t *fiber)
         th->ec->root_svar = Qfalse;
 
         EXEC_EVENT_HOOK(th->ec, RUBY_EVENT_FIBER_SWITCH, th->self, 0, 0, 0, Qnil);
-        cont->value = rb_vm_invoke_proc(th->ec, proc, argc, argv, cont->kw_splat, VM_BLOCK_HANDLER_NONE);
+        cont->value = rb_vm_invoke_proc(th->ec, proc, argc, argv, cont->kw_splat, VM_BLOCK_HANDLER_NONE,
+                                        rb_proc_refinements_cref(fiber->first_proc));
     }
     EC_POP_TAG();
 

--- a/eval.c
+++ b/eval.c
@@ -1462,15 +1462,20 @@ using_refinement(VALUE klass, VALUE module, VALUE arg)
     return ST_CONTINUE;
 }
 
-static void
-using_module_recursive(const rb_cref_t *cref, VALUE klass)
+/*!
+ * \private
+ * rb_using_module without the refinement method cache flush, for a fresh
+ * cref that no call site references yet (Proc#refined).
+ */
+void
+rb_using_module_recursive(rb_cref_t *cref, VALUE klass)
 {
     ID id_refinements;
     VALUE super, module, refinements;
 
     super = RCLASS_SUPER(klass);
     if (super) {
-        using_module_recursive(cref, super);
+        rb_using_module_recursive(cref, super);
     }
     switch (BUILTIN_TYPE(klass)) {
       case T_MODULE:
@@ -1496,10 +1501,10 @@ using_module_recursive(const rb_cref_t *cref, VALUE klass)
  * \private
  */
 static void
-rb_using_module(const rb_cref_t *cref, VALUE module)
+rb_using_module(rb_cref_t *cref, VALUE module)
 {
     Check_Type(module, T_MODULE);
-    using_module_recursive(cref, module);
+    rb_using_module_recursive(cref, module);
     rb_clear_all_refinement_method_cache();
 }
 
@@ -1638,6 +1643,21 @@ ignored_block(VALUE module, const char *klass)
     rb_warn("%s""using doesn't call the given block""%s.", klass, anon);
 }
 
+/* Reject `using` anywhere inside a refined proc's body: the procs sharing
+ * the memoized iseq copy (and its call caches) must all run under the same
+ * refinement set. */
+static void
+check_not_refined_proc_scope(const char *using_name)
+{
+    const rb_cref_t *cref;
+    for (cref = rb_vm_cref(); cref; cref = CREF_NEXT(cref)) {
+        if (CREF_REFINED_PROC(cref)) {
+            rb_raise(rb_eRuntimeError,
+                     "%s is not permitted in a proc with refinements", using_name);
+        }
+    }
+}
+
 /*
  *  call-seq:
  *     using(module)    -> self
@@ -1661,6 +1681,7 @@ mod_using(VALUE self, VALUE module)
     if (rb_block_given_p()) {
         ignored_block(module, "Module#");
     }
+    check_not_refined_proc_scope("Module#using");
     rb_using_module(rb_vm_cref_replace_with_duplicated_cref(), module);
     return self;
 }
@@ -2004,6 +2025,7 @@ top_using(VALUE self, VALUE module)
     if (rb_block_given_p()) {
         ignored_block(module, "main.");
     }
+    check_not_refined_proc_scope("main.using");
     rb_using_module(rb_vm_cref_replace_with_duplicated_cref(), module);
     return self;
 }

--- a/eval_intern.h
+++ b/eval_intern.h
@@ -189,6 +189,7 @@ rb_ec_tag_jump(const rb_execution_context_t *ec, enum ruby_tag_type st)
 #define CREF_FL_OMOD_SHARED      IMEMO_FL_USER2
 #define CREF_FL_SINGLETON        IMEMO_FL_USER3
 #define CREF_FL_DYNAMIC_CREF IMEMO_FL_USER4
+#define CREF_FL_REFINED_PROC IMEMO_FL_USER5
 
 static inline int CREF_SINGLETON(const rb_cref_t *cref);
 
@@ -290,6 +291,18 @@ static inline void
 CREF_OMOD_SHARED_UNSET(rb_cref_t *cref)
 {
     cref->flags &= ~CREF_FL_OMOD_SHARED;
+}
+
+static inline int
+CREF_REFINED_PROC(const rb_cref_t *cref)
+{
+    return cref->flags & CREF_FL_REFINED_PROC;
+}
+
+static inline void
+CREF_REFINED_PROC_SET(rb_cref_t *cref)
+{
+    cref->flags |= CREF_FL_REFINED_PROC;
 }
 
 enum {

--- a/internal/eval.h
+++ b/internal/eval.h
@@ -29,6 +29,7 @@ void rb_class_modify_check(VALUE);
 NORETURN(VALUE rb_f_raise(int argc, VALUE *argv));
 VALUE rb_exception_setup(int argc, VALUE *argv);
 void rb_refinement_setup(struct rb_refinements_data *data, VALUE module, VALUE klass);
+void rb_using_module_recursive(rb_cref_t *cref, VALUE module);
 VALUE rb_top_main_class(const char *method);
 VALUE rb_ec_ensure(rb_execution_context_t *ec, VALUE (*b_proc)(VALUE), VALUE data1, VALUE (*e_proc)(VALUE), VALUE data2);
 

--- a/internal/vm.h
+++ b/internal/vm.h
@@ -24,6 +24,7 @@
 
 struct rb_callable_method_entry_struct; /* in method.h */
 struct rb_method_definition_struct;     /* in method.h */
+struct rb_cref_struct;                  /* in method.h */
 struct rb_execution_context_struct;     /* in vm_core.h */
 struct rb_control_frame_struct;         /* in vm_core.h */
 struct rb_callinfo;                     /* in vm_core.h */
@@ -55,6 +56,7 @@ void rb_vm_pop_cfunc_frame(void);
 void rb_vm_check_redefinition_by_prepend(VALUE klass);
 int rb_vm_check_optimizable_mid(VALUE mid);
 VALUE rb_yield_refine_block(VALUE refinement, VALUE refinements);
+struct rb_cref_struct *rb_vm_cref_dup(const struct rb_cref_struct *cref);
 VALUE ruby_vm_special_exception_copy(VALUE);
 
 void rb_lastline_set_up(VALUE val, unsigned int up);

--- a/iseq.h
+++ b/iseq.h
@@ -189,6 +189,7 @@ void rb_ibf_load_iseq_complete(rb_iseq_t *iseq);
 const rb_iseq_t *rb_iseq_ibf_load(VALUE str);
 const rb_iseq_t *rb_iseq_ibf_load_bytes(const char *cstr, size_t);
 VALUE rb_iseq_ibf_load_extra_data(VALUE str);
+const rb_iseq_t *rb_iseq_dup_with_independent_caches(const rb_iseq_t *iseq);
 void rb_iseq_init_trace(rb_iseq_t *iseq);
 int rb_iseq_add_local_tracepoint_recursively(const rb_iseq_t *iseq, rb_event_flag_t turnon_events, VALUE tpval, unsigned int target_line, bool target_bmethod);
 int rb_iseq_remove_local_tracepoint_recursively(const rb_iseq_t *iseq, VALUE tpval, rb_ractor_t *r);

--- a/jit.c
+++ b/jit.c
@@ -234,7 +234,8 @@ rb_optimized_call(VALUE recv, rb_execution_context_t *ec, int argc, VALUE *argv,
 {
     rb_proc_t *proc;
     GetProcPtr(recv, proc);
-    return rb_vm_invoke_proc(ec, proc, argc, argv, kw_splat, block_handler);
+    return rb_vm_invoke_proc(ec, proc, argc, argv, kw_splat, block_handler,
+                             rb_proc_refinements_cref(recv));
 }
 
 unsigned int

--- a/proc.c
+++ b/proc.c
@@ -19,6 +19,7 @@
 #include "internal/object.h"
 #include "internal/proc.h"
 #include "internal/symbol.h"
+#include "internal/vm.h"
 #include "method.h"
 #include "iseq.h"
 #include "vm_core.h"
@@ -267,11 +268,32 @@ block_mark_and_move(struct rb_block *block)
     }
 }
 
+/* hidden ivar holding a refined proc's cref; see Proc#refined */
+static ID id_refinements_cref;
+
 static void
 proc_mark_and_move(void *ptr)
 {
     rb_proc_t *proc = ptr;
     block_mark_and_move((struct rb_block *)&proc->block);
+}
+
+const rb_cref_t *
+rb_proc_refinements_cref(VALUE procval)
+{
+    rb_proc_t *proc;
+    GetProcPtr(procval, proc);
+    if (!proc->is_refined) return NULL;
+    return (const rb_cref_t *)rb_ivar_get(procval, id_refinements_cref);
+}
+
+void
+rb_proc_set_refinements_cref(VALUE procval, const rb_cref_t *cref)
+{
+    rb_proc_t *proc;
+    GetProcPtr(procval, proc);
+    rb_ivar_set(procval, id_refinements_cref, (VALUE)cref);
+    proc->is_refined = 1;
 }
 
 typedef struct {
@@ -318,7 +340,7 @@ rb_obj_is_proc(VALUE proc)
 static VALUE
 proc_clone(VALUE self)
 {
-    VALUE procval = rb_proc_dup(self);
+    VALUE procval = rb_proc_dup_0(self);
     return rb_obj_clone_setup(self, procval, Qnil);
 }
 
@@ -326,8 +348,209 @@ proc_clone(VALUE self)
 static VALUE
 proc_dup(VALUE self)
 {
-    VALUE procval = rb_proc_dup(self);
+    VALUE procval = rb_proc_dup_0(self);
     return rb_obj_dup_setup(self, procval);
+}
+
+rb_cref_t *rb_vm_get_cref(const VALUE *ep);
+VALUE rb_proc_dup_with_iseq_and_cref(VALUE self, const rb_iseq_t *iseq, const rb_cref_t *cref);
+
+/* Proc#refined memoizes the most recent {copied iseq, cref} pair per
+ * source iseq, since rb_iseq_dup_with_independent_caches is expensive.
+ * The memo lives in a hidden identity Hash (source iseq -> frozen Array):
+ *
+ *   [base_cref, copied_iseq, cref, mod1, mod2, ...]
+ *
+ * keyed by (base_cref, modules).
+ * An entry is retained for the VM's lifetime */
+
+enum refinement_memo_index {
+    REFINEMENT_MEMO_BASE_CREF,   /* key: captured cref of the source proc */
+    REFINEMENT_MEMO_COPIED_ISEQ, /* value: copied iseq with independent caches */
+    REFINEMENT_MEMO_CREF,        /* value: cref with refinements activated */
+    REFINEMENT_MEMO_MODS         /* key: modules, in argument order */
+};
+
+static VALUE refinement_memo_map; /* set once under the VM lock */
+
+static bool
+refinement_memo_key_match(VALUE memo, VALUE base_cref, long argc, const VALUE *mods)
+{
+    const VALUE *p = RARRAY_CONST_PTR(memo);
+    if (p[REFINEMENT_MEMO_BASE_CREF] != base_cref) return false;
+    if (RARRAY_LEN(memo) - REFINEMENT_MEMO_MODS != argc) return false;
+    for (long i = 0; i < argc; i++) {
+        if (p[REFINEMENT_MEMO_MODS + i] != mods[i]) return false;
+    }
+    return true;
+}
+
+static bool
+refinement_memo_lookup(const rb_iseq_t *src_iseq, VALUE base_cref,
+                       long argc, const VALUE *mods,
+                       const rb_iseq_t **iseq_out, const rb_cref_t **cref_out)
+{
+    VM_ASSERT(ISEQ_BODY(src_iseq)->type == ISEQ_TYPE_BLOCK);
+    VALUE memo = Qnil;
+    RB_VM_LOCKING() {
+        if (refinement_memo_map) {
+            memo = rb_hash_lookup(refinement_memo_map, (VALUE)src_iseq);
+        }
+    }
+    if (!NIL_P(memo)) {
+        const VALUE *p = RARRAY_CONST_PTR(memo);
+        if (refinement_memo_key_match(memo, base_cref, argc, mods)) {
+            const rb_iseq_t *copied_iseq = (const rb_iseq_t *)p[REFINEMENT_MEMO_COPIED_ISEQ];
+            if (ISEQ_BODY(copied_iseq)->param.flags.ruby2_keywords ==
+                ISEQ_BODY(src_iseq)->param.flags.ruby2_keywords) {
+                *iseq_out = copied_iseq;
+                *cref_out = (const rb_cref_t *)p[REFINEMENT_MEMO_CREF];
+                return true;
+            }
+            rb_category_warn(
+                RB_WARN_CATEGORY_PERFORMANCE,
+                "Proc#refined re-copies the block because the ruby2_keywords flag changed after the copy was memoized"
+            );
+            return false;
+        }
+        rb_category_warn(
+            RB_WARN_CATEGORY_PERFORMANCE,
+            "Proc#refined called with different modules for the same block disables memoization"
+        );
+    }
+    return false;
+}
+
+static void
+refinement_memo_store(const rb_iseq_t *src_iseq, VALUE base_cref,
+                      long argc, const VALUE *mods,
+                      const rb_iseq_t *copied_iseq, const rb_cref_t *cref)
+{
+    VM_ASSERT(ISEQ_BODY(src_iseq)->type == ISEQ_TYPE_BLOCK);
+
+    VALUE memo = rb_ary_hidden_new(REFINEMENT_MEMO_MODS + argc);
+    rb_ary_push(memo, base_cref);
+    rb_ary_push(memo, (VALUE)copied_iseq);
+    rb_ary_push(memo, (VALUE)cref);
+    for (long i = 0; i < argc; i++) {
+        rb_ary_push(memo, mods[i]);
+    }
+    OBJ_FREEZE(memo);
+
+    /* create the map outside the lock; losing the race just discards it */
+    VALUE new_map = 0;
+    if (!refinement_memo_map) {
+        new_map = rb_obj_hide(rb_ident_hash_new());
+    }
+
+    RB_VM_LOCKING() {
+        if (!refinement_memo_map) {
+            rb_vm_register_global_object(new_map);
+            refinement_memo_map = new_map;
+        }
+        rb_hash_aset(refinement_memo_map, (VALUE)src_iseq, memo);
+    }
+}
+
+/*
+ * call-seq:
+ *   prc.refined(mod, ...) -> a_proc
+ *
+ * Returns a new Proc that behaves like the receiver but with the refinements
+ * activated by the given modules in effect inside its body.  The receiver is
+ * left unchanged.
+ *
+ *   module StringRefinement
+ *     refine String do
+ *       def shout = upcase + "!"
+ *     end
+ *   end
+ *
+ *   original = ->(s) { s.shout }
+ *   refined_proc = original.refined(StringRefinement)
+ *   refined_proc.call("hi")  #=> "HI!"
+ *   original.call("hi")      #=> NoMethodError
+ *
+ * Only Procs created from a Ruby block are supported; calling this on a Proc
+ * backed by a C function, a Symbol, or a method raises ArgumentError.
+ *
+ * Calling this method on a Proc that already has refinements applied by this
+ * method also raises ArgumentError.  To activate the refinements of multiple
+ * modules, pass them all in a single call:
+ *
+ *   refined_proc = original.refined(StringRefinement, OtherRefinement)
+ *
+ * The refinement set of the returned Proc is fixed when it is created:
+ * calling +using+ inside its body raises RuntimeError.
+ *
+ * The refinements are in effect throughout the body, including nested blocks
+ * and methods defined with +def+ inside it.  As with a +def+ inside a +using+
+ * scope, such a method keeps the refinements even when it is called later:
+ *
+ *   refined_proc = ->(s) {
+ *     -> { s.shout }.call          # nested block: "HI!"
+ *   }.refined(StringRefinement)
+ *
+ *   refined_proc = -> {
+ *     obj = Object.new
+ *     def obj.shout_hi = "hi".shout  # the method sees the refinement
+ *     obj.shout_hi                   #=> "HI!"
+ *   }.refined(StringRefinement)
+ *
+ * This method copies the instruction sequence of the block and of all of its
+ * nested blocks so that the copy can resolve methods through the refinements
+ * without affecting the original Proc.  Applying refinements therefore
+ * increases memory use roughly in proportion to the size of the block.  The
+ * copy is cached and reused for the same receiver and the same modules.
+ */
+static VALUE
+proc_refined(int argc, VALUE *argv, VALUE self)
+{
+    rb_proc_t *src;
+    GetProcPtr(self, src);
+
+    rb_check_arity(argc, 1, UNLIMITED_ARGUMENTS);
+
+    if (vm_block_type(&src->block) != block_type_iseq || src->is_from_method) {
+        rb_raise(rb_eArgError, "can't apply refinements to a Proc without a Ruby block");
+    }
+
+    if (src->is_refined) {
+        rb_raise(rb_eArgError, "can't apply refinements to a Proc that already has refinements");
+    }
+
+    for (int i = 0; i < argc; i++) {
+        Check_Type(argv[i], T_MODULE);
+    }
+
+    VALUE base_cref = (VALUE)rb_vm_get_cref(src->block.as.captured.ep);
+    const rb_iseq_t *src_iseq = src->block.as.captured.code.iseq;
+
+    const rb_iseq_t *new_iseq;
+    const rb_cref_t *new_cref;
+    if (!refinement_memo_lookup(src_iseq, base_cref, argc, argv, &new_iseq, &new_cref)) {
+        new_iseq = rb_iseq_dup_with_independent_caches(src_iseq);
+        rb_cref_t *cref = rb_vm_cref_dup((const rb_cref_t *)base_cref);
+        /* rb_using_module_recursive modifies shared subclass lists */
+        RB_VM_LOCKING() {
+            for (int i = 0; i < argc; i++) {
+                rb_using_module_recursive(cref, argv[i]);
+            }
+        }
+        /* Freeze the refinements table and mark it shareable so the memoized
+         * cref can be reused from any Ractor. */
+        VALUE refs = CREF_REFINEMENTS(cref);
+        if (!NIL_P(refs)) {
+            OBJ_FREEZE(refs);
+            RB_OBJ_SET_SHAREABLE(refs);
+        }
+        CREF_OMOD_SHARED_SET(cref);
+        CREF_REFINED_PROC_SET(cref);
+        new_cref = cref;
+        refinement_memo_store(src_iseq, base_cref, argc, argv, new_iseq, new_cref);
+    }
+
+    return rb_proc_dup_with_iseq_and_cref(self, new_iseq, new_cref);
 }
 
 /*
@@ -1342,7 +1565,8 @@ rb_proc_call_kw(VALUE self, VALUE args, int kw_splat)
     VALUE *argv = RARRAY_PTR(args);
     GetProcPtr(self, proc);
     vret = rb_vm_invoke_proc(GET_EC(), proc, argc, argv,
-                             kw_splat, VM_BLOCK_HANDLER_NONE);
+                             kw_splat, VM_BLOCK_HANDLER_NONE,
+                             rb_proc_refinements_cref(self));
     RB_GC_GUARD(self);
     RB_GC_GUARD(args);
     return vret;
@@ -1367,7 +1591,8 @@ rb_proc_call_with_block_kw(VALUE self, int argc, const VALUE *argv, VALUE passed
     VALUE vret;
     rb_proc_t *proc;
     GetProcPtr(self, proc);
-    vret = rb_vm_invoke_proc(ec, proc, argc, argv, kw_splat, proc_to_block_handler(passed_procval));
+    vret = rb_vm_invoke_proc(ec, proc, argc, argv, kw_splat, proc_to_block_handler(passed_procval),
+                             rb_proc_refinements_cref(self));
     RB_GC_GUARD(self);
     return vret;
 }
@@ -2695,6 +2920,14 @@ rb_mod_define_method_with_visibility(int argc, VALUE *argv, VALUE mod, const str
         RB_GC_GUARD(body);
     }
     else {
+        rb_proc_t *body_proc;
+        GetProcPtr(body, body_proc);
+        /* A bmethod never reads the refinement cref carried on the proc;
+         * reject rather than silently drop the refinements. */
+        if (body_proc->is_refined) {
+            rb_raise(rb_eArgError,
+                     "can't define a method from a Proc with refinements");
+        }
         VALUE procval = rb_proc_dup(body);
         if (vm_proc_iseq(procval) != NULL) {
             rb_proc_t *proc;
@@ -4901,6 +5134,8 @@ void
 Init_Proc(void)
 {
 #undef rb_intern
+    id_refinements_cref = rb_make_internal_id();
+
     VALUE mRuby = rb_define_module("Ruby");
 
     /* Ruby::SourceRange */
@@ -4936,6 +5171,7 @@ Init_Proc(void)
     rb_define_method(rb_cProc, "arity", proc_arity, 0);
     rb_define_method(rb_cProc, "clone", proc_clone, 0);
     rb_define_method(rb_cProc, "dup", proc_dup, 0);
+    rb_define_method(rb_cProc, "refined", proc_refined, -1);
     rb_define_method(rb_cProc, "hash", proc_hash, 0);
     rb_define_method(rb_cProc, "to_s", proc_to_s, 0);
     rb_define_alias(rb_cProc, "inspect", "to_s");

--- a/spec/ruby/core/proc/fixtures/refined.rb
+++ b/spec/ruby/core/proc/fixtures/refined.rb
@@ -1,0 +1,24 @@
+module ProcRefinedSpecs
+  module StringShout
+    refine String do
+      def shout
+        upcase + "!"
+      end
+    end
+  end
+
+  # Refines the same String#shout as StringShout, plus its own #quiet, so
+  # specs can observe both which module wins for a conflicting method and
+  # that all given modules are activated.
+  module StringQuiet
+    refine String do
+      def shout
+        downcase
+      end
+
+      def quiet
+        "..."
+      end
+    end
+  end
+end

--- a/spec/ruby/core/proc/refined_spec.rb
+++ b/spec/ruby/core/proc/refined_spec.rb
@@ -1,0 +1,115 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/refined'
+
+ruby_version_is "4.1" do
+  describe "Proc#refined" do
+    it "returns a new Proc with the refinements of the given module activated inside its body" do
+      pr = -> s { s.shout }
+      refined = pr.refined(ProcRefinedSpecs::StringShout)
+      refined.should be_an_instance_of(Proc)
+      refined.should_not equal(pr)
+      refined.call("hi").should == "HI!"
+    end
+
+    it "does not change the receiver" do
+      pr = -> s { s.shout }
+      pr.refined(ProcRefinedSpecs::StringShout)
+      -> { pr.call("hi") }.should.raise(NoMethodError)
+    end
+
+    it "activates the refinements of all the given modules" do
+      pr = -> s { [s.shout, s.quiet] }
+      refined = pr.refined(ProcRefinedSpecs::StringShout, ProcRefinedSpecs::StringQuiet)
+      refined.call("Hi").should == ["hi", "..."]
+    end
+
+    it "gives precedence to the module applied last for the same refined method, as with nested using" do
+      pr = -> s { s.shout }
+      pr.refined(ProcRefinedSpecs::StringShout, ProcRefinedSpecs::StringQuiet).call("Hi").should == "hi"
+      pr.refined(ProcRefinedSpecs::StringQuiet, ProcRefinedSpecs::StringShout).call("Hi").should == "HI!"
+    end
+
+    it "shares the closure environment with the receiver" do
+      counter = 0
+      pr = -> { counter += 1 }
+      refined = pr.refined(ProcRefinedSpecs::StringShout)
+      refined.call
+      pr.call
+      counter.should == 2
+    end
+
+    it "preserves lambda-ness and arity" do
+      l = -> s { s }.refined(ProcRefinedSpecs::StringShout)
+      l.should.lambda?
+      l.arity.should == 1
+
+      pr = proc { |s| s }.refined(ProcRefinedSpecs::StringShout)
+      pr.should_not.lambda?
+    end
+
+    it "keeps the refinements active in blocks nested inside the body" do
+      pr = -> a { a.map { |s| s.shout } }
+      pr.refined(ProcRefinedSpecs::StringShout).call(%w[a b]).should == ["A!", "B!"]
+    end
+
+    it "keeps the refinements active in methods defined inside the body" do
+      pr = -> {
+        obj = Object.new
+        def obj.shout_hi
+          "hi".shout
+        end
+        obj.shout_hi
+      }
+      pr.refined(ProcRefinedSpecs::StringShout).call.should == "HI!"
+    end
+
+    it "keeps the refinements active when called via instance_eval, instance_exec and class_eval" do
+      pr = proc { "hi".shout }
+      refined = pr.refined(ProcRefinedSpecs::StringShout)
+      Object.new.instance_eval(&refined).should == "HI!"
+      Object.new.instance_exec(&refined).should == "HI!"
+      Class.new.class_eval(&refined).should == "HI!"
+    end
+
+    it "raises ArgumentError when called with no modules" do
+      -> { -> {}.refined }.should.raise(ArgumentError)
+    end
+
+    it "raises TypeError when called with a non-Module argument" do
+      -> { -> {}.refined(42) }.should.raise(TypeError)
+      -> { -> {}.refined(String) }.should.raise(TypeError)
+    end
+
+    it "raises ArgumentError for a Proc not created from a Ruby block" do
+      -> { :upcase.to_proc.refined(ProcRefinedSpecs::StringShout) }.should.raise(ArgumentError)
+      method_proc = "hi".method(:upcase).to_proc
+      -> { method_proc.refined(ProcRefinedSpecs::StringShout) }.should.raise(ArgumentError)
+    end
+
+    it "raises ArgumentError for a Proc that already has refinements applied" do
+      refined = -> s { s.shout }.refined(ProcRefinedSpecs::StringShout)
+      -> { refined.refined(ProcRefinedSpecs::StringQuiet) }.should.raise(ArgumentError)
+    end
+
+    it "keeps the refinements on dup and clone" do
+      refined = -> s { s.shout }.refined(ProcRefinedSpecs::StringShout)
+      refined.dup.call("hi").should == "HI!"
+      refined.clone.call("hi").should == "HI!"
+      -> { refined.dup.refined(ProcRefinedSpecs::StringQuiet) }.should.raise(ArgumentError)
+      -> { refined.clone.refined(ProcRefinedSpecs::StringQuiet) }.should.raise(ArgumentError)
+    end
+
+    it "raises ArgumentError when the result is passed to define_method" do
+      refined = -> s { s.shout }.refined(ProcRefinedSpecs::StringShout)
+      -> { Class.new { define_method(:m, refined) } }.should.raise(ArgumentError)
+      -> { Object.new.define_singleton_method(:m, refined) }.should.raise(ArgumentError)
+    end
+
+    it "raises RuntimeError when the body calls using" do
+      mod = Module.new { refine(String) { def whisper; downcase; end } }
+      pr = proc { using mod }
+      refined = pr.refined(ProcRefinedSpecs::StringShout)
+      -> { Module.new.module_eval(&refined) }.should.raise(RuntimeError)
+    end
+  end
+end

--- a/test/ruby/test_proc.rb
+++ b/test/ruby/test_proc.rb
@@ -500,6 +500,615 @@ class TestProc < Test::Unit::TestCase
     RUBY
   end
 
+  module RefinementsModule
+    refine String do
+      def shout = upcase + "!"
+    end
+    refine Integer do
+      def tripled = self * 3
+    end
+  end
+
+  def test_refined
+    orig = ->(s) { s.shout }
+    refined = orig.refined(RefinementsModule)
+    assert_equal("HI!", refined.call("hi"))
+    # the original Proc is unaffected
+    assert_raise(NoMethodError) { orig.call("hi") }
+    # idempotent: calling repeatedly keeps using the refinement
+    assert_equal("HI!", refined.call("hi"))
+  end
+
+  def test_refined_nested_block
+    orig = ->(a) { a.map { |s| s.shout } }
+    refined = orig.refined(RefinementsModule)
+    assert_equal(["A!", "B!"], refined.call(["a", "b"]))
+    assert_raise(NoMethodError) { orig.call(["a"]) }
+  end
+
+  def test_refined_multiple_modules
+    refined = ->(s, n) { "#{s.shout}#{n.tripled}" }.refined(RefinementsModule)
+    assert_equal("A!6", refined.call("a", 2))
+  end
+
+  def test_refined_shares_environment
+    counter = 0
+    inc = -> { counter += 1 }
+    refined = inc.refined(RefinementsModule)
+    refined.call
+    inc.call
+    # the closure environment is shared with the original Proc
+    assert_equal(2, counter)
+  end
+
+  def test_refined_via_yield
+    refined = ->(s) { s.shout }.refined(RefinementsModule)
+    result = [].tap {|a| [1, 2].each {|i| a << refined.call("x#{i}") } }
+    assert_equal(["X1!", "X2!"], result)
+
+    forwarded = []
+    rr = ->(s) { forwarded << s.shout }.refined(RefinementsModule)
+    %w[p q].each(&rr)
+    assert_equal(["P!", "Q!"], forwarded)
+  end
+
+  def test_refined_via_c_call_paths
+    refined = ->(s) { s.shout }.refined(RefinementsModule)
+    # These reach the proc via the C invocation path (rb_vm_invoke_proc) rather
+    # than the optimized opt_call, so the refinement cref must be carried there.
+    assert_equal("A!", refined.send(:call, "a"))
+    assert_equal("B!", refined.method(:call).call("b"))
+    assert_equal("C!", Fiber.new(&refined).resume("c"))
+    assert_equal("D!", Thread.new("d", &refined).value)
+  end
+
+  def test_refined_instance_eval
+    refined = proc { self.shout }.refined(RefinementsModule)
+    assert_equal("HI!", "hi".instance_eval(&refined))
+    assert_equal("HI!", "hi".instance_exec(&refined))
+    # the original Proc is still unaffected via instance_eval
+    orig = proc { self.shout }
+    assert_raise(NoMethodError) { "hi".instance_eval(&orig) }
+  end
+
+  def test_refined_module_eval
+    refined = proc { "ok".shout }.refined(RefinementsModule)
+    klass = Class.new
+    assert_equal("OK!", klass.class_eval(&refined))
+  end
+
+  def test_refined_instance_eval_does_not_leak_refinements
+    # instance_eval/class_eval gets its own copy of the refinements hash, so a
+    # `using` inside must not mutate the cref shared by every derived proc.
+    refined = proc { "ok".shout }.refined(RefinementsModule)
+    Class.new.class_eval(&refined)
+    # a second proc derived from the same source iseq still sees the refinement
+    again = proc { "ok".shout }.refined(RefinementsModule)
+    assert_equal("OK!", Class.new.class_eval(&again))
+  end
+
+  def test_refined_once_regexp
+    # A /o (once) regexp literal interpolating a refined-method call must be
+    # built under the refinement, and the copy's once cache is independent of
+    # the source iseq's (which may be mid-flight or already completed).
+    refined = ->(s) { /\A#{s.shout}\z/o }.refined(RefinementsModule)
+    r1 = refined.call("ab")
+    assert_equal('\AAB!\z', r1.source)
+    # /o caches the first regexp on the copy's own once entry
+    assert_same(r1, refined.call("zz"))
+    # the original proc has no refinement, so building the regexp raises
+    assert_raise(NoMethodError) { ->(s) { /\A#{s.shout}\z/o }.call("ab") }
+  end
+
+  def test_refined_preserved_by_dup
+    refined = ->(s) { s.shout }.refined(RefinementsModule)
+    # dup/clone copy the refinement cref (a hidden ivar) with the other ivars
+    assert_equal("Z!", refined.dup.call("z"))
+    assert_equal("Z!", refined.clone.call("z"))
+  end
+
+  def test_refined_errors
+    assert_raise(ArgumentError) { ->(s) { s }.refined }
+    assert_raise(TypeError) { ->(s) { s }.refined(42) }
+    # non-iseq Procs are not supported
+    assert_raise(ArgumentError) { :upcase.to_proc.refined(RefinementsModule) }
+    assert_raise(ArgumentError) { method(:p).to_proc.refined(RefinementsModule) }
+  end
+
+  def test_refined_non_main_ractor
+    assert_separately([], <<~'RUBY')
+      Warning[:experimental] = false
+      module M1; refine(String) { def shout = upcase + "!" }; end
+      module M2; refine(String) { def shout = downcase }; end
+      ractors = 10.times.map { |i|
+        Ractor.new(i) { |i|
+          ->(s) { s.shout }.refined(i.even? ? M1 : M2).call("Hi")
+        }
+      }
+      values = ractors.map(&:value)
+      assert_equal(["HI!", "hi"] * 5, values)
+    RUBY
+  end
+
+  def test_refined_shareable_proc_across_ractors
+    assert_separately([], <<~'RUBY')
+      Warning[:experimental] = false
+      module RefMod; refine(String) { def shout = upcase + "!" }; end
+      module RefHolder
+        # module body: self is shareable, as make_shareable requires
+        PROC = Ractor.make_shareable(->(s) { s.shout })
+      end
+      orig = RefHolder::PROC
+      # Store a memo in the main Ractor first, then refine the same shareable
+      # proc in another Ractor: cross-Ractor reuse of the memo is legal
+      # because the memoized cref's refinements table is frozen and shareable.
+      assert_equal("HI!", orig.refined(RefMod).call("hi"))
+      r = Ractor.new(orig) { |pr| pr.refined(RefMod).call("hi") }
+      assert_equal("HI!", r.value)
+      assert_equal("HI!", orig.refined(RefMod).call("hi"))
+    RUBY
+  end
+
+  def test_refined_coverage
+    assert_separately(%w[-rcoverage -rtempfile], <<~'RUBY')
+      f = Tempfile.open(["refined_coverage", ".rb"])
+      f.write(<<~'FIXTURE')
+        module RefinedCoverageExt
+          refine String do
+            def shout = upcase + "!"
+          end
+        end
+        REFINED_COVERAGE_PROC = ->(s) {
+          a = s.length
+          s.shout * a
+        }
+      FIXTURE
+      f.close
+      Coverage.start(lines: true)
+      load f.path
+      refined = REFINED_COVERAGE_PROC.refined(RefinedCoverageExt)
+      assert_equal("HI!HI!", refined.call("hi"))
+      lines = Coverage.result[f.path][:lines]
+      assert_equal(1, lines[6], "line 7 (a = s.length) must be counted when run through the refined copy")
+      assert_equal(1, lines[7], "line 8 (s.shout * a) must be counted when run through the refined copy")
+    RUBY
+  end
+
+  def test_refined_chain_rejected
+    # Chaining would need merge-or-replace semantics for the refinement sets;
+    # both are confusing, so a refined proc rejects further refined.
+    # Multiple modules can be activated by passing them in a single call.
+    refined = ->(s) { s.shout }.refined(RefinementsModule)
+    assert_raise(ArgumentError) { refined.refined(RefinementsModule2) }
+    # the refinement state survives dup, so the dup is rejected too
+    assert_raise(ArgumentError) { refined.dup.refined(RefinementsModule2) }
+    # the receiver remains usable
+    assert_equal("HI!", refined.call("hi"))
+  end
+
+  def test_refined_using_in_body_rejected
+    # The refinement set of a refined proc is fixed at refined() time: procs
+    # derived from the same source and modules share the copied iseq (and its
+    # refined call caches), so `using` inside the body would diverge one
+    # proc's refinement set and poison the caches its siblings use.
+    assert_separately([], <<~'RUBY')
+      module M1; refine(String) { def shout = upcase + "!" }; end
+      module M2; refine(String) { def whisper = downcase + "..." }; end
+      msg = /using is not permitted in a proc with refinements/
+      r = proc { using M2 }.refined(M1)
+      assert_raise_with_message(RuntimeError, msg) { r.call }
+      # through module_eval (Module#using) as well
+      e = proc { using M2 }.refined(M1)
+      assert_raise_with_message(RuntimeError, msg) { Module.new.module_eval(&e) }
+      # in a class body or a nested block inside the refined proc
+      c = proc { class ::RefinedUsingTmp; using M2; end }.refined(M1)
+      assert_raise_with_message(RuntimeError, msg) { c.call }
+      n = proc { -> { using M2 }.call }.refined(M1)
+      assert_raise_with_message(RuntimeError, msg) { n.call }
+      # plain procs are unaffected
+      assert_equal("ok...", Module.new.module_eval(&proc { using M2; "ok".whisper }))
+      # and the refined proc itself still works
+      assert_equal("OK!", proc { "ok".shout }.refined(M1).call)
+    RUBY
+  end
+
+  def test_refined_rejected_by_define_method
+    # A bmethod is invoked against its method entry, not the proc's refinement
+    # cref, so defining a method from a refined proc would silently drop
+    # the refinements; it is rejected instead.
+    refined = ->(s) { s.shout }.refined(RefinementsModule)
+    assert_raise(ArgumentError) { Class.new { define_method(:m, refined) } }
+    assert_raise(ArgumentError) { Class.new { define_method(:m, &refined) } }
+    assert_raise(ArgumentError) { Object.new.define_singleton_method(:m, refined) }
+  end
+
+  # Each refinement module refines only one class so the nested test below can
+  # tell apart the refinement added on the inner Proc (String) from the one
+  # inherited from the enclosing refined Proc (Integer).
+  module RefinementsStringOnly
+    refine String do
+      def shout = upcase + "!"
+    end
+  end
+
+  module RefinementsIntegerOnly
+    refine Integer do
+      def doubled = self * 2
+    end
+  end
+
+  def test_refined_nested_proc_is_not_a_chain
+    # A Proc created lexically INSIDE a refined Proc is not itself "a
+    # Proc that already has refinements": it only inherits the enclosing
+    # refinements lexically.  refined (and define_method) must therefore
+    # be accepted on it, and the inner Proc must see both the enclosing
+    # refinement and the one it adds.  Only the Proc returned by refined
+    # is rejected for chaining.
+    result = -> {
+      inner = ->(s, n) { [s.shout, n.doubled] }
+      inner.refined(RefinementsStringOnly).call("hi", 3)
+    }.refined(RefinementsIntegerOnly).call
+    # RefinementsStringOnly is added on the inner copy; RefinementsIntegerOnly
+    # is inherited from the enclosing refined Proc.
+    assert_equal(["HI!", 6], result)
+
+    # define_method from such a nested Proc is allowed (it is not the
+    # refined result itself).
+    assert_nothing_raised do
+      -> { Class.new { define_method(:m, ->(s) { s }) } }.refined(RefinementsIntegerOnly).call
+    end
+  end
+
+  def test_refined_gc
+    assert_normal_exit(<<~RUBY)
+      module M
+        refine(String) { def shout = upcase + "!" }
+      end
+      procs = 100.times.map { |i| ->(s) { s.shout } .refined(M) }
+      GC.start
+      GC.compact rescue nil
+      procs.each { |pr| raise "bad" unless pr.call("a") == "A!" }
+    RUBY
+  end
+
+  def test_refined_gc_stress
+    # Under GC.stress, the memo store allocates its module array while the memo
+    # is reachable from the iseq; a GC during that allocation must not observe a
+    # half-initialized memo (argc set but mods not yet allocated).  Alternating
+    # module sets keeps missing the memo so each call re-runs the store; one
+    # small iseq keeps it cheap enough for slow CI runners.
+    assert_normal_exit(<<~RUBY)
+      module M1; refine(String) { def shout = upcase + "!" }; end
+      module M2; refine(String) { def shout = downcase }; end
+      orig = ->(s) { s.shout }
+      r = nil
+      GC.stress = true
+      6.times { |i| r = orig.refined(i.even? ? M1 : M2) }
+      GC.stress = false
+      raise "bad" unless r.call("Hi") == "hi"
+    RUBY
+  end
+
+  def test_refined_iseq_to_binary
+    # A block iseq that has memoized copies must still serialize cleanly
+    # (the memo lives outside the iseq).
+    assert_separately([], <<~'RUBY')
+      module M
+        refine(String) { def shout = upcase + "!" }
+      end
+      src = 'x = ->(s) { s.shout }; x.refined(M).call("hi")'
+      iseq = RubyVM::InstructionSequence.compile(src)
+      eval(src) # runs refined, setting the memo on the block iseq
+      bin = iseq.to_binary
+      loaded = RubyVM::InstructionSequence.load_from_binary(bin)
+      assert_equal("HI!", loaded.eval)
+    RUBY
+  end
+
+  module RefinementsModule2
+    refine String do
+      def shout = "?"
+    end
+  end
+
+  def test_refined_memoized
+    orig = ->(s) { s.shout }
+    # Repeating the same (proc, modules) reuses the cached copy but stays correct.
+    assert_equal("HI!", orig.refined(RefinementsModule).call("hi"))
+    assert_equal("HI!", orig.refined(RefinementsModule).call("hi"))
+    # A different module set must not return the previously cached copy.
+    assert_equal("?", orig.refined(RefinementsModule2).call("hi"))
+    # ...and switching back is still correct.
+    assert_equal("HI!", orig.refined(RefinementsModule).call("hi"))
+  end
+
+  def test_refined_ruby2_keywords_memo
+    # Proc#ruby2_keywords marks the shared block iseq, possibly after a copy
+    # was memoized.  The stale memo is rebuilt (with a warning naming the
+    # cause) rather than reused or mutated: the new proc delegates keywords
+    # like its source, while procs built before the mark keep their
+    # creation-time behavior.
+    assert_separately([], <<~'RUBY')
+      module M; refine(String) { def shout = upcase + "!" }; end
+      Warning[:performance] = true
+      $warned = []
+      def Warning.warn(msg, category: nil) = $warned << msg
+      target = ->(a, k: nil) { [a, k] }
+      pr = proc { |*args| target.call(*args) }
+      q1 = pr.refined(M) # memoize a copy before the mark
+      pr.ruby2_keywords
+      assert_equal([1, 2], pr.call(1, k: 2))
+      q2 = pr.refined(M)
+      assert_equal([1, 2], q2.call(1, k: 2))
+      assert_equal(1, $warned.grep(/ruby2_keywords/).size)
+      # the copy made before the mark is not retroactively changed
+      assert_raise(ArgumentError) { q1.call(1, k: 2) }
+      # the rebuilt memo is hit from now on; no further warnings
+      assert_equal([1, 2], pr.refined(M).call(1, k: 2))
+      assert_equal(1, $warned.grep(/ruby2_keywords/).size)
+    RUBY
+  end
+
+  def test_refined_memo_distinct_environments
+    # Procs sharing the same block iseq but capturing different closure
+    # environments hit the same memo entry (env is not part of the key), yet each
+    # result must keep its own environment.
+    factory = ->(tag) { ->(s) { "#{tag}:#{s.shout}" } }
+    p1 = factory.call("A")
+    p2 = factory.call("B")
+    r1 = p1.refined(RefinementsModule)
+    r2 = p2.refined(RefinementsModule)
+    assert_equal("A:X!", r1.call("x"))
+    assert_equal("B:Y!", r2.call("y"))
+    # the original closures still see their own captured tag too
+    assert_equal("A:X!", r1.call("x"))
+  end
+
+  def test_refined_memo_avoids_recopy
+    orig = ->(s) { s.shout }
+    orig.refined(RefinementsModule) # warm the memo
+    GC.disable
+    begin
+      before = GC.stat(:total_allocated_objects)
+      100.times { orig.refined(RefinementsModule) }
+      hits = GC.stat(:total_allocated_objects) - before
+
+      before = GC.stat(:total_allocated_objects)
+      100.times do |i|
+        orig.refined(i.even? ? RefinementsModule : RefinementsModule2)
+      end
+      misses = GC.stat(:total_allocated_objects) - before
+    ensure
+      GC.enable
+    end
+    # Memo hits must allocate far less than recomputing the iseq copy each time.
+    assert_operator(misses, :>, hits * 2,
+                    "expected memo hits (#{hits}) to allocate much less than misses (#{misses})")
+  end
+
+  def test_refined_memo_different_modules_warning
+    assert_separately([], <<~'RUBY')
+      module M1; refine(String) { def shout = "1" }; end
+      module M2; refine(String) { def shout = "2" }; end
+      Warning[:performance] = true
+      $warned = []
+      def Warning.warn(msg, category: nil) = $warned << msg
+      pr = ->(s) { s.shout }
+      pr.refined(M1)
+      pr.refined(M2) # evicts the M1 entry
+      assert_equal(1, $warned.grep(/different modules/).size)
+    RUBY
+  end
+
+  def test_refined_memo_survives_gc
+    assert_separately([], <<~'RUBY')
+      module M; refine(String) { def shout = upcase + "!" }; end
+      pr = ->(s) { [1].each { }; s.shout }
+      # the memo lives as long as its source iseq, so the copy stays
+      # memoized even when no refined proc survives the GC
+      pr.refined(M)
+      GC.start
+      assert_equal("HI!", pr.refined(M).call("hi"))
+      rp = pr.refined(M)
+      GC.start
+      assert_equal("HI!", rp.call("hi"))
+      assert_equal("HI!", pr.refined(M).call("hi"))
+    RUBY
+  end
+
+  def test_refined_memo_gc_compact
+    assert_separately([], <<~'RUBY')
+      module M; refine(String) { def shout = upcase + "!" }; end
+      pr = ->(s) { [1].each { }; s.shout }
+      rp = pr.refined(M)
+      begin
+        GC.compact
+      rescue NotImplementedError
+        omit "GC compaction not supported on this platform"
+      end
+      assert_equal("HI!", rp.call("hi"))
+      assert_equal("HI!", pr.refined(M).call("hi"))
+    RUBY
+  end
+
+  def test_refined_memo_survives_compaction
+    # the memo is a hidden identity Hash: its keys (source iseqs) are pinned,
+    # while its values (copied iseqs, crefs) move and must be updated correctly
+    assert_separately([], <<~'RUBY')
+      omit "compaction unsupported" unless GC.respond_to?(:verify_compaction_references)
+      module M; refine(String) { def shout = upcase + "!" }; end
+      blocks = eval("[" + (["->(s) { s.shout }"] * 500).join(",\n") + "]")
+      kept = blocks.map { |b| b.refined(M) }
+      begin
+        GC.verify_compaction_references(expand_heap: true, toward: :empty)
+      rescue NotImplementedError
+        omit "compaction unsupported on this platform"
+      end
+      kept.each { |r| assert_equal("HI!", r.call("hi")) }
+      blocks.each { |b| assert_equal("HI!", b.refined(M).call("hi")) }
+      GC.compact
+      blocks.each { |b| assert_equal("HI!", b.refined(M).call("hi")) }
+    RUBY
+  end
+
+  def test_refined_rescue_ensure
+    # exercises the copied catch table and shared rescue local table
+    refined = ->(s) {
+      r = nil
+      begin
+        r = s.shout
+      rescue NoMethodError
+        r = "rescued"
+      ensure
+        r = "#{r}."
+      end
+      r
+    }.refined(RefinementsModule)
+    assert_equal("YO!.", refined.call("yo"))
+  end
+
+  def test_refined_def_in_block
+    # a literal def inside the block creates a nested method iseq whose
+    # local_iseq is itself (in-subtree); the copy must rebuild it.
+    # Specified behavior: like a def inside a `using` scope, a method defined
+    # inside the block sees the refinements (the def captures the block's
+    # cref), so the refinement also applies when the method is called later.
+    refined = ->(s) {
+      o = Object.new
+      def o.m = "hi".shout
+      [s.shout, o.m]
+    }.refined(RefinementsModule)
+    assert_equal(["YO!", "HI!"], refined.call("yo"))
+  end
+
+  def test_refined_keyword_and_optional_args
+    refined = ->(a, b = "z", c:, d: "w") {
+      [a, b, c, d].map(&:shout).join
+    }.refined(RefinementsModule)
+    assert_equal("A!Z!C!W!", refined.call("a", c: "c"))
+    assert_equal("A!B!C!D!", refined.call("a", "b", c: "c", d: "d"))
+  end
+
+  def test_refined_case_when_literal
+    # literal when-clauses compile to a CDHASH operand that must round-trip
+    refined = ->(s) {
+      case s.shout
+      when "A!" then 1
+      when "B!" then 2
+      else 0
+      end
+    }.refined(RefinementsModule)
+    assert_equal(1, refined.call("a"))
+    assert_equal(2, refined.call("b"))
+    assert_equal(0, refined.call("c"))
+  end
+
+  def test_refined_flip_flop
+    # flip-flop allocates a special-variable slot keyed off the local iseq;
+    # the copy must run its own flip state independent of the original
+    body = ->(arr) {
+      out = []
+      arr.each { |i| out << i if (i == 2)..(i == 4) }
+      out
+    }
+    refined = body.refined(RefinementsModule)
+    assert_equal([2, 3, 4], refined.call([1, 2, 3, 4, 5]))
+    # a second call starts from a fresh flip state
+    assert_equal([2, 3, 4], refined.call([1, 2, 3, 4, 5]))
+  end
+
+  def test_refined_preserves_location_and_parameters
+    orig = ->(a, b = 1, *c, d:, **e, &f) { a }
+    refined = orig.refined(RefinementsModule)
+    assert_equal(orig.source_location, refined.source_location)
+    assert_equal(orig.parameters, refined.parameters)
+    assert_equal(orig.arity, refined.arity)
+  end
+
+  module RefinementsOperators
+    refine Integer do
+      def +(other) = "plus(#{self},#{other})"
+      def <(other) = "lt"
+    end
+    refine Array do
+      def [](i) = "at#{i}"
+    end
+  end
+
+  def test_refined_operators
+    # Specialized instructions (opt_plus, opt_lt, opt_aref, ...) must honor the
+    # refinement on the copy without leaking it into the original Proc.
+    refined = ->(a, b) { [a + b, a < b] }.refined(RefinementsOperators)
+    assert_equal(["plus(1,2)", "lt"], refined.call(1, 2))
+    aref = ->(a) { a[0] }.refined(RefinementsOperators)
+    assert_equal("at0", aref.call([9]))
+    # the original Procs keep using the builtin operators
+    assert_equal(3, ->(a, b) { a + b }.call(1, 2))
+  end
+
+  def test_refined_preserves_lambda
+    # The copy must keep the receiver's lambda/proc nature, including a lambda's
+    # strict argument checking.
+    lam = ->(a, b) { [a, b] }.refined(RefinementsModule)
+    assert_equal(true, lam.lambda?)
+    assert_raise(ArgumentError) { lam.call(1) }
+    pr = proc { |a, b| [a, b] }.refined(RefinementsModule)
+    assert_equal(false, pr.lambda?)
+    # proc argument handling fills missing parameters with nil instead of raising
+    assert_equal([1, nil], pr.call(1))
+  end
+
+  def test_refined_preserved_by_clone
+    refined = ->(s) { s.shout }.refined(RefinementsModule)
+    assert_equal("Z!", refined.clone.call("z"))
+    # the refinement state survives clone, so chaining on the clone is rejected too
+    assert_raise(ArgumentError) { refined.clone.refined(RefinementsModule2) }
+  end
+
+  def test_refined_module_precedence
+    # When several modules refine the same method, the last one wins, matching
+    # the precedence of nested `using`.
+    body = ->(s) { s.shout }
+    assert_equal("?", body.refined(RefinementsModule, RefinementsModule2).call("Hi"))
+    assert_equal("HI!", body.refined(RefinementsModule2, RefinementsModule).call("Hi"))
+  end
+
+  class RefinementsSuperBase
+    def greet = "base"
+  end
+
+  module RefinementsSuperModule
+    refine RefinementsSuperBase do
+      def greet = "ref-" + super
+    end
+  end
+
+  def test_refined_super
+    # A refined method may call super to reach the method it refines.
+    refined = ->(o) { o.greet }.refined(RefinementsSuperModule)
+    assert_equal("ref-base", refined.call(RefinementsSuperBase.new))
+  end
+
+  def test_refined_tracepoint
+    # Line events fire on the copied iseq just like on the original.
+    src = "->(s) {\n  x = s.shout\n  x\n}"
+    refined = eval(src, binding, "wr_trace_eval").refined(RefinementsModule)
+    lines = []
+    tp = TracePoint.new(:line) { |t| lines << t.lineno if t.path == "wr_trace_eval" }
+    result = tp.enable { refined.call("hi") }
+    assert_equal("HI!", result)
+    assert_equal([2, 3], lines)
+  end
+
+  def test_refined_recursion_sees_refinements
+    # The copy shares the source Proc's environment, so a recursive call through
+    # the captured local reaches the refined Proc and keeps the refinements.
+    fact = nil
+    fact = ->(s) { s.empty? ? "" : s[0].shout + fact.call(s[1..]) }
+              .refined(RefinementsModule)
+    assert_equal("A!B!C!", fact.call("abc"))
+  end
+
   def test_clone_subclass
     c1 = Class.new(Proc)
     assert_equal c1, c1.new{}.clone.class, '[Bug #17545]'

--- a/thread.c
+++ b/thread.c
@@ -589,7 +589,8 @@ rb_vm_proc_local_ep(VALUE proc)
 
 // for ractor, defined in vm.c
 VALUE rb_vm_invoke_proc_with_self(rb_execution_context_t *ec, rb_proc_t *proc, VALUE self,
-                                  int argc, const VALUE *argv, int kw_splat, VALUE passed_block_handler);
+                                  int argc, const VALUE *argv, int kw_splat, VALUE passed_block_handler,
+                                  const rb_cref_t *cref);
 
 static VALUE
 thread_do_start_proc(rb_thread_t *th)
@@ -600,6 +601,7 @@ thread_do_start_proc(rb_thread_t *th)
     VALUE procval = th->invoke_arg.proc.proc;
     rb_proc_t *proc;
     GetProcPtr(procval, proc);
+    const rb_cref_t *cref = rb_proc_refinements_cref(procval);
 
     th->ec->errinfo = Qnil;
     th->ec->root_lep = rb_vm_proc_local_ep(procval);
@@ -621,7 +623,8 @@ thread_do_start_proc(rb_thread_t *th)
             th->ec, proc, self,
             args_len, args_ptr,
             th->invoke_arg.proc.kw_splat,
-            VM_BLOCK_HANDLER_NONE
+            VM_BLOCK_HANDLER_NONE,
+            cref
         );
     }
     else {
@@ -642,7 +645,8 @@ thread_do_start_proc(rb_thread_t *th)
             th->ec, proc,
             args_len, args_ptr,
             th->invoke_arg.proc.kw_splat,
-            VM_BLOCK_HANDLER_NONE
+            VM_BLOCK_HANDLER_NONE,
+            cref
         );
     }
 }

--- a/vm.c
+++ b/vm.c
@@ -360,8 +360,8 @@ ref_delete_symkey(VALUE key, VALUE value, VALUE unused)
     return SYMBOL_P(key) ? ST_DELETE : ST_CONTINUE;
 }
 
-static rb_cref_t *
-vm_cref_dup(const rb_cref_t *cref)
+rb_cref_t *
+rb_vm_cref_dup(const rb_cref_t *cref)
 {
     const rb_scope_visibility_t *visi = CREF_SCOPE_VISI(cref);
     rb_cref_t *next_cref = CREF_NEXT(cref), *new_cref;
@@ -379,7 +379,6 @@ vm_cref_dup(const rb_cref_t *cref)
 
     return new_cref;
 }
-
 
 rb_cref_t *
 rb_vm_cref_dup_without_refinements(const rb_cref_t *cref)
@@ -454,7 +453,7 @@ static VALUE vm_make_env_object(const rb_execution_context_t *ec, rb_control_fra
 static VALUE vm_invoke_bmethod(rb_execution_context_t *ec, rb_proc_t *proc, VALUE self,
                                   int argc, const VALUE *argv, int kw_splat, VALUE block_handler,
                                   const rb_callable_method_entry_t *me);
-static VALUE vm_invoke_proc(rb_execution_context_t *ec, rb_proc_t *proc, VALUE self, int argc, const VALUE *argv, int kw_splat, VALUE block_handler);
+static VALUE vm_invoke_proc(rb_execution_context_t *ec, rb_proc_t *proc, VALUE self, int argc, const VALUE *argv, int kw_splat, VALUE block_handler, const rb_cref_t *cref);
 
 #if USE_YJIT
 // Counter to serve as a proxy for execution time, total number of calls
@@ -1339,7 +1338,7 @@ proc_create(VALUE klass, const struct rb_block *block, int8_t is_from_method, in
 }
 
 VALUE
-rb_proc_dup(VALUE self)
+rb_proc_dup_0(VALUE self)
 {
     VALUE procval;
     rb_proc_t *src;
@@ -1355,8 +1354,42 @@ rb_proc_dup(VALUE self)
         break;
     }
 
+    if (src->is_refined) {
+        rb_proc_t *dst;
+        GetProcPtr(procval, dst);
+        dst->is_refined = 1;
+    }
+
     if (RB_OBJ_SHAREABLE_P(self)) RB_OBJ_SET_SHAREABLE(procval);
     RB_GC_GUARD(self); /* for: body = rb_proc_dup(body) */
+    return procval;
+}
+
+VALUE
+rb_proc_dup(VALUE self)
+{
+    VALUE procval = rb_proc_dup_0(self);
+    const rb_cref_t *cref = rb_proc_refinements_cref(self);
+    if (cref) rb_proc_set_refinements_cref(procval, cref);
+    return procval;
+}
+
+/* Proc#refined: build a Proc that runs `iseq` (a copy of self's block iseq)
+ * with `cref` as its refinement cref, sharing self's environment. */
+VALUE
+rb_proc_dup_with_iseq_and_cref(VALUE self, const rb_iseq_t *iseq, const rb_cref_t *cref)
+{
+    rb_proc_t *src;
+    GetProcPtr(self, src);
+    VM_ASSERT(vm_block_type(&src->block) == block_type_iseq);
+
+    struct rb_block block = src->block;
+    block.as.captured.code.iseq = iseq;
+
+    VALUE procval = proc_create(rb_obj_class(self), &block, src->is_from_method, src->is_lambda);
+    rb_proc_set_refinements_cref(procval, cref);
+
+    RB_GC_GUARD(self);
     return procval;
 }
 
@@ -1842,11 +1875,17 @@ invoke_block_from_c_bh(rb_execution_context_t *ec, VALUE block_handler,
         return vm_yield_with_symbol(ec, VM_BH_TO_SYMBOL(block_handler),
                                     argc, argv, kw_splat, passed_block_handler);
       case block_handler_type_proc:
-        if (force_blockarg == FALSE) {
-            is_lambda = block_proc_is_lambda(VM_BH_TO_PROC(block_handler));
+        {
+            VALUE procval = VM_BH_TO_PROC(block_handler);
+            rb_proc_t *po;
+            GetProcPtr(procval, po);
+            if (po->is_refined) cref = rb_proc_refinements_cref(procval);
+            if (force_blockarg == FALSE) {
+                is_lambda = po->is_lambda;
+            }
+            block_handler = vm_block_to_block_handler(&po->block);
+            goto again;
         }
-        block_handler = vm_proc_to_block_handler(VM_BH_TO_PROC(block_handler));
-        goto again;
     }
     VM_UNREACHABLE(invoke_block_from_c_splattable);
     return Qundef;
@@ -1897,12 +1936,14 @@ ALWAYS_INLINE(static VALUE
               invoke_block_from_c_proc(rb_execution_context_t *ec, const rb_proc_t *proc,
                                        VALUE self, int argc, const VALUE *argv,
                                        int kw_splat, VALUE passed_block_handler, int is_lambda,
+                                       const rb_cref_t *cref,
                                        const rb_callable_method_entry_t *me));
 
 static inline VALUE
 invoke_block_from_c_proc(rb_execution_context_t *ec, const rb_proc_t *proc,
                          VALUE self, int argc, const VALUE *argv,
                          int kw_splat, VALUE passed_block_handler, int is_lambda,
+                         const rb_cref_t *cref,
                          const rb_callable_method_entry_t *me)
 {
     const struct rb_block *block = &proc->block;
@@ -1910,7 +1951,7 @@ invoke_block_from_c_proc(rb_execution_context_t *ec, const rb_proc_t *proc,
   again:
     switch (vm_block_type(block)) {
       case block_type_iseq:
-        return invoke_iseq_block_from_c(ec, &block->as.captured, self, argc, argv, kw_splat, passed_block_handler, NULL, is_lambda, me);
+        return invoke_iseq_block_from_c(ec, &block->as.captured, self, argc, argv, kw_splat, passed_block_handler, cref, is_lambda, me);
       case block_type_ifunc:
         if (kw_splat == 1) {
             VALUE keyword_hash = argv[argc-1];
@@ -1938,21 +1979,24 @@ invoke_block_from_c_proc(rb_execution_context_t *ec, const rb_proc_t *proc,
 
 static VALUE
 vm_invoke_proc(rb_execution_context_t *ec, rb_proc_t *proc, VALUE self,
-               int argc, const VALUE *argv, int kw_splat, VALUE passed_block_handler)
+               int argc, const VALUE *argv, int kw_splat, VALUE passed_block_handler,
+               const rb_cref_t *cref)
 {
-    return invoke_block_from_c_proc(ec, proc, self, argc, argv, kw_splat, passed_block_handler, proc->is_lambda, NULL);
+    return invoke_block_from_c_proc(ec, proc, self, argc, argv, kw_splat, passed_block_handler, proc->is_lambda, cref, NULL);
 }
 
 static VALUE
 vm_invoke_bmethod(rb_execution_context_t *ec, rb_proc_t *proc, VALUE self,
                      int argc, const VALUE *argv, int kw_splat, VALUE block_handler, const rb_callable_method_entry_t *me)
 {
-    return invoke_block_from_c_proc(ec, proc, self, argc, argv, kw_splat, block_handler, TRUE, me);
+    /* bmethod procs never carry a refinement cref (Proc#refined rejects them) */
+    return invoke_block_from_c_proc(ec, proc, self, argc, argv, kw_splat, block_handler, TRUE, NULL, me);
 }
 
 VALUE
 rb_vm_invoke_proc(rb_execution_context_t *ec, rb_proc_t *proc,
-                  int argc, const VALUE *argv, int kw_splat, VALUE passed_block_handler)
+                  int argc, const VALUE *argv, int kw_splat, VALUE passed_block_handler,
+                  const rb_cref_t *cref)
 {
     VALUE self = vm_block_self(&proc->block);
     vm_block_handler_verify(passed_block_handler);
@@ -1961,13 +2005,14 @@ rb_vm_invoke_proc(rb_execution_context_t *ec, rb_proc_t *proc,
         return vm_invoke_bmethod(ec, proc, self, argc, argv, kw_splat, passed_block_handler, NULL);
     }
     else {
-        return vm_invoke_proc(ec, proc, self, argc, argv, kw_splat, passed_block_handler);
+        return vm_invoke_proc(ec, proc, self, argc, argv, kw_splat, passed_block_handler, cref);
     }
 }
 
 VALUE
 rb_vm_invoke_proc_with_self(rb_execution_context_t *ec, rb_proc_t *proc, VALUE self,
-                            int argc, const VALUE *argv, int kw_splat, VALUE passed_block_handler)
+                            int argc, const VALUE *argv, int kw_splat, VALUE passed_block_handler,
+                            const rb_cref_t *cref)
 {
     vm_block_handler_verify(passed_block_handler);
 
@@ -1975,7 +2020,7 @@ rb_vm_invoke_proc_with_self(rb_execution_context_t *ec, rb_proc_t *proc, VALUE s
         return vm_invoke_bmethod(ec, proc, self, argc, argv, kw_splat, passed_block_handler, NULL);
     }
     else {
-        return vm_invoke_proc(ec, proc, self, argc, argv, kw_splat, passed_block_handler);
+        return vm_invoke_proc(ec, proc, self, argc, argv, kw_splat, passed_block_handler, cref);
     }
 }
 

--- a/vm_args.c
+++ b/vm_args.c
@@ -1149,7 +1149,10 @@ vm_caller_setup_arg_block(const rb_execution_context_t *ec, rb_control_frame_t *
                     rb_ary_push(callback_arg, ref);
                     OBJ_FREEZE(callback_arg);
                     func = rb_func_lambda_new(refine_sym_proc_call, callback_arg, 1, UNLIMITED_ARGUMENTS);
-                    rb_hash_aset(ref, block_code, func);
+                    /* the table is frozen when it belongs to a Proc#refined memo; skip the cache then */
+                    if (!OBJ_FROZEN(ref)) {
+                        rb_hash_aset(ref, block_code, func);
+                    }
                 }
                 block_code = func;
             }

--- a/vm_core.h
+++ b/vm_core.h
@@ -1318,7 +1318,13 @@ typedef struct {
     unsigned int is_from_method: 1;	/* bool */
     unsigned int is_lambda: 1;		/* bool */
     unsigned int is_isolated: 1;        /* bool */
+    unsigned int is_refined: 1;         /* bool: Proc#refined */
 } rb_proc_t;
+
+/* A refined proc's cref lives in a hidden ivar on the proc object;
+ * rb_proc_refinements_cref returns NULL unless is_refined is set. */
+const rb_cref_t *rb_proc_refinements_cref(VALUE procval);
+void rb_proc_set_refinements_cref(VALUE procval, const rb_cref_t *cref);
 
 RUBY_SYMBOL_EXPORT_BEGIN
 VALUE rb_proc_isolate(VALUE self);
@@ -1954,6 +1960,7 @@ VALUE rb_thread_alloc(VALUE klass);
 VALUE rb_binding_alloc(VALUE klass);
 VALUE rb_proc_alloc(VALUE klass);
 VALUE rb_proc_dup(VALUE self);
+VALUE rb_proc_dup_0(VALUE self);
 
 /* for debug */
 extern bool rb_vmdebug_stack_dump_raw(const rb_execution_context_t *ec, const rb_control_frame_t *cfp, FILE *);
@@ -1981,7 +1988,7 @@ void rb_iseq_pathobj_set(const rb_iseq_t *iseq, VALUE path, VALUE realpath);
 int rb_ec_frame_method_id_and_class(const rb_execution_context_t *ec, ID *idp, ID *called_idp, VALUE *klassp);
 void rb_ec_setup_exception(const rb_execution_context_t *ec, VALUE mesg, VALUE cause);
 
-VALUE rb_vm_invoke_proc(rb_execution_context_t *ec, rb_proc_t *proc, int argc, const VALUE *argv, int kw_splat, VALUE block_handler);
+VALUE rb_vm_invoke_proc(rb_execution_context_t *ec, rb_proc_t *proc, int argc, const VALUE *argv, int kw_splat, VALUE block_handler, const rb_cref_t *cref);
 
 VALUE rb_vm_make_proc_lambda(const rb_execution_context_t *ec, const struct rb_captured_block *captured, VALUE klass, int8_t is_lambda);
 static inline VALUE

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -290,7 +290,8 @@ vm_call0_body(rb_execution_context_t *ec, struct rb_calling_info *calling, const
             {
                 rb_proc_t *proc;
                 GetProcPtr(calling->recv, proc);
-                ret = rb_vm_invoke_proc(ec, proc, calling->argc, argv, calling->kw_splat, calling->block_handler);
+                ret = rb_vm_invoke_proc(ec, proc, calling->argc, argv, calling->kw_splat, calling->block_handler,
+                                        rb_proc_refinements_cref(calling->recv));
                 goto success;
             }
           case OPTIMIZED_METHOD_TYPE_STRUCT_AREF:
@@ -2005,7 +2006,7 @@ eval_string_with_cref(VALUE self, VALUE src, rb_cref_t *cref, VALUE file, int li
     /* TODO: what the code checking? */
     if (!cref && block.as.captured.code.val) {
         rb_cref_t *orig_cref = vm_get_cref(vm_block_ep(&block));
-        cref = vm_cref_dup(orig_cref);
+        cref = rb_vm_cref_dup(orig_cref);
     }
     vm_set_eval_stack(ec, iseq, cref, &block);
 
@@ -2217,6 +2218,7 @@ yield_under(VALUE self, int singleton, int argc, const VALUE *argv, int kw_splat
     const VALUE *ep = NULL;
     rb_cref_t *cref;
     int is_lambda = FALSE;
+    const rb_cref_t *proc_cref = NULL;
 
     if (block_handler != VM_BLOCK_HANDLER_NONE) {
       again:
@@ -2232,8 +2234,14 @@ yield_under(VALUE self, int singleton, int argc, const VALUE *argv, int kw_splat
             new_block_handler = VM_BH_FROM_IFUNC_BLOCK(&new_captured);
             break;
           case block_handler_type_proc:
-            is_lambda = rb_proc_lambda_p(block_handler) != Qfalse;
-            block_handler = vm_proc_to_block_handler(VM_BH_TO_PROC(block_handler));
+            {
+                VALUE procval = VM_BH_TO_PROC(block_handler);
+                rb_proc_t *po;
+                GetProcPtr(procval, po);
+                is_lambda = po->is_lambda;
+                if (po->is_refined) proc_cref = rb_proc_refinements_cref(procval);
+                block_handler = vm_block_to_block_handler(&po->block);
+            }
             goto again;
           case block_handler_type_symbol:
             return rb_sym_proc_call(SYM2ID(VM_BH_TO_SYMBOL(block_handler)),
@@ -2249,6 +2257,11 @@ yield_under(VALUE self, int singleton, int argc, const VALUE *argv, int kw_splat
 
     VM_ASSERT(singleton || RB_TYPE_P(self, T_MODULE) || RB_TYPE_P(self, T_CLASS));
     cref = vm_cref_push(ec, self, ep, TRUE, singleton);
+
+    if (proc_cref && !NIL_P(CREF_REFINEMENTS(proc_cref))) {
+        CREF_REFINEMENTS_SET(cref, rb_hash_dup(CREF_REFINEMENTS(proc_cref)));
+        CREF_REFINED_PROC_SET(cref);
+    }
 
     return vm_yield_with_cref(ec, argc, argv, kw_splat, cref, is_lambda);
 }

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -908,7 +908,7 @@ cref_replace_with_duplicated_cref_each_frame(const VALUE *vptr, int can_be_svar,
         switch (imemo_type(v)) {
           case imemo_cref:
             cref = (rb_cref_t *)v;
-            new_cref = vm_cref_dup(cref);
+            new_cref = rb_vm_cref_dup(cref);
             if (parent) {
                 RB_OBJ_WRITE(parent, vptr, new_cref);
             }
@@ -5298,9 +5298,9 @@ vm_yield_setup_args(rb_execution_context_t *ec, const rb_iseq_t *iseq, const int
 /* ruby iseq -> ruby block */
 
 static VALUE
-vm_invoke_iseq_block(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp,
-                     struct rb_calling_info *calling, const struct rb_callinfo *ci,
-                     bool is_lambda, VALUE block_handler)
+vm_invoke_iseq_block_with_cref(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp,
+                               struct rb_calling_info *calling, const struct rb_callinfo *ci,
+                               bool is_lambda, VALUE block_handler, const rb_cref_t *cref)
 {
     const struct rb_captured_block *captured = VM_BH_TO_ISEQ_BLOCK(block_handler);
     const rb_iseq_t *iseq = rb_iseq_check(captured->code.iseq);
@@ -5312,15 +5312,24 @@ vm_invoke_iseq_block(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp,
 
     SET_SP(rsp);
 
+    /* cref is normally 0; Proc#refined supplies a refinement cref */
     vm_push_frame(ec, iseq,
                   frame_flag,
                   captured->self,
-                  VM_GUARDED_PREV_EP(captured->ep), 0,
+                  VM_GUARDED_PREV_EP(captured->ep), (VALUE)cref,
                   ISEQ_BODY(iseq)->iseq_encoded + opt_pc,
                   rsp + arg_size,
                   ISEQ_BODY(iseq)->local_table_size - arg_size, ISEQ_BODY(iseq)->stack_max);
 
     return Qundef;
+}
+
+static VALUE
+vm_invoke_iseq_block(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp,
+                     struct rb_calling_info *calling, const struct rb_callinfo *ci,
+                     bool is_lambda, VALUE block_handler)
+{
+    return vm_invoke_iseq_block_with_cref(ec, reg_cfp, calling, ci, is_lambda, block_handler, NULL);
 }
 
 static VALUE
@@ -5386,11 +5395,9 @@ vm_invoke_ifunc_block(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp,
     return val;
 }
 
-static VALUE
-vm_proc_to_block_handler(VALUE procval)
+static inline VALUE
+vm_block_to_block_handler(const struct rb_block *block)
 {
-    const struct rb_block *block = vm_proc_block(procval);
-
     switch (vm_block_type(block)) {
       case block_type_iseq:
         return VM_BH_FROM_ISEQ_BLOCK(&block->as.captured);
@@ -5406,14 +5413,44 @@ vm_proc_to_block_handler(VALUE procval)
 }
 
 static VALUE
+vm_proc_to_block_handler(VALUE procval)
+{
+    return vm_block_to_block_handler(vm_proc_block(procval));
+}
+
+NOINLINE(static VALUE
+vm_invoke_proc_block_with_cref(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp,
+                               struct rb_calling_info *calling, const struct rb_callinfo *ci,
+                               bool is_lambda, VALUE block_handler, VALUE refined_procval));
+static VALUE
+vm_invoke_proc_block_with_cref(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp,
+                               struct rb_calling_info *calling, const struct rb_callinfo *ci,
+                               bool is_lambda, VALUE block_handler, VALUE refined_procval)
+{
+    const rb_cref_t *cref = rb_proc_refinements_cref(refined_procval);
+    return vm_invoke_iseq_block_with_cref(ec, reg_cfp, calling, ci, is_lambda, block_handler, cref);
+}
+
+static VALUE
 vm_invoke_proc_block(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp,
                      struct rb_calling_info *calling, const struct rb_callinfo *ci,
                      bool is_lambda, VALUE block_handler)
 {
+    VALUE refined_procval = 0;
+
     while (vm_block_handler_type(block_handler) == block_handler_type_proc) {
-        VALUE proc = VM_BH_TO_PROC(block_handler);
-        is_lambda = block_proc_is_lambda(proc);
-        block_handler = vm_proc_to_block_handler(proc);
+        VALUE procval = VM_BH_TO_PROC(block_handler);
+        rb_proc_t *po;
+        GetProcPtr(procval, po);
+        if (po->is_refined) refined_procval = procval;
+        is_lambda = po->is_lambda;
+        block_handler = vm_block_to_block_handler(&po->block);
+    }
+
+    if (UNLIKELY(refined_procval) && vm_block_handler_type(block_handler) == block_handler_type_iseq) {
+        /* should not be inlined so that vm_invoke_proc_block stays leaf/frameless. */
+        return vm_invoke_proc_block_with_cref(ec, reg_cfp, calling, ci, is_lambda, block_handler,
+                                              refined_procval);
     }
 
     return vm_invoke_block(ec, reg_cfp, calling, ci, is_lambda, block_handler);

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -569,10 +569,22 @@ impl rb_proc_t {
         }
     }
     #[inline]
+    pub fn is_refined(&self) -> ::std::os::raw::c_uint {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(3usize, 1u8) as u32) }
+    }
+    #[inline]
+    pub fn set_is_refined(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(3usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
     pub fn new_bitfield_1(
         is_from_method: ::std::os::raw::c_uint,
         is_lambda: ::std::os::raw::c_uint,
         is_isolated: ::std::os::raw::c_uint,
+        is_refined: ::std::os::raw::c_uint,
     ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
         let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
         __bindgen_bitfield_unit.set(0usize, 1u8, {
@@ -586,6 +598,10 @@ impl rb_proc_t {
         __bindgen_bitfield_unit.set(2usize, 1u8, {
             let is_isolated: u32 = unsafe { ::std::mem::transmute(is_isolated) };
             is_isolated as u64
+        });
+        __bindgen_bitfield_unit.set(3usize, 1u8, {
+            let is_refined: u32 = unsafe { ::std::mem::transmute(is_refined) };
+            is_refined as u64
         });
         __bindgen_bitfield_unit
     }

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -1443,10 +1443,44 @@ impl rb_proc_t {
         }
     }
     #[inline]
+    pub fn is_refined(&self) -> ::std::os::raw::c_uint {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(3usize, 1u8) as u32) }
+    }
+    #[inline]
+    pub fn set_is_refined(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(3usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn is_refined_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 1usize]>>::raw_get(
+                ::std::ptr::addr_of!((*this)._bitfield_1),
+                3usize,
+                1u8,
+            ) as u32)
+        }
+    }
+    #[inline]
+    pub unsafe fn set_is_refined_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            <__BindgenBitfieldUnit<[u8; 1usize]>>::raw_set(
+                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
+                3usize,
+                1u8,
+                val as u64,
+            )
+        }
+    }
+    #[inline]
     pub fn new_bitfield_1(
         is_from_method: ::std::os::raw::c_uint,
         is_lambda: ::std::os::raw::c_uint,
         is_isolated: ::std::os::raw::c_uint,
+        is_refined: ::std::os::raw::c_uint,
     ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
         let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
         __bindgen_bitfield_unit.set(0usize, 1u8, {
@@ -1460,6 +1494,10 @@ impl rb_proc_t {
         __bindgen_bitfield_unit.set(2usize, 1u8, {
             let is_isolated: u32 = unsafe { ::std::mem::transmute(is_isolated) };
             is_isolated as u64
+        });
+        __bindgen_bitfield_unit.set(3usize, 1u8, {
+            let is_refined: u32 = unsafe { ::std::mem::transmute(is_refined) };
+            is_refined as u64
         });
         __bindgen_bitfield_unit
     }


### PR DESCRIPTION
Add Proc#refined(mod, ...), which returns a new Proc that behaves like
the receiver but with the refinements activated by the given modules in
effect inside its body, without affecting the original Proc.  This is
an alternative to the previously proposed Proc#using
(https://bugs.ruby-lang.org/issues/16461) that does not modify the
existing block and needs no `using Proc::Refinements` declaration.

Refinements are resolved at run time through the cref, so a refined
proc gets two pieces of its own:

* A cref carrying the additional refinements, built by activating the
  modules (rb_using_module_recursive, under the VM lock) on a duplicate
  of the block's captured cref.  It is stored in a hidden ivar on the
  Proc and injected into the block frame on every proc-invocation path
  (Proc#call, yield from C methods, invokeblock/opt_call, and
  instance_eval/instance_exec/module_eval/class_eval via yield_under).
  The captured environment stays shared, so closure variables are still
  shared with the original Proc.  `using` inside the body is rejected
  (CREF_REFINED_PROC), so the cref's refinements never change after
  publication.

* A recursive deep copy of the block's instruction sequences
  (rb_iseq_dup_with_independent_caches) so the new Proc has its own
  inline method caches.  This is required for correctness: the VM
  caches refinement method resolution per call site assuming a single
  lexical cref per iseq, so sharing the iseq would leak the refined
  methods into the original Proc.  Coverage keeps measuring the copied
  iseq.

The copy and the cref are memoized in a single-entry, atomically
published memo on the source iseq, keyed by the captured cref and the
module arguments, so repeated calls at the same site reuse one copy and
procs refined with the same modules share the iseq and the cref.  A
ruby2_keywords flag mismatch invalidates the entry (with a performance
warning).  The refinements table of the memoized cref is frozen and
marked shareable so the memo also serves other Ractors.

Procs without an iseq block (Symbol#to_proc, C-function procs), procs
created from methods, and procs that already have refinements are
rejected with ArgumentError.

The YJIT/ZJIT Rust bindings are regenerated for the new
rb_iseq_constant_body field.
