### PR TITLE
ZJIT: Add Braun SSA optimization pass

### DIFF
--- a/zjit.rb
+++ b/zjit.rb
@@ -152,6 +152,7 @@ class << RubyVM::ZJIT
       :compile_hir_build_time_ns,
       :compile_hir_strength_reduce_time_ns,
       :compile_hir_inline_methods_time_ns,
+      :compile_hir_remove_trivial_block_params_time_ns,
       :compile_hir_optimize_load_store_time_ns,
       :compile_hir_canonicalize_time_ns,
       :compile_hir_fold_constants_time_ns,

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5873,103 +5873,145 @@ impl Function {
     /// This function implements algorithm 2 from <https://c9x.me/compile/bib/braun13cc.pdf>.
     /// Light modifications are made to use block params instead of phis.
     fn remove_trivial_block_params(&mut self) {
+        // This abstract domain represents block param optimization potential
+        // If it were constructed as a lattice, Unknown is bottom, trivial is above, nontrivial is top (and above trivial)
+        #[derive(Clone)]
+        enum ParamState {
+            Unknown,
+            NonTrivial,
+            Trivial(InsnId)
+        }
 
-        // Helper function for remove_trivial_block_params
+        fn prune_vec_by_indices<T>(v: &mut Vec<T>, indices: &[usize]) {
+            let mut i: usize = 0;
+            v.retain(|_| {
+                let valid_id = !indices.contains(&i);
+                i += 1;
+                valid_id
+            })
+        }
+
         // Remove an argument of the edge at index if the conditional matches target_block
-        fn prune_branch_edge(edge: BranchEdge, target_block: BlockId, index: usize) -> BranchEdge {
+        fn prune_branch_edge(edge: BranchEdge, indices: &Vec<usize>) -> BranchEdge {
             let mut args = edge.args.clone();
-            if edge.target == target_block {
-                args.remove(index);
-            }
+            prune_vec_by_indices(&mut args, indices);
             BranchEdge { target: edge.target, args }
         }
 
-        // TODO: This stupid function causes borrowing issues so we just duplicated the code for it all over the place omg. Do we remove this or fix it??
-        // fetch_last_insn is a helper to retrieve the final instruction from a block.
-        // We use standard basic blocks so we know that each jump msut be the final instruction in a block.
-        fn fetch_last_insn(blocks: Vec<Block>, block_id: BlockId) -> InsnId {
-            *blocks[block_id.0].insns.last().unwrap()
+        let mut changed = true;
+
+        while changed {
+
+        changed = false;
+
+        // Instantiate the domain for abstract interpretation
+        // Outer index is block
+        // Inner index is param index
+        // Value is the state of the param. This is used to determine whether block param optimization can occur.
+        let mut predecessor_domain: Vec<Vec<ParamState>> = vec![Vec::new(); self.blocks.len()];
+        for (i, block) in self.blocks.iter().enumerate() {
+            predecessor_domain[i].extend(std::iter::repeat_n(ParamState::Unknown, block.params.len()))
         }
 
-        // Find each block that ends with Insn::Jump or Insn::CondBranch. (Equivalently, this is all blocks that don't end with Insn::Return)
-        let jump_blocks: Vec<BlockId> = self.reverse_post_order().into_iter()
+        // Store references to all the conditional instructions.
+        // We need to update these conditionals in the case of trivial block params.
+        let jumps: Vec<(BlockId, usize)> = self.reverse_post_order().into_iter()
             .filter(|&block_id| matches!(
                 self.find(*self.blocks[block_id.0].insns.last().unwrap()),
-                Insn::CondBranch {..} | Insn::Jump {..} )
-            ).collect();
+                Insn::CondBranch {..} | Insn::Jump {..}
+            ))
+            .map(|block_id| (block_id, self.blocks[block_id.0].insns.len() - 1))
+            .collect();
 
-        // Note: The outer vec represents all blocks in the CFG. Using a vec instead of HashMap with keys is safe
-        // because blocks are represented by contiguous values between 0 and len() - 1
-        // This invariant holds because new_block adds a new id based on length, and remove_block only allows the highest block value to be removed.
-        // These are the two functions used to modify block sizes.
-        #[derive(Hash, Eq, PartialEq, Clone, Copy)]
-        struct ArgKey {
-            block: BlockId,
-            index: usize
-        }
-        let mut predecessors: HashMap<ArgKey, Vec<InsnId>> = HashMap::new();
 
-        let mut add_preds = |block: BlockId, args: Vec<InsnId>| {
-            for index in 0..args.len() {
-                predecessors.entry(ArgKey{ block, index }).or_default().push(args[index]);
-            }
-        };
+        // Scan through each jump, collecting edges from CondBranch and Jump insns.
+        for (block_id, insn_index) in &jumps {
+            let insn_id = self.blocks[block_id.0].insns[*insn_index];
+            let mut edges: Vec<BranchEdge> = vec![];
 
-        // Find the predecessors for each conditional HIR instruction in the CFG
-        for insn_id in jump_blocks.iter().map(|block_id| {self.blocks[block_id.0].insns.last().unwrap()}) {
-            match self.find(*insn_id) {
+            match self.find(insn_id) {
                 Insn::CondBranch { if_true, if_false, .. } => {
-                    add_preds(if_true.target, if_true.args);
-                    add_preds(if_false.target, if_false.args);
+                    edges.push(if_true);
+                    edges.push(if_false);
                 }
                 Insn::Jump(edge) => {
-                    add_preds(edge.target, edge.args);
+                    edges.push(edge);
                 }
                 _ => {}
             }
-        }
 
-        // Remove the predecessor self-references
-        let mut external_preds = predecessors.clone();
-        for (key, predecessors) in external_preds.iter_mut() {
-            let pred_from_current_block = self.chase_insn(*self.block(key.block).params().nth(key.index).unwrap());
-            predecessors.retain(|insn_id| self.chase_insn(*insn_id) != pred_from_current_block);
-        }
-
-        // Identify the trivial block params. Trivial means that each external predecessor has the same insn_id.
-        for (ArgKey { block, index }, predecessors) in external_preds.iter() {
-            match predecessors.as_slice() {
-                [] => {} // Unreachable. This should never happen
-                [first, rest @ ..] if rest.iter().any(|insn_id| insn_id != first) => {} // non-trivial
-                [insn_id, ..] => {
-                    // Save the insn_id of the block param to be removed
-                    let trivial_block_param = self.blocks[block.0].params[*index];
-                    // Remove the trivial block param from the block definition
-                    self.blocks[block.0].params.remove(*index);
-                    // Replace the trivial block param with the SSA insn_id that it must always be.
-                    self.make_equal_to(trivial_block_param, *insn_id);
-
-                    // At this point we have fixed params at the block definition, but not to conditionals that branch to the block.
-
-                    // Prune the block params from each Insn::Jump and Insn::CondBranch that targets `block`
-                    for &block_with_jump in &jump_blocks {
-                        let insn_id = self.blocks[block_with_jump.0].insns.last().unwrap();
-                        match self.find(*insn_id) {
-                            Insn::Jump(edge) => {
-                                let new_edge = prune_branch_edge(edge, *block, *index);
-                                self.insns[insn_id.0] = Insn::Jump(new_edge);
+            // Update the states
+            for BranchEdge { target, args } in edges {
+                for (i, arg) in args.iter().enumerate().rev() {
+                    // If the param is the same as passed into the block, this means it is a self loop
+                    // We can safely ignore these cases.
+                    if self.chase_insn(*arg) == self.chase_insn(self.blocks[target.0].params[i]) {
+                        continue
+                    }
+                    let state = &mut predecessor_domain[target.0][i];
+                    match *state {
+                        ParamState::Unknown => {
+                            *state = ParamState::Trivial(self.chase_insn(*arg));
+                        },
+                        ParamState::Trivial(value) => {
+                            if value != self.chase_insn(*arg) {
+                                *state = ParamState::NonTrivial;
                             }
-                            Insn::CondBranch { val, if_true, if_false } => {
-                                let new_true_edge = prune_branch_edge(if_true, *block, *index);
-                                let new_false_edge = prune_branch_edge(if_false, *block, *index);
-                                self.insns[insn_id.0] = Insn::CondBranch { val, if_true: new_true_edge, if_false: new_false_edge };
-                            }
-                            _ => {} // This is unreachable
                         }
+                        ParamState::NonTrivial => {},
                     }
                 }
             }
         }
+
+        // Remove the trivial block params and fix up our SSA representation
+        // This is done by as follows.
+        // 1. Replace uses of the trivial params with the concretized value
+        // 2. Remove trivial params from the basic block definition
+        // 3. Remove trivial params from each CondBranch and Jump that targets the basic block that was just updated
+        for (block_id, block) in predecessor_domain.iter().enumerate() {
+            // TODO: Don't do this
+            let block_id = BlockId(block_id);
+
+            let trivial_indices: Vec<usize> = block.iter().enumerate()
+                .filter_map(|(idx, state)|
+                    matches!(state, ParamState::Trivial(_)).then_some(idx)
+                ).collect();
+
+            // Replace uses of the trivial params with the concretized value
+            for param_index in &trivial_indices {
+                if let ParamState::Trivial(concretized_insn) = block[*param_index] {
+                    self.make_equal_to(self.blocks[block_id.0].params[*param_index], concretized_insn);
+                    changed = true;
+                }
+            }
+
+            // Update the block
+            prune_vec_by_indices(&mut self.blocks[block_id.0].params, &trivial_indices);
+
+            // Update the conditionals that branch to block
+            for (jump_block_id, index) in &jumps {
+                let cond_insn_id = self.blocks[jump_block_id.0].insns[*index];
+                match self.find(cond_insn_id) {
+                    Insn::Jump(edge) => {
+                        if edge.target == block_id {
+                            let edge = prune_branch_edge(edge, &trivial_indices);
+                            self.insns[cond_insn_id.0] = Insn::Jump(edge);
+                        }
+                    }
+                    Insn::CondBranch { val, if_true, if_false } => {
+                        if if_true.target == block_id || if_false.target == block_id {
+                            let if_true = prune_branch_edge(if_true, &trivial_indices);
+                            let if_false = prune_branch_edge(if_false, &trivial_indices);
+                            self.insns[cond_insn_id.0] = Insn::CondBranch{ val, if_true, if_false };
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+        }
+
     }
 
 

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5913,103 +5913,145 @@ impl Function {
     /// This function implements algorithm 2 from <https://c9x.me/compile/bib/braun13cc.pdf>.
     /// Light modifications are made to use block params instead of phis.
     fn remove_trivial_block_params(&mut self) {
+        // This abstract domain represents block param optimization potential
+        // If it were constructed as a lattice, Unknown is bottom, trivial is above, nontrivial is top (and above trivial)
+        #[derive(Clone)]
+        enum ParamState {
+            Unknown,
+            NonTrivial,
+            Trivial(InsnId)
+        }
 
-        // Helper function for remove_trivial_block_params
+        fn prune_vec_by_indices<T>(v: &mut Vec<T>, indices: &[usize]) {
+            let mut i: usize = 0;
+            v.retain(|_| {
+                let valid_id = !indices.contains(&i);
+                i += 1;
+                valid_id
+            })
+        }
+
         // Remove an argument of the edge at index if the conditional matches target_block
-        fn prune_branch_edge(edge: BranchEdge, target_block: BlockId, index: usize) -> BranchEdge {
+        fn prune_branch_edge(edge: BranchEdge, indices: &Vec<usize>) -> BranchEdge {
             let mut args = edge.args.clone();
-            if edge.target == target_block {
-                args.remove(index);
-            }
+            prune_vec_by_indices(&mut args, indices);
             BranchEdge { target: edge.target, args }
         }
 
-        // TODO: This stupid function causes borrowing issues so we just duplicated the code for it all over the place omg. Do we remove this or fix it??
-        // fetch_last_insn is a helper to retrieve the final instruction from a block.
-        // We use standard basic blocks so we know that each jump msut be the final instruction in a block.
-        fn fetch_last_insn(blocks: Vec<Block>, block_id: BlockId) -> InsnId {
-            *blocks[block_id.0].insns.last().unwrap()
+        let mut changed = true;
+
+        while changed {
+
+        changed = false;
+
+        // Instantiate the domain for abstract interpretation
+        // Outer index is block
+        // Inner index is param index
+        // Value is the state of the param. This is used to determine whether block param optimization can occur.
+        let mut predecessor_domain: Vec<Vec<ParamState>> = vec![Vec::new(); self.blocks.len()];
+        for (i, block) in self.blocks.iter().enumerate() {
+            predecessor_domain[i].extend(std::iter::repeat_n(ParamState::Unknown, block.params.len()))
         }
 
-        // Find each block that ends with Insn::Jump or Insn::CondBranch. (Equivalently, this is all blocks that don't end with Insn::Return)
-        let jump_blocks: Vec<BlockId> = self.reverse_post_order().into_iter()
+        // Store references to all the conditional instructions.
+        // We need to update these conditionals in the case of trivial block params.
+        let jumps: Vec<(BlockId, usize)> = self.reverse_post_order().into_iter()
             .filter(|&block_id| matches!(
                 self.find(*self.blocks[block_id.0].insns.last().unwrap()),
-                Insn::CondBranch {..} | Insn::Jump {..} )
-            ).collect();
+                Insn::CondBranch {..} | Insn::Jump {..}
+            ))
+            .map(|block_id| (block_id, self.blocks[block_id.0].insns.len() - 1))
+            .collect();
 
-        // Note: The outer vec represents all blocks in the CFG. Using a vec instead of HashMap with keys is safe
-        // because blocks are represented by contiguous values between 0 and len() - 1
-        // This invariant holds because new_block adds a new id based on length, and remove_block only allows the highest block value to be removed.
-        // These are the two functions used to modify block sizes.
-        #[derive(Hash, Eq, PartialEq, Clone, Copy)]
-        struct ArgKey {
-            block: BlockId,
-            index: usize
-        }
-        let mut predecessors: HashMap<ArgKey, Vec<InsnId>> = HashMap::new();
 
-        let mut add_preds = |block: BlockId, args: Vec<InsnId>| {
-            for index in 0..args.len() {
-                predecessors.entry(ArgKey{ block, index }).or_default().push(args[index]);
-            }
-        };
+        // Scan through each jump, collecting edges from CondBranch and Jump insns.
+        for (block_id, insn_index) in &jumps {
+            let insn_id = self.blocks[block_id.0].insns[*insn_index];
+            let mut edges: Vec<BranchEdge> = vec![];
 
-        // Find the predecessors for each conditional HIR instruction in the CFG
-        for insn_id in jump_blocks.iter().map(|block_id| {self.blocks[block_id.0].insns.last().unwrap()}) {
-            match self.find(*insn_id) {
+            match self.find(insn_id) {
                 Insn::CondBranch { if_true, if_false, .. } => {
-                    add_preds(if_true.target, if_true.args);
-                    add_preds(if_false.target, if_false.args);
+                    edges.push(if_true);
+                    edges.push(if_false);
                 }
                 Insn::Jump(edge) => {
-                    add_preds(edge.target, edge.args);
+                    edges.push(edge);
                 }
                 _ => {}
             }
-        }
 
-        // Remove the predecessor self-references
-        let mut external_preds = predecessors.clone();
-        for (key, predecessors) in external_preds.iter_mut() {
-            let pred_from_current_block = self.chase_insn(*self.block(key.block).params().nth(key.index).unwrap());
-            predecessors.retain(|insn_id| self.chase_insn(*insn_id) != pred_from_current_block);
-        }
-
-        // Identify the trivial block params. Trivial means that each external predecessor has the same insn_id.
-        for (ArgKey { block, index }, predecessors) in external_preds.iter() {
-            match predecessors.as_slice() {
-                [] => {} // Unreachable. This should never happen
-                [first, rest @ ..] if rest.iter().any(|insn_id| insn_id != first) => {} // non-trivial
-                [insn_id, ..] => {
-                    // Save the insn_id of the block param to be removed
-                    let trivial_block_param = self.blocks[block.0].params[*index];
-                    // Remove the trivial block param from the block definition
-                    self.blocks[block.0].params.remove(*index);
-                    // Replace the trivial block param with the SSA insn_id that it must always be.
-                    self.make_equal_to(trivial_block_param, *insn_id);
-
-                    // At this point we have fixed params at the block definition, but not to conditionals that branch to the block.
-
-                    // Prune the block params from each Insn::Jump and Insn::CondBranch that targets `block`
-                    for &block_with_jump in &jump_blocks {
-                        let insn_id = self.blocks[block_with_jump.0].insns.last().unwrap();
-                        match self.find(*insn_id) {
-                            Insn::Jump(edge) => {
-                                let new_edge = prune_branch_edge(edge, *block, *index);
-                                self.insns[insn_id.0] = Insn::Jump(new_edge);
+            // Update the states
+            for BranchEdge { target, args } in edges {
+                for (i, arg) in args.iter().enumerate().rev() {
+                    // If the param is the same as passed into the block, this means it is a self loop
+                    // We can safely ignore these cases.
+                    if self.chase_insn(*arg) == self.chase_insn(self.blocks[target.0].params[i]) {
+                        continue
+                    }
+                    let state = &mut predecessor_domain[target.0][i];
+                    match *state {
+                        ParamState::Unknown => {
+                            *state = ParamState::Trivial(self.chase_insn(*arg));
+                        },
+                        ParamState::Trivial(value) => {
+                            if value != self.chase_insn(*arg) {
+                                *state = ParamState::NonTrivial;
                             }
-                            Insn::CondBranch { val, if_true, if_false } => {
-                                let new_true_edge = prune_branch_edge(if_true, *block, *index);
-                                let new_false_edge = prune_branch_edge(if_false, *block, *index);
-                                self.insns[insn_id.0] = Insn::CondBranch { val, if_true: new_true_edge, if_false: new_false_edge };
-                            }
-                            _ => {} // This is unreachable
                         }
+                        ParamState::NonTrivial => {},
                     }
                 }
             }
         }
+
+        // Remove the trivial block params and fix up our SSA representation
+        // This is done by as follows.
+        // 1. Replace uses of the trivial params with the concretized value
+        // 2. Remove trivial params from the basic block definition
+        // 3. Remove trivial params from each CondBranch and Jump that targets the basic block that was just updated
+        for (block_id, block) in predecessor_domain.iter().enumerate() {
+            // TODO: Don't do this
+            let block_id = BlockId(block_id);
+
+            let trivial_indices: Vec<usize> = block.iter().enumerate()
+                .filter_map(|(idx, state)|
+                    matches!(state, ParamState::Trivial(_)).then_some(idx)
+                ).collect();
+
+            // Replace uses of the trivial params with the concretized value
+            for param_index in &trivial_indices {
+                if let ParamState::Trivial(concretized_insn) = block[*param_index] {
+                    self.make_equal_to(self.blocks[block_id.0].params[*param_index], concretized_insn);
+                    changed = true;
+                }
+            }
+
+            // Update the block
+            prune_vec_by_indices(&mut self.blocks[block_id.0].params, &trivial_indices);
+
+            // Update the conditionals that branch to block
+            for (jump_block_id, index) in &jumps {
+                let cond_insn_id = self.blocks[jump_block_id.0].insns[*index];
+                match self.find(cond_insn_id) {
+                    Insn::Jump(edge) => {
+                        if edge.target == block_id {
+                            let edge = prune_branch_edge(edge, &trivial_indices);
+                            self.insns[cond_insn_id.0] = Insn::Jump(edge);
+                        }
+                    }
+                    Insn::CondBranch { val, if_true, if_false } => {
+                        if if_true.target == block_id || if_false.target == block_id {
+                            let if_true = prune_branch_edge(if_true, &trivial_indices);
+                            let if_false = prune_branch_edge(if_false, &trivial_indices);
+                            self.insns[cond_insn_id.0] = Insn::CondBranch{ val, if_true, if_false };
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+        }
+
     }
 
 

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5902,6 +5902,14 @@ impl Function {
             BranchEdge { target: edge.target, args }
         }
 
+        fn insn_passes_params(insn: Insn) -> bool {
+            match insn {
+                Insn::CondBranch {if_true, if_false, ..} => !if_true.args.is_empty() || !if_false.args.is_empty(),
+                Insn::Jump(edge) => !edge.args.is_empty(),
+                _ => false
+            }
+        }
+
         // Instantiate the domain for abstract interpretation
         // Outer index is block
         // Inner index is param index
@@ -5910,14 +5918,11 @@ impl Function {
 
         let mut updated = true;
 
-        // Store references to all the conditional instructions.
-        // We need to update these conditionals in the case of trivial block params.
-        let terminators: Vec<(BlockId, usize)> = self.reverse_post_order().into_iter()
-            .filter(|&block_id| matches!(
-                self.find(*self.blocks[block_id.0].insns.last().unwrap()),
-                Insn::CondBranch {..} | Insn::Jump {..}
-            ))
-            .map(|block_id| (block_id, self.blocks[block_id.0].insns.len() - 1))
+        // Find blocks that terminate with Jump or CondBranch instructions that pass block params along.
+        // These terminators are later analyzed for trivial block params.
+        let param_passing_blocks: Vec<BlockId> = self.reverse_post_order().into_iter()
+            .filter(|&block_id|
+                insn_passes_params(self.find(*self.blocks[block_id.0].insns.last().unwrap())))
             .collect();
 
         while updated {
@@ -5930,18 +5935,25 @@ impl Function {
             // TODO: Maybe move this outside the loop somehow? probably can't immediately, but we could keep track of a worklist of edges that change maybe?
             // And only use the changed ones like a worklist? And then instead of looping to fixpoint we use a worklist based approach?
             //
-            // Scan through each jump, collecting edges from CondBranch and Jump insns.
-            for (block_id, insn_index) in &terminators {
-                let insn_id = self.blocks[block_id.0].insns[*insn_index];
+            // Scan through each jump, collecting edges with params to analyze from CondBranch and Jump insns.
+            for block_id in &param_passing_blocks {
+                let insn_index = self.blocks[block_id.0].insns.len() - 1;
+                let insn_id = self.blocks[block_id.0].insns[insn_index];
                 let mut edges: Vec<BranchEdge> = vec![];
 
                 match self.find(insn_id) {
                     Insn::CondBranch { if_true, if_false, .. } => {
-                        edges.push(if_true);
-                        edges.push(if_false);
+                        if if_true.args.len() > 0 {
+                            edges.push(if_true);
+                        }
+                        if if_false.args.len() > 0 {
+                            edges.push(if_false);
+                        }
                     }
                     Insn::Jump(edge) => {
-                        edges.push(edge);
+                        if edge.args.len() > 0 {
+                            edges.push(edge);
+                        }
                     }
                     _ => {}
                 }
@@ -5976,18 +5988,26 @@ impl Function {
             // 1. Replace uses of the trivial params with the concretized value
             // 2. Remove trivial params from the basic block definition
             // 3. Remove trivial params from each CondBranch and Jump that targets the basic block that was just updated
-            for (block_id, block) in predecessor_domain.iter().enumerate() {
-                // TODO: Don't do this
+            for (block_id, block_preds) in predecessor_domain.iter().enumerate() {
+                // If there are no block params, there is nothing to optimize
+                // TODO: We scan predecessors and only keep track of blocks that pass params.
+                // We don't do this for block_preds but we should. This requires it kind of becoming hash-mappy again :|
+                // This conditional is a stop-gap to get most of the gains from such an optimization, though it should be removed
+                // Maybe we can get around this easier by not iterating over the predecessor domain, but over a subset of indices we care about
+                if block_preds.len() == 0 {
+                    continue
+                }
+
                 let block_id = BlockId(block_id);
 
-                let trivial_indices: Vec<usize> = block.iter().enumerate()
+                let trivial_indices: Vec<usize> = block_preds.iter().enumerate()
                     .filter_map(|(idx, state)|
                         matches!(state, ParamValue::One(_)).then_some(idx)
                     ).collect();
 
                 // Replace uses of the trivial params with the concretized value
                 for param_index in &trivial_indices {
-                    if let ParamValue::One(insn_id) = block[*param_index] {
+                    if let ParamValue::One(insn_id) = block_preds[*param_index] {
                         self.make_equal_to(self.blocks[block_id.0].params[*param_index], insn_id);
                         updated = true;
                     }
@@ -5997,8 +6017,9 @@ impl Function {
                 prune_vec_by_indices(&mut self.blocks[block_id.0].params, &trivial_indices);
 
                 // Update the terminators (basic blocks can only branch at the terminator. This is where block params are passed)
-                for (jump_block_id, index) in &terminators {
-                    let cond_insn_id = self.blocks[jump_block_id.0].insns[*index];
+                for jump_block_id in &param_passing_blocks {
+                    let index = self.blocks[jump_block_id.0].insns.len() - 1;
+                    let cond_insn_id = self.blocks[jump_block_id.0].insns[index];
                     match self.find(cond_insn_id) {
                         Insn::Jump(edge) => {
                             if edge.target == block_id {

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5944,16 +5944,24 @@ impl Function {
             *fun.blocks[block_id.0].insns().last().unwrap()
         }
 
-        fn outgoing_edges(fun: &mut Function, block_id: BlockId) -> impl Iterator<Item = &mut BranchEdge> {
-            let insn_id = block_terminator(fun, block_id);
-            let (first, second) = match fun.resolve(insn_id).insn_mut(fun) {
-                Insn::Jump(edge) => (Some(edge), None),
-                Insn::CondBranch { if_true, if_false, ..} => (Some(if_true), Some(if_false)),
-                _ => (None, None)
+        macro_rules! edges_of {
+            ($insn:expr) => {
+                match $insn {
+                    Insn::Jump(edge) => [Some(edge), None],
+                    Insn::CondBranch { if_true, if_false, .. } => [Some(if_true), Some(if_false)],
+                    _ => [None, None],
+                }.into_iter().flatten()
             };
+        }
 
-            // Keep all edges that pass params
-            first.into_iter().chain(second).filter(|edge| edge.args.len() > 0)
+        fn outgoing_edges(fun: &Function, block_id: BlockId) -> impl Iterator<Item = &BranchEdge> {
+            let insn_id = block_terminator(fun, block_id);
+            edges_of!(&fun.insns[insn_id.0])
+        }
+
+        fn outgoing_edges_mut(fun: &mut Function, block_id: BlockId) -> impl Iterator<Item = &mut BranchEdge> {
+            let insn_id = block_terminator(fun, block_id);
+            edges_of!(&mut fun.insns[insn_id.0])
         }
 
         // Instantiate the domain for abstract interpretation.
@@ -5962,21 +5970,14 @@ impl Function {
 
         let blocks = self.reverse_post_order();
 
-        // Find blocks that terminate with Jump or CondBranch instructions that pass block params along.
-        // These terminators are later analyzed for trivial block params.
-        let predecessor_blocks: Vec<BlockId> = blocks.iter().copied()
+        // Collect blocks that terminate with Jump or CondBranch instructions that pass at least one block param along.
+        let blocks_sending_params: Vec<BlockId> = blocks.iter().copied()
             .filter(|&block_id|
-                // Match against the final instruction which terminates the basic block.
-                // If it has any non-empty edges, keep it.
-                match self.find(block_terminator(self, block_id)) {
-                    Insn::CondBranch { if_true, if_false, .. } => !if_true.args.is_empty() || !if_false.args.is_empty(),
-                    Insn::Jump(edge) => !edge.args.is_empty(),
-                    _ => false
-                })
+                outgoing_edges(self, block_id).any(|edge| !edge.args.is_empty()))
             .collect();
 
         // We only need to update blocks that have params. (Blocks without params cannot be improved)
-        let param_blocks: Vec<BlockId> = blocks.into_iter()
+        let blocks_receiving_params: Vec<BlockId> = blocks.into_iter()
             .filter(|&block_id|
                 self.blocks[block_id.0].params().len() != 0)
             .collect();
@@ -5997,21 +5998,10 @@ impl Function {
             }
 
             // Scan through each jump, collecting edges with params to analyze from CondBranch and Jump insns.
-            for block_id in &predecessor_blocks {
-                let insn_id = block_terminator(self, *block_id);
-
-                let (first, second) = match self.resolve(insn_id).insn(self) {
-                    Insn::Jump(edge) => (Some(edge), None),
-                    Insn::CondBranch { if_true, if_false, ..} => (Some(if_true), Some(if_false)),
-                    _ => (None, None)
-                };
-
-                // Keep all edges that pass params
-                let edges = first.into_iter().chain(second).filter(|edge| edge.args.len() > 0);
-
+            for block_id in &blocks_sending_params {
                 // Use the results of abstract interpretation to update the states
                 // Perform abstract interpretation
-                for BranchEdge { target: block_id, args: params } in edges {
+                for BranchEdge { target: block_id, args: params } in outgoing_edges(self, *block_id) {
                     for (i, param) in params.iter().enumerate() {
                         let param = self.find_id(*param);
                         // If the param is the same as passed into the block, it is a self loop and provides no new predecessor information.
@@ -6028,7 +6018,7 @@ impl Function {
             // 1. Replace uses of the trivial params with the concretized value
             // 2. Remove trivial params from the basic block definition
             // 3. Remove trivial params from each CondBranch and Jump that targets the basic block that was just updated
-            for block_id in &param_blocks {
+            for block_id in &blocks_receiving_params {
                 let block_preds = &predecessor_domain[block_id.0];
                 let trivial_indices: Vec<usize> = block_preds.iter().enumerate()
                     .filter_map(|(idx, state)|
@@ -6047,24 +6037,11 @@ impl Function {
                 prune_vec_by_indices(&mut self.blocks[block_id.0].params, &trivial_indices);
 
                 // Update the terminators (basic blocks can only branch at the terminator. This is where block params are passed)
-                for jump_block_id in &predecessor_blocks {
-                    let index = self.blocks[jump_block_id.0].insns.len() - 1;
-                    let cond_insn_id = self.blocks[jump_block_id.0].insns[index];
-                    match self.resolve(cond_insn_id).insn_mut(self) {
-                        Insn::Jump(edge) => {
-                            if edge.target == *block_id {
-                                prune_vec_by_indices(&mut edge.args, &trivial_indices);
-                            }
+                for jump_block_id in &blocks_sending_params {
+                    for edge in outgoing_edges_mut(self, *jump_block_id) {
+                        if edge.target == *block_id {
+                            prune_vec_by_indices(&mut edge.args, &trivial_indices);
                         }
-                        Insn::CondBranch { if_true, if_false, .. } => {
-                            if if_true.target == *block_id {
-                                prune_vec_by_indices(&mut if_true.args, &trivial_indices);
-                            }
-                            if if_false.target == *block_id {
-                                prune_vec_by_indices(&mut if_false.args, &trivial_indices);
-                            }
-                        }
-                        _ => {}
                     }
                 }
             }

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5944,11 +5944,48 @@ impl Function {
             *fun.blocks[block_id.0].insns().last().unwrap()
         }
 
+        fn outgoing_edges(fun: &mut Function, block_id: BlockId) -> impl Iterator<Item = &mut BranchEdge> {
+            let insn_id = block_terminator(fun, block_id);
+            let (first, second) = match fun.resolve(insn_id).insn_mut(fun) {
+                Insn::Jump(edge) => (Some(edge), None),
+                Insn::CondBranch { if_true, if_false, ..} => (Some(if_true), Some(if_false)),
+                _ => (None, None)
+            };
+
+            // Keep all edges that pass params
+            first.into_iter().chain(second).filter(|edge| edge.args.len() > 0)
+        }
+
         // Instantiate the domain for abstract interpretation.
         // We store possible param values for each block
         let mut predecessor_domain: Vec<Vec<ParamValue>> = vec![Vec::new(); self.blocks.len()];
 
         let blocks = self.reverse_post_order();
+
+        // Find blocks that terminate with Jump or CondBranch instructions that pass block params along.
+        // These terminators are later analyzed for trivial block params.
+        let predecessor_blocks: Vec<BlockId> = blocks.iter().copied()
+            .filter(|&block_id|
+                // Match against the final instruction which terminates the basic block.
+                // If it has any non-empty edges, keep it.
+                match self.find(block_terminator(self, block_id)) {
+                    Insn::CondBranch { if_true, if_false, .. } => !if_true.args.is_empty() || !if_false.args.is_empty(),
+                    Insn::Jump(edge) => !edge.args.is_empty(),
+                    _ => false
+                })
+            .collect();
+
+        // We only need to update blocks that have params. (Blocks without params cannot be improved)
+        let param_blocks: Vec<BlockId> = blocks.into_iter()
+            .filter(|&block_id|
+                self.blocks[block_id.0].params().len() != 0)
+            .collect();
+
+        // NOTE: It is possible that once some block_params are removed, there will be no params.
+        // This means that predecessor_blocks or param_blocks could be pruned. This minor optimization can be added if desired.
+        // Importantly, we do not keep track of exactly which edges correspond to which blocks. While doing so
+        // would allow us to replace our "loop until fixpoint" with a "iterate through the worklist, only checking relevant edges",
+        // the construction of the mapping from predecessor edges to blocks seems expensive.
 
         let mut changed = true;
 
@@ -5960,7 +5997,7 @@ impl Function {
             }
 
             // Scan through each jump, collecting edges with params to analyze from CondBranch and Jump insns.
-            for block_id in &blocks {
+            for block_id in &predecessor_blocks {
                 let insn_id = block_terminator(self, *block_id);
 
                 let (first, second) = match self.resolve(insn_id).insn(self) {
@@ -5991,11 +6028,7 @@ impl Function {
             // 1. Replace uses of the trivial params with the concretized value
             // 2. Remove trivial params from the basic block definition
             // 3. Remove trivial params from each CondBranch and Jump that targets the basic block that was just updated
-            // TODO: Repalce RPO with blocks
-            for block_id in &blocks {
-                // TODO: Add a note about why we can skip these
-                if self.blocks[block_id.0].params().len() == 0 { continue }
-
+            for block_id in &param_blocks {
                 let block_preds = &predecessor_domain[block_id.0];
                 let trivial_indices: Vec<usize> = block_preds.iter().enumerate()
                     .filter_map(|(idx, state)|
@@ -6014,15 +6047,9 @@ impl Function {
                 prune_vec_by_indices(&mut self.blocks[block_id.0].params, &trivial_indices);
 
                 // Update the terminators (basic blocks can only branch at the terminator. This is where block params are passed)
-                for jump_block_id in &blocks {
-                    let optimizable = match self.find(block_terminator(self, *jump_block_id)) {
-                        Insn::CondBranch { if_true, if_false, .. } => !if_true.args.is_empty() || !if_false.args.is_empty(),
-                        Insn::Jump(edge) => !edge.args.is_empty(),
-                        _ => false
-                    };
-                    if !optimizable { continue }
-
-                    let cond_insn_id = block_terminator(self, *jump_block_id);
+                for jump_block_id in &predecessor_blocks {
+                    let index = self.blocks[jump_block_id.0].insns.len() - 1;
+                    let cond_insn_id = self.blocks[jump_block_id.0].insns[index];
                     match self.resolve(cond_insn_id).insn_mut(self) {
                         Insn::Jump(edge) => {
                             if edge.target == *block_id {

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5966,7 +5966,7 @@ impl Function {
 
         // Instantiate the domain for abstract interpretation.
         // We store possible param values for each block
-        let mut predecessor_domain: Vec<Vec<ParamValue>> = vec![Vec::new(); self.blocks.len()];
+        let mut param_values: Vec<Vec<ParamValue>> = vec![Vec::new(); self.blocks.len()];
 
         let blocks = self.reverse_post_order();
 
@@ -5993,7 +5993,7 @@ impl Function {
         while changed {
             changed = false;
 
-            for (row, block) in predecessor_domain.iter_mut().zip(&self.blocks) {
+            for (row, block) in param_values.iter_mut().zip(&self.blocks) {
                 row.resize(block.params.len(), ParamValue::None);
             }
 
@@ -6008,7 +6008,7 @@ impl Function {
                         if param == self.find_id(self.blocks[block_id.0].params[i]) {
                             continue
                         }
-                        predecessor_domain[block_id.0][i].update(param);
+                        param_values[block_id.0][i].update(param);
                     }
                 }
             }
@@ -6019,7 +6019,7 @@ impl Function {
             // 2. Remove trivial params from the basic block definition
             // 3. Remove trivial params from each CondBranch and Jump that targets the basic block that was just updated
             for block_id in &blocks_receiving_params {
-                let block_preds = &predecessor_domain[block_id.0];
+                let block_preds = &param_values[block_id.0];
                 let trivial_indices: Vec<usize> = block_preds.iter().enumerate()
                     .filter_map(|(idx, state)|
                         matches!(state, ParamValue::One(_)).then_some(idx)

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5861,81 +5861,97 @@ impl Function {
         }
     }
 
-    /// Convert maximal SSA (constructed from YARV with `add_iseq_to_hir`) to minimal SSA
-    /// We implement the SSA construction described by Braun et al.
-    /// SSA Paper reference: <https://c9x.me/compile/bib/braun13cc.pdf>
-    fn minify_ssa(&mut self) {
-        // This PR is _very_ much an early draft. I've spent some time reading the paper, and isolating some of the concepts.
-        // There will be lots of lengthy comments that get removed and reworked. There are concepts in ZJIT that are identical but named different things.
-        // We need to map these to each other. It probably makes sense to keep some reference comments performing this mapping for the future too.
-        //
-        // Important difference: Braun et al construct SSA from scratch. We already have a maximal SSA representation. We may be able to get away with only the pruning parts of the paper
-        // Alternatively, we may just need to overhaul our entire SSA construction. I'm not sure what makes sense yet.
-        //
-        // TODO: Make tests for single blocks and multiple block constructions of minimal SSA
-        // It would be great to faithfully recreate examples from the paper but with ZJIT specifics. If there's a way to construct ruby code that maps to this HIR, that would be awesome but jury is still out
-        //
-        // First Test Idea for LVN (page 3):
-        // This first version isn't entirely implementable because `d` and `v?` are intentionally unspecified but it's a good starting point
-        // source (make into ruby)    SSA (make into ZJIT)
-        // a <- 42                    v1: 42
-        // b <- a
-        // c <- a + b                 v2: v1 + v1
-        //                            v3: 23
-        // a <- c + 23                v4: v2 + v3
-        // c <- a + d                 v5: v4 + v?
+    fn try_remove_trivial_phi(BlockId: block_id) {
 
-        // ------------ SINGLE BLOCK ----------------
-        // This section contains all the tech we need for single blocks. For implementation, let's pass tests for this part first before adding in the rest
-        // These two functions handle local value numbering. I don't know if this is something that Max landed in a PR, nor what can / should be repurposed vs written from scratch
-        fn read_variable() {
-            // TODO: Specify and define arguments
-            // TODO: Figure out if this already exists in ZJIT. Likely this uses find or chase_insn?
-        }
+    }
 
-        fn write_variable() {
-            // TODO: Specify and define arguments
-            // TODO: Figure out if this already exists in ZJIT. Likely this uses find or chase_insn?
+    fn remove_trivial_phis(&mut self) {
+        let mut fixpoint = False;
+        while not fixpoint {
+            for block in self.reverse_post_order() {
+                // TODO: Figure out where the predecessors come from
+                predecessors = vec![];
+                try_remove_trivial_phi(block);
+            }
         }
-        //
-        // ------------ MULTIPLE BLOCKS ----------------
-        // When we get to multiple blocks, we need to deal with phi nodes. It seems that in ZJIT, these are referred to as block arguments or block params
-        // It would be really nice to check my knowledge on this, and potentially rename them if so
-        fn read_variable_recursive() {
-            // TODO: fill out
-            // This function is the global value numbering version of the single block variant
-        }
+    }
 
-        fn add_phi_operands() {
-            // See comments in try_remove_triival_phi
-        }
+    // TODO: Probably throw this next big comment away
+    // /// Convert maximal SSA (constructed from YARV with `add_iseq_to_hir`) to minimal SSA
+    // /// We implement the SSA construction described by Braun et al.
+    // /// SSA Paper reference: <https://c9x.me/compile/bib/braun13cc.pdf>
+    // fn minify_ssa(&mut self) {
+    //     // This PR is _very_ much an early draft. I've spent some time reading the paper, and isolating some of the concepts.
+    //     // There will be lots of lengthy comments that get removed and reworked. There are concepts in ZJIT that are identical but named different things.
+    //     // We need to map these to each other. It probably makes sense to keep some reference comments performing this mapping for the future too.
+    //     //
+    //     // Important difference: Braun et al construct SSA from scratch. We already have a maximal SSA representation. We may be able to get away with only the pruning parts of the paper
+    //     // Alternatively, we may just need to overhaul our entire SSA construction. I'm not sure what makes sense yet.
+    //     //
+    //     // TODO: Make tests for single blocks and multiple block constructions of minimal SSA
+    //     // It would be great to faithfully recreate examples from the paper but with ZJIT specifics. If there's a way to construct ruby code that maps to this HIR, that would be awesome but jury is still out
+    //     //
+    //     // First Test Idea for LVN (page 3):
+    //     // This first version isn't entirely implementable because `d` and `v?` are intentionally unspecified but it's a good starting point
+    //     // source (make into ruby)    SSA (make into ZJIT)
+    //     // a <- 42                    v1: 42
+    //     // b <- a
+    //     // c <- a + b                 v2: v1 + v1
+    //     //                            v3: 23
+    //     // a <- c + 23                v4: v2 + v3
+    //     // c <- a + d                 v5: v4 + v?
 
-        fn try_remove_trivial_phi() {
-            // TODO: fill out
-            // This function cleans up the opportunistic phis that get added in Braun's algorithm.
-            // If we didn't add such phis, we run into all sorts of recursion issues. This is a key idea in the algorithm we are implementing
-        }
+    //     // ------------ SINGLE BLOCK ----------------
+    //     // This section contains all the tech we need for single blocks. For implementation, let's pass tests for this part first before adding in the rest
+    //     // These two functions handle local value numbering. I don't know if this is something that Max landed in a PR, nor what can / should be repurposed vs written from scratch
+    //     fn read_variable() {
+    //         // TODO: Specify and define arguments
+    //         // TODO: Figure out if this already exists in ZJIT. Likely this uses find or chase_insn?
+    //     }
 
-        // ---------- INCOMPLETE CFGS --------------
-        // While technically part of the multiple blocks section, the next functions are even more complicated so they get their own section
-        fn seal_block() {
-            // We call a block "sealed" when we know there will not be predecessors added to the block.
-            // This function adds all necessary phis to incomplete blocks and adds this block to the sealed list
-        }
+    //     fn write_variable() {
+    //         // TODO: Specify and define arguments
+    //         // TODO: Figure out if this already exists in ZJIT. Likely this uses find or chase_insn?
+    //     }
+    //     //
+    //     // ------------ MULTIPLE BLOCKS ----------------
+    //     // When we get to multiple blocks, we need to deal with phi nodes. It seems that in ZJIT, these are referred to as block arguments or block params
+    //     // It would be really nice to check my knowledge on this, and potentially rename them if so
+    //     fn read_variable_recursive() {
+    //         // TODO: fill out
+    //         // This function is the global value numbering version of the single block variant
+    //     }
 
-        // I don't yet know which optimizations we want to include during construction. Pages 8 and 9 of the paper show why this is non-trivial and important for us to figure out
-        // However, the following tools are definitely necessary
-        fn remove_redundant_phis() {
-            // In the paper, they innovate by considering irreducible control flow from the perspective of the strongly connected component that _must_ exist if there are redundant phis
-            // By computing this strongly connected component, we can figure out what to remove (with the following function)
-        }
+    //     fn add_phi_operands() {
+    //         // See comments in try_remove_triival_phi
+    //     }
 
-        fn process_strongly_connected_component() {
-            // Do some fancy logic to iterate across all the phis in the SCC, tracking "inner" and "outer" operations
-        }
+    //     fn try_remove_trivial_phi() {
+    //         // TODO: fill out
+    //         // This function cleans up the opportunistic phis that get added in Braun's algorithm.
+    //         // If we didn't add such phis, we run into all sorts of recursion issues. This is a key idea in the algorithm we are implementing
+    //     }
 
-        // TODO: Close reading of page 11 after implementing everything else to see if there are further optimizations to be made
-        // Key issue: we construct a lot of phis and then remove a lot of phis. Can we construct fewer in the first place?
+    //     // ---------- INCOMPLETE CFGS --------------
+    //     // While technically part of the multiple blocks section, the next functions are even more complicated so they get their own section
+    //     fn seal_block() {
+    //         // We call a block "sealed" when we know there will not be predecessors added to the block.
+    //         // This function adds all necessary phis to incomplete blocks and adds this block to the sealed list
+    //     }
+
+    //     // I don't yet know which optimizations we want to include during construction. Pages 8 and 9 of the paper show why this is non-trivial and important for us to figure out
+    //     // However, the following tools are definitely necessary
+    //     fn remove_redundant_phis() {
+    //         // In the paper, they innovate by considering irreducible control flow from the perspective of the strongly connected component that _must_ exist if there are redundant phis
+    //         // By computing this strongly connected component, we can figure out what to remove (with the following function)
+    //     }
+
+    //     fn process_strongly_connected_component() {
+    //         // Do some fancy logic to iterate across all the phis in the SCC, tracking "inner" and "outer" operations
+    //     }
+
+    //     // TODO: Close reading of page 11 after implementing everything else to see if there are further optimizations to be made
+    //     // Key issue: we construct a lot of phis and then remove a lot of phis. Can we construct fewer in the first place?
 
     }
 
@@ -6733,7 +6749,7 @@ impl Function {
             (convert_no_profile_sends) => { Counter::compile_hir_strength_reduce_time_ns };
             // End strength reduction bucket
             (inline_methods) => { Counter::compile_hir_inline_methods_time_ns };
-            (minify_ssa) => { Counter::compile_hir_minify_ssa_time_ns };
+            (remove_trivial_phis) => { Counter::compile_hir_remove_trivial_phis_time_ns };
             (optimize_load_store) => { Counter::compile_hir_optimize_load_store_time_ns };
             (canonicalize) => { Counter::compile_hir_canonicalize_time_ns };
             (fold_constants) => { Counter::compile_hir_fold_constants_time_ns };
@@ -6787,7 +6803,7 @@ impl Function {
             // TODO: Figure out where the pass should go and remove these comments
             // It's not clear where converting to minimal SSA should occur
             // We need it for a global optimize_load_store, so this is a good starting point
-            run_pass!(minify_ssa);
+            run_pass!(remove_trivial_phis);
             run_pass!(optimize_load_store);
             run_pass!(canonicalize);
             run_pass!(fold_constants);

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5861,28 +5861,33 @@ impl Function {
         }
     }
 
-
-    // TODO: Add a comment about the paper and where this function comes from, as well as how it's used in ZJIT
-    // (It's used more individually and differently than the paper)
-    // TODO: Update comments to consider block params rather than phi nodes and demarcate differences from the algorithm clearly
-    // TODO: Fix input arguments. We need block params, not just the phi
-    // If all possible phi values are the same, replace the phi with the value
-    // TODO: Add Max's optimization about not checking the first block. Maybe do this by keeping track of all changing edges and using a worklist?
-
-    /// Sometimes block params can only come from one place and safely removed as block params.
-    /// Trivial block param removal increases the efficacy of CFG-based optimization passes.
-    /// This function implements algorithm 2 from <https://c9x.me/compile/bib/braun13cc.pdf>.
-    /// Light modifications are made to use block params instead of phis.
+    /// ZJIT uses block parameters in HIR SSA representation.
+    /// Sometimes, we can prove that a block param is only called with a single value.
+    /// This pass identifies such trivial block params and replaces them with the concretized value.
+    /// This produces a minimal SSA representation amenable to further optimizations.
+    /// The implementation is inspired from algorithm 2 in <https://c9x.me/compile/bib/braun13cc.pdf>.
     fn remove_trivial_block_params(&mut self) {
-        // Each block param corresponds to a ParamValue
-        // This is the abstract domain used for abstract interpretation
-        // If there are no predecessors or multiple predecessors to a param, no optimization can happen
-        // However if there is a single unique predecessor, then the block param is trivial and we can replace with its concretized value
-        #[derive(Clone)]
+        // Each block param is lifted to an abstract domain of ParamValues.
+        // The lattice is simple. None is Bottom, Multiple is Top, and One is between both.
+        // During analysis, all block params start with None.
+        // New values passed to the block transition up the lattice.
+        // Trivial block params have one unique value. This is the case we optimize away.
+        // Lattice structure taken from cranelift: <https://github.com/bytecodealliance/wasmtime/blob/main/cranelift/codegen/src/remove_constant_phis.rs>
+        #[derive(Clone, Copy)]
         enum ParamValue {
             None,
             One(InsnId),
-            Multiple
+            Many
+        }
+
+        impl ParamValue {
+            fn update(&mut self, value: InsnId) {
+                *self = match *self {
+                    ParamValue::None => ParamValue::One(value),
+                    ParamValue::One(original) if original != value => ParamValue::Many,
+                    other => other
+                };
+            }
         }
 
         // Helper function to remove selected indices from a vec in place
@@ -5902,61 +5907,59 @@ impl Function {
             BranchEdge { target: edge.target, args }
         }
 
-        fn insn_passes_params(insn: Insn) -> bool {
-            match insn {
-                Insn::CondBranch {if_true, if_false, ..} => !if_true.args.is_empty() || !if_false.args.is_empty(),
-                Insn::Jump(edge) => !edge.args.is_empty(),
-                _ => false
-            }
-        }
-
-        // Instantiate the domain for abstract interpretation
-        // Outer index is block
-        // Inner index is param index
-        // Value is the state of the param. This is used to determine whether block param optimization can occur.
+        // Instantiate the domain for abstract interpretation.
+        // We store possible param values for each block
         let mut predecessor_domain: Vec<Vec<ParamValue>> = vec![Vec::new(); self.blocks.len()];
 
-        let mut updated = true;
+        let blocks = self.reverse_post_order();
 
         // Find blocks that terminate with Jump or CondBranch instructions that pass block params along.
         // These terminators are later analyzed for trivial block params.
-        let param_passing_blocks: Vec<BlockId> = self.reverse_post_order().into_iter()
+        let predecessor_blocks: Vec<BlockId> = blocks.iter().copied()
             .filter(|&block_id|
-                insn_passes_params(self.find(*self.blocks[block_id.0].insns.last().unwrap())))
+                // Match against the final instruction which terminates the basic block.
+                // If it has any non-empty edges, keep it.
+                match self.find(*self.blocks[block_id.0].insns().last().unwrap()) {
+                    Insn::CondBranch {if_true, if_false, ..} => !if_true.args.is_empty() || !if_false.args.is_empty(),
+                    Insn::Jump(edge) => !edge.args.is_empty(),
+                    _ => false
+                })
             .collect();
 
-        while updated {
+        // We only need to update blocks that have params. (Blocks without params cannot be improved)
+        let param_blocks: Vec<BlockId> = blocks.into_iter()
+            .filter(|&block_id|
+                self.blocks[block_id.0].params().len() != 0)
+            .collect();
+
+        // NOTE: It is possible that once some block_params are removed, there will be no params.
+        // This means that predecessor_blocks or param_blocks could be pruned. This minor optimization can be added if desired.
+        // Importantly, we do not keep track of exactly which edges correspond to which blocks. While doing so
+        // would allow us to replace our "loop until fixpoint" with a "iterate through the worklist, only checking relevant edges",
+        // the construction of the mapping from predecessor edges to blocks seems expensive.
+
+        let mut changed = true;
+
+        while changed {
+            changed = false;
 
             for (row, block) in predecessor_domain.iter_mut().zip(&self.blocks) {
                 row.resize(block.params.len(), ParamValue::None);
             }
-            updated = false;
 
-            // TODO: Maybe move this outside the loop somehow? probably can't immediately, but we could keep track of a worklist of edges that change maybe?
-            // And only use the changed ones like a worklist? And then instead of looping to fixpoint we use a worklist based approach?
-            //
             // Scan through each jump, collecting edges with params to analyze from CondBranch and Jump insns.
-            for block_id in &param_passing_blocks {
-                let insn_index = self.blocks[block_id.0].insns.len() - 1;
-                let insn_id = self.blocks[block_id.0].insns[insn_index];
-                let mut edges: Vec<BranchEdge> = vec![];
+            for block_id in &predecessor_blocks {
+                let insn_id = *self.blocks[block_id.0].insns.last().unwrap();
 
-                match self.find(insn_id) {
-                    Insn::CondBranch { if_true, if_false, .. } => {
-                        if if_true.args.len() > 0 {
-                            edges.push(if_true);
-                        }
-                        if if_false.args.len() > 0 {
-                            edges.push(if_false);
-                        }
-                    }
-                    Insn::Jump(edge) => {
-                        if edge.args.len() > 0 {
-                            edges.push(edge);
-                        }
-                    }
-                    _ => {}
-                }
+                // Extract edges into a tuple for processing
+                let (first, second) = match self.find(insn_id) {
+                    Insn::Jump(edge) => (Some(edge), None),
+                    Insn::CondBranch { if_true, if_false, ..} => (Some(if_true), Some(if_false)),
+                    _ => (None, None)
+                };
+
+                // Keep all edges that pass params
+                let edges = first.into_iter().chain(second).filter(|edge| edge.args.len() > 0);
 
                 // Use the results of abstract interpretation to update the states
                 // Perform abstract interpretation
@@ -5967,18 +5970,7 @@ impl Function {
                         if param == self.find_id(self.blocks[block_id.0].params[i]) {
                             continue
                         }
-                        let state = &mut predecessor_domain[block_id.0][i];
-                        match *state {
-                            ParamValue::None => {
-                                *state = ParamValue::One(param);
-                            },
-                            ParamValue::One(value) => {
-                                if value != param {
-                                    *state = ParamValue::Multiple;
-                                }
-                            }
-                            ParamValue::Multiple => {},
-                        }
+                        predecessor_domain[block_id.0][i].update(param);
                     }
                 }
             }
@@ -5988,18 +5980,8 @@ impl Function {
             // 1. Replace uses of the trivial params with the concretized value
             // 2. Remove trivial params from the basic block definition
             // 3. Remove trivial params from each CondBranch and Jump that targets the basic block that was just updated
-            for (block_id, block_preds) in predecessor_domain.iter().enumerate() {
-                // If there are no block params, there is nothing to optimize
-                // TODO: We scan predecessors and only keep track of blocks that pass params.
-                // We don't do this for block_preds but we should. This requires it kind of becoming hash-mappy again :|
-                // This conditional is a stop-gap to get most of the gains from such an optimization, though it should be removed
-                // Maybe we can get around this easier by not iterating over the predecessor domain, but over a subset of indices we care about
-                if block_preds.len() == 0 {
-                    continue
-                }
-
-                let block_id = BlockId(block_id);
-
+            for block_id in &param_blocks {
+                let block_preds = &predecessor_domain[block_id.0];
                 let trivial_indices: Vec<usize> = block_preds.iter().enumerate()
                     .filter_map(|(idx, state)|
                         matches!(state, ParamValue::One(_)).then_some(idx)
@@ -6009,7 +5991,7 @@ impl Function {
                 for param_index in &trivial_indices {
                     if let ParamValue::One(insn_id) = block_preds[*param_index] {
                         self.make_equal_to(self.blocks[block_id.0].params[*param_index], insn_id);
-                        updated = true;
+                        changed = true;
                     }
                 }
 
@@ -6017,23 +5999,23 @@ impl Function {
                 prune_vec_by_indices(&mut self.blocks[block_id.0].params, &trivial_indices);
 
                 // Update the terminators (basic blocks can only branch at the terminator. This is where block params are passed)
-                for jump_block_id in &param_passing_blocks {
+                for jump_block_id in &predecessor_blocks {
                     let index = self.blocks[jump_block_id.0].insns.len() - 1;
                     let cond_insn_id = self.blocks[jump_block_id.0].insns[index];
                     match self.find(cond_insn_id) {
                         Insn::Jump(edge) => {
-                            if edge.target == block_id {
+                            if edge.target == *block_id {
                                 let edge = prune_branch_edge(edge, &trivial_indices);
                                 self.insns[cond_insn_id.0] = Insn::Jump(edge);
                             }
                         }
                         Insn::CondBranch { val, if_true, if_false } => {
-                            let if_true = if if_true.target == block_id {
+                            let if_true = if if_true.target == *block_id {
                                 prune_branch_edge(if_true, &trivial_indices)
                             } else {
                                 if_true
                             };
-                            let if_false = if if_false.target == block_id {
+                            let if_false = if if_false.target == *block_id {
                                 prune_branch_edge(if_false, &trivial_indices)
                             } else {
                                 if_false

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5901,6 +5901,84 @@ impl Function {
         }
     }
 
+    /// Convert maximal SSA (constructed from YARV with `add_iseq_to_hir`) to minimal SSA
+    /// We implement the SSA construction described by Braun et al.
+    /// SSA Paper reference: <https://c9x.me/compile/bib/braun13cc.pdf>
+    fn minify_ssa(&mut self) {
+        // This PR is _very_ much an early draft. I've spent some time reading the paper, and isolating some of the concepts.
+        // There will be lots of lengthy comments that get removed and reworked. There are concepts in ZJIT that are identical but named different things.
+        // We need to map these to each other. It probably makes sense to keep some reference comments performing this mapping for the future too.
+        //
+        // Important difference: Braun et al construct SSA from scratch. We already have a maximal SSA representation. We may be able to get away with only the pruning parts of the paper
+        // Alternatively, we may just need to overhaul our entire SSA construction. I'm not sure what makes sense yet.
+        //
+        // TODO: Make tests for single blocks and multiple block constructions of minimal SSA
+        // It would be great to faithfully recreate examples from the paper but with ZJIT specifics. If there's a way to construct ruby code that maps to this HIR, that would be awesome but jury is still out
+        //
+        // First Test Idea for LVN (page 3):
+        // This first version isn't entirely implementable because `d` and `v?` are intentionally unspecified but it's a good starting point
+        // source (make into ruby)    SSA (make into ZJIT)
+        // a <- 42                    v1: 42
+        // b <- a
+        // c <- a + b                 v2: v1 + v1
+        //                            v3: 23
+        // a <- c + 23                v4: v2 + v3
+        // c <- a + d                 v5: v4 + v?
+
+        // ------------ SINGLE BLOCK ----------------
+        // This section contains all the tech we need for single blocks. For implementation, let's pass tests for this part first before adding in the rest
+        // These two functions handle local value numbering. I don't know if this is something that Max landed in a PR, nor what can / should be repurposed vs written from scratch
+        fn read_variable() {
+            // TODO: Specify and define arguments
+            // TODO: Figure out if this already exists in ZJIT. Likely this uses find or chase_insn?
+        }
+
+        fn write_variable() {
+            // TODO: Specify and define arguments
+            // TODO: Figure out if this already exists in ZJIT. Likely this uses find or chase_insn?
+        }
+        //
+        // ------------ MULTIPLE BLOCKS ----------------
+        // When we get to multiple blocks, we need to deal with phi nodes. It seems that in ZJIT, these are referred to as block arguments or block params
+        // It would be really nice to check my knowledge on this, and potentially rename them if so
+        fn read_variable_recursive() {
+            // TODO: fill out
+            // This function is the global value numbering version of the single block variant
+        }
+
+        fn add_phi_operands() {
+            // See comments in try_remove_triival_phi
+        }
+
+        fn try_remove_trivial_phi() {
+            // TODO: fill out
+            // This function cleans up the opportunistic phis that get added in Braun's algorithm.
+            // If we didn't add such phis, we run into all sorts of recursion issues. This is a key idea in the algorithm we are implementing
+        }
+
+        // ---------- INCOMPLETE CFGS --------------
+        // While technically part of the multiple blocks section, the next functions are even more complicated so they get their own section
+        fn seal_block() {
+            // We call a block "sealed" when we know there will not be predecessors added to the block.
+            // This function adds all necessary phis to incomplete blocks and adds this block to the sealed list
+        }
+
+        // I don't yet know which optimizations we want to include during construction. Pages 8 and 9 of the paper show why this is non-trivial and important for us to figure out
+        // However, the following tools are definitely necessary
+        fn remove_redundant_phis() {
+            // In the paper, they innovate by considering irreducible control flow from the perspective of the strongly connected component that _must_ exist if there are redundant phis
+            // By computing this strongly connected component, we can figure out what to remove (with the following function)
+        }
+
+        fn process_strongly_connected_component() {
+            // Do some fancy logic to iterate across all the phis in the SCC, tracking "inner" and "outer" operations
+        }
+
+        // TODO: Close reading of page 11 after implementing everything else to see if there are further optimizations to be made
+        // Key issue: we construct a lot of phis and then remove a lot of phis. Can we construct fewer in the first place?
+
+    }
+
     fn optimize_load_store(&mut self) {
         for block in self.reverse_post_order() {
             let mut compile_time_heap: HashMap<(InsnId, i32), InsnId>  = HashMap::new();
@@ -6727,6 +6805,7 @@ impl Function {
             (convert_no_profile_sends) => { Counter::compile_hir_strength_reduce_time_ns };
             // End strength reduction bucket
             (inline_methods) => { Counter::compile_hir_inline_methods_time_ns };
+            (minify_ssa) => { Counter::compile_hir_minify_ssa_time_ns };
             (optimize_load_store) => { Counter::compile_hir_optimize_load_store_time_ns };
             (canonicalize) => { Counter::compile_hir_canonicalize_time_ns };
             (fold_constants) => { Counter::compile_hir_fold_constants_time_ns };
@@ -6777,6 +6856,10 @@ impl Function {
                 false
             };
             run_pass!(convert_no_profile_sends);
+            // TODO: Figure out where the pass should go and remove these comments
+            // It's not clear where converting to minimal SSA should occur
+            // We need it for a global optimize_load_store, so this is a good starting point
+            run_pass!(minify_ssa);
             run_pass!(optimize_load_store);
             run_pass!(canonicalize);
             run_pass!(fold_constants);

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5906,14 +5906,8 @@ impl Function {
         // Inner index is param index
         // Value is the state of the param. This is used to determine whether block param optimization can occur.
         let mut predecessor_domain: Vec<Vec<ParamValue>> = vec![Vec::new(); self.blocks.len()];
+
         let mut updated = true;
-
-        while updated {
-
-        for (row, block) in predecessor_domain.iter_mut().zip(&self.blocks) {
-            row.resize(block.params.len(), ParamValue::None);
-        }
-        updated = false;
 
         // Store references to all the conditional instructions.
         // We need to update these conditionals in the case of trivial block params.
@@ -5925,6 +5919,12 @@ impl Function {
             .map(|block_id| (block_id, self.blocks[block_id.0].insns.len() - 1))
             .collect();
 
+        while updated {
+
+        for (row, block) in predecessor_domain.iter_mut().zip(&self.blocks) {
+            row.resize(block.params.len(), ParamValue::None);
+        }
+        updated = false;
 
         // Scan through each jump, collecting edges from CondBranch and Jump insns.
         for (block_id, insn_index) in &terminators {

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5940,13 +5940,6 @@ impl Function {
             })
         }
 
-        // Remove arguments of the edge at selected indices
-        fn prune_branch_edge(edge: BranchEdge, indices: &Vec<usize>) -> BranchEdge {
-            let mut args = edge.args.clone();
-            prune_vec_by_indices(&mut args, indices);
-            BranchEdge { target: edge.target, args }
-        }
-
         // Instantiate the domain for abstract interpretation.
         // We store possible param values for each block
         let mut predecessor_domain: Vec<Vec<ParamValue>> = vec![Vec::new(); self.blocks.len()];
@@ -5991,8 +5984,10 @@ impl Function {
             for block_id in &predecessor_blocks {
                 let insn_id = *self.blocks[block_id.0].insns.last().unwrap();
 
+                // TODO: Add a function to flatten edges into an iterator for jumps and condbranches.
+                // TODO: Make sure to use this when we update edges in the block later
                 // Extract edges into a tuple for processing
-                let (first, second) = match self.find(insn_id) {
+                let (first, second) = match self.resolve(insn_id).insn(self) {
                     Insn::Jump(edge) => (Some(edge), None),
                     Insn::CondBranch { if_true, if_false, ..} => (Some(if_true), Some(if_false)),
                     _ => (None, None)
@@ -6004,7 +5999,7 @@ impl Function {
                 // Use the results of abstract interpretation to update the states
                 // Perform abstract interpretation
                 for BranchEdge { target: block_id, args: params } in edges {
-                    for (i, param) in params.iter().enumerate().rev() {
+                    for (i, param) in params.iter().enumerate() {
                         let param = self.find_id(*param);
                         // If the param is the same as passed into the block, it is a self loop and provides no new predecessor information.
                         if param == self.find_id(self.blocks[block_id.0].params[i]) {
@@ -6042,25 +6037,19 @@ impl Function {
                 for jump_block_id in &predecessor_blocks {
                     let index = self.blocks[jump_block_id.0].insns.len() - 1;
                     let cond_insn_id = self.blocks[jump_block_id.0].insns[index];
-                    match self.find(cond_insn_id) {
+                    match self.resolve(cond_insn_id).insn_mut(self) {
                         Insn::Jump(edge) => {
                             if edge.target == *block_id {
-                                let edge = prune_branch_edge(edge, &trivial_indices);
-                                self.insns[cond_insn_id.0] = Insn::Jump(edge);
+                                prune_vec_by_indices(&mut edge.args, &trivial_indices);
                             }
                         }
-                        Insn::CondBranch { val, if_true, if_false } => {
-                            let if_true = if if_true.target == *block_id {
-                                prune_branch_edge(if_true, &trivial_indices)
-                            } else {
-                                if_true
-                            };
-                            let if_false = if if_false.target == *block_id {
-                                prune_branch_edge(if_false, &trivial_indices)
-                            } else {
-                                if_false
-                            };
-                            self.insns[cond_insn_id.0] = Insn::CondBranch{ val, if_true, if_false };
+                        Insn::CondBranch { if_true, if_false, .. } => {
+                            if if_true.target == *block_id {
+                                prune_vec_by_indices(&mut if_true.args, &trivial_indices);
+                            }
+                            if if_false.target == *block_id {
+                                prune_vec_by_indices(&mut if_false.args, &trivial_indices);
+                            }
                         }
                         _ => {}
                     }

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5901,129 +5901,117 @@ impl Function {
         }
     }
 
+
     // TODO: Add a comment about the paper and where this function comes from, as well as how it's used in ZJIT
     // (It's used more individually and differently than the paper)
     // TODO: Update comments to consider block params rather than phi nodes and demarcate differences from the algorithm clearly
     // TODO: Fix input arguments. We need block params, not just the phi
     /// If all possible phi values are the same, replace the phi with the value
 
-    fn remove_trivial_phis(&mut self) {
-        // TODO: Find all of the phis and predecessors
-        let phi = &InsnId(5); // FIX: this shouldn't be just a random dummy value
-        let predecessors = vec![];
-        // TODO: Run the following in a loop once we've gotten all the phis
-        // TODO: Figure out if we want to do this mutably and in one pass with into_iter or take instead.
-        let phis: Vec<(BlockId, InsnId)> = self.reverse_post_order().iter().flat_map(|block_id| {
-            self.blocks[block_id.0].params().map(|&param| (*block_id, param))
-        }).collect();
-        // FIX: The logic if this is wrong. We want to make sure `p` is not a self reference. Equality with phi likely does not do this
-        let external_preds: Vec<&InsnId> = predecessors.iter().filter(|p| *p != phi).collect();
+    /// Sometimes block params can only come from one place and safely removed as block params.
+    /// Trivial block param removal increases the efficacy of CFG-based optimization passes.
+    /// This function implements algorithm 2 from <https://c9x.me/compile/bib/braun13cc.pdf>.
+    /// Light modifications are made to use block params instead of phis.
+    fn remove_trivial_block_params(&mut self) {
 
-        match external_preds.as_slice() {
-            [] => {} // Phi is unreachable
-            [first, rest @ ..] if rest.iter().any(|p| p != first) => {} // Phi is non-trivial
-            [value, ..] => { // Phi is trivial
-
+        // Helper function for remove_trivial_block_params
+        // Remove an argument of the edge at index if the conditional matches target_block
+        fn prune_branch_edge(edge: BranchEdge, target_block: BlockId, index: usize) -> BranchEdge {
+            let mut args = edge.args.clone();
+            if edge.target == target_block {
+                args.remove(index);
             }
-
+            BranchEdge { target: edge.target, args }
         }
-        let new_phi = match external_preds.as_slice() {
-            [] => {
-                // Phi is unreachable
-                // TODO: Figure out how we are supposed to handle an unreachable phi
-                *phi // FIX: We don't want to return phi in this case. What do we want to do with an unreachable value??
-            }
-            [first, rest @ ..] if rest.iter().any(|p| p != first) => {
-                // Phi is non-trivial
-                *phi
-            }
-            [value, ..] => {
-                // Phi is trivial. All elements of the vec are `value`.
-                // TODO: Replace all uses of phi with value with make_equal_to
-                // TODO: Iteratively call try_remove_trivial_phi on uses. Can we get uses with find?
-                **value
+
+        // TODO: This stupid function causes borrowing issues so we just duplicated the code for it all over the place omg. Do we remove this or fix it??
+        // fetch_last_insn is a helper to retrieve the final instruction from a block.
+        // We use standard basic blocks so we know that each jump msut be the final instruction in a block.
+        fn fetch_last_insn(blocks: Vec<Block>, block_id: BlockId) -> InsnId {
+            *blocks[block_id.0].insns.last().unwrap()
+        }
+
+        // Find each block that ends with Insn::Jump or Insn::CondBranch. (Equivalently, this is all blocks that don't end with Insn::Return)
+        let jump_blocks: Vec<BlockId> = self.reverse_post_order().into_iter()
+            .filter(|&block_id| matches!(
+                self.find(*self.blocks[block_id.0].insns.last().unwrap()),
+                Insn::CondBranch {..} | Insn::Jump {..} )
+            ).collect();
+
+        // Note: The outer vec represents all blocks in the CFG. Using a vec instead of HashMap with keys is safe
+        // because blocks are represented by contiguous values between 0 and len() - 1
+        // This invariant holds because new_block adds a new id based on length, and remove_block only allows the highest block value to be removed.
+        // These are the two functions used to modify block sizes.
+        #[derive(Hash, Eq, PartialEq, Clone, Copy)]
+        struct ArgKey {
+            block: BlockId,
+            index: usize
+        }
+        let mut predecessors: HashMap<ArgKey, Vec<InsnId>> = HashMap::new();
+
+        let mut add_preds = |block: BlockId, args: Vec<InsnId>| {
+            for index in 0..args.len() {
+                predecessors.entry(ArgKey{ block, index }).or_default().push(args[index]);
             }
         };
+
+        // Find the predecessors for each conditional HIR instruction in the CFG
+        for insn_id in jump_blocks.iter().map(|block_id| {self.blocks[block_id.0].insns.last().unwrap()}) {
+            match self.find(*insn_id) {
+                Insn::CondBranch { if_true, if_false, .. } => {
+                    add_preds(if_true.target, if_true.args);
+                    add_preds(if_false.target, if_false.args);
+                }
+                Insn::Jump(edge) => {
+                    add_preds(edge.target, edge.args);
+                }
+                _ => {}
+            }
+        }
+
+        // Remove the predecessor self-references
+        let mut external_preds = predecessors.clone();
+        for (key, predecessors) in external_preds.iter_mut() {
+            let pred_from_current_block = self.chase_insn(*self.block(key.block).params().nth(key.index).unwrap());
+            predecessors.retain(|insn_id| self.chase_insn(*insn_id) != pred_from_current_block);
+        }
+
+        // Identify the trivial block params. Trivial means that each external predecessor has the same insn_id.
+        for (ArgKey { block, index }, predecessors) in external_preds.iter() {
+            match predecessors.as_slice() {
+                [] => {} // Unreachable. This should never happen
+                [first, rest @ ..] if rest.iter().any(|insn_id| insn_id != first) => {} // non-trivial
+                [insn_id, ..] => {
+                    // Save the insn_id of the block param to be removed
+                    let trivial_block_param = self.blocks[block.0].params[*index];
+                    // Remove the trivial block param from the block definition
+                    self.blocks[block.0].params.remove(*index);
+                    // Replace the trivial block param with the SSA insn_id that it must always be.
+                    self.make_equal_to(trivial_block_param, *insn_id);
+
+                    // At this point we have fixed params at the block definition, but not to conditionals that branch to the block.
+
+                    // Prune the block params from each Insn::Jump and Insn::CondBranch that targets `block`
+                    for &block_with_jump in &jump_blocks {
+                        let insn_id = self.blocks[block_with_jump.0].insns.last().unwrap();
+                        match self.find(*insn_id) {
+                            Insn::Jump(edge) => {
+                                let new_edge = prune_branch_edge(edge, *block, *index);
+                                self.insns[insn_id.0] = Insn::Jump(new_edge);
+                            }
+                            Insn::CondBranch { val, if_true, if_false } => {
+                                let new_true_edge = prune_branch_edge(if_true, *block, *index);
+                                let new_false_edge = prune_branch_edge(if_false, *block, *index);
+                                self.insns[insn_id.0] = Insn::CondBranch { val, if_true: new_true_edge, if_false: new_false_edge };
+                            }
+                            _ => {} // This is unreachable
+                        }
+                    }
+                }
+            }
+        }
     }
 
-    // TODO: Probably throw this next big comment away
-    // /// Convert maximal SSA (constructed from YARV with `add_iseq_to_hir`) to minimal SSA
-    // /// We implement the SSA construction described by Braun et al.
-    // /// SSA Paper reference: <https://c9x.me/compile/bib/braun13cc.pdf>
-    // fn minify_ssa(&mut self) {
-    //     // This PR is _very_ much an early draft. I've spent some time reading the paper, and isolating some of the concepts.
-    //     // There will be lots of lengthy comments that get removed and reworked. There are concepts in ZJIT that are identical but named different things.
-    //     // We need to map these to each other. It probably makes sense to keep some reference comments performing this mapping for the future too.
-    //     //
-    //     // Important difference: Braun et al construct SSA from scratch. We already have a maximal SSA representation. We may be able to get away with only the pruning parts of the paper
-    //     // Alternatively, we may just need to overhaul our entire SSA construction. I'm not sure what makes sense yet.
-    //     //
-    //     // TODO: Make tests for single blocks and multiple block constructions of minimal SSA
-    //     // It would be great to faithfully recreate examples from the paper but with ZJIT specifics. If there's a way to construct ruby code that maps to this HIR, that would be awesome but jury is still out
-    //     //
-    //     // First Test Idea for LVN (page 3):
-    //     // This first version isn't entirely implementable because `d` and `v?` are intentionally unspecified but it's a good starting point
-    //     // source (make into ruby)    SSA (make into ZJIT)
-    //     // a <- 42                    v1: 42
-    //     // b <- a
-    //     // c <- a + b                 v2: v1 + v1
-    //     //                            v3: 23
-    //     // a <- c + 23                v4: v2 + v3
-    //     // c <- a + d                 v5: v4 + v?
-
-    //     // ------------ SINGLE BLOCK ----------------
-    //     // This section contains all the tech we need for single blocks. For implementation, let's pass tests for this part first before adding in the rest
-    //     // These two functions handle local value numbering. I don't know if this is something that Max landed in a PR, nor what can / should be repurposed vs written from scratch
-    //     fn read_variable() {
-    //         // TODO: Specify and define arguments
-    //         // TODO: Figure out if this already exists in ZJIT. Likely this uses find or chase_insn?
-    //     }
-
-    //     fn write_variable() {
-    //         // TODO: Specify and define arguments
-    //         // TODO: Figure out if this already exists in ZJIT. Likely this uses find or chase_insn?
-    //     }
-    //     //
-    //     // ------------ MULTIPLE BLOCKS ----------------
-    //     // When we get to multiple blocks, we need to deal with phi nodes. It seems that in ZJIT, these are referred to as block arguments or block params
-    //     // It would be really nice to check my knowledge on this, and potentially rename them if so
-    //     fn read_variable_recursive() {
-    //         // TODO: fill out
-    //         // This function is the global value numbering version of the single block variant
-    //     }
-
-    //     fn add_phi_operands() {
-    //         // See comments in try_remove_triival_phi
-    //     }
-
-    //     fn try_remove_trivial_phi() {
-    //         // TODO: fill out
-    //         // This function cleans up the opportunistic phis that get added in Braun's algorithm.
-    //         // If we didn't add such phis, we run into all sorts of recursion issues. This is a key idea in the algorithm we are implementing
-    //     }
-
-    //     // ---------- INCOMPLETE CFGS --------------
-    //     // While technically part of the multiple blocks section, the next functions are even more complicated so they get their own section
-    //     fn seal_block() {
-    //         // We call a block "sealed" when we know there will not be predecessors added to the block.
-    //         // This function adds all necessary phis to incomplete blocks and adds this block to the sealed list
-    //     }
-
-    //     // I don't yet know which optimizations we want to include during construction. Pages 8 and 9 of the paper show why this is non-trivial and important for us to figure out
-    //     // However, the following tools are definitely necessary
-    //     fn remove_redundant_phis() {
-    //         // In the paper, they innovate by considering irreducible control flow from the perspective of the strongly connected component that _must_ exist if there are redundant phis
-    //         // By computing this strongly connected component, we can figure out what to remove (with the following function)
-    //     }
-
-    //     fn process_strongly_connected_component() {
-    //         // Do some fancy logic to iterate across all the phis in the SCC, tracking "inner" and "outer" operations
-    //     }
-
-    //     // TODO: Close reading of page 11 after implementing everything else to see if there are further optimizations to be made
-    //     // Key issue: we construct a lot of phis and then remove a lot of phis. Can we construct fewer in the first place?
-    //
-    // }
 
     fn optimize_load_store(&mut self) {
         for block in self.reverse_post_order() {
@@ -6851,7 +6839,7 @@ impl Function {
             (convert_no_profile_sends) => { Counter::compile_hir_strength_reduce_time_ns };
             // End strength reduction bucket
             (inline_methods) => { Counter::compile_hir_inline_methods_time_ns };
-            (remove_trivial_phis) => { Counter::compile_hir_remove_trivial_phis_time_ns };
+            (remove_trivial_block_params) => { Counter::compile_hir_remove_trivial_block_params_time_ns };
             (optimize_load_store) => { Counter::compile_hir_optimize_load_store_time_ns };
             (canonicalize) => { Counter::compile_hir_canonicalize_time_ns };
             (fold_constants) => { Counter::compile_hir_fold_constants_time_ns };
@@ -6905,7 +6893,7 @@ impl Function {
             // TODO: Figure out where the pass should go and remove these comments
             // It's not clear where converting to minimal SSA should occur
             // We need it for a global optimize_load_store, so this is a good starting point
-            run_pass!(remove_trivial_phis);
+            run_pass!(remove_trivial_block_params);
             run_pass!(optimize_load_store);
             run_pass!(canonicalize);
             run_pass!(fold_constants);

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5946,14 +5946,8 @@ impl Function {
         // Inner index is param index
         // Value is the state of the param. This is used to determine whether block param optimization can occur.
         let mut predecessor_domain: Vec<Vec<ParamValue>> = vec![Vec::new(); self.blocks.len()];
+
         let mut updated = true;
-
-        while updated {
-
-        for (row, block) in predecessor_domain.iter_mut().zip(&self.blocks) {
-            row.resize(block.params.len(), ParamValue::None);
-        }
-        updated = false;
 
         // Store references to all the conditional instructions.
         // We need to update these conditionals in the case of trivial block params.
@@ -5965,6 +5959,12 @@ impl Function {
             .map(|block_id| (block_id, self.blocks[block_id.0].insns.len() - 1))
             .collect();
 
+        while updated {
+
+        for (row, block) in predecessor_domain.iter_mut().zip(&self.blocks) {
+            row.resize(block.params.len(), ParamValue::None);
+        }
+        updated = false;
 
         // Scan through each jump, collecting edges from CondBranch and Jump insns.
         for (block_id, insn_index) in &terminators {

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5861,6 +5861,84 @@ impl Function {
         }
     }
 
+    /// Convert maximal SSA (constructed from YARV with `add_iseq_to_hir`) to minimal SSA
+    /// We implement the SSA construction described by Braun et al.
+    /// SSA Paper reference: <https://c9x.me/compile/bib/braun13cc.pdf>
+    fn minify_ssa(&mut self) {
+        // This PR is _very_ much an early draft. I've spent some time reading the paper, and isolating some of the concepts.
+        // There will be lots of lengthy comments that get removed and reworked. There are concepts in ZJIT that are identical but named different things.
+        // We need to map these to each other. It probably makes sense to keep some reference comments performing this mapping for the future too.
+        //
+        // Important difference: Braun et al construct SSA from scratch. We already have a maximal SSA representation. We may be able to get away with only the pruning parts of the paper
+        // Alternatively, we may just need to overhaul our entire SSA construction. I'm not sure what makes sense yet.
+        //
+        // TODO: Make tests for single blocks and multiple block constructions of minimal SSA
+        // It would be great to faithfully recreate examples from the paper but with ZJIT specifics. If there's a way to construct ruby code that maps to this HIR, that would be awesome but jury is still out
+        //
+        // First Test Idea for LVN (page 3):
+        // This first version isn't entirely implementable because `d` and `v?` are intentionally unspecified but it's a good starting point
+        // source (make into ruby)    SSA (make into ZJIT)
+        // a <- 42                    v1: 42
+        // b <- a
+        // c <- a + b                 v2: v1 + v1
+        //                            v3: 23
+        // a <- c + 23                v4: v2 + v3
+        // c <- a + d                 v5: v4 + v?
+
+        // ------------ SINGLE BLOCK ----------------
+        // This section contains all the tech we need for single blocks. For implementation, let's pass tests for this part first before adding in the rest
+        // These two functions handle local value numbering. I don't know if this is something that Max landed in a PR, nor what can / should be repurposed vs written from scratch
+        fn read_variable() {
+            // TODO: Specify and define arguments
+            // TODO: Figure out if this already exists in ZJIT. Likely this uses find or chase_insn?
+        }
+
+        fn write_variable() {
+            // TODO: Specify and define arguments
+            // TODO: Figure out if this already exists in ZJIT. Likely this uses find or chase_insn?
+        }
+        //
+        // ------------ MULTIPLE BLOCKS ----------------
+        // When we get to multiple blocks, we need to deal with phi nodes. It seems that in ZJIT, these are referred to as block arguments or block params
+        // It would be really nice to check my knowledge on this, and potentially rename them if so
+        fn read_variable_recursive() {
+            // TODO: fill out
+            // This function is the global value numbering version of the single block variant
+        }
+
+        fn add_phi_operands() {
+            // See comments in try_remove_triival_phi
+        }
+
+        fn try_remove_trivial_phi() {
+            // TODO: fill out
+            // This function cleans up the opportunistic phis that get added in Braun's algorithm.
+            // If we didn't add such phis, we run into all sorts of recursion issues. This is a key idea in the algorithm we are implementing
+        }
+
+        // ---------- INCOMPLETE CFGS --------------
+        // While technically part of the multiple blocks section, the next functions are even more complicated so they get their own section
+        fn seal_block() {
+            // We call a block "sealed" when we know there will not be predecessors added to the block.
+            // This function adds all necessary phis to incomplete blocks and adds this block to the sealed list
+        }
+
+        // I don't yet know which optimizations we want to include during construction. Pages 8 and 9 of the paper show why this is non-trivial and important for us to figure out
+        // However, the following tools are definitely necessary
+        fn remove_redundant_phis() {
+            // In the paper, they innovate by considering irreducible control flow from the perspective of the strongly connected component that _must_ exist if there are redundant phis
+            // By computing this strongly connected component, we can figure out what to remove (with the following function)
+        }
+
+        fn process_strongly_connected_component() {
+            // Do some fancy logic to iterate across all the phis in the SCC, tracking "inner" and "outer" operations
+        }
+
+        // TODO: Close reading of page 11 after implementing everything else to see if there are further optimizations to be made
+        // Key issue: we construct a lot of phis and then remove a lot of phis. Can we construct fewer in the first place?
+
+    }
+
     fn optimize_load_store(&mut self) {
         for block in self.reverse_post_order() {
             let mut compile_time_heap: HashMap<(InsnId, i32), InsnId>  = HashMap::new();
@@ -6655,6 +6733,7 @@ impl Function {
             (convert_no_profile_sends) => { Counter::compile_hir_strength_reduce_time_ns };
             // End strength reduction bucket
             (inline_methods) => { Counter::compile_hir_inline_methods_time_ns };
+            (minify_ssa) => { Counter::compile_hir_minify_ssa_time_ns };
             (optimize_load_store) => { Counter::compile_hir_optimize_load_store_time_ns };
             (canonicalize) => { Counter::compile_hir_canonicalize_time_ns };
             (fold_constants) => { Counter::compile_hir_fold_constants_time_ns };
@@ -6705,6 +6784,10 @@ impl Function {
                 false
             };
             run_pass!(convert_no_profile_sends);
+            // TODO: Figure out where the pass should go and remove these comments
+            // It's not clear where converting to minimal SSA should occur
+            // We need it for a global optimize_load_store, so this is a good starting point
+            run_pass!(minify_ssa);
             run_pass!(optimize_load_store);
             run_pass!(canonicalize);
             run_pass!(fold_constants);

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5861,129 +5861,117 @@ impl Function {
         }
     }
 
+
     // TODO: Add a comment about the paper and where this function comes from, as well as how it's used in ZJIT
     // (It's used more individually and differently than the paper)
     // TODO: Update comments to consider block params rather than phi nodes and demarcate differences from the algorithm clearly
     // TODO: Fix input arguments. We need block params, not just the phi
     /// If all possible phi values are the same, replace the phi with the value
 
-    fn remove_trivial_phis(&mut self) {
-        // TODO: Find all of the phis and predecessors
-        let phi = &InsnId(5); // FIX: this shouldn't be just a random dummy value
-        let predecessors = vec![];
-        // TODO: Run the following in a loop once we've gotten all the phis
-        // TODO: Figure out if we want to do this mutably and in one pass with into_iter or take instead.
-        let phis: Vec<(BlockId, InsnId)> = self.reverse_post_order().iter().flat_map(|block_id| {
-            self.blocks[block_id.0].params().map(|&param| (*block_id, param))
-        }).collect();
-        // FIX: The logic if this is wrong. We want to make sure `p` is not a self reference. Equality with phi likely does not do this
-        let external_preds: Vec<&InsnId> = predecessors.iter().filter(|p| *p != phi).collect();
+    /// Sometimes block params can only come from one place and safely removed as block params.
+    /// Trivial block param removal increases the efficacy of CFG-based optimization passes.
+    /// This function implements algorithm 2 from <https://c9x.me/compile/bib/braun13cc.pdf>.
+    /// Light modifications are made to use block params instead of phis.
+    fn remove_trivial_block_params(&mut self) {
 
-        match external_preds.as_slice() {
-            [] => {} // Phi is unreachable
-            [first, rest @ ..] if rest.iter().any(|p| p != first) => {} // Phi is non-trivial
-            [value, ..] => { // Phi is trivial
-
+        // Helper function for remove_trivial_block_params
+        // Remove an argument of the edge at index if the conditional matches target_block
+        fn prune_branch_edge(edge: BranchEdge, target_block: BlockId, index: usize) -> BranchEdge {
+            let mut args = edge.args.clone();
+            if edge.target == target_block {
+                args.remove(index);
             }
-
+            BranchEdge { target: edge.target, args }
         }
-        let new_phi = match external_preds.as_slice() {
-            [] => {
-                // Phi is unreachable
-                // TODO: Figure out how we are supposed to handle an unreachable phi
-                *phi // FIX: We don't want to return phi in this case. What do we want to do with an unreachable value??
-            }
-            [first, rest @ ..] if rest.iter().any(|p| p != first) => {
-                // Phi is non-trivial
-                *phi
-            }
-            [value, ..] => {
-                // Phi is trivial. All elements of the vec are `value`.
-                // TODO: Replace all uses of phi with value with make_equal_to
-                // TODO: Iteratively call try_remove_trivial_phi on uses. Can we get uses with find?
-                **value
+
+        // TODO: This stupid function causes borrowing issues so we just duplicated the code for it all over the place omg. Do we remove this or fix it??
+        // fetch_last_insn is a helper to retrieve the final instruction from a block.
+        // We use standard basic blocks so we know that each jump msut be the final instruction in a block.
+        fn fetch_last_insn(blocks: Vec<Block>, block_id: BlockId) -> InsnId {
+            *blocks[block_id.0].insns.last().unwrap()
+        }
+
+        // Find each block that ends with Insn::Jump or Insn::CondBranch. (Equivalently, this is all blocks that don't end with Insn::Return)
+        let jump_blocks: Vec<BlockId> = self.reverse_post_order().into_iter()
+            .filter(|&block_id| matches!(
+                self.find(*self.blocks[block_id.0].insns.last().unwrap()),
+                Insn::CondBranch {..} | Insn::Jump {..} )
+            ).collect();
+
+        // Note: The outer vec represents all blocks in the CFG. Using a vec instead of HashMap with keys is safe
+        // because blocks are represented by contiguous values between 0 and len() - 1
+        // This invariant holds because new_block adds a new id based on length, and remove_block only allows the highest block value to be removed.
+        // These are the two functions used to modify block sizes.
+        #[derive(Hash, Eq, PartialEq, Clone, Copy)]
+        struct ArgKey {
+            block: BlockId,
+            index: usize
+        }
+        let mut predecessors: HashMap<ArgKey, Vec<InsnId>> = HashMap::new();
+
+        let mut add_preds = |block: BlockId, args: Vec<InsnId>| {
+            for index in 0..args.len() {
+                predecessors.entry(ArgKey{ block, index }).or_default().push(args[index]);
             }
         };
+
+        // Find the predecessors for each conditional HIR instruction in the CFG
+        for insn_id in jump_blocks.iter().map(|block_id| {self.blocks[block_id.0].insns.last().unwrap()}) {
+            match self.find(*insn_id) {
+                Insn::CondBranch { if_true, if_false, .. } => {
+                    add_preds(if_true.target, if_true.args);
+                    add_preds(if_false.target, if_false.args);
+                }
+                Insn::Jump(edge) => {
+                    add_preds(edge.target, edge.args);
+                }
+                _ => {}
+            }
+        }
+
+        // Remove the predecessor self-references
+        let mut external_preds = predecessors.clone();
+        for (key, predecessors) in external_preds.iter_mut() {
+            let pred_from_current_block = self.chase_insn(*self.block(key.block).params().nth(key.index).unwrap());
+            predecessors.retain(|insn_id| self.chase_insn(*insn_id) != pred_from_current_block);
+        }
+
+        // Identify the trivial block params. Trivial means that each external predecessor has the same insn_id.
+        for (ArgKey { block, index }, predecessors) in external_preds.iter() {
+            match predecessors.as_slice() {
+                [] => {} // Unreachable. This should never happen
+                [first, rest @ ..] if rest.iter().any(|insn_id| insn_id != first) => {} // non-trivial
+                [insn_id, ..] => {
+                    // Save the insn_id of the block param to be removed
+                    let trivial_block_param = self.blocks[block.0].params[*index];
+                    // Remove the trivial block param from the block definition
+                    self.blocks[block.0].params.remove(*index);
+                    // Replace the trivial block param with the SSA insn_id that it must always be.
+                    self.make_equal_to(trivial_block_param, *insn_id);
+
+                    // At this point we have fixed params at the block definition, but not to conditionals that branch to the block.
+
+                    // Prune the block params from each Insn::Jump and Insn::CondBranch that targets `block`
+                    for &block_with_jump in &jump_blocks {
+                        let insn_id = self.blocks[block_with_jump.0].insns.last().unwrap();
+                        match self.find(*insn_id) {
+                            Insn::Jump(edge) => {
+                                let new_edge = prune_branch_edge(edge, *block, *index);
+                                self.insns[insn_id.0] = Insn::Jump(new_edge);
+                            }
+                            Insn::CondBranch { val, if_true, if_false } => {
+                                let new_true_edge = prune_branch_edge(if_true, *block, *index);
+                                let new_false_edge = prune_branch_edge(if_false, *block, *index);
+                                self.insns[insn_id.0] = Insn::CondBranch { val, if_true: new_true_edge, if_false: new_false_edge };
+                            }
+                            _ => {} // This is unreachable
+                        }
+                    }
+                }
+            }
+        }
     }
 
-    // TODO: Probably throw this next big comment away
-    // /// Convert maximal SSA (constructed from YARV with `add_iseq_to_hir`) to minimal SSA
-    // /// We implement the SSA construction described by Braun et al.
-    // /// SSA Paper reference: <https://c9x.me/compile/bib/braun13cc.pdf>
-    // fn minify_ssa(&mut self) {
-    //     // This PR is _very_ much an early draft. I've spent some time reading the paper, and isolating some of the concepts.
-    //     // There will be lots of lengthy comments that get removed and reworked. There are concepts in ZJIT that are identical but named different things.
-    //     // We need to map these to each other. It probably makes sense to keep some reference comments performing this mapping for the future too.
-    //     //
-    //     // Important difference: Braun et al construct SSA from scratch. We already have a maximal SSA representation. We may be able to get away with only the pruning parts of the paper
-    //     // Alternatively, we may just need to overhaul our entire SSA construction. I'm not sure what makes sense yet.
-    //     //
-    //     // TODO: Make tests for single blocks and multiple block constructions of minimal SSA
-    //     // It would be great to faithfully recreate examples from the paper but with ZJIT specifics. If there's a way to construct ruby code that maps to this HIR, that would be awesome but jury is still out
-    //     //
-    //     // First Test Idea for LVN (page 3):
-    //     // This first version isn't entirely implementable because `d` and `v?` are intentionally unspecified but it's a good starting point
-    //     // source (make into ruby)    SSA (make into ZJIT)
-    //     // a <- 42                    v1: 42
-    //     // b <- a
-    //     // c <- a + b                 v2: v1 + v1
-    //     //                            v3: 23
-    //     // a <- c + 23                v4: v2 + v3
-    //     // c <- a + d                 v5: v4 + v?
-
-    //     // ------------ SINGLE BLOCK ----------------
-    //     // This section contains all the tech we need for single blocks. For implementation, let's pass tests for this part first before adding in the rest
-    //     // These two functions handle local value numbering. I don't know if this is something that Max landed in a PR, nor what can / should be repurposed vs written from scratch
-    //     fn read_variable() {
-    //         // TODO: Specify and define arguments
-    //         // TODO: Figure out if this already exists in ZJIT. Likely this uses find or chase_insn?
-    //     }
-
-    //     fn write_variable() {
-    //         // TODO: Specify and define arguments
-    //         // TODO: Figure out if this already exists in ZJIT. Likely this uses find or chase_insn?
-    //     }
-    //     //
-    //     // ------------ MULTIPLE BLOCKS ----------------
-    //     // When we get to multiple blocks, we need to deal with phi nodes. It seems that in ZJIT, these are referred to as block arguments or block params
-    //     // It would be really nice to check my knowledge on this, and potentially rename them if so
-    //     fn read_variable_recursive() {
-    //         // TODO: fill out
-    //         // This function is the global value numbering version of the single block variant
-    //     }
-
-    //     fn add_phi_operands() {
-    //         // See comments in try_remove_triival_phi
-    //     }
-
-    //     fn try_remove_trivial_phi() {
-    //         // TODO: fill out
-    //         // This function cleans up the opportunistic phis that get added in Braun's algorithm.
-    //         // If we didn't add such phis, we run into all sorts of recursion issues. This is a key idea in the algorithm we are implementing
-    //     }
-
-    //     // ---------- INCOMPLETE CFGS --------------
-    //     // While technically part of the multiple blocks section, the next functions are even more complicated so they get their own section
-    //     fn seal_block() {
-    //         // We call a block "sealed" when we know there will not be predecessors added to the block.
-    //         // This function adds all necessary phis to incomplete blocks and adds this block to the sealed list
-    //     }
-
-    //     // I don't yet know which optimizations we want to include during construction. Pages 8 and 9 of the paper show why this is non-trivial and important for us to figure out
-    //     // However, the following tools are definitely necessary
-    //     fn remove_redundant_phis() {
-    //         // In the paper, they innovate by considering irreducible control flow from the perspective of the strongly connected component that _must_ exist if there are redundant phis
-    //         // By computing this strongly connected component, we can figure out what to remove (with the following function)
-    //     }
-
-    //     fn process_strongly_connected_component() {
-    //         // Do some fancy logic to iterate across all the phis in the SCC, tracking "inner" and "outer" operations
-    //     }
-
-    //     // TODO: Close reading of page 11 after implementing everything else to see if there are further optimizations to be made
-    //     // Key issue: we construct a lot of phis and then remove a lot of phis. Can we construct fewer in the first place?
-    //
-    // }
 
     fn optimize_load_store(&mut self) {
         for block in self.reverse_post_order() {
@@ -6779,7 +6767,7 @@ impl Function {
             (convert_no_profile_sends) => { Counter::compile_hir_strength_reduce_time_ns };
             // End strength reduction bucket
             (inline_methods) => { Counter::compile_hir_inline_methods_time_ns };
-            (remove_trivial_phis) => { Counter::compile_hir_remove_trivial_phis_time_ns };
+            (remove_trivial_block_params) => { Counter::compile_hir_remove_trivial_block_params_time_ns };
             (optimize_load_store) => { Counter::compile_hir_optimize_load_store_time_ns };
             (canonicalize) => { Counter::compile_hir_canonicalize_time_ns };
             (fold_constants) => { Counter::compile_hir_fold_constants_time_ns };
@@ -6833,7 +6821,7 @@ impl Function {
             // TODO: Figure out where the pass should go and remove these comments
             // It's not clear where converting to minimal SSA should occur
             // We need it for a global optimize_load_store, so this is a good starting point
-            run_pass!(remove_trivial_phis);
+            run_pass!(remove_trivial_block_params);
             run_pass!(optimize_load_store);
             run_pass!(canonicalize);
             run_pass!(fold_constants);

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5913,8 +5913,10 @@ impl Function {
     /// This function implements algorithm 2 from <https://c9x.me/compile/bib/braun13cc.pdf>.
     /// Light modifications are made to use block params instead of phis.
     fn remove_trivial_block_params(&mut self) {
-        // This abstract domain represents block param optimization potential
-        // If it were constructed as a lattice, Unknown is bottom, trivial is above, nontrivial is top (and above trivial)
+        // Each block param corresponds to a ParamValue
+        // This is the abstract domain used for abstract interpretation
+        // If there are no predecessors or multiple predecessors to a param, no optimization can happen
+        // However if there is a single unique predecessor, then the block param is trivial and we can replace with its concretized value
         #[derive(Clone)]
         enum ParamValue {
             None,
@@ -5922,10 +5924,7 @@ impl Function {
             Multiple
         }
 
-        // TODO: Make a note about how this breaks Dak2's test in the PR and this should probably be a discussion.
-        // canonicalize is block-local, and the generated test used block params. This caused a use of a value to be canonicalized (I think)
-        // which removed a type refinement that was passed
-
+        // Helper function to remove selected indices from a vec in place
         fn prune_vec_by_indices<T>(v: &mut Vec<T>, indices: &[usize]) {
             let mut i: usize = 0;
             v.retain(|_| {
@@ -5935,31 +5934,30 @@ impl Function {
             })
         }
 
-        // Remove an argument of the edge at index if the conditional matches target_block
+        // Remove arguments of the edge at selected indices
         fn prune_branch_edge(edge: BranchEdge, indices: &Vec<usize>) -> BranchEdge {
             let mut args = edge.args.clone();
             prune_vec_by_indices(&mut args, indices);
             BranchEdge { target: edge.target, args }
         }
 
-        let mut changed = true;
-
-        while changed {
-
-        changed = false;
-
         // Instantiate the domain for abstract interpretation
         // Outer index is block
         // Inner index is param index
         // Value is the state of the param. This is used to determine whether block param optimization can occur.
         let mut predecessor_domain: Vec<Vec<ParamValue>> = vec![Vec::new(); self.blocks.len()];
-        for (i, block) in self.blocks.iter().enumerate() {
-            predecessor_domain[i].extend(std::iter::repeat_n(ParamValue::None, block.params.len()))
+        let mut updated = true;
+
+        while updated {
+
+        for (row, block) in predecessor_domain.iter_mut().zip(&self.blocks) {
+            row.resize(block.params.len(), ParamValue::None);
         }
+        updated = false;
 
         // Store references to all the conditional instructions.
         // We need to update these conditionals in the case of trivial block params.
-        let jumps: Vec<(BlockId, usize)> = self.reverse_post_order().into_iter()
+        let terminators: Vec<(BlockId, usize)> = self.reverse_post_order().into_iter()
             .filter(|&block_id| matches!(
                 self.find(*self.blocks[block_id.0].insns.last().unwrap()),
                 Insn::CondBranch {..} | Insn::Jump {..}
@@ -5969,7 +5967,7 @@ impl Function {
 
 
         // Scan through each jump, collecting edges from CondBranch and Jump insns.
-        for (block_id, insn_index) in &jumps {
+        for (block_id, insn_index) in &terminators {
             let insn_id = self.blocks[block_id.0].insns[*insn_index];
             let mut edges: Vec<BranchEdge> = vec![];
 
@@ -5987,14 +5985,9 @@ impl Function {
             // Update the states
             for BranchEdge { target: block_id, args: params } in edges {
                 for (i, param) in params.iter().enumerate().rev() {
-                    // If the param is the same as passed into the block, this means it is a self loop
-                    // We can safely ignore these cases.
-                    // FIX: Do we always want the representative in the group? This throws away type information.
-                    // Seems like we have a strange edge case where we want to consider multiple different guards of a value to represent the same value and elide blockparams
-                    // But at the same time, we want subsequent blocks to use the most type information that we have, rather than the original canonical value.
-                    // I'm not sure how we can do this more generally. It feels like it's not the responsibility of this phi reduction pass, but of a type inference pass
-                    // Feels like we should do some kind of guard code motion of some kind...
                     let param = self.find_id(*param);
+                    // If the param is the same as passed into the block, it is a self loop
+                    // We ignore self loops because they do not provide new information
                     if param == self.find_id(self.blocks[block_id.0].params[i]) {
                         continue
                     }
@@ -6032,15 +6025,15 @@ impl Function {
             for param_index in &trivial_indices {
                 if let ParamValue::One(insn_id) = block[*param_index] {
                     self.make_equal_to(self.blocks[block_id.0].params[*param_index], insn_id);
-                    changed = true;
+                    updated = true;
                 }
             }
 
             // Update the block
             prune_vec_by_indices(&mut self.blocks[block_id.0].params, &trivial_indices);
 
-            // Update the conditionals that branch to block
-            for (jump_block_id, index) in &jumps {
+            // Update the terminators (basic blocks can only branch at the terminator. This is where block params are passed)
+            for (jump_block_id, index) in &terminators {
                 let cond_insn_id = self.blocks[jump_block_id.0].insns[*index];
                 match self.find(cond_insn_id) {
                     Insn::Jump(edge) => {
@@ -6050,11 +6043,17 @@ impl Function {
                         }
                     }
                     Insn::CondBranch { val, if_true, if_false } => {
-                        if if_true.target == block_id || if_false.target == block_id {
-                            let if_true = prune_branch_edge(if_true, &trivial_indices);
-                            let if_false = prune_branch_edge(if_false, &trivial_indices);
-                            self.insns[cond_insn_id.0] = Insn::CondBranch{ val, if_true, if_false };
-                        }
+                        let if_true = if if_true.target == block_id {
+                            prune_branch_edge(if_true, &trivial_indices)
+                        } else {
+                            if_true
+                        };
+                        let if_false = if if_false.target == block_id {
+                            prune_branch_edge(if_false, &trivial_indices)
+                        } else {
+                            if_false
+                        };
+                        self.insns[cond_insn_id.0] = Insn::CondBranch{ val, if_true, if_false };
                     }
                     _ => {}
                 }

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5901,19 +5901,38 @@ impl Function {
         }
     }
 
-    fn try_remove_trivial_phi(BlockId: block_id) {
-
-    }
+    // TODO: Add a comment about the paper and where this function comes from, as well as how it's used in ZJIT
+    // (It's used more individually and differently than the paper)
+    // TODO: Update comments to consider block params rather than phi nodes and demarcate differences from the algorithm clearly
+    // TODO: Fix input arguments. We need block params, not just the phi
+    /// If all possible phi values are the same, replace the phi with the value
 
     fn remove_trivial_phis(&mut self) {
-        let mut fixpoint = False;
-        while not fixpoint {
-            for block in self.reverse_post_order() {
-                // TODO: Figure out where the predecessors come from
-                predecessors = vec![];
-                try_remove_trivial_phi(block);
+        // TODO: Find all of the phis and predecessors
+        let phi = &InsnId(5); // FIX: this shouldn't be just a random dummy value
+        let predecessors = vec![];
+        // TODO: Run the following in a loop once we've gotten all the phis
+        let phis: Vec<&InsnId> = vec![];
+        // FIX: The logic if this is wrong. We want to make sure `p` is not a self reference. Equality with phi likely does not do this
+        let external_preds: Vec<&InsnId> = predecessors.iter().filter(|p| *p != phi).collect();
+
+        let new_phi = match external_preds.as_slice() {
+            [] => {
+                // Phi is unreachable
+                // TODO: Figure out how we are supposed to handle an unreachable phi
+                *phi // FIX: We don't want to return phi in this case. What do we want to do with an unreachable value??
             }
-        }
+            [first, rest @ ..] if rest.iter().any(|p| p != first) => {
+                // Phi is non-trivial
+                *phi
+            }
+            [value, ..] => {
+                // Phi is trivial. All elements of the vec are `value`.
+                // TODO: Replace all uses of phi with value with make_equal_to
+                // TODO: Iteratively call try_remove_trivial_phi on uses. Can we get uses with find?
+                **value
+            }
+        };
     }
 
     // TODO: Probably throw this next big comment away
@@ -5992,8 +6011,8 @@ impl Function {
 
     //     // TODO: Close reading of page 11 after implementing everything else to see if there are further optimizations to be made
     //     // Key issue: we construct a lot of phis and then remove a lot of phis. Can we construct fewer in the first place?
-
-    }
+    //
+    // }
 
     fn optimize_load_store(&mut self) {
         for block in self.reverse_post_order() {

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -6875,11 +6875,8 @@ impl Function {
             } else {
                 false
             };
-            run_pass!(convert_no_profile_sends);
-            // TODO: Figure out where the pass should go and remove these comments
-            // It's not clear where converting to minimal SSA should occur
-            // We need it for a global optimize_load_store, so this is a good starting point
             run_pass!(remove_trivial_block_params);
+            run_pass!(convert_no_profile_sends);
             run_pass!(optimize_load_store);
             run_pass!(canonicalize);
             run_pass!(fold_constants);

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5941,7 +5941,7 @@ impl Function {
         }
 
         fn block_terminator(fun: &Function, block_id: BlockId) -> InsnId {
-            *fun.blocks[block_id.0].insns().last().unwrap()
+            *fun.blocks[block_id.to_usize() as usize].insns().last().unwrap()
         }
 
         macro_rules! edges_of {
@@ -5956,12 +5956,12 @@ impl Function {
 
         fn outgoing_edges(fun: &Function, block_id: BlockId) -> impl Iterator<Item = &BranchEdge> {
             let insn_id = block_terminator(fun, block_id);
-            edges_of!(&fun.insns[insn_id.0])
+            edges_of!(&fun.insns[insn_id.to_usize()])
         }
 
         fn outgoing_edges_mut(fun: &mut Function, block_id: BlockId) -> impl Iterator<Item = &mut BranchEdge> {
             let insn_id = block_terminator(fun, block_id);
-            edges_of!(&mut fun.insns[insn_id.0])
+            edges_of!(&mut fun.insns[insn_id.to_usize()])
         }
 
         // Instantiate the domain for abstract interpretation.
@@ -5979,7 +5979,7 @@ impl Function {
         // We only need to update blocks that have params. (Blocks without params cannot be improved)
         let blocks_receiving_params: Vec<BlockId> = blocks.into_iter()
             .filter(|&block_id|
-                self.blocks[block_id.0].params().len() != 0)
+                self.blocks[block_id.to_usize()].params().len() != 0)
             .collect();
 
         // NOTE: It is possible that once some block_params are removed, there will be no params.
@@ -6005,10 +6005,10 @@ impl Function {
                     for (i, param) in params.iter().enumerate() {
                         let param = self.find_id(*param);
                         // If the param is the same as passed into the block, it is a self loop and provides no new predecessor information.
-                        if param == self.find_id(self.blocks[block_id.0].params[i]) {
+                        if param == self.find_id(self.blocks[block_id.to_usize()].params[i]) {
                             continue
                         }
-                        param_values[block_id.0][i].update(param);
+                        param_values[block_id.to_usize()][i].update(param);
                     }
                 }
             }
@@ -6019,7 +6019,7 @@ impl Function {
             // 2. Remove trivial params from the basic block definition
             // 3. Remove trivial params from each CondBranch and Jump that targets the basic block that was just updated
             for block_id in &blocks_receiving_params {
-                let block_preds = &param_values[block_id.0];
+                let block_preds = &param_values[block_id.to_usize()];
                 let trivial_indices: Vec<usize> = block_preds.iter().enumerate()
                     .filter_map(|(idx, state)|
                         matches!(state, ParamValue::One(_)).then_some(idx)
@@ -6028,13 +6028,13 @@ impl Function {
                 // Replace uses of the trivial params with the concretized value
                 for param_index in &trivial_indices {
                     if let ParamValue::One(insn_id) = block_preds[*param_index] {
-                        self.make_equal_to(self.blocks[block_id.0].params[*param_index], insn_id);
+                        self.make_equal_to(self.blocks[block_id.to_usize()].params[*param_index], insn_id);
                         changed = true;
                     }
                 }
 
                 // Update the block
-                prune_vec_by_indices(&mut self.blocks[block_id.0].params, &trivial_indices);
+                prune_vec_by_indices(&mut self.blocks[block_id.to_usize()].params, &trivial_indices);
 
                 // Update the terminators (basic blocks can only branch at the terminator. This is where block params are passed)
                 for jump_block_id in &blocks_sending_params {

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5900,13 +5900,6 @@ impl Function {
             })
         }
 
-        // Remove arguments of the edge at selected indices
-        fn prune_branch_edge(edge: BranchEdge, indices: &Vec<usize>) -> BranchEdge {
-            let mut args = edge.args.clone();
-            prune_vec_by_indices(&mut args, indices);
-            BranchEdge { target: edge.target, args }
-        }
-
         // Instantiate the domain for abstract interpretation.
         // We store possible param values for each block
         let mut predecessor_domain: Vec<Vec<ParamValue>> = vec![Vec::new(); self.blocks.len()];
@@ -5951,8 +5944,10 @@ impl Function {
             for block_id in &predecessor_blocks {
                 let insn_id = *self.blocks[block_id.0].insns.last().unwrap();
 
+                // TODO: Add a function to flatten edges into an iterator for jumps and condbranches.
+                // TODO: Make sure to use this when we update edges in the block later
                 // Extract edges into a tuple for processing
-                let (first, second) = match self.find(insn_id) {
+                let (first, second) = match self.resolve(insn_id).insn(self) {
                     Insn::Jump(edge) => (Some(edge), None),
                     Insn::CondBranch { if_true, if_false, ..} => (Some(if_true), Some(if_false)),
                     _ => (None, None)
@@ -5964,7 +5959,7 @@ impl Function {
                 // Use the results of abstract interpretation to update the states
                 // Perform abstract interpretation
                 for BranchEdge { target: block_id, args: params } in edges {
-                    for (i, param) in params.iter().enumerate().rev() {
+                    for (i, param) in params.iter().enumerate() {
                         let param = self.find_id(*param);
                         // If the param is the same as passed into the block, it is a self loop and provides no new predecessor information.
                         if param == self.find_id(self.blocks[block_id.0].params[i]) {
@@ -6002,25 +5997,19 @@ impl Function {
                 for jump_block_id in &predecessor_blocks {
                     let index = self.blocks[jump_block_id.0].insns.len() - 1;
                     let cond_insn_id = self.blocks[jump_block_id.0].insns[index];
-                    match self.find(cond_insn_id) {
+                    match self.resolve(cond_insn_id).insn_mut(self) {
                         Insn::Jump(edge) => {
                             if edge.target == *block_id {
-                                let edge = prune_branch_edge(edge, &trivial_indices);
-                                self.insns[cond_insn_id.0] = Insn::Jump(edge);
+                                prune_vec_by_indices(&mut edge.args, &trivial_indices);
                             }
                         }
-                        Insn::CondBranch { val, if_true, if_false } => {
-                            let if_true = if if_true.target == *block_id {
-                                prune_branch_edge(if_true, &trivial_indices)
-                            } else {
-                                if_true
-                            };
-                            let if_false = if if_false.target == *block_id {
-                                prune_branch_edge(if_false, &trivial_indices)
-                            } else {
-                                if_false
-                            };
-                            self.insns[cond_insn_id.0] = Insn::CondBranch{ val, if_true, if_false };
+                        Insn::CondBranch { if_true, if_false, .. } => {
+                            if if_true.target == *block_id {
+                                prune_vec_by_indices(&mut if_true.args, &trivial_indices);
+                            }
+                            if if_false.target == *block_id {
+                                prune_vec_by_indices(&mut if_false.args, &trivial_indices);
+                            }
                         }
                         _ => {}
                     }

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5901,28 +5901,33 @@ impl Function {
         }
     }
 
-
-    // TODO: Add a comment about the paper and where this function comes from, as well as how it's used in ZJIT
-    // (It's used more individually and differently than the paper)
-    // TODO: Update comments to consider block params rather than phi nodes and demarcate differences from the algorithm clearly
-    // TODO: Fix input arguments. We need block params, not just the phi
-    // If all possible phi values are the same, replace the phi with the value
-    // TODO: Add Max's optimization about not checking the first block. Maybe do this by keeping track of all changing edges and using a worklist?
-
-    /// Sometimes block params can only come from one place and safely removed as block params.
-    /// Trivial block param removal increases the efficacy of CFG-based optimization passes.
-    /// This function implements algorithm 2 from <https://c9x.me/compile/bib/braun13cc.pdf>.
-    /// Light modifications are made to use block params instead of phis.
+    /// ZJIT uses block parameters in HIR SSA representation.
+    /// Sometimes, we can prove that a block param is only called with a single value.
+    /// This pass identifies such trivial block params and replaces them with the concretized value.
+    /// This produces a minimal SSA representation amenable to further optimizations.
+    /// The implementation is inspired from algorithm 2 in <https://c9x.me/compile/bib/braun13cc.pdf>.
     fn remove_trivial_block_params(&mut self) {
-        // Each block param corresponds to a ParamValue
-        // This is the abstract domain used for abstract interpretation
-        // If there are no predecessors or multiple predecessors to a param, no optimization can happen
-        // However if there is a single unique predecessor, then the block param is trivial and we can replace with its concretized value
-        #[derive(Clone)]
+        // Each block param is lifted to an abstract domain of ParamValues.
+        // The lattice is simple. None is Bottom, Multiple is Top, and One is between both.
+        // During analysis, all block params start with None.
+        // New values passed to the block transition up the lattice.
+        // Trivial block params have one unique value. This is the case we optimize away.
+        // Lattice structure taken from cranelift: <https://github.com/bytecodealliance/wasmtime/blob/main/cranelift/codegen/src/remove_constant_phis.rs>
+        #[derive(Clone, Copy)]
         enum ParamValue {
             None,
             One(InsnId),
-            Multiple
+            Many
+        }
+
+        impl ParamValue {
+            fn update(&mut self, value: InsnId) {
+                *self = match *self {
+                    ParamValue::None => ParamValue::One(value),
+                    ParamValue::One(original) if original != value => ParamValue::Many,
+                    other => other
+                };
+            }
         }
 
         // Helper function to remove selected indices from a vec in place
@@ -5942,61 +5947,59 @@ impl Function {
             BranchEdge { target: edge.target, args }
         }
 
-        fn insn_passes_params(insn: Insn) -> bool {
-            match insn {
-                Insn::CondBranch {if_true, if_false, ..} => !if_true.args.is_empty() || !if_false.args.is_empty(),
-                Insn::Jump(edge) => !edge.args.is_empty(),
-                _ => false
-            }
-        }
-
-        // Instantiate the domain for abstract interpretation
-        // Outer index is block
-        // Inner index is param index
-        // Value is the state of the param. This is used to determine whether block param optimization can occur.
+        // Instantiate the domain for abstract interpretation.
+        // We store possible param values for each block
         let mut predecessor_domain: Vec<Vec<ParamValue>> = vec![Vec::new(); self.blocks.len()];
 
-        let mut updated = true;
+        let blocks = self.reverse_post_order();
 
         // Find blocks that terminate with Jump or CondBranch instructions that pass block params along.
         // These terminators are later analyzed for trivial block params.
-        let param_passing_blocks: Vec<BlockId> = self.reverse_post_order().into_iter()
+        let predecessor_blocks: Vec<BlockId> = blocks.iter().copied()
             .filter(|&block_id|
-                insn_passes_params(self.find(*self.blocks[block_id.0].insns.last().unwrap())))
+                // Match against the final instruction which terminates the basic block.
+                // If it has any non-empty edges, keep it.
+                match self.find(*self.blocks[block_id.0].insns().last().unwrap()) {
+                    Insn::CondBranch {if_true, if_false, ..} => !if_true.args.is_empty() || !if_false.args.is_empty(),
+                    Insn::Jump(edge) => !edge.args.is_empty(),
+                    _ => false
+                })
             .collect();
 
-        while updated {
+        // We only need to update blocks that have params. (Blocks without params cannot be improved)
+        let param_blocks: Vec<BlockId> = blocks.into_iter()
+            .filter(|&block_id|
+                self.blocks[block_id.0].params().len() != 0)
+            .collect();
+
+        // NOTE: It is possible that once some block_params are removed, there will be no params.
+        // This means that predecessor_blocks or param_blocks could be pruned. This minor optimization can be added if desired.
+        // Importantly, we do not keep track of exactly which edges correspond to which blocks. While doing so
+        // would allow us to replace our "loop until fixpoint" with a "iterate through the worklist, only checking relevant edges",
+        // the construction of the mapping from predecessor edges to blocks seems expensive.
+
+        let mut changed = true;
+
+        while changed {
+            changed = false;
 
             for (row, block) in predecessor_domain.iter_mut().zip(&self.blocks) {
                 row.resize(block.params.len(), ParamValue::None);
             }
-            updated = false;
 
-            // TODO: Maybe move this outside the loop somehow? probably can't immediately, but we could keep track of a worklist of edges that change maybe?
-            // And only use the changed ones like a worklist? And then instead of looping to fixpoint we use a worklist based approach?
-            //
             // Scan through each jump, collecting edges with params to analyze from CondBranch and Jump insns.
-            for block_id in &param_passing_blocks {
-                let insn_index = self.blocks[block_id.0].insns.len() - 1;
-                let insn_id = self.blocks[block_id.0].insns[insn_index];
-                let mut edges: Vec<BranchEdge> = vec![];
+            for block_id in &predecessor_blocks {
+                let insn_id = *self.blocks[block_id.0].insns.last().unwrap();
 
-                match self.find(insn_id) {
-                    Insn::CondBranch { if_true, if_false, .. } => {
-                        if if_true.args.len() > 0 {
-                            edges.push(if_true);
-                        }
-                        if if_false.args.len() > 0 {
-                            edges.push(if_false);
-                        }
-                    }
-                    Insn::Jump(edge) => {
-                        if edge.args.len() > 0 {
-                            edges.push(edge);
-                        }
-                    }
-                    _ => {}
-                }
+                // Extract edges into a tuple for processing
+                let (first, second) = match self.find(insn_id) {
+                    Insn::Jump(edge) => (Some(edge), None),
+                    Insn::CondBranch { if_true, if_false, ..} => (Some(if_true), Some(if_false)),
+                    _ => (None, None)
+                };
+
+                // Keep all edges that pass params
+                let edges = first.into_iter().chain(second).filter(|edge| edge.args.len() > 0);
 
                 // Use the results of abstract interpretation to update the states
                 // Perform abstract interpretation
@@ -6007,18 +6010,7 @@ impl Function {
                         if param == self.find_id(self.blocks[block_id.0].params[i]) {
                             continue
                         }
-                        let state = &mut predecessor_domain[block_id.0][i];
-                        match *state {
-                            ParamValue::None => {
-                                *state = ParamValue::One(param);
-                            },
-                            ParamValue::One(value) => {
-                                if value != param {
-                                    *state = ParamValue::Multiple;
-                                }
-                            }
-                            ParamValue::Multiple => {},
-                        }
+                        predecessor_domain[block_id.0][i].update(param);
                     }
                 }
             }
@@ -6028,18 +6020,8 @@ impl Function {
             // 1. Replace uses of the trivial params with the concretized value
             // 2. Remove trivial params from the basic block definition
             // 3. Remove trivial params from each CondBranch and Jump that targets the basic block that was just updated
-            for (block_id, block_preds) in predecessor_domain.iter().enumerate() {
-                // If there are no block params, there is nothing to optimize
-                // TODO: We scan predecessors and only keep track of blocks that pass params.
-                // We don't do this for block_preds but we should. This requires it kind of becoming hash-mappy again :|
-                // This conditional is a stop-gap to get most of the gains from such an optimization, though it should be removed
-                // Maybe we can get around this easier by not iterating over the predecessor domain, but over a subset of indices we care about
-                if block_preds.len() == 0 {
-                    continue
-                }
-
-                let block_id = BlockId(block_id);
-
+            for block_id in &param_blocks {
+                let block_preds = &predecessor_domain[block_id.0];
                 let trivial_indices: Vec<usize> = block_preds.iter().enumerate()
                     .filter_map(|(idx, state)|
                         matches!(state, ParamValue::One(_)).then_some(idx)
@@ -6049,7 +6031,7 @@ impl Function {
                 for param_index in &trivial_indices {
                     if let ParamValue::One(insn_id) = block_preds[*param_index] {
                         self.make_equal_to(self.blocks[block_id.0].params[*param_index], insn_id);
-                        updated = true;
+                        changed = true;
                     }
                 }
 
@@ -6057,23 +6039,23 @@ impl Function {
                 prune_vec_by_indices(&mut self.blocks[block_id.0].params, &trivial_indices);
 
                 // Update the terminators (basic blocks can only branch at the terminator. This is where block params are passed)
-                for jump_block_id in &param_passing_blocks {
+                for jump_block_id in &predecessor_blocks {
                     let index = self.blocks[jump_block_id.0].insns.len() - 1;
                     let cond_insn_id = self.blocks[jump_block_id.0].insns[index];
                     match self.find(cond_insn_id) {
                         Insn::Jump(edge) => {
-                            if edge.target == block_id {
+                            if edge.target == *block_id {
                                 let edge = prune_branch_edge(edge, &trivial_indices);
                                 self.insns[cond_insn_id.0] = Insn::Jump(edge);
                             }
                         }
                         Insn::CondBranch { val, if_true, if_false } => {
-                            let if_true = if if_true.target == block_id {
+                            let if_true = if if_true.target == *block_id {
                                 prune_branch_edge(if_true, &trivial_indices)
                             } else {
                                 if_true
                             };
-                            let if_false = if if_false.target == block_id {
+                            let if_false = if if_false.target == *block_id {
                                 prune_branch_edge(if_false, &trivial_indices)
                             } else {
                                 if_false

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5960,7 +5960,7 @@ impl Function {
                 // Match against the final instruction which terminates the basic block.
                 // If it has any non-empty edges, keep it.
                 match self.find(*self.blocks[block_id.0].insns().last().unwrap()) {
-                    Insn::CondBranch {if_true, if_false, ..} => !if_true.args.is_empty() || !if_false.args.is_empty(),
+                    Insn::CondBranch { if_true, if_false, .. } => !if_true.args.is_empty() || !if_false.args.is_empty(),
                     Insn::Jump(edge) => !edge.args.is_empty(),
                     _ => false
                 })

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5906,7 +5906,8 @@ impl Function {
     // (It's used more individually and differently than the paper)
     // TODO: Update comments to consider block params rather than phi nodes and demarcate differences from the algorithm clearly
     // TODO: Fix input arguments. We need block params, not just the phi
-    /// If all possible phi values are the same, replace the phi with the value
+    // If all possible phi values are the same, replace the phi with the value
+    // TODO: Add Max's optimization about not checking the first block. Maybe do this by keeping track of all changing edges and using a worklist?
 
     /// Sometimes block params can only come from one place and safely removed as block params.
     /// Trivial block param removal increases the efficacy of CFG-based optimization passes.
@@ -5961,104 +5962,107 @@ impl Function {
 
         while updated {
 
-        for (row, block) in predecessor_domain.iter_mut().zip(&self.blocks) {
-            row.resize(block.params.len(), ParamValue::None);
-        }
-        updated = false;
-
-        // Scan through each jump, collecting edges from CondBranch and Jump insns.
-        for (block_id, insn_index) in &terminators {
-            let insn_id = self.blocks[block_id.0].insns[*insn_index];
-            let mut edges: Vec<BranchEdge> = vec![];
-
-            match self.find(insn_id) {
-                Insn::CondBranch { if_true, if_false, .. } => {
-                    edges.push(if_true);
-                    edges.push(if_false);
-                }
-                Insn::Jump(edge) => {
-                    edges.push(edge);
-                }
-                _ => {}
+            for (row, block) in predecessor_domain.iter_mut().zip(&self.blocks) {
+                row.resize(block.params.len(), ParamValue::None);
             }
+            updated = false;
 
-            // Update the states
-            for BranchEdge { target: block_id, args: params } in edges {
-                for (i, param) in params.iter().enumerate().rev() {
-                    let param = self.find_id(*param);
-                    // If the param is the same as passed into the block, it is a self loop
-                    // We ignore self loops because they do not provide new information
-                    if param == self.find_id(self.blocks[block_id.0].params[i]) {
-                        continue
+            // TODO: Maybe move this outside the loop somehow? probably can't immediately, but we could keep track of a worklist of edges that change maybe?
+            // And only use the changed ones like a worklist? And then instead of looping to fixpoint we use a worklist based approach?
+            //
+            // Scan through each jump, collecting edges from CondBranch and Jump insns.
+            for (block_id, insn_index) in &terminators {
+                let insn_id = self.blocks[block_id.0].insns[*insn_index];
+                let mut edges: Vec<BranchEdge> = vec![];
+
+                match self.find(insn_id) {
+                    Insn::CondBranch { if_true, if_false, .. } => {
+                        edges.push(if_true);
+                        edges.push(if_false);
                     }
-                    let state = &mut predecessor_domain[block_id.0][i];
-                    match *state {
-                        ParamValue::None => {
-                            *state = ParamValue::One(param);
-                        },
-                        ParamValue::One(value) => {
-                            if value != param {
-                                *state = ParamValue::Multiple;
-                            }
-                        }
-                        ParamValue::Multiple => {},
-                    }
-                }
-            }
-        }
-
-        // Remove the trivial block params and fix up our SSA representation
-        // This is done by as follows.
-        // 1. Replace uses of the trivial params with the concretized value
-        // 2. Remove trivial params from the basic block definition
-        // 3. Remove trivial params from each CondBranch and Jump that targets the basic block that was just updated
-        for (block_id, block) in predecessor_domain.iter().enumerate() {
-            // TODO: Don't do this
-            let block_id = BlockId(block_id);
-
-            let trivial_indices: Vec<usize> = block.iter().enumerate()
-                .filter_map(|(idx, state)|
-                    matches!(state, ParamValue::One(_)).then_some(idx)
-                ).collect();
-
-            // Replace uses of the trivial params with the concretized value
-            for param_index in &trivial_indices {
-                if let ParamValue::One(insn_id) = block[*param_index] {
-                    self.make_equal_to(self.blocks[block_id.0].params[*param_index], insn_id);
-                    updated = true;
-                }
-            }
-
-            // Update the block
-            prune_vec_by_indices(&mut self.blocks[block_id.0].params, &trivial_indices);
-
-            // Update the terminators (basic blocks can only branch at the terminator. This is where block params are passed)
-            for (jump_block_id, index) in &terminators {
-                let cond_insn_id = self.blocks[jump_block_id.0].insns[*index];
-                match self.find(cond_insn_id) {
                     Insn::Jump(edge) => {
-                        if edge.target == block_id {
-                            let edge = prune_branch_edge(edge, &trivial_indices);
-                            self.insns[cond_insn_id.0] = Insn::Jump(edge);
-                        }
-                    }
-                    Insn::CondBranch { val, if_true, if_false } => {
-                        let if_true = if if_true.target == block_id {
-                            prune_branch_edge(if_true, &trivial_indices)
-                        } else {
-                            if_true
-                        };
-                        let if_false = if if_false.target == block_id {
-                            prune_branch_edge(if_false, &trivial_indices)
-                        } else {
-                            if_false
-                        };
-                        self.insns[cond_insn_id.0] = Insn::CondBranch{ val, if_true, if_false };
+                        edges.push(edge);
                     }
                     _ => {}
                 }
+
+                // Use the results of abstract interpretation to update the states
+                // Perform abstract interpretation
+                for BranchEdge { target: block_id, args: params } in edges {
+                    for (i, param) in params.iter().enumerate().rev() {
+                        let param = self.find_id(*param);
+                        // If the param is the same as passed into the block, it is a self loop and provides no new predecessor information.
+                        if param == self.find_id(self.blocks[block_id.0].params[i]) {
+                            continue
+                        }
+                        let state = &mut predecessor_domain[block_id.0][i];
+                        match *state {
+                            ParamValue::None => {
+                                *state = ParamValue::One(param);
+                            },
+                            ParamValue::One(value) => {
+                                if value != param {
+                                    *state = ParamValue::Multiple;
+                                }
+                            }
+                            ParamValue::Multiple => {},
+                        }
+                    }
+                }
             }
-        }
+
+            // Remove the trivial block params and fix up our SSA representation
+            // This is done by as follows.
+            // 1. Replace uses of the trivial params with the concretized value
+            // 2. Remove trivial params from the basic block definition
+            // 3. Remove trivial params from each CondBranch and Jump that targets the basic block that was just updated
+            for (block_id, block) in predecessor_domain.iter().enumerate() {
+                // TODO: Don't do this
+                let block_id = BlockId(block_id);
+
+                let trivial_indices: Vec<usize> = block.iter().enumerate()
+                    .filter_map(|(idx, state)|
+                        matches!(state, ParamValue::One(_)).then_some(idx)
+                    ).collect();
+
+                // Replace uses of the trivial params with the concretized value
+                for param_index in &trivial_indices {
+                    if let ParamValue::One(insn_id) = block[*param_index] {
+                        self.make_equal_to(self.blocks[block_id.0].params[*param_index], insn_id);
+                        updated = true;
+                    }
+                }
+
+                // Update the block
+                prune_vec_by_indices(&mut self.blocks[block_id.0].params, &trivial_indices);
+
+                // Update the terminators (basic blocks can only branch at the terminator. This is where block params are passed)
+                for (jump_block_id, index) in &terminators {
+                    let cond_insn_id = self.blocks[jump_block_id.0].insns[*index];
+                    match self.find(cond_insn_id) {
+                        Insn::Jump(edge) => {
+                            if edge.target == block_id {
+                                let edge = prune_branch_edge(edge, &trivial_indices);
+                                self.insns[cond_insn_id.0] = Insn::Jump(edge);
+                            }
+                        }
+                        Insn::CondBranch { val, if_true, if_false } => {
+                            let if_true = if if_true.target == block_id {
+                                prune_branch_edge(if_true, &trivial_indices)
+                            } else {
+                                if_true
+                            };
+                            let if_false = if if_false.target == block_id {
+                                prune_branch_edge(if_false, &trivial_indices)
+                            } else {
+                                if_false
+                            };
+                            self.insns[cond_insn_id.0] = Insn::CondBranch{ val, if_true, if_false };
+                        }
+                        _ => {}
+                    }
+                }
+            }
         }
 
     }

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5977,16 +5977,14 @@ impl Function {
             .collect();
 
         // We only need to update blocks that have params. (Blocks without params cannot be improved)
-        let blocks_receiving_params: Vec<BlockId> = blocks.into_iter()
+        let blocks_receiving_params: Vec<BlockId> = blocks.iter().copied()
             .filter(|&block_id|
                 self.blocks[block_id.to_usize()].params().len() != 0)
             .collect();
 
-        // NOTE: It is possible that once some block_params are removed, there will be no params.
-        // This means that predecessor_blocks or param_blocks could be pruned. This minor optimization can be added if desired.
-        // Importantly, we do not keep track of exactly which edges correspond to which blocks. While doing so
-        // would allow us to replace our "loop until fixpoint" with a "iterate through the worklist, only checking relevant edges",
-        // the construction of the mapping from predecessor edges to blocks seems expensive.
+        // Create a vec to represent trivial indices
+        let max_params = blocks.iter().copied().map(|id| self.blocks[id.to_usize()].params.len()).max().unwrap_or(0);
+        let mut trivial_indices: Vec<usize> = Vec::with_capacity(max_params);
 
         let mut changed = true;
 
@@ -6020,10 +6018,12 @@ impl Function {
             // 3. Remove trivial params from each CondBranch and Jump that targets the basic block that was just updated
             for block_id in &blocks_receiving_params {
                 let block_preds = &param_values[block_id.to_usize()];
-                let trivial_indices: Vec<usize> = block_preds.iter().enumerate()
-                    .filter_map(|(idx, state)|
-                        matches!(state, ParamValue::One(_)).then_some(idx)
-                    ).collect();
+                trivial_indices.clear();
+                for (idx, state) in block_preds.iter().enumerate() {
+                    if let ParamValue::One(_) = state {
+                        trivial_indices.push(idx);
+                    }
+                }
 
                 // Replace uses of the trivial params with the concretized value
                 for param_index in &trivial_indices {

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5940,36 +5940,15 @@ impl Function {
             })
         }
 
+        fn block_terminator(fun: &Function, block_id: BlockId) -> InsnId {
+            *fun.blocks[block_id.0].insns().last().unwrap()
+        }
+
         // Instantiate the domain for abstract interpretation.
         // We store possible param values for each block
         let mut predecessor_domain: Vec<Vec<ParamValue>> = vec![Vec::new(); self.blocks.len()];
 
         let blocks = self.reverse_post_order();
-
-        // Find blocks that terminate with Jump or CondBranch instructions that pass block params along.
-        // These terminators are later analyzed for trivial block params.
-        let predecessor_blocks: Vec<BlockId> = blocks.iter().copied()
-            .filter(|&block_id|
-                // Match against the final instruction which terminates the basic block.
-                // If it has any non-empty edges, keep it.
-                match self.find(*self.blocks[block_id.0].insns().last().unwrap()) {
-                    Insn::CondBranch { if_true, if_false, .. } => !if_true.args.is_empty() || !if_false.args.is_empty(),
-                    Insn::Jump(edge) => !edge.args.is_empty(),
-                    _ => false
-                })
-            .collect();
-
-        // We only need to update blocks that have params. (Blocks without params cannot be improved)
-        let param_blocks: Vec<BlockId> = blocks.into_iter()
-            .filter(|&block_id|
-                self.blocks[block_id.0].params().len() != 0)
-            .collect();
-
-        // NOTE: It is possible that once some block_params are removed, there will be no params.
-        // This means that predecessor_blocks or param_blocks could be pruned. This minor optimization can be added if desired.
-        // Importantly, we do not keep track of exactly which edges correspond to which blocks. While doing so
-        // would allow us to replace our "loop until fixpoint" with a "iterate through the worklist, only checking relevant edges",
-        // the construction of the mapping from predecessor edges to blocks seems expensive.
 
         let mut changed = true;
 
@@ -5981,12 +5960,9 @@ impl Function {
             }
 
             // Scan through each jump, collecting edges with params to analyze from CondBranch and Jump insns.
-            for block_id in &predecessor_blocks {
-                let insn_id = *self.blocks[block_id.0].insns.last().unwrap();
+            for block_id in &blocks {
+                let insn_id = block_terminator(self, *block_id);
 
-                // TODO: Add a function to flatten edges into an iterator for jumps and condbranches.
-                // TODO: Make sure to use this when we update edges in the block later
-                // Extract edges into a tuple for processing
                 let (first, second) = match self.resolve(insn_id).insn(self) {
                     Insn::Jump(edge) => (Some(edge), None),
                     Insn::CondBranch { if_true, if_false, ..} => (Some(if_true), Some(if_false)),
@@ -6015,7 +5991,11 @@ impl Function {
             // 1. Replace uses of the trivial params with the concretized value
             // 2. Remove trivial params from the basic block definition
             // 3. Remove trivial params from each CondBranch and Jump that targets the basic block that was just updated
-            for block_id in &param_blocks {
+            // TODO: Repalce RPO with blocks
+            for block_id in &blocks {
+                // TODO: Add a note about why we can skip these
+                if self.blocks[block_id.0].params().len() == 0 { continue }
+
                 let block_preds = &predecessor_domain[block_id.0];
                 let trivial_indices: Vec<usize> = block_preds.iter().enumerate()
                     .filter_map(|(idx, state)|
@@ -6034,9 +6014,15 @@ impl Function {
                 prune_vec_by_indices(&mut self.blocks[block_id.0].params, &trivial_indices);
 
                 // Update the terminators (basic blocks can only branch at the terminator. This is where block params are passed)
-                for jump_block_id in &predecessor_blocks {
-                    let index = self.blocks[jump_block_id.0].insns.len() - 1;
-                    let cond_insn_id = self.blocks[jump_block_id.0].insns[index];
+                for jump_block_id in &blocks {
+                    let optimizable = match self.find(block_terminator(self, *jump_block_id)) {
+                        Insn::CondBranch { if_true, if_false, .. } => !if_true.args.is_empty() || !if_false.args.is_empty(),
+                        Insn::Jump(edge) => !edge.args.is_empty(),
+                        _ => false
+                    };
+                    if !optimizable { continue }
+
+                    let cond_insn_id = block_terminator(self, *jump_block_id);
                     match self.resolve(cond_insn_id).insn_mut(self) {
                         Insn::Jump(edge) => {
                             if edge.target == *block_id {
@@ -6056,7 +6042,6 @@ impl Function {
                 }
             }
         }
-
     }
 
 

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5872,10 +5872,21 @@ impl Function {
         let phi = &InsnId(5); // FIX: this shouldn't be just a random dummy value
         let predecessors = vec![];
         // TODO: Run the following in a loop once we've gotten all the phis
-        let phis: Vec<&InsnId> = vec![];
+        // TODO: Figure out if we want to do this mutably and in one pass with into_iter or take instead.
+        let phis: Vec<(BlockId, InsnId)> = self.reverse_post_order().iter().flat_map(|block_id| {
+            self.blocks[block_id.0].params().map(|&param| (*block_id, param))
+        }).collect();
         // FIX: The logic if this is wrong. We want to make sure `p` is not a self reference. Equality with phi likely does not do this
         let external_preds: Vec<&InsnId> = predecessors.iter().filter(|p| *p != phi).collect();
 
+        match external_preds.as_slice() {
+            [] => {} // Phi is unreachable
+            [first, rest @ ..] if rest.iter().any(|p| p != first) => {} // Phi is non-trivial
+            [value, ..] => { // Phi is trivial
+
+            }
+
+        }
         let new_phi = match external_preds.as_slice() {
             [] => {
                 // Phi is unreachable

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5901,81 +5901,97 @@ impl Function {
         }
     }
 
-    /// Convert maximal SSA (constructed from YARV with `add_iseq_to_hir`) to minimal SSA
-    /// We implement the SSA construction described by Braun et al.
-    /// SSA Paper reference: <https://c9x.me/compile/bib/braun13cc.pdf>
-    fn minify_ssa(&mut self) {
-        // This PR is _very_ much an early draft. I've spent some time reading the paper, and isolating some of the concepts.
-        // There will be lots of lengthy comments that get removed and reworked. There are concepts in ZJIT that are identical but named different things.
-        // We need to map these to each other. It probably makes sense to keep some reference comments performing this mapping for the future too.
-        //
-        // Important difference: Braun et al construct SSA from scratch. We already have a maximal SSA representation. We may be able to get away with only the pruning parts of the paper
-        // Alternatively, we may just need to overhaul our entire SSA construction. I'm not sure what makes sense yet.
-        //
-        // TODO: Make tests for single blocks and multiple block constructions of minimal SSA
-        // It would be great to faithfully recreate examples from the paper but with ZJIT specifics. If there's a way to construct ruby code that maps to this HIR, that would be awesome but jury is still out
-        //
-        // First Test Idea for LVN (page 3):
-        // This first version isn't entirely implementable because `d` and `v?` are intentionally unspecified but it's a good starting point
-        // source (make into ruby)    SSA (make into ZJIT)
-        // a <- 42                    v1: 42
-        // b <- a
-        // c <- a + b                 v2: v1 + v1
-        //                            v3: 23
-        // a <- c + 23                v4: v2 + v3
-        // c <- a + d                 v5: v4 + v?
+    fn try_remove_trivial_phi(BlockId: block_id) {
 
-        // ------------ SINGLE BLOCK ----------------
-        // This section contains all the tech we need for single blocks. For implementation, let's pass tests for this part first before adding in the rest
-        // These two functions handle local value numbering. I don't know if this is something that Max landed in a PR, nor what can / should be repurposed vs written from scratch
-        fn read_variable() {
-            // TODO: Specify and define arguments
-            // TODO: Figure out if this already exists in ZJIT. Likely this uses find or chase_insn?
-        }
+    }
 
-        fn write_variable() {
-            // TODO: Specify and define arguments
-            // TODO: Figure out if this already exists in ZJIT. Likely this uses find or chase_insn?
+    fn remove_trivial_phis(&mut self) {
+        let mut fixpoint = False;
+        while not fixpoint {
+            for block in self.reverse_post_order() {
+                // TODO: Figure out where the predecessors come from
+                predecessors = vec![];
+                try_remove_trivial_phi(block);
+            }
         }
-        //
-        // ------------ MULTIPLE BLOCKS ----------------
-        // When we get to multiple blocks, we need to deal with phi nodes. It seems that in ZJIT, these are referred to as block arguments or block params
-        // It would be really nice to check my knowledge on this, and potentially rename them if so
-        fn read_variable_recursive() {
-            // TODO: fill out
-            // This function is the global value numbering version of the single block variant
-        }
+    }
 
-        fn add_phi_operands() {
-            // See comments in try_remove_triival_phi
-        }
+    // TODO: Probably throw this next big comment away
+    // /// Convert maximal SSA (constructed from YARV with `add_iseq_to_hir`) to minimal SSA
+    // /// We implement the SSA construction described by Braun et al.
+    // /// SSA Paper reference: <https://c9x.me/compile/bib/braun13cc.pdf>
+    // fn minify_ssa(&mut self) {
+    //     // This PR is _very_ much an early draft. I've spent some time reading the paper, and isolating some of the concepts.
+    //     // There will be lots of lengthy comments that get removed and reworked. There are concepts in ZJIT that are identical but named different things.
+    //     // We need to map these to each other. It probably makes sense to keep some reference comments performing this mapping for the future too.
+    //     //
+    //     // Important difference: Braun et al construct SSA from scratch. We already have a maximal SSA representation. We may be able to get away with only the pruning parts of the paper
+    //     // Alternatively, we may just need to overhaul our entire SSA construction. I'm not sure what makes sense yet.
+    //     //
+    //     // TODO: Make tests for single blocks and multiple block constructions of minimal SSA
+    //     // It would be great to faithfully recreate examples from the paper but with ZJIT specifics. If there's a way to construct ruby code that maps to this HIR, that would be awesome but jury is still out
+    //     //
+    //     // First Test Idea for LVN (page 3):
+    //     // This first version isn't entirely implementable because `d` and `v?` are intentionally unspecified but it's a good starting point
+    //     // source (make into ruby)    SSA (make into ZJIT)
+    //     // a <- 42                    v1: 42
+    //     // b <- a
+    //     // c <- a + b                 v2: v1 + v1
+    //     //                            v3: 23
+    //     // a <- c + 23                v4: v2 + v3
+    //     // c <- a + d                 v5: v4 + v?
 
-        fn try_remove_trivial_phi() {
-            // TODO: fill out
-            // This function cleans up the opportunistic phis that get added in Braun's algorithm.
-            // If we didn't add such phis, we run into all sorts of recursion issues. This is a key idea in the algorithm we are implementing
-        }
+    //     // ------------ SINGLE BLOCK ----------------
+    //     // This section contains all the tech we need for single blocks. For implementation, let's pass tests for this part first before adding in the rest
+    //     // These two functions handle local value numbering. I don't know if this is something that Max landed in a PR, nor what can / should be repurposed vs written from scratch
+    //     fn read_variable() {
+    //         // TODO: Specify and define arguments
+    //         // TODO: Figure out if this already exists in ZJIT. Likely this uses find or chase_insn?
+    //     }
 
-        // ---------- INCOMPLETE CFGS --------------
-        // While technically part of the multiple blocks section, the next functions are even more complicated so they get their own section
-        fn seal_block() {
-            // We call a block "sealed" when we know there will not be predecessors added to the block.
-            // This function adds all necessary phis to incomplete blocks and adds this block to the sealed list
-        }
+    //     fn write_variable() {
+    //         // TODO: Specify and define arguments
+    //         // TODO: Figure out if this already exists in ZJIT. Likely this uses find or chase_insn?
+    //     }
+    //     //
+    //     // ------------ MULTIPLE BLOCKS ----------------
+    //     // When we get to multiple blocks, we need to deal with phi nodes. It seems that in ZJIT, these are referred to as block arguments or block params
+    //     // It would be really nice to check my knowledge on this, and potentially rename them if so
+    //     fn read_variable_recursive() {
+    //         // TODO: fill out
+    //         // This function is the global value numbering version of the single block variant
+    //     }
 
-        // I don't yet know which optimizations we want to include during construction. Pages 8 and 9 of the paper show why this is non-trivial and important for us to figure out
-        // However, the following tools are definitely necessary
-        fn remove_redundant_phis() {
-            // In the paper, they innovate by considering irreducible control flow from the perspective of the strongly connected component that _must_ exist if there are redundant phis
-            // By computing this strongly connected component, we can figure out what to remove (with the following function)
-        }
+    //     fn add_phi_operands() {
+    //         // See comments in try_remove_triival_phi
+    //     }
 
-        fn process_strongly_connected_component() {
-            // Do some fancy logic to iterate across all the phis in the SCC, tracking "inner" and "outer" operations
-        }
+    //     fn try_remove_trivial_phi() {
+    //         // TODO: fill out
+    //         // This function cleans up the opportunistic phis that get added in Braun's algorithm.
+    //         // If we didn't add such phis, we run into all sorts of recursion issues. This is a key idea in the algorithm we are implementing
+    //     }
 
-        // TODO: Close reading of page 11 after implementing everything else to see if there are further optimizations to be made
-        // Key issue: we construct a lot of phis and then remove a lot of phis. Can we construct fewer in the first place?
+    //     // ---------- INCOMPLETE CFGS --------------
+    //     // While technically part of the multiple blocks section, the next functions are even more complicated so they get their own section
+    //     fn seal_block() {
+    //         // We call a block "sealed" when we know there will not be predecessors added to the block.
+    //         // This function adds all necessary phis to incomplete blocks and adds this block to the sealed list
+    //     }
+
+    //     // I don't yet know which optimizations we want to include during construction. Pages 8 and 9 of the paper show why this is non-trivial and important for us to figure out
+    //     // However, the following tools are definitely necessary
+    //     fn remove_redundant_phis() {
+    //         // In the paper, they innovate by considering irreducible control flow from the perspective of the strongly connected component that _must_ exist if there are redundant phis
+    //         // By computing this strongly connected component, we can figure out what to remove (with the following function)
+    //     }
+
+    //     fn process_strongly_connected_component() {
+    //         // Do some fancy logic to iterate across all the phis in the SCC, tracking "inner" and "outer" operations
+    //     }
+
+    //     // TODO: Close reading of page 11 after implementing everything else to see if there are further optimizations to be made
+    //     // Key issue: we construct a lot of phis and then remove a lot of phis. Can we construct fewer in the first place?
 
     }
 
@@ -6805,7 +6821,7 @@ impl Function {
             (convert_no_profile_sends) => { Counter::compile_hir_strength_reduce_time_ns };
             // End strength reduction bucket
             (inline_methods) => { Counter::compile_hir_inline_methods_time_ns };
-            (minify_ssa) => { Counter::compile_hir_minify_ssa_time_ns };
+            (remove_trivial_phis) => { Counter::compile_hir_remove_trivial_phis_time_ns };
             (optimize_load_store) => { Counter::compile_hir_optimize_load_store_time_ns };
             (canonicalize) => { Counter::compile_hir_canonicalize_time_ns };
             (fold_constants) => { Counter::compile_hir_fold_constants_time_ns };
@@ -6859,7 +6875,7 @@ impl Function {
             // TODO: Figure out where the pass should go and remove these comments
             // It's not clear where converting to minimal SSA should occur
             // We need it for a global optimize_load_store, so this is a good starting point
-            run_pass!(minify_ssa);
+            run_pass!(remove_trivial_phis);
             run_pass!(optimize_load_store);
             run_pass!(canonicalize);
             run_pass!(fold_constants);

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -6947,11 +6947,8 @@ impl Function {
             } else {
                 false
             };
-            run_pass!(convert_no_profile_sends);
-            // TODO: Figure out where the pass should go and remove these comments
-            // It's not clear where converting to minimal SSA should occur
-            // We need it for a global optimize_load_store, so this is a good starting point
             run_pass!(remove_trivial_block_params);
+            run_pass!(convert_no_profile_sends);
             run_pass!(optimize_load_store);
             run_pass!(canonicalize);
             run_pass!(fold_constants);

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5920,7 +5920,7 @@ impl Function {
                 // Match against the final instruction which terminates the basic block.
                 // If it has any non-empty edges, keep it.
                 match self.find(*self.blocks[block_id.0].insns().last().unwrap()) {
-                    Insn::CondBranch {if_true, if_false, ..} => !if_true.args.is_empty() || !if_false.args.is_empty(),
+                    Insn::CondBranch { if_true, if_false, .. } => !if_true.args.is_empty() || !if_false.args.is_empty(),
                     Insn::Jump(edge) => !edge.args.is_empty(),
                     _ => false
                 })

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5912,10 +5912,21 @@ impl Function {
         let phi = &InsnId(5); // FIX: this shouldn't be just a random dummy value
         let predecessors = vec![];
         // TODO: Run the following in a loop once we've gotten all the phis
-        let phis: Vec<&InsnId> = vec![];
+        // TODO: Figure out if we want to do this mutably and in one pass with into_iter or take instead.
+        let phis: Vec<(BlockId, InsnId)> = self.reverse_post_order().iter().flat_map(|block_id| {
+            self.blocks[block_id.0].params().map(|&param| (*block_id, param))
+        }).collect();
         // FIX: The logic if this is wrong. We want to make sure `p` is not a self reference. Equality with phi likely does not do this
         let external_preds: Vec<&InsnId> = predecessors.iter().filter(|p| *p != phi).collect();
 
+        match external_preds.as_slice() {
+            [] => {} // Phi is unreachable
+            [first, rest @ ..] if rest.iter().any(|p| p != first) => {} // Phi is non-trivial
+            [value, ..] => { // Phi is trivial
+
+            }
+
+        }
         let new_phi = match external_preds.as_slice() {
             [] => {
                 // Phi is unreachable

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5942,6 +5942,14 @@ impl Function {
             BranchEdge { target: edge.target, args }
         }
 
+        fn insn_passes_params(insn: Insn) -> bool {
+            match insn {
+                Insn::CondBranch {if_true, if_false, ..} => !if_true.args.is_empty() || !if_false.args.is_empty(),
+                Insn::Jump(edge) => !edge.args.is_empty(),
+                _ => false
+            }
+        }
+
         // Instantiate the domain for abstract interpretation
         // Outer index is block
         // Inner index is param index
@@ -5950,14 +5958,11 @@ impl Function {
 
         let mut updated = true;
 
-        // Store references to all the conditional instructions.
-        // We need to update these conditionals in the case of trivial block params.
-        let terminators: Vec<(BlockId, usize)> = self.reverse_post_order().into_iter()
-            .filter(|&block_id| matches!(
-                self.find(*self.blocks[block_id.0].insns.last().unwrap()),
-                Insn::CondBranch {..} | Insn::Jump {..}
-            ))
-            .map(|block_id| (block_id, self.blocks[block_id.0].insns.len() - 1))
+        // Find blocks that terminate with Jump or CondBranch instructions that pass block params along.
+        // These terminators are later analyzed for trivial block params.
+        let param_passing_blocks: Vec<BlockId> = self.reverse_post_order().into_iter()
+            .filter(|&block_id|
+                insn_passes_params(self.find(*self.blocks[block_id.0].insns.last().unwrap())))
             .collect();
 
         while updated {
@@ -5970,18 +5975,25 @@ impl Function {
             // TODO: Maybe move this outside the loop somehow? probably can't immediately, but we could keep track of a worklist of edges that change maybe?
             // And only use the changed ones like a worklist? And then instead of looping to fixpoint we use a worklist based approach?
             //
-            // Scan through each jump, collecting edges from CondBranch and Jump insns.
-            for (block_id, insn_index) in &terminators {
-                let insn_id = self.blocks[block_id.0].insns[*insn_index];
+            // Scan through each jump, collecting edges with params to analyze from CondBranch and Jump insns.
+            for block_id in &param_passing_blocks {
+                let insn_index = self.blocks[block_id.0].insns.len() - 1;
+                let insn_id = self.blocks[block_id.0].insns[insn_index];
                 let mut edges: Vec<BranchEdge> = vec![];
 
                 match self.find(insn_id) {
                     Insn::CondBranch { if_true, if_false, .. } => {
-                        edges.push(if_true);
-                        edges.push(if_false);
+                        if if_true.args.len() > 0 {
+                            edges.push(if_true);
+                        }
+                        if if_false.args.len() > 0 {
+                            edges.push(if_false);
+                        }
                     }
                     Insn::Jump(edge) => {
-                        edges.push(edge);
+                        if edge.args.len() > 0 {
+                            edges.push(edge);
+                        }
                     }
                     _ => {}
                 }
@@ -6016,18 +6028,26 @@ impl Function {
             // 1. Replace uses of the trivial params with the concretized value
             // 2. Remove trivial params from the basic block definition
             // 3. Remove trivial params from each CondBranch and Jump that targets the basic block that was just updated
-            for (block_id, block) in predecessor_domain.iter().enumerate() {
-                // TODO: Don't do this
+            for (block_id, block_preds) in predecessor_domain.iter().enumerate() {
+                // If there are no block params, there is nothing to optimize
+                // TODO: We scan predecessors and only keep track of blocks that pass params.
+                // We don't do this for block_preds but we should. This requires it kind of becoming hash-mappy again :|
+                // This conditional is a stop-gap to get most of the gains from such an optimization, though it should be removed
+                // Maybe we can get around this easier by not iterating over the predecessor domain, but over a subset of indices we care about
+                if block_preds.len() == 0 {
+                    continue
+                }
+
                 let block_id = BlockId(block_id);
 
-                let trivial_indices: Vec<usize> = block.iter().enumerate()
+                let trivial_indices: Vec<usize> = block_preds.iter().enumerate()
                     .filter_map(|(idx, state)|
                         matches!(state, ParamValue::One(_)).then_some(idx)
                     ).collect();
 
                 // Replace uses of the trivial params with the concretized value
                 for param_index in &trivial_indices {
-                    if let ParamValue::One(insn_id) = block[*param_index] {
+                    if let ParamValue::One(insn_id) = block_preds[*param_index] {
                         self.make_equal_to(self.blocks[block_id.0].params[*param_index], insn_id);
                         updated = true;
                     }
@@ -6037,8 +6057,9 @@ impl Function {
                 prune_vec_by_indices(&mut self.blocks[block_id.0].params, &trivial_indices);
 
                 // Update the terminators (basic blocks can only branch at the terminator. This is where block params are passed)
-                for (jump_block_id, index) in &terminators {
-                    let cond_insn_id = self.blocks[jump_block_id.0].insns[*index];
+                for jump_block_id in &param_passing_blocks {
+                    let index = self.blocks[jump_block_id.0].insns.len() - 1;
+                    let cond_insn_id = self.blocks[jump_block_id.0].insns[index];
                     match self.find(cond_insn_id) {
                         Insn::Jump(edge) => {
                             if edge.target == block_id {

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5861,19 +5861,38 @@ impl Function {
         }
     }
 
-    fn try_remove_trivial_phi(BlockId: block_id) {
-
-    }
+    // TODO: Add a comment about the paper and where this function comes from, as well as how it's used in ZJIT
+    // (It's used more individually and differently than the paper)
+    // TODO: Update comments to consider block params rather than phi nodes and demarcate differences from the algorithm clearly
+    // TODO: Fix input arguments. We need block params, not just the phi
+    /// If all possible phi values are the same, replace the phi with the value
 
     fn remove_trivial_phis(&mut self) {
-        let mut fixpoint = False;
-        while not fixpoint {
-            for block in self.reverse_post_order() {
-                // TODO: Figure out where the predecessors come from
-                predecessors = vec![];
-                try_remove_trivial_phi(block);
+        // TODO: Find all of the phis and predecessors
+        let phi = &InsnId(5); // FIX: this shouldn't be just a random dummy value
+        let predecessors = vec![];
+        // TODO: Run the following in a loop once we've gotten all the phis
+        let phis: Vec<&InsnId> = vec![];
+        // FIX: The logic if this is wrong. We want to make sure `p` is not a self reference. Equality with phi likely does not do this
+        let external_preds: Vec<&InsnId> = predecessors.iter().filter(|p| *p != phi).collect();
+
+        let new_phi = match external_preds.as_slice() {
+            [] => {
+                // Phi is unreachable
+                // TODO: Figure out how we are supposed to handle an unreachable phi
+                *phi // FIX: We don't want to return phi in this case. What do we want to do with an unreachable value??
             }
-        }
+            [first, rest @ ..] if rest.iter().any(|p| p != first) => {
+                // Phi is non-trivial
+                *phi
+            }
+            [value, ..] => {
+                // Phi is trivial. All elements of the vec are `value`.
+                // TODO: Replace all uses of phi with value with make_equal_to
+                // TODO: Iteratively call try_remove_trivial_phi on uses. Can we get uses with find?
+                **value
+            }
+        };
     }
 
     // TODO: Probably throw this next big comment away
@@ -5952,8 +5971,8 @@ impl Function {
 
     //     // TODO: Close reading of page 11 after implementing everything else to see if there are further optimizations to be made
     //     // Key issue: we construct a lot of phis and then remove a lot of phis. Can we construct fewer in the first place?
-
-    }
+    //
+    // }
 
     fn optimize_load_store(&mut self) {
         for block in self.reverse_post_order() {

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5873,8 +5873,10 @@ impl Function {
     /// This function implements algorithm 2 from <https://c9x.me/compile/bib/braun13cc.pdf>.
     /// Light modifications are made to use block params instead of phis.
     fn remove_trivial_block_params(&mut self) {
-        // This abstract domain represents block param optimization potential
-        // If it were constructed as a lattice, Unknown is bottom, trivial is above, nontrivial is top (and above trivial)
+        // Each block param corresponds to a ParamValue
+        // This is the abstract domain used for abstract interpretation
+        // If there are no predecessors or multiple predecessors to a param, no optimization can happen
+        // However if there is a single unique predecessor, then the block param is trivial and we can replace with its concretized value
         #[derive(Clone)]
         enum ParamValue {
             None,
@@ -5882,10 +5884,7 @@ impl Function {
             Multiple
         }
 
-        // TODO: Make a note about how this breaks Dak2's test in the PR and this should probably be a discussion.
-        // canonicalize is block-local, and the generated test used block params. This caused a use of a value to be canonicalized (I think)
-        // which removed a type refinement that was passed
-
+        // Helper function to remove selected indices from a vec in place
         fn prune_vec_by_indices<T>(v: &mut Vec<T>, indices: &[usize]) {
             let mut i: usize = 0;
             v.retain(|_| {
@@ -5895,31 +5894,30 @@ impl Function {
             })
         }
 
-        // Remove an argument of the edge at index if the conditional matches target_block
+        // Remove arguments of the edge at selected indices
         fn prune_branch_edge(edge: BranchEdge, indices: &Vec<usize>) -> BranchEdge {
             let mut args = edge.args.clone();
             prune_vec_by_indices(&mut args, indices);
             BranchEdge { target: edge.target, args }
         }
 
-        let mut changed = true;
-
-        while changed {
-
-        changed = false;
-
         // Instantiate the domain for abstract interpretation
         // Outer index is block
         // Inner index is param index
         // Value is the state of the param. This is used to determine whether block param optimization can occur.
         let mut predecessor_domain: Vec<Vec<ParamValue>> = vec![Vec::new(); self.blocks.len()];
-        for (i, block) in self.blocks.iter().enumerate() {
-            predecessor_domain[i].extend(std::iter::repeat_n(ParamValue::None, block.params.len()))
+        let mut updated = true;
+
+        while updated {
+
+        for (row, block) in predecessor_domain.iter_mut().zip(&self.blocks) {
+            row.resize(block.params.len(), ParamValue::None);
         }
+        updated = false;
 
         // Store references to all the conditional instructions.
         // We need to update these conditionals in the case of trivial block params.
-        let jumps: Vec<(BlockId, usize)> = self.reverse_post_order().into_iter()
+        let terminators: Vec<(BlockId, usize)> = self.reverse_post_order().into_iter()
             .filter(|&block_id| matches!(
                 self.find(*self.blocks[block_id.0].insns.last().unwrap()),
                 Insn::CondBranch {..} | Insn::Jump {..}
@@ -5929,7 +5927,7 @@ impl Function {
 
 
         // Scan through each jump, collecting edges from CondBranch and Jump insns.
-        for (block_id, insn_index) in &jumps {
+        for (block_id, insn_index) in &terminators {
             let insn_id = self.blocks[block_id.0].insns[*insn_index];
             let mut edges: Vec<BranchEdge> = vec![];
 
@@ -5947,14 +5945,9 @@ impl Function {
             // Update the states
             for BranchEdge { target: block_id, args: params } in edges {
                 for (i, param) in params.iter().enumerate().rev() {
-                    // If the param is the same as passed into the block, this means it is a self loop
-                    // We can safely ignore these cases.
-                    // FIX: Do we always want the representative in the group? This throws away type information.
-                    // Seems like we have a strange edge case where we want to consider multiple different guards of a value to represent the same value and elide blockparams
-                    // But at the same time, we want subsequent blocks to use the most type information that we have, rather than the original canonical value.
-                    // I'm not sure how we can do this more generally. It feels like it's not the responsibility of this phi reduction pass, but of a type inference pass
-                    // Feels like we should do some kind of guard code motion of some kind...
                     let param = self.find_id(*param);
+                    // If the param is the same as passed into the block, it is a self loop
+                    // We ignore self loops because they do not provide new information
                     if param == self.find_id(self.blocks[block_id.0].params[i]) {
                         continue
                     }
@@ -5992,15 +5985,15 @@ impl Function {
             for param_index in &trivial_indices {
                 if let ParamValue::One(insn_id) = block[*param_index] {
                     self.make_equal_to(self.blocks[block_id.0].params[*param_index], insn_id);
-                    changed = true;
+                    updated = true;
                 }
             }
 
             // Update the block
             prune_vec_by_indices(&mut self.blocks[block_id.0].params, &trivial_indices);
 
-            // Update the conditionals that branch to block
-            for (jump_block_id, index) in &jumps {
+            // Update the terminators (basic blocks can only branch at the terminator. This is where block params are passed)
+            for (jump_block_id, index) in &terminators {
                 let cond_insn_id = self.blocks[jump_block_id.0].insns[*index];
                 match self.find(cond_insn_id) {
                     Insn::Jump(edge) => {
@@ -6010,11 +6003,17 @@ impl Function {
                         }
                     }
                     Insn::CondBranch { val, if_true, if_false } => {
-                        if if_true.target == block_id || if_false.target == block_id {
-                            let if_true = prune_branch_edge(if_true, &trivial_indices);
-                            let if_false = prune_branch_edge(if_false, &trivial_indices);
-                            self.insns[cond_insn_id.0] = Insn::CondBranch{ val, if_true, if_false };
-                        }
+                        let if_true = if if_true.target == block_id {
+                            prune_branch_edge(if_true, &trivial_indices)
+                        } else {
+                            if_true
+                        };
+                        let if_false = if if_false.target == block_id {
+                            prune_branch_edge(if_false, &trivial_indices)
+                        } else {
+                            if_false
+                        };
+                        self.insns[cond_insn_id.0] = Insn::CondBranch{ val, if_true, if_false };
                     }
                     _ => {}
                 }

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5916,11 +5916,15 @@ impl Function {
         // This abstract domain represents block param optimization potential
         // If it were constructed as a lattice, Unknown is bottom, trivial is above, nontrivial is top (and above trivial)
         #[derive(Clone)]
-        enum ParamState {
-            Unknown,
-            NonTrivial,
-            Trivial(InsnId)
+        enum ParamValue {
+            None,
+            One(InsnId),
+            Multiple
         }
+
+        // TODO: Make a note about how this breaks Dak2's test in the PR and this should probably be a discussion.
+        // canonicalize is block-local, and the generated test used block params. This caused a use of a value to be canonicalized (I think)
+        // which removed a type refinement that was passed
 
         fn prune_vec_by_indices<T>(v: &mut Vec<T>, indices: &[usize]) {
             let mut i: usize = 0;
@@ -5948,9 +5952,9 @@ impl Function {
         // Outer index is block
         // Inner index is param index
         // Value is the state of the param. This is used to determine whether block param optimization can occur.
-        let mut predecessor_domain: Vec<Vec<ParamState>> = vec![Vec::new(); self.blocks.len()];
+        let mut predecessor_domain: Vec<Vec<ParamValue>> = vec![Vec::new(); self.blocks.len()];
         for (i, block) in self.blocks.iter().enumerate() {
-            predecessor_domain[i].extend(std::iter::repeat_n(ParamState::Unknown, block.params.len()))
+            predecessor_domain[i].extend(std::iter::repeat_n(ParamValue::None, block.params.len()))
         }
 
         // Store references to all the conditional instructions.
@@ -5981,24 +5985,30 @@ impl Function {
             }
 
             // Update the states
-            for BranchEdge { target, args } in edges {
-                for (i, arg) in args.iter().enumerate().rev() {
+            for BranchEdge { target: block_id, args: params } in edges {
+                for (i, param) in params.iter().enumerate().rev() {
                     // If the param is the same as passed into the block, this means it is a self loop
                     // We can safely ignore these cases.
-                    if self.chase_insn(*arg) == self.chase_insn(self.blocks[target.0].params[i]) {
+                    // FIX: Do we always want the representative in the group? This throws away type information.
+                    // Seems like we have a strange edge case where we want to consider multiple different guards of a value to represent the same value and elide blockparams
+                    // But at the same time, we want subsequent blocks to use the most type information that we have, rather than the original canonical value.
+                    // I'm not sure how we can do this more generally. It feels like it's not the responsibility of this phi reduction pass, but of a type inference pass
+                    // Feels like we should do some kind of guard code motion of some kind...
+                    let param = self.find_id(*param);
+                    if param == self.find_id(self.blocks[block_id.0].params[i]) {
                         continue
                     }
-                    let state = &mut predecessor_domain[target.0][i];
+                    let state = &mut predecessor_domain[block_id.0][i];
                     match *state {
-                        ParamState::Unknown => {
-                            *state = ParamState::Trivial(self.chase_insn(*arg));
+                        ParamValue::None => {
+                            *state = ParamValue::One(param);
                         },
-                        ParamState::Trivial(value) => {
-                            if value != self.chase_insn(*arg) {
-                                *state = ParamState::NonTrivial;
+                        ParamValue::One(value) => {
+                            if value != param {
+                                *state = ParamValue::Multiple;
                             }
                         }
-                        ParamState::NonTrivial => {},
+                        ParamValue::Multiple => {},
                     }
                 }
             }
@@ -6015,13 +6025,13 @@ impl Function {
 
             let trivial_indices: Vec<usize> = block.iter().enumerate()
                 .filter_map(|(idx, state)|
-                    matches!(state, ParamState::Trivial(_)).then_some(idx)
+                    matches!(state, ParamValue::One(_)).then_some(idx)
                 ).collect();
 
             // Replace uses of the trivial params with the concretized value
             for param_index in &trivial_indices {
-                if let ParamState::Trivial(concretized_insn) = block[*param_index] {
-                    self.make_equal_to(self.blocks[block_id.0].params[*param_index], concretized_insn);
+                if let ParamValue::One(insn_id) = block[*param_index] {
+                    self.make_equal_to(self.blocks[block_id.0].params[*param_index], insn_id);
                     changed = true;
                 }
             }

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5876,11 +5876,15 @@ impl Function {
         // This abstract domain represents block param optimization potential
         // If it were constructed as a lattice, Unknown is bottom, trivial is above, nontrivial is top (and above trivial)
         #[derive(Clone)]
-        enum ParamState {
-            Unknown,
-            NonTrivial,
-            Trivial(InsnId)
+        enum ParamValue {
+            None,
+            One(InsnId),
+            Multiple
         }
+
+        // TODO: Make a note about how this breaks Dak2's test in the PR and this should probably be a discussion.
+        // canonicalize is block-local, and the generated test used block params. This caused a use of a value to be canonicalized (I think)
+        // which removed a type refinement that was passed
 
         fn prune_vec_by_indices<T>(v: &mut Vec<T>, indices: &[usize]) {
             let mut i: usize = 0;
@@ -5908,9 +5912,9 @@ impl Function {
         // Outer index is block
         // Inner index is param index
         // Value is the state of the param. This is used to determine whether block param optimization can occur.
-        let mut predecessor_domain: Vec<Vec<ParamState>> = vec![Vec::new(); self.blocks.len()];
+        let mut predecessor_domain: Vec<Vec<ParamValue>> = vec![Vec::new(); self.blocks.len()];
         for (i, block) in self.blocks.iter().enumerate() {
-            predecessor_domain[i].extend(std::iter::repeat_n(ParamState::Unknown, block.params.len()))
+            predecessor_domain[i].extend(std::iter::repeat_n(ParamValue::None, block.params.len()))
         }
 
         // Store references to all the conditional instructions.
@@ -5941,24 +5945,30 @@ impl Function {
             }
 
             // Update the states
-            for BranchEdge { target, args } in edges {
-                for (i, arg) in args.iter().enumerate().rev() {
+            for BranchEdge { target: block_id, args: params } in edges {
+                for (i, param) in params.iter().enumerate().rev() {
                     // If the param is the same as passed into the block, this means it is a self loop
                     // We can safely ignore these cases.
-                    if self.chase_insn(*arg) == self.chase_insn(self.blocks[target.0].params[i]) {
+                    // FIX: Do we always want the representative in the group? This throws away type information.
+                    // Seems like we have a strange edge case where we want to consider multiple different guards of a value to represent the same value and elide blockparams
+                    // But at the same time, we want subsequent blocks to use the most type information that we have, rather than the original canonical value.
+                    // I'm not sure how we can do this more generally. It feels like it's not the responsibility of this phi reduction pass, but of a type inference pass
+                    // Feels like we should do some kind of guard code motion of some kind...
+                    let param = self.find_id(*param);
+                    if param == self.find_id(self.blocks[block_id.0].params[i]) {
                         continue
                     }
-                    let state = &mut predecessor_domain[target.0][i];
+                    let state = &mut predecessor_domain[block_id.0][i];
                     match *state {
-                        ParamState::Unknown => {
-                            *state = ParamState::Trivial(self.chase_insn(*arg));
+                        ParamValue::None => {
+                            *state = ParamValue::One(param);
                         },
-                        ParamState::Trivial(value) => {
-                            if value != self.chase_insn(*arg) {
-                                *state = ParamState::NonTrivial;
+                        ParamValue::One(value) => {
+                            if value != param {
+                                *state = ParamValue::Multiple;
                             }
                         }
-                        ParamState::NonTrivial => {},
+                        ParamValue::Multiple => {},
                     }
                 }
             }
@@ -5975,13 +5985,13 @@ impl Function {
 
             let trivial_indices: Vec<usize> = block.iter().enumerate()
                 .filter_map(|(idx, state)|
-                    matches!(state, ParamState::Trivial(_)).then_some(idx)
+                    matches!(state, ParamValue::One(_)).then_some(idx)
                 ).collect();
 
             // Replace uses of the trivial params with the concretized value
             for param_index in &trivial_indices {
-                if let ParamState::Trivial(concretized_insn) = block[*param_index] {
-                    self.make_equal_to(self.blocks[block_id.0].params[*param_index], concretized_insn);
+                if let ParamValue::One(insn_id) = block[*param_index] {
+                    self.make_equal_to(self.blocks[block_id.0].params[*param_index], insn_id);
                     changed = true;
                 }
             }

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5866,7 +5866,8 @@ impl Function {
     // (It's used more individually and differently than the paper)
     // TODO: Update comments to consider block params rather than phi nodes and demarcate differences from the algorithm clearly
     // TODO: Fix input arguments. We need block params, not just the phi
-    /// If all possible phi values are the same, replace the phi with the value
+    // If all possible phi values are the same, replace the phi with the value
+    // TODO: Add Max's optimization about not checking the first block. Maybe do this by keeping track of all changing edges and using a worklist?
 
     /// Sometimes block params can only come from one place and safely removed as block params.
     /// Trivial block param removal increases the efficacy of CFG-based optimization passes.
@@ -5921,104 +5922,107 @@ impl Function {
 
         while updated {
 
-        for (row, block) in predecessor_domain.iter_mut().zip(&self.blocks) {
-            row.resize(block.params.len(), ParamValue::None);
-        }
-        updated = false;
-
-        // Scan through each jump, collecting edges from CondBranch and Jump insns.
-        for (block_id, insn_index) in &terminators {
-            let insn_id = self.blocks[block_id.0].insns[*insn_index];
-            let mut edges: Vec<BranchEdge> = vec![];
-
-            match self.find(insn_id) {
-                Insn::CondBranch { if_true, if_false, .. } => {
-                    edges.push(if_true);
-                    edges.push(if_false);
-                }
-                Insn::Jump(edge) => {
-                    edges.push(edge);
-                }
-                _ => {}
+            for (row, block) in predecessor_domain.iter_mut().zip(&self.blocks) {
+                row.resize(block.params.len(), ParamValue::None);
             }
+            updated = false;
 
-            // Update the states
-            for BranchEdge { target: block_id, args: params } in edges {
-                for (i, param) in params.iter().enumerate().rev() {
-                    let param = self.find_id(*param);
-                    // If the param is the same as passed into the block, it is a self loop
-                    // We ignore self loops because they do not provide new information
-                    if param == self.find_id(self.blocks[block_id.0].params[i]) {
-                        continue
+            // TODO: Maybe move this outside the loop somehow? probably can't immediately, but we could keep track of a worklist of edges that change maybe?
+            // And only use the changed ones like a worklist? And then instead of looping to fixpoint we use a worklist based approach?
+            //
+            // Scan through each jump, collecting edges from CondBranch and Jump insns.
+            for (block_id, insn_index) in &terminators {
+                let insn_id = self.blocks[block_id.0].insns[*insn_index];
+                let mut edges: Vec<BranchEdge> = vec![];
+
+                match self.find(insn_id) {
+                    Insn::CondBranch { if_true, if_false, .. } => {
+                        edges.push(if_true);
+                        edges.push(if_false);
                     }
-                    let state = &mut predecessor_domain[block_id.0][i];
-                    match *state {
-                        ParamValue::None => {
-                            *state = ParamValue::One(param);
-                        },
-                        ParamValue::One(value) => {
-                            if value != param {
-                                *state = ParamValue::Multiple;
-                            }
-                        }
-                        ParamValue::Multiple => {},
-                    }
-                }
-            }
-        }
-
-        // Remove the trivial block params and fix up our SSA representation
-        // This is done by as follows.
-        // 1. Replace uses of the trivial params with the concretized value
-        // 2. Remove trivial params from the basic block definition
-        // 3. Remove trivial params from each CondBranch and Jump that targets the basic block that was just updated
-        for (block_id, block) in predecessor_domain.iter().enumerate() {
-            // TODO: Don't do this
-            let block_id = BlockId(block_id);
-
-            let trivial_indices: Vec<usize> = block.iter().enumerate()
-                .filter_map(|(idx, state)|
-                    matches!(state, ParamValue::One(_)).then_some(idx)
-                ).collect();
-
-            // Replace uses of the trivial params with the concretized value
-            for param_index in &trivial_indices {
-                if let ParamValue::One(insn_id) = block[*param_index] {
-                    self.make_equal_to(self.blocks[block_id.0].params[*param_index], insn_id);
-                    updated = true;
-                }
-            }
-
-            // Update the block
-            prune_vec_by_indices(&mut self.blocks[block_id.0].params, &trivial_indices);
-
-            // Update the terminators (basic blocks can only branch at the terminator. This is where block params are passed)
-            for (jump_block_id, index) in &terminators {
-                let cond_insn_id = self.blocks[jump_block_id.0].insns[*index];
-                match self.find(cond_insn_id) {
                     Insn::Jump(edge) => {
-                        if edge.target == block_id {
-                            let edge = prune_branch_edge(edge, &trivial_indices);
-                            self.insns[cond_insn_id.0] = Insn::Jump(edge);
-                        }
-                    }
-                    Insn::CondBranch { val, if_true, if_false } => {
-                        let if_true = if if_true.target == block_id {
-                            prune_branch_edge(if_true, &trivial_indices)
-                        } else {
-                            if_true
-                        };
-                        let if_false = if if_false.target == block_id {
-                            prune_branch_edge(if_false, &trivial_indices)
-                        } else {
-                            if_false
-                        };
-                        self.insns[cond_insn_id.0] = Insn::CondBranch{ val, if_true, if_false };
+                        edges.push(edge);
                     }
                     _ => {}
                 }
+
+                // Use the results of abstract interpretation to update the states
+                // Perform abstract interpretation
+                for BranchEdge { target: block_id, args: params } in edges {
+                    for (i, param) in params.iter().enumerate().rev() {
+                        let param = self.find_id(*param);
+                        // If the param is the same as passed into the block, it is a self loop and provides no new predecessor information.
+                        if param == self.find_id(self.blocks[block_id.0].params[i]) {
+                            continue
+                        }
+                        let state = &mut predecessor_domain[block_id.0][i];
+                        match *state {
+                            ParamValue::None => {
+                                *state = ParamValue::One(param);
+                            },
+                            ParamValue::One(value) => {
+                                if value != param {
+                                    *state = ParamValue::Multiple;
+                                }
+                            }
+                            ParamValue::Multiple => {},
+                        }
+                    }
+                }
             }
-        }
+
+            // Remove the trivial block params and fix up our SSA representation
+            // This is done by as follows.
+            // 1. Replace uses of the trivial params with the concretized value
+            // 2. Remove trivial params from the basic block definition
+            // 3. Remove trivial params from each CondBranch and Jump that targets the basic block that was just updated
+            for (block_id, block) in predecessor_domain.iter().enumerate() {
+                // TODO: Don't do this
+                let block_id = BlockId(block_id);
+
+                let trivial_indices: Vec<usize> = block.iter().enumerate()
+                    .filter_map(|(idx, state)|
+                        matches!(state, ParamValue::One(_)).then_some(idx)
+                    ).collect();
+
+                // Replace uses of the trivial params with the concretized value
+                for param_index in &trivial_indices {
+                    if let ParamValue::One(insn_id) = block[*param_index] {
+                        self.make_equal_to(self.blocks[block_id.0].params[*param_index], insn_id);
+                        updated = true;
+                    }
+                }
+
+                // Update the block
+                prune_vec_by_indices(&mut self.blocks[block_id.0].params, &trivial_indices);
+
+                // Update the terminators (basic blocks can only branch at the terminator. This is where block params are passed)
+                for (jump_block_id, index) in &terminators {
+                    let cond_insn_id = self.blocks[jump_block_id.0].insns[*index];
+                    match self.find(cond_insn_id) {
+                        Insn::Jump(edge) => {
+                            if edge.target == block_id {
+                                let edge = prune_branch_edge(edge, &trivial_indices);
+                                self.insns[cond_insn_id.0] = Insn::Jump(edge);
+                            }
+                        }
+                        Insn::CondBranch { val, if_true, if_false } => {
+                            let if_true = if if_true.target == block_id {
+                                prune_branch_edge(if_true, &trivial_indices)
+                            } else {
+                                if_true
+                            };
+                            let if_false = if if_false.target == block_id {
+                                prune_branch_edge(if_false, &trivial_indices)
+                            } else {
+                                if_false
+                            };
+                            self.insns[cond_insn_id.0] = Insn::CondBranch{ val, if_true, if_false };
+                        }
+                        _ => {}
+                    }
+                }
+            }
         }
 
     }

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -19002,27 +19002,6 @@ mod hir_opt_tests {
     }
 
     #[test]
-    fn test_dedup_guard_type_across_cfg_join() {
-        eval("
-            def test(n, cond)
-              if cond
-                a = n + 1
-              else
-                a = n + 2
-              end
-              n + a
-            end
-            test(1, true); test(1, false)
-        ");
-        let hir = hir_string("test");
-        let guard_count = hir.matches("GuardType").count();
-        assert_eq!(
-            guard_count, 2,
-            "expected 2 GuardType instructions after cross-block dedup, found {guard_count}\n\nHIR:\n{hir}"
-        );
-    }
-
-    #[test]
     fn test_forward_guard_through_conditional_branch() {
         eval("
             def test(n, a, b)

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -9431,11 +9431,11 @@ mod hir_opt_tests {
         bb6():
           v18:Truthy = RefineType v10, Truthy
           v20:FalseClass = Const Value(false)
-          Jump bb5(v18, v20)
+          Jump bb5(v9, v18, v20)
         bb4():
           v27:NilClass = Const Value(nil)
-          Jump bb5(v16, v27)
-        bb5(v30:BasicObject, v31:Falsy):
+          Jump bb5(v9, v16, v27)
+        bb5(v29:BasicObject, v30:BasicObject, v31:Falsy):
           v36:CBool = HasType v31, FalseClass
           CondBranch v36, bb8(), bb9()
         bb8():
@@ -18363,9 +18363,9 @@ mod hir_opt_tests {
           CondBranch v17, bb9(), bb4()
         bb9():
           v35:Fixnum[0] = Const Value(0)
-          Jump bb8(v35)
-        bb8(v49:Fixnum):
-          v52:Array = RefineType v8, Array
+          Jump bb8(v8, v35)
+        bb8(v48:BasicObject, v49:Fixnum):
+          v52:Array = RefineType v48, Array
           v53:CInt64 = ArrayLength v52
           v54:Fixnum = BoxFixnum v53
           v55:BoolExact = FixnumGe v49, v54
@@ -18373,9 +18373,9 @@ mod hir_opt_tests {
           CondBranch v57, bb11(), bb7()
         bb11():
           CheckInterrupts
-          Return v8
+          Return v48
         bb7():
-          v75:Array = RefineType v8, Array
+          v75:Array = RefineType v48, Array
           v76:CInt64 = UnboxFixnum v49
           v77:BasicObject = ArrayAref v75, v76
           v79:CPtr = GetEP 0
@@ -18391,7 +18391,7 @@ mod hir_opt_tests {
           v92:Fixnum[1] = Const Value(1)
           v93:Fixnum = FixnumAdd v49, v92
           PatchPoint NoEPEscape(each)
-          Jump bb8(v93)
+          Jump bb8(v48, v93)
         bb4():
           v28:BasicObject = InvokeBuiltin <inline_expr>, v8
           CheckInterrupts
@@ -18999,6 +18999,27 @@ mod hir_opt_tests {
           CheckInterrupts
           Return v44
         ");
+    }
+
+    #[test]
+    fn test_dedup_guard_type_across_cfg_join() {
+        eval("
+            def test(n, cond)
+              if cond
+                a = n + 1
+              else
+                a = n + 2
+              end
+              n + a
+            end
+            test(1, true); test(1, false)
+        ");
+        let hir = hir_string("test");
+        let guard_count = hir.matches("GuardType").count();
+        assert_eq!(
+            guard_count, 2,
+            "expected 2 GuardType instructions after cross-block dedup, found {guard_count}\n\nHIR:\n{hir}"
+        );
     }
 
     #[test]

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -21595,7 +21595,7 @@ mod hir_opt_tests {
           v75:Fixnum = GuardType v37, Fixnum recompile
           v77:BoolExact = FixnumLe v75, v72
           v49:CBool = Test v77
-          CondBranch v49, bb5(), bb4(v11)
+          CondBranch v49, bb5(), bb4()
         bb5():
           PatchPoint NoSingletonClass(C@0x1070)
           PatchPoint MethodRedefined(C@0x1070, foo@0x1078, cme:0x1080)
@@ -21603,7 +21603,7 @@ mod hir_opt_tests {
           v81:Fixnum[4] = Const Value(4)
           CheckInterrupts
           Return v81
-        bb4(v60:HeapBasicObject):
+        bb4():
           v63:NilClass = Const Value(nil)
           CheckInterrupts
           Return v63

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -18804,27 +18804,6 @@ mod hir_opt_tests {
     }
 
     #[test]
-    fn test_dedup_guard_type_across_cfg_join() {
-        eval("
-            def test(n, cond)
-              if cond
-                a = n + 1
-              else
-                a = n + 2
-              end
-              n + a
-            end
-            test(1, true); test(1, false)
-        ");
-        let hir = hir_string("test");
-        let guard_count = hir.matches("GuardType").count();
-        assert_eq!(
-            guard_count, 2,
-            "expected 2 GuardType instructions after cross-block dedup, found {guard_count}\n\nHIR:\n{hir}"
-        );
-    }
-
-    #[test]
     fn test_forward_guard_through_conditional_branch() {
         eval("
             def test(n, a, b)

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -9233,11 +9233,11 @@ mod hir_opt_tests {
         bb6():
           v18:Truthy = RefineType v10, Truthy
           v20:FalseClass = Const Value(false)
-          Jump bb5(v18, v20)
+          Jump bb5(v9, v18, v20)
         bb4():
           v27:NilClass = Const Value(nil)
-          Jump bb5(v16, v27)
-        bb5(v30:BasicObject, v31:Falsy):
+          Jump bb5(v9, v16, v27)
+        bb5(v29:BasicObject, v30:BasicObject, v31:Falsy):
           v36:CBool = HasType v31, FalseClass
           CondBranch v36, bb8(), bb9()
         bb8():
@@ -18165,9 +18165,9 @@ mod hir_opt_tests {
           CondBranch v17, bb9(), bb4()
         bb9():
           v35:Fixnum[0] = Const Value(0)
-          Jump bb8(v35)
-        bb8(v49:Fixnum):
-          v52:Array = RefineType v8, Array
+          Jump bb8(v8, v35)
+        bb8(v48:BasicObject, v49:Fixnum):
+          v52:Array = RefineType v48, Array
           v53:CInt64 = ArrayLength v52
           v54:Fixnum = BoxFixnum v53
           v55:BoolExact = FixnumGe v49, v54
@@ -18175,9 +18175,9 @@ mod hir_opt_tests {
           CondBranch v57, bb11(), bb7()
         bb11():
           CheckInterrupts
-          Return v8
+          Return v48
         bb7():
-          v75:Array = RefineType v8, Array
+          v75:Array = RefineType v48, Array
           v76:CInt64 = UnboxFixnum v49
           v77:BasicObject = ArrayAref v75, v76
           v79:CPtr = GetEP 0
@@ -18193,7 +18193,7 @@ mod hir_opt_tests {
           v92:Fixnum[1] = Const Value(1)
           v93:Fixnum = FixnumAdd v49, v92
           PatchPoint NoEPEscape(each)
-          Jump bb8(v93)
+          Jump bb8(v48, v93)
         bb4():
           v28:BasicObject = InvokeBuiltin <inline_expr>, v8
           CheckInterrupts
@@ -18801,6 +18801,27 @@ mod hir_opt_tests {
           CheckInterrupts
           Return v44
         ");
+    }
+
+    #[test]
+    fn test_dedup_guard_type_across_cfg_join() {
+        eval("
+            def test(n, cond)
+              if cond
+                a = n + 1
+              else
+                a = n + 2
+              end
+              n + a
+            end
+            test(1, true); test(1, false)
+        ");
+        let hir = hir_string("test");
+        let guard_count = hir.matches("GuardType").count();
+        assert_eq!(
+            guard_count, 2,
+            "expected 2 GuardType instructions after cross-block dedup, found {guard_count}\n\nHIR:\n{hir}"
+        );
     }
 
     #[test]

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -6499,6 +6499,7 @@ mod hir_opt_tests {
           Jump bb3(v7, v8, v9)
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           v18:CBool = Test v12
+          v19:Falsy = RefineType v12, Falsy
           CondBranch v18, bb5(), bb4()
         bb5():
           v21:Truthy = RefineType v12, Truthy
@@ -9425,14 +9426,16 @@ mod hir_opt_tests {
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
           v15:CBool = Test v10
+          v16:Falsy = RefineType v10, Falsy
           CondBranch v15, bb6(), bb4()
         bb6():
+          v18:Truthy = RefineType v10, Truthy
           v20:FalseClass = Const Value(false)
-          Jump bb5(v20)
+          Jump bb5(v18, v20)
         bb4():
           v27:NilClass = Const Value(nil)
-          Jump bb5(v27)
-        bb5(v31:Falsy):
+          Jump bb5(v16, v27)
+        bb5(v30:BasicObject, v31:Falsy):
           v36:CBool = HasType v31, FalseClass
           CondBranch v36, bb8(), bb9()
         bb8():
@@ -17746,6 +17749,7 @@ mod hir_opt_tests {
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
           v15:CBool = Test v10
+          v16:Falsy = RefineType v10, Falsy
           CondBranch v15, bb7(), bb6()
         bb7():
           v18:Truthy = RefineType v10, Truthy
@@ -18726,6 +18730,7 @@ mod hir_opt_tests {
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
           v15:CBool = Test v10
+          v16:Falsy = RefineType v10, Falsy
           CondBranch v15, bb5(), bb4()
         bb5():
           v18:Truthy = RefineType v10, Truthy
@@ -18797,6 +18802,7 @@ mod hir_opt_tests {
           Jump bb3(v7, v8, v9)
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           v18:CBool = Test v12
+          v19:Falsy = RefineType v12, Falsy
           CondBranch v18, bb5(), bb4()
         bb5():
           v21:Truthy = RefineType v12, Truthy
@@ -18855,6 +18861,7 @@ mod hir_opt_tests {
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
           v15:CBool = Test v10
+          v16:Falsy = RefineType v10, Falsy
           CondBranch v15, bb5(), bb4()
         bb5():
           v18:Truthy = RefineType v10, Truthy
@@ -19089,8 +19096,8 @@ mod hir_opt_tests {
           Jump bb3(v5, v6)
         bb3(v8:HeapBasicObject, v9:NilClass):
           v13:Fixnum[0] = Const Value(0)
-          Jump bb6(v13)
-        bb6(v19:Fixnum):
+          Jump bb6(v8, v13)
+        bb6(v18:HeapBasicObject, v19:Fixnum):
           v23:Fixnum[10] = Const Value(10)
           PatchPoint MethodRedefined(Integer@0x1000, <@0x1008, cme:0x1010)
           v94:BoolExact = FixnumLt v19, v23
@@ -19099,12 +19106,12 @@ mod hir_opt_tests {
           CondBranch v29, bb4(), bb7()
         bb4():
           PatchPoint SingleRactorMode
-          v46:CShape = LoadField v8, :shape_id@0x1038
+          v46:CShape = LoadField v18, :shape_id@0x1038
           v48:CShape[0x1039] = Const CShape(0x1039)
           v49:CBool = IsBitEqual v46, v48
           CondBranch v49, bb9(), bb10()
         bb9():
-          v51:BasicObject = LoadField v8, :@levar@0x103a
+          v51:BasicObject = LoadField v18, :@levar@0x103a
           Jump bb8(v51)
         bb10():
           v53:CShape[0x103b] = GuardBitEquals v46, CShape(0x103b) recompile
@@ -19112,23 +19119,23 @@ mod hir_opt_tests {
           Jump bb8(v55)
         bb8(v47:BasicObject):
           v58:CBool = Test v47
-          CondBranch v58, bb5(), bb12()
+          CondBranch v58, bb5(v18), bb12()
         bb12():
           PatchPoint NoEPEscape(set_value_loop)
           PatchPoint SingleRactorMode
-          v68:CShape = LoadField v8, :shape_id@0x1038
+          v68:CShape = LoadField v18, :shape_id@0x1038
           v69:CShape[0x103b] = GuardBitEquals v68, CShape(0x103b) recompile
-          StoreField v8, :@levar@0x103a, v19
-          WriteBarrier v8, v19
+          StoreField v18, :@levar@0x103a, v19
+          WriteBarrier v18, v19
           v72:CShape[0x1039] = Const CShape(0x1039)
-          StoreField v8, :shape_id@0x1038, v72
-          Jump bb5()
-        bb5():
+          StoreField v18, :shape_id@0x1038, v72
+          Jump bb5(v18)
+        bb5(v76:HeapBasicObject):
           PatchPoint NoEPEscape(set_value_loop)
           v84:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Integer@0x1000, +@0x103c, cme:0x1040)
           v98:Fixnum = FixnumAdd v19, v84
-          Jump bb6(v98)
+          Jump bb6(v76, v98)
         bb7():
           v34:NilClass = Const Value(nil)
           CheckInterrupts
@@ -21524,6 +21531,7 @@ mod hir_opt_tests {
           v45:Falsy = RefineType v15, Falsy
           CondBranch v44, bb5(), bb4(v13, v14, v45, v37)
           v42:CBool = Test v15
+          v43:Falsy = RefineType v15, Falsy
           CondBranch v42, bb5(), bb4()
         bb5():
           v47:Truthy = RefineType v15, Truthy

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -20088,6 +20088,11 @@ mod hir_opt_tests {
 
     #[test]
     fn test_inline_method_with_multiple_returns() {
+        // TODO: remove_trivial_block_params affects the entire CFG and runs before canonicalize.
+        // This means that some optimizations from canonicalize that affect block params have regressed,
+        // such as test_inline_method_with_multiple_returns in opt_tests.
+        // If we make canonicalize global, we should be able to pass Fixnum instead of BasicObject to bb4
+
         // `clamp_nonneg` has two Return instructions (one from the early `return 0 if ...`,
         // one from the implicit trailing `x`). Inlining rewrites each Return to a Jump into
         // the continuation block, whose single Param merges the return values.

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -21389,7 +21389,7 @@ mod hir_opt_tests {
           v75:Fixnum = GuardType v37, Fixnum recompile
           v77:BoolExact = FixnumLe v75, v72
           v49:CBool = Test v77
-          CondBranch v49, bb5(), bb4(v11)
+          CondBranch v49, bb5(), bb4()
         bb5():
           PatchPoint NoSingletonClass(C@0x1070)
           PatchPoint MethodRedefined(C@0x1070, foo@0x1078, cme:0x1080)
@@ -21397,7 +21397,7 @@ mod hir_opt_tests {
           v81:Fixnum[4] = Const Value(4)
           CheckInterrupts
           Return v81
-        bb4(v60:HeapBasicObject):
+        bb4():
           v63:NilClass = Const Value(nil)
           CheckInterrupts
           Return v63

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -6301,6 +6301,7 @@ mod hir_opt_tests {
           Jump bb3(v7, v8, v9)
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           v18:CBool = Test v12
+          v19:Falsy = RefineType v12, Falsy
           CondBranch v18, bb5(), bb4()
         bb5():
           v21:Truthy = RefineType v12, Truthy
@@ -9227,14 +9228,16 @@ mod hir_opt_tests {
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
           v15:CBool = Test v10
+          v16:Falsy = RefineType v10, Falsy
           CondBranch v15, bb6(), bb4()
         bb6():
+          v18:Truthy = RefineType v10, Truthy
           v20:FalseClass = Const Value(false)
-          Jump bb5(v20)
+          Jump bb5(v18, v20)
         bb4():
           v27:NilClass = Const Value(nil)
-          Jump bb5(v27)
-        bb5(v31:Falsy):
+          Jump bb5(v16, v27)
+        bb5(v30:BasicObject, v31:Falsy):
           v36:CBool = HasType v31, FalseClass
           CondBranch v36, bb8(), bb9()
         bb8():
@@ -17548,6 +17551,7 @@ mod hir_opt_tests {
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
           v15:CBool = Test v10
+          v16:Falsy = RefineType v10, Falsy
           CondBranch v15, bb7(), bb6()
         bb7():
           v18:Truthy = RefineType v10, Truthy
@@ -18528,6 +18532,7 @@ mod hir_opt_tests {
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
           v15:CBool = Test v10
+          v16:Falsy = RefineType v10, Falsy
           CondBranch v15, bb5(), bb4()
         bb5():
           v18:Truthy = RefineType v10, Truthy
@@ -18599,6 +18604,7 @@ mod hir_opt_tests {
           Jump bb3(v7, v8, v9)
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           v18:CBool = Test v12
+          v19:Falsy = RefineType v12, Falsy
           CondBranch v18, bb5(), bb4()
         bb5():
           v21:Truthy = RefineType v12, Truthy
@@ -18657,6 +18663,7 @@ mod hir_opt_tests {
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
           v15:CBool = Test v10
+          v16:Falsy = RefineType v10, Falsy
           CondBranch v15, bb5(), bb4()
         bb5():
           v18:Truthy = RefineType v10, Truthy
@@ -18891,8 +18898,8 @@ mod hir_opt_tests {
           Jump bb3(v5, v6)
         bb3(v8:HeapBasicObject, v9:NilClass):
           v13:Fixnum[0] = Const Value(0)
-          Jump bb6(v13)
-        bb6(v19:Fixnum):
+          Jump bb6(v8, v13)
+        bb6(v18:HeapBasicObject, v19:Fixnum):
           v23:Fixnum[10] = Const Value(10)
           PatchPoint MethodRedefined(Integer@0x1000, <@0x1008, cme:0x1010)
           v94:BoolExact = FixnumLt v19, v23
@@ -18901,12 +18908,12 @@ mod hir_opt_tests {
           CondBranch v29, bb4(), bb7()
         bb4():
           PatchPoint SingleRactorMode
-          v46:CShape = LoadField v8, :shape_id@0x1038
+          v46:CShape = LoadField v18, :shape_id@0x1038
           v48:CShape[0x1039] = Const CShape(0x1039)
           v49:CBool = IsBitEqual v46, v48
           CondBranch v49, bb9(), bb10()
         bb9():
-          v51:BasicObject = LoadField v8, :@levar@0x103a
+          v51:BasicObject = LoadField v18, :@levar@0x103a
           Jump bb8(v51)
         bb10():
           v53:CShape[0x103b] = GuardBitEquals v46, CShape(0x103b) recompile
@@ -18914,23 +18921,23 @@ mod hir_opt_tests {
           Jump bb8(v55)
         bb8(v47:BasicObject):
           v58:CBool = Test v47
-          CondBranch v58, bb5(), bb12()
+          CondBranch v58, bb5(v18), bb12()
         bb12():
           PatchPoint NoEPEscape(set_value_loop)
           PatchPoint SingleRactorMode
-          v68:CShape = LoadField v8, :shape_id@0x1038
+          v68:CShape = LoadField v18, :shape_id@0x1038
           v69:CShape[0x103b] = GuardBitEquals v68, CShape(0x103b) recompile
-          StoreField v8, :@levar@0x103a, v19
-          WriteBarrier v8, v19
+          StoreField v18, :@levar@0x103a, v19
+          WriteBarrier v18, v19
           v72:CShape[0x1039] = Const CShape(0x1039)
-          StoreField v8, :shape_id@0x1038, v72
-          Jump bb5()
-        bb5():
+          StoreField v18, :shape_id@0x1038, v72
+          Jump bb5(v18)
+        bb5(v76:HeapBasicObject):
           PatchPoint NoEPEscape(set_value_loop)
           v84:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Integer@0x1000, +@0x103c, cme:0x1040)
           v98:Fixnum = FixnumAdd v19, v84
-          Jump bb6(v98)
+          Jump bb6(v76, v98)
         bb7():
           v34:NilClass = Const Value(nil)
           CheckInterrupts
@@ -21321,6 +21328,7 @@ mod hir_opt_tests {
           v35:BasicObject = Send v14, :seven, v21, v23, v25, v27, v29, v31, v33 # SendFallbackReason: Too many arguments for LIR
           PatchPoint NoEPEscape(test)
           v42:CBool = Test v15
+          v43:Falsy = RefineType v15, Falsy
           CondBranch v42, bb5(), bb4()
         bb5():
           v45:Truthy = RefineType v15, Truthy

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -21534,19 +21534,13 @@ mod hir_opt_tests {
           PatchPoint NoEPEscape(test)
           v44:CBool = Test v15
           v45:Falsy = RefineType v15, Falsy
-          CondBranch v44, bb5(), bb4(v13, v14, v45, v37)
-          v42:CBool = Test v15
-          v43:Falsy = RefineType v15, Falsy
-          CondBranch v42, bb5(), bb4()
+          CondBranch v44, bb5(), bb4()
         bb5():
           v47:Truthy = RefineType v15, Truthy
           CheckInterrupts
           Return v37
-        bb4(v54:BasicObject, v55:BasicObject, v56:Falsy, v57:BasicObject):
-          v61:NilClass = Const Value(nil)
-          Return v35
         bb4():
-          v59:NilClass = Const Value(nil)
+          v61:NilClass = Const Value(nil)
           CheckInterrupts
           Return v61
         ");

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -19890,6 +19890,11 @@ mod hir_opt_tests {
 
     #[test]
     fn test_inline_method_with_multiple_returns() {
+        // TODO: remove_trivial_block_params affects the entire CFG and runs before canonicalize.
+        // This means that some optimizations from canonicalize that affect block params have regressed,
+        // such as test_inline_method_with_multiple_returns in opt_tests.
+        // If we make canonicalize global, we should be able to pass Fixnum instead of BasicObject to bb4
+
         // `clamp_nonneg` has two Return instructions (one from the early `return 0 if ...`,
         // one from the implicit trailing `x`). Inlining rewrites each Return to a Jump into
         // the continuation block, whose single Param merges the return values.

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -6301,8 +6301,7 @@ mod hir_opt_tests {
           Jump bb3(v7, v8, v9)
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           v18:CBool = Test v12
-          v19:Falsy = RefineType v12, Falsy
-          CondBranch v18, bb5(), bb4(v11, v19, v13)
+          CondBranch v18, bb5(), bb4()
         bb5():
           v21:Truthy = RefineType v12, Truthy
           v24:Fixnum[0] = Const Value(0)
@@ -6326,7 +6325,7 @@ mod hir_opt_tests {
           CheckInterrupts
           PopInlineFrame
           Return v76
-        bb4(v44:BasicObject, v45:Falsy, v46:BasicObject):
+        bb4():
           v50:StaticSymbol[:skip] = Const Value(VALUE(0x1068))
           CheckInterrupts
           Return v50
@@ -9228,16 +9227,14 @@ mod hir_opt_tests {
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
           v15:CBool = Test v10
-          v16:Falsy = RefineType v10, Falsy
-          CondBranch v15, bb6(), bb4(v9, v16)
+          CondBranch v15, bb6(), bb4()
         bb6():
-          v18:Truthy = RefineType v10, Truthy
           v20:FalseClass = Const Value(false)
-          Jump bb5(v9, v18, v20)
-        bb4(v23:BasicObject, v24:Falsy):
+          Jump bb5(v20)
+        bb4():
           v27:NilClass = Const Value(nil)
-          Jump bb5(v23, v24, v27)
-        bb5(v29:BasicObject, v30:BasicObject, v31:Falsy):
+          Jump bb5(v27)
+        bb5(v31:Falsy):
           v36:CBool = HasType v31, FalseClass
           CondBranch v36, bb8(), bb9()
         bb8():
@@ -10894,7 +10891,7 @@ mod hir_opt_tests {
           Jump bb9(v36, v71)
         bb9(v26:BasicObject, v27:BasicObject):
           v39:CBool = Test v26
-          CondBranch v39, bb10(), bb6(v18, v27)
+          CondBranch v39, bb10(), bb6()
         bb10():
           v46:CPtr = GetEP 0
           v47:CUInt64 = LoadField v46, :VM_ENV_DATA_INDEX_FLAGS@0x1060
@@ -10912,7 +10909,7 @@ mod hir_opt_tests {
           v57:BasicObject = Send v44, :call # SendFallbackReason: Send: no profile data available
           CheckInterrupts
           Jump bb4(v57)
-        bb6(v62:ObjectSubclass[class_exact*:Object@VALUE(0x1000)], v63:BasicObject):
+        bb6():
           v66:Fixnum[42] = Const Value(42)
           CheckInterrupts
           Jump bb4(v66)
@@ -17551,14 +17548,13 @@ mod hir_opt_tests {
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
           v15:CBool = Test v10
-          v16:Falsy = RefineType v10, Falsy
-          CondBranch v15, bb7(), bb6(v9, v16)
+          CondBranch v15, bb7(), bb6()
         bb7():
           v18:Truthy = RefineType v10, Truthy
           v35:Fixnum[3] = Const Value(3)
           CheckInterrupts
           Return v35
-        bb6(v40:BasicObject, v41:Falsy):
+        bb6():
           v45:Fixnum[6] = Const Value(6)
           CheckInterrupts
           Return v45
@@ -18110,7 +18106,7 @@ mod hir_opt_tests {
         bb7(v73:BasicObject, v74:BasicObject, v75:BasicObject, v76:BasicObject, v77:NilClass):
           v82:CBool = Test v75
           v83:Truthy = RefineType v75, Truthy
-          CondBranch v82, bb8(v73, v74, v83, v76, v77), bb11()
+          CondBranch v82, bb8(v74, v83, v76, v77), bb11()
         bb11():
           v85:Falsy = RefineType v75, Falsy
           PatchPoint MethodRedefined(Object@0x1010, lambda@0x1018, cme:0x1020)
@@ -18122,8 +18118,8 @@ mod hir_opt_tests {
           v92:BasicObject = LoadField v89, :iter_method@0x1005
           v93:BasicObject = LoadField v89, :kwsplat@0x1006
           SetLocal :sep, l0, EP@5, v132
-          Jump bb8(v131, v90, v132, v92, v93)
-        bb8(v97:BasicObject, v98:BasicObject, v99:BasicObject, v100:BasicObject, v101:BasicObject):
+          Jump bb8(v90, v132, v92, v93)
+        bb8(v98:BasicObject, v99:BasicObject, v100:BasicObject, v101:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1078, CONST)
           v107:HashExact[VALUE(0x1080)] = Const Value(VALUE(0x1080))
@@ -18162,23 +18158,23 @@ mod hir_opt_tests {
           v13:NilClass = Const Value(nil)
           v15:TrueClass|NilClass = Defined yield, v13
           v17:CBool = Test v15
-          CondBranch v17, bb9(), bb4(v8, v9)
+          CondBranch v17, bb9(), bb4()
         bb9():
           v35:Fixnum[0] = Const Value(0)
-          Jump bb8(v8, v35)
-        bb8(v48:BasicObject, v49:Fixnum):
-          v52:Array = RefineType v48, Array
+          Jump bb8(v35)
+        bb8(v49:Fixnum):
+          v52:Array = RefineType v8, Array
           v53:CInt64 = ArrayLength v52
           v54:Fixnum = BoxFixnum v53
           v55:BoolExact = FixnumGe v49, v54
           v57:CBool = Test v55
-          CondBranch v57, bb11(), bb7(v48, v49)
+          CondBranch v57, bb11(), bb7()
         bb11():
           CheckInterrupts
-          Return v48
-        bb7(v70:BasicObject, v71:Fixnum):
-          v75:Array = RefineType v70, Array
-          v76:CInt64 = UnboxFixnum v71
+          Return v8
+        bb7():
+          v75:Array = RefineType v8, Array
+          v76:CInt64 = UnboxFixnum v49
           v77:BasicObject = ArrayAref v75, v76
           v79:CPtr = GetEP 0
           v80:CInt64 = LoadField v79, :VM_ENV_DATA_INDEX_SPECVAL@0x1000
@@ -18191,11 +18187,11 @@ mod hir_opt_tests {
           v87:CPtr[CPtr(0x1002)] = GuardBitEquals v86, CPtr(0x1002) recompile
           v88:BasicObject = InvokeBlockIseqDirect (0x1002), v85, v77
           v92:Fixnum[1] = Const Value(1)
-          v93:Fixnum = FixnumAdd v71, v92
+          v93:Fixnum = FixnumAdd v49, v92
           PatchPoint NoEPEscape(each)
-          Jump bb8(v70, v93)
-        bb4(v23:BasicObject, v24:NilClass):
-          v28:BasicObject = InvokeBuiltin <inline_expr>, v23
+          Jump bb8(v93)
+        bb4():
+          v28:BasicObject = InvokeBuiltin <inline_expr>, v8
           CheckInterrupts
           Return v28
         ");
@@ -18281,29 +18277,29 @@ mod hir_opt_tests {
           PatchPoint MethodRedefined(Array@0x1008, each@0x1010, cme:0x1018)
           PushInlineFrame v11 (0x1040)
           v51:Fixnum[0] = Const Value(0)
-          Jump bb10(v11, v51)
-        bb10(v64:ArrayExact, v65:Fixnum):
-          v69:CInt64 = ArrayLength v64
+          Jump bb10(v51)
+        bb10(v65:Fixnum):
+          v69:CInt64 = ArrayLength v11
           v70:Fixnum = BoxFixnum v69
           v71:BoolExact = FixnumGe v65, v70
           v73:CBool = Test v71
-          CondBranch v73, bb13(), bb9(v64, v65)
+          CondBranch v73, bb13(), bb9()
         bb13():
           CheckInterrupts
           PopInlineFrame
-          Return v64
-        bb9(v86:ArrayExact, v87:Fixnum):
-          v92:CInt64 = UnboxFixnum v87
-          v93:BasicObject = ArrayAref v86, v92
+          Return v11
+        bb9():
+          v92:CInt64 = UnboxFixnum v65
+          v93:BasicObject = ArrayAref v11, v92
           v95:CPtr = GetEP 0
           v96:CInt64 = LoadField v95, :VM_ENV_DATA_INDEX_SPECVAL@0x1068
           v97:CInt64[-4] = Const CInt64(-4)
           v98:CInt64 = IntAnd v96, v97
           v99:BasicObject = InvokeBlockIseqDirect (0x1070), v98, v93
           v103:Fixnum[1] = Const Value(1)
-          v104:Fixnum = FixnumAdd v87, v103
+          v104:Fixnum = FixnumAdd v65, v103
           PatchPoint NoEPEscape(each)
-          Jump bb10(v86, v104)
+          Jump bb10(v104)
         ");
     }
 
@@ -18532,8 +18528,7 @@ mod hir_opt_tests {
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
           v15:CBool = Test v10
-          v16:Falsy = RefineType v10, Falsy
-          CondBranch v15, bb5(), bb4(v9, v16)
+          CondBranch v15, bb5(), bb4()
         bb5():
           v18:Truthy = RefineType v10, Truthy
           v22:Fixnum[42] = Const Value(42)
@@ -18545,7 +18540,7 @@ mod hir_opt_tests {
           CheckInterrupts
           PopInlineFrame
           Return v63
-        bb4(v29:BasicObject, v30:Falsy):
+        bb4():
           v34:StringExact[VALUE(0x10a8)] = Const Value(VALUE(0x10a8))
           v35:StringExact = StringCopy v34
           CheckInterrupts
@@ -18604,15 +18599,14 @@ mod hir_opt_tests {
           Jump bb3(v7, v8, v9)
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           v18:CBool = Test v12
-          v19:Falsy = RefineType v12, Falsy
-          CondBranch v18, bb5(), bb4(v11, v19, v13)
+          CondBranch v18, bb5(), bb4()
         bb5():
           v21:Truthy = RefineType v12, Truthy
           v25:Fixnum[42] = Const Value(42)
           v28:BasicObject = Send v11, &block, :passthrough_recompile_blockarg, v25, v13 # SendFallbackReason: Send: block argument is not nil
           CheckInterrupts
           Return v28
-        bb4(v33:BasicObject, v34:Falsy, v35:BasicObject):
+        bb4():
           v39:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           v40:StringExact = StringCopy v39
           CheckInterrupts
@@ -18663,15 +18657,14 @@ mod hir_opt_tests {
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
           v15:CBool = Test v10
-          v16:Falsy = RefineType v10, Falsy
-          CondBranch v15, bb5(), bb4(v9, v16)
+          CondBranch v15, bb5(), bb4()
         bb5():
           v18:Truthy = RefineType v10, Truthy
           v22:Fixnum[42] = Const Value(42)
           v24:BasicObject = Send v9, :greet_final, v22 # SendFallbackReason: Send: no profile data available
           CheckInterrupts
           Return v24
-        bb4(v29:BasicObject, v30:Falsy):
+        bb4():
           v34:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           v35:StringExact = StringCopy v34
           CheckInterrupts
@@ -18898,22 +18891,22 @@ mod hir_opt_tests {
           Jump bb3(v5, v6)
         bb3(v8:HeapBasicObject, v9:NilClass):
           v13:Fixnum[0] = Const Value(0)
-          Jump bb6(v8, v13)
-        bb6(v18:HeapBasicObject, v19:Fixnum):
+          Jump bb6(v13)
+        bb6(v19:Fixnum):
           v23:Fixnum[10] = Const Value(10)
           PatchPoint MethodRedefined(Integer@0x1000, <@0x1008, cme:0x1010)
           v94:BoolExact = FixnumLt v19, v23
           CheckInterrupts
           v29:CBool = Test v94
-          CondBranch v29, bb4(v18, v19), bb7()
-        bb4(v39:HeapBasicObject, v40:Fixnum):
+          CondBranch v29, bb4(), bb7()
+        bb4():
           PatchPoint SingleRactorMode
-          v46:CShape = LoadField v39, :shape_id@0x1038
+          v46:CShape = LoadField v8, :shape_id@0x1038
           v48:CShape[0x1039] = Const CShape(0x1039)
           v49:CBool = IsBitEqual v46, v48
           CondBranch v49, bb9(), bb10()
         bb9():
-          v51:BasicObject = LoadField v39, :@levar@0x103a
+          v51:BasicObject = LoadField v8, :@levar@0x103a
           Jump bb8(v51)
         bb10():
           v53:CShape[0x103b] = GuardBitEquals v46, CShape(0x103b) recompile
@@ -18921,23 +18914,23 @@ mod hir_opt_tests {
           Jump bb8(v55)
         bb8(v47:BasicObject):
           v58:CBool = Test v47
-          CondBranch v58, bb5(v39, v40), bb12()
+          CondBranch v58, bb5(), bb12()
         bb12():
           PatchPoint NoEPEscape(set_value_loop)
           PatchPoint SingleRactorMode
-          v68:CShape = LoadField v39, :shape_id@0x1038
+          v68:CShape = LoadField v8, :shape_id@0x1038
           v69:CShape[0x103b] = GuardBitEquals v68, CShape(0x103b) recompile
-          StoreField v39, :@levar@0x103a, v40
-          WriteBarrier v39, v40
+          StoreField v8, :@levar@0x103a, v19
+          WriteBarrier v8, v19
           v72:CShape[0x1039] = Const CShape(0x1039)
-          StoreField v39, :shape_id@0x1038, v72
-          Jump bb5(v39, v40)
-        bb5(v76:HeapBasicObject, v77:Fixnum):
+          StoreField v8, :shape_id@0x1038, v72
+          Jump bb5()
+        bb5():
           PatchPoint NoEPEscape(set_value_loop)
           v84:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Integer@0x1000, +@0x103c, cme:0x1040)
-          v98:Fixnum = FixnumAdd v77, v84
-          Jump bb6(v76, v98)
+          v98:Fixnum = FixnumAdd v19, v84
+          Jump bb6(v98)
         bb7():
           v34:NilClass = Const Value(nil)
           CheckInterrupts
@@ -19649,12 +19642,12 @@ mod hir_opt_tests {
           PatchPoint MethodRedefined(Symbol@0x1008, ==@0x1010, cme:0x1018)
           v47:StaticSymbol = GuardType v12, StaticSymbol recompile
           v48:CBool = IsBitEqual v47, v13
-          CondBranch v48, bb5(), bb4(v11, v47, v13)
+          CondBranch v48, bb5(), bb4()
         bb5():
           v28:Fixnum[3] = Const Value(3)
           CheckInterrupts
           Return v28
-        bb4(v33:BasicObject, v34:StaticSymbol, v35:BasicObject):
+        bb4():
           v39:Fixnum[4] = Const Value(4)
           CheckInterrupts
           Return v39
@@ -19926,15 +19919,15 @@ mod hir_opt_tests {
           v62:Fixnum = GuardType v10, Fixnum recompile
           v63:BoolExact = FixnumLt v62, v32
           v37:CBool = Test v63
-          CondBranch v37, bb7(), bb6(v23, v62)
+          CondBranch v37, bb7(), bb6()
         bb7():
           v42:Fixnum[0] = Const Value(0)
           CheckInterrupts
           Jump bb4(v42)
-        bb6(v47:ObjectSubclass[class_exact*:Object@VALUE(0x1008)], v48:Fixnum):
+        bb6():
           CheckInterrupts
-          Jump bb4(v48)
-        bb4(v56:Fixnum):
+          Jump bb4(v10)
+        bb4(v56:BasicObject):
           PopInlineFrame
           CheckInterrupts
           Return v56
@@ -20863,16 +20856,16 @@ mod hir_opt_tests {
           PushInlineFrame v25 (0x1040), v10, v22
           v34:BoolExact = FixnumBitCheck v63, 0
           v36:CBool = Test v34
-          CondBranch v36, bb6(v25, v10, v22, v63), bb7()
+          CondBranch v36, bb6(v22), bb7()
         bb7():
           v42:Fixnum[2] = Const Value(2)
           PatchPoint MethodRedefined(Integer@0x1068, *@0x1070, cme:0x1078)
           v70:Fixnum = GuardType v10, Fixnum recompile
           v71:Fixnum = FixnumMult v70, v42
-          Jump bb6(v25, v70, v71, v63)
-        bb6(v48:ObjectSubclass[class_exact*:Object@VALUE(0x1008)], v49:BasicObject, v50:NilClass|Fixnum, v51:Fixnum[1]):
+          Jump bb6(v71)
+        bb6(v50:NilClass|Fixnum):
           PatchPoint MethodRedefined(Integer@0x1068, +@0x10a0, cme:0x10a8)
-          v74:Fixnum = GuardType v49, Fixnum recompile
+          v74:Fixnum = GuardType v10, Fixnum recompile
           v75:Fixnum = GuardType v50, Fixnum
           v76:Fixnum = FixnumAdd v74, v75
           CheckInterrupts
@@ -21233,7 +21226,7 @@ mod hir_opt_tests {
           v257:BoolExact = FixnumEq v255, v51
           v212:CBool = Test v257
           v213:FalseClass = RefineType v257, Falsy
-          CondBranch v212, bb19(), bb18(v89, v99, v213)
+          CondBranch v212, bb19(), bb18(v213)
         bb19():
           PatchPoint SingleRactorMode
           v220:CShape = LoadField v89, :shape_id@0x1090
@@ -21249,8 +21242,8 @@ mod hir_opt_tests {
           v267:Fixnum = GuardType v222, Fixnum recompile
           v268:Fixnum = GuardType v264, Fixnum
           v269:BoolExact = FixnumEq v267, v268
-          Jump bb18(v89, v99, v269)
-        bb18(v232:ObjectSubclass[class_exact:Point], v233:ObjectSubclass[class_exact:Point], v234:BoolExact):
+          Jump bb18(v269)
+        bb18(v234:BoolExact):
           CheckInterrupts
           PopInlineFrame
           Return v234
@@ -21328,13 +21321,12 @@ mod hir_opt_tests {
           v35:BasicObject = Send v14, :seven, v21, v23, v25, v27, v29, v31, v33 # SendFallbackReason: Too many arguments for LIR
           PatchPoint NoEPEscape(test)
           v42:CBool = Test v15
-          v43:Falsy = RefineType v15, Falsy
-          CondBranch v42, bb5(), bb4(v13, v14, v43, v35)
+          CondBranch v42, bb5(), bb4()
         bb5():
           v45:Truthy = RefineType v15, Truthy
           CheckInterrupts
           Return v35
-        bb4(v52:BasicObject, v53:BasicObject, v54:Falsy, v55:BasicObject):
+        bb4():
           v59:NilClass = Const Value(nil)
           CheckInterrupts
           Return v59

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -6499,8 +6499,7 @@ mod hir_opt_tests {
           Jump bb3(v7, v8, v9)
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           v18:CBool = Test v12
-          v19:Falsy = RefineType v12, Falsy
-          CondBranch v18, bb5(), bb4(v11, v19, v13)
+          CondBranch v18, bb5(), bb4()
         bb5():
           v21:Truthy = RefineType v12, Truthy
           v24:Fixnum[0] = Const Value(0)
@@ -6524,7 +6523,7 @@ mod hir_opt_tests {
           CheckInterrupts
           PopInlineFrame
           Return v76
-        bb4(v44:BasicObject, v45:Falsy, v46:BasicObject):
+        bb4():
           v50:StaticSymbol[:skip] = Const Value(VALUE(0x1068))
           CheckInterrupts
           Return v50
@@ -9426,16 +9425,14 @@ mod hir_opt_tests {
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
           v15:CBool = Test v10
-          v16:Falsy = RefineType v10, Falsy
-          CondBranch v15, bb6(), bb4(v9, v16)
+          CondBranch v15, bb6(), bb4()
         bb6():
-          v18:Truthy = RefineType v10, Truthy
           v20:FalseClass = Const Value(false)
-          Jump bb5(v9, v18, v20)
-        bb4(v23:BasicObject, v24:Falsy):
+          Jump bb5(v20)
+        bb4():
           v27:NilClass = Const Value(nil)
-          Jump bb5(v23, v24, v27)
-        bb5(v29:BasicObject, v30:BasicObject, v31:Falsy):
+          Jump bb5(v27)
+        bb5(v31:Falsy):
           v36:CBool = HasType v31, FalseClass
           CondBranch v36, bb8(), bb9()
         bb8():
@@ -11092,7 +11089,7 @@ mod hir_opt_tests {
           Jump bb9(v36, v71)
         bb9(v26:BasicObject, v27:BasicObject):
           v39:CBool = Test v26
-          CondBranch v39, bb10(), bb6(v18, v27)
+          CondBranch v39, bb10(), bb6()
         bb10():
           v46:CPtr = GetEP 0
           v47:CUInt64 = LoadField v46, :VM_ENV_DATA_INDEX_FLAGS@0x1060
@@ -11110,7 +11107,7 @@ mod hir_opt_tests {
           v57:BasicObject = Send v44, :call # SendFallbackReason: Send: no profile data available
           CheckInterrupts
           Jump bb4(v57)
-        bb6(v62:ObjectSubclass[class_exact*:Object@VALUE(0x1000)], v63:BasicObject):
+        bb6():
           v66:Fixnum[42] = Const Value(42)
           CheckInterrupts
           Jump bb4(v66)
@@ -17749,14 +17746,13 @@ mod hir_opt_tests {
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
           v15:CBool = Test v10
-          v16:Falsy = RefineType v10, Falsy
-          CondBranch v15, bb7(), bb6(v9, v16)
+          CondBranch v15, bb7(), bb6()
         bb7():
           v18:Truthy = RefineType v10, Truthy
           v35:Fixnum[3] = Const Value(3)
           CheckInterrupts
           Return v35
-        bb6(v40:BasicObject, v41:Falsy):
+        bb6():
           v45:Fixnum[6] = Const Value(6)
           CheckInterrupts
           Return v45
@@ -18308,7 +18304,7 @@ mod hir_opt_tests {
         bb7(v73:BasicObject, v74:BasicObject, v75:BasicObject, v76:BasicObject, v77:NilClass):
           v82:CBool = Test v75
           v83:Truthy = RefineType v75, Truthy
-          CondBranch v82, bb8(v73, v74, v83, v76, v77), bb11()
+          CondBranch v82, bb8(v74, v83, v76, v77), bb11()
         bb11():
           v85:Falsy = RefineType v75, Falsy
           PatchPoint MethodRedefined(Object@0x1010, lambda@0x1018, cme:0x1020)
@@ -18320,8 +18316,8 @@ mod hir_opt_tests {
           v92:BasicObject = LoadField v89, :iter_method@0x1005
           v93:BasicObject = LoadField v89, :kwsplat@0x1006
           SetLocal :sep, l0, EP@5, v132
-          Jump bb8(v131, v90, v132, v92, v93)
-        bb8(v97:BasicObject, v98:BasicObject, v99:BasicObject, v100:BasicObject, v101:BasicObject):
+          Jump bb8(v90, v132, v92, v93)
+        bb8(v98:BasicObject, v99:BasicObject, v100:BasicObject, v101:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1078, CONST)
           v107:HashExact[VALUE(0x1080)] = Const Value(VALUE(0x1080))
@@ -18360,23 +18356,23 @@ mod hir_opt_tests {
           v13:NilClass = Const Value(nil)
           v15:TrueClass|NilClass = Defined yield, v13
           v17:CBool = Test v15
-          CondBranch v17, bb9(), bb4(v8, v9)
+          CondBranch v17, bb9(), bb4()
         bb9():
           v35:Fixnum[0] = Const Value(0)
-          Jump bb8(v8, v35)
-        bb8(v48:BasicObject, v49:Fixnum):
-          v52:Array = RefineType v48, Array
+          Jump bb8(v35)
+        bb8(v49:Fixnum):
+          v52:Array = RefineType v8, Array
           v53:CInt64 = ArrayLength v52
           v54:Fixnum = BoxFixnum v53
           v55:BoolExact = FixnumGe v49, v54
           v57:CBool = Test v55
-          CondBranch v57, bb11(), bb7(v48, v49)
+          CondBranch v57, bb11(), bb7()
         bb11():
           CheckInterrupts
-          Return v48
-        bb7(v70:BasicObject, v71:Fixnum):
-          v75:Array = RefineType v70, Array
-          v76:CInt64 = UnboxFixnum v71
+          Return v8
+        bb7():
+          v75:Array = RefineType v8, Array
+          v76:CInt64 = UnboxFixnum v49
           v77:BasicObject = ArrayAref v75, v76
           v79:CPtr = GetEP 0
           v80:CInt64 = LoadField v79, :VM_ENV_DATA_INDEX_SPECVAL@0x1000
@@ -18389,11 +18385,11 @@ mod hir_opt_tests {
           v87:CPtr[CPtr(0x1002)] = GuardBitEquals v86, CPtr(0x1002) recompile
           v88:BasicObject = InvokeBlockIseqDirect (0x1002), v85, v77
           v92:Fixnum[1] = Const Value(1)
-          v93:Fixnum = FixnumAdd v71, v92
+          v93:Fixnum = FixnumAdd v49, v92
           PatchPoint NoEPEscape(each)
-          Jump bb8(v70, v93)
-        bb4(v23:BasicObject, v24:NilClass):
-          v28:BasicObject = InvokeBuiltin <inline_expr>, v23
+          Jump bb8(v93)
+        bb4():
+          v28:BasicObject = InvokeBuiltin <inline_expr>, v8
           CheckInterrupts
           Return v28
         ");
@@ -18479,29 +18475,29 @@ mod hir_opt_tests {
           PatchPoint MethodRedefined(Array@0x1008, each@0x1010, cme:0x1018)
           PushInlineFrame :each, v11 (0x1040), num_args=0
           v51:Fixnum[0] = Const Value(0)
-          Jump bb10(v11, v51)
-        bb10(v64:ArrayExact, v65:Fixnum):
-          v69:CInt64 = ArrayLength v64
+          Jump bb10(v51)
+        bb10(v65:Fixnum):
+          v69:CInt64 = ArrayLength v11
           v70:Fixnum = BoxFixnum v69
           v71:BoolExact = FixnumGe v65, v70
           v73:CBool = Test v71
-          CondBranch v73, bb13(), bb9(v64, v65)
+          CondBranch v73, bb13(), bb9()
         bb13():
           CheckInterrupts
           PopInlineFrame
-          Return v64
-        bb9(v86:ArrayExact, v87:Fixnum):
-          v92:CInt64 = UnboxFixnum v87
-          v93:BasicObject = ArrayAref v86, v92
+          Return v11
+        bb9():
+          v92:CInt64 = UnboxFixnum v65
+          v93:BasicObject = ArrayAref v11, v92
           v95:CPtr = GetEP 0
           v96:CInt64 = LoadField v95, :VM_ENV_DATA_INDEX_SPECVAL@0x1068
           v97:CInt64[-4] = Const CInt64(-4)
           v98:CInt64 = IntAnd v96, v97
           v99:BasicObject = InvokeBlockIseqDirect (0x1070), v98, v93
           v103:Fixnum[1] = Const Value(1)
-          v104:Fixnum = FixnumAdd v87, v103
+          v104:Fixnum = FixnumAdd v65, v103
           PatchPoint NoEPEscape(each)
-          Jump bb10(v86, v104)
+          Jump bb10(v104)
         ");
     }
 
@@ -18730,8 +18726,7 @@ mod hir_opt_tests {
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
           v15:CBool = Test v10
-          v16:Falsy = RefineType v10, Falsy
-          CondBranch v15, bb5(), bb4(v9, v16)
+          CondBranch v15, bb5(), bb4()
         bb5():
           v18:Truthy = RefineType v10, Truthy
           v22:Fixnum[42] = Const Value(42)
@@ -18743,7 +18738,7 @@ mod hir_opt_tests {
           CheckInterrupts
           PopInlineFrame
           Return v63
-        bb4(v29:BasicObject, v30:Falsy):
+        bb4():
           v34:StringExact[VALUE(0x10a8)] = Const Value(VALUE(0x10a8))
           v35:StringExact = StringCopy v34
           CheckInterrupts
@@ -18802,15 +18797,14 @@ mod hir_opt_tests {
           Jump bb3(v7, v8, v9)
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           v18:CBool = Test v12
-          v19:Falsy = RefineType v12, Falsy
-          CondBranch v18, bb5(), bb4(v11, v19, v13)
+          CondBranch v18, bb5(), bb4()
         bb5():
           v21:Truthy = RefineType v12, Truthy
           v25:Fixnum[42] = Const Value(42)
           v28:BasicObject = Send v11, &block, :passthrough_recompile_blockarg, v25, v13 # SendFallbackReason: Send: block argument is not nil
           CheckInterrupts
           Return v28
-        bb4(v33:BasicObject, v34:Falsy, v35:BasicObject):
+        bb4():
           v39:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           v40:StringExact = StringCopy v39
           CheckInterrupts
@@ -18861,15 +18855,14 @@ mod hir_opt_tests {
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
           v15:CBool = Test v10
-          v16:Falsy = RefineType v10, Falsy
-          CondBranch v15, bb5(), bb4(v9, v16)
+          CondBranch v15, bb5(), bb4()
         bb5():
           v18:Truthy = RefineType v10, Truthy
           v22:Fixnum[42] = Const Value(42)
           v24:BasicObject = Send v9, :greet_final, v22 # SendFallbackReason: Send: no profile data available
           CheckInterrupts
           Return v24
-        bb4(v29:BasicObject, v30:Falsy):
+        bb4():
           v34:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           v35:StringExact = StringCopy v34
           CheckInterrupts
@@ -19096,22 +19089,22 @@ mod hir_opt_tests {
           Jump bb3(v5, v6)
         bb3(v8:HeapBasicObject, v9:NilClass):
           v13:Fixnum[0] = Const Value(0)
-          Jump bb6(v8, v13)
-        bb6(v18:HeapBasicObject, v19:Fixnum):
+          Jump bb6(v13)
+        bb6(v19:Fixnum):
           v23:Fixnum[10] = Const Value(10)
           PatchPoint MethodRedefined(Integer@0x1000, <@0x1008, cme:0x1010)
           v94:BoolExact = FixnumLt v19, v23
           CheckInterrupts
           v29:CBool = Test v94
-          CondBranch v29, bb4(v18, v19), bb7()
-        bb4(v39:HeapBasicObject, v40:Fixnum):
+          CondBranch v29, bb4(), bb7()
+        bb4():
           PatchPoint SingleRactorMode
-          v46:CShape = LoadField v39, :shape_id@0x1038
+          v46:CShape = LoadField v8, :shape_id@0x1038
           v48:CShape[0x1039] = Const CShape(0x1039)
           v49:CBool = IsBitEqual v46, v48
           CondBranch v49, bb9(), bb10()
         bb9():
-          v51:BasicObject = LoadField v39, :@levar@0x103a
+          v51:BasicObject = LoadField v8, :@levar@0x103a
           Jump bb8(v51)
         bb10():
           v53:CShape[0x103b] = GuardBitEquals v46, CShape(0x103b) recompile
@@ -19119,23 +19112,23 @@ mod hir_opt_tests {
           Jump bb8(v55)
         bb8(v47:BasicObject):
           v58:CBool = Test v47
-          CondBranch v58, bb5(v39, v40), bb12()
+          CondBranch v58, bb5(), bb12()
         bb12():
           PatchPoint NoEPEscape(set_value_loop)
           PatchPoint SingleRactorMode
-          v68:CShape = LoadField v39, :shape_id@0x1038
+          v68:CShape = LoadField v8, :shape_id@0x1038
           v69:CShape[0x103b] = GuardBitEquals v68, CShape(0x103b) recompile
-          StoreField v39, :@levar@0x103a, v40
-          WriteBarrier v39, v40
+          StoreField v8, :@levar@0x103a, v19
+          WriteBarrier v8, v19
           v72:CShape[0x1039] = Const CShape(0x1039)
-          StoreField v39, :shape_id@0x1038, v72
-          Jump bb5(v39, v40)
-        bb5(v76:HeapBasicObject, v77:Fixnum):
+          StoreField v8, :shape_id@0x1038, v72
+          Jump bb5()
+        bb5():
           PatchPoint NoEPEscape(set_value_loop)
           v84:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Integer@0x1000, +@0x103c, cme:0x1040)
-          v98:Fixnum = FixnumAdd v77, v84
-          Jump bb6(v76, v98)
+          v98:Fixnum = FixnumAdd v19, v84
+          Jump bb6(v98)
         bb7():
           v34:NilClass = Const Value(nil)
           CheckInterrupts
@@ -19847,12 +19840,12 @@ mod hir_opt_tests {
           PatchPoint MethodRedefined(Symbol@0x1008, ==@0x1010, cme:0x1018)
           v47:StaticSymbol = GuardType v12, StaticSymbol recompile
           v48:CBool = IsBitEqual v47, v13
-          CondBranch v48, bb5(), bb4(v11, v47, v13)
+          CondBranch v48, bb5(), bb4()
         bb5():
           v28:Fixnum[3] = Const Value(3)
           CheckInterrupts
           Return v28
-        bb4(v33:BasicObject, v34:StaticSymbol, v35:BasicObject):
+        bb4():
           v39:Fixnum[4] = Const Value(4)
           CheckInterrupts
           Return v39
@@ -20124,15 +20117,15 @@ mod hir_opt_tests {
           v62:Fixnum = GuardType v10, Fixnum recompile
           v63:BoolExact = FixnumLt v62, v32
           v37:CBool = Test v63
-          CondBranch v37, bb7(), bb6(v23, v62)
+          CondBranch v37, bb7(), bb6()
         bb7():
           v42:Fixnum[0] = Const Value(0)
           CheckInterrupts
           Jump bb4(v42)
-        bb6(v47:ObjectSubclass[class_exact*:Object@VALUE(0x1008)], v48:Fixnum):
+        bb6():
           CheckInterrupts
-          Jump bb4(v48)
-        bb4(v56:Fixnum):
+          Jump bb4(v10)
+        bb4(v56:BasicObject):
           PopInlineFrame
           CheckInterrupts
           Return v56
@@ -21061,16 +21054,16 @@ mod hir_opt_tests {
           PushInlineFrame :add_optkw_dyn, v25 (0x1040), num_args=2
           v34:BoolExact = FixnumBitCheck v63, 0
           v36:CBool = Test v34
-          CondBranch v36, bb6(v25, v10, v22, v63), bb7()
+          CondBranch v36, bb6(v22), bb7()
         bb7():
           v42:Fixnum[2] = Const Value(2)
           PatchPoint MethodRedefined(Integer@0x1068, *@0x1070, cme:0x1078)
           v70:Fixnum = GuardType v10, Fixnum recompile
           v71:Fixnum = FixnumMult v70, v42
-          Jump bb6(v25, v70, v71, v63)
-        bb6(v48:ObjectSubclass[class_exact*:Object@VALUE(0x1008)], v49:BasicObject, v50:NilClass|Fixnum, v51:Fixnum[1]):
+          Jump bb6(v71)
+        bb6(v50:NilClass|Fixnum):
           PatchPoint MethodRedefined(Integer@0x1068, +@0x10a0, cme:0x10a8)
-          v74:Fixnum = GuardType v49, Fixnum recompile
+          v74:Fixnum = GuardType v10, Fixnum recompile
           v75:Fixnum = GuardType v50, Fixnum
           v76:Fixnum = FixnumAdd v74, v75
           CheckInterrupts
@@ -21431,7 +21424,7 @@ mod hir_opt_tests {
           v257:BoolExact = FixnumEq v255, v51
           v212:CBool = Test v257
           v213:FalseClass = RefineType v257, Falsy
-          CondBranch v212, bb19(), bb18(v89, v99, v213)
+          CondBranch v212, bb19(), bb18(v213)
         bb19():
           PatchPoint SingleRactorMode
           v220:CShape = LoadField v89, :shape_id@0x1090
@@ -21447,8 +21440,8 @@ mod hir_opt_tests {
           v267:Fixnum = GuardType v222, Fixnum recompile
           v268:Fixnum = GuardType v264, Fixnum
           v269:BoolExact = FixnumEq v267, v268
-          Jump bb18(v89, v99, v269)
-        bb18(v232:ObjectSubclass[class_exact:Point], v233:ObjectSubclass[class_exact:Point], v234:BoolExact):
+          Jump bb18(v269)
+        bb18(v234:BoolExact):
           CheckInterrupts
           PopInlineFrame
           Return v234
@@ -21530,12 +21523,17 @@ mod hir_opt_tests {
           v44:CBool = Test v15
           v45:Falsy = RefineType v15, Falsy
           CondBranch v44, bb5(), bb4(v13, v14, v45, v37)
+          v42:CBool = Test v15
+          CondBranch v42, bb5(), bb4()
         bb5():
           v47:Truthy = RefineType v15, Truthy
           CheckInterrupts
           Return v37
         bb4(v54:BasicObject, v55:BasicObject, v56:Falsy, v57:BasicObject):
           v61:NilClass = Const Value(nil)
+          Return v35
+        bb4():
+          v59:NilClass = Const Value(nil)
           CheckInterrupts
           Return v61
         ");

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -21608,4 +21608,50 @@ mod hir_opt_tests {
           Return v63
         ");
     }
+
+    #[test]
+    fn test_while_loop() {
+        eval(r#"
+            def test
+              i = 0
+              while i < 10
+                i += 1
+              end
+              i
+            end
+
+            test
+        "#);
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:3:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          v2:NilClass = Const Value(nil)
+          Jump bb3(v1, v2)
+        bb2():
+          EntryPoint JIT(0)
+          v5:BasicObject = LoadArg :self@0
+          v6:NilClass = Const Value(nil)
+          Jump bb3(v5, v6)
+        bb3(v8:BasicObject, v9:NilClass):
+          v13:Fixnum[0] = Const Value(0)
+          Jump bb5(v8, v13)
+        bb5(v18:BasicObject, v19:Fixnum):
+          v23:Fixnum[10] = Const Value(10)
+          PatchPoint MethodRedefined(Integer@0x1000, <@0x1008, cme:0x1010)
+          v58:BoolExact = FixnumLt v19, v23
+          CheckInterrupts
+          v29:CBool = Test v58
+          CondBranch v29, bb4(), bb6()
+        bb4():
+          v48:Fixnum[1] = Const Value(1)
+          PatchPoint MethodRedefined(Integer@0x1000, +@0x1038, cme:0x1040)
+          v62:Fixnum = FixnumAdd v19, v48
+          Jump bb5(v18, v62)
+        bb6():
+          CheckInterrupts
+          Return v19
+        ");
+    }
 }

--- a/zjit/src/stats.rs
+++ b/zjit/src/stats.rs
@@ -171,6 +171,7 @@ make_counters! {
         compile_hir_build_time_ns,
         compile_hir_strength_reduce_time_ns,
         compile_hir_inline_methods_time_ns,
+        compile_hir_minify_ssa_time_ns,
         compile_hir_optimize_load_store_time_ns,
         compile_hir_canonicalize_time_ns,
         compile_hir_fold_constants_time_ns,

--- a/zjit/src/stats.rs
+++ b/zjit/src/stats.rs
@@ -171,7 +171,7 @@ make_counters! {
         compile_hir_build_time_ns,
         compile_hir_strength_reduce_time_ns,
         compile_hir_inline_methods_time_ns,
-        compile_hir_minify_ssa_time_ns,
+        compile_hir_remove_trivial_phis_time_ns,
         compile_hir_optimize_load_store_time_ns,
         compile_hir_canonicalize_time_ns,
         compile_hir_fold_constants_time_ns,

--- a/zjit/src/stats.rs
+++ b/zjit/src/stats.rs
@@ -171,7 +171,7 @@ make_counters! {
         compile_hir_build_time_ns,
         compile_hir_strength_reduce_time_ns,
         compile_hir_inline_methods_time_ns,
-        compile_hir_remove_trivial_phis_time_ns,
+        compile_hir_remove_trivial_block_params_time_ns,
         compile_hir_optimize_load_store_time_ns,
         compile_hir_canonicalize_time_ns,
         compile_hir_fold_constants_time_ns,


### PR DESCRIPTION
This PR adds a pass to prune block params to a minimal SSA form. This will improve performance of future CFG-based optimizations.

The stats are interesting. While we are adding a new pass and the compiler is doing more work, the block param optimization speeds up most HIR passes, counteracting the added time taken to remove trivial block params. Additionally, this pass speeds up LIR by roughly 75ms and reduces ZJIT's overall compile time by a similar margin.

```
Label                                                          Previous           Current
compile_side_exit_time:                                          136ms              133ms
compile_side_exit_time_ratio:                                     5.2%               5.2%
compile_hir_time:                                                785ms              787ms
compile_hir_build_time:                                          255ms              249ms
compile_hir_strength_reduce_time:                                159ms              154ms
compile_hir_inline_methods_time:                                  52ms               51ms
compile_hir_remove_trivial_block_params_time:                     ----               33ms
compile_hir_optimize_load_store_time:                             41ms               39ms
compile_hir_canonicalize_time:                                    80ms               76ms
compile_hir_fold_constants_time:                                  36ms               33ms
compile_hir_clean_cfg_time:                                       46ms               43ms
compile_hir_remove_redundant_patch_points_time:                   28ms               27ms
compile_hir_remove_duplicate_check_interrupts_time:               19ms               19ms
compile_hir_eliminate_dead_code_time:                             51ms               47ms
compile_lir_time:                                              1,711ms            1,635ms
profile_time:                                                     27ms               26ms
gc_time:                                                          34ms               33ms
invalidation_time:                                                14ms               13ms
vm_write_jit_frame_count:                                  127,658,794        127,600,476
vm_write_sp_count:                                         127,658,794        127,600,476
vm_write_locals_count:                                     121,141,931        121,115,691
vm_write_stack_count:                                       50,887,864         50,829,668
vm_write_to_parent_iseq_local_count:                           642,025            642,025
guard_type_count:                                           91,727,380         97,020,625
guard_type_exit_ratio:                                            0.0%               0.0%
guard_shape_count:                                          37,710,469         37,526,791
guard_shape_exit_ratio:                                           0.0%               0.0%
load_field_count:                                          181,271,938        181,162,450
store_field_count:                                          25,514,468         25,514,468
side_exit_size:                                             26,917,388         27,227,984
code_region_bytes:                                          62,373,888         62,570,496
side_exit_size_ratio:                                            43.2%              43.5%
zjit_alloc_bytes:                                           31,767,782         31,775,489
total_mem_bytes:                                            94,141,670         94,345,985
total_native_stack_bytes:                                    1,741,824          1,487,360
side_exit_count:                                               783,200            783,209
total_insn_count:                                          816,108,127        816,108,866
vm_insn_count:                                              16,074,628         16,074,310
zjit_insn_count:                                           800,033,499        800,034,556
ratio_in_zjit:                                                   98.0%              98.0%

```