### PR TITLE
[Bug #21994] Drop warning for ambiguous regexp use

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -9179,12 +9179,7 @@ static int
 arg_ambiguous(struct parser_params *p, char c)
 {
 #ifndef RIPPER
-    if (c == '/') {
-        rb_warning1("ambiguity between regexp and two divisions: wrap regexp in parentheses or add a space after '%c' operator", WARN_I(c));
-    }
-    else {
-        rb_warning1("ambiguous first argument; put parentheses or a space even after '%c' operator", WARN_I(c));
-    }
+    rb_warning1("ambiguous first argument; put parentheses or a space even after '%c' operator", WARN_I(c));
 #else
     dispatch1(arg_ambiguous, rb_usascii_str_new(&c, 1));
 #endif
@@ -11024,7 +11019,6 @@ parser_yylex(struct parser_params *p)
         }
         pushback(p, c);
         if (IS_SPCARG(c)) {
-            arg_ambiguous(p, '/');
             p->lex.strterm = NEW_STRTERM(str_regexp, '/', 0);
             return tREGEXP_BEG;
         }

--- a/prism/prism.c
+++ b/prism/prism.c
@@ -11035,7 +11035,10 @@ parser_lex(pm_parser_t *parser) {
                     }
 
                     if (lex_state_spcarg_p(parser, space_seen)) {
-                        pm_parser_warn_token(parser, &parser->current, PM_WARN_AMBIGUOUS_SLASH);
+                        // https://bugs.ruby-lang.org/issues/21994
+                        if (parser->version <= PM_OPTIONS_VERSION_CRUBY_4_0) {
+                            pm_parser_warn_token(parser, &parser->current, PM_WARN_AMBIGUOUS_SLASH);
+                        }
                         lex_mode_push_regexp(parser, '\0', '/');
                         LEX(PM_TOKEN_REGEXP_BEGIN);
                     }

--- a/test/prism/result/warnings_test.rb
+++ b/test/prism/result/warnings_test.rb
@@ -19,7 +19,8 @@ module Prism
     end
 
     def test_ambiguous_regexp
-      assert_warning("a /b/", "wrap regexp in parentheses")
+      assert_warning("a /b/", "wrap regexp in parentheses", compare: false, version: "4.0")
+      refute_warning("a /b/", compare: false, version: "4.1")
     end
 
     def test_ambiguous_ampersand
@@ -408,8 +409,8 @@ module Prism
       assert_equal "END in method; use at_exit", warning.message
       assert_equal :default, warning.level
 
-      warning = Prism.parse("foo /regexp/").warnings.first
-      assert_equal "ambiguous `/`; wrap regexp in parentheses or add a space after `/` operator", warning.message
+      warning = Prism.parse("foo +1").warnings.first
+      assert_equal "ambiguous first argument; put parentheses or a space even after `+` operator", warning.message
       assert_equal :verbose, warning.level
     end
 

--- a/test/ripper/test_parser_events.rb
+++ b/test/ripper/test_parser_events.rb
@@ -233,7 +233,7 @@ class TestRipper::ParserEvents < Test::Unit::TestCase
 
   def test_arg_ambiguous
     thru_arg_ambiguous = false
-    parse('m //', :on_arg_ambiguous) {thru_arg_ambiguous = true}
+    parse('m +1', :on_arg_ambiguous) {thru_arg_ambiguous = true}
     assert_equal true, thru_arg_ambiguous
   end
 


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/21994