### PR TITLE
Fix bundled gem require attribution to the issuing gem

### DIFF
--- a/lib/bundled_gems.rb
+++ b/lib/bundled_gems.rb
@@ -165,31 +165,22 @@ module Gem::BUNDLED_GEMS # :nodoc:
       motivation = level == :warning ? "silence this warning" : "fix this error"
       msg += "\nYou can add #{name} to your Gemfile or gemspec to #{motivation}."
 
-      # We detect the gem name from caller_locations. First we walk until we find `require`
-      # then take the first frame that's not from `require`.
+      # We detect the gem name from caller_locations. The frame that issued the
+      # require we are warning about sits just above our own machinery: the
+      # `warning?` call and the `require` wrapper installed by replace_require.
+      # Skip those by matching this file's path rather than a fixed frame count,
+      # so the detection does not break when the call depth into build_message
+      # changes.
       #
       # Additionally, we need to skip Bootsnap and Zeitwerk if present, these
       # gems decorate Kernel#require, so they are not really the ones issuing
       # the require call users should be warned about. Those are upwards.
-      frames_to_skip = 3
       location = nil
-      require_found = false
       Thread.each_caller_location do |cl|
-        if frames_to_skip >= 1
-          frames_to_skip -= 1
-          next
-        end
-
-        if require_found
-          if cl.base_label != "require"
-            location = cl.path
-            break
-          end
-        else
-          if cl.base_label == "require"
-            require_found = true
-          end
-        end
+        next if cl.path == __FILE__
+        next if cl.base_label == "require"
+        location = cl.path
+        break
       end
 
       if location && File.file?(location) && !location.start_with?(Gem::BUNDLED_GEMS::LIBDIR)

--- a/spec/bundled_gems_spec.rb
+++ b/spec/bundled_gems_spec.rb
@@ -92,6 +92,30 @@ RSpec.describe "bundled_gems.rb" do
     expect(err).to include(/-e:18/)
   end
 
+  it "Show warning to contact the author when the require is issued from a gem" do
+    # Install the gem under the system gem path so its require shows up as
+    # coming from `<gem_path>/gems/tinygem-1.0.0`, the same shape as the
+    # childprocess-5.0.0 case the attribution logic targets.
+    gem_dir = system_gem_path("gems/tinygem-1.0.0")
+    build_lib "tinygem", "1.0.0", path: gem_dir do |s|
+      s.write "lib/tinygem.rb", "require 'openssl'"
+    end
+
+    script <<-RUBY
+      gemfile do
+        source "https://rubygems.org"
+        path "#{gem_dir}" do
+          gem "tinygem", "1.0.0"
+        end
+      end
+
+      require "tinygem"
+    RUBY
+
+    expect(err).to include(/openssl used to be loaded from (.*) since Ruby #{RUBY_VERSION}/)
+    expect(err).to include("Also please contact the author of tinygem-1.0.0 to request adding openssl into its gemspec.")
+  end
+
   it "Show warning when bundled gems called as dependency" do
     build_lib "activesupport", "7.0.7.2" do |s|
       s.write "lib/active_support/all.rb", "require 'openssl'"


### PR DESCRIPTION
The fixed `frames_to_skip = 3` skipped the frame of the gem that issued the require, so `location` resolved to `bundled_gems.rb` and the "contact the author" line never fired.

Skip our own frames by path instead of a hardcoded count, which also removes the coupling to the warning? -> build_message call depth.