### PR TITLE
[Feature #17944] Remove deprecated socket methods

### DIFF
--- a/ext/socket/socket.c
+++ b/ext/socket/socket.c
@@ -942,111 +942,6 @@ sock_sockaddr(struct sockaddr *addr, socklen_t len)
 
 /*
  * call-seq:
- *   Socket.gethostbyname(hostname) => [official_hostname, alias_hostnames, address_family, *address_list]
- *
- * Use Addrinfo.getaddrinfo instead.
- * This method is deprecated for the following reasons:
- *
- * - The 3rd element of the result is the address family of the first address.
- *   The address families of the rest of the addresses are not returned.
- * - Uncommon address representation:
- *   4/16-bytes binary string to represent IPv4/IPv6 address.
- * - gethostbyname() may take a long time and it may block other threads.
- *   (GVL cannot be released since gethostbyname() is not thread safe.)
- * - This method uses gethostbyname() function already removed from POSIX.
- *
- * This method obtains the host information for _hostname_.
- *
- *   p Socket.gethostbyname("hal") #=> ["localhost", ["hal"], 2, "\x7F\x00\x00\x01"]
- *
- */
-static VALUE
-sock_s_gethostbyname(VALUE obj, VALUE host)
-{
-    rb_warn("Socket.gethostbyname is deprecated; use Addrinfo.getaddrinfo instead.");
-    struct rb_addrinfo *res =
-        rsock_addrinfo(host, Qnil, AF_UNSPEC, SOCK_STREAM, AI_CANONNAME, Qnil);
-    return rsock_make_hostent(host, res, sock_sockaddr);
-}
-
-/*
- * call-seq:
- *   Socket.gethostbyaddr(address_string [, address_family]) => hostent
- *
- * Use Addrinfo#getnameinfo instead.
- * This method is deprecated for the following reasons:
- *
- * - Uncommon address representation:
- *   4/16-bytes binary string to represent IPv4/IPv6 address.
- * - gethostbyaddr() may take a long time and it may block other threads.
- *   (GVL cannot be released since gethostbyname() is not thread safe.)
- * - This method uses gethostbyname() function already removed from POSIX.
- *
- * This method obtains the host information for _address_.
- *
- *   p Socket.gethostbyaddr([221,186,184,68].pack("CCCC"))
- *   #=> ["carbon.ruby-lang.org", [], 2, "\xDD\xBA\xB8D"]
- *
- *   p Socket.gethostbyaddr([127,0,0,1].pack("CCCC"))
- *   ["localhost", [], 2, "\x7F\x00\x00\x01"]
- *   p Socket.gethostbyaddr(([0]*15+[1]).pack("C"*16))
- *   #=> ["localhost", ["ip6-localhost", "ip6-loopback"], 10,
- *        "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01"]
- *
- */
-static VALUE
-sock_s_gethostbyaddr(int argc, VALUE *argv, VALUE _)
-{
-    VALUE addr, family;
-    struct hostent *h;
-    char **pch;
-    VALUE ary, names;
-    int t = AF_INET;
-
-    rb_warn("Socket.gethostbyaddr is deprecated; use Addrinfo#getnameinfo instead.");
-
-    rb_scan_args(argc, argv, "11", &addr, &family);
-    StringValue(addr);
-    if (!NIL_P(family)) {
-        t = rsock_family_arg(family);
-    }
-#ifdef AF_INET6
-    else if (RSTRING_LEN(addr) == 16) {
-        t = AF_INET6;
-    }
-#endif
-    h = gethostbyaddr(RSTRING_PTR(addr), RSTRING_SOCKLEN(addr), t);
-    if (h == NULL) {
-#ifdef HAVE_HSTRERROR
-        extern int h_errno;
-        rb_raise(rb_eSocket, "%s", (char*)hstrerror(h_errno));
-#else
-        rb_raise(rb_eSocket, "host not found");
-#endif
-    }
-    ary = rb_ary_new();
-    rb_ary_push(ary, rb_str_new2(h->h_name));
-    names = rb_ary_new();
-    rb_ary_push(ary, names);
-    if (h->h_aliases != NULL) {
-        for (pch = h->h_aliases; *pch; pch++) {
-            rb_ary_push(names, rb_str_new2(*pch));
-        }
-    }
-    rb_ary_push(ary, INT2NUM(h->h_addrtype));
-#ifdef h_addr
-    for (pch = h->h_addr_list; *pch; pch++) {
-        rb_ary_push(ary, rb_str_new(*pch, h->h_length));
-    }
-#else
-    rb_ary_push(ary, rb_str_new(h->h_addr, h->h_length));
-#endif
-
-    return ary;
-}
-
-/*
- * call-seq:
  *   Socket.getservbyname(service_name)                => port_number
  *   Socket.getservbyname(service_name, protocol_name) => port_number
  *
@@ -2081,8 +1976,6 @@ Init_socket(void)
     rb_define_singleton_method(rb_cSocket, "socketpair", rsock_sock_s_socketpair, -1);
     rb_define_singleton_method(rb_cSocket, "pair", rsock_sock_s_socketpair, -1);
     rb_define_singleton_method(rb_cSocket, "gethostname", sock_gethostname, 0);
-    rb_define_singleton_method(rb_cSocket, "gethostbyname", sock_s_gethostbyname, 1);
-    rb_define_singleton_method(rb_cSocket, "gethostbyaddr", sock_s_gethostbyaddr, -1);
     rb_define_singleton_method(rb_cSocket, "getservbyname", sock_s_getservbyname, -1);
     rb_define_singleton_method(rb_cSocket, "getservbyport", sock_s_getservbyport, -1);
     rb_define_singleton_method(rb_cSocket, "getaddrinfo", sock_s_getaddrinfo, -1);

--- a/ext/socket/tcpsocket.c
+++ b/ext/socket/tcpsocket.c
@@ -89,34 +89,6 @@ tcp_sockaddr(struct sockaddr *addr, socklen_t len)
     return rsock_make_ipaddr(addr, len);
 }
 
-/*
- * call-seq:
- *   TCPSocket.gethostbyname(hostname) => [official_hostname, alias_hostnames, address_family, *address_list]
- *
- * Use Addrinfo.getaddrinfo instead.
- * This method is deprecated for the following reasons:
- *
- * - The 3rd element of the result is the address family of the first address.
- *   The address families of the rest of the addresses are not returned.
- * - gethostbyname() may take a long time and it may block other threads.
- *   (GVL cannot be released since gethostbyname() is not thread safe.)
- * - This method uses gethostbyname() function already removed from POSIX.
- *
- * This method lookups host information by _hostname_.
- *
- *   TCPSocket.gethostbyname("localhost")
- *   #=> ["localhost", ["hal"], 2, "127.0.0.1"]
- *
- */
-static VALUE
-tcp_s_gethostbyname(VALUE obj, VALUE host)
-{
-    rb_warn("TCPSocket.gethostbyname is deprecated; use Addrinfo.getaddrinfo instead.");
-    struct rb_addrinfo *res =
-        rsock_addrinfo(host, Qnil, AF_UNSPEC, SOCK_STREAM, AI_CANONNAME, Qnil);
-    return rsock_make_hostent(host, res, tcp_sockaddr);
-}
-
 void
 rsock_init_tcpsocket(void)
 {
@@ -139,6 +111,5 @@ rsock_init_tcpsocket(void)
      *
      */
     rb_cTCPSocket = rb_define_class("TCPSocket", rb_cIPSocket);
-    rb_define_singleton_method(rb_cTCPSocket, "gethostbyname", tcp_s_gethostbyname, 1);
     rb_define_method(rb_cTCPSocket, "initialize", tcp_init, -1);
 }

--- a/spec/ruby/library/socket/socket/gethostbyaddr_spec.rb
+++ b/spec/ruby/library/socket/socket/gethostbyaddr_spec.rb
@@ -1,68 +1,13 @@
 require_relative '../spec_helper'
-require_relative '../fixtures/classes'
-require 'ipaddr'
 
-describe 'Socket.gethostbyaddr' do
-  describe 'using an IPv4 address' do
-    before do
-      @addr = IPAddr.new('127.0.0.1').hton
-    end
+ruby_version_is ""..."4.1" do
+  require_relative '../fixtures/classes'
+  require 'ipaddr'
 
-    describe 'without an explicit address family' do
-      it 'returns an Array' do
-        suppress_warning { Socket.gethostbyaddr(@addr) }.should.instance_of?(Array)
-      end
-
-      describe 'the returned Array' do
-        before do
-          @array = suppress_warning { Socket.gethostbyaddr(@addr) }
-        end
-
-        it 'includes the hostname as the first value' do
-          @array[0].should == SocketSpecs.hostname_reverse_lookup
-        end
-
-        it 'includes the aliases as the 2nd value' do
-          @array[1].should.instance_of?(Array)
-
-          @array[1].each do |val|
-            val.should.instance_of?(String)
-          end
-        end
-
-        it 'includes the address type as the 3rd value' do
-          @array[2].should == Socket::AF_INET
-        end
-
-        it 'includes all address strings as the remaining values' do
-          @array[3].should == @addr
-
-          @array[4..-1].each do |val|
-            val.should.instance_of?(String)
-          end
-        end
-      end
-    end
-
-    describe 'with an explicit address family' do
-      it 'returns an Array when using an Integer as the address family' do
-        suppress_warning { Socket.gethostbyaddr(@addr, Socket::AF_INET) }.should.instance_of?(Array)
-      end
-
-      it 'returns an Array when using a Symbol as the address family' do
-        suppress_warning { Socket.gethostbyaddr(@addr, :INET) }.should.instance_of?(Array)
-      end
-
-      it 'raises SocketError when the address is not supported by the family' do
-        -> { suppress_warning { Socket.gethostbyaddr(@addr, :INET6) } }.should.raise(SocketError)
-      end
-    end
-  end
-
-  guard -> { SocketSpecs.ipv6_available? && platform_is_not(:aix) } do
-    describe 'using an IPv6 address' do
+  describe 'Socket.gethostbyaddr' do
+    describe 'using an IPv4 address' do
       before do
-        @addr = IPAddr.new('::1').hton
+        @addr = IPAddr.new('127.0.0.1').hton
       end
 
       describe 'without an explicit address family' do
@@ -76,7 +21,7 @@ describe 'Socket.gethostbyaddr' do
           end
 
           it 'includes the hostname as the first value' do
-            @array[0].should == SocketSpecs.hostname_reverse_lookup("::1")
+            @array[0].should == SocketSpecs.hostname_reverse_lookup
           end
 
           it 'includes the aliases as the 2nd value' do
@@ -88,11 +33,11 @@ describe 'Socket.gethostbyaddr' do
           end
 
           it 'includes the address type as the 3rd value' do
-            @array[2].should == Socket::AF_INET6
+            @array[2].should == Socket::AF_INET
           end
 
           it 'includes all address strings as the remaining values' do
-            @array[3].should.instance_of?(String)
+            @array[3].should == @addr
 
             @array[4..-1].each do |val|
               val.should.instance_of?(String)
@@ -103,16 +48,74 @@ describe 'Socket.gethostbyaddr' do
 
       describe 'with an explicit address family' do
         it 'returns an Array when using an Integer as the address family' do
-          suppress_warning { Socket.gethostbyaddr(@addr, Socket::AF_INET6) }.should.instance_of?(Array)
+          suppress_warning { Socket.gethostbyaddr(@addr, Socket::AF_INET) }.should.instance_of?(Array)
         end
 
         it 'returns an Array when using a Symbol as the address family' do
-          suppress_warning { Socket.gethostbyaddr(@addr, :INET6) }.should.instance_of?(Array)
+          suppress_warning { Socket.gethostbyaddr(@addr, :INET) }.should.instance_of?(Array)
         end
 
-        platform_is_not :windows, :wsl do
-          it 'raises SocketError when the address is not supported by the family' do
-            -> { suppress_warning { Socket.gethostbyaddr(@addr, :INET) } }.should.raise(SocketError)
+        it 'raises SocketError when the address is not supported by the family' do
+          -> { suppress_warning { Socket.gethostbyaddr(@addr, :INET6) } }.should.raise(SocketError)
+        end
+      end
+    end
+
+    guard -> { SocketSpecs.ipv6_available? && platform_is_not(:aix) } do
+      describe 'using an IPv6 address' do
+        before do
+          @addr = IPAddr.new('::1').hton
+        end
+
+        describe 'without an explicit address family' do
+          it 'returns an Array' do
+            suppress_warning { Socket.gethostbyaddr(@addr) }.should.instance_of?(Array)
+          end
+
+          describe 'the returned Array' do
+            before do
+              @array = suppress_warning { Socket.gethostbyaddr(@addr) }
+            end
+
+            it 'includes the hostname as the first value' do
+              @array[0].should == SocketSpecs.hostname_reverse_lookup("::1")
+            end
+
+            it 'includes the aliases as the 2nd value' do
+              @array[1].should.instance_of?(Array)
+
+              @array[1].each do |val|
+                val.should.instance_of?(String)
+              end
+            end
+
+            it 'includes the address type as the 3rd value' do
+              @array[2].should == Socket::AF_INET6
+            end
+
+            it 'includes all address strings as the remaining values' do
+              @array[3].should.instance_of?(String)
+
+              @array[4..-1].each do |val|
+                val.should.instance_of?(String)
+              end
+            end
+          end
+        end
+
+        describe 'with an explicit address family' do
+          it 'returns an Array when using an Integer as the address family' do
+            suppress_warning { Socket.gethostbyaddr(@addr, Socket::AF_INET6) }.should.instance_of?(Array)
+          end
+
+          it 'returns an Array when using a Symbol as the address family' do
+            suppress_warning { Socket.gethostbyaddr(@addr, :INET6) }.should.instance_of?(Array)
+          end
+
+          platform_is_not :windows, :wsl do
+            it 'raises SocketError when the address is not supported by the family' do
+              -> { suppress_warning { Socket.gethostbyaddr(@addr, :INET) } }.should.raise(SocketError)
+            end
           end
         end
       end

--- a/spec/ruby/library/socket/socket/gethostbyname_spec.rb
+++ b/spec/ruby/library/socket/socket/gethostbyname_spec.rb
@@ -1,133 +1,136 @@
 # encoding: binary
 require_relative '../spec_helper'
-require_relative '../fixtures/classes'
 
-describe "Socket.gethostbyname" do
-  it "returns broadcast address info for '<broadcast>'" do
-    addr = suppress_warning { Socket.gethostbyname('<broadcast>') }
-    addr.should == ["255.255.255.255", [], 2, "\xFF\xFF\xFF\xFF"]
-  end
+ruby_version_is ""..."4.1" do
+  require_relative '../fixtures/classes'
 
-  it "returns broadcast address info for '<any>'" do
-    addr = suppress_warning { Socket.gethostbyname('<any>') }
-    addr.should == ["0.0.0.0", [], 2, "\x00\x00\x00\x00"]
-  end
-end
-
-describe 'Socket.gethostbyname' do
-  it 'returns an Array' do
-    suppress_warning { Socket.gethostbyname('127.0.0.1') }.should.instance_of?(Array)
-  end
-
-  describe 'the returned Array' do
-    before do
-      @array = suppress_warning { Socket.gethostbyname('127.0.0.1') }
+  describe "Socket.gethostbyname" do
+    it "returns broadcast address info for '<broadcast>'" do
+      addr = suppress_warning { Socket.gethostbyname('<broadcast>') }
+      addr.should == ["255.255.255.255", [], 2, "\xFF\xFF\xFF\xFF"]
     end
 
-    it 'includes the hostname as the first value' do
-      @array[0].should == '127.0.0.1'
-    end
-
-    it 'includes the aliases as the 2nd value' do
-      @array[1].should.instance_of?(Array)
-
-      @array[1].each do |val|
-        val.should.instance_of?(String)
-      end
-    end
-
-    it 'includes the address type as the 3rd value' do
-      possible = [Socket::AF_INET, Socket::AF_INET6]
-
-      possible.include?(@array[2]).should == true
-    end
-
-    it 'includes the address strings as the remaining values' do
-      @array[3].should.instance_of?(String)
-
-      @array[4..-1].each do |val|
-        val.should.instance_of?(String)
-      end
+    it "returns broadcast address info for '<any>'" do
+      addr = suppress_warning { Socket.gethostbyname('<any>') }
+      addr.should == ["0.0.0.0", [], 2, "\x00\x00\x00\x00"]
     end
   end
 
-  describe 'using <broadcast> as the input address' do
+  describe 'Socket.gethostbyname' do
+    it 'returns an Array' do
+      suppress_warning { Socket.gethostbyname('127.0.0.1') }.should.instance_of?(Array)
+    end
+
     describe 'the returned Array' do
       before do
-        @addr = suppress_warning { Socket.gethostbyname('<broadcast>') }
+        @array = suppress_warning { Socket.gethostbyname('127.0.0.1') }
       end
 
-      it 'includes the broadcast address as the first value' do
-        @addr[0].should == '255.255.255.255'
+      it 'includes the hostname as the first value' do
+        @array[0].should == '127.0.0.1'
+      end
+
+      it 'includes the aliases as the 2nd value' do
+        @array[1].should.instance_of?(Array)
+
+        @array[1].each do |val|
+          val.should.instance_of?(String)
+        end
       end
 
       it 'includes the address type as the 3rd value' do
-        @addr[2].should == Socket::AF_INET
+        possible = [Socket::AF_INET, Socket::AF_INET6]
+
+        possible.include?(@array[2]).should == true
       end
 
-      it 'includes the address string as the 4th value' do
-        @addr[3].should == [255, 255, 255, 255].pack('C4')
-      end
-    end
-  end
+      it 'includes the address strings as the remaining values' do
+        @array[3].should.instance_of?(String)
 
-  describe 'using <any> as the input address' do
-    describe 'the returned Array' do
-      before do
-        @addr = suppress_warning { Socket.gethostbyname('<any>') }
-      end
-
-      it 'includes the wildcard address as the first value' do
-        @addr[0].should == '0.0.0.0'
-      end
-
-      it 'includes the address type as the 3rd value' do
-        @addr[2].should == Socket::AF_INET
-      end
-
-      it 'includes the address string as the 4th value' do
-        @addr[3].should == [0, 0, 0, 0].pack('C4')
+        @array[4..-1].each do |val|
+          val.should.instance_of?(String)
+        end
       end
     end
-  end
 
-  describe 'using an IPv4 address' do
-    describe 'the returned Array' do
-      before do
-        @addr = suppress_warning { Socket.gethostbyname('127.0.0.1') }
-      end
-
-      it 'includes the IP address as the first value' do
-        @addr[0].should == '127.0.0.1'
-      end
-
-      it 'includes the address type as the 3rd value' do
-        @addr[2].should == Socket::AF_INET
-      end
-
-      it 'includes the address string as the 4th value' do
-        @addr[3].should == [127, 0, 0, 1].pack('C4')
-      end
-    end
-  end
-
-  guard -> { SocketSpecs.ipv6_available? } do
-    describe 'using an IPv6 address' do
+    describe 'using <broadcast> as the input address' do
       describe 'the returned Array' do
         before do
-          @addr = suppress_warning { Socket.gethostbyname('::1') }
+          @addr = suppress_warning { Socket.gethostbyname('<broadcast>') }
         end
 
-        it 'includes the IP address as the first value' do
-          @addr[0].should == '::1'
+        it 'includes the broadcast address as the first value' do
+          @addr[0].should == '255.255.255.255'
         end
 
         it 'includes the address type as the 3rd value' do
-          @addr[2].should == Socket::AF_INET6
+          @addr[2].should == Socket::AF_INET
         end
 
         it 'includes the address string as the 4th value' do
-          @addr[3].should == [0, 0, 0, 0, 0, 0, 0, 1].pack('n8')
+          @addr[3].should == [255, 255, 255, 255].pack('C4')
+        end
+      end
+    end
+
+    describe 'using <any> as the input address' do
+      describe 'the returned Array' do
+        before do
+          @addr = suppress_warning { Socket.gethostbyname('<any>') }
+        end
+
+        it 'includes the wildcard address as the first value' do
+          @addr[0].should == '0.0.0.0'
+        end
+
+        it 'includes the address type as the 3rd value' do
+          @addr[2].should == Socket::AF_INET
+        end
+
+        it 'includes the address string as the 4th value' do
+          @addr[3].should == [0, 0, 0, 0].pack('C4')
+        end
+      end
+    end
+
+    describe 'using an IPv4 address' do
+      describe 'the returned Array' do
+        before do
+          @addr = suppress_warning { Socket.gethostbyname('127.0.0.1') }
+        end
+
+        it 'includes the IP address as the first value' do
+          @addr[0].should == '127.0.0.1'
+        end
+
+        it 'includes the address type as the 3rd value' do
+          @addr[2].should == Socket::AF_INET
+        end
+
+        it 'includes the address string as the 4th value' do
+          @addr[3].should == [127, 0, 0, 1].pack('C4')
+        end
+      end
+    end
+
+    guard -> { SocketSpecs.ipv6_available? } do
+      describe 'using an IPv6 address' do
+        describe 'the returned Array' do
+          before do
+            @addr = suppress_warning { Socket.gethostbyname('::1') }
+          end
+
+          it 'includes the IP address as the first value' do
+            @addr[0].should == '::1'
+          end
+
+          it 'includes the address type as the 3rd value' do
+            @addr[2].should == Socket::AF_INET6
+          end
+
+          it 'includes the address string as the 4th value' do
+            @addr[3].should == [0, 0, 0, 0, 0, 0, 0, 1].pack('n8')
+          end
         end
       end
     end

--- a/spec/ruby/library/socket/socket/gethostname_spec.rb
+++ b/spec/ruby/library/socket/socket/gethostname_spec.rb
@@ -1,18 +1,21 @@
 require_relative '../spec_helper'
-require_relative '../fixtures/classes'
 
-describe "Socket.gethostname" do
-  def system_hostname
-    if platform_is_not :windows
-      # `uname -n` is the most portable way to get the hostname, as it is a POSIX standard:
-      `uname -n`.strip
-    else
-      # Windows does not have uname, so we use hostname instead:
-      `hostname`.strip
+ruby_version_is ""..."4.1" do
+  require_relative '../fixtures/classes'
+
+  describe "Socket.gethostname" do
+    def system_hostname
+      if platform_is_not :windows
+        # `uname -n` is the most portable way to get the hostname, as it is a POSIX standard:
+        `uname -n`.strip
+      else
+        # Windows does not have uname, so we use hostname instead:
+        `hostname`.strip
+      end
     end
-  end
 
-  it "returns the host name" do
-    Socket.gethostname.should == system_hostname
+    it "returns the host name" do
+      Socket.gethostname.should == system_hostname
+    end
   end
 end

--- a/spec/ruby/library/socket/tcpsocket/gethostbyname_spec.rb
+++ b/spec/ruby/library/socket/tcpsocket/gethostbyname_spec.rb
@@ -1,118 +1,121 @@
 require_relative '../spec_helper'
-require_relative '../fixtures/classes'
 
-# TODO: verify these for windows
-describe "TCPSocket.gethostbyname" do
-  before :each do
-    suppress_warning do
-      @host_info = TCPSocket.gethostbyname(SocketSpecs.hostname)
-    end
-  end
+ruby_version_is ""..."4.1" do
+  require_relative '../fixtures/classes'
 
-  it "returns an array elements of information on the hostname" do
-    @host_info.should.is_a?(Array)
-  end
-
-  platform_is_not :windows do
-    it "returns the canonical name as first value" do
-      @host_info[0].should == SocketSpecs.hostname
+  # TODO: verify these for windows
+  describe "TCPSocket.gethostbyname" do
+    before :each do
+      suppress_warning do
+        @host_info = TCPSocket.gethostbyname(SocketSpecs.hostname)
+      end
     end
 
-    it "returns the address type as the third value" do
-      address_type = @host_info[2]
-      [Socket::AF_INET, Socket::AF_INET6].include?(address_type).should == true
+    it "returns an array elements of information on the hostname" do
+      @host_info.should.is_a?(Array)
     end
 
-    it "returns the IP address as the fourth value" do
-      ip = @host_info[3]
-      ["127.0.0.1", "::1"].include?(ip).should == true
-    end
-  end
-
-  platform_is :windows do
-    quarantine! do # name lookup seems not working on Windows CI
+    platform_is_not :windows do
       it "returns the canonical name as first value" do
-        host = "#{ENV['COMPUTERNAME'].downcase}"
-        host << ".#{ENV['USERDNSDOMAIN'].downcase}" if ENV['USERDNSDOMAIN']
-        @host_info[0].should == host
+        @host_info[0].should == SocketSpecs.hostname
+      end
+
+      it "returns the address type as the third value" do
+        address_type = @host_info[2]
+        [Socket::AF_INET, Socket::AF_INET6].include?(address_type).should == true
+      end
+
+      it "returns the IP address as the fourth value" do
+        ip = @host_info[3]
+        ["127.0.0.1", "::1"].include?(ip).should == true
       end
     end
 
-    it "returns the address type as the third value" do
-      @host_info[2].should == Socket::AF_INET
-    end
-
-    it "returns the IP address as the fourth value" do
-      @host_info[3].should == "127.0.0.1"
-    end
-  end
-
-  it "returns any aliases to the address as second value" do
-    @host_info[1].should.is_a?(Array)
-  end
-end
-
-describe 'TCPSocket.gethostbyname' do
-  it 'returns an Array' do
-    suppress_warning do
-      TCPSocket.gethostbyname('127.0.0.1').should.instance_of?(Array)
-    end
-  end
-
-  describe 'using a hostname' do
-    describe 'the returned Array' do
-      before do
-        suppress_warning do
-          @array = TCPSocket.gethostbyname('127.0.0.1')
+    platform_is :windows do
+      quarantine! do # name lookup seems not working on Windows CI
+        it "returns the canonical name as first value" do
+          host = "#{ENV['COMPUTERNAME'].downcase}"
+          host << ".#{ENV['USERDNSDOMAIN'].downcase}" if ENV['USERDNSDOMAIN']
+          @host_info[0].should == host
         end
       end
 
-      it 'includes the canonical name as the 1st value' do
-        @array[0].should == '127.0.0.1'
+      it "returns the address type as the third value" do
+        @host_info[2].should == Socket::AF_INET
       end
 
-      it 'includes an array of alternative hostnames as the 2nd value' do
-        @array[1].should.instance_of?(Array)
+      it "returns the IP address as the fourth value" do
+        @host_info[3].should == "127.0.0.1"
       end
+    end
 
-      it 'includes the address family as the 3rd value' do
-        @array[2].should.is_a?(Integer)
-      end
-
-      it 'includes the IP addresses as all the remaining values' do
-        ips = %w{::1 127.0.0.1}
-
-        ips.include?(@array[3]).should == true
-
-        # Not all machines might have both IPv4 and IPv6 set up, so this value is
-        # optional.
-        ips.include?(@array[4]).should == true if @array[4]
-      end
+    it "returns any aliases to the address as second value" do
+      @host_info[1].should.is_a?(Array)
     end
   end
 
-  SocketSpecs.each_ip_protocol do |family, ip_address|
-    describe 'the returned Array' do
-      before do
-        suppress_warning do
-          @array = TCPSocket.gethostbyname(ip_address)
+  describe 'TCPSocket.gethostbyname' do
+    it 'returns an Array' do
+      suppress_warning do
+        TCPSocket.gethostbyname('127.0.0.1').should.instance_of?(Array)
+      end
+    end
+
+    describe 'using a hostname' do
+      describe 'the returned Array' do
+        before do
+          suppress_warning do
+            @array = TCPSocket.gethostbyname('127.0.0.1')
+          end
+        end
+
+        it 'includes the canonical name as the 1st value' do
+          @array[0].should == '127.0.0.1'
+        end
+
+        it 'includes an array of alternative hostnames as the 2nd value' do
+          @array[1].should.instance_of?(Array)
+        end
+
+        it 'includes the address family as the 3rd value' do
+          @array[2].should.is_a?(Integer)
+        end
+
+        it 'includes the IP addresses as all the remaining values' do
+          ips = %w{::1 127.0.0.1}
+
+          ips.include?(@array[3]).should == true
+
+          # Not all machines might have both IPv4 and IPv6 set up, so this value is
+          # optional.
+          ips.include?(@array[4]).should == true if @array[4]
         end
       end
+    end
 
-      it 'includes the IP address as the 1st value' do
-        @array[0].should == ip_address
-      end
+    SocketSpecs.each_ip_protocol do |family, ip_address|
+      describe 'the returned Array' do
+        before do
+          suppress_warning do
+            @array = TCPSocket.gethostbyname(ip_address)
+          end
+        end
 
-      it 'includes an empty list of aliases as the 2nd value' do
-        @array[1].should == []
-      end
+        it 'includes the IP address as the 1st value' do
+          @array[0].should == ip_address
+        end
 
-      it 'includes the address family as the 3rd value' do
-        @array[2].should == family
-      end
+        it 'includes an empty list of aliases as the 2nd value' do
+          @array[1].should == []
+        end
 
-      it 'includes the IP address as the 4th value' do
-        @array[3].should == ip_address
+        it 'includes the address family as the 3rd value' do
+          @array[2].should == family
+        end
+
+        it 'includes the IP address as the 4th value' do
+          @array[3].should == ip_address
+        end
       end
     end
   end


### PR DESCRIPTION
These methods have been deprecated since nine years ago.
[[Feature #17944]](https://bugs.ruby-lang.org/issues/17944)