### PR TITLE
[Box] Delay BUNDLER_SETUP until the main box

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -1471,4 +1471,8 @@ else
 end
 eval File.read(path), nil, file
 
-require ENV["BUNDLER_SETUP"] if ENV["BUNDLER_SETUP"] && !defined?(Bundler)
+if ENV["BUNDLER_SETUP"] && !defined?(Bundler)
+  # In Ruby::Box, the root box loads gem_prelude before the main box.
+  # Loading Bundler there can evaluate gemspecs in the main box too early.
+  require ENV["BUNDLER_SETUP"] if !defined?(Ruby::Box) || !Ruby::Box.enabled? || Ruby::Box.current.main?
+end

--- a/test/ruby/test_box.rb
+++ b/test/ruby/test_box.rb
@@ -938,6 +938,21 @@ class TestBox < Test::Unit::TestCase
     end
   end
 
+  def test_bundler_setup_is_not_loaded_from_root_box_prelude
+    Tempfile.create(["bundler_setup", ".rb"]) do |t|
+      t.puts 'eval("Gem::Specification", TOPLEVEL_BINDING.dup)'
+      t.puts 'puts "ok"'
+      t.close
+
+      env = ENV_ENABLE_BOX.merge("BUNDLER_SETUP" => t.path)
+      assert_in_out_err([env, "--enable=gems"], "") do |output, error|
+        assert_equal ["ok"], output
+        assert_match EXPERIMENTAL_WARNING_LINE_PATTERNS[0], error[0]
+        assert_match EXPERIMENTAL_WARNING_LINE_PATTERNS[1], error[1]
+      end
+    end
+  end
+
   def test_require_list_loaded_only_in_main_box
     Tempfile.create(["req_a", ".rb"]) do |t1|
       Tempfile.create(["req_b", ".rb"]) do |t2|


### PR DESCRIPTION
## Summary

When Ruby::Box is enabled, avoid loading `bundler/setup` from the root box `gem_prelude` through RubyGems' `BUNDLER_SETUP` hook.

The root box loads `gem_prelude` before the main box. If `BUNDLER_SETUP` is consumed while loading RubyGems in the root box, Bundler can evaluate path gemspecs through `TOPLEVEL_BINDING` in the main box before RubyGems has been loaded there.

This can fail with:

```text
uninitialized constant Gem::Specification
```

## Details

`bundle exec` sets `BUNDLER_SETUP` for child Ruby processes. With `RUBY_BOX=1`, RubyGems currently consumes this hook while loading the root box prelude.

Bundler evaluates path gemspecs with `TOPLEVEL_BINDING`, so this can run gemspec code in the main box while the main box still has only the initial `Gem` module, not the full RubyGems constants such as `Gem::Specification`.

This change keeps the existing behavior when Ruby::Box is disabled, but when Ruby::Box is enabled, it lets the main box consume `BUNDLER_SETUP` instead of the root box.

## Test

Added a regression test that sets `BUNDLER_SETUP` to a small Ruby file which evaluates `Gem::Specification` through `TOPLEVEL_BINDING`.

The new test fails without this change and passes with it.

```sh
RUBYLIB=./lib \
./ruby -Itool/lib -rcore_assertions -Itest/lib \
  test/ruby/test_box.rb \
  --name=test_bundler_setup_is_not_loaded_from_root_box_prelude
```

Result:

```text
1 tests, 3 assertions, 0 failures, 0 errors, 0 skips
```

## Notes for reviewers

This touches Ruby::Box startup behavior. I chose the smallest fix in
RubyGems' `BUNDLER_SETUP` hook, but another possible approach is to
handle this in Ruby::Box prelude sequencing.

cc @tagomoris