### PR TITLE
Ruby 3.4: Bump net-imap to 0.5.15

### DIFF
--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -13,7 +13,7 @@ test-unit           3.6.7   https://github.com/test-unit/test-unit
 rexml               3.4.4   https://github.com/ruby/rexml
 rss                 0.3.1   https://github.com/ruby/rss
 net-ftp             0.3.8   https://github.com/ruby/net-ftp
-net-imap            0.5.8   https://github.com/ruby/net-imap
+net-imap            0.5.15  https://github.com/ruby/net-imap
 net-pop             0.1.2   https://github.com/ruby/net-pop
 net-smtp            0.5.1   https://github.com/ruby/net-smtp
 matrix              0.4.2   https://github.com/ruby/matrix


### PR DESCRIPTION
Fixes CVE-2026-47240, CVE-2026-47241, and CVE-2026-47242. The bump from 0.5.8 also includes the 0.5.14 security fixes (CVE-2026-42246 et al.) not yet backported to this branch.

https://github.com/ruby/net-imap/releases/tag/v0.5.15