### PR TITLE
Inline GC fastpath in ZJIT for newarray instruction

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -698,7 +698,7 @@ clean-local:: clean-runnable
 	-$(Q)$(RMALL) dump_ast$(BUILD_EXEEXT)*
 	-$(Q)$(RMALL) target
 	-$(Q) $(RMDIR) enc/jis enc/trans enc $(COROUTINE_H:/Context.h=) coroutine target \
-	  $(PRISM_BUILD_DIR)/*/ $(PRISM_BUILD_DIR) tmp \
+	  $(PRISM_BUILD_DIR)/*/ $(PRISM_BUILD_DIR) gc/default gc tmp \
 	2> $(NULL) || $(NULLCMD)
 
 bin/clean-runnable:: PHONY

--- a/depend
+++ b/depend
@@ -5936,6 +5936,7 @@ gc.$(OBJEXT): $(hdrdir)/ruby.h
 gc.$(OBJEXT): $(hdrdir)/ruby/ruby.h
 gc.$(OBJEXT): $(hdrdir)/ruby/version.h
 gc.$(OBJEXT): $(top_srcdir)/gc/default/default.c
+gc.$(OBJEXT): $(top_srcdir)/gc/default/zjit_fastpath.h
 gc.$(OBJEXT): $(top_srcdir)/gc/gc.h
 gc.$(OBJEXT): $(top_srcdir)/gc/gc_impl.h
 gc.$(OBJEXT): $(top_srcdir)/internal/array.h
@@ -21717,6 +21718,8 @@ zjit.$(OBJEXT): {$(VPATH)}prism_xallocator.h
 zjit.$(OBJEXT): {$(VPATH)}probes.dmyh
 zjit.$(OBJEXT): {$(VPATH)}probes.h
 zjit.$(OBJEXT): {$(VPATH)}probes_helper.h
+zjit.$(OBJEXT): {$(VPATH)}ractor.h
+zjit.$(OBJEXT): {$(VPATH)}ractor_core.h
 zjit.$(OBJEXT): {$(VPATH)}ruby_assert.h
 zjit.$(OBJEXT): {$(VPATH)}ruby_atomic.h
 zjit.$(OBJEXT): {$(VPATH)}rubyparser.h

--- a/gc.c
+++ b/gc.c
@@ -622,6 +622,7 @@ typedef struct gc_function_map {
     struct rb_gc_vm_context *(*get_vm_context)(void *objspace_ptr);
     // Object allocation
     VALUE (*new_obj)(void *objspace_ptr, void *cache_ptr, VALUE klass, VALUE flags, bool wb_protected, size_t alloc_size, size_t *actual_alloc_size);
+    bool (*zjit_new_obj_fastpath)(void *objspace_ptr, size_t alloc_size, VALUE flags, VALUE klass, struct rb_gc_zjit_fastpath *fastpath);
     size_t (*obj_slot_size)(VALUE obj);
     size_t (*size_slot_size)(void *objspace_ptr, size_t size);
     bool (*size_allocatable_p)(size_t size);
@@ -801,6 +802,7 @@ ruby_modular_gc_init(void)
     load_modular_gc_func(get_vm_context);
     // Object allocation
     load_modular_gc_func(new_obj);
+    load_modular_gc_func(zjit_new_obj_fastpath);
     load_modular_gc_func(obj_slot_size);
     load_modular_gc_func(size_slot_size);
     load_modular_gc_func(size_allocatable_p);
@@ -889,6 +891,7 @@ ruby_modular_gc_init(void)
 # define rb_gc_impl_get_vm_context rb_gc_functions.get_vm_context
 // Object allocation
 # define rb_gc_impl_new_obj rb_gc_functions.new_obj
+# define rb_gc_impl_zjit_new_obj_fastpath rb_gc_functions.zjit_new_obj_fastpath
 # define rb_gc_impl_obj_slot_size rb_gc_functions.obj_slot_size
 # define rb_gc_impl_size_slot_size rb_gc_functions.size_slot_size
 # define rb_gc_impl_size_allocatable_p rb_gc_functions.size_allocatable_p
@@ -3712,6 +3715,16 @@ void
 rb_gc_ractor_cache_free(void *cache)
 {
     rb_gc_impl_ractor_cache_free(rb_gc_get_objspace(), cache);
+}
+
+bool
+rb_gc_zjit_new_obj_fastpath(size_t alloc_size, VALUE flags, VALUE klass, struct rb_gc_zjit_fastpath *fastpath)
+{
+#if RACTOR_CHECK_MODE || defined(RUBY_ASAN_ENABLED)
+    return false;
+#else
+    return rb_gc_impl_zjit_new_obj_fastpath(rb_gc_get_objspace(), alloc_size, flags, klass, fastpath);
+#endif
 }
 
 void

--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -1,6 +1,7 @@
 #include "ruby/internal/config.h"
 
 #include <signal.h>
+#include <string.h>
 
 #ifndef _WIN32
 # include <sys/mman.h>
@@ -72,6 +73,10 @@ rb_hrtime_sub(rb_hrtime_t a, rb_hrtime_t b)
 #endif
 
 #include "probes.h"
+
+#if USE_ZJIT
+# include "gc/default/zjit_fastpath.h"
+#endif
 
 #ifdef BUILDING_MODULAR_GC
 # define RB_DEBUG_COUNTER_INC(_name) ((void)0)
@@ -233,16 +238,15 @@ static RB_THREAD_LOCAL_SPECIFIER int malloc_increase_local;
 #endif
 
 typedef struct ractor_newobj_heap_cache {
-    uintptr_t cursor;
-    uintptr_t cursor_end;
     struct free_region *next_region;
     struct heap_page *using_page;
-    size_t allocated_objects_count;
+    uintptr_t region_end;
 } rb_ractor_newobj_heap_cache_t;
 
 typedef struct ractor_newobj_cache {
     size_t incremental_mark_step_allocated_slots;
     rb_ractor_newobj_heap_cache_t heap_caches[HEAP_COUNT];
+    struct gc_bump_pointer_heap bump_heaps[];
 } rb_ractor_newobj_cache_t;
 
 typedef struct {
@@ -1757,11 +1761,31 @@ calloc1(size_t n)
     return calloc(1, n);
 }
 
+static void
+gc_ractor_jit_cursor_sync(void *c, void *data)
+{
+    rb_ractor_newobj_cache_t *gc_cache = c;
+    bool tracing = (bool)(uintptr_t)data;
+
+    for (size_t heap_idx = 0; heap_idx < HEAP_COUNT; heap_idx++) {
+        struct gc_bump_pointer_heap *bump = &gc_cache->bump_heaps[heap_idx];
+        bump->jit_cursor_end = tracing ? bump->cursor : bump->cursor_end;
+    }
+}
+
 void
 rb_gc_impl_set_event_hook(void *objspace_ptr, const rb_event_flag_t event)
 {
     rb_objspace_t *objspace = objspace_ptr;
+    rb_event_flag_t old_events = objspace->hook_events;
     objspace->hook_events = event & RUBY_INTERNAL_EVENT_OBJSPACE_MASK;
+
+    bool was_tracing = old_events & RUBY_INTERNAL_EVENT_NEWOBJ;
+    bool now_tracing = objspace->hook_events & RUBY_INTERNAL_EVENT_NEWOBJ;
+    if (was_tracing != now_tracing) {
+        rb_gc_ractor_newobj_cache_foreach(gc_ractor_jit_cursor_sync,
+                                          (void *)(uintptr_t)now_tracing);
+    }
 }
 
 unsigned long long
@@ -2470,22 +2494,48 @@ rb_gc_impl_size_allocatable_p(size_t size)
     return size <= rb_gc_impl_max_allocation_size();
 }
 
-static const size_t ALLOCATED_COUNT_STEP = 1024;
-static void
-ractor_cache_flush_count(rb_objspace_t *objspace, rb_ractor_newobj_cache_t *cache)
+static inline void
+gc_bump_flush_alloc_count(struct gc_bump_pointer_heap *bump, rb_heap_t *heap)
 {
-    for (int heap_idx = 0; heap_idx < HEAP_COUNT; heap_idx++) {
-        rb_ractor_newobj_heap_cache_t *heap_cache = &cache->heap_caches[heap_idx];
+    if (bump->slot_size == 0) return;
 
-        rb_heap_t *heap = &heaps[heap_idx];
-        RUBY_ATOMIC_SIZE_ADD(heap->total_allocated_objects, heap_cache->allocated_objects_count);
-        heap_cache->allocated_objects_count = 0;
+    size_t n = (bump->cursor - bump->region_start) / bump->slot_size;
+    if (n > 0) {
+        RUBY_ATOMIC_SIZE_ADD(heap->total_allocated_objects, n);
+        bump->region_start = bump->cursor;
     }
 }
 
-static inline bool
-ractor_cache_advance_region(rb_ractor_newobj_heap_cache_t *heap_cache)
+static void
+ractor_cache_flush_count(rb_objspace_t *objspace, rb_ractor_newobj_cache_t *gc_cache)
 {
+    for (int heap_idx = 0; heap_idx < HEAP_COUNT; heap_idx++) {
+        gc_bump_flush_alloc_count(&gc_cache->bump_heaps[heap_idx], &heaps[heap_idx]);
+    }
+}
+
+static inline void
+ractor_cache_open_window(rb_objspace_t *objspace, struct gc_bump_pointer_heap *bump,
+                         rb_ractor_newobj_heap_cache_t *heap_cache)
+{
+    uintptr_t end = heap_cache->region_end;
+
+    if (RB_UNLIKELY(is_incremental_marking(objspace))) {
+        uintptr_t window_end = bump->cursor + INCREMENTAL_MARK_STEP_ALLOCATIONS * bump->slot_size;
+        if (window_end < end) end = window_end;
+    }
+
+    bump->cursor_end = end;
+    bump->jit_cursor_end =
+        RB_UNLIKELY(objspace->hook_events & RUBY_INTERNAL_EVENT_NEWOBJ) ? bump->cursor : end;
+}
+
+static inline bool
+ractor_cache_advance_region(rb_objspace_t *objspace, struct gc_bump_pointer_heap *bump,
+                            rb_ractor_newobj_heap_cache_t *heap_cache, rb_heap_t *heap)
+{
+    gc_bump_flush_alloc_count(bump, heap);
+
     struct free_region *region = heap_cache->next_region;
     if (region == NULL) {
         return false;
@@ -2493,51 +2543,42 @@ ractor_cache_advance_region(rb_ractor_newobj_heap_cache_t *heap_cache)
 
     rb_asan_unpoison_object((VALUE)region, false);
     GC_ASSERT(RB_TYPE_P((VALUE)region, T_NONE));
-    heap_cache->cursor = (uintptr_t)region;
-    heap_cache->cursor_end = region->end;
+    bump->cursor = (uintptr_t)region;
+    bump->region_start = (uintptr_t)region;
+    heap_cache->region_end = region->end;
     heap_cache->next_region = region->next;
     rb_asan_poison_object((VALUE)region);
+
+    ractor_cache_open_window(objspace, bump, heap_cache);
 
     return true;
 }
 
 static inline VALUE
-ractor_cache_allocate_slot(rb_objspace_t *objspace, rb_ractor_newobj_cache_t *cache,
+ractor_cache_allocate_slot(rb_objspace_t *objspace, rb_ractor_newobj_cache_t *gc_cache,
                            size_t heap_idx)
 {
-    rb_ractor_newobj_heap_cache_t *heap_cache = &cache->heap_caches[heap_idx];
+    struct gc_bump_pointer_heap *bump = &gc_cache->bump_heaps[heap_idx];
 
-    uintptr_t cursor = heap_cache->cursor;
-    if (RB_UNLIKELY(cursor >= heap_cache->cursor_end)) {
-        if (!ractor_cache_advance_region(heap_cache)) {
-            return Qfalse;
-        }
-        cursor = heap_cache->cursor;
-    }
-
-    if (RB_UNLIKELY(is_incremental_marking(objspace))) {
-        // Not allowed to allocate without running an incremental marking step
-        if (cache->incremental_mark_step_allocated_slots >= INCREMENTAL_MARK_STEP_ALLOCATIONS) {
+    uintptr_t cursor = bump->cursor;
+    if (RB_UNLIKELY(cursor + bump->slot_size > bump->cursor_end)) {
+        if (RB_UNLIKELY(is_incremental_marking(objspace))) {
             return Qfalse;
         }
 
-        cache->incremental_mark_step_allocated_slots++;
+        rb_ractor_newobj_heap_cache_t *heap_cache = &gc_cache->heap_caches[heap_idx];
+        if (!ractor_cache_advance_region(objspace, bump, heap_cache, &heaps[heap_idx])) {
+            return Qfalse;
+        }
+        cursor = bump->cursor;
     }
 
     VALUE obj = (VALUE)cursor;
     rb_asan_unpoison_object(obj, true);
-    heap_cache->cursor = cursor + pool_slot_sizes[heap_idx];
-
-    heap_cache->allocated_objects_count++;
-    rb_heap_t *heap = &heaps[heap_idx];
-    if (heap_cache->allocated_objects_count >= ALLOCATED_COUNT_STEP) {
-        RUBY_ATOMIC_SIZE_ADD(heap->total_allocated_objects, heap_cache->allocated_objects_count);
-        heap_cache->allocated_objects_count = 0;
-    }
+    bump->cursor = cursor + bump->slot_size;
 
 #if RGENGC_CHECK_MODE
     GC_ASSERT(rb_gc_impl_obj_slot_size(obj) == heap_slot_size(heap_idx));
-    // zero clear
     MEMZERO((char *)obj, char, heap_slot_size(heap_idx));
 #endif
     return obj;
@@ -2563,14 +2604,15 @@ heap_next_free_page(rb_objspace_t *objspace, rb_heap_t *heap)
 }
 
 static inline void
-ractor_cache_set_page(rb_objspace_t *objspace, rb_ractor_newobj_cache_t *cache, size_t heap_idx,
+ractor_cache_set_page(rb_objspace_t *objspace, rb_ractor_newobj_cache_t *gc_cache, size_t heap_idx,
                       struct heap_page *page)
 {
     gc_report(3, objspace, "ractor_set_cache: Using page %p\n", (void *)page->body);
 
-    rb_ractor_newobj_heap_cache_t *heap_cache = &cache->heap_caches[heap_idx];
+    struct gc_bump_pointer_heap *bump = &gc_cache->bump_heaps[heap_idx];
+    rb_ractor_newobj_heap_cache_t *heap_cache = &gc_cache->heap_caches[heap_idx];
 
-    GC_ASSERT(heap_cache->cursor >= heap_cache->cursor_end);
+    GC_ASSERT(bump->cursor + bump->slot_size > bump->cursor_end);
     GC_ASSERT(heap_cache->next_region == NULL);
     GC_ASSERT(page->free_slots != 0);
     GC_ASSERT(page->free_region != NULL);
@@ -2580,10 +2622,13 @@ ractor_cache_set_page(rb_objspace_t *objspace, rb_ractor_newobj_cache_t *cache, 
     struct free_region *region = page->free_region;
     rb_asan_unpoison_object((VALUE)region, false);
     GC_ASSERT(RB_TYPE_P((VALUE)region, T_NONE));
-    heap_cache->cursor = (uintptr_t)region;
-    heap_cache->cursor_end = region->end;
+    bump->cursor = (uintptr_t)region;
+    bump->region_start = (uintptr_t)region;
+    heap_cache->region_end = region->end;
     heap_cache->next_region = region->next;
     rb_asan_poison_object((VALUE)region);
+
+    ractor_cache_open_window(objspace, bump, heap_cache);
 
     page->free_slots = 0;
     page->free_region = NULL;
@@ -2621,11 +2666,50 @@ rb_gc_impl_size_slot_size(void *objspace_ptr, size_t size)
     return heap_slot_size((unsigned char)heap_idx_for_size(size));
 }
 
-NOINLINE(static VALUE newobj_cache_miss(rb_objspace_t *objspace, rb_ractor_newobj_cache_t *cache, size_t heap_idx, bool vm_locked));
+bool
+rb_gc_impl_zjit_new_obj_fastpath(void *objspace_ptr, size_t alloc_size, VALUE flags, VALUE klass,
+                                 struct rb_gc_zjit_fastpath *fastpath)
+{
+#if USE_ZJIT
+    size_t heap_idx = 0;
+    size_t slot_size = 0;
+    for (; pool_slot_sizes[heap_idx] != 0; heap_idx++) {
+        if (alloc_size <= pool_slot_sizes[heap_idx]) {
+            slot_size = pool_slot_sizes[heap_idx];
+            break;
+        }
+    }
+    if (slot_size == 0) return false;
+
+    size_t bump_base = offsetof(rb_ractor_newobj_cache_t, bump_heaps) +
+                       heap_idx * sizeof(struct gc_bump_pointer_heap);
+
+    struct rb_gc_zjit_default_new_obj_fastpath default_fastpath = {
+        bump_base + offsetof(struct gc_bump_pointer_heap, cursor),
+        bump_base + offsetof(struct gc_bump_pointer_heap, jit_cursor_end),
+        slot_size,
+        flags,
+        klass
+    };
+
+    memset(fastpath, 0, sizeof(*fastpath));
+    fastpath->kind = RB_GC_ZJIT_FASTPATH_DEFAULT;
+    memcpy(fastpath->data.words, &default_fastpath, sizeof(default_fastpath));
+
+    return true;
+#else
+    return false;
+#endif
+}
+
+NOINLINE(static VALUE newobj_bump_pointer_miss(rb_objspace_t *objspace, rb_ractor_newobj_cache_t *gc_cache, size_t heap_idx, bool vm_locked));
 
 static VALUE
-newobj_cache_miss(rb_objspace_t *objspace, rb_ractor_newobj_cache_t *cache, size_t heap_idx, bool vm_locked)
+newobj_bump_pointer_miss(rb_objspace_t *objspace, rb_ractor_newobj_cache_t *gc_cache, size_t heap_idx, bool vm_locked)
 {
+    struct gc_bump_pointer_heap *bump = &gc_cache->bump_heaps[heap_idx];
+    rb_ractor_newobj_cache_t *cache = gc_cache;
+    rb_ractor_newobj_heap_cache_t *heap_cache = &cache->heap_caches[heap_idx];
     rb_heap_t *heap = &heaps[heap_idx];
     VALUE obj = Qfalse;
 
@@ -2637,56 +2721,6 @@ newobj_cache_miss(rb_objspace_t *objspace, rb_ractor_newobj_cache_t *cache, size
         unlock_vm = true;
     }
 
-    {
-        if (is_incremental_marking(objspace)) {
-            gc_continue(objspace, heap);
-            cache->incremental_mark_step_allocated_slots = 0;
-
-            // Retry allocation after resetting incremental_mark_step_allocated_slots
-            obj = ractor_cache_allocate_slot(objspace, cache, heap_idx);
-        }
-
-        if (obj == Qfalse) {
-            // Get next free page (possibly running GC)
-            struct heap_page *page = heap_next_free_page(objspace, heap);
-            ractor_cache_set_page(objspace, cache, heap_idx, page);
-
-            // Retry allocation after moving to new page
-            obj = ractor_cache_allocate_slot(objspace, cache, heap_idx);
-        }
-    }
-
-    if (unlock_vm) {
-        RB_GC_CR_UNLOCK(lev);
-    }
-
-    if (RB_UNLIKELY(obj == Qfalse)) {
-        rb_memerror();
-    }
-    return obj;
-}
-
-static VALUE
-newobj_alloc(rb_objspace_t *objspace, rb_ractor_newobj_cache_t *cache, size_t heap_idx, bool vm_locked)
-{
-    VALUE obj = ractor_cache_allocate_slot(objspace, cache, heap_idx);
-
-    if (RB_UNLIKELY(obj == Qfalse)) {
-        obj = newobj_cache_miss(objspace, cache, heap_idx, vm_locked);
-    }
-
-    return obj;
-}
-
-ALWAYS_INLINE(static VALUE newobj_slowpath(VALUE klass, VALUE flags, rb_objspace_t *objspace, rb_ractor_newobj_cache_t *cache, int wb_protected, size_t heap_idx));
-
-static inline VALUE
-newobj_slowpath(VALUE klass, VALUE flags, rb_objspace_t *objspace, rb_ractor_newobj_cache_t *cache, int wb_protected, size_t heap_idx)
-{
-    VALUE obj;
-    unsigned int lev;
-
-    lev = RB_GC_CR_LOCK();
     {
         if (RB_UNLIKELY(during_gc || ruby_gc_stressful)) {
             if (during_gc) {
@@ -2705,7 +2739,76 @@ newobj_slowpath(VALUE klass, VALUE flags, rb_objspace_t *objspace, rb_ractor_new
             }
         }
 
-        obj = newobj_alloc(objspace, cache, heap_idx, true);
+        if (is_incremental_marking(objspace)) {
+            if (bump->slot_size > 0) {
+                cache->incremental_mark_step_allocated_slots +=
+                    (bump->cursor - bump->region_start) / bump->slot_size;
+            }
+            gc_bump_flush_alloc_count(bump, heap);
+
+            if (cache->incremental_mark_step_allocated_slots >= INCREMENTAL_MARK_STEP_ALLOCATIONS) {
+                gc_continue(objspace, heap);
+                cache->incremental_mark_step_allocated_slots = 0;
+            }
+
+            if (bump->cursor + bump->slot_size <= heap_cache->region_end) {
+                ractor_cache_open_window(objspace, bump, heap_cache);
+                obj = ractor_cache_allocate_slot(objspace, gc_cache, heap_idx);
+            }
+        }
+
+        if (obj == Qfalse) {
+            if (ractor_cache_advance_region(objspace, bump, heap_cache, heap)) {
+                obj = ractor_cache_allocate_slot(objspace, gc_cache, heap_idx);
+            }
+        }
+
+        if (obj == Qfalse) {
+            struct heap_page *page = heap_next_free_page(objspace, heap);
+            ractor_cache_set_page(objspace, gc_cache, heap_idx, page);
+
+            obj = ractor_cache_allocate_slot(objspace, gc_cache, heap_idx);
+        }
+
+        if (RB_UNLIKELY(ruby_gc_stressful)) {
+            bump->cursor_end = bump->cursor;
+            bump->jit_cursor_end = bump->cursor;
+        }
+    }
+
+    if (unlock_vm) {
+        RB_GC_CR_UNLOCK(lev);
+    }
+
+    if (RB_UNLIKELY(obj == Qfalse)) {
+        rb_memerror();
+    }
+    return obj;
+}
+
+static VALUE
+newobj_alloc(rb_objspace_t *objspace, rb_ractor_newobj_cache_t *gc_cache, size_t heap_idx, bool vm_locked)
+{
+    VALUE obj = ractor_cache_allocate_slot(objspace, gc_cache, heap_idx);
+
+    if (RB_UNLIKELY(obj == Qfalse)) {
+        obj = newobj_bump_pointer_miss(objspace, gc_cache, heap_idx, vm_locked);
+    }
+
+    return obj;
+}
+
+ALWAYS_INLINE(static VALUE newobj_slowpath(VALUE klass, VALUE flags, rb_objspace_t *objspace, rb_ractor_newobj_cache_t *gc_cache, int wb_protected, size_t heap_idx));
+
+static inline VALUE
+newobj_slowpath(VALUE klass, VALUE flags, rb_objspace_t *objspace, rb_ractor_newobj_cache_t *gc_cache, int wb_protected, size_t heap_idx)
+{
+    VALUE obj;
+    unsigned int lev;
+
+    lev = RB_GC_CR_LOCK();
+    {
+        obj = newobj_alloc(objspace, gc_cache, heap_idx, true);
         newobj_init(klass, flags, wb_protected, objspace, obj);
     }
     RB_GC_CR_UNLOCK(lev);
@@ -2714,20 +2817,20 @@ newobj_slowpath(VALUE klass, VALUE flags, rb_objspace_t *objspace, rb_ractor_new
 }
 
 NOINLINE(static VALUE newobj_slowpath_wb_protected(VALUE klass, VALUE flags,
-                                                   rb_objspace_t *objspace, rb_ractor_newobj_cache_t *cache, size_t heap_idx));
+                                                   rb_objspace_t *objspace, rb_ractor_newobj_cache_t *gc_cache, size_t heap_idx));
 NOINLINE(static VALUE newobj_slowpath_wb_unprotected(VALUE klass, VALUE flags,
-                                                     rb_objspace_t *objspace, rb_ractor_newobj_cache_t *cache, size_t heap_idx));
+                                                     rb_objspace_t *objspace, rb_ractor_newobj_cache_t *gc_cache, size_t heap_idx));
 
 static VALUE
-newobj_slowpath_wb_protected(VALUE klass, VALUE flags, rb_objspace_t *objspace, rb_ractor_newobj_cache_t *cache, size_t heap_idx)
+newobj_slowpath_wb_protected(VALUE klass, VALUE flags, rb_objspace_t *objspace, rb_ractor_newobj_cache_t *gc_cache, size_t heap_idx)
 {
-    return newobj_slowpath(klass, flags, objspace, cache, TRUE, heap_idx);
+    return newobj_slowpath(klass, flags, objspace, gc_cache, TRUE, heap_idx);
 }
 
 static VALUE
-newobj_slowpath_wb_unprotected(VALUE klass, VALUE flags, rb_objspace_t *objspace, rb_ractor_newobj_cache_t *cache, size_t heap_idx)
+newobj_slowpath_wb_unprotected(VALUE klass, VALUE flags, rb_objspace_t *objspace, rb_ractor_newobj_cache_t *gc_cache, size_t heap_idx)
 {
-    return newobj_slowpath(klass, flags, objspace, cache, FALSE, heap_idx);
+    return newobj_slowpath(klass, flags, objspace, gc_cache, FALSE, heap_idx);
 }
 
 VALUE
@@ -2748,19 +2851,19 @@ rb_gc_impl_new_obj(void *objspace_ptr, void *cache_ptr, VALUE klass, VALUE flags
     size_t heap_idx = heap_idx_for_size(alloc_size);
     *actual_alloc_size = heap_slot_size((unsigned char)heap_idx);
 
-    rb_ractor_newobj_cache_t *cache = (rb_ractor_newobj_cache_t *)cache_ptr;
+    rb_ractor_newobj_cache_t *gc_cache = (rb_ractor_newobj_cache_t *)cache_ptr;
 
     if (!RB_UNLIKELY(during_gc || ruby_gc_stressful) &&
             wb_protected) {
-        obj = newobj_alloc(objspace, cache, heap_idx, false);
+        obj = newobj_alloc(objspace, gc_cache, heap_idx, false);
         newobj_init(klass, flags, wb_protected, objspace, obj);
     }
     else {
         RB_DEBUG_COUNTER_INC(obj_newobj_slowpath);
 
         obj = wb_protected ?
-          newobj_slowpath_wb_protected(klass, flags, objspace, cache, heap_idx) :
-          newobj_slowpath_wb_unprotected(klass, flags, objspace, cache, heap_idx);
+          newobj_slowpath_wb_protected(klass, flags, objspace, gc_cache, heap_idx) :
+          newobj_slowpath_wb_unprotected(klass, flags, objspace, gc_cache, heap_idx);
     }
 
     return obj;
@@ -3481,7 +3584,6 @@ heap_page_alloc_slot_from_region(struct heap_page *free_page)
 
     asan_unlock_freelist(free_page);
     if (new_start < region_end) {
-        /* Shrink the region: rewrite its header one slot forward. */
         VALUE next_start = (VALUE)new_start;
         rb_asan_unpoison_object(next_start, false);
         struct free_region *new_region = (struct free_region *)new_start;
@@ -3492,7 +3594,6 @@ heap_page_alloc_slot_from_region(struct heap_page *free_page)
         free_page->free_region = new_region;
     }
     else {
-        /* The region held a single slot. */
         free_page->free_region = next;
     }
     asan_lock_freelist(free_page);
@@ -3517,7 +3618,6 @@ try_move(rb_objspace_t *objspace, rb_heap_t *heap, struct heap_page *free_page, 
 
     uintptr_t dest_slot = heap_page_alloc_slot_from_region(free_page);
     if (dest_slot == 0) {
-        /* if we can't get a slot then the page must be full */
         return false;
     }
     VALUE dest = (VALUE)dest_slot;
@@ -4009,16 +4109,17 @@ gc_mode_transition(rb_objspace_t *objspace, enum gc_mode mode)
 }
 
 static void
-heap_page_flush_cache_regions(struct heap_page *page, rb_ractor_newobj_heap_cache_t *heap_cache)
+heap_page_flush_cache_regions(struct heap_page *page, struct gc_bump_pointer_heap *bump,
+                              rb_ractor_newobj_heap_cache_t *heap_cache)
 {
     struct free_region *chain = heap_cache->next_region;
 
-    if (heap_cache->cursor < heap_cache->cursor_end) {
-        VALUE start = (VALUE)heap_cache->cursor;
+    if (bump->cursor < heap_cache->region_end) {
+        VALUE start = (VALUE)bump->cursor;
         rb_asan_unpoison_object(start, false);
         struct free_region *remnant = (struct free_region *)start;
         remnant->flags = 0;
-        remnant->end = heap_cache->cursor_end;
+        remnant->end = heap_cache->region_end;
         remnant->next = chain;
         rb_asan_poison_object(start);
         chain = remnant;
@@ -4075,30 +4176,45 @@ static int compare_pinned_slots(const void *left, const void *right, void *d);
 static void
 gc_ractor_newobj_cache_clear(void *c, void *data)
 {
-    rb_objspace_t *objspace = rb_gc_get_objspace();
-    rb_ractor_newobj_cache_t *newobj_cache = c;
+    rb_objspace_t *objspace = data;
+    rb_ractor_newobj_cache_t *gc_cache = c;
+    rb_ractor_newobj_cache_t *newobj_cache = gc_cache;
 
     newobj_cache->incremental_mark_step_allocated_slots = 0;
 
     for (size_t heap_idx = 0; heap_idx < HEAP_COUNT; heap_idx++) {
-
+        struct gc_bump_pointer_heap *bump = &gc_cache->bump_heaps[heap_idx];
         rb_ractor_newobj_heap_cache_t *cache = &newobj_cache->heap_caches[heap_idx];
 
         rb_heap_t *heap = &heaps[heap_idx];
-        RUBY_ATOMIC_SIZE_ADD(heap->total_allocated_objects, cache->allocated_objects_count);
-        cache->allocated_objects_count = 0;
+        gc_bump_flush_alloc_count(bump, heap);
 
         struct heap_page *page = cache->using_page;
-        RUBY_DEBUG_LOG("ractor using_page:%p cursor:%p", (void *)page, (void *)cache->cursor);
+        RUBY_DEBUG_LOG("ractor using_page:%p cursor:%p", (void *)page, (void *)bump->cursor);
 
         if (page) {
-            heap_page_flush_cache_regions(page, cache);
+            heap_page_flush_cache_regions(page, bump, cache);
         }
 
         cache->using_page = NULL;
-        cache->cursor = 0;
-        cache->cursor_end = 0;
         cache->next_region = NULL;
+        cache->region_end = 0;
+        bump->cursor = 0;
+        bump->cursor_end = 0;
+        bump->jit_cursor_end = 0;
+        bump->region_start = 0;
+    }
+}
+
+static void
+gc_ractor_newobj_cache_exhaust(void *c, void *data)
+{
+    rb_ractor_newobj_cache_t *gc_cache = c;
+
+    for (size_t heap_idx = 0; heap_idx < HEAP_COUNT; heap_idx++) {
+        struct gc_bump_pointer_heap *bump = &gc_cache->bump_heaps[heap_idx];
+        bump->cursor_end = bump->cursor;
+        bump->jit_cursor_end = bump->cursor;
     }
 }
 
@@ -4189,7 +4305,7 @@ gc_sweep_start(rb_objspace_t *objspace)
         }
     }
 
-    rb_gc_ractor_newobj_cache_foreach(gc_ractor_newobj_cache_clear, NULL);
+    rb_gc_ractor_newobj_cache_foreach(gc_ractor_newobj_cache_clear, objspace);
 }
 
 static void
@@ -6241,6 +6357,10 @@ gc_marks_start(rb_objspace_t *objspace, int full_mark)
 
     mark_roots(objspace, NULL);
 
+    if (is_incremental_marking(objspace)) {
+        rb_gc_ractor_newobj_cache_foreach(gc_ractor_newobj_cache_exhaust, NULL);
+    }
+
     gc_report(1, objspace, "gc_marks_start: (%s) end, stack in %"PRIdSIZE"\n",
               full_mark ? "full" : "minor", mark_stack_size(&objspace->mark_stack));
 }
@@ -6698,17 +6818,25 @@ rb_gc_impl_ractor_cache_alloc(void *objspace_ptr, void *ractor)
 
     objspace->live_ractor_cache_count++;
 
-    return calloc1(sizeof(rb_ractor_newobj_cache_t));
+    rb_ractor_newobj_cache_t *gc_cache =
+        calloc1(sizeof(rb_ractor_newobj_cache_t) +
+                sizeof(struct gc_bump_pointer_heap) * (HEAP_COUNT + 1));
+
+    for (size_t i = 0; i < HEAP_COUNT; i++) {
+        gc_cache->bump_heaps[i].slot_size = pool_slot_sizes[i];
+    }
+    return gc_cache;
 }
 
 void
-rb_gc_impl_ractor_cache_free(void *objspace_ptr, void *cache)
+rb_gc_impl_ractor_cache_free(void *objspace_ptr, void *cache_ptr)
 {
     rb_objspace_t *objspace = objspace_ptr;
+    rb_ractor_newobj_cache_t *gc_cache = cache_ptr;
 
     objspace->live_ractor_cache_count--;
-    gc_ractor_newobj_cache_clear(cache, NULL);
-    free(cache);
+    gc_ractor_newobj_cache_clear(gc_cache, objspace);
+    free(gc_cache);
 }
 
 static void
@@ -7245,6 +7373,8 @@ gc_sweeping_enter(rb_objspace_t *objspace)
     if (MEASURE_GC) {
         gc_clock_start(&objspace->profile.sweeping_start_time);
     }
+
+    rb_gc_initialize_vm_context(&objspace->vm_context);
 }
 
 static void
@@ -8334,6 +8464,10 @@ rb_gc_impl_stress_set(void *objspace_ptr, VALUE flag)
 
     objspace->flags.gc_stressful = RTEST(flag);
     objspace->gc_stress_mode = flag;
+
+    if (objspace->flags.gc_stressful) {
+        rb_gc_ractor_newobj_cache_foreach(gc_ractor_newobj_cache_exhaust, NULL);
+    }
 }
 
 static int
@@ -10204,7 +10338,7 @@ rb_gc_impl_after_fork(void *objspace_ptr, rb_pid_t pid)
     objspace->fork_vm_lock_lev = 0;
 
     if (pid == 0) { /* child process */
-        rb_gc_ractor_newobj_cache_foreach(gc_ractor_newobj_cache_clear, NULL);
+        rb_gc_ractor_newobj_cache_foreach(gc_ractor_newobj_cache_clear, objspace);
     }
 }
 

--- a/gc/default/zjit_fastpath.h
+++ b/gc/default/zjit_fastpath.h
@@ -1,0 +1,21 @@
+#ifndef RUBY_GC_DEFAULT_ZJIT_FASTPATH_H
+#define RUBY_GC_DEFAULT_ZJIT_FASTPATH_H
+
+#include <stddef.h>
+
+#include "gc/gc_impl.h"
+#include "ruby/internal/static_assert.h"
+#include "ruby/ruby.h"
+
+struct rb_gc_zjit_default_new_obj_fastpath {
+    size_t cursor_offset;
+    size_t jit_cursor_end_offset;
+    size_t slot_size;
+    VALUE flags;
+    VALUE klass;
+};
+
+RBIMPL_STATIC_ASSERT(zjit_default_fastpath_fits,
+                     sizeof(struct rb_gc_zjit_default_new_obj_fastpath) <= sizeof(union rb_gc_zjit_fastpath_data));
+
+#endif /* RUBY_GC_DEFAULT_ZJIT_FASTPATH_H */

--- a/gc/gc_impl.h
+++ b/gc/gc_impl.h
@@ -10,6 +10,33 @@
  */
 #include "ruby/ruby.h"
 
+#include <stddef.h>
+#include <stdint.h>
+
+struct gc_bump_pointer_heap {
+    uintptr_t cursor;
+    uintptr_t cursor_end;
+    uintptr_t jit_cursor_end;
+    uintptr_t region_start;
+    size_t    slot_size;
+};
+
+enum rb_gc_zjit_fastpath_kind {
+    RB_GC_ZJIT_FASTPATH_DEFAULT = 1,
+    RB_GC_ZJIT_FASTPATH_MMTK = 2,
+};
+
+#define RB_GC_ZJIT_FASTPATH_DATA_WORDS 19
+
+union rb_gc_zjit_fastpath_data {
+    uintptr_t words[RB_GC_ZJIT_FASTPATH_DATA_WORDS];
+};
+
+struct rb_gc_zjit_fastpath {
+    enum rb_gc_zjit_fastpath_kind kind;
+    union rb_gc_zjit_fastpath_data data;
+};
+
 #ifndef RB_GC_OBJECT_METADATA_ENTRY_DEFINED
 # define RB_GC_OBJECT_METADATA_ENTRY_DEFINED
 struct rb_gc_object_metadata_entry {
@@ -56,6 +83,16 @@ GC_IMPL_FN void rb_gc_impl_config_set(void *objspace_ptr, VALUE hash);
 GC_IMPL_FN struct rb_gc_vm_context *rb_gc_impl_get_vm_context(void *objspace_ptr);
 // Object allocation
 GC_IMPL_FN VALUE rb_gc_impl_new_obj(void *objspace_ptr, void *cache_ptr, VALUE klass, VALUE flags, bool wb_protected, size_t alloc_size, size_t *actual_alloc_size);
+/* This is an (optional) function that allows the GC implementation to return
+ * metadata for ZJIT's fast path object allocator. Returns `true` if ZJIT can
+ * use the fast path allocator, `false` otherwise.
+ *
+ * The GC is provided `alloc_size`, `flags`, and `class` which describe the
+ * object to be allocated. The GC can use this information to perform
+ * precomputation and fill `fastpath` with GC-specific metadata. ZJIT owns the
+ * generated instruction sequence; see zjit/src/gc_fastpath.rs.
+ */
+GC_IMPL_FN bool rb_gc_impl_zjit_new_obj_fastpath(void *objspace_ptr, size_t alloc_size, VALUE flags, VALUE klass, struct rb_gc_zjit_fastpath *fastpath);
 GC_IMPL_FN size_t rb_gc_impl_obj_slot_size(VALUE obj);
 GC_IMPL_FN size_t rb_gc_impl_size_slot_size(void *objspace_ptr, size_t size);
 GC_IMPL_FN bool rb_gc_impl_size_allocatable_p(size_t size);

--- a/gc/mmtk/mmtk.c
+++ b/gc/mmtk/mmtk.c
@@ -1,5 +1,6 @@
 #include <pthread.h>
 #include <stdbool.h>
+#include <string.h>
 
 #include "ruby/assert.h"
 #include "ruby/atomic.h"
@@ -8,6 +9,10 @@
 #include "gc/gc.h"
 #include "gc/gc_impl.h"
 #include "gc/mmtk/mmtk.h"
+
+#if USE_ZJIT
+# include "gc/mmtk/zjit_fastpath.h"
+#endif
 
 #include "ccan/list/list.h"
 #include "darray.h"
@@ -103,6 +108,8 @@ RB_THREAD_LOCAL_SPECIFIER VALUE marking_parent_object;
 #endif
 
 #include <pthread.h>
+
+#define MMTK_ALLOCATION_SEMANTICS_DEFAULT 0
 
 static inline VALUE rb_mmtk_call_object_closure(VALUE obj, bool pin);
 
@@ -643,6 +650,20 @@ rb_gc_impl_ractor_cache_free(void *objspace_ptr, void *cache_ptr)
     objspace->live_ractor_cache_count--;
 
     mmtk_destroy_mutator(cache->mutator);
+
+    free(cache);
+}
+
+static bool
+zjit_mmtk_gc_stress_p(void *objspace_ptr)
+{
+    return ((struct objspace *)objspace_ptr)->gc_stress;
+}
+
+static bool
+zjit_mmtk_newobj_tracing_p(void)
+{
+    return rb_gc_event_hook_required_p(RUBY_INTERNAL_EVENT_NEWOBJ);
 }
 
 void rb_gc_impl_set_params(void *objspace_ptr) { }
@@ -662,6 +683,59 @@ static size_t heap_sizes[MMTK_HEAP_COUNT + 1] = {
     32, 64, 128, 256, MMTK_MAX_OBJ_SIZE, 0
 };
 #endif
+
+bool
+rb_gc_impl_zjit_new_obj_fastpath(void *objspace_ptr, size_t alloc_size, VALUE flags, VALUE klass,
+                                 struct rb_gc_zjit_fastpath *fastpath)
+{
+#if USE_ZJIT && RB_GC_OBJ_SUFFIX_SIZE == 0
+    struct objspace *objspace = objspace_ptr;
+
+    size_t payload_size = alloc_size;
+    for (int i = 0; i < MMTK_HEAP_COUNT; i++) {
+        if (payload_size == heap_sizes[i]) break;
+        if (payload_size < heap_sizes[i]) {
+            payload_size = heap_sizes[i];
+            break;
+        }
+    }
+
+    if (payload_size > MMTK_MAX_OBJ_SIZE) return false;
+
+    size_t total_size = payload_size + sizeof(VALUE) + RB_GC_OBJ_SUFFIX_SIZE;
+    size_t value_size_shift = sizeof(VALUE) == 8 ? 3 : 2;
+
+    struct rb_gc_zjit_mmtk_new_obj_fastpath mmtk_fastpath = {
+        objspace,
+        offsetof(struct objspace, total_allocated_objects),
+        offsetof(struct MMTk_ractor_cache, mutator),
+        offsetof(struct MMTk_ractor_cache, bump_pointer),
+        offsetof(struct MMTk_ractor_cache, obj_free_parallel_buf),
+        offsetof(struct MMTk_ractor_cache, obj_free_parallel_count),
+        offsetof(MMTk_BumpPointer, cursor),
+        offsetof(MMTk_BumpPointer, limit),
+        MMTk_MIN_OBJ_ALIGN,
+        payload_size,
+        total_size,
+        MMTK_ALLOCATION_SEMANTICS_DEFAULT,
+        (uintptr_t)zjit_mmtk_gc_stress_p,
+        (uintptr_t)zjit_mmtk_newobj_tracing_p,
+        (uintptr_t)mmtk_post_alloc,
+        OBJ_FREE_BUF_CAPACITY - 1,
+        value_size_shift,
+        flags,
+        klass
+    };
+
+    memset(fastpath, 0, sizeof(*fastpath));
+    fastpath->kind = RB_GC_ZJIT_FASTPATH_MMTK;
+    memcpy(fastpath->data.words, &mmtk_fastpath, sizeof(mmtk_fastpath));
+
+    return true;
+#else
+    return false;
+#endif
+}
 
 void
 rb_gc_impl_init(void)
@@ -898,7 +972,6 @@ mmtk_post_alloc_fast_immix(struct objspace *objspace, struct MMTk_ractor_cache *
 VALUE
 rb_gc_impl_new_obj(void *objspace_ptr, void *cache_ptr, VALUE klass, VALUE flags, bool wb_protected, size_t alloc_size, size_t *actual_alloc_size)
 {
-#define MMTK_ALLOCATION_SEMANTICS_DEFAULT 0
     struct objspace *objspace = objspace_ptr;
     struct MMTk_ractor_cache *ractor_cache = cache_ptr;
 

--- a/gc/mmtk/zjit_fastpath.h
+++ b/gc/mmtk/zjit_fastpath.h
@@ -1,0 +1,36 @@
+#ifndef RUBY_GC_MMTK_ZJIT_FASTPATH_H
+#define RUBY_GC_MMTK_ZJIT_FASTPATH_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "gc/gc_impl.h"
+#include "ruby/internal/static_assert.h"
+#include "ruby/ruby.h"
+
+struct rb_gc_zjit_mmtk_new_obj_fastpath {
+    const void *objspace;
+    size_t objspace_total_allocated_objects_offset;
+    size_t ractor_cache_mutator_offset;
+    size_t ractor_cache_bump_pointer_offset;
+    size_t ractor_cache_obj_free_parallel_buf_offset;
+    size_t ractor_cache_obj_free_parallel_count_offset;
+    size_t bump_pointer_cursor_offset;
+    size_t bump_pointer_limit_offset;
+    size_t min_obj_align;
+    size_t payload_size;
+    size_t total_alloc_size;
+    uint32_t allocation_semantics_default;
+    uintptr_t gc_stress_p_func;
+    uintptr_t newobj_tracing_p_func;
+    uintptr_t post_alloc_func;
+    size_t obj_free_buf_capacity_minus_one;
+    size_t value_size_shift;
+    VALUE flags;
+    VALUE klass;
+};
+
+RBIMPL_STATIC_ASSERT(zjit_mmtk_fastpath_fits,
+                     sizeof(struct rb_gc_zjit_mmtk_new_obj_fastpath) <= sizeof(union rb_gc_zjit_fastpath_data));
+
+#endif /* RUBY_GC_MMTK_ZJIT_FASTPATH_H */

--- a/gc/wbcheck/wbcheck.c
+++ b/gc/wbcheck/wbcheck.c
@@ -498,6 +498,13 @@ rb_gc_impl_ractor_cache_alloc(void *objspace_ptr, void *ractor)
     return NULL;
 }
 
+bool
+rb_gc_impl_zjit_new_obj_fastpath(void *objspace_ptr, size_t alloc_size, VALUE flags, VALUE klass,
+                                 struct rb_gc_zjit_fastpath *fastpath)
+{
+    return false;
+}
+
 void
 rb_gc_impl_set_params(void *objspace_ptr)
 {

--- a/internal/gc.h
+++ b/internal/gc.h
@@ -16,6 +16,8 @@
 #include "ruby/ruby.h"          /* for rb_event_flag_t */
 #include "vm_core.h"            /* for GET_EC() */
 
+struct rb_gc_zjit_fastpath;
+
 #ifndef USE_MODULAR_GC
 # define USE_MODULAR_GC 0
 #endif
@@ -203,6 +205,7 @@ rb_execution_context_t *rb_gc_get_ec(void);
 
 void *rb_gc_ractor_cache_alloc(rb_ractor_t *ractor);
 void rb_gc_ractor_cache_free(void *cache);
+bool rb_gc_zjit_new_obj_fastpath(size_t alloc_size, VALUE flags, VALUE klass, struct rb_gc_zjit_fastpath *fastpath);
 
 bool rb_gc_size_allocatable_p(size_t size);
 size_t rb_gc_size_slot_size(size_t size);

--- a/zjit.c
+++ b/zjit.c
@@ -23,6 +23,7 @@
 #include "iseq.h"
 #include "ruby/debug.h"
 #include "internal/cont.h"
+#include "ractor_core.h"
 
 // This build config impacts the pointer tagging scheme and we only want to
 // support one scheme for simplicity.
@@ -30,7 +31,8 @@ STATIC_ASSERT(pointer_tagging_scheme, USE_FLONUM);
 
 enum zjit_struct_offsets {
     ISEQ_BODY_OFFSET_PARAM = offsetof(struct rb_iseq_constant_body, param),
-    ISEQ_BODY_OFFSET_OUTER_VARIABLES = offsetof(struct rb_iseq_constant_body, outer_variables)
+    ISEQ_BODY_OFFSET_OUTER_VARIABLES = offsetof(struct rb_iseq_constant_body, outer_variables),
+    RUBY_OFFSET_THREAD_RACTOR = offsetof(rb_thread_t, ractor),
 };
 
 // Special JITFrame used by all C method calls. We don't control the native
@@ -164,6 +166,12 @@ bool
 rb_zjit_singleton_class_p(VALUE klass)
 {
     return RCLASS_SINGLETON_P(klass);
+}
+
+size_t
+rb_zjit_offset_ractor_newobj_cache(void)
+{
+    return offsetof(rb_ractor_t, newobj_cache);
 }
 
 VALUE

--- a/zjit/bindgen/src/main.rs
+++ b/zjit/bindgen/src/main.rs
@@ -53,6 +53,10 @@ fn main() {
         .header(src_root.join(c_file).to_str().unwrap())
         .header(src_root.join("jit.c").to_str().unwrap())
 
+        .header(src_root.join("gc/gc_impl.h").to_str().unwrap())
+        .header(src_root.join("gc/default/zjit_fastpath.h").to_str().unwrap())
+        .header(src_root.join("gc/mmtk/zjit_fastpath.h").to_str().unwrap())
+
         // Don't want to copy over C comment
         .generate_comments(false)
 
@@ -85,6 +89,15 @@ fn main() {
 
         // This struct is public to Ruby C extensions
         .allowlist_type("RBasic")
+
+        .allowlist_type("RArray")
+        .allowlist_type("gc_bump_pointer_heap")
+        .allowlist_type("rb_gc_zjit_fastpath_kind")
+        .allowlist_type("rb_gc_zjit_fastpath")
+        .allowlist_type("rb_gc_zjit_fastpath_data")
+        .allowlist_type("rb_gc_zjit_default_new_obj_fastpath")
+        .allowlist_type("rb_gc_zjit_mmtk_new_obj_fastpath")
+        .allowlist_var("RB_GC_ZJIT_FASTPATH_.*")
 
         .allowlist_type("ruby_rstring_flags")
 

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -2,6 +2,8 @@
 
 #![allow(clippy::let_and_return)]
 
+mod gc_fastpath;
+
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 use std::ffi::{c_int, c_long, c_void};
@@ -1965,7 +1967,7 @@ fn gen_array_dup(
 
 /// Compile a new array instruction
 fn gen_new_array(
-    jit: &JITState,
+    jit: &mut JITState,
     asm: &mut Assembler,
     elements: Vec<Opnd>,
     state: &FrameState,
@@ -1974,12 +1976,19 @@ fn gen_new_array(
 
     let num: c_long = elements.len().try_into().expect("Unable to fit length of elements into c_long");
 
-    if elements.is_empty() {
-        asm_ccall!(asm, rb_ec_ary_new_from_values, EC, 0i64.into(), Opnd::UImm(0))
-    } else {
+    if !elements.is_empty() {
         let argv = gen_push_opnds(jit, asm, &elements);
-        asm_ccall!(asm, rb_ec_ary_new_from_values, EC, num.into(), argv)
+        return asm_ccall!(asm, rb_ec_ary_new_from_values, EC, num.into(), argv);
     }
+
+    let alloc_size = std::mem::size_of::<RArray>();
+
+    let flags = (RUBY_T_ARRAY as u64) | (RARRAY_EMBED_FLAG as u64);
+    let klass = unsafe { rb_cArray };
+
+    gc_fastpath::gc_fast_path_new_obj(jit, asm, alloc_size, flags, klass, |asm| {
+        asm_ccall!(asm, rb_ec_ary_new_from_values, EC, 0i64.into(), Opnd::UImm(0))
+    })
 }
 
 /// Adjust potentially-negative index by the given length, returning the adjusted index. If still negative,

--- a/zjit/src/codegen/gc_fastpath.rs
+++ b/zjit/src/codegen/gc_fastpath.rs
@@ -1,0 +1,367 @@
+use std::ffi::c_void;
+
+use crate::backend::lir::{self, Assembler, EC, Opnd, Target, asm_comment};
+use crate::cruby::{
+    RB_GC_ZJIT_FASTPATH_DEFAULT, RB_GC_ZJIT_FASTPATH_MMTK,
+    RUBY_OFFSET_EC_THREAD_PTR, RUBY_OFFSET_RBASIC_FLAGS, RUBY_OFFSET_RBASIC_KLASS,
+    RUBY_OFFSET_THREAD_RACTOR, VALUE, VALUE_BITS, rb_zjit_offset_ractor_newobj_cache,
+};
+use super::JITState;
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct RbGcZjitDefaultNewObjFastpath {
+    cursor_offset: usize,
+    jit_cursor_end_offset: usize,
+    slot_size: usize,
+    flags: VALUE,
+    klass: VALUE,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct RbGcZjitMmtkNewObjFastpath {
+    objspace: *const c_void,
+    objspace_total_allocated_objects_offset: usize,
+    ractor_cache_mutator_offset: usize,
+    ractor_cache_bump_pointer_offset: usize,
+    ractor_cache_obj_free_parallel_buf_offset: usize,
+    ractor_cache_obj_free_parallel_count_offset: usize,
+    bump_pointer_cursor_offset: usize,
+    bump_pointer_limit_offset: usize,
+    min_obj_align: usize,
+    payload_size: usize,
+    total_alloc_size: usize,
+    allocation_semantics_default: u32,
+    gc_stress_p_func: usize,
+    newobj_tracing_p_func: usize,
+    post_alloc_func: usize,
+    obj_free_buf_capacity_minus_one: usize,
+    value_size_shift: usize,
+    flags: VALUE,
+    klass: VALUE,
+}
+
+#[repr(C)]
+union RbGcZjitFastpathData {
+    default_gc: RbGcZjitDefaultNewObjFastpath,
+    mmtk: RbGcZjitMmtkNewObjFastpath,
+}
+
+#[repr(C)]
+struct RbGcZjitFastpath {
+    kind: u32,
+    data: RbGcZjitFastpathData,
+}
+
+unsafe extern "C" {
+    fn rb_gc_zjit_new_obj_fastpath(
+        alloc_size: usize,
+        flags: VALUE,
+        klass: VALUE,
+        fastpath: *mut RbGcZjitFastpath,
+    ) -> bool;
+}
+
+enum PreparedNewObjFastpath {
+    Default(RbGcZjitDefaultNewObjFastpath),
+    Mmtk(RbGcZjitMmtkNewObjFastpath),
+}
+
+pub(super) fn gc_fast_path_new_obj(
+    jit: &mut JITState,
+    asm: &mut Assembler,
+    alloc_size: usize,
+    flags: u64,
+    klass: VALUE,
+    slow_path: impl Fn(&mut Assembler) -> lir::Opnd,
+) -> lir::Opnd {
+    let Some(fastpath) = prepare_new_obj_fastpath(alloc_size, flags, klass) else {
+        return slow_path(asm);
+    };
+
+    asm_comment!(asm, "GC inline allocation");
+
+    let hir_block_id = asm.current_block().hir_block_id;
+    let rpo_idx = asm.current_block().rpo_index;
+
+    let result_block = asm.new_block(hir_block_id, false, rpo_idx);
+    let miss_block = asm.new_block(hir_block_id, false, rpo_idx);
+
+    let result_edge = |v: Opnd| Target::Block(Box::new(lir::BranchEdge { target: result_block, args: vec![v] }));
+
+    let obj = emit_new_obj_fastpath(jit, asm, &fastpath, miss_block)
+        .expect("validated GC fastpath must return an object");
+    asm.jmp(result_edge(obj));
+
+    asm.set_current_block(miss_block);
+    let label = jit.get_label(asm, miss_block, hir_block_id);
+    asm.write_label(label);
+    let obj = slow_path(asm);
+    asm.jmp(result_edge(obj));
+
+    asm.set_current_block(result_block);
+    let label = jit.get_label(asm, result_block, hir_block_id);
+    asm.write_label(label);
+    let param = asm.new_block_param(VALUE_BITS);
+    asm.current_block().add_parameter(param);
+    param
+}
+
+fn prepare_new_obj_fastpath(alloc_size: usize, flags: u64, klass: VALUE) -> Option<PreparedNewObjFastpath> {
+    let mut fastpath: RbGcZjitFastpath = unsafe { std::mem::zeroed() };
+    let has_fastpath = unsafe {
+        rb_gc_zjit_new_obj_fastpath(alloc_size, VALUE(flags as usize), klass, &mut fastpath)
+    };
+
+    if !has_fastpath {
+        return None;
+    }
+
+    match fastpath.kind {
+        RB_GC_ZJIT_FASTPATH_DEFAULT => {
+            let fastpath = unsafe { fastpath.data.default_gc };
+            Some(PreparedNewObjFastpath::Default(fastpath))
+        }
+        RB_GC_ZJIT_FASTPATH_MMTK => {
+            let fastpath = unsafe { fastpath.data.mmtk };
+            if fastpath.objspace.is_null()
+                || fastpath.gc_stress_p_func == 0
+                || fastpath.newobj_tracing_p_func == 0
+                || fastpath.post_alloc_func == 0
+                || fastpath.min_obj_align == 0
+                || !fastpath.min_obj_align.is_power_of_two()
+            {
+                return None;
+            }
+
+            Some(PreparedNewObjFastpath::Mmtk(fastpath))
+        }
+        _ => None,
+    }
+}
+
+fn emit_new_obj_fastpath(
+    jit: &mut JITState,
+    asm: &mut Assembler,
+    prepared: &PreparedNewObjFastpath,
+    miss_block: lir::BlockId,
+) -> Option<Opnd> {
+    let miss = Target::Block(Box::new(lir::BranchEdge {
+        target: miss_block,
+        args: vec![],
+    }));
+
+    match prepared {
+        PreparedNewObjFastpath::Default(fastpath) => {
+            emit_default_new_obj_fastpath(jit, asm, fastpath, &miss)
+        }
+        PreparedNewObjFastpath::Mmtk(fastpath) => {
+            emit_mmtk_new_obj_fastpath(jit, asm, fastpath, &miss)
+        }
+    }
+}
+
+/* This function implements the GC fast path for the default GC. It implements
+ * the fast path defined in function ractor_cache_allocate_slot (but not the
+ * medium path in ractor_cache_advance_region). It also implements newobj_init
+ * to write the flags and klass in the object.  */
+fn emit_default_new_obj_fastpath(
+    jit: &mut JITState,
+    asm: &mut Assembler,
+    fastpath: &RbGcZjitDefaultNewObjFastpath,
+    miss: &Target,
+) -> Option<Opnd> {
+    let cursor_offset: i32 = fastpath.cursor_offset.try_into().ok()?;
+    let jit_cursor_end_offset: i32 = fastpath.jit_cursor_end_offset.try_into().ok()?;
+    let slot_size: u64 = fastpath.slot_size.try_into().ok()?;
+
+    let thread = asm.load(Opnd::mem(64, EC, RUBY_OFFSET_EC_THREAD_PTR as i32));
+    let ractor = asm.load(Opnd::mem(64, thread, RUBY_OFFSET_THREAD_RACTOR as i32));
+    let ractor_newobj_cache_offset: i32 = unsafe { rb_zjit_offset_ractor_newobj_cache() }
+        .try_into()
+        .expect("ractor newobj cache offset fits in i32");
+    let gc_cache = asm.load(Opnd::mem(64, ractor, ractor_newobj_cache_offset));
+
+    let cursor = asm.load(Opnd::mem(64, gc_cache, cursor_offset));
+    let cursor_end = asm.load(Opnd::mem(64, gc_cache, jit_cursor_end_offset));
+
+    let new_cursor = asm.add(cursor, Opnd::UImm(slot_size));
+    asm.cmp(cursor_end, new_cursor);
+    asm.jl(jit, miss.clone());
+
+    asm.store(Opnd::mem(64, gc_cache, cursor_offset), new_cursor);
+    asm.store(
+        Opnd::mem(VALUE_BITS, cursor, RUBY_OFFSET_RBASIC_FLAGS),
+        fastpath.flags.into(),
+    );
+    asm.store(
+        Opnd::mem(VALUE_BITS, cursor, RUBY_OFFSET_RBASIC_KLASS),
+        fastpath.klass.into(),
+    );
+
+    Some(cursor)
+}
+
+/* This function implements the GC fast path for MMTk. It implements the fast
+ * path defined in function rb_mmtk_alloc_fast_path, as well as writing the
+ * flags and klass into the object. */
+fn emit_mmtk_new_obj_fastpath(
+    jit: &mut JITState,
+    asm: &mut Assembler,
+    fastpath: &RbGcZjitMmtkNewObjFastpath,
+    miss: &Target,
+) -> Option<Opnd> {
+    let objspace_total_allocated_objects_offset: i32 = fastpath
+        .objspace_total_allocated_objects_offset
+        .try_into()
+        .ok()?;
+    let ractor_cache_mutator_offset: i32 = fastpath.ractor_cache_mutator_offset.try_into().ok()?;
+    let ractor_cache_bump_pointer_offset: i32 = fastpath
+        .ractor_cache_bump_pointer_offset
+        .try_into()
+        .ok()?;
+    let ractor_cache_obj_free_parallel_buf_offset: u64 = fastpath
+        .ractor_cache_obj_free_parallel_buf_offset
+        .try_into()
+        .ok()?;
+    let ractor_cache_obj_free_parallel_count_offset: i32 = fastpath
+        .ractor_cache_obj_free_parallel_count_offset
+        .try_into()
+        .ok()?;
+    let bump_pointer_cursor_offset: i32 = fastpath.bump_pointer_cursor_offset.try_into().ok()?;
+    let bump_pointer_limit_offset: i32 = fastpath.bump_pointer_limit_offset.try_into().ok()?;
+    let payload_size: u64 = fastpath.payload_size.try_into().ok()?;
+    let total_alloc_size: u64 = fastpath.total_alloc_size.try_into().ok()?;
+    let obj_free_buf_capacity_minus_one: u64 = fastpath
+        .obj_free_buf_capacity_minus_one
+        .try_into()
+        .ok()?;
+    let value_size_shift: u64 = fastpath.value_size_shift.try_into().ok()?;
+    let newobj_tracing_p_func = (fastpath.newobj_tracing_p_func != 0)
+        .then_some(fastpath.newobj_tracing_p_func as *const u8)?;
+    let gc_stress_p_func = (fastpath.gc_stress_p_func != 0)
+        .then_some(fastpath.gc_stress_p_func as *const u8)?;
+    let post_alloc_func = (fastpath.post_alloc_func != 0)
+        .then_some(fastpath.post_alloc_func as *const u8)?;
+
+    let event_hook = asm.ccall(newobj_tracing_p_func, vec![]);
+    asm.test(event_hook, event_hook);
+    asm.jnz(jit, miss.clone());
+
+    let objspace_const = Opnd::const_ptr(fastpath.objspace);
+    let gc_stress = asm.ccall(gc_stress_p_func, vec![objspace_const]);
+    asm.test(gc_stress, gc_stress);
+    asm.jnz(jit, miss.clone());
+
+    let objspace = asm.load(objspace_const);
+    let thread = asm.load(Opnd::mem(64, EC, RUBY_OFFSET_EC_THREAD_PTR as i32));
+    let ractor = asm.load(Opnd::mem(64, thread, RUBY_OFFSET_THREAD_RACTOR as i32));
+    let ractor_newobj_cache_offset: i32 = unsafe { rb_zjit_offset_ractor_newobj_cache() }
+        .try_into()
+        .expect("ractor newobj cache offset fits in i32");
+    let ractor_cache = asm.load(Opnd::mem(64, ractor, ractor_newobj_cache_offset));
+
+    let bump_pointer = asm.load(Opnd::mem(
+        64,
+        ractor_cache,
+        ractor_cache_bump_pointer_offset,
+    ));
+    asm.test(bump_pointer, bump_pointer);
+    asm.jz(jit, miss.clone());
+
+    let obj_free_count = asm.load(Opnd::mem(
+        64,
+        ractor_cache,
+        ractor_cache_obj_free_parallel_count_offset,
+    ));
+    asm.cmp(obj_free_count, Opnd::UImm(obj_free_buf_capacity_minus_one));
+    asm.jge(jit, miss.clone());
+
+    let cursor = asm.load(Opnd::mem(
+        64,
+        bump_pointer,
+        bump_pointer_cursor_offset,
+    ));
+    let align_mask: i64 = (fastpath.min_obj_align - 1).try_into().ok()?;
+    let adjusted = asm.add(cursor, Opnd::UImm(align_mask as u64));
+    let aligned = asm.and(adjusted, Opnd::Imm(!align_mask));
+    let new_cursor = asm.add(aligned, Opnd::UImm(total_alloc_size));
+    let limit = asm.load(Opnd::mem(
+        64,
+        bump_pointer,
+        bump_pointer_limit_offset,
+    ));
+    asm.cmp(limit, new_cursor);
+    asm.jl(jit, miss.clone());
+
+    asm.store(
+        Opnd::mem(
+            64,
+            bump_pointer,
+            bump_pointer_cursor_offset,
+        ),
+        new_cursor,
+    );
+
+    let value_size: u64 = std::mem::size_of::<VALUE>().try_into().ok()?;
+    let obj = asm.add(aligned, Opnd::UImm(value_size));
+    asm.store(Opnd::mem(VALUE_BITS, aligned, 0), Opnd::UImm(payload_size));
+    asm.store(
+        Opnd::mem(VALUE_BITS, obj, RUBY_OFFSET_RBASIC_FLAGS),
+        fastpath.flags.into(),
+    );
+    asm.store(
+        Opnd::mem(VALUE_BITS, obj, RUBY_OFFSET_RBASIC_KLASS),
+        fastpath.klass.into(),
+    );
+
+    let mutator = asm.load(Opnd::mem(
+        64,
+        ractor_cache,
+        ractor_cache_mutator_offset,
+    ));
+    asm.ccall(
+        post_alloc_func,
+        vec![
+            mutator,
+            obj,
+            Opnd::UImm(total_alloc_size),
+            Opnd::UImm(u64::from(fastpath.allocation_semantics_default)),
+        ],
+    );
+
+    let obj_free_index = asm.lshift(obj_free_count, Opnd::UImm(value_size_shift));
+    let obj_free_buf = asm.add(
+        ractor_cache,
+        Opnd::UImm(ractor_cache_obj_free_parallel_buf_offset),
+    );
+    let obj_free_slot = asm.add(obj_free_buf, obj_free_index);
+    asm.store(Opnd::mem(64, obj_free_slot, 0), obj);
+    let new_obj_free_count = asm.add(obj_free_count, Opnd::UImm(1));
+    asm.store(
+        Opnd::mem(
+            64,
+            ractor_cache,
+            ractor_cache_obj_free_parallel_count_offset,
+        ),
+        new_obj_free_count,
+    );
+
+    let total_allocated_objects = asm.load(Opnd::mem(
+        64,
+        objspace,
+        objspace_total_allocated_objects_offset,
+    ));
+    let new_total_allocated_objects = asm.add(total_allocated_objects, Opnd::UImm(1));
+    asm.store(
+        Opnd::mem(
+            64,
+            objspace,
+            objspace_total_allocated_objects_offset,
+        ),
+        new_total_allocated_objects,
+    );
+
+    Some(obj)
+}

--- a/zjit/src/cruby.rs
+++ b/zjit/src/cruby.rs
@@ -122,6 +122,8 @@ unsafe extern "C" {
         ci: *const rb_callinfo,
     ) -> *const rb_callable_method_entry_t;
 
+    pub fn rb_zjit_offset_ractor_newobj_cache() -> usize;
+
     // Floats within range will be encoded without creating objects in the heap.
     // (Range is 0x3000000000000001 to 0x4fffffffffffffff (1.7272337110188893E-77 to 2.3158417847463237E+77).
     pub fn rb_float_new(d: f64) -> VALUE;

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -237,6 +237,7 @@ pub const SHAPE_ID_NUM_BITS: u32 = 32;
 pub const ZJIT_STACK_MAP_VREG_TAG: u32 = 8;
 pub const ZJIT_STACK_MAP_SHIFT: u32 = 8;
 pub const ZJIT_JIT_RETURN_C_FRAME: u32 = 1;
+pub const RB_GC_ZJIT_FASTPATH_DATA_WORDS: u32 = 19;
 pub type rb_alloc_func_t = ::std::option::Option<unsafe extern "C" fn(klass: VALUE) -> VALUE>;
 pub const RUBY_Qfalse: ruby_special_consts = 0;
 pub const RUBY_Qnil: ruby_special_consts = 4;
@@ -340,6 +341,29 @@ pub const RARRAY_EMBED_LEN_MASK: ruby_rarray_flags = 4161536;
 pub type ruby_rarray_flags = u32;
 pub const RARRAY_EMBED_LEN_SHIFT: ruby_rarray_consts = 15;
 pub type ruby_rarray_consts = u32;
+#[repr(C)]
+pub struct RArray {
+    pub basic: RBasic,
+    pub as_: RArray__bindgen_ty_1,
+}
+#[repr(C)]
+pub struct RArray__bindgen_ty_1 {
+    pub heap: __BindgenUnionField<RArray__bindgen_ty_1__bindgen_ty_1>,
+    pub ary: __BindgenUnionField<[VALUE; 1usize]>,
+    pub bindgen_union_field: [u64; 3usize],
+}
+#[repr(C)]
+pub struct RArray__bindgen_ty_1__bindgen_ty_1 {
+    pub len: ::std::os::raw::c_long,
+    pub aux: RArray__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1,
+    pub ptr: *const VALUE,
+}
+#[repr(C)]
+pub struct RArray__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 {
+    pub capa: __BindgenUnionField<::std::os::raw::c_long>,
+    pub shared_root: __BindgenUnionField<VALUE>,
+    pub bindgen_union_field: u64,
+}
 pub const RMODULE_IS_REFINEMENT: ruby_rmodule_flags = 8192;
 pub type ruby_rmodule_flags = u32;
 pub const ROBJECT_HEAP: ruby_robject_flags = 65536;
@@ -1925,6 +1949,7 @@ pub struct zjit_jit_frame {
 }
 pub const ISEQ_BODY_OFFSET_PARAM: zjit_struct_offsets = 16;
 pub const ISEQ_BODY_OFFSET_OUTER_VARIABLES: zjit_struct_offsets = 288;
+pub const RUBY_OFFSET_THREAD_RACTOR: zjit_struct_offsets = 24;
 pub type zjit_struct_offsets = u32;
 pub const ROBJECT_OFFSET_AS_HEAP_FIELDS: jit_bindgen_constants = 16;
 pub const ROBJECT_OFFSET_AS_ARY: jit_bindgen_constants = 16;
@@ -1941,6 +1966,59 @@ pub type jit_bindgen_constants = i32;
 pub const rb_invalid_shape_id: shape_id_t = 524287;
 pub type rb_iseq_param_keyword_struct =
     rb_iseq_constant_body_rb_iseq_parameters_rb_iseq_param_keyword;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct gc_bump_pointer_heap {
+    pub cursor: usize,
+    pub cursor_end: usize,
+    pub jit_cursor_end: usize,
+    pub region_start: usize,
+    pub slot_size: usize,
+}
+pub const RB_GC_ZJIT_FASTPATH_DEFAULT: rb_gc_zjit_fastpath_kind = 1;
+pub const RB_GC_ZJIT_FASTPATH_MMTK: rb_gc_zjit_fastpath_kind = 2;
+pub type rb_gc_zjit_fastpath_kind = u32;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union rb_gc_zjit_fastpath_data {
+    pub words: [usize; 19usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct rb_gc_zjit_fastpath {
+    pub kind: rb_gc_zjit_fastpath_kind,
+    pub data: rb_gc_zjit_fastpath_data,
+}
+#[repr(C)]
+pub struct rb_gc_zjit_default_new_obj_fastpath {
+    pub cursor_offset: usize,
+    pub jit_cursor_end_offset: usize,
+    pub slot_size: usize,
+    pub flags: VALUE,
+    pub klass: VALUE,
+}
+#[repr(C)]
+pub struct rb_gc_zjit_mmtk_new_obj_fastpath {
+    pub objspace: *const ::std::os::raw::c_void,
+    pub objspace_total_allocated_objects_offset: usize,
+    pub ractor_cache_mutator_offset: usize,
+    pub ractor_cache_bump_pointer_offset: usize,
+    pub ractor_cache_obj_free_parallel_buf_offset: usize,
+    pub ractor_cache_obj_free_parallel_count_offset: usize,
+    pub bump_pointer_cursor_offset: usize,
+    pub bump_pointer_limit_offset: usize,
+    pub min_obj_align: usize,
+    pub payload_size: usize,
+    pub total_alloc_size: usize,
+    pub allocation_semantics_default: u32,
+    pub gc_stress_p_func: usize,
+    pub newobj_tracing_p_func: usize,
+    pub post_alloc_func: usize,
+    pub obj_free_buf_capacity_minus_one: usize,
+    pub value_size_shift: usize,
+    pub flags: VALUE,
+    pub klass: VALUE,
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct succ_index_table {


### PR DESCRIPTION
This commit implements support in ZJIT for inlining GC fast path. The GC fast path is defined in gc_fastpath.rs for both the default GC and MMTk.

For the default GC, the fast path uses the bump pointer allocator that was implemented in https://github.com/ruby/ruby/pull/17201. If the bump pointer region is full, it will bail out and fall back to the slow path.

This GC fast path is used by the newarray instruction in ZJIT in the empty array case. We can see significant improvements in the following microbenchmark, which allocates 100 million empty arrays:

```ruby
def run(max)
  i = 0
  while i < max
    a = []
    i += 1
  end
end

30.times { run(2) }
run(100_000_000)
```

This microbenchmark runs 1.5x faster on my machine:

    Benchmark 1: master
      Time (mean ± σ):     583.3 ms ±  10.1 ms    [User: 569.3 ms, System: 12.0 ms]
      Range (min … max):   571.9 ms … 600.0 ms    10 runs

    Benchmark 2: branch
      Time (mean ± σ):     389.5 ms ±   8.2 ms    [User: 375.0 ms, System: 12.1 ms]
      Range (min … max):   380.2 ms … 405.3 ms    10 runs

    Summary
      branch ran
        1.50 ± 0.04 times faster than master