### PR TITLE
Fix stale runnable_hot_th hint causing assertion failure with MN threads

### DIFF
--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -866,6 +866,13 @@ thread_sched_wait_running_turn(struct rb_thread_sched *sched, rb_thread_t *th, b
             thread_sched_set_running(sched, th);
             rb_ractor_thread_switch(th->ractor, th, false);
         }
+        else if (th == sched->runnable_hot_th) {
+            // The hot thread cannot steal the control (e.g. the running thread
+            // is an MN thread). It is going to sleep, so it is no longer spinning;
+            // drop the hint so that other threads don't yield the lock to it.
+            sched->runnable_hot_th = NULL;
+            sched->runnable_hot_th_waiting = 0;
+        }
 
         // already deleted from running threads
         // VM_ASSERT(!ractor_sched_running_threads_contain_p(th->vm, th)); // need locking


### PR DESCRIPTION
On a `VM_CHECK_MODE` build with `RUBY_MN_THREADS=1`, the following script aborts almost every run with `thread_pthread.c:887: Assertion Failed: thread_sched_wait_running_turn: sched->runnable_hot_th != th`. `make btest` fails the same way at bootstraptest/test_thread.rb (observed on macOS arm64 with `--enable-yjit=dev`, which enables `RUBY_DEBUG`).

```ruby
Thread.new { loop {} }
100.times { File.read(IO::NULL) }
```

`sched->runnable_hot_th` is set in `thread_sched_to_waiting_common` and cleared only at the end of `thread_sched_wait_running_turn`. When the hot thread returns from a blocking region while `sched->running` is an MN thread, the hot-steal path is skipped because `sched->running->has_dedicated_nt` is false, and the thread goes to sleep in `rb_native_cond_wait` with the hint still pointing to itself. The next wakeup then hits the assertion. In the script above the `loop {}` thread starts via `co_start`, which never passes the tail of `thread_sched_wait_running_turn`, so nothing clears the hint and the assertion fires almost deterministically.

The hint only exists to let a spinning hot thread grab the sched lock back, so this patch drops it once the thread commits to sleeping. Leaving it stale also makes other threads keep yielding the sched lock to a thread that is no longer spinning.

Introduced by ddb8d353acdf and 5796bc37d5e. With this fix, the script above and the full btest suite pass with `RUBY_MN_THREADS=1`. cc @jpl-coconut