### PR TITLE
Fix flaky test_tracepoint_callee_id

### DIFF
--- a/test/ruby/test_settracefunc.rb
+++ b/test/ruby/test_settracefunc.rb
@@ -1904,6 +1904,14 @@ CODE
     events = []
     capture_events = Proc.new{|tp|
       next unless target_thread?
+      # Skip events from other code interrupting this thread, such as
+      # finalizers of objects left by other tests (e.g. Tempfile's),
+      # whose frames are pushed on top of the interrupted frame of this
+      # file. The event is ours iff the innermost frame, ignoring core
+      # methods written in Ruby (e.g. Kernel#tap in <internal:kernel>),
+      # belongs to this file.
+      innermost = caller_locations.drop_while{|loc| loc.path.start_with?("<internal:")}.first
+      next unless innermost&.path == __FILE__
       events << [tp.event, tp.method_id, tp.callee_id]
     }
 


### PR DESCRIPTION
In parallel test-all, a worker process may hold garbage Tempfile objects left by previously run test files. When GC is triggered while a TracePoint of this test is enabled, their finalizers (Tempfile::FinalizerManager#call) run on the main thread at an interrupt checkpoint, so the target_thread? guard cannot reject their events and the test fails like:

  TestSetTraceFunc#test_tracepoint_callee_id:
  <[:c_return, :each_char, :each]> expected but was
  <[:c_return, :delete, :delete]>.  # Hash#delete in the finalizer

Reject such events by looking at caller_locations: an event is ours iff the innermost frame, ignoring core methods written in Ruby (<internal:*> such as Kernel#tap), belongs to this file. Finalizer frames are pushed on top of the interrupted frame of this file, so their events are rejected even when a finalizer calls core methods written in Ruby.