### PR TITLE
Annotate String#ascii_only? and #valid_encoding? as leaf

### DIFF
--- a/benchmark/string_ascii_only_p.yml
+++ b/benchmark/string_ascii_only_p.yml
@@ -1,0 +1,7 @@
+prelude: |
+  ascii = "hello world"
+  utf8 = "héllo wörld 晦"
+benchmark:
+  ascii_only_true: ascii.ascii_only?
+  ascii_only_false: utf8.ascii_only?
+loop_count: 20000000

--- a/benchmark/string_valid_encoding_p.yml
+++ b/benchmark/string_valid_encoding_p.yml
@@ -1,0 +1,7 @@
+prelude: |
+  utf8 = "héllo wörld 晦"
+  broken = "\xff\xfe".dup.force_encoding("UTF-8")
+benchmark:
+  valid_enc_true: utf8.valid_encoding?
+  valid_enc_false: broken.valid_encoding?
+loop_count: 20000000

--- a/common.mk
+++ b/common.mk
@@ -1199,6 +1199,7 @@ BUILTIN_RB_SRCS = \
 		$(srcdir)/kernel.rb \
 		$(srcdir)/pathname_builtin.rb \
 		$(srcdir)/ractor.rb \
+		$(srcdir)/string.rb \
 		$(srcdir)/symbol.rb \
 		$(srcdir)/timev.rb \
 		$(srcdir)/thread_sync.rb \

--- a/depend
+++ b/depend
@@ -17718,6 +17718,7 @@ string.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 string.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
 string.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 string.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
+string.$(OBJEXT): {$(VPATH)}builtin.h
 string.$(OBJEXT): {$(VPATH)}config.h
 string.$(OBJEXT): {$(VPATH)}constant.h
 string.$(OBJEXT): {$(VPATH)}debug_counter.h
@@ -17896,6 +17897,7 @@ string.$(OBJEXT): {$(VPATH)}rubyparser.h
 string.$(OBJEXT): {$(VPATH)}shape.h
 string.$(OBJEXT): {$(VPATH)}st.h
 string.$(OBJEXT): {$(VPATH)}string.c
+string.$(OBJEXT): {$(VPATH)}string.rbinc
 string.$(OBJEXT): {$(VPATH)}subst.h
 string.$(OBJEXT): {$(VPATH)}thread.h
 string.$(OBJEXT): {$(VPATH)}thread_$(THREAD_MODEL).h

--- a/inits.c
+++ b/inits.c
@@ -105,6 +105,7 @@ rb_call_builtin_inits(void)
     BUILTIN(warning);
     BUILTIN(array);
     BUILTIN(hash);
+    BUILTIN(string);
     BUILTIN(symbol);
     BUILTIN(timev);
     BUILTIN(thread_sync);

--- a/string.c
+++ b/string.c
@@ -11736,6 +11736,7 @@ rb_str_b(VALUE str)
     return str2;
 }
 
+/* Defined as a leaf builtin in string.rb, so this must never raise or call into Ruby. */
 static VALUE
 rb_str_valid_encoding_p(VALUE str)
 {
@@ -11744,6 +11745,7 @@ rb_str_valid_encoding_p(VALUE str)
     return RBOOL(cr != ENC_CODERANGE_BROKEN);
 }
 
+/* Defined as a leaf builtin in string.rb, so this must never raise or call into Ruby. */
 static VALUE
 rb_str_is_ascii_only_p(VALUE str)
 {
@@ -13086,4 +13088,3 @@ Init_String(void)
 }
 
 #include "string.rbinc"
-

--- a/string.c
+++ b/string.c
@@ -11736,14 +11736,6 @@ rb_str_b(VALUE str)
     return str2;
 }
 
-/*
- *  call-seq:
- *    valid_encoding? -> true or false
- *
- *  :include: doc/string/valid_encoding_p.rdoc
- *
- */
-
 static VALUE
 rb_str_valid_encoding_p(VALUE str)
 {
@@ -11751,18 +11743,6 @@ rb_str_valid_encoding_p(VALUE str)
 
     return RBOOL(cr != ENC_CODERANGE_BROKEN);
 }
-
-/*
- *  call-seq:
- *    ascii_only? -> true or false
- *
- *  Returns whether +self+ contains only ASCII characters:
- *
- *    'abc'.ascii_only?         # => true
- *    "abc\u{6666}".ascii_only? # => false
- *
- *  Related: see {Querying}[rdoc-ref:String@Querying].
- */
 
 static VALUE
 rb_str_is_ascii_only_p(VALUE str)
@@ -13053,8 +13033,6 @@ Init_String(void)
     rb_define_method(rb_cString, "encoding", rb_obj_encoding, 0); /* in encoding.c */
     rb_define_method(rb_cString, "force_encoding", rb_str_force_encoding, 1);
     rb_define_method(rb_cString, "b", rb_str_b, 0);
-    rb_define_method(rb_cString, "valid_encoding?", rb_str_valid_encoding_p, 0);
-    rb_define_method(rb_cString, "ascii_only?", rb_str_is_ascii_only_p, 0);
 
     /* define UnicodeNormalize module here so that we don't have to look it up */
     mUnicodeNormalize          = rb_define_module("UnicodeNormalize");
@@ -13106,4 +13084,6 @@ Init_String(void)
 
     rb_define_method(rb_cSymbol, "encoding", sym_encoding, 0);
 }
+
+#include "string.rbinc"
 

--- a/string.rb
+++ b/string.rb
@@ -1,0 +1,25 @@
+class String
+  #  call-seq:
+  #    valid_encoding? -> true or false
+  #
+  #  :include: doc/string/valid_encoding_p.rdoc
+  #
+  def valid_encoding?
+    Primitive.attr! :leaf
+    Primitive.cexpr! 'rb_str_valid_encoding_p(self)'
+  end
+
+  #  call-seq:
+  #    ascii_only? -> true or false
+  #
+  #  Returns whether +self+ contains only ASCII characters:
+  #
+  #    'abc'.ascii_only?         # => true
+  #    "abc\u{6666}".ascii_only? # => false
+  #
+  #  Related: see {Querying}[rdoc-ref:String@Querying].
+  def ascii_only?
+    Primitive.attr! :leaf
+    Primitive.cexpr! 'rb_str_is_ascii_only_p(self)'
+  end
+end

--- a/zjit/bindgen/src/main.rs
+++ b/zjit/bindgen/src/main.rs
@@ -80,6 +80,9 @@ fn main() {
         .allowlist_type("ruby_preserved_encindex")
         .allowlist_function("rb_class2name")
 
+        // Coderange constants (ENC_CODERANGE_*) for inlining String predicates
+        .allowlist_type("ruby_coderange_type")
+
         // This struct is public to Ruby C extensions
         .allowlist_type("RBasic")
 

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -355,6 +355,12 @@ pub type rb_block_call_func = ::std::option::Option<
     ) -> VALUE,
 >;
 pub type rb_block_call_func_t = rb_block_call_func;
+pub const RUBY_ENC_CODERANGE_UNKNOWN: ruby_coderange_type = 0;
+pub const RUBY_ENC_CODERANGE_7BIT: ruby_coderange_type = 1048576;
+pub const RUBY_ENC_CODERANGE_VALID: ruby_coderange_type = 2097152;
+pub const RUBY_ENC_CODERANGE_BROKEN: ruby_coderange_type = 3145728;
+pub const RUBY_ENC_CODERANGE_MASK: ruby_coderange_type = 3145728;
+pub type ruby_coderange_type = u32;
 pub const RUBY_ENCODING_INLINE_MAX: ruby_encoding_consts = 127;
 pub const RUBY_ENCODING_SHIFT: ruby_encoding_consts = 22;
 pub const RUBY_ENCODING_MASK: ruby_encoding_consts = 532676608;

--- a/zjit/src/cruby_methods.rs
+++ b/zjit/src/cruby_methods.rs
@@ -222,9 +222,6 @@ pub fn init() -> Annotations {
     annotate!(rb_cString, "<<", inline_string_append);
     annotate!(rb_cString, "==", inline_string_eq);
     // Not elidable; has a side effect of setting the encoding if ENC_CODERANGE_UNKNOWN.
-    // TOOD(max): Turn this into a load/compare. Will need to side-exit or do the full call if
-    // ENC_CODERANGE_UNKNOWN.
-    annotate!(rb_cString, "ascii_only?", types::BoolExact, no_gc, leaf);
     annotate!(rb_cModule, "name", types::StringExact.union(types::NilClass), no_gc, leaf, elidable);
     annotate!(rb_cModule, "===", inline_module_eqq, types::BoolExact, no_gc, leaf);
     annotate!(rb_cArray, "length", inline_array_length, types::Fixnum, no_gc, leaf, elidable);
@@ -291,6 +288,10 @@ pub fn init() -> Annotations {
     annotate_builtin!(rb_mKernel, "frozen?", types::BoolExact);
     annotate_builtin!(rb_cSymbol, "name", types::StringExact);
     annotate_builtin!(rb_cSymbol, "to_s", types::StringExact);
+    // TOOD(max): Turn this into a load/compare. Will need to side-exit or do the full call if
+    // ENC_CODERANGE_UNKNOWN.
+    annotate_builtin!(rb_cString, "ascii_only?", types::BoolExact, no_gc, leaf);
+    annotate_builtin!(rb_cString, "valid_encoding?", types::BoolExact, no_gc, leaf);
 
     // Array iteration builtins (used in with_jit Array#each, map, select, find)
     builtin_funcs.insert(rb_jit_fixnum_inc as *mut c_void, FnProperties { inline: inline_fixnum_inc, return_type: types::Fixnum, ..Default::default() });

--- a/zjit/src/cruby_methods.rs
+++ b/zjit/src/cruby_methods.rs
@@ -288,10 +288,8 @@ pub fn init() -> Annotations {
     annotate_builtin!(rb_mKernel, "frozen?", types::BoolExact);
     annotate_builtin!(rb_cSymbol, "name", types::StringExact);
     annotate_builtin!(rb_cSymbol, "to_s", types::StringExact);
-    // TOOD(max): Turn this into a load/compare. Will need to side-exit or do the full call if
-    // ENC_CODERANGE_UNKNOWN.
-    annotate_builtin!(rb_cString, "ascii_only?", types::BoolExact, no_gc, leaf);
-    annotate_builtin!(rb_cString, "valid_encoding?", types::BoolExact, no_gc, leaf);
+    annotate_builtin!(rb_cString, "ascii_only?", inline_string_ascii_only_p, types::BoolExact, no_gc, leaf);
+    annotate_builtin!(rb_cString, "valid_encoding?", inline_string_valid_encoding_p, types::BoolExact, no_gc, leaf);
 
     // Array iteration builtins (used in with_jit Array#each, map, select, find)
     builtin_funcs.insert(rb_jit_fixnum_inc as *mut c_void, FnProperties { inline: inline_fixnum_inc, return_type: types::Fixnum, ..Default::default() });
@@ -550,6 +548,36 @@ fn inline_string_empty_p(fun: &mut hir::Function, block: hir::BlockId, recv: hir
     let is_zero = fun.push_insn(block, hir::Insn::IsBitEqual { left: len, right: zero });
     let result = fun.push_insn(block, hir::Insn::BoxBool { val: is_zero });
     Some(result)
+}
+
+// Load self's cached coderange (flags & MASK), guarding it's been computed
+// (UNKNOWN is 0, so side-exit there and let the builtin scan the string).
+fn guard_string_coderange(fun: &mut hir::Function, block: hir::BlockId, args: &[hir::InsnId], state: hir::InsnId) -> Option<hir::InsnId> {
+    use crate::hir::SideExitReason;
+    let &[recv] = args else { return None; };
+    if !fun.likely_a(recv, types::String, state) { return None; }
+    let recv = fun.coerce_to(block, recv, types::String, state);
+    let flags = fun.load_rbasic_flags(block, recv);
+    let mask = fun.push_insn(block, hir::Insn::Const { val: hir::Const::CUInt64(RUBY_ENC_CODERANGE_MASK.into()) });
+    let cr = fun.push_insn(block, hir::Insn::IntAnd { left: flags, right: mask });
+    let min_known = fun.push_insn(block, hir::Insn::Const { val: hir::Const::CInt64(RUBY_ENC_CODERANGE_7BIT.into()) });
+    Some(fun.push_insn(block, hir::Insn::GuardGreaterEq { left: cr, right: min_known, reason: SideExitReason::GuardGreaterEq, state }))
+}
+
+// Inlines String#ascii_only? (rb_str_is_ascii_only_p): coderange == 7BIT.
+fn inline_string_ascii_only_p(fun: &mut hir::Function, block: hir::BlockId, _recv: hir::InsnId, args: &[hir::InsnId], state: hir::InsnId) -> Option<hir::InsnId> {
+    let cr = guard_string_coderange(fun, block, args, state)?;
+    let seven_bit = fun.push_insn(block, hir::Insn::Const { val: hir::Const::CInt64(RUBY_ENC_CODERANGE_7BIT.into()) });
+    let is_7bit = fun.push_insn(block, hir::Insn::IsBitEqual { left: cr, right: seven_bit });
+    Some(fun.push_insn(block, hir::Insn::BoxBool { val: is_7bit }))
+}
+
+// Inlines String#valid_encoding? (rb_str_valid_encoding_p): coderange != BROKEN.
+fn inline_string_valid_encoding_p(fun: &mut hir::Function, block: hir::BlockId, _recv: hir::InsnId, args: &[hir::InsnId], state: hir::InsnId) -> Option<hir::InsnId> {
+    let cr = guard_string_coderange(fun, block, args, state)?;
+    let broken = fun.push_insn(block, hir::Insn::Const { val: hir::Const::CInt64(RUBY_ENC_CODERANGE_BROKEN.into()) });
+    let is_valid = fun.push_insn(block, hir::Insn::IsBitNotEqual { left: cr, right: broken });
+    Some(fun.push_insn(block, hir::Insn::BoxBool { val: is_valid }))
 }
 
 fn inline_string_append(fun: &mut hir::Function, block: hir::BlockId, recv: hir::InsnId, args: &[hir::InsnId], state: hir::InsnId) -> Option<hir::InsnId> {

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -11910,8 +11910,8 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, ascii_only?@0x1010, cme:0x1018)
-          v24:StringExact = GuardType v10, StringExact recompile
-          v25:BoolExact = CCall v24, :String#ascii_only?@0x1040
+          v23:StringExact = GuardType v10, StringExact recompile
+          v25:BoolExact = InvokeBuiltin leaf <inline_expr>, v23
           CheckInterrupts
           Return v25
         ");

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -11911,9 +11911,16 @@ mod hir_opt_tests {
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, ascii_only?@0x1010, cme:0x1018)
           v23:StringExact = GuardType v10, StringExact recompile
-          v25:BoolExact = InvokeBuiltin leaf <inline_expr>, v23
+          v26:CUInt64 = LoadField v23, :RBASIC_FLAGS@0x1040
+          v27:CUInt64[3145728] = Const CUInt64(3145728)
+          v28:CInt64 = IntAnd v26, v27
+          v29:CInt64[1048576] = Const CInt64(1048576)
+          v30:CInt64 = GuardGreaterEq v28, v29
+          v31:CInt64[1048576] = Const CInt64(1048576)
+          v32:CBool = IsBitEqual v30, v31
+          v33:BoolExact = BoxBool v32
           CheckInterrupts
-          Return v25
+          Return v33
         ");
     }
 


### PR DESCRIPTION
Get rid of the CFUNC overhead in String#ascii_only? and #valid_encoding?. Define them as leaf Primitive.cexpr! builtins in a new string.rb, following the pattern of numeric.rb.

This makes them 1.2x-1.4x faster across the interpreter, YJIT, and ZJIT.

Move ZJIT's cfunc annotation for String#ascii_only? to annotate_builtin!, and add one for String#valid_encoding?.

### Benchmark results

Measured with `benchmark/string_ascii_only_p.yml` and `benchmark/string_valid_encoding_p.yml` (added in this PR), benchmark-driver `--repeat-count=8 --repeat-result=average`, macOS arm64 (Apple Silicon). Control = master (26f09eb6af), Experiment = this branch.

| Benchmark | Control | Experiment | Speedup |
|---|---:|---:|---:|
| ascii_only_true | 84.12M i/s | 105.79M i/s | 1.26x |
| ascii_only_false | 69.76M i/s | 89.04M i/s | 1.28x |
| valid_enc_true | 73.10M i/s | 88.94M i/s | 1.22x |
| valid_enc_false | 68.39M i/s | 86.84M i/s | 1.27x |

The gain comes from the interpreter's leaf-builtin fastpath (`vm_call_single_noarg_leaf_builtin`), which skips the CFUNC frame push.

JIT sample:

```yaml
prelude: |
  ASCII = "hello world"
  UTF8 = "héllo wörld 晦"
  def hot_ascii(s)
    i = 0
    r = false
    while i < 1000 # while loop, not Integer#times: keeps block dispatch out of the measurement
      r = s.ascii_only?
      i += 1
    end
    r
  end
  def hot_valid(s)
    i = 0
    r = false
    while i < 1000
      r = s.valid_encoding?
      i += 1
    end
    r
  end
benchmark:
  method_ascii_only: hot_ascii(ASCII)
  method_valid_enc: hot_valid(UTF8)
loop_count: 30000
```

| Benchmark | Mode | Control | Experiment | Speedup |
|---|---|---:|---:|---:|
| ascii_only? | YJIT | 179.86k i/s | 367.43k i/s | 2.04x |
| valid_encoding? | YJIT | 183.95k i/s | 382.50k i/s | 2.08x |
| ascii_only? | ZJIT | 217.18k i/s | 241.10k i/s | 1.11x |
| valid_encoding? | ZJIT | 162.31k i/s | 236.00k i/s | 1.45x |

(i/s above counts calls to the outer method; each iteration performs 1000 predicate calls.)

ZJIT already optimized `ascii_only?` on master via a hand-written cfunc annotation in `cruby_methods.rs` (which this PR converts to `annotate_builtin!`), hence the smaller delta there. `valid_encoding?` was previously unannotated.

