### PR TITLE
[DOC] Fix documentation for String#gsub!

### DIFF
--- a/string.c
+++ b/string.c
@@ -6505,7 +6505,7 @@ str_gsub(int argc, VALUE *argv, VALUE str, int bang)
  *  Like String#gsub, except that:
  *
  *  - Performs substitutions in +self+ (not in a copy of +self+).
- *  - Returns +self+ if any characters are removed, +nil+ otherwise.
+ *  - Returns +self+ if any substitutions were performed, +nil+ otherwise.
  *
  *  Related: see {Modifying}[rdoc-ref:String@Modifying].
  */


### PR DESCRIPTION
String#gsub! returns self if any substitutions were performed, not characters removed.