### PR TITLE
Transition to COMPLEX when object_id overflows the max fields

### DIFF
--- a/shape.c
+++ b/shape.c
@@ -698,8 +698,13 @@ rb_shape_transition_object_id(shape_id_t original_shape_id)
 {
     RUBY_ASSERT(!rb_shape_has_object_id(original_shape_id));
 
+    rb_shape_t *original_shape = RSHAPE(original_shape_id);
+
     bool dont_care;
-    rb_shape_t *shape = get_next_shape_internal(RSHAPE(original_shape_id), id_object_id, SHAPE_OBJ_ID, &dont_care, true);
+    rb_shape_t *shape = NULL;
+    if (LIKELY(original_shape->next_field_index < rb_shape_tree.max_capacity)) {
+        shape = get_next_shape_internal(original_shape, id_object_id, SHAPE_OBJ_ID, &dont_care, true);
+    }
     if (!shape) {
         return rb_shape_layout(original_shape_id) | ROOT_COMPLEX_WITH_OBJ_ID | RSHAPE_FLAGS(original_shape_id);
     }

--- a/test/ruby/test_shapes.rb
+++ b/test/ruby/test_shapes.rb
@@ -724,6 +724,26 @@ class TestShapes < Test::Unit::TestCase
     end;
   end
 
+  def test_object_id_when_fields_are_full
+    # Adding object_id to an object with exactly SHAPE_MAX_FIELDS fields must
+    # transition to COMPLEX instead of asserting.
+    assert_separately([], "#{<<~"begin;"}\n#{<<~'end;'}")
+    begin;
+      obj = Object.new
+      max = RubyVM::Shape::SHAPE_MAX_FIELDS
+      max.times { |i| obj.instance_variable_set(:"@v#{i}", i) }
+      refute_predicate RubyVM::Shape.of(obj), :complex?
+
+      id = obj.object_id
+      assert_kind_of Integer, id
+      assert_equal id, obj.object_id
+      assert_predicate RubyVM::Shape.of(obj), :complex?
+
+      max.times { |i| assert_equal i, obj.instance_variable_get(:"@v#{i}") }
+      assert_equal max, obj.instance_variables.size
+    end;
+  end
+
   def test_complex_and_frozen_and_object_id
     assert_separately([], "#{<<~"begin;"}\n#{<<~'end;'}")
     begin;


### PR DESCRIPTION
```ruby
obj = Object.new
RubyVM::Shape::SHAPE_MAX_FIELDS.times { |i| obj.instance_variable_set(:"@v#{i}", i) }
obj.object_id
```

On a `RUBY_DEBUG` build this aborts with:

```
shape.c:543: Assertion Failed: rb_shape_alloc_new_child:new_shape->capacity > shape->next_field_index
```

`rb_shape_transition_object_id` called `get_next_shape_internal` directly, without the `next_field_index >= max_capacity` guard that the instance variable path applies in `shape_get_next`. An object filled to exactly `SHAPE_MAX_FIELDS` fields is still a simple (non-complex) shape, so assigning an object_id tried to add one more field and hit an assertion in `rb_shape_alloc_new_child`.

Apply the same guard so such objects transition to COMPLEX instead.