### PR TITLE
[DOC] Restore missing GC docs

### DIFF
--- a/.document
+++ b/.document
@@ -42,6 +42,9 @@ lib
 # and some of the ext/ directory (which has its own .document file)
 ext
 
+# GC is split between gc.rb and gc/default/default.c
+gc/default
+
 # For `prism`, ruby code is in lib and c in the prism folder
 prism
 

--- a/gc.c
+++ b/gc.c
@@ -5787,24 +5787,6 @@ rb_gc_checking_shareable(void)
  *     Finalizer one on 537763480
  */
 
-/*  Document-class: GC::Profiler
- *
- *  The GC profiler provides access to information on GC runs including time,
- *  length and object space size.
- *
- *  Example:
- *
- *    GC::Profiler.enable
- *
- *    require 'rdoc/rdoc'
- *
- *    GC::Profiler.report
- *
- *    GC::Profiler.disable
- *
- *  See also GC.count, GC.malloc_allocated_size and GC.malloc_allocations
- */
-
 #include "gc.rbinc"
 
 void

--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -9984,6 +9984,23 @@ rb_gc_impl_init(void)
     rb_define_singleton_method(rb_mGC, "malloc_allocations", gc_malloc_allocations, 0);
 #endif
 
+    /*  Document-class: GC::Profiler
+     *
+     *  The GC profiler provides access to information on GC runs including time,
+     *  length and object space size.
+     *
+     *  Example:
+     *
+     *    GC::Profiler.enable
+     *
+     *    require 'rdoc/rdoc'
+     *
+     *    GC::Profiler.report
+     *
+     *    GC::Profiler.disable
+     *
+     *  See also GC.count, GC.malloc_allocated_size and GC.malloc_allocations
+     */
     VALUE rb_mProfiler = rb_define_module_under(rb_mGC, "Profiler");
     rb_define_singleton_method(rb_mProfiler, "enabled?", gc_profile_enable_get, 0);
     rb_define_singleton_method(rb_mProfiler, "enable", gc_profile_enable, 0);


### PR DESCRIPTION
Since modular GC was done, the GC module is missing a bunch of methods.

https://docs.ruby-lang.org/en/4.0/GC.html. No `compact`, among others. This adds them back.

