### PR TITLE
[DOC] Reenable docs for `MakeMakefile#have_const`

### DIFF
--- a/lib/mkmf.rb
+++ b/lib/mkmf.rb
@@ -1416,6 +1416,8 @@ SRC
     end
   end
 
+  # :startdoc:
+
   # Returns whether or not the constant +const+ is defined.  You may
   # optionally pass the +type+ of +const+ as <code>[const, type]</code>,
   # such as:


### PR DESCRIPTION
It was already present in [the Ruby 3.3 docs](https://docs.ruby-lang.org/en/3.3/MakeMakefile.html), but disappeared after [Ruby 3.4](https://docs.ruby-lang.org/en/3.4/MakeMakefile.html).

See also: bca1493815ae7ab504ed4f9b049f62a27f30d779