### PR TITLE
Update the revision for ruby/debug#1181

### DIFF
--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -18,7 +18,7 @@ matrix              0.4.3   https://github.com/ruby/matrix
 prime               0.1.4   https://github.com/ruby/prime
 rbs                 4.0.2   https://github.com/ruby/rbs 1582ce76429810b057a2816e5000cf5de4b1363d
 typeprof            0.32.0  https://github.com/ruby/typeprof
-debug               1.11.1  https://github.com/ruby/debug 9dc2024a5a05116b3d38afbc5579d9503d8913f3
+debug               1.11.1  https://github.com/ruby/debug 6510cfbc7496c55ebbefa437a25c17ca58f7c5eb
 racc                1.8.1   https://github.com/ruby/racc
 mutex_m             0.3.0   https://github.com/ruby/mutex_m
 getoptlong          0.2.1   https://github.com/ruby/getoptlong


### PR DESCRIPTION
Add sleep to USE_TMP_HOME check for macOS.

It looks like the same as https://bugs.ruby-lang.org/issues/20682 and https://github.com/ruby/ruby/pull/12691.