### PR TITLE
Reuse a single MEMO per lazy enumerator iteration

### DIFF
--- a/benchmark/enum_lazy_chain.yml
+++ b/benchmark/enum_lazy_chain.yml
@@ -1,0 +1,12 @@
+prelude: |
+  range = (1..1000)
+  hash = (1..1000).to_h { |i| [i, i] }
+benchmark:
+  lazy_map: range.lazy.map { |x| x * 2 }.first(1000)
+  lazy_map_select: range.lazy.map { |x| x * 2 }.select { |x| x % 4 == 0 }.first(250)
+  lazy_filter_map: range.lazy.filter_map { |x| x * 2 if x.even? }.first(500)
+  lazy_flat_map: range.lazy.flat_map { |x| [x, x] }.first(2000)
+  lazy_hash_map_packed: hash.lazy.map { |k, v| k + v }.first(1000)
+  lazy_with_index: range.lazy.with_index.first(1000)
+  lazy_uniq: range.lazy.uniq.first(1000)
+loop_count: 1000

--- a/enumerator.c
+++ b/enumerator.c
@@ -178,7 +178,7 @@
 VALUE rb_cEnumerator;
 static VALUE rb_cLazy;
 static ID id_rewind, id_to_enum, id_each_entry;
-static ID id_next, id_result, id_receiver, id_arguments, id_memo, id_method, id_force;
+static ID id_next, id_result, id_receiver, id_arguments, id_method, id_force;
 static VALUE sym_each, sym_yield;
 
 static VALUE lazy_use_super_method;
@@ -1624,6 +1624,7 @@ lazy_init_block_i(RB_BLOCK_CALL_FUNC_ARGLIST(val, m))
 #define LAZY_MEMO_SET_VALUE(memo, value) MEMO_V2_SET(memo, value)
 #define LAZY_MEMO_SET_PACKED(memo) ((memo)->memo_flags |= LAZY_MEMO_PACKED)
 #define LAZY_MEMO_RESET_PACKED(memo) ((memo)->memo_flags &= ~LAZY_MEMO_PACKED)
+#define LAZY_MEMO_SET_FLAGS(memo, flags) ((memo)->memo_flags = (flags))
 
 #define LAZY_NEED_BLOCK(func) \
     if (!rb_block_given_p()) { \
@@ -1637,11 +1638,12 @@ lazy_init_yielder(RB_BLOCK_CALL_FUNC_ARGLIST(_, m))
 {
     VALUE yielder = RARRAY_AREF(m, 0);
     VALUE procs_array = RARRAY_AREF(m, 1);
-    VALUE memos = rb_attr_get(yielder, id_memo);
-    struct MEMO *result;
+    VALUE memos = RARRAY_AREF(m, 2);
+    /* the MEMO is shared by all elements of this iteration */
+    struct MEMO *result = MEMO_CAST(RARRAY_AREF(m, 3));
 
-    result = rb_imemo_memo_new(m, rb_enum_values_pack(argc, argv),
-                      argc > 1 ? LAZY_MEMO_PACKED : 0);
+    LAZY_MEMO_SET_VALUE(result, rb_enum_values_pack(argc, argv));
+    LAZY_MEMO_SET_FLAGS(result, argc > 1 ? LAZY_MEMO_PACKED : 0);
     return lazy_yielder_result(result, yielder, procs_array, memos, 0);
 }
 
@@ -1651,7 +1653,7 @@ lazy_yielder_yield(struct MEMO *result, long memo_index, int argc, const VALUE *
     VALUE m = result->v1;
     VALUE yielder = RARRAY_AREF(m, 0);
     VALUE procs_array = RARRAY_AREF(m, 1);
-    VALUE memos = rb_attr_get(yielder, id_memo);
+    VALUE memos = RARRAY_AREF(m, 2);
     LAZY_MEMO_SET_VALUE(result, rb_enum_values_pack(argc, argv));
     if (argc > 1)
         LAZY_MEMO_SET_PACKED(result);
@@ -1687,10 +1689,13 @@ static VALUE
 lazy_init_block(RB_BLOCK_CALL_FUNC_ARGLIST(val, m))
 {
     VALUE procs = RARRAY_AREF(m, 1);
+    VALUE memos = rb_ary_new2(RARRAY_LEN(procs));
+    VALUE arg = rb_ary_new3(3, val, procs, memos);
+    struct MEMO *result = rb_imemo_memo_new(arg, Qnil, 0);
 
-    rb_ivar_set(val, id_memo, rb_ary_new2(RARRAY_LEN(procs)));
+    rb_ary_push(arg, (VALUE)result);
     rb_block_call(RARRAY_AREF(m, 0), id_each, 0, 0,
-                  lazy_init_yielder, rb_ary_new3(2, val, procs));
+                  lazy_init_yielder, arg);
     return Qnil;
 }
 
@@ -4789,7 +4794,6 @@ Init_Enumerator(void)
     id_result = rb_intern_const("result");
     id_receiver = rb_intern_const("receiver");
     id_arguments = rb_intern_const("arguments");
-    id_memo = rb_intern_const("memo");
     id_method = rb_intern_const("method");
     id_force = rb_intern_const("force");
     id_to_enum = rb_intern_const("to_enum");


### PR DESCRIPTION
Each element passing through an Enumerator::Lazy chain allocated a fresh MEMO struct in lazy_init_yielder just to carry the current value and the PACKED/BREAK flags through the proc chain. Nothing retains the MEMO across elements (lazy_flat_map_proc already reuses one MEMO for all of its sub-yields), so allocate one MEMO per iteration in lazy_init_block and reset its value and flags for each element.

Also pass the per-iteration memos array through the block argument array instead of re-reading it from the yielder's ivar on every element, and drop the now-unused id_memo.

This removes one object allocation per element from every lazy chain and speeds up lazy enumeration. Add benchmark/enum_lazy_chain.yml to measure this.

Objects allocated by a single run of each `benchmark/enum_lazy_chain.yml` case (`GC.stat(:total_allocated_objects)` delta, after warmup):

| Benchmark | master | this branch | removed |
|---|---:|---:|---|
| lazy_map | 1,031 | 31 | −1,000 (one MEMO per element) |
| lazy_map_select | 542 | 42 | −500 (one MEMO per element) |
| lazy_filter_map | 1,030 | 30 | −1,000 (one MEMO per element) |
| lazy_flat_map | 2,030 | 1,030 | −1,000 (remaining 1,000 are the block's `[x, x]` arrays) |
| lazy_hash_map_packed | 2,030 | 1,030 | −1,000 (remaining 1,000 are the packed `[key, value]` arrays) |
| lazy_with_index | 2,028 | 1,028 | −1,000 (remaining 1,000 are the `[value, index]` pairs) |
| lazy_uniq | 1,028 | 28 | −1,000 (one MEMO per element) |

Results of `benchmark/enum_lazy_chain.yml` (benchmark-driver, `--repeat-count=3`, macOS arm64), master vs. this branch in each execution mode:

| Benchmark | Interpreter | YJIT | ZJIT |
|---|---|---|---|
| lazy_map | 7.77k → 9.18k i/s (**1.18x**) | 8.07k → 9.28k i/s (**1.15x**) | 8.20k → 9.22k i/s (**1.12x**) |
| lazy_map_select | 13.30k → 15.32k i/s (**1.15x**) | 14.26k → 16.36k i/s (**1.15x**) | 14.34k → 16.36k i/s (**1.14x**) |
| lazy_filter_map | 8.66k → 10.02k i/s (**1.16x**) | 10.29k → 12.46k i/s (**1.21x**) | 9.69k → 12.26k i/s (**1.27x**) |
| lazy_flat_map | 4.62k → 5.27k i/s (**1.14x**) | 4.81k → 5.51k i/s (**1.15x**) | 4.80k → 5.42k i/s (**1.13x**) |
| lazy_hash_map_packed | 6.54k → 7.20k i/s (**1.10x**) | 6.77k → 7.62k i/s (**1.13x**) | 6.76k → 7.64k i/s (**1.13x**) |
| lazy_with_index | 7.88k → 9.41k i/s (**1.19x**) | 7.94k → 9.34k i/s (**1.18x**) | 7.92k → 8.95k i/s (**1.13x**) |
| lazy_uniq | 7.66k → 8.96k i/s (**1.17x**) | 7.82k → 8.97k i/s (**1.15x**) | 7.88k → 8.96k i/s (**1.14x**) |
