### PR TITLE
Allow prefix in build directory

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -173,8 +173,8 @@ AS_CASE([$RUBY_PATCHLEVEL], [-*], [
 AS_IF([test "$program_prefix" = NONE], [
   program_prefix=
 ])
-AS_IF([test "$prefix" -ef .], [
-  AC_MSG_ERROR(--prefix cannot be the current working directory.)
+AS_IF([test "$prefix" -ef "$srcdir"], [
+  AC_MSG_ERROR(--prefix cannot be the source directory.)
 ])
 RUBY_BASE_NAME=`echo ruby | sed "$program_transform_name"`
 RUBYW_BASE_NAME=`echo rubyw | sed "$program_transform_name"`


### PR DESCRIPTION
Still disallow in source directory because it conflicts with source files.

---

I found it comes from [[Issue #8409]](https://bugs.ruby-lang.org/issues/8409) but I've tried and there was no problem building and installing in the same directory.
In the build directory, there's no `bin/`, `include/`, `lib/`, or `share/` so I don't think the installation could conflict, but maybe I'm missing something?

In the source directory, there's [bin/gem](https://github.com/ruby/ruby/blob/9a90ac21ffd17ef8165ab8324514d2f4c7ed81a8/bin/gem), so installing in the source directory results in at least that file being modified, and a number of other untracked files. So I changed the condition to at least ensure we're not installing in the source directory.

I still don't recommend doing this for "real" installations, but when working on Ruby, it's useful to have everything contained in the build directory (without an additional subdirectory).