### PR TITLE
Add timeout scale to all macos check CI jobs

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -137,6 +137,10 @@ jobs:
           echo "RUBY_TEST_TIMEOUT_SCALE=10" >> $GITHUB_ENV # With --repeat-count=2, flaky test by timeout occurs frequently for some reason
         if: matrix.test_opts
 
+      - name: Set timeout scale
+        run: echo "RUBY_TEST_TIMEOUT_SCALE=10" >> $GITHUB_ENV # subprocess assertion timeouts flake on slower/contended macOS runners
+        if: ${{ matrix.test_task == 'check' }}
+
       - name: make ${{ matrix.test_task }}
         run: |
           test -n "${LAUNCHABLE_STDOUT}" && exec 1> >(tee "${LAUNCHABLE_STDOUT}")


### PR DESCRIPTION
MacOS CI jobs are prone to flake on Github Actions with timeouts using assert_separately.

I had a hunch this was happening a lot, so I had GPT take a look at the last 85 days of macOS CI runs. Here is what it found:

- 36 of 84 macOS CI failures (43%) over the window involved a subprocess-assertion timeout — the single largest flaky-failure cause.
- 47 timeout occurrences across 39 build jobs.
- It's accelerating: ~5/month background Mar–May, then 32 occurrences in the first 11 days of June — coinciding exactly with macos-15-intel
  landing on 2026-05-29          (5c762e786b).
- macos-15-intel is the epicentre: since it was added, 144 job runs → 25
  failures (17%), and 21 of those 25 (84%) were subprocess timeouts →
  timeouts alone redded 15% of  all intel runs. It accounts for 26 of 47
  occurrences (55%).
- Culprit helpers: assert_separately ×26, assert_in_out_err ×9,
  assert_ruby_status ×5, assert_normal_exit ×3.

 This patch applies the same timout scale environment variable used in
 the --repeat-count=2 tests, to all `make check` jobs running on macOS runners.