### PR TITLE
[Feature #22111] parse.y: Non-symbolic hash keys with expr-colon syntax

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -6632,6 +6632,11 @@ assoc		: arg_value tASSOC arg_value
                         $$ = list_append(p, NEW_LIST($1, &@$), $3);
                     /*% ripper: assoc_new!($:1, $:3) %*/
                     }
+                | arg_value ':' arg_value
+                    {
+                        $$ = list_append(p, NEW_LIST($1, &@$), $3);
+                    /*% ripper: assoc_new!($:1, $:3) %*/
+                    }
                 | tLABEL arg_value
                     {
                         $$ = list_append(p, NEW_LIST(NEW_SYM(rb_id2str($1), &@1), &@$), $2);

--- a/prism/prism.c
+++ b/prism/prism.c
@@ -13680,8 +13680,12 @@ parse_assocs(pm_parser_t *parser, pm_static_literals_t *literals, pm_node_t *nod
 
                 pm_token_t operator = { 0 };
                 if (!pm_symbol_node_label_p(parser, key)) {
-                    expect1(parser, PM_TOKEN_EQUAL_GREATER, PM_ERR_HASH_ROCKET);
-                    operator = parser->previous;
+                    if (accept1(parser, PM_TOKEN_COLON)) {
+                        operator = parser->previous;
+                    } else {
+                        expect1(parser, PM_TOKEN_EQUAL_GREATER, PM_ERR_HASH_ROCKET);
+                        operator = parser->previous;
+                    }
                 }
 
                 pm_node_t *value = parse_value_expression(parser, PM_BINDING_POWER_DEFINED, PM_PARSE_ACCEPTS_DO_BLOCK, PM_ERR_HASH_VALUE, (uint16_t) (depth + 1));

--- a/test/ruby/test_syntax.rb
+++ b/test/ruby/test_syntax.rb
@@ -626,13 +626,17 @@ class TestSyntax < Test::Unit::TestCase
     assert_not_label(:foo, 'class Foo < not_label:foo; end', bug6347)
   end
 
-  def test_no_label_with_percent
-    assert_syntax_error('{%"a": 1}', /unexpected ':'/)
-    assert_syntax_error("{%'a': 1}", /unexpected ':'/)
-    assert_syntax_error('{%Q"a": 1}', /unexpected ':'/)
-    assert_syntax_error("{%Q'a': 1}", /unexpected ':'/)
-    assert_syntax_error('{%q"a": 1}', /unexpected ':'/)
-    assert_syntax_error("{%q'a': 1}", /unexpected ':'/)
+  def test_percent_string_hash_key
+    [
+      '%"a"',
+      "%'a'",
+      '%Q"a"',
+      "%Q'a'",
+      '%q"a"',
+      "%q'a'",
+    ].each do |key|
+      assert_equal({"a" => 1}, eval("{#{key}: 1}"), key)
+    end
   end
 
   def test_block_after_cond
@@ -651,6 +655,36 @@ class TestSyntax < Test::Unit::TestCase
     bug11812 = '[ruby-core:72084]'
     assert_valid_syntax('{label:%w(*)}', bug11812)
     assert_valid_syntax('{label: %w(*)}', bug11812)
+  end
+
+  def test_expr_colon_hash_keys
+    expr = 3
+    h = eval(<<~'RUBY')
+      {
+        key1: 1,
+        "key-2": :two,
+        expr : "3-expr",
+        "key4" : "4-String",
+        (5+0): "5-parentheses",
+        6: "6-Integer",
+        7.001: "7-Float",
+        "key" + "8": "8-String expr",
+        9+0: "9-Integer expr",
+        [10,0]: "10-Array",
+        true ? 11 : 0 : "11-ternary"
+      }
+    RUBY
+    assert_equal(1, h[:key1])
+    assert_equal(:two, h[:"key-2"])
+    assert_equal("3-expr", h[3])
+    assert_equal("4-String", h["key4"])
+    assert_equal("5-parentheses", h[5])
+    assert_equal("6-Integer", h[6])
+    assert_equal("7-Float", h[7.001])
+    assert_equal("8-String expr", h["key8"])
+    assert_equal("9-Integer expr", h[9])
+    assert_equal("10-Array", h[[10,0]])
+    assert_equal("11-ternary", h[11])
   end
 
   def test_heredoc_after_label


### PR DESCRIPTION
Allow `{ expr : value }` for non-symbolic hash keys, completing the colon-notation family:

```ruby
h = {
  name: "symbol shorthand",        # Ruby 1.9+
  "quoted label": "symbol label",  # Ruby 2.2+ (Feature #4935)
  value_omission: ,                # Ruby 3.1+ (Feature #14579)
  expr : "non symbol",             # Ruby ???  (Feature #22111)
}
```

* parse.y: Add assoc: arg_value ':' arg_value grammar rule.
* prism.c: In parse_assocs, accept PM_TOKEN_COLON as assoc separator when pm_symbol_node_label_p returns false.
* test/ruby/test_syntax.rb: Add test_expr_colon_hash_keys. Rename test_no_label_with_percent to test_percent_string_hash_key.

(See: [Feature #22111](https://bugs.ruby-lang.org/issues/22111))

Dependencies:
 * https://github.com/ruby/prism/pull/4134 (but `prism/prism.c` is copied in here ahead of being synced from the upstream)

Assisted-by: OpenCode 1.17.3 (opencode/big-pickle)