### PR TITLE
Remove duplicate tests in test_call.rb and test_rational.rb

### DIFF
--- a/test/ruby/test_call.rb
+++ b/test/ruby/test_call.rb
@@ -180,7 +180,6 @@ class TestCall < Test::Unit::TestCase
     assert_syntax_error(%q{h[0, *a, **kw] += 1}, message)
     assert_syntax_error(%q{h[kw: 5] += 1}, message)
     assert_syntax_error(%q{h[kw: 5, a: 2] += 1}, message)
-    assert_syntax_error(%q{h[kw: 5, a: 2] += 1}, message)
     assert_syntax_error(%q{h[0, kw: 5, a: 2] += 1}, message)
     assert_syntax_error(%q{h[0, *a, kw: 5, a: 2, nil: 3] += 1}, message)
 
@@ -199,7 +198,6 @@ class TestCall < Test::Unit::TestCase
     assert_syntax_error(%q{h[0, **kw] += 1; nil}, message)
     assert_syntax_error(%q{h[0, *a, **kw] += 1; nil}, message)
     assert_syntax_error(%q{h[kw: 5] += 1; nil}, message)
-    assert_syntax_error(%q{h[kw: 5, a: 2] += 1; nil}, message)
     assert_syntax_error(%q{h[kw: 5, a: 2] += 1; nil}, message)
     assert_syntax_error(%q{h[0, kw: 5, a: 2] += 1; nil}, message)
     assert_syntax_error(%q{h[0, *a, kw: 5, a: 2, nil: 3] += 1; nil}, message)
@@ -220,7 +218,6 @@ class TestCall < Test::Unit::TestCase
     assert_syntax_error(%q{h[0, *a, **kw] &&= 1}, message)
     assert_syntax_error(%q{h[kw: 5] &&= 1}, message)
     assert_syntax_error(%q{h[kw: 5, a: 2] &&= 1}, message)
-    assert_syntax_error(%q{h[kw: 5, a: 2] &&= 1}, message)
     assert_syntax_error(%q{h[0, kw: 5, a: 2] &&= 1}, message)
     assert_syntax_error(%q{h[0, *a, kw: 5, a: 2, nil: 3] &&= 1}, message)
 
@@ -239,7 +236,6 @@ class TestCall < Test::Unit::TestCase
     assert_syntax_error(%q{h[0, **kw] &&= 1; nil}, message)
     assert_syntax_error(%q{h[0, *a, **kw] &&= 1; nil}, message)
     assert_syntax_error(%q{h[kw: 5] &&= 1; nil}, message)
-    assert_syntax_error(%q{h[kw: 5, a: 2] &&= 1; nil}, message)
     assert_syntax_error(%q{h[kw: 5, a: 2] &&= 1; nil}, message)
     assert_syntax_error(%q{h[0, kw: 5, a: 2] &&= 1; nil}, message)
     assert_syntax_error(%q{h[0, *a, kw: 5, a: 2, nil: 3] &&= 1; nil}, message)
@@ -260,7 +256,6 @@ class TestCall < Test::Unit::TestCase
     assert_syntax_error(%q{h[0, *a, **kw] ||= 1}, message)
     assert_syntax_error(%q{h[kw: 5] ||= 1}, message)
     assert_syntax_error(%q{h[kw: 5, a: 2] ||= 1}, message)
-    assert_syntax_error(%q{h[kw: 5, a: 2] ||= 1}, message)
     assert_syntax_error(%q{h[0, kw: 5, a: 2] ||= 1}, message)
     assert_syntax_error(%q{h[0, *a, kw: 5, a: 2, nil: 3] ||= 1}, message)
 
@@ -279,7 +274,6 @@ class TestCall < Test::Unit::TestCase
     assert_syntax_error(%q{h[0, **kw] ||= 1; nil}, message)
     assert_syntax_error(%q{h[0, *a, **kw] ||= 1; nil}, message)
     assert_syntax_error(%q{h[kw: 5] ||= 1; nil}, message)
-    assert_syntax_error(%q{h[kw: 5, a: 2] ||= 1; nil}, message)
     assert_syntax_error(%q{h[kw: 5, a: 2] ||= 1; nil}, message)
     assert_syntax_error(%q{h[0, kw: 5, a: 2] ||= 1; nil}, message)
     assert_syntax_error(%q{h[0, *a, kw: 5, a: 2, nil: 3] ||= 1; nil}, message)

--- a/test/ruby/test_rational.rb
+++ b/test/ruby/test_rational.rb
@@ -701,7 +701,6 @@ class Rational_Test < Test::Unit::TestCase
     assert_equal('-1/2', Rational(-1,2).to_s)
     assert_equal('1/2', Rational(-1,-2).to_s)
     assert_equal('-1/2', Rational(1,-2).to_s)
-    assert_equal('1/2', Rational(-1,-2).to_s)
   end
 
   def test_inspect


### PR DESCRIPTION
Removes 6 duplicate assertions in `test/ruby/test_call.rb` and one duplicate in `test/ruby/test_rational.rb`.