### PR TITLE
Fix flaky test: Parse heap dumps outside the Ractors in test_dump_all_with_ractors

### DIFF
--- a/test/objspace/test_objspace.rb
+++ b/test/objspace/test_objspace.rb
@@ -846,16 +846,23 @@ class TestObjSpace < Test::Unit::TestCase
       require "json"
       rs = 4.times.map do
         Ractor.new do
-          Tempfile.create do |f|
-            ObjectSpace.dump_all(output: f)
-            f.close
-            File.readlines(f.path).each do |line|
-              JSON.parse(line)
-            end
-          end
+          f = Tempfile.create("dump_all")
+          ObjectSpace.dump_all(output: f)
+          f.close
+          f.path
         end
       end
-      rs.each(&:join)
+      # Parse the dumps in the main Ractor so smaller CI instances don't time out
+      rs.each do |r|
+        path = r.value
+        begin
+          File.foreach(path) do |line|
+            JSON.parse(line)
+          end
+        ensure
+          File.unlink(path)
+        end
+      end
     end;
   end
 


### PR DESCRIPTION
This test catches the dump_all VM barrier deadlock (#15569), which only needs the four concurrent dumps. JSON-parsing all four heap dumps inside the Ractors allocates heavily in parallel and sometimes blew the 100s timeout on macOS CI. Parse in the main Ractor after the workers finish instead. Every line is still validated.

Locally takes the same time as the original, but even locally this has smaller variance than the original. 