### PR TITLE
vm_dump.c: note when there is no Ruby execution context

### DIFF
--- a/vm_dump.c
+++ b/vm_dump.c
@@ -1450,6 +1450,20 @@ rb_vm_bugreport(const void *ctx, FILE *errout)
         }
         kputs("\n");
     }
+    else {
+        /* No Ruby level information is available: there is no current execution
+         * context, or the VM is not ready.  State it explicitly instead of
+         * silently jumping to the machine register context. */
+        kprintf("-- Control frame information "
+                "-----------------------------------------------\n");
+        if (!vm) {
+            kprintf("  The VM is not available.\n");
+        }
+        else {
+            kprintf("  No Ruby execution context on the current thread.\n");
+        }
+        kputs("\n");
+    }
 
     rb_dump_machine_register(errout, ctx);
 


### PR DESCRIPTION
rb_vm_bugreport() silently skipped the control frame information, Ruby level backtrace, and threading sections when vm or ec was NULL, so the report jumped straight to the machine register context with no explanation of why no Ruby level information was shown. ec can be NULL for various reasons (e.g. a process-directed signal delivered to a non-Ruby thread, or simply a window where the current thread has no execution context yet).

Emit an explicit note under the "Control frame information" header in that case, without speculating about the cause. This makes the report self-explanatory and keeps the section present, so test_crash_report no longer fails intermittently when ec happens to be NULL.