### PR TITLE
Fix ASAN use-after-poison in bump allocator sweep

### DIFF
--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -3719,17 +3719,29 @@ gc_sweep_register_free_slot(rb_objspace_t *objspace, struct heap_page *page, str
 {
     rb_asan_unpoison_object(p, false);
     ((struct RBasic *)p)->flags = 0;
-    rb_asan_poison_object(p);
 
-    if (RB_LIKELY(ctx->free_region && p == ctx->free_region->end)) {
-        ctx->free_region->end = p + slot_size;
+    /* The region header lives in a free slot that is kept poisoned at rest, so
+     * unpoison the current region head before inspecting or updating it. */
+    struct free_region *cur = ctx->free_region;
+    if (cur) rb_asan_unpoison_object((VALUE)cur, false);
+
+    if (RB_LIKELY(cur && p == cur->end)) {
+        /* Contiguous with the current region: extend it to cover this slot. */
+        cur->end = p + slot_size;
+        rb_asan_poison_object((VALUE)cur);
+        rb_asan_poison_object(p);
     }
     else {
+        if (cur) rb_asan_poison_object((VALUE)cur);
+
+        /* Start a new region whose header lives in this slot. The header must
+         * be written before the slot is re-poisoned. */
         struct free_region *free_region = (struct free_region *)p;
         free_region->end = p + slot_size;
-        free_region->next = ctx->free_region;
-
+        free_region->next = cur;
         ctx->free_region = free_region;
+
+        rb_asan_poison_object(p);
     }
 }
 
@@ -3867,7 +3879,9 @@ gc_sweep_page(rb_objspace_t *objspace, rb_heap_t *heap, struct gc_sweep_context 
         p += BITS_BITLENGTH * slot_size;
     }
 
+    asan_unlock_freelist(sweep_page);
     sweep_page->free_region = ctx->free_region;
+    asan_lock_freelist(sweep_page);
 
     if (!heap->compact_cursor) {
         gc_setup_mark_bits(sweep_page);


### PR DESCRIPTION
## Problem

Since the switch to the bump pointer allocator (4f259bc25d), ASAN builds fail to bootstrap. `miniruby` is run during the build itself (e.g. to generate `builtin_binary.rbbin`), and the first GC sweep aborts with:

```
==ERROR: AddressSanitizer: use-after-poison ...
WRITE of size 8 ... in gc_sweep_page default.c
    #0 gc_sweep_page
    #1 gc_sweep_step
    #2 gc_sweep
    #3 gc_start
    ...
SUMMARY: AddressSanitizer: use-after-poison default.c in gc_sweep_page
```

Ruby's sanitizer death callback turns this into `[BUG] ASAN error`, so the build dies.

## Cause

With the bump allocator, free slots are kept ASAN-poisoned at rest, and each free region's header (`flags`/`end`/`next`) lives in the first slot of the run. Every site that touches a region header must unpoison → access → re-poison (see `heap_page_add_free_region`, `ractor_cache_advance_region`, `heap_page_alloc_slot_from_region`), and the page's `free_region` pointer is guarded by `asan_lock_freelist()`/`asan_unlock_freelist()`.

Two spots in the sweep path broke that discipline and wrote into poisoned memory:

- `gc_sweep_register_free_slot()` called `rb_asan_poison_object(p)` **before** writing the new region header into the slot, and accessed `ctx->free_region->end` while that head slot was poisoned.
- `gc_sweep_page()` stored into `sweep_page->free_region` while the freelist pointer was still locked (re-poisoned at the top of the function).

This restores the unpoison/access/re-poison discipline so the region header and the page freelist pointer are addressable while being updated.