### PR TITLE
[Backport 4.0] Fix use-after-poison in compile.c and prism_compile.c

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -5377,6 +5377,7 @@ compile_hash(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, int meth
                 }
                 VALUE hash = rb_hash_new_with_size(RARRAY_LEN(ary) / 2);
                 rb_hash_bulk_insert(RARRAY_LEN(ary), RARRAY_CONST_PTR(ary), hash);
+                RB_GC_GUARD(ary);
                 hash = RB_OBJ_SET_FROZEN_SHAREABLE(rb_obj_hide(hash));
 
                 /* Emit optimized code */

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -785,6 +785,7 @@ pm_static_literal_value(rb_iseq_t *iseq, const pm_node_t *node, const pm_scope_n
 
         VALUE value = rb_hash_new_with_size(elements->size);
         rb_hash_bulk_insert(RARRAY_LEN(array), RARRAY_CONST_PTR(array), value);
+        RB_GC_GUARD(array);
 
         value = rb_obj_hide(value);
         RB_OBJ_SET_FROZEN_SHAREABLE(value);
@@ -1452,6 +1453,7 @@ pm_compile_hash_elements(rb_iseq_t *iseq, const pm_node_t *node, const pm_node_l
 
                     VALUE hash = rb_hash_new_with_size(RARRAY_LEN(ary) / 2);
                     rb_hash_bulk_insert(RARRAY_LEN(ary), RARRAY_CONST_PTR(ary), hash);
+                    RB_GC_GUARD(ary);
                     hash = rb_obj_hide(hash);
                     RB_OBJ_SET_FROZEN_SHAREABLE(hash);
 


### PR DESCRIPTION
Prevent GC from accidentally collecting (Backport 30ec9c0)
AFAIK no ruby ticket for this bug.