### PR TITLE
[Backport 4.0] Add and use rb_ivar_foreach_buffered

### DIFF
--- a/internal/variable.h
+++ b/internal/variable.h
@@ -52,6 +52,7 @@ void rb_obj_init_too_complex(VALUE obj, st_table *table);
 void rb_evict_ivars_to_hash(VALUE obj);
 VALUE rb_obj_field_get(VALUE obj, shape_id_t target_shape_id);
 void rb_ivar_set_internal(VALUE obj, ID id, VALUE val);
+void rb_ivar_foreach_buffered(VALUE obj, int (*func)(ID name, VALUE val, st_data_t arg), st_data_t arg);
 attr_index_t rb_ivar_set_index(VALUE obj, ID id, VALUE val);
 attr_index_t rb_obj_field_set(VALUE obj, shape_id_t target_shape_id, ID field_name, VALUE val);
 VALUE rb_ivar_get_at(VALUE obj, attr_index_t index, ID id);

--- a/marshal.c
+++ b/marshal.c
@@ -727,26 +727,9 @@ has_ivars(VALUE obj, VALUE encname, VALUE *ivobj)
 static void
 w_ivar_each(VALUE obj, st_index_t num, struct dump_call_arg *arg)
 {
-    shape_id_t shape_id = rb_obj_shape_id(arg->obj);
     struct w_ivar_arg ivarg = {arg, num};
     if (!num) return;
-    rb_ivar_foreach(obj, w_obj_each, (st_data_t)&ivarg);
-
-    shape_id_t actual_shape_id = rb_obj_shape_id(arg->obj);
-    if (shape_id != actual_shape_id) {
-        // If the shape tree got _shorter_ then we probably removed an IV
-        // If the shape tree got longer, then we probably added an IV.
-        // The exception message might not be accurate when someone adds and
-        // removes the same number of IVs, but they will still get an exception
-        if (rb_shape_depth(shape_id) > rb_shape_depth(rb_obj_shape_id(arg->obj))) {
-            rb_raise(rb_eRuntimeError, "instance variable removed from %"PRIsVALUE" instance",
-                    CLASS_OF(arg->obj));
-        }
-        else {
-            rb_raise(rb_eRuntimeError, "instance variable added to %"PRIsVALUE" instance",
-                    CLASS_OF(arg->obj));
-        }
-    }
+    rb_ivar_foreach_buffered(obj, w_obj_each, (st_data_t)&ivarg);
 }
 
 static void
@@ -1351,6 +1334,7 @@ r_byte1_buffered(struct load_arg *arg)
         memcpy(arg->buf, RSTRING_PTR(str), RSTRING_LEN(str));
         arg->offset = 0;
         arg->buflen = RSTRING_LEN(str);
+        RB_GC_GUARD(str);
     }
     arg->buflen--;
     return arg->buf[arg->offset++];

--- a/object.c
+++ b/object.c
@@ -794,7 +794,7 @@ inspect_obj(VALUE obj, VALUE a, int recur)
         rb_str_cat2(str, " ...");
     }
     else {
-        rb_ivar_foreach(obj, inspect_i, a);
+        rb_ivar_foreach_buffered(obj, inspect_i, a);
     }
     rb_str_cat2(str, ">");
     RSTRING_PTR(str)[0] = '#';

--- a/test/ruby/test_marshal.rb
+++ b/test/ruby/test_marshal.rb
@@ -859,17 +859,15 @@ class TestMarshal < Test::Unit::TestCase
 
   def test_marshal_dump_adding_instance_variable
     obj = Bug15968.new
-    assert_raise_with_message(RuntimeError, /instance variable added/) do
-      Marshal.dump(obj)
-    end
+    loaded = Marshal.load(Marshal.dump(obj))
+    assert_nil loaded.baz
   end
 
   def test_marshal_dump_removing_instance_variable
     obj = Bug15968.new
     obj.baz = :Bug15968
-    assert_raise_with_message(RuntimeError, /instance variable removed/) do
-      Marshal.dump(obj)
-    end
+    loaded = Marshal.load(Marshal.dump(obj))
+    assert_equal :Bug15968, loaded.baz
   end
 
   ruby2_keywords def ruby2_keywords_hash(*a)

--- a/test/ruby/test_object.rb
+++ b/test/ruby/test_object.rb
@@ -968,6 +968,69 @@ class TestObject < Test::Unit::TestCase
     assert_not_include(s, "@password=")
   end
 
+  def test_inspect_mutating_ivar
+    obj = Object.new
+    evil = Object.new
+    evil.define_singleton_method(:inspect) do
+      obj.instance_variables.each { |v| obj.remove_instance_variable(v) }
+      "evil"
+    end
+    obj.instance_variable_set(:@evil, evil)
+    10.times { |i| obj.instance_variable_set(:"@v#{i}", 0) }
+    # Buffered iteration: inspect sees a snapshot of the original ivars
+    result = obj.inspect
+    assert_include result, "@evil=evil"
+    10.times { |i| assert_include result, "@v#{i}=0" }
+  end
+
+  def test_inspect_mutating_ivar_too_complex
+    # Force too_complex by creating many shape variations on the same class
+    c = Class.new
+    50.times do |i|
+      o = c.new
+      o.instance_variable_set(:"@unique_#{i}", 0)
+    end
+
+    obj = c.new
+    evil = Object.new
+    evil.define_singleton_method(:inspect) do
+      obj.instance_variables.each { |v| obj.remove_instance_variable(v) }
+      ""
+    end
+    obj.instance_variable_set(:@evil, evil)
+    10.times { |i| obj.instance_variable_set(:"@v#{i}", 0) }
+    # too_complex objects use st_foreach which handles mutation gracefully
+    obj.inspect
+  end
+
+  def test_inspect_too_complex
+    kernel_inspect = Kernel.instance_method(:inspect)
+
+    klasses = [
+      Class.new,
+      Class.new(String),
+      Class.new(Array),
+      Class.new(Hash),
+      Struct.new(:x),
+      Class.new(Thread::Mutex),
+      # It's very difficult to get a too_complex T_CLASS, so that isn't tested here
+    ]
+
+    klasses.each_with_index do |klass, idx|
+      8.times do |i|
+        klass.new.instance_variable_set(:"@sib_#{rand(999999)}", 1)
+      end
+
+      obj = klass.new
+      obj.instance_variable_set(:@a, 1)
+      obj.instance_variable_set(:@b, 2)
+
+      s = kernel_inspect.bind_call(obj)
+      assert_include(s, "@a=1")
+      assert_include(s, "@b=2")
+    end
+  end
+
   def test_singleton_methods
     assert_equal([], Object.new.singleton_methods)
     assert_equal([], Object.new.singleton_methods(false))

--- a/variable.c
+++ b/variable.c
@@ -2134,6 +2134,7 @@ struct iv_itr_data {
     st_data_t arg;
     rb_ivar_foreach_callback_func *func;
     VALUE *fields;
+    shape_id_t shape_id;
     bool ivar_only;
 };
 
@@ -2162,8 +2163,14 @@ iterate_over_shapes_callback(shape_id_t shape_id, void *data)
         rb_bug("Unreachable");
     }
 
+    RUBY_ASSERT(itr_data->shape_id == RBASIC_SHAPE_ID(itr_data->obj));
+
     VALUE val = fields[RSHAPE_INDEX(shape_id)];
-    return itr_data->func(RSHAPE_EDGE_NAME(shape_id), val, itr_data->arg);
+    int ret = itr_data->func(RSHAPE_EDGE_NAME(shape_id), val, itr_data->arg);
+
+    RUBY_ASSERT(itr_data->shape_id == RBASIC_SHAPE_ID(itr_data->obj));
+
+    return ret;
 }
 
 /*
@@ -2198,10 +2205,11 @@ obj_fields_each(VALUE obj, rb_ivar_foreach_callback_func *func, st_data_t arg, b
 
     shape_id_t shape_id = RBASIC_SHAPE_ID(obj);
     if (rb_shape_too_complex_p(shape_id)) {
-        rb_st_foreach(ROBJECT_FIELDS_HASH(obj), each_hash_iv, (st_data_t)&itr_data);
+        st_foreach_safe(ROBJECT_FIELDS_HASH(obj), each_hash_iv, (st_data_t)&itr_data);
     }
     else {
         itr_data.fields = ROBJECT_FIELDS(obj);
+        itr_data.shape_id = shape_id;
         iterate_over_shapes(shape_id, func, &itr_data);
     }
 }
@@ -2224,6 +2232,7 @@ imemo_fields_each(VALUE fields_obj, rb_ivar_foreach_callback_func *func, st_data
     }
     else {
         itr_data.fields = rb_imemo_fields_ptr(fields_obj);
+        itr_data.shape_id = shape_id;
         iterate_over_shapes(shape_id, func, &itr_data);
     }
 }
@@ -2336,10 +2345,45 @@ rb_field_foreach(VALUE obj, rb_ivar_foreach_callback_func *func, st_data_t arg, 
     }
 }
 
+struct ivar_buf_entry {
+    ID name;
+    VALUE val;
+};
+
+static int
+collect_ivar_i(ID id, VALUE val, st_data_t arg)
+{
+    struct ivar_buf_entry **pos = (struct ivar_buf_entry **)arg;
+    (*pos)->name = id;
+    (*pos)->val = val;
+    (*pos)++;
+    return ST_CONTINUE;
+}
+
 void
 rb_ivar_foreach(VALUE obj, rb_ivar_foreach_callback_func *func, st_data_t arg)
 {
     rb_field_foreach(obj, func, arg, true);
+}
+
+void
+rb_ivar_foreach_buffered(VALUE obj, rb_ivar_foreach_callback_func *func, st_data_t arg)
+{
+    st_index_t count = rb_ivar_count(obj);
+    if (count == 0) return;
+
+    VALUE tmpbuf;
+    struct ivar_buf_entry *buf = ALLOCV_N(struct ivar_buf_entry, tmpbuf, count);
+    struct ivar_buf_entry *pos = buf;
+
+    rb_field_foreach(obj, collect_ivar_i, (st_data_t)&pos, true);
+    RUBY_ASSERT((st_index_t)(pos - buf) == count);
+
+    for (st_index_t i = 0; i < count; i++) {
+        if (func(buf[i].name, buf[i].val, arg) == ST_STOP) break;
+    }
+
+    ALLOCV_END(tmpbuf);
 }
 
 st_index_t
@@ -2385,7 +2429,7 @@ rb_ivar_count(VALUE obj)
             VALUE fields_obj = rb_obj_fields_no_ractor_check(obj);
             if (fields_obj) {
                 if (rb_shape_obj_too_complex_p(fields_obj)) {
-                    rb_st_table_size(rb_imemo_fields_complex_tbl(fields_obj));
+                    iv_count = rb_st_table_size(rb_imemo_fields_complex_tbl(fields_obj));
                 }
                 else {
                     iv_count = RBASIC_FIELDS_COUNT(obj);


### PR DESCRIPTION
Previously, rb_ivar_foreach would walk up the shape tree, but yield instance variables to the callback as it went. If the object shape was modified during this callback, particularly with removing an instance variable, it could result in reading free'd memory.

This commit solves this by adding a version which buffering all instance variable names and values before calling the callback, giving a snapshot of the object at the time rb_ivar_foreach_buffered is called.

The buffer is made with ALLOCV_N, so the performance difference should be minimal, and I don't think this method is particuarly heavily used.

[Bug #21996] (Backport)