### PR TITLE
Optimize trace arg line event location

### DIFF
--- a/ext/-test-/tracepoint/tracepoint.c
+++ b/ext/-test-/tracepoint/tracepoint.c
@@ -15,6 +15,10 @@ struct tracepoint_track {
 
 #define objects_max (sizeof(((struct tracepoint_track *)NULL)->objects)/sizeof(VALUE))
 
+struct tracepoint_raw_line {
+    VALUE events;
+};
+
 static void
 tracepoint_track_objspace_events_i(VALUE tpval, void *data)
 {
@@ -78,6 +82,47 @@ tracepoint_track_objspace_events(VALUE self)
     return result;
 }
 
+static void
+tracepoint_track_raw_line_events_i(VALUE data, const rb_trace_arg_t *trace_arg)
+{
+    struct tracepoint_raw_line *track = (struct tracepoint_raw_line *)data;
+    VALUE event = rb_ary_new_capa(2);
+
+    rb_ary_push(event, rb_tracearg_path((rb_trace_arg_t *)trace_arg));
+    rb_ary_push(event, rb_tracearg_lineno((rb_trace_arg_t *)trace_arg));
+    rb_ary_push(track->events, event);
+}
+
+static VALUE
+tracepoint_track_raw_line_events_yield(VALUE data)
+{
+    rb_yield(Qundef);
+    return Qnil;
+}
+
+static VALUE
+tracepoint_track_raw_line_events_ensure(VALUE data)
+{
+    rb_remove_event_hook((rb_event_hook_func_t)tracepoint_track_raw_line_events_i);
+    return Qnil;
+}
+
+static VALUE
+tracepoint_track_raw_line_events(VALUE self)
+{
+    struct tracepoint_raw_line track = {rb_ary_new()};
+
+    rb_add_event_hook2((rb_event_hook_func_t)tracepoint_track_raw_line_events_i,
+                       RUBY_EVENT_LINE,
+                       (VALUE)&track,
+                       RUBY_EVENT_HOOK_FLAG_SAFE | RUBY_EVENT_HOOK_FLAG_RAW_ARG);
+
+    rb_ensure(tracepoint_track_raw_line_events_yield, Qnil,
+              tracepoint_track_raw_line_events_ensure, Qnil);
+
+    return track.events;
+}
+
 static VALUE
 tracepoint_specify_normal_and_internal_events(VALUE self)
 {
@@ -94,5 +139,6 @@ Init_tracepoint(void)
     tp_mBug = rb_define_module("Bug"); // GC root
     Init_gc_hook(tp_mBug);
     rb_define_module_function(tp_mBug, "tracepoint_track_objspace_events", tracepoint_track_objspace_events, 0);
+    rb_define_module_function(tp_mBug, "tracepoint_track_raw_line_events", tracepoint_track_raw_line_events, 0);
     rb_define_module_function(tp_mBug, "tracepoint_specify_normal_and_internal_events", tracepoint_specify_normal_and_internal_events, 0);
 }

--- a/iseq.c
+++ b/iseq.c
@@ -2469,6 +2469,12 @@ rb_iseq_line_no(const rb_iseq_t *iseq, size_t pos)
     }
 }
 
+const struct iseq_insn_info_entry *
+rb_iseq_insn_info_entry(const rb_iseq_t *iseq, size_t pos)
+{
+    return get_insn_info(iseq, pos);
+}
+
 #ifdef USE_ISEQ_NODE_ID
 int
 rb_iseq_node_id(const rb_iseq_t *iseq, size_t pos)

--- a/iseq.h
+++ b/iseq.h
@@ -218,6 +218,7 @@ void rb_iseq_mark_and_move_insn_storage(struct iseq_compile_data_storage *arena)
 VALUE rb_iseq_load(VALUE data, VALUE parent, VALUE opt);
 VALUE rb_iseq_parameters(const rb_iseq_t *iseq, int is_proc);
 unsigned int rb_iseq_line_no(const rb_iseq_t *iseq, size_t pos);
+const struct iseq_insn_info_entry *rb_iseq_insn_info_entry(const rb_iseq_t *iseq, size_t pos);
 #ifdef USE_ISEQ_NODE_ID
 int rb_iseq_node_id(const rb_iseq_t *iseq, size_t pos);
 #endif

--- a/test/-ext-/tracepoint/test_tracepoint.rb
+++ b/test/-ext-/tracepoint/test_tracepoint.rb
@@ -59,6 +59,16 @@ class TestTracepointObj < Test::Unit::TestCase
     assert_raise(TypeError){ Bug.tracepoint_specify_normal_and_internal_events }
   end
 
+  def test_raw_line_tracepoint_uses_current_path_and_lineno
+    target_line = nil
+
+    events = Bug.tracepoint_track_raw_line_events do
+      target_line = __LINE__
+    end
+
+    assert_include events, [__FILE__, target_line]
+  end
+
   def test_after_gc_start_hook_with_GC_stress
     bug8492 = '[ruby-dev:47400] [Bug #8492]: infinite after_gc_start_hook reentrance'
     assert_nothing_raised(Timeout::Error, bug8492) do

--- a/vm_core.h
+++ b/vm_core.h
@@ -2329,8 +2329,9 @@ void rb_exec_event_hooks(struct rb_trace_arg_struct *trace_arg, rb_hook_list_t *
 } while (0)
 
 static inline void
-rb_exec_event_hook_orig(rb_execution_context_t *ec, rb_hook_list_t *hooks, rb_event_flag_t flag,
-                        VALUE self, ID id, ID called_id, VALUE klass, VALUE data, int pop_p)
+rb_exec_event_hook_with_location(rb_execution_context_t *ec, rb_hook_list_t *hooks, rb_event_flag_t flag,
+                                 VALUE self, ID id, ID called_id, VALUE klass, VALUE data, int pop_p,
+                                 VALUE path, int lineno)
 {
     struct rb_trace_arg_struct trace_arg;
 
@@ -2344,10 +2345,18 @@ rb_exec_event_hook_orig(rb_execution_context_t *ec, rb_hook_list_t *hooks, rb_ev
     trace_arg.called_id = called_id;
     trace_arg.klass = klass;
     trace_arg.data = data;
-    trace_arg.path = Qundef;
+    trace_arg.lineno = lineno;
+    trace_arg.path = path;
     trace_arg.klass_solved = 0;
 
     rb_exec_event_hooks(&trace_arg, hooks, pop_p);
+}
+
+static inline void
+rb_exec_event_hook_orig(rb_execution_context_t *ec, rb_hook_list_t *hooks, rb_event_flag_t flag,
+                        VALUE self, ID id, ID called_id, VALUE klass, VALUE data, int pop_p)
+{
+    rb_exec_event_hook_with_location(ec, hooks, flag, self, id, called_id, klass, data, pop_p, Qundef, 0);
 }
 
 struct rb_ractor_pub {

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -7117,14 +7117,13 @@ vm_opt_regexpmatch2(VALUE recv, VALUE obj)
     }
 }
 
-rb_event_flag_t rb_iseq_event_flags(const rb_iseq_t *iseq, size_t pos);
-
 NOINLINE(static void vm_trace(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp));
 
 static inline void
 vm_trace_hook(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, const VALUE *pc,
               rb_event_flag_t pc_events, rb_event_flag_t target_event,
-              rb_hook_list_t *global_hooks, rb_hook_list_t *local_hooks, VALUE val)
+              rb_hook_list_t *global_hooks, rb_hook_list_t *local_hooks, VALUE val,
+              VALUE path, int lineno)
 {
     rb_event_flag_t event = pc_events & target_event;
     VALUE self = GET_SELF();
@@ -7137,7 +7136,7 @@ vm_trace_hook(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, const VAL
         /* increment PC because source line is calculated with PC-1 */
         reg_cfp->pc++;
         vm_dtrace(event, ec);
-        rb_exec_event_hook_orig(ec, global_hooks, event, self, 0, 0, 0 , val, 0);
+        rb_exec_event_hook_with_location(ec, global_hooks, event, self, 0, 0, 0 , val, 0, path, lineno);
         reg_cfp->pc--;
     }
 
@@ -7146,7 +7145,7 @@ vm_trace_hook(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, const VAL
         if (event & local_hooks->events) {
             /* increment PC because source line is calculated with PC-1 */
             reg_cfp->pc++;
-            rb_exec_event_hook_orig(ec, local_hooks, event, self, 0, 0, 0 , val, 0);
+            rb_exec_event_hook_with_location(ec, local_hooks, event, self, 0, 0, 0 , val, 0, path, lineno);
             reg_cfp->pc--;
         }
     }
@@ -7154,7 +7153,9 @@ vm_trace_hook(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, const VAL
 
 #define VM_TRACE_HOOK(target_event, val) do { \
     if ((pc_events & (target_event)) & enabled_flags) { \
-        vm_trace_hook(ec, reg_cfp, pc, pc_events, (target_event), global_hooks, local_hooks, (val)); \
+        VALUE trace_path_ = ((target_event) & RUBY_EVENT_LINE) ? rb_iseq_path(iseq) : Qundef; \
+        int trace_lineno_ = ((target_event) & RUBY_EVENT_LINE) ? lineno : 0; \
+        vm_trace_hook(ec, reg_cfp, pc, pc_events, (target_event), global_hooks, local_hooks, (val), trace_path_, trace_lineno_); \
     } \
 } while (0)
 
@@ -7180,7 +7181,9 @@ vm_trace(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp)
     else {
         const rb_iseq_t *iseq = CFP_ISEQ(reg_cfp);
         size_t pos = pc - ISEQ_BODY(iseq)->iseq_encoded;
-        rb_event_flag_t pc_events = rb_iseq_event_flags(iseq, pos);
+        const struct iseq_insn_info_entry *entry = rb_iseq_insn_info_entry(iseq, pos);
+        rb_event_flag_t pc_events = entry ? entry->events : 0;
+        int lineno = entry ? entry->line_no : 0;
         unsigned int local_hooks_cnt = iseq->aux.exec.local_hooks_cnt;
         rb_hook_list_t *local_hooks = NULL;
         if (RB_UNLIKELY(local_hooks_cnt > 0)) {
@@ -7249,7 +7252,7 @@ vm_trace(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp)
             /* check traces */
             if ((pc_events & RUBY_EVENT_B_CALL) && bmethod_frame && (bmethod_events & RUBY_EVENT_CALL)) {
                 /* b_call instruction running as a method. Fire call event. */
-                vm_trace_hook(ec, reg_cfp, pc, RUBY_EVENT_CALL, RUBY_EVENT_CALL, global_hooks, bmethod_local_hooks, Qundef);
+                vm_trace_hook(ec, reg_cfp, pc, RUBY_EVENT_CALL, RUBY_EVENT_CALL, global_hooks, bmethod_local_hooks, Qundef, Qundef, 0);
             }
             VM_TRACE_HOOK(RUBY_EVENT_CLASS | RUBY_EVENT_CALL | RUBY_EVENT_B_CALL,   Qundef);
             VM_TRACE_HOOK(RUBY_EVENT_RESCUE,                                        rescue_errinfo(ec, reg_cfp));
@@ -7259,7 +7262,7 @@ vm_trace(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp)
             VM_TRACE_HOOK(RUBY_EVENT_END | RUBY_EVENT_RETURN | RUBY_EVENT_B_RETURN, TOPN(0));
             if ((pc_events & RUBY_EVENT_B_RETURN) && bmethod_frame && (bmethod_events & RUBY_EVENT_RETURN)) {
                 /* b_return instruction running as a method. Fire return event. */
-                vm_trace_hook(ec, reg_cfp, pc, RUBY_EVENT_RETURN, RUBY_EVENT_RETURN, global_hooks, bmethod_local_hooks, TOPN(0));
+                vm_trace_hook(ec, reg_cfp, pc, RUBY_EVENT_RETURN, RUBY_EVENT_RETURN, global_hooks, bmethod_local_hooks, TOPN(0), Qundef, 0);
             }
         }
     }


### PR DESCRIPTION
When dispatching VM trace hooks, `vm_trace` already resolves the instruction info entry for the current PC in order to determine which events should fire. That entry also contains the current source line, and the current `iseq` already contains the source path.

This change threads that location through `rb_trace_arg_t` for `RUBY_EVENT_LINE`, so raw C hooks using `rb_tracearg_path` and `rb_tracearg_lineno` do not need to recompute it via the current control frame. The existing lazy fallback remains in place for other events.

Changes:

* expose an internal `rb_iseq_insn_info_entry` helper so trace dispatch can reuse the instruction info entry
* add an internal event hook helper that can prefill `trace_arg.path` and `trace_arg.lineno`
* pass precomputed path/line for `RUBY_EVENT_LINE`
* add a C extension test for raw line hook `rb_tracearg_path` / `rb_tracearg_lineno`

Focused tests run:

```console
$ make test-all TESTS='test/ruby/test_settracefunc.rb test/-ext-/tracepoint/test_tracepoint.rb'
105 tests, 1112 assertions, 0 failures, 0 errors, 1 skips

$ make test-spec MSPECOPT='spec/ruby/core/tracepoint/lineno_spec.rb spec/ruby/core/tracepoint/path_spec.rb spec/ruby/core/tracepoint/inspect_spec.rb'
3 files, 13 examples, 13 expectations, 0 failures, 0 errors, 0 tagged
```
