### PR TITLE
Keep C printf result encodings ASCII-compatible

### DIFF
--- a/ext/-test-/printf/printf.c
+++ b/ext/-test-/printf/printf.c
@@ -19,6 +19,12 @@ printf_test_q(VALUE self, VALUE obj)
     return rb_enc_sprintf(rb_usascii_encoding(), "[% "PRIsVALUE"]", obj);
 }
 
+static VALUE
+printf_test_value(VALUE self, VALUE obj)
+{
+    return rb_enc_sprintf(rb_usascii_encoding(), "%"PRIsVALUE, obj);
+}
+
 static char *
 uint_to_str(char *p, char *e, unsigned int x)
 {
@@ -91,6 +97,19 @@ printf_test_call(int argc, VALUE *argv, VALUE self)
 }
 
 static VALUE
+printf_test_enc_sprintf(VALUE self, VALUE enc)
+{
+    return rb_enc_sprintf(rb_to_encoding(enc), "%s", "x");
+}
+
+static VALUE
+printf_test_catf(VALUE self, VALUE str)
+{
+    StringValue(str);
+    return rb_str_catf(str, "%s", "x");
+}
+
+static VALUE
 snprintf_count(VALUE self, VALUE str)
 {
     int n = ruby_snprintf(NULL, 0, "%s", StringValueCStr(str));
@@ -104,6 +123,9 @@ Init_printf(void)
     rb_define_singleton_method(m, "s", printf_test_s, 1);
     rb_define_singleton_method(m, "v", printf_test_v, 1);
     rb_define_singleton_method(m, "q", printf_test_q, 1);
+    rb_define_singleton_method(m, "value", printf_test_value, 1);
     rb_define_singleton_method(m, "call", printf_test_call, -1);
+    rb_define_singleton_method(m, "enc_sprintf", printf_test_enc_sprintf, 1);
+    rb_define_singleton_method(m, "catf", printf_test_catf, 1);
     rb_define_singleton_method(m, "sncount", snprintf_count, 1);
 }

--- a/sprintf.c
+++ b/sprintf.c
@@ -1133,7 +1133,7 @@ ruby__sfvextra(rb_printf_buffer *fp, size_t valsize, void *valp, long *sz, int s
         if (sign == ' ') value = QUOTE(value);
     }
     enc = rb_enc_compatible(result, value);
-    if (enc) {
+    if (enc && rb_enc_asciicompat(enc)) {
         rb_enc_associate(result, enc);
     }
     else {
@@ -1183,6 +1183,15 @@ ruby_vsprintf0(VALUE result, char *p, const char *fmt, va_list ap)
 #undef f
 }
 
+static rb_encoding *
+enc_check(rb_encoding *enc)
+{
+    if (!rb_enc_asciicompat(enc)) {
+        rb_raise(rb_eEncCompatError, "ASCII incompatible encoding: %s", rb_enc_name(enc));
+    }
+    return enc;
+}
+
 VALUE
 rb_enc_vsprintf(rb_encoding *enc, const char *fmt, va_list ap)
 {
@@ -1191,12 +1200,7 @@ rb_enc_vsprintf(rb_encoding *enc, const char *fmt, va_list ap)
 
     result = rb_str_buf_new(initial_len);
     if (enc) {
-        if (rb_enc_mbminlen(enc) > 1) {
-            /* the implementation deeply depends on plain char */
-            rb_raise(rb_eArgError, "cannot construct wchar_t based encoding string: %s",
-                     rb_enc_name(enc));
-        }
-        rb_enc_associate(result, enc);
+        rb_enc_associate(result, enc_check(enc));
     }
     ruby_vsprintf0(result, RSTRING_PTR(result), fmt, ap);
     return result;
@@ -1238,6 +1242,7 @@ VALUE
 rb_str_vcatf(VALUE str, const char *fmt, va_list ap)
 {
     StringValue(str);
+    enc_check(rb_enc_get(str));
     rb_str_modify(str);
     ruby_vsprintf0(str, RSTRING_END(str), fmt, ap);
 

--- a/test/-ext-/test_printf.rb
+++ b/test/-ext-/test_printf.rb
@@ -181,4 +181,23 @@ class Test_SPrintf < Test::Unit::TestCase
   def test_snprintf_count
     assert_equal(3, Bug::Printf.sncount("foo"))
   end
+
+  def test_ascii_incompatible_result_encoding
+    assert_raise(Encoding::CompatibilityError) {
+      Bug::Printf.enc_sprintf(Encoding::UTF_16LE)
+    }
+  end
+
+  def test_ascii_incompatible_catf_receiver
+    assert_raise(Encoding::CompatibilityError) {
+      Bug::Printf.catf("".encode(Encoding::UTF_16LE))
+    }
+  end
+
+  def test_ascii_incompatible_encoding
+    s = ("\x41\x01" * 61).force_encoding(Encoding::UTF_16LE)
+    result = Bug::Printf.value(s)
+    assert_equal(s.encode(Encoding::US_ASCII, invalid: :replace, undef: :replace), result)
+    assert_equal(Encoding::US_ASCII, result.encoding)
+  end
 end


### PR DESCRIPTION
Reject ASCII-incompatible result encodings, and avoid associating such encodings from `PRIsVALUE` arguments; convert them to the existing result encoding instead.