### PR TITLE
Improve performance of `String#dump` using lookup table

### DIFF
--- a/benchmark/string_dump.yml
+++ b/benchmark/string_dump.yml
@@ -1,0 +1,17 @@
+prelude: |
+  ascii = "Hello, World! This is a benchmark test string." * 100
+  utf8 = "こんにちは世界。これはベンチマーク用のテスト文字列です。" * 100
+  mixed = ("Hello World! " + "テスト" + " is great! ") * 100
+  binary_ascii = ("Hello\x00World\xFF" * 100).b
+  binary_nonascii = ("\xE3\x81\x82" * 100).b
+  escaped_chars = "\n\r\t\f\v\b\a\e\"\\#" * 100
+  evstr = 'abc#$x def#@x ghi#{$x} ' * 100
+
+benchmark:
+  dump_ascii: ascii.dump
+  dump_utf8: utf8.dump
+  dump_mixed: mixed.dump
+  dump_binary_ascii: binary_ascii.dump
+  dump_binary_nonascii: binary_nonascii.dump
+  dump_escaped_chars: escaped_chars.dump
+  dump_evstr: evstr.dump

--- a/string.c
+++ b/string.c
@@ -7252,11 +7252,11 @@ rb_str_escape(VALUE str)
     return result;
 }
 
-/* Lookup table for the inspect fast path. 1 marks bytes that need
- * no escaping. 0 marks bytes that need escape inspection: 0x00-0x1F
+/* Lookup table for string escape fast paths. 1 marks bytes that need
+ * no escaping. 0 marks bytes that need escape handling: 0x00-0x1F
  * (control), 0x22 ("), 0x23 (#), 0x5C (\), 0x7F (DEL), 0x80-0xFF
  * (non-ASCII). */
-static const bool inspect_no_escape[256] = {
+static const bool ascii_no_escape[256] = {
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 0x00-0x0F */
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 0x10-0x1F */
     1, 1, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, /* 0x20-0x2F */
@@ -7304,7 +7304,7 @@ rb_str_inspect(VALUE str)
          * are eligible. */
         if (cr == ENC_CODERANGE_7BIT ||
             (encidx == ENCINDEX_UTF_8 && cr == ENC_CODERANGE_VALID)) {
-            while (p < pend && inspect_no_escape[(unsigned char)*p]) p++;
+            while (p < pend && ascii_no_escape[(unsigned char)*p]) p++;
             if (p >= pend) break;
         }
 
@@ -7412,7 +7412,7 @@ rb_str_dump(VALUE str)
 
     p = RSTRING_PTR(str); pend = p + RSTRING_LEN(str);
     while (p < pend) {
-        int clen;
+        long clen;
         unsigned char c = *p++;
 
         switch (c) {
@@ -7430,6 +7430,10 @@ rb_str_dump(VALUE str)
           default:
             if (ISPRINT(c)) {
                 clen = 1;
+                while (p < pend && ascii_no_escape[(unsigned char)*p]) {
+                    p++;
+                    clen++;
+                }
             }
             else {
                 if (u8 && c > 0x7F) {	/* \u notation */
@@ -7507,6 +7511,7 @@ rb_str_dump(VALUE str)
         }
         else if (ISPRINT(c)) {
             *q++ = c;
+            while (p < pend && ascii_no_escape[(unsigned char)*p]) *q++ = *p++;
         }
         else {
             *q++ = '\\';


### PR DESCRIPTION
## Background

`String#dump` currently walks the input twice: once to compute the exact result length, and once to write the escaped output.

For printable ASCII bytes, both passes still advance one byte at a time through the full switch/branch structure:

```c
if (ISPRINT(c)) {
    clen = 1;
}
```

That is cheap for small strings, but it leaves a lot of overhead on common long strings where most bytes are safe ASCII and do not need escaping.

## Proposal:

Reuse the existing `String#inspect` safe-ASCII lookup table introduced in #17126 for `String#dump`, and make it a shared string escaping table:

```c
while (p < pend && ascii_no_escape[(unsigned char)*p]) p++;
```

The existing handling for quotes, backslashes, control bytes, UTF-8 non-ASCII bytes, invalid bytes, and non-ASCII-compatible encodings stays on the current paths.

### Justification:

The common case for `String#dump` is printable ASCII text with only occasional bytes that need escaping. Before this change, a long run like:

```ruby
"The quick brown fox jumps over the lazy dog. " * 1000
```

still paid per-byte dispatch in both the length calculation and the copy pass. After this change, those runs are skipped/copied in bulk, while unsafe bytes still fall back to the existing logic.

### Tradeoffs:

This adds a lookup-table scan after the first printable byte in the generic printable branch. Inputs with long safe ASCII runs benefit substantially.

Inputs with few or no safe ASCII runs can be slower because they pay the added table check without getting much bulk-copy benefit.

### Results:

| Benchmark | Control | Experiment | Speedup |
|---|---:|---:|---:|
| dump_ascii | 82.382k i/s | 383.097k i/s | 4.65x |
| dump_utf8 | 12.289k i/s | 12.006k i/s | 0.98x |
| dump_mixed | 64.189k i/s | 85.939k i/s | 1.34x |
| dump_binary_ascii | 186.546k i/s | 204.016k i/s | 1.09x |
| dump_binary_nonascii | 176.486k i/s | 169.944k i/s | 0.96x |
| dump_escaped_chars | 642.436k i/s | 694.995k i/s | 1.08x |
| dump_evstr | 198.574k i/s | 388.391k i/s | 1.96x |

- Apple M4 Pro, macOS 26.3.1.
- Used built-in benchmark tooling
- Experiment: built ruby 4.1.0dev from this branch

