### PR TITLE
ZJIT: Call make_equal_to when folding GuardBitEquals

### DIFF
--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5218,6 +5218,7 @@ impl Function {
                     Insn::GuardBitEquals { val, expected, .. } => {
                         let recv_type = self.type_of(val);
                         if recv_type.has_value(expected) {
+                            self.make_equal_to(insn_id, val);
                             continue;
                         } else {
                             insn_id


### PR DESCRIPTION
We need to actually link it up in the union-find instead of dropping it
on the floor.

Co-authored-by: Kevin Menard <kevin@nirvdrum.com>
