### PR TITLE
Free the converted replacement string with its buffer size

### DIFF
--- a/test/ruby/test_transcode.rb
+++ b/test/ruby/test_transcode.rb
@@ -1358,6 +1358,10 @@ class TestTranscode < Test::Unit::TestCase
     assert_equal("?", "\u20AC".encode("EUC-JP", :undef=>:replace), "[ruby-dev:35709]")
   end
 
+  def test_replace_converted_to_destination_encoding
+    assert_equal("\uFF21".encode("SJIS"), "\uFF21".encode("SJIS", undef: :replace, replace: "\uFF1F"))
+  end
+
   def test_undef_replace_string
     assert_equal("a<x>A", "a\u3042A".encode("us-ascii", :undef=>:replace, :replace=>"<x>"))
   end

--- a/transcode.c
+++ b/transcode.c
@@ -1744,7 +1744,7 @@ rb_econv_close(rb_econv_t *ec)
     int i;
 
     if (ec->replacement_allocated) {
-        SIZED_FREE_N((char *)ec->replacement_str, ec->replacement_len);
+        SIZED_FREE_N((char *)ec->replacement_str, ec->replacement_bufsize);
     }
     for (i = 0; i < ec->num_trans; i++) {
         rb_transcoding_close(ec->elems[i].tc);


### PR DESCRIPTION
```ruby
"Ａ".encode("SJIS", replace: "？")
```

produces the following error with RUBY_DEBUG

```
-e:1: [BUG] buffer 0x000059414a128728 freed with old_size=2, but was allocated with size=3
ruby 4.1.0dev (2026-06-14T17:21:39Z master 39c0b0b6da) +PRISM [x86_64-linux]

-- C level backtrace information -------------------------------------------
.../ruby(rb_gc_impl_free)            gc/default/default.c:8649
.../ruby(ruby_xfree_sized)           gc.c:5537
.../ruby(rb_econv_close+0xb5)        transcode.c:1747
.../ruby(str_transcode0+0x398)       transcode.c:2463
.../ruby(str_encode)                 transcode.c:2973
```

I think this was introduced by 24bdf6a40e ("transcode.c: Use ruby_sized_xfree").