### PR TITLE
[Backport 3.3] Avoid reading TypedData type after dfree

### DIFF
--- a/ext/-test-/typeddata/typeddata.c
+++ b/ext/-test-/typeddata/typeddata.c
@@ -33,6 +33,42 @@ test_make(VALUE klass, VALUE num)
     return Qnil;
 }
 
+/*
+ * Used to verify that rb_data_free does not read rb_data_type_t after dfree.
+ * This intentionally frees the type descriptor from dfree so ASAN can catch
+ * stale post-dfree reads.
+ */
+typedef struct {
+    rb_data_type_t *type;
+    char padding[4096];
+} dynamic_type_data;
+
+static void
+dynamic_type_free(void *ptr)
+{
+    dynamic_type_data *data = ptr;
+    xfree(data->type);
+}
+
+static VALUE
+test_dynamic_type(VALUE klass)
+{
+    rb_data_type_t *type;
+    dynamic_type_data *data;
+    VALUE obj;
+
+    type = ALLOC(rb_data_type_t);
+    memset(type, 0, sizeof(rb_data_type_t));
+    type->wrap_struct_name = "dynamic_typed_data";
+    type->function.dfree = dynamic_type_free;
+    type->flags = RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_EMBEDDABLE;
+
+    obj = TypedData_Make_Struct(klass, dynamic_type_data, type, data);
+    data->type = type;
+
+    return obj;
+}
+
 void
 Init_typeddata(void)
 {
@@ -41,4 +77,5 @@ Init_typeddata(void)
     rb_define_alloc_func(klass, test_alloc);
     rb_define_singleton_method(klass, "check", test_check, 1);
     rb_define_singleton_method(klass, "make", test_make, 1);
+    rb_define_singleton_method(klass, "dynamic_type", test_dynamic_type, 0);
 }

--- a/gc.c
+++ b/gc.c
@@ -3476,14 +3476,22 @@ obj_free_object_id(rb_objspace_t *objspace, VALUE obj)
 static bool
 rb_data_free(rb_objspace_t *objspace, VALUE obj)
 {
-    void *data = RTYPEDDATA_P(obj) ? RTYPEDDATA_GET_DATA(obj) : DATA_PTR(obj);
+    bool typed = RTYPEDDATA_P(obj);
+    void *data = typed ? RTYPEDDATA_GET_DATA(obj) : DATA_PTR(obj);
     if (data) {
         int free_immediately = false;
+        bool embedded = false;
+        bool free_embeddable_data = false;
         void (*dfree)(void *);
 
-        if (RTYPEDDATA_P(obj)) {
-            free_immediately = (RANY(obj)->as.typeddata.type->flags & RUBY_TYPED_FREE_IMMEDIATELY) != 0;
-            dfree = RANY(obj)->as.typeddata.type->function.dfree;
+        if (typed) {
+            const rb_data_type_t *type = RTYPEDDATA_TYPE(obj);
+            dfree = type->function.dfree;
+            if (dfree) {
+                embedded = RTYPEDDATA_EMBEDDED_P(obj);
+                free_immediately = (type->flags & RUBY_TYPED_FREE_IMMEDIATELY) != 0;
+                free_embeddable_data = (type->flags & RUBY_TYPED_EMBEDDABLE) && !embedded;
+            }
         }
         else {
             dfree = RANY(obj)->as.data.dfree;
@@ -3491,14 +3499,14 @@ rb_data_free(rb_objspace_t *objspace, VALUE obj)
 
         if (dfree) {
             if (dfree == RUBY_DEFAULT_FREE) {
-                if (!RTYPEDDATA_P(obj) || !RTYPEDDATA_EMBEDDED_P(obj)) {
+                if (!typed || !embedded) {
                     xfree(data);
                     RB_DEBUG_COUNTER_INC(obj_data_xfree);
                 }
             }
             else if (free_immediately) {
                 (*dfree)(data);
-                if (RTYPEDDATA_TYPE(obj)->flags & RUBY_TYPED_EMBEDDABLE && !RTYPEDDATA_EMBEDDED_P(obj)) {
+                if (free_embeddable_data) {
                     xfree(data);
                 }
 

--- a/test/-ext-/typeddata/test_typeddata.rb
+++ b/test/-ext-/typeddata/test_typeddata.rb
@@ -26,4 +26,13 @@ class Test_TypedData < Test::Unit::TestCase
       Bug::TypedData.make(n)
     end;
   end
+
+  def test_dynamic_data_type_free
+    assert_ruby_status([], "#{<<-"begin;"}\n#{<<-"end;"}")
+    require "-test-/typeddata"
+    begin;
+      100.times { Bug::TypedData.dynamic_type }
+      GC.start
+    end;
+  end
 end


### PR DESCRIPTION
[Bug #22101] (Backport)
