### PR TITLE
Trigger nofree majors on a per-heap basis

### DIFF
--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -516,6 +516,8 @@ typedef struct rb_heap_struct {
     size_t freed_slots;
     size_t empty_slots;
 
+    size_t minors_since_last_major;
+
     struct heap_page *free_pages;
     struct ccan_list_head pages;
     struct heap_page *sweeping_page; /* iterator for .pages */
@@ -691,7 +693,6 @@ typedef struct rb_objspace {
         VALUE parent_object;
 
         int need_major_gc;
-        size_t last_major_gc;
         size_t uncollectible_wb_unprotected_objects;
         size_t uncollectible_wb_unprotected_objects_limit;
         size_t old_objects;
@@ -4202,16 +4203,17 @@ gc_sweep_finish_heap(rb_objspace_t *objspace, rb_heap_t *heap)
     size_t total_slots = heap->total_slots;
     size_t swept_slots = heap->freed_slots + heap->empty_slots;
 
-    size_t init_slots = gc_params.heap_init_bytes / heap->slot_size;
-    size_t min_free_slots = (size_t)(MAX(total_slots, init_slots) * gc_params.heap_free_slots_min_ratio);
+    if (total_slots == 0) {
+        return;
+    }
 
-    if (swept_slots < min_free_slots &&
-            /* The heap is a growth heap if it freed more slots than had empty slots. */
-            ((heap->empty_slots == 0 && total_slots > 0) || heap->freed_slots > heap->empty_slots)) {
-        /* If we don't have enough slots and we have pages on the tomb heap, move
-        * pages from the tomb heap to the eden heap. This may prevent page
-        * creation thrashing (frequently allocating and deallocting pages) and
-        * GC thrashing (running GC more frequently than required). */
+    size_t min_free_slots = (size_t)(total_slots * gc_params.heap_free_slots_min_ratio);
+
+    bool growth_pressured =
+        (heap->empty_slots == 0) ||
+        (heap->freed_slots > heap->empty_slots);
+
+    if (swept_slots < min_free_slots && growth_pressured) {
         struct heap_page *resurrected_page;
         while (swept_slots < min_free_slots &&
                 (resurrected_page = heap_page_resurrect(objspace))) {
@@ -4222,18 +4224,27 @@ gc_sweep_finish_heap(rb_objspace_t *objspace, rb_heap_t *heap)
         }
 
         if (swept_slots < min_free_slots) {
-            /* Grow this heap if we are in a major GC or if we haven't run at least
-             * RVALUE_OLD_AGE minor GC since the last major GC. */
-            if (is_full_marking(objspace) ||
-                    objspace->profile.count - objspace->rgengc.last_major_gc < RVALUE_OLD_AGE) {
-                if (objspace->heap_pages.allocatable_bytes < min_free_slots * heap->slot_size) {
-                    heap_allocatable_bytes_expand(objspace, heap, swept_slots, heap->total_slots, heap->slot_size);
+            size_t required_allocatable_bytes = min_free_slots * heap->slot_size;
+
+            if (is_full_marking(objspace)) {
+                if (objspace->heap_pages.allocatable_bytes < required_allocatable_bytes) {
+                    heap_allocatable_bytes_expand(objspace, heap, swept_slots,
+                            heap->total_slots, heap->slot_size);
                 }
+                return;
             }
-            else if (swept_slots < min_free_slots * 7 / 8 &&
-                     objspace->heap_pages.allocatable_bytes < (min_free_slots * 7 / 8 - swept_slots) * heap->slot_size) {
+
+            if (objspace->heap_pages.allocatable_bytes >= required_allocatable_bytes) {
+                return;
+            }
+
+            if (heap->minors_since_last_major >= RVALUE_OLD_AGE) {
                 gc_needs_major_flags |= GPR_FLAG_MAJOR_BY_NOFREE;
                 heap->force_major_gc_count++;
+            }
+            else {
+                heap_allocatable_bytes_expand(objspace, heap, swept_slots,
+                        heap->total_slots, heap->slot_size);
             }
         }
     }
@@ -4252,6 +4263,13 @@ gc_sweep_finish(rb_objspace_t *objspace)
 
         heap->freed_slots = 0;
         heap->empty_slots = 0;
+
+        if (is_full_marking(objspace)) {
+            heap->minors_since_last_major = 0;
+        }
+        else {
+            heap->minors_since_last_major++;
+        }
 
         if (!will_be_incremental_marking(objspace)) {
             struct heap_page *end_page = heap->free_pages;
@@ -5888,12 +5906,6 @@ gc_marks_finish(rb_objspace_t *objspace)
         size_t total_slots = objspace_available_slots(objspace);
         size_t sweep_slots = total_slots - objspace->marked_slots; /* will be swept slots */
         size_t max_free_slots = (size_t)(total_slots * gc_params.heap_free_slots_max_ratio);
-        size_t min_free_slots = (size_t)(total_slots * gc_params.heap_free_slots_min_ratio);
-        if (min_free_slots < gc_params.heap_free_slots * r_mul) {
-            min_free_slots = gc_params.heap_free_slots * r_mul;
-        }
-
-        int full_marking = is_full_marking(objspace);
 
         GC_ASSERT(objspace_available_slots(objspace) >= objspace->marked_slots);
 
@@ -5919,23 +5931,7 @@ gc_marks_finish(rb_objspace_t *objspace)
             heap_pages_freeable_pages = 0;
         }
 
-        if (objspace->heap_pages.allocatable_bytes == 0 && sweep_slots < min_free_slots) {
-            if (!full_marking && sweep_slots < min_free_slots * 7 / 8) {
-                if (objspace->profile.count - objspace->rgengc.last_major_gc < RVALUE_OLD_AGE) {
-                    full_marking = TRUE;
-                }
-                else {
-                    gc_report(1, objspace, "gc_marks_finish: next is full GC!!)\n");
-                    gc_needs_major_flags |= GPR_FLAG_MAJOR_BY_NOFREE;
-                }
-            }
-
-            if (full_marking) {
-                heap_allocatable_bytes_expand(objspace, NULL, sweep_slots, total_slots, heaps[0].slot_size);
-            }
-        }
-
-        if (full_marking) {
+        if (is_full_marking(objspace)) {
             /* See the comment about RUBY_GC_HEAP_OLDOBJECT_LIMIT_FACTOR */
             const double r = gc_params.oldobject_limit_factor;
             objspace->rgengc.uncollectible_wb_unprotected_objects_limit = MAX(
@@ -6215,7 +6211,6 @@ gc_marks_start(rb_objspace_t *objspace, int full_mark)
         objspace->profile.major_gc_count++;
         objspace->rgengc.uncollectible_wb_unprotected_objects = 0;
         objspace->rgengc.old_objects = 0;
-        objspace->rgengc.last_major_gc = objspace->profile.count;
         objspace->marked_slots = 0;
 
         for (int i = 0; i < HEAP_COUNT; i++) {


### PR DESCRIPTION
When deciding whether to trigger a major_by_nofree or grow the heap in gc_sweep_finish_heap, we were just counting global GC cycles (at least RVALUE_OLD_AGE`` GC's since last major). We weren't taking into account the state that each individual heap could be in and whether the heap that was finishing GC actually needed a major, or would benefit from
one.

This commit changes the way each heap makes a decision to be based on the previous GC behaviour of that heap.

We track minors_since_last_major per heap. When a heap finishes sweeping, if it:

- Has failed to free min_free_slots
- Is a growth heap (has no empty pages, or freed more than empty)
- has run at least RVALUE_OLD_AGE minors since the last major (to allow
  new objects to age out so that a major is worth it).

Then we request a major_by_nofree, and reset the minors_since_last_major counter.

Otherwise we just expand allocatable_bytes and let the heap grow.

Essentially this patch moves the "at least RVALUE_OLD_AGE GC's since last major" test to be measured per heap rather than globally.

### Benchmarks

Headline benchmarks show small but modest improvements with generally reduced variance.

```
master: ruby 4.1.0dev (2026-06-08T09:39:45Z master 7ed00ca7a9) +YJIT +PRISM [x86_64-linux]
experiment: ruby 4.1.0dev (2026-06-09T12:32:53Z mvh-experiment-maj.. 3ef837de63) +YJIT +PRISM [x86_64-linux]

--------------  -------------  ---------------  ------------------  -----------------
bench             master (ms)  experiment (ms)  experiment 1st itr  master/experiment
liquid-c                  N/A              N/A                 N/A                N/A
activerecord     128.3 ± 5.8%     122.4 ± 0.7%               1.014              1.048
chunky-png       439.8 ± 0.1%     439.5 ± 0.4%               0.991              1.001
erubi-rails      804.8 ± 2.5%     750.0 ± 0.3%               1.132              1.073
hexapdf         1436.2 ± 1.3%    1441.0 ± 2.3%               1.029              0.997
liquid-compile    35.1 ± 7.0%      34.5 ± 2.0%               0.984              1.019
liquid-render     64.6 ± 4.3%      64.2 ± 0.8%               1.014              1.006
lobsters         717.8 ± 1.1%     716.0 ± 1.3%               0.918              1.002
mail              86.8 ± 2.3%      94.1 ± 0.4%               1.021              0.923
psych-load      1438.1 ± 1.5%    1388.0 ± 1.0%               1.021              1.036
railsbench      1312.5 ± 0.2%    1311.3 ± 0.1%               1.010              1.001
rubocop         124.5 ± 13.0%     117.5 ± 6.1%               1.048              1.059
ruby-lsp         118.0 ± 3.0%     115.1 ± 1.6%               0.987              1.025
sequel            52.1 ± 3.9%      54.2 ± 0.5%               0.962              0.962
shipit          1036.9 ± 1.1%    1007.8 ± 3.4%               1.018              1.029
--------------  -------------  ---------------  ------------------  -----------------

Legend:
- experiment 1st itr: ratio of master/experiment time for the first benchmarking iteration.
- master/experiment: ratio of master/experiment time. Higher is better for experiment. Above 1 represents a speedup.
```

GC Bench results:

```
ubuntu@ip-172-31-30-75:~/src/ruby-bench$ ./run_benchmarks.rb --category=gc --chruby="master::ruby-base --yjit" --chruby="experiment::ruby-test --yjit" --interleave
Running benchmark "gcbench" [master] (1/1)
+ setarch x86_64 -R taskset -c 31 /home/ubuntu/.rubies/ruby-base/bin/ruby --yjit -I harness-gc /home/ubuntu/src/ruby-bench/benchmarks/gcbench.rb
ruby 4.1.0dev (2026-06-08T09:39:45Z master 7ed00ca7a9) +YJIT +PRISM [x86_64-linux]
itr:   time   marking  sweeping  gc_count     major     minor  maj/min
 #1:  572ms    44.0ms   103.0ms       125         1       124     0.01
 #2:  540ms    15.0ms    77.0ms        52         0        52     0.00
 #3:  534ms    14.0ms    73.0ms        52         0        52     0.00
 #4:  533ms    15.0ms    72.0ms        52         0        52     0.00
 #5:  533ms    14.0ms    73.0ms        52         0        52     0.00
 #6:  533ms    15.0ms    74.0ms        52         0        52     0.00
 #7:  527ms    14.0ms    72.0ms        52         0        52     0.00
 #8:  529ms    15.0ms    73.0ms        52         0        52     0.00
 #9:  529ms    14.0ms    73.0ms        52         0        52     0.00
#10:  533ms    15.0ms    73.0ms        52         0        52     0.00
#11:  528ms    14.0ms    73.0ms        52         0        52     0.00
#12:  528ms    15.0ms    72.0ms        52         0        52     0.00
#13:  528ms    14.0ms    72.0ms        52         0        52     0.00
#14:  528ms    15.0ms    71.0ms        52         0        52     0.00
#15:  528ms    14.0ms    73.0ms        52         0        52     0.00
#16:  529ms    15.0ms    73.0ms        52         0        52     0.00
#17:  533ms    15.0ms    74.0ms        52         0        52     0.00
#18:  528ms    14.0ms    72.0ms        52         0        52     0.00
#19:  529ms    15.0ms    72.0ms        52         0        52     0.00
#20:  528ms    14.0ms    73.0ms        52         0        52     0.00
#21:  528ms    14.0ms    72.0ms        52         0        52     0.00
#22:  528ms    15.0ms    72.0ms        52         0        52     0.00
#23:  528ms    14.0ms    73.0ms        52         0        52     0.00
#24:  528ms    15.0ms    72.0ms        52         0        52     0.00
#25:  528ms    14.0ms    72.0ms        52         0        52     0.00
YJIT stats:
inline_code_size:         9,376
outlined_code_size:      16,068
code_region_size:        32,768
yjit_alloc_size:        221,636
compile_time             6.08ms
RSS: 47.4MiB
MAXRSS: 53.6MiB
Average of last 10, non-warmup iters: 529ms
Average marking time: 14.0ms
Average sweeping time: 72.0ms

Heap utilisation (after full GC):
heap  slot_size  eden_slots  live_slots  free_slots  eden_pages  live_pct  mem_KiB
   0         32        2047         580        1467            1     28.3%     64.0
   1         40       24561       12934       11627           15     52.7%    960.0
   2         64      163680      134812       28868          160     82.4%  10240.0
   3         80        2454         640        1814            3     26.1%    192.0
   4         96        1363         219        1144            2     16.1%    128.0
   5        128        1022         148         874            2     14.5%    128.0
   6        160        2859        1296        1563            7     45.3%    448.0
   7        256         255           6         249            1      2.4%     64.0
   8        512         254          53         201            2     20.9%    128.0
   9        640         102           3          99            1      2.9%     64.0
  10        768          85           4          81            1      4.7%     64.0
  11       1024          63           1          62            1      1.6%     64.0
Running benchmark "gcbench" [experiment] (1/1)
+ setarch x86_64 -R taskset -c 31 /home/ubuntu/.rubies/ruby-test/bin/ruby --yjit -I harness-gc /home/ubuntu/src/ruby-bench/benchmarks/gcbench.rb
ruby 4.1.0dev (2026-06-09T12:32:53Z mvh-experiment-maj.. 3ef837de63) +YJIT +PRISM [x86_64-linux]
itr:   time   marking  sweeping  gc_count     major     minor  maj/min
 #1:  566ms    39.0ms    80.0ms        50         2        48     0.04
 #2:  533ms    16.0ms    77.0ms        53         0        53     0.00
 #3:  528ms    15.0ms    74.0ms        52         0        52     0.00
 #4:  527ms    16.0ms    73.0ms        53         0        53     0.00
 #5:  525ms    15.0ms    72.0ms        52         0        52     0.00
 #6:  523ms    16.0ms    73.0ms        53         0        53     0.00
 #7:  526ms    15.0ms    75.0ms        52         0        52     0.00
 #8:  523ms    16.0ms    73.0ms        53         0        53     0.00
 #9:  522ms    15.0ms    72.0ms        52         0        52     0.00
#10:  528ms    16.0ms    76.0ms        53         0        53     0.00
#11:  522ms    15.0ms    73.0ms        52         0        52     0.00
#12:  523ms    16.0ms    73.0ms        53         0        53     0.00
#13:  521ms    15.0ms    72.0ms        52         0        52     0.00
#14:  523ms    16.0ms    73.0ms        53         0        53     0.00
#15:  521ms    15.0ms    71.0ms        52         0        52     0.00
#16:  523ms    16.0ms    73.0ms        53         0        53     0.00
#17:  526ms    15.0ms    72.0ms        52         0        52     0.00
#18:  523ms    16.0ms    73.0ms        53         0        53     0.00
#19:  520ms    15.0ms    72.0ms        52         0        52     0.00
#20:  523ms    15.0ms    72.0ms        53         0        53     0.00
#21:  520ms    15.0ms    72.0ms        52         0        52     0.00
#22:  523ms    16.0ms    73.0ms        53         0        53     0.00
#23:  520ms    15.0ms    72.0ms        52         0        52     0.00
#24:  523ms    16.0ms    73.0ms        53         0        53     0.00
#25:  521ms    15.0ms    72.0ms        52         0        52     0.00
YJIT stats:
inline_code_size:         9,376
outlined_code_size:      16,068
code_region_size:        32,768
yjit_alloc_size:        221,636
compile_time             6.09ms
RSS: 47.9MiB
MAXRSS: 71.6MiB
Average of last 10, non-warmup iters: 522ms
Average marking time: 15.0ms
Average sweeping time: 72.0ms

Heap utilisation (after full GC):
heap  slot_size  eden_slots  live_slots  free_slots  eden_pages  live_pct  mem_KiB
   0         32        4094         580        3514            2     14.2%    128.0
   1         40       24561       12934       11627           15     52.7%    960.0
   2         64      163680      134812       28868          160     82.4%  10240.0
   3         80        2454         640        1814            3     26.1%    192.0
   4         96        1363         219        1144            2     16.1%    128.0
   5        128        1022         148         874            2     14.5%    128.0
   6        160        2859        1296        1563            7     45.3%    448.0
   7        256         255           6         249            1      2.4%     64.0
   8        512         254          53         201            2     20.9%    128.0
   9        640         102           3          99            1      2.9%     64.0
  10        768          85           4          81            1      4.7%     64.0
  11       1024          63           1          62            1      1.6%     64.0
Total time spent benchmarking: 26s

master: ruby 4.1.0dev (2026-06-08T09:39:45Z master 7ed00ca7a9) +YJIT +PRISM [x86_64-linux]
experiment: ruby 4.1.0dev (2026-06-09T12:32:53Z mvh-experiment-maj.. 3ef837de63) +YJIT +PRISM [x86_64-linux]

-------  ------------  ----------------  -----------------  ---------------  --------------------  ---------------------  ------------------  -----------------  ----------------------  -----------------------
bench     master (ms)  master mark (ms)  master sweep (ms)  experiment (ms)  experiment mark (ms)  experiment sweep (ms)  experiment 1st itr  master/experiment  mark master/experiment  sweep master/experiment
gcbench  529.2 ± 0.3%       14.5 ± 3.4%        72.5 ± 0.9%     522.8 ± 0.3%           15.4 ± 3.2%            72.4 ± 0.7%               1.010              1.012                   0.942                    1.001
-------  ------------  ----------------  -----------------  ---------------  --------------------  ---------------------  ------------------  -----------------  ----------------------  -----------------------

Legend:
- experiment 1st itr: ratio of master/experiment time for the first benchmarking iteration.
- master/experiment: ratio of master/experiment time. Higher is better for experiment. Above 1 represents a speedup.
- mark master/experiment: ratio of GC marking time. Higher is better for experiment. Above 1 represents faster marking.
- sweep master/experiment: ratio of GC sweeping time. Higher is better for experiment. Above 1 represents faster sweeping.
```