### PR TITLE
Add ASAN ci build

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -40,6 +40,10 @@ jobs:
           - test_task: check
             os: ubuntu-24.04
             extra_checks: [capi]
+          - test_task: check
+            os: ubuntu-24.04
+            configure: 'CC=clang-18 cflags=-fsanitize=address cppflags=-DUSE_MN_THREADS=0'
+            timeout: 60
           # ubuntu-24.04-arm jobs don't start on ruby/ruby as of 2025-10-29
           #- test_task: check
           #  os: ubuntu-24.04-arm


### PR DESCRIPTION
Example failure: https://github.com/ruby/ruby/actions/runs/27376665828/job/80902570938?pr=17284