### PR TITLE
ZJIT: Post-process bindings to use i32 for offset type, removing casts

### DIFF
--- a/zjit/bindgen/src/main.rs
+++ b/zjit/bindgen/src/main.rs
@@ -462,13 +462,15 @@ fn main() {
     bindings.write(Box::new(&mut bindings_string)).expect("Couldn't write bindings!");
 
     // Use i32 for this type since that's what the assembler APIs expect
-    const JIT_CONSTANTS_NEEDLE: &str       =  "\npub type jit_bindgen_constants = u32;\n";
-    const JIT_CONSTANTS_REPLACEMENT: &[u8] = b"\npub type jit_bindgen_constants = i32;\n";
-    // Yes, this search and replace could be faster, but it's a small file.
-    let bindings_str = str::from_utf8(bindings_string.as_ref()).expect("bindings should be in UTF-8");
-    let type_needle_start = bindings_str.find(JIT_CONSTANTS_NEEDLE).expect("bindings should have jit_bindgen_constants");
-    (&mut bindings_string[type_needle_start..type_needle_start + JIT_CONSTANTS_NEEDLE.len()])
-        .copy_from_slice(JIT_CONSTANTS_REPLACEMENT);
+    const JIT_CONSTANTS_NEEDLE: &[u8]      = b"pub type jit_bindgen_constants = u32;";
+    const JIT_CONSTANTS_REPLACEMENT: &[u8] = b"pub type jit_bindgen_constants = i32;";
+    // Yes, this search-and-replace could be faster, but it's a small file.
+    for line in bindings_string.as_mut_slice().split_mut(|&byte| byte == b'\n') {
+        if line == JIT_CONSTANTS_NEEDLE {
+            line.copy_from_slice(JIT_CONSTANTS_REPLACEMENT);
+            break;
+        }
+    }
 
     // Write out to file
     let mut out_path: PathBuf = src_root;

--- a/zjit/bindgen/src/main.rs
+++ b/zjit/bindgen/src/main.rs
@@ -457,12 +457,23 @@ fn main() {
         // Unwrap the Result and panic on failure.
         .expect("Unable to generate bindings");
 
+    // Write to a Vec for post-processing
+    let mut bindings_string = Vec::new();
+    bindings.write(Box::new(&mut bindings_string)).expect("Couldn't write bindings!");
+
+    // Use i32 for this type since that's what the assembler APIs expect
+    const JIT_CONSTANTS_NEEDLE: &str       =  "\npub type jit_bindgen_constants = u32;\n";
+    const JIT_CONSTANTS_REPLACEMENT: &[u8] = b"\npub type jit_bindgen_constants = i32;\n";
+    // Yes, this search and replace could be faster, but it's a small file.
+    let bindings_str = str::from_utf8(bindings_string.as_ref()).expect("bindings should be in UTF-8");
+    let type_needle_start = bindings_str.find(JIT_CONSTANTS_NEEDLE).expect("bindings should have jit_bindgen_constants");
+    (&mut bindings_string[type_needle_start..type_needle_start + JIT_CONSTANTS_NEEDLE.len()])
+        .copy_from_slice(JIT_CONSTANTS_REPLACEMENT);
+
+    // Write out to file
     let mut out_path: PathBuf = src_root;
     out_path.push(jit_name);
     out_path.push("src");
     out_path.push("cruby_bindings.inc.rs");
-
-    bindings
-        .write_to_file(out_path)
-        .expect("Couldn't write bindings!");
+    std::fs::write(out_path, bindings_string).expect("file output failed");
 }

--- a/zjit/src/backend/tests.rs
+++ b/zjit/src/backend/tests.rs
@@ -182,9 +182,9 @@ fn test_jcc_ptr()
     let (mut asm, mut cb) = setup_asm();
 
     let side_exit = Target::CodePtr(cb.get_write_ptr().add_bytes(4));
-    let not_mask = asm.not(Opnd::mem(32, EC, RUBY_OFFSET_EC_INTERRUPT_MASK as i32));
+    let not_mask = asm.not(Opnd::mem(32, EC, RUBY_OFFSET_EC_INTERRUPT_MASK));
     asm.test(
-        Opnd::mem(32, EC, RUBY_OFFSET_EC_INTERRUPT_FLAG as i32),
+        Opnd::mem(32, EC, RUBY_OFFSET_EC_INTERRUPT_FLAG),
         not_mask,
     );
     asm.push_insn(Insn::Jnz(side_exit));

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -1077,7 +1077,7 @@ fn gen_ccall_with_frame(
     asm_comment!(asm, "switch to new CFP");
     let new_cfp = asm.sub(CFP, RUBY_SIZEOF_CONTROL_FRAME.into());
     asm.mov(CFP, new_cfp);
-    asm.store(Opnd::mem(64, EC, RUBY_OFFSET_EC_CFP as i32), CFP);
+    asm.store(Opnd::mem(64, EC, RUBY_OFFSET_EC_CFP), CFP);
 
     let mut cfunc_args = vec![recv];
     cfunc_args.extend(args);
@@ -1087,7 +1087,7 @@ fn gen_ccall_with_frame(
     asm_comment!(asm, "pop C frame");
     let new_cfp = asm.add(CFP, RUBY_SIZEOF_CONTROL_FRAME.into());
     asm.mov(CFP, new_cfp);
-    asm.store(Opnd::mem(64, EC, RUBY_OFFSET_EC_CFP as i32), CFP);
+    asm.store(Opnd::mem(64, EC, RUBY_OFFSET_EC_CFP), CFP);
 
     asm_comment!(asm, "restore SP register for the caller");
     let new_sp = asm.sub(SP, sp_offset.into());
@@ -1166,7 +1166,7 @@ fn gen_ccall_variadic(
     asm_comment!(asm, "switch to new CFP");
     let new_cfp = asm.sub(CFP, RUBY_SIZEOF_CONTROL_FRAME.into());
     asm.mov(CFP, new_cfp);
-    asm.store(Opnd::mem(64, EC, RUBY_OFFSET_EC_CFP as i32), CFP);
+    asm.store(Opnd::mem(64, EC, RUBY_OFFSET_EC_CFP), CFP);
 
     let argv_ptr = gen_push_opnds(jit, asm, &args);
     asm.count_call_to(&name.contents_lossy());
@@ -1175,7 +1175,7 @@ fn gen_ccall_variadic(
     asm_comment!(asm, "pop C frame");
     let new_cfp = asm.add(CFP, RUBY_SIZEOF_CONTROL_FRAME.into());
     asm.mov(CFP, new_cfp);
-    asm.store(Opnd::mem(64, EC, RUBY_OFFSET_EC_CFP as i32), CFP);
+    asm.store(Opnd::mem(64, EC, RUBY_OFFSET_EC_CFP), CFP);
 
     asm_comment!(asm, "restore SP register for the caller");
     let new_sp = asm.sub(SP, sp_offset.into());
@@ -1300,7 +1300,7 @@ fn gen_check_interrupts(jit: &mut JITState, asm: &mut Assembler, state: &FrameSt
     asm_comment!(asm, "RUBY_VM_CHECK_INTS(ec)");
     // Not checking interrupt_mask since it's zero outside finalize_deferred_heap_pages,
     // signal_exec, or rb_postponed_job_flush.
-    let interrupt_flag = asm.load(Opnd::mem(32, EC, RUBY_OFFSET_EC_INTERRUPT_FLAG as i32));
+    let interrupt_flag = asm.load(Opnd::mem(32, EC, RUBY_OFFSET_EC_INTERRUPT_FLAG));
     asm.test(interrupt_flag, interrupt_flag);
     asm.jnz(jit, side_exit(jit, state, SideExitReason::Interrupt));
 }
@@ -1623,7 +1623,7 @@ fn gen_send_iseq_direct(
     asm_comment!(asm, "switch to new CFP");
     let new_cfp = asm.sub(CFP, RUBY_SIZEOF_CONTROL_FRAME.into());
     asm.mov(CFP, new_cfp);
-    asm.store(Opnd::mem(64, EC, RUBY_OFFSET_EC_CFP as i32), CFP);
+    asm.store(Opnd::mem(64, EC, RUBY_OFFSET_EC_CFP), CFP);
 
     let params = unsafe { iseq.params() };
 
@@ -2231,7 +2231,7 @@ fn gen_return(asm: &mut Assembler, val: lir::Opnd) {
     asm_comment!(asm, "pop stack frame");
     let incr_cfp = asm.add(CFP, RUBY_SIZEOF_CONTROL_FRAME.into());
     asm.mov(CFP, incr_cfp);
-    asm.mov(Opnd::mem(64, EC, RUBY_OFFSET_EC_CFP as i32), CFP);
+    asm.mov(Opnd::mem(64, EC, RUBY_OFFSET_EC_CFP), CFP);
 
     // Order here is important. Because we're about to tear down the frame,
     // we need to load the return value, which might be part of the frame.

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -1940,7 +1940,7 @@ pub const RUBY_OFFSET_EC_INTERRUPT_FLAG: jit_bindgen_constants = 32;
 pub const RUBY_OFFSET_EC_INTERRUPT_MASK: jit_bindgen_constants = 36;
 pub const RUBY_OFFSET_EC_THREAD_PTR: jit_bindgen_constants = 48;
 pub const RUBY_OFFSET_EC_RACTOR_ID: jit_bindgen_constants = 64;
-pub type jit_bindgen_constants = u32;
+pub type jit_bindgen_constants = i32;
 pub const rb_invalid_shape_id: shape_id_t = 524287;
 pub type rb_iseq_param_keyword_struct =
     rb_iseq_constant_body_rb_iseq_parameters_rb_iseq_param_keyword;

--- a/zjit/src/cruby_methods.rs
+++ b/zjit/src/cruby_methods.rs
@@ -321,13 +321,13 @@ fn inline_thread_current(fun: &mut hir::Function, block: hir::BlockId, _recv: hi
     let thread_ptr = fun.push_insn(block, hir::Insn::LoadField {
         recv: ec,
         id: FieldName::thread_ptr,
-        offset: RUBY_OFFSET_EC_THREAD_PTR as i32,
+        offset: RUBY_OFFSET_EC_THREAD_PTR,
         return_type: types::CPtr,
     });
     let thread_self = fun.push_insn(block, hir::Insn::LoadField {
         recv: thread_ptr,
         id: FieldName::SelfParam,
-        offset: RUBY_OFFSET_THREAD_SELF as i32,
+        offset: RUBY_OFFSET_THREAD_SELF,
         // TODO(max): Add Thread type. But Thread.current is not guaranteed to be an exact Thread.
         // You can make subclasses...
         return_type: types::BasicObject,
@@ -461,7 +461,7 @@ fn inline_string_bytesize(fun: &mut hir::Function, block: hir::BlockId, recv: hi
         let len = fun.push_insn(block, hir::Insn::LoadField {
             recv,
             id: FieldName::len,
-            offset: RUBY_OFFSET_RSTRING_LEN as i32,
+            offset: RUBY_OFFSET_RSTRING_LEN,
             return_type: types::CInt64,
         });
 
@@ -485,7 +485,7 @@ fn inline_string_getbyte(fun: &mut hir::Function, block: hir::BlockId, recv: hir
         let len = fun.push_insn(block, hir::Insn::LoadField {
             recv,
             id: FieldName::len,
-            offset: RUBY_OFFSET_RSTRING_LEN as i32,
+            offset: RUBY_OFFSET_RSTRING_LEN,
             return_type: types::CInt64,
         });
         // TODO(max): Find a way to mark these guards as not needed for correctness... as in, once
@@ -513,7 +513,7 @@ fn inline_string_setbyte(fun: &mut hir::Function, block: hir::BlockId, recv: hir
         let len = fun.push_insn(block, hir::Insn::LoadField {
             recv,
             id: FieldName::len,
-            offset: RUBY_OFFSET_RSTRING_LEN as i32,
+            offset: RUBY_OFFSET_RSTRING_LEN,
             return_type: types::CInt64,
         });
         let unboxed_index = fun.push_insn(block, hir::Insn::GuardLess { left: unboxed_index, right: len, reason: SideExitReason::GuardLess, state });
@@ -536,7 +536,7 @@ fn inline_string_empty_p(fun: &mut hir::Function, block: hir::BlockId, recv: hir
     let len = fun.push_insn(block, hir::Insn::LoadField {
         recv,
         id: FieldName::len,
-        offset: RUBY_OFFSET_RSTRING_LEN as i32,
+        offset: RUBY_OFFSET_RSTRING_LEN,
         return_type: types::CInt64,
     });
     let zero = fun.push_insn(block, hir::Insn::Const { val: hir::Const::CInt64(0) });

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -4374,7 +4374,7 @@ impl Function {
         // See ROBJECT_FIELDS() from include/ruby/internal/core/robject.h
         let ptr = self.push_insn(block, Insn::LoadField {
             recv, id: FieldName::as_heap,
-            offset: ROBJECT_OFFSET_AS_HEAP_FIELDS as i32,
+            offset: ROBJECT_OFFSET_AS_HEAP_FIELDS,
             return_type: types::CPtr,
         });
         let offset = SIZEOF_VALUE_I32 * ivar_index as i32;
@@ -4386,7 +4386,7 @@ impl Function {
 
     fn load_ivar_embedded(&mut self, block: BlockId, recv: InsnId, id: ID, ivar_index: attr_index_t) -> InsnId {
         // See ROBJECT_FIELDS() from include/ruby/internal/core/robject.h
-        let offset = ROBJECT_OFFSET_AS_ARY as i32
+        let offset = ROBJECT_OFFSET_AS_ARY
             + (SIZEOF_VALUE * ivar_index.to_usize()) as i32;
         self.push_insn(block, Insn::LoadField {
             recv, id: id.into(), offset,
@@ -4416,9 +4416,9 @@ impl Function {
         match layout {
             ShapeLayout::RClass | ShapeLayout::RData => {
                 let offset = if layout == ShapeLayout::RClass {
-                    RCLASS_OFFSET_PRIME_FIELDS_OBJ as i32
+                    RCLASS_OFFSET_PRIME_FIELDS_OBJ
                 } else {
-                    TDATA_OFFSET_FIELDS_OBJ as i32
+                    TDATA_OFFSET_FIELDS_OBJ
                 };
 
                 let fields_obj = self.push_insn(block, Insn::LoadField {
@@ -4597,10 +4597,10 @@ impl Function {
                         // Current shape contains this ivar
                         let (ivar_storage, offset) = if recv_type.flags().is_embedded() {
                             // See ROBJECT_FIELDS() from include/ruby/internal/core/robject.h
-                            let offset = ROBJECT_OFFSET_AS_ARY as i32 + (SIZEOF_VALUE * ivar_index.to_usize()) as i32;
+                            let offset = ROBJECT_OFFSET_AS_ARY + (SIZEOF_VALUE * ivar_index.to_usize()) as i32;
                             (self_val, offset)
                         } else {
-                            let as_heap = self.push_insn(block, Insn::LoadField { recv: self_val, id: FieldName::as_heap, offset: ROBJECT_OFFSET_AS_HEAP_FIELDS as i32, return_type: types::CPtr });
+                            let as_heap = self.push_insn(block, Insn::LoadField { recv: self_val, id: FieldName::as_heap, offset: ROBJECT_OFFSET_AS_HEAP_FIELDS, return_type: types::CPtr });
                             let offset = SIZEOF_VALUE_I32 * ivar_index as i32;
                             (as_heap, offset)
                         };
@@ -9385,13 +9385,13 @@ mod validation_tests {
         function.push_insn(entry, Insn::LoadField {
             recv,
             id: FieldName::as_heap,
-            offset: ROBJECT_OFFSET_AS_HEAP_FIELDS as i32,
+            offset: ROBJECT_OFFSET_AS_HEAP_FIELDS,
             return_type: types::CPtr,
         });
         let ivar = function.push_insn(entry, Insn::LoadField {
             recv,
             id: FieldName::Id(ID(1)),
-            offset: ROBJECT_OFFSET_AS_ARY as i32,
+            offset: ROBJECT_OFFSET_AS_ARY,
             return_type: types::BasicObject,
         });
         function.push_insn(entry, Insn::Return { val: ivar });
@@ -9418,13 +9418,13 @@ mod validation_tests {
         function.push_insn(entry, Insn::LoadField {
             recv,
             id: FieldName::as_heap,
-            offset: ROBJECT_OFFSET_AS_HEAP_FIELDS as i32,
+            offset: ROBJECT_OFFSET_AS_HEAP_FIELDS,
             return_type: types::BasicObject,
         });
         let ivar = function.push_insn(entry, Insn::LoadField {
             recv,
             id: FieldName::Id(ID(1)),
-            offset: ROBJECT_OFFSET_AS_ARY as i32,
+            offset: ROBJECT_OFFSET_AS_ARY,
             return_type: types::Array,
         });
         function.push_insn(entry, Insn::Return { val: ivar });


### PR DESCRIPTION
As you may know, `as` casts can be dangerous since they may be lossy, and
with type inference, it's hard to tell what kind of conversion is
happening.

This commit removes the safe `as i32` casts from members of
`jit_bindgen_constants` enum. This builds, so we know all the constants
fit in i32, with this, they match what `Assembler` expects without
the need to cast.
