### PR TITLE
ZJIT: Recompile getblockparamproxy on side exits

### DIFF
--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -2560,9 +2560,9 @@ impl Assembler
                     EC,
                     recompile.frame_iseq,
                     recompile.compiled_iseq,
-                    Opnd::UImm(recompile.insn_idx as u64),
-                    Opnd::Imm(profile_kind.into()),
-                    Opnd::Imm(profile_payload.into())
+                    recompile.insn_idx.into(),
+                    profile_kind.into(),
+                    profile_payload.into()
                 );
             }
         }

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -2554,7 +2554,7 @@ impl Assembler
                 let payload = get_or_create_iseq_payload(exit.iseq);
                 payload.reset_profiles_remaining(recompile.insn_idx as YarvInsnIdx);
                 use crate::codegen::exit_recompile;
-                let (profile_kind, profile_payload) = recompile.strategy.to_abi_args();
+                let (profile_kind, profile_payload) = recompile.strategy.to_c_args();
                 asm_comment!(asm, "profile and maybe recompile");
                 asm_ccall!(asm, exit_recompile,
                     EC,

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -2554,16 +2554,15 @@ impl Assembler
                 let payload = get_or_create_iseq_payload(exit.iseq);
                 payload.reset_profiles_remaining(recompile.insn_idx as YarvInsnIdx);
                 use crate::codegen::exit_recompile;
+                let (profile_kind, profile_payload) = recompile.strategy.to_abi_args();
                 asm_comment!(asm, "profile and maybe recompile");
                 asm_ccall!(asm, exit_recompile,
                     EC,
                     recompile.frame_iseq,
                     recompile.compiled_iseq,
                     Opnd::UImm(recompile.insn_idx as u64),
-                    Opnd::Imm(match recompile.strategy {
-                        hir::Recompile::ProfileSend { argc } => argc as i64,
-                        hir::Recompile::ProfileSelf => -1,
-                    })
+                    Opnd::Imm(profile_kind.into()),
+                    Opnd::Imm(profile_payload.into())
                 );
             }
         }

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -710,7 +710,7 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
             gen_guard_type(jit, asm, opnd!(val), val_type, guard_type, recompile, &function.frame_state(state))
         }
         &Insn::GuardBitEquals { val, expected, reason, state, recompile } => gen_guard_bit_equals(jit, asm, opnd!(val), expected, reason, recompile, &function.frame_state(state)),
-        &Insn::GuardAnyBitSet { val, mask, reason, state, .. } => gen_guard_any_bit_set(jit, asm, opnd!(val), mask, reason, &function.frame_state(state)),
+        &Insn::GuardAnyBitSet { val, mask, reason, state, recompile, .. } => gen_guard_any_bit_set(jit, asm, opnd!(val), mask, reason, recompile, &function.frame_state(state)),
         &Insn::GuardNoBitsSet { val, mask, reason, state, .. } => gen_guard_no_bits_set(jit, asm, opnd!(val), mask, reason, &function.frame_state(state)),
         &Insn::GuardLess { left, right, reason, state } => gen_guard_less(jit, asm, opnd!(left), opnd!(right), reason, &function.frame_state(state)),
         &Insn::GuardGreaterEq { left, right, state, .. } => gen_guard_greater_eq(jit, asm, opnd!(left), opnd!(right), &function.frame_state(state)),
@@ -2776,10 +2776,10 @@ fn mask_to_opnd(mask: crate::hir::Const) -> Option<Opnd> {
 }
 
 /// Compile a bitmask check with a side exit if none of the masked bits are not set
-fn gen_guard_any_bit_set(jit: &mut JITState, asm: &mut Assembler, val: lir::Opnd, mask: crate::hir::Const, reason: SideExitReason, state: &FrameState) -> lir::Opnd {
+fn gen_guard_any_bit_set(jit: &mut JITState, asm: &mut Assembler, val: lir::Opnd, mask: crate::hir::Const, reason: SideExitReason, recompile: Option<Recompile>, state: &FrameState) -> lir::Opnd {
     let mask_opnd = mask_to_opnd(mask).unwrap_or_else(|| panic!("gen_guard_any_bit_set: unexpected hir::Const {mask:?}"));
     asm.test(val, mask_opnd);
-    asm.jz(jit, side_exit(jit, state, reason));
+    asm.jz(jit, side_exit_with_recompile(jit, state, reason, recompile));
     val
 }
 
@@ -3208,8 +3208,7 @@ pub(crate) use c_callable;
 
 c_callable! {
     /// Called from JIT side-exit code to profile operands and trigger recompilation.
-    /// For send instructions (argc >= 0): profiles receiver + args from the stack.
-    /// For shape guard exits (argc == -1): profiles self from the CFP.
+    /// `profile_kind` selects what to profile; `profile_payload` carries kind-specific data.
     /// Once enough profiles are gathered, invalidates the compiled unit for recompilation.
     ///
     /// Two iseqs are passed because they diverge for inlined code. `frame_iseq_raw` is
@@ -3219,7 +3218,9 @@ c_callable! {
     /// inliner folds the callee's body into it), so its version is the one holding the
     /// failing guard and the one we must invalidate to force a recompile. For
     /// non-inlined code the two are identical.
-    pub(crate) fn exit_recompile(ec: EcPtr, frame_iseq_raw: VALUE, compiled_iseq_raw: VALUE, insn_idx: u32, argc: i32) {
+    pub(crate) fn exit_recompile(ec: EcPtr, frame_iseq_raw: VALUE, compiled_iseq_raw: VALUE, insn_idx: u32, profile_kind: i32, profile_payload: i32) {
+        let recompile = Recompile::from_abi_args(profile_kind, profile_payload);
+
         // Fast check before taking the VM lock: skip if the compiled unit is already
         // invalidated or at the version limit. This avoids expensive lock acquisition
         // on every shape guard exit after the recompile has already been triggered.
@@ -3240,9 +3241,10 @@ c_callable! {
             let compiled_iseq: IseqPtr = compiled_iseq_raw.as_iseq();
 
             // For no-profile sends, skip if already profiled at this insn_idx.
-            // For shape guard exits (argc == -1), always re-profile because the
+            // For shape guard exits, always re-profile because the
             // original YARV profiles were monomorphic but runtime showed new shapes.
-            if argc >= 0 && get_or_create_iseq_payload(frame_iseq).profile.done_profiling_at(insn_idx as usize) {
+            if matches!(recompile, Recompile::ProfileSend { .. }) &&
+                get_or_create_iseq_payload(frame_iseq).profile.done_profiling_at(insn_idx as usize) {
                 return;
             }
 
@@ -3250,14 +3252,21 @@ c_callable! {
                 let cfp = unsafe { get_ec_cfp(ec) };
                 let payload = get_or_create_iseq_payload(frame_iseq);
 
-                if argc >= 0 {
-                    let sp = unsafe { get_cfp_sp(cfp) };
-                    // Profile the receiver and arguments for this send instruction
-                    payload.profile.profile_send_at(frame_iseq, insn_idx as usize, sp, argc as usize)
-                } else {
-                    // Profile self for shape guard exits (argc == -1)
-                    let self_val = unsafe { get_cfp_self(cfp) };
-                    payload.profile.profile_self_at(frame_iseq, insn_idx as usize, self_val)
+                match recompile {
+                    Recompile::ProfileSend { argc } => {
+                        let sp = unsafe { get_cfp_sp(cfp) };
+                        // Profile the receiver and arguments for this send instruction
+                        payload.profile.profile_send_at(frame_iseq, insn_idx as usize, sp, argc as usize)
+                    }
+                    Recompile::ProfileSelf => {
+                        // Profile self for shape guard exits
+                        let self_val = unsafe { get_cfp_self(cfp) };
+                        payload.profile.profile_self_at(frame_iseq, insn_idx as usize, self_val)
+                    }
+                    Recompile::ProfileBlockHandler => {
+                        // Profile the block handler for this getblockparamproxy instruction
+                        payload.profile.profile_getblockparamproxy_at(frame_iseq, insn_idx as usize, cfp)
+                    }
                 }
             });
 

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -3219,7 +3219,7 @@ c_callable! {
     /// failing guard and the one we must invalidate to force a recompile. For
     /// non-inlined code the two are identical.
     pub(crate) fn exit_recompile(ec: EcPtr, frame_iseq_raw: VALUE, compiled_iseq_raw: VALUE, insn_idx: u32, profile_kind: i32, profile_payload: i32) {
-        let recompile = Recompile::from_abi_args(profile_kind, profile_payload);
+        let recompile = Recompile::from_c_args(profile_kind, profile_payload);
 
         // Fast check before taking the VM lock: skip if the compiled unit is already
         // invalidated or at the version limit. This avoids expensive lock acquisition

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -584,7 +584,7 @@ pub enum Recompile {
 
 impl Recompile {
     /// Convert to primitive arguments for passing across the C ABI.
-    pub fn to_abi_args(self) -> (i32, i32) {
+    pub fn to_c_args(self) -> (i32, i32) {
         match self {
             Recompile::ProfileSend { argc } => (RECOMPILE_PROFILE_SEND, argc),
             Recompile::ProfileSelf => (RECOMPILE_PROFILE_SELF, 0),
@@ -593,7 +593,7 @@ impl Recompile {
     }
 
     /// Reconstruct from primitive arguments received across the C ABI.
-    pub fn from_abi_args(kind: i32, payload: i32) -> Self {
+    pub fn from_c_args(kind: i32, payload: i32) -> Self {
         match kind {
             RECOMPILE_PROFILE_SEND => Recompile::ProfileSend { argc: payload },
             RECOMPILE_PROFILE_SELF => Recompile::ProfileSelf,

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -568,12 +568,39 @@ pub enum SideExitReason {
 }
 
 /// Controls how a side exit triggers recompilation.
+pub const RECOMPILE_PROFILE_SEND: i32 = 0;
+pub const RECOMPILE_PROFILE_SELF: i32 = 1;
+pub const RECOMPILE_PROFILE_BLOCK_HANDLER: i32 = 2;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Recompile {
     /// Profile receiver + arguments from the stack (for sends without profile data).
     ProfileSend { argc: i32 },
     /// Profile self from the CFP (for shape guard failures).
     ProfileSelf,
+    /// Profile the block handler from the CFP (for getblockparamproxy guard failures).
+    ProfileBlockHandler,
+}
+
+impl Recompile {
+    /// Convert to primitive arguments for passing across the C ABI.
+    pub fn to_abi_args(self) -> (i32, i32) {
+        match self {
+            Recompile::ProfileSend { argc } => (RECOMPILE_PROFILE_SEND, argc),
+            Recompile::ProfileSelf => (RECOMPILE_PROFILE_SELF, 0),
+            Recompile::ProfileBlockHandler => (RECOMPILE_PROFILE_BLOCK_HANDLER, 0),
+        }
+    }
+
+    /// Reconstruct from primitive arguments received across the C ABI.
+    pub fn from_abi_args(kind: i32, payload: i32) -> Self {
+        match kind {
+            RECOMPILE_PROFILE_SEND => Recompile::ProfileSend { argc: payload },
+            RECOMPILE_PROFILE_SELF => Recompile::ProfileSelf,
+            RECOMPILE_PROFILE_BLOCK_HANDLER => Recompile::ProfileBlockHandler,
+            _ => unreachable!("unknown recompile profile kind: {kind}"),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -1191,7 +1218,7 @@ pub enum Insn {
     /// Side-exit if val is not the expected Const.
     GuardBitEquals { val: InsnId, expected: Const, reason: SideExitReason, state: InsnId, recompile: Option<Recompile> },
     /// Side-exit if (val & mask) == 0
-    GuardAnyBitSet { val: InsnId, mask: Const, mask_name: Option<ID>, reason: SideExitReason, state: InsnId },
+    GuardAnyBitSet { val: InsnId, mask: Const, mask_name: Option<ID>, reason: SideExitReason, state: InsnId, recompile: Option<Recompile> },
     /// Side-exit if (val & mask) != 0
     GuardNoBitsSet { val: InsnId, mask: Const, mask_name: Option<ID>, reason: SideExitReason, state: InsnId },
     /// Side-exit if left is not greater than or equal to right (both operands are C long).
@@ -2196,8 +2223,15 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
                 }
                 return Ok(())
             },
-            Insn::GuardAnyBitSet { val, mask, mask_name: Some(name), .. } => { write!(f, "GuardAnyBitSet {val}, {name}={}", mask.print(self.ptr_map)) },
-            Insn::GuardAnyBitSet { val, mask, .. } => { write!(f, "GuardAnyBitSet {val}, {}", mask.print(self.ptr_map)) },
+            Insn::GuardAnyBitSet { val, mask, mask_name, recompile, .. } => {
+                let mask = mask.print(self.ptr_map);
+                let recompile = if recompile.is_some() { " recompile" } else { "" };
+                if let Some(name) = mask_name {
+                    write!(f, "GuardAnyBitSet {val}, {name}={mask}{recompile}")
+                } else {
+                    write!(f, "GuardAnyBitSet {val}, {mask}{recompile}")
+                }
+            },
             Insn::GuardNoBitsSet { val, mask, mask_name: Some(name), .. } => { write!(f, "GuardNoBitsSet {val}, {name}={}", mask.print(self.ptr_map)) },
             Insn::GuardNoBitsSet { val, mask, .. } => { write!(f, "GuardNoBitsSet {val}, {}", mask.print(self.ptr_map)) },
             Insn::GuardLess { left, right, .. } => write!(f, "GuardLess {left}, {right}"),
@@ -8273,7 +8307,7 @@ fn add_iseq_to_hir(
                             // So to check for either of those cases we can use: val & 0x1 == 0x1
 
                             // Bail out if the block handler is neither ISEQ nor ifunc
-                            fun.push_insn(unmodified_block, Insn::GuardAnyBitSet { val: block_handler, mask: Const::CUInt64(0x1), mask_name: None, reason: SideExitReason::BlockParamProxyFallbackMiss, state: exit_id });
+                            fun.push_insn(unmodified_block, Insn::GuardAnyBitSet { val: block_handler, mask: Const::CUInt64(0x1), mask_name: None, reason: SideExitReason::BlockParamProxyFallbackMiss, state: exit_id, recompile: Some(Recompile::ProfileBlockHandler) });
                             // TODO(Shopify/ruby#753): GC root, so we should be able to avoid unnecessary GC tracing
                             let proxy_val = fun.push_insn(unmodified_block, Insn::Const { val: Const::Value(unsafe { rb_block_param_proxy }) });
                             let mut args = vec![proxy_val];
@@ -8286,7 +8320,7 @@ fn add_iseq_to_hir(
                         [profiled_handler] => match profiled_handler {
                             ProfiledBlockHandlerFamily::Nil => {
                                 let block_handler = fun.load_ep_env_field(unmodified_block, ep, FieldName::VM_ENV_DATA_INDEX_SPECVAL, VM_ENV_DATA_INDEX_SPECVAL, types::CInt64);
-                                fun.push_insn(unmodified_block, Insn::GuardBitEquals { val: block_handler, expected: Const::CInt64(VM_BLOCK_HANDLER_NONE.into()), reason: SideExitReason::BlockParamProxyNotNil, state: exit_id, recompile: None });
+                                fun.push_insn(unmodified_block, Insn::GuardBitEquals { val: block_handler, expected: Const::CInt64(VM_BLOCK_HANDLER_NONE.into()), reason: SideExitReason::BlockParamProxyNotNil, state: exit_id, recompile: Some(Recompile::ProfileBlockHandler) });
                                 let nil_val = fun.push_insn(unmodified_block, Insn::Const { val: Const::Value(Qnil) });
                                 let mut args = vec![nil_val];
                                 if let Some(local) = original_local {
@@ -8303,7 +8337,7 @@ fn add_iseq_to_hir(
                                 // So to check for either of those cases we can use: val & 0x1 == 0x1
 
                                 // Bail out if the block handler is neither ISEQ nor ifunc
-                                fun.push_insn(unmodified_block, Insn::GuardAnyBitSet { val: block_handler, mask: Const::CUInt64(0x1), mask_name: None, reason: SideExitReason::BlockParamProxyNotIseqOrIfunc, state: exit_id });
+                                fun.push_insn(unmodified_block, Insn::GuardAnyBitSet { val: block_handler, mask: Const::CUInt64(0x1), mask_name: None, reason: SideExitReason::BlockParamProxyNotIseqOrIfunc, state: exit_id, recompile: Some(Recompile::ProfileBlockHandler) });
                                 // TODO(Shopify/ruby#753): GC root, so we should be able to avoid unnecessary GC tracing
                                 let proxy_val = fun.push_insn(unmodified_block, Insn::Const { val: Const::Value(unsafe { rb_block_param_proxy }) });
                                 let mut args = vec![proxy_val];
@@ -8323,7 +8357,7 @@ fn add_iseq_to_hir(
                                     return_type: types::BasicObject,
                                     elidable: true,
                                 });
-                                fun.push_insn(unmodified_block, Insn::GuardBitEquals { val: is_proc, expected: Const::Value(Qtrue), reason: SideExitReason::BlockParamProxyNotProc, state: exit_id, recompile: None });
+                                fun.push_insn(unmodified_block, Insn::GuardBitEquals { val: is_proc, expected: Const::Value(Qtrue), reason: SideExitReason::BlockParamProxyNotProc, state: exit_id, recompile: Some(Recompile::ProfileBlockHandler) });
                                 let mut args = vec![proc_val];
                                 if let Some(local) = original_local {
                                     args.push(local);

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -5035,7 +5035,7 @@ mod hir_opt_tests {
           Jump bb6(v21, v21)
         bb5():
           v23:CInt64 = LoadField v17, :VM_ENV_DATA_INDEX_SPECVAL@0x1003
-          v24:CInt64 = GuardAnyBitSet v23, CUInt64(1)
+          v24:CInt64 = GuardAnyBitSet v23, CUInt64(1) recompile
           v25:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
           Jump bb6(v25, v10)
         bb6(v15:BasicObject, v16:BasicObject):
@@ -5078,12 +5078,72 @@ mod hir_opt_tests {
         bb5():
           v24:BasicObject = LoadField v18, :VM_ENV_DATA_INDEX_SPECVAL@0x1003
           v25:BasicObject = CCall v24, :rb_obj_is_proc@0x1008
-          v26:TrueClass = GuardBitEquals v25, Value(true)
+          v26:TrueClass = GuardBitEquals v25, Value(true) recompile
           Jump bb6(v24, v10)
         bb6(v16:BasicObject, v17:BasicObject):
           v29:BasicObject = Send v14, &block, :then, v16 # SendFallbackReason: Complex argument passing
           CheckInterrupts
           Return v29
+        ");
+    }
+
+    #[test]
+    fn test_recompile_no_profile_getblockparamproxy() {
+        eval("
+            def test(flag, &block)
+              if flag
+                0.then(&block)
+              else
+                :skip
+              end
+            end
+            test(false)
+            test(false)
+            test(true)
+        ");
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:3:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          v2:CPtr = LoadSP
+          v3:BasicObject = LoadField v2, :flag@0x1000
+          v4:BasicObject = LoadField v2, :block@0x1001
+          Jump bb3(v1, v3, v4)
+        bb2():
+          EntryPoint JIT(0)
+          v7:BasicObject = LoadArg :self@0
+          v8:BasicObject = LoadArg :flag@1
+          v9:BasicObject = LoadArg :block@2
+          Jump bb3(v7, v8, v9)
+        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          CheckInterrupts
+          v19:CBool = Test v12
+          v20:Falsy = RefineType v12, Falsy
+          CondBranch v19, bb5(), bb4(v11, v20, v13)
+        bb5():
+          v22:Truthy = RefineType v12, Truthy
+          v25:Fixnum[0] = Const Value(0)
+          v29:CPtr = GetEP 0
+          v30:CUInt64 = LoadField v29, :VM_ENV_DATA_INDEX_FLAGS@0x1002
+          v31:CBool = IsBlockParamModified v30
+          CondBranch v31, bb6(), bb7()
+        bb6():
+          v33:BasicObject = LoadField v29, :block@0x1003
+          Jump bb8(v33, v33)
+        bb7():
+          v35:CInt64 = LoadField v29, :VM_ENV_DATA_INDEX_SPECVAL@0x1004
+          v36:CInt64[0] = GuardBitEquals v35, CInt64(0) recompile
+          v37:NilClass = Const Value(nil)
+          Jump bb8(v37, v13)
+        bb8(v27:BasicObject, v28:BasicObject):
+          v40:BasicObject = Send v25, &block, :then, v27 # SendFallbackReason: Complex argument passing
+          CheckInterrupts
+          Return v40
+        bb4(v45:BasicObject, v46:Falsy, v47:BasicObject):
+          v51:StaticSymbol[:skip] = Const Value(VALUE(0x1008))
+          CheckInterrupts
+          Return v51
         ");
     }
 
@@ -5132,7 +5192,7 @@ mod hir_opt_tests {
           Jump bb9(v36, v36)
         bb8():
           v38:CInt64 = LoadField v32, :VM_ENV_DATA_INDEX_SPECVAL@0x1003
-          v39:CInt64 = GuardAnyBitSet v38, CUInt64(1)
+          v39:CInt64 = GuardAnyBitSet v38, CUInt64(1) recompile
           v40:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
           Jump bb9(v40, v17)
         bb9(v30:BasicObject, v31:BasicObject):
@@ -5183,7 +5243,7 @@ mod hir_opt_tests {
           Jump bb9(v31)
         bb8():
           v33:CInt64 = LoadField v27, :VM_ENV_DATA_INDEX_SPECVAL@0x1002
-          v34:CInt64 = GuardAnyBitSet v33, CUInt64(1)
+          v34:CInt64 = GuardAnyBitSet v33, CUInt64(1) recompile
           v35:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
           Jump bb9(v35)
         bb9(v26:BasicObject):
@@ -9328,7 +9388,7 @@ mod hir_opt_tests {
           Jump bb6(v22, v22)
         bb5():
           v24:CInt64 = LoadField v18, :VM_ENV_DATA_INDEX_SPECVAL@0x1003
-          v25:CInt64 = GuardAnyBitSet v24, CUInt64(1)
+          v25:CInt64 = GuardAnyBitSet v24, CUInt64(1) recompile
           v26:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
           Jump bb6(v26, v10)
         bb6(v16:BasicObject, v17:BasicObject):
@@ -9368,7 +9428,7 @@ mod hir_opt_tests {
           Jump bb6(v22, v22)
         bb5():
           v24:CInt64 = LoadField v18, :VM_ENV_DATA_INDEX_SPECVAL@0x1003
-          v25:CInt64[0] = GuardBitEquals v24, CInt64(0)
+          v25:CInt64[0] = GuardBitEquals v24, CInt64(0) recompile
           v26:NilClass = Const Value(nil)
           Jump bb6(v26, v10)
         bb6(v16:BasicObject, v17:BasicObject):
@@ -9409,7 +9469,7 @@ mod hir_opt_tests {
           Jump bb6(v17)
         bb5():
           v19:CInt64 = LoadField v13, :VM_ENV_DATA_INDEX_SPECVAL@0x1002
-          v20:CInt64 = GuardAnyBitSet v19, CUInt64(1)
+          v20:CInt64 = GuardAnyBitSet v19, CUInt64(1) recompile
           v21:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
           Jump bb6(v21)
         bb6(v12:BasicObject):
@@ -12901,7 +12961,7 @@ mod hir_opt_tests {
           Jump bb6(v22, v22)
         bb5():
           v24:CInt64 = LoadField v18, :VM_ENV_DATA_INDEX_SPECVAL@0x1003
-          v25:CInt64 = GuardAnyBitSet v24, CUInt64(1)
+          v25:CInt64 = GuardAnyBitSet v24, CUInt64(1) recompile
           v26:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
           Jump bb6(v26, v10)
         bb6(v16:BasicObject, v17:BasicObject):
@@ -18779,7 +18839,7 @@ mod hir_opt_tests {
           Jump bb8(v41, v41)
         bb7():
           v43:CInt64 = LoadField v37, :VM_ENV_DATA_INDEX_SPECVAL@0x104a
-          v44:CInt64 = GuardAnyBitSet v43, CUInt64(1)
+          v44:CInt64 = GuardAnyBitSet v43, CUInt64(1) recompile
           v45:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1050))
           Jump bb8(v45, v54)
         bb8(v35:BasicObject, v36:BasicObject):
@@ -18843,7 +18903,7 @@ mod hir_opt_tests {
           Jump bb8(v43, v43)
         bb7():
           v45:CInt64 = LoadField v39, :VM_ENV_DATA_INDEX_SPECVAL@0x104a
-          v46:CInt64 = GuardAnyBitSet v45, CUInt64(1)
+          v46:CInt64 = GuardAnyBitSet v45, CUInt64(1) recompile
           v47:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1050))
           Jump bb8(v47, v55)
         bb8(v37:BasicObject, v38:BasicObject):

--- a/zjit/src/hir/tests.rs
+++ b/zjit/src/hir/tests.rs
@@ -2502,7 +2502,7 @@ pub(crate) mod hir_build_tests {
           Jump bb6(v40, v40)
         bb5():
           v42:CInt64 = LoadField v36, :VM_ENV_DATA_INDEX_SPECVAL@0x1006
-          v43:CInt64 = GuardAnyBitSet v42, CUInt64(1)
+          v43:CInt64 = GuardAnyBitSet v42, CUInt64(1) recompile
           v44:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
           Jump bb6(v44, v21)
         bb6(v34:BasicObject, v35:BasicObject):
@@ -3458,7 +3458,7 @@ pub(crate) mod hir_build_tests {
           Jump bb6(v21, v21)
         bb5():
           v23:CInt64 = LoadField v17, :VM_ENV_DATA_INDEX_SPECVAL@0x1003
-          v24:CInt64 = GuardAnyBitSet v23, CUInt64(1)
+          v24:CInt64 = GuardAnyBitSet v23, CUInt64(1) recompile
           v25:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
           Jump bb6(v25, v10)
         bb6(v15:BasicObject, v16:BasicObject):
@@ -3503,7 +3503,7 @@ pub(crate) mod hir_build_tests {
         bb5():
           v24:BasicObject = LoadField v18, :VM_ENV_DATA_INDEX_SPECVAL@0x1003
           v25:BasicObject = CCall v24, :rb_obj_is_proc@0x1008
-          v26:TrueClass = GuardBitEquals v25, Value(true)
+          v26:TrueClass = GuardBitEquals v25, Value(true) recompile
           Jump bb6(v24, v10)
         bb6(v16:BasicObject, v17:BasicObject):
           v29:BasicObject = Send v14, &block, :then, v16 # SendFallbackReason: Uncategorized(send)
@@ -3557,7 +3557,7 @@ pub(crate) mod hir_build_tests {
           Jump bb9(v36, v36)
         bb8():
           v38:CInt64 = LoadField v32, :VM_ENV_DATA_INDEX_SPECVAL@0x1003
-          v39:CInt64 = GuardAnyBitSet v38, CUInt64(1)
+          v39:CInt64 = GuardAnyBitSet v38, CUInt64(1) recompile
           v40:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
           Jump bb9(v40, v17)
         bb9(v30:BasicObject, v31:BasicObject):
@@ -3610,7 +3610,7 @@ pub(crate) mod hir_build_tests {
           Jump bb9(v31)
         bb8():
           v33:CInt64 = LoadField v27, :VM_ENV_DATA_INDEX_SPECVAL@0x1002
-          v34:CInt64 = GuardAnyBitSet v33, CUInt64(1)
+          v34:CInt64 = GuardAnyBitSet v33, CUInt64(1) recompile
           v35:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
           Jump bb9(v35)
         bb9(v26:BasicObject):
@@ -3883,7 +3883,7 @@ pub(crate) mod hir_build_tests {
           Jump bb6(v25, v25)
         bb5():
           v27:CInt64 = LoadField v21, :VM_ENV_DATA_INDEX_SPECVAL@0x1004
-          v28:CInt64 = GuardAnyBitSet v27, CUInt64(1)
+          v28:CInt64 = GuardAnyBitSet v27, CUInt64(1) recompile
           v29:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
           Jump bb6(v29, v13)
         bb6(v19:BasicObject, v20:BasicObject):
@@ -3932,7 +3932,7 @@ pub(crate) mod hir_build_tests {
           Jump bb6(v40, v40)
         bb5():
           v42:CInt64 = LoadField v36, :VM_ENV_DATA_INDEX_SPECVAL@0x1006
-          v43:CInt64[0] = GuardBitEquals v42, CInt64(0)
+          v43:CInt64[0] = GuardBitEquals v42, CInt64(0) recompile
           v44:NilClass = Const Value(nil)
           Jump bb6(v44, v21)
         bb6(v34:BasicObject, v35:BasicObject):
@@ -3977,7 +3977,7 @@ pub(crate) mod hir_build_tests {
         bb5():
           v27:BasicObject = LoadField v21, :VM_ENV_DATA_INDEX_SPECVAL@0x1004
           v28:BasicObject = CCall v27, :rb_obj_is_proc@0x1008
-          v29:TrueClass = GuardBitEquals v28, Value(true)
+          v29:TrueClass = GuardBitEquals v28, Value(true) recompile
           Jump bb6(v27, v13)
         bb6(v19:BasicObject, v20:BasicObject):
           v32:HashExact = GuardType v12, HashExact
@@ -4021,7 +4021,7 @@ pub(crate) mod hir_build_tests {
         bb5():
           v27:BasicObject = LoadField v21, :VM_ENV_DATA_INDEX_SPECVAL@0x1004
           v28:BasicObject = CCall v27, :rb_obj_is_proc@0x1008
-          v29:TrueClass = GuardBitEquals v28, Value(true)
+          v29:TrueClass = GuardBitEquals v28, Value(true) recompile
           Jump bb6(v27, v13)
         bb6(v19:BasicObject, v20:BasicObject):
           v32:HashExact = GuardType v12, HashExact
@@ -4074,7 +4074,7 @@ pub(crate) mod hir_build_tests {
           Jump bb6(v40, v40)
         bb5():
           v42:CInt64 = LoadField v36, :VM_ENV_DATA_INDEX_SPECVAL@0x1006
-          v43:CInt64[0] = GuardBitEquals v42, CInt64(0)
+          v43:CInt64[0] = GuardBitEquals v42, CInt64(0) recompile
           v44:NilClass = Const Value(nil)
           Jump bb6(v44, v21)
         bb6(v34:BasicObject, v35:BasicObject):
@@ -4117,7 +4117,7 @@ pub(crate) mod hir_build_tests {
           Jump bb6(v25, v25)
         bb5():
           v27:CInt64 = LoadField v21, :VM_ENV_DATA_INDEX_SPECVAL@0x1004
-          v28:CInt64 = GuardAnyBitSet v27, CUInt64(1)
+          v28:CInt64 = GuardAnyBitSet v27, CUInt64(1) recompile
           v29:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
           Jump bb6(v29, v13)
         bb6(v19:BasicObject, v20:BasicObject):
@@ -4817,7 +4817,7 @@ pub(crate) mod hir_build_tests {
           Jump bb7(v39, v39)
         bb6():
           v41:CInt64 = LoadField v35, :VM_ENV_DATA_INDEX_SPECVAL@0x1006
-          v42:CInt64 = GuardAnyBitSet v41, CUInt64(1)
+          v42:CInt64 = GuardAnyBitSet v41, CUInt64(1) recompile
           v43:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
           Jump bb7(v43, v22)
         bb7(v33:BasicObject, v34:BasicObject):

--- a/zjit/src/profile.rs
+++ b/zjit/src/profile.rs
@@ -467,6 +467,29 @@ impl IseqProfile {
         entry.profiles_remaining == 0
     }
 
+    /// Profile the block handler for a getblockparamproxy guard exit at runtime.
+    pub fn profile_getblockparamproxy_at(&mut self, iseq: IseqPtr, insn_idx: YarvInsnIdx, cfp: CfpPtr) -> bool {
+        let pc = unsafe { rb_iseq_pc_at_idx(iseq, insn_idx as u32) };
+        let level = unsafe { pc.add(2).read() }.as_u32();
+
+        let entry = self.entry_mut(insn_idx);
+        if entry.profiles_remaining == 0 {
+            entry.profiles_remaining = get_option!(num_profiles);
+        }
+        if entry.opnd_types.is_empty() {
+            entry.opnd_types.resize(1, TypeDistribution::new());
+        }
+        let ep = unsafe { get_cfp_ep_level(cfp, level) };
+        let block_handler = unsafe { *ep.offset(VM_ENV_DATA_INDEX_SPECVAL as isize) };
+        let untagged = unsafe { rb_vm_untag_block_handler(block_handler) };
+
+        let ty = ProfiledType::object(untagged);
+        VALUE::from(iseq).write_barrier(ty.class());
+        entry.opnd_types[0].observe(ty);
+        entry.profiles_remaining = entry.profiles_remaining.saturating_sub(1);
+        entry.profiles_remaining == 0
+    }
+
     /// Get profiled operand types for a given instruction index
     pub fn get_operand_types(&self, insn_idx: YarvInsnIdx) -> Option<&[TypeDistribution]> {
         self.entry(insn_idx).map(|e| e.opnd_types.as_slice()).filter(|s| !s.is_empty())


### PR DESCRIPTION
Add recompile support for monomorphic and unprofiled getblockparamproxy.
This reduces side exits on monomorphic block handler paths.

## Benchmarks
### lobsters
Summary:
```diff
Top-18 side exit reasons:
- block_param_proxy_not_nil:    68,637 ( 2.3%)
+ block_param_proxy_not_nil:        31 ( 0.0%)
- block_param_proxy_not_iseq_or_ifunc:    14,126 ( 0.5%)
+ block_param_proxy_not_iseq_or_ifunc:        62 ( 0.0%)

- side_exit_count:                 3,038,011
+ side_exit_count:                 2,946,991

ratio_in_zjit:                                        94.3%
```

### railsbench
Summary:
```diff
Top-18 side exit reasons:
- block_param_proxy_not_nil:  99,658 ( 4.1%)
+ block_param_proxy_not_nil:       6 ( 0.0%)

- side_exit_count:                 2,455,095
+ side_exit_count:                 2,356,445

- ratio_in_zjit:                                        96.1%
+ ratio_in_zjit:                                        96.2%
```

