### PR TITLE
[Feature #22108] parse.y: Computed hash keys with (expr): syntax

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -514,6 +514,8 @@ struct parser_params {
         int lpar_beg;
         /* track the nest level of only braces "{}" */
         int brace_nest;
+        /* track the nest level of hash literal braces "{}" */
+        int hash_nest;
     } lex;
     stack_type cond_stack;
     stack_type cmdarg_stack;
@@ -2874,6 +2876,7 @@ rb_parser_ary_free(rb_parser_t *p, rb_parser_ary_t *ary)
  */
 
 %nonassoc tLOWEST
+%nonassoc ')'
 %nonassoc tLBRACE_ARG
 
 %nonassoc  modifier_if modifier_unless modifier_while modifier_until keyword_in
@@ -6649,6 +6652,11 @@ assoc		: arg_value tASSOC arg_value
                         YYLTYPE loc = code_loc_gen(&@1, &@3);
                         $$ = list_append(p, NEW_LIST(dsym_node(p, $2, &loc), &loc), $4);
                     /*% ripper: assoc_new!(dyna_symbol!($:2), $:4) %*/
+                    }
+                | tLPAREN compstmt(stmts)[body] ')' tLABEL_END arg_value
+                    {
+                        $$ = list_append(p, NEW_LIST($body, &@$), $5);
+                    /*% ripper: assoc_new!($:body, $:5) %*/
                     }
                 | tDSTAR arg_value
                     {
@@ -10975,6 +10983,7 @@ parser_yylex(struct parser_params *p)
       case '}':
         /* tSTRING_DEND does COND_POP and CMDARG_POP in the yacc's rule */
         if (!p->lex.brace_nest--) return tSTRING_DEND;
+        if (p->lex.hash_nest > 0) p->lex.hash_nest--;
         COND_POP();
         CMDARG_POP();
         SET_LEX_STATE(EXPR_END);
@@ -10991,6 +11000,11 @@ parser_yylex(struct parser_params *p)
             set_yylval_id(idCOLON2);
             SET_LEX_STATE(EXPR_DOT);
             return tCOLON2;
+        }
+        if (IS_lex_state(EXPR_ENDFN) && !space_seen && c != '#' && p->lex.hash_nest > 0) {
+            pushback(p, c);
+            SET_LEX_STATE(EXPR_ARG|EXPR_LABELED);
+            return tLABEL_END;
         }
         if (IS_END() || ISSPACE(c) || c == '#') {
             pushback(p, c);
@@ -11113,14 +11127,18 @@ parser_yylex(struct parser_params *p)
         ++p->lex.brace_nest;
         if (lambda_beginning_p())
             c = tLAMBEG;
-        else if (IS_lex_state(EXPR_LABELED))
+        else if (IS_lex_state(EXPR_LABELED)) {
             c = tLBRACE;      /* hash */
+            ++p->lex.hash_nest;
+        }
         else if (IS_lex_state(EXPR_ARG_ANY | EXPR_END | EXPR_ENDFN))
             c = '{';          /* block (primary) */
         else if (IS_lex_state(EXPR_ENDARG))
             c = tLBRACE_ARG;  /* block (expr) */
-        else
+        else {
             c = tLBRACE;      /* hash */
+            ++p->lex.hash_nest;
+        }
         if (c != tLBRACE) {
             p->command_start = TRUE;
             SET_LEX_STATE(EXPR_BEG);

--- a/prism/prism.c
+++ b/prism/prism.c
@@ -13679,7 +13679,9 @@ parse_assocs(pm_parser_t *parser, pm_static_literals_t *literals, pm_node_t *nod
                 pm_hash_key_static_literals_add(parser, literals, key);
 
                 pm_token_t operator = { 0 };
-                if (!pm_symbol_node_label_p(parser, key)) {
+                if (PM_NODE_TYPE_P(key, PM_PARENTHESES_NODE) && (parser->start + key->location.start + key->location.length) == parser->current.start && accept1(parser, PM_TOKEN_COLON)) {
+                    // Computed hash key (expr): — no => needed
+                } else if (!pm_symbol_node_label_p(parser, key)) {
                     expect1(parser, PM_TOKEN_EQUAL_GREATER, PM_ERR_HASH_ROCKET);
                     operator = parser->previous;
                 }

--- a/test/ruby/test_syntax.rb
+++ b/test/ruby/test_syntax.rb
@@ -647,6 +647,13 @@ class TestSyntax < Test::Unit::TestCase
     assert_valid_syntax("{foo: /=/}", bug11456)
   end
 
+  def test_computed_key_hash
+    assert_valid_syntax '{ (a + b): c }'
+    assert_valid_syntax '{ ("a" + "b"): c }'
+    assert_valid_syntax '{ (1): c }'
+    assert_syntax_error '{ (a + b) : c }', /expect/  # space before colon
+  end
+
   def test_percent_string_after_label
     bug11812 = '[ruby-core:72084]'
     assert_valid_syntax('{label:%w(*)}', bug11812)


### PR DESCRIPTION
Allow `{ (expr): value }` as a computed hash key, completing the colon-notation family:

```ruby
h = {
  name: "symbol shorthand",          # Ruby 1.9+
  "quoted label": "symbol label",    # Ruby 2.2+ (Feature #4935)
  value_omission: ,                  # Ruby 3.1+ (Feature #14579)
  (expr): "computed",                # Ruby ???  (Feature #22108)
}
```

* parse.y: Add precedence declaration for ')'.
* parse.y: Add assoc: tLPAREN compstmt ")" tLABEL_END arg_value grammar rule.
* parse.y: Emit tLABEL_END from lexer when EXPR_ENDFN state, no space before ":", and inside braces (brace_nest > 0).
* prism.c: Emit PM_TOKEN_LABEL_END in lexer when PM_LEX_STATE_ENDFN and inside braces; accept PM_TOKEN_LABEL_END in parse_assocs default case.
* test/ruby/test_syntax.rb: Add test_computed_key_hash.

(See: [Feature #22108](https://bugs.ruby-lang.org/issues/22108))

Dependencies:
 * https://github.com/ruby/prism/pull/4132 (but `prism/prism.c` is copied in here ahead of being synced from the upstream)

(Potentially) obsoleted by:
 * https://github.com/ruby/ruby/pull/17318

Assisted-by: OpenCode 1.17.3 (opencode/big-pickle)