### PR TITLE
IO::Buffer.map: Show actual values in error messages

### DIFF
--- a/io_buffer.c
+++ b/io_buffer.c
@@ -740,7 +740,11 @@ io_buffer_map(int argc, VALUE *argv, VALUE klass)
             rb_raise(rb_eArgError, "Size can't be zero!");
         }
         if (UNLIKELY(size > (size_t)file_size)) {
-            rb_raise(rb_eArgError, "Size can't be larger than file size!");
+            rb_raise(rb_eArgError,
+                     "Size (%" PRIuSIZE ") can't be larger than "
+                     "file size (%" PRIuSIZE ")",
+                     size,
+                     (size_t)file_size);
         }
     }
     else {
@@ -753,17 +757,32 @@ io_buffer_map(int argc, VALUE *argv, VALUE klass)
     if (argc >= 3) {
         offset = NUM2OFFT(argv[2]);
         if (UNLIKELY(offset < 0)) {
-            rb_raise(rb_eArgError, "Offset can't be negative!");
+            rb_raise(rb_eArgError,
+                     "Offset (%" PRIsVALUE ") can't be negative!",
+                     argv[2]);
         }
         if (UNLIKELY(offset >= file_size)) {
-            rb_raise(rb_eArgError, "Offset too large!");
+            rb_raise(rb_eArgError,
+                     "Offset (%" PRIsVALUE ") can't be larger than "
+                     "file size (%" PRIuSIZE ")",
+                     argv[2],
+                     (size_t)file_size);
         }
         if (RB_NIL_P(argv[1])) {
             // Decrease size if it's set from the actual file size:
             size = (size_t)(file_size - offset);
         }
         else if (UNLIKELY((size_t)(file_size - offset) < size)) {
-            rb_raise(rb_eArgError, "Offset too large!");
+            size_t maximum_page_count =
+                (file_size - size) / RUBY_IO_BUFFER_PAGE_SIZE;
+            size_t maximum_offset =
+                RUBY_IO_BUFFER_PAGE_SIZE * maximum_page_count;
+            rb_raise(rb_eArgError,
+                     "Offset (%" PRIsVALUE ") can't be larger than "
+                     "%" PRIuSIZE " for requested size (%" PRIuSIZE ")",
+                     argv[2],
+                     maximum_offset,
+                     size);
         }
     }
 

--- a/spec/ruby/core/io/buffer/map_spec.rb
+++ b/spec/ruby/core/io/buffer/map_spec.rb
@@ -163,10 +163,17 @@ describe "IO::Buffer.map" do
       it "is undefined behavior if size is larger than file size"
     end
 
-    ruby_version_is "4.0" do
+    ruby_version_is "4.0"..."4.1" do
       it "raises ArgumentError if size is larger than file size" do
         @file = open_fixture
         -> { IO::Buffer.map(@file, 8192) }.should.raise(ArgumentError, "Size can't be larger than file size!")
+      end
+    end
+
+    ruby_version_is "4.1" do
+      it "raises ArgumentError if size is larger than file size" do
+        @file = open_fixture
+        -> { IO::Buffer.map(@file, 8192) }.should.raise(ArgumentError, "Size (8192) can't be larger than file size (#{@file.size})")
       end
     end
   end
@@ -233,10 +240,22 @@ describe "IO::Buffer.map" do
       it "is undefined behavior if offset+size is larger than file size"
     end
 
-    ruby_version_is "4.0" do
+    ruby_version_is "4.0"..."4.1" do
       it "raises ArgumentError if offset+size is larger than file size" do
         @file = open_big_file_fixture
         -> { IO::Buffer.map(@file, 17, IO::Buffer::PAGE_SIZE) }.should.raise(ArgumentError, "Offset too large!")
+      ensure
+        # Windows requires the file to be closed before deletion.
+        @file.close unless @file.closed?
+      end
+    end
+
+    ruby_version_is "4.1" do
+      it "raises ArgumentError if offset+size is larger than file size" do
+        @file = open_big_file_fixture
+        size = 17
+        maximum_page_size = 0
+        -> { IO::Buffer.map(@file, size, IO::Buffer::PAGE_SIZE) }.should.raise(ArgumentError, "Offset (#{IO::Buffer::PAGE_SIZE}) can't be larger than #{maximum_page_size} for requested size (#{size})")
       ensure
         # Windows requires the file to be closed before deletion.
         @file.close unless @file.closed?
@@ -249,10 +268,17 @@ describe "IO::Buffer.map" do
       -> { IO::Buffer.map(@file, 4, nil) }.should.raise(TypeError, /no implicit conversion/)
     end
 
-    ruby_version_is "4.0" do
+    ruby_version_is "4.0"..."4.1" do
       it "raises ArgumentError if offset is negative" do
         @file = open_fixture
         -> { IO::Buffer.map(@file, 4, -1) }.should.raise(ArgumentError, "Offset can't be negative!")
+      end
+    end
+
+    ruby_version_is "4.1" do
+      it "raises ArgumentError if offset is negative" do
+        @file = open_fixture
+        -> { IO::Buffer.map(@file, 4, -1) }.should.raise(ArgumentError, "Offset (-1) can't be negative!")
       end
     end
   end

--- a/test/ruby/test_io_buffer.rb
+++ b/test/ruby/test_io_buffer.rb
@@ -91,11 +91,11 @@ class TestIOBuffer < Test::Unit::TestCase
   end
 
   def test_file_mapped_size_too_large
-    assert_raise ArgumentError do
-      File.open(__FILE__) {|file| IO::Buffer.map(file, 200_000, 0, IO::Buffer::READONLY)}
-    end
-    assert_raise ArgumentError do
-      File.open(__FILE__) {|file| IO::Buffer.map(file, File.size(__FILE__) + 1, 0, IO::Buffer::READONLY)}
+    size = File.size(__FILE__) + 1
+    file_size = File.size(__FILE__)
+    message = "Size (#{size}) can't be larger than file size (#{file_size})"
+    assert_raise_with_message ArgumentError, message do
+      File.open(__FILE__) {|file| IO::Buffer.map(file, size, 0, IO::Buffer::READONLY)}
     end
   end
 
@@ -105,12 +105,34 @@ class TestIOBuffer < Test::Unit::TestCase
     }
   end
 
-  def test_file_mapped_offset_too_large
-    assert_raise ArgumentError do
-      File.open(__FILE__) {|file| IO::Buffer.map(file, nil, IO::Buffer::PAGE_SIZE * 100, IO::Buffer::READONLY)}
+  def test_file_mapped_offset_negative
+    offset = -1
+    message = "Offset (#{offset}) can't be negative!"
+    assert_raise_with_message ArgumentError, message do
+      File.open(__FILE__) {|file| IO::Buffer.map(file, nil, offset, IO::Buffer::READONLY)}
     end
-    assert_raise ArgumentError do
-      File.open(__FILE__) {|file| IO::Buffer.map(file, 20, IO::Buffer::PAGE_SIZE * 100, IO::Buffer::READONLY)}
+  end
+
+  def test_file_mapped_offset_too_large
+    file_size = File.size(__FILE__)
+    page_count = file_size / IO::Buffer::PAGE_SIZE
+    offset = IO::Buffer::PAGE_SIZE * (page_count + 1)
+    message = "Offset (#{offset}) can't be larger than file size (#{file_size})"
+    assert_raise_with_message ArgumentError, message do
+      File.open(__FILE__) {|file| IO::Buffer.map(file, nil, offset, IO::Buffer::READONLY)}
+    end
+
+    if page_count > 0
+      offset = IO::Buffer::PAGE_SIZE * page_count
+      available_size = file_size - offset
+      size = available_size + 1
+      maximum_page_count = (file_size - size) / IO::Buffer::PAGE_SIZE
+      maximum_offset = IO::Buffer::PAGE_SIZE * maximum_page_count
+      message = "Offset (#{offset}) can't be larger than #{maximum_offset} " +
+                "for requested size (#{size})"
+      assert_raise_with_message ArgumentError, message do
+        File.open(__FILE__) {|file| IO::Buffer.map(file, size, offset, IO::Buffer::READONLY)}
+      end
     end
   end
 


### PR DESCRIPTION
This is for easy to find what was wrong.