### PR TITLE
[Backport 4.0] compile.c: fix dupstring-of-Regexp from folded /o regexp

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -3935,6 +3935,11 @@ iseq_peephole_optimize(rb_iseq_t *iseq, LINK_ELEMENT *list, const int do_tailcal
                 else {
                     RB_OBJ_SET_SHAREABLE(re);
                 }
+                /* The folded operand is a Regexp, so the instruction must be
+                 * putobject: dupstring/dupchilledstring would resurrect the
+                 * Regexp as a String at run time (e.g. for a /o regexp whose
+                 * interpolation folds to a constant, such as /#{"a"}/o). */
+                iobj->insn_id = BIN(putobject);
                 RB_OBJ_WRITE(iseq, &OPERAND_AT(iobj, 0), re);
                 ELEM_REMOVE(iobj->link.next);
             }

--- a/test/ruby/test_regexp.rb
+++ b/test/ruby/test_regexp.rb
@@ -1805,6 +1805,21 @@ class TestRegexp < Test::Unit::TestCase
     assert_equal(/0/, pr1.call(2))
   end
 
+  def test_once_constant_interpolation
+    # A /o regexp whose interpolation folds to a constant must build a Regexp,
+    # not resurrect it as a String.  The peephole optimizer rewrites
+    # "dupstring str; toregexp" into a single literal-push instruction; that
+    # instruction must become putobject (not keep dupstring).
+    assert_separately([], <<~'RUBY')
+      def m; /#{"a"}#{"b"}/o; end
+      assert_equal(/ab/, m)
+      assert_equal(/ab/, m)
+      assert_predicate(m, :frozen?)
+      assert_equal(/a/i, eval('/#{"a"}/io'))
+      assert_equal(0, ("ab" =~ /#{"a"}/o))
+    RUBY
+  end
+
   def test_once_recursive
     pr2 = proc{|i|
       if i > 0


### PR DESCRIPTION
The peephole optimizer folds "dupstring str; toregexp" (and the dupchilledstring / putobject-string variants) into a single literal-push by compiling the Regexp at compile time and replacing the operand with it.  It replaced the operand but kept the original opcode, so a dupstring/dupchilledstring instruction was left holding a Regexp. At run time dupstring resurrects its operand as a String (rb_ec_str_resurrect), reading the Regexp as if it were a string and crashing ("heap_idx_for_size: allocation size too large").

This is reachable from a /o regexp whose interpolation folds to a constant, e.g. `def m; /#{"a"}/o; end`: the once body is compiled via the dynamic-regexp path (dupstring + toregexp) and then folded, unlike a plain /#{"a"}/ which is pushed directly with putobject.

Set the opcode to putobject when folding, matching what a static regexp literal emits.

Fixes [Bug #22103]. (Backport)