### PR TITLE
Refactor `lib/bundled_gems.rb`

### DIFF
--- a/lib/bundled_gems.rb
+++ b/lib/bundled_gems.rb
@@ -93,14 +93,22 @@ module Gem::BUNDLED_GEMS # :nodoc:
     require_found ? 1 : (frame_count - 1).nonzero?
   end
 
-  def self.warning?(name, specs: nil)
-    # name can be a feature name or a file path with String or Pathname
+  # Resolve a require target to the bundled gem it belongs to.
+  #
+  # +name+ is a feature name or a file path (String or Pathname). Returns
+  # +[feature, gem_name, subfeature]+ where +feature+ is the normalized feature
+  # string (extension and bootsnap-expanded LIBDIR/ARCHDIR prefix removed),
+  # +gem_name+ is the matching SINCE key, and +subfeature+ is true when the
+  # require targets a nested path (e.g. "benchmark/ips") rather than the gem's
+  # top-level feature. Returns nil when the target is not a bundled gem.
+  #
+  # This is a deliberately cheap check: the SINCE membership test here excludes
+  # the vast majority of candidates before the costly checks in warning?
+  # (see [Bug #20641]).
+  def self.find_gem(name)
     feature = File.path(name).sub(LIBEXT, "")
 
-    # The actual checks needed to properly identify the gem being required
-    # are costly (see [Bug #20641]), so we first do a much cheaper check
-    # to exclude the vast majority of candidates.
-    subfeature = if feature.include?("/")
+    if feature.include?("/")
       # bootsnap expands `require "csv"` to `require "#{LIBDIR}/csv.rb"`,
       # and `require "syslog"` to `require "#{ARCHDIR}/syslog.so"`.
       feature.delete_prefix!(ARCHDIR)
@@ -109,18 +117,24 @@ module Gem::BUNDLED_GEMS # :nodoc:
       # 2. A segment for the SINCE check for dashed names
       # 3. A segment to check if there's a subfeature
       segments = feature.split("/", 3)
-      name = segments.shift
-      name = EXACT[name] || name
-      if !SINCE[name]
-        name = "#{name}-#{segments.shift}"
-        return unless SINCE[name]
+      gem = segments.shift
+      gem = EXACT[gem] || gem
+      if !SINCE[gem]
+        gem = "#{gem}-#{segments.shift}"
+        return unless SINCE[gem]
       end
-      segments.any?
+      [feature, gem, segments.any?]
     else
-      name = EXACT[feature] || feature
-      return unless SINCE[name]
-      false
+      gem = EXACT[feature] || feature
+      return unless SINCE[gem]
+      [feature, gem, false]
     end
+  end
+
+  def self.warning?(name, specs: nil)
+    # name can be a feature name or a file path with String or Pathname
+    feature, name, subfeature = find_gem(name)
+    return unless feature
 
     if suppress_list = Thread.current[:__bundled_gems_warning_suppression]
       return if suppress_list.include?(name) || suppress_list.include?(feature)

--- a/lib/bundled_gems.rb
+++ b/lib/bundled_gems.rb
@@ -46,6 +46,14 @@ module Gem::BUNDLED_GEMS # :nodoc:
   DLEXT = /\.#{Regexp.union(dlext)}\z/
   LIBEXT = /\.#{Regexp.union("rb", *dlext)}\z/
 
+  # Decorate Kernel#require so that requiring a gem that is no longer a default
+  # gem emits a warning. Called by Bundler during setup
+  # (lib/bundler/rubygems_integration.rb), guarded by respond_to?(:replace_require)
+  # because older Ruby versions ship without this file.
+  #
+  # The decorating method is defined via define_method, so its base_label is
+  # "replace_require" rather than "require"; this is why uplevel has to recognize
+  # both labels (build_message instead skips our own frames by file path).
   def self.replace_require(specs)
     return if [::Kernel.singleton_class, ::Kernel].any? {|klass| klass.respond_to?(:no_warning_require) }
 
@@ -67,20 +75,28 @@ module Gem::BUNDLED_GEMS # :nodoc:
     end
   end
 
+  # base_labels that belong to the require machinery: "replace_require" is the
+  # define_method block installed by replace_require, "require" covers both
+  # Kernel#require and the wrappers that Bootsnap and Zeitwerk install on top.
+  REQUIRE_LABELS = ["replace_require", "require"].freeze
+
+  # Compute the uplevel: argument for Kernel#warn so the warning points at the
+  # user's require call site rather than at our machinery. We walk down the run
+  # of require frames (there can be several when Bootsnap/Zeitwerk are present)
+  # and stop at the first frame past them.
   def self.uplevel
     frame_count = 0
-    require_labels = ["replace_require", "require"]
     uplevel = 0
     require_found = false
     Thread.each_caller_location do |cl|
       frame_count += 1
 
       if require_found
-        unless require_labels.include?(cl.base_label)
+        unless REQUIRE_LABELS.include?(cl.base_label)
           return uplevel
         end
       else
-        if require_labels.include?(cl.base_label)
+        if REQUIRE_LABELS.include?(cl.base_label)
           require_found = true
         end
       end
@@ -110,7 +126,8 @@ module Gem::BUNDLED_GEMS # :nodoc:
 
     if feature.include?("/")
       # bootsnap expands `require "csv"` to `require "#{LIBDIR}/csv.rb"`,
-      # and `require "syslog"` to `require "#{ARCHDIR}/syslog.so"`.
+      # and `require "syslog"` to `require "#{ARCHDIR}/syslog.so"`, so strip
+      # those prefixes back off before matching. [Bug #20450]
       feature.delete_prefix!(ARCHDIR)
       feature.delete_prefix!(LIBDIR)
       # 1. A segment for the EXACT mapping and SINCE check
@@ -136,6 +153,9 @@ module Gem::BUNDLED_GEMS # :nodoc:
     feature, name, subfeature = find_gem(name)
     return unless feature
 
+    # Callers can suppress warnings for specific gems/features for the duration
+    # of a block via this thread-local. prelude.rb uses it so that `binding.irb`
+    # can load irb (which pulls in reline and rdoc) without warning. [Bug #21723]
     if suppress_list = Thread.current[:__bundled_gems_warning_suppression]
       return if suppress_list.include?(name) || suppress_list.include?(feature)
     end

--- a/lib/bundled_gems.rb
+++ b/lib/bundled_gems.rb
@@ -236,16 +236,13 @@ module Gem::BUNDLED_GEMS # :nodoc:
     msg
   end
 
-  # ---------------------------------------------------------------------------
-  # On-demand activation
+  # Activate +gem+ even when it is not declared in the current Gemfile, by
+  # building and setting up a temporary Bundler definition.
   #
-  # Unlike the warning machinery above, force_activate does not detect or warn
-  # about bundled gems. It activates a bundled gem that is not in the current
-  # Gemfile by building a temporary Bundler definition, so that callers such as
-  # `binding.irb` (see prelude.rb) and `bundle console`
-  # (lib/bundler/cli/console.rb) can load irb even when it is not declared.
-  # It is only reachable when Bundler is available.
-  # ---------------------------------------------------------------------------
+  # Unlike the rest of this file, this neither detects nor warns about bundled
+  # gems. It exists so that +binding.irb+ (see prelude.rb) and
+  # <tt>bundle console</tt> (lib/bundler/cli/console.rb) can load irb even when
+  # it is not declared. Only usable when Bundler is available.
   def self.force_activate(gem)
     require "bundler"
     Bundler.reset!

--- a/lib/bundled_gems.rb
+++ b/lib/bundled_gems.rb
@@ -216,6 +216,16 @@ module Gem::BUNDLED_GEMS # :nodoc:
     msg
   end
 
+  # ---------------------------------------------------------------------------
+  # On-demand activation
+  #
+  # Unlike the warning machinery above, force_activate does not detect or warn
+  # about bundled gems. It activates a bundled gem that is not in the current
+  # Gemfile by building a temporary Bundler definition, so that callers such as
+  # `binding.irb` (see prelude.rb) and `bundle console`
+  # (lib/bundler/cli/console.rb) can load irb even when it is not declared.
+  # It is only reachable when Bundler is available.
+  # ---------------------------------------------------------------------------
   def self.force_activate(gem)
     require "bundler"
     Bundler.reset!

--- a/test/test_bundled_gems.rb
+++ b/test/test_bundled_gems.rb
@@ -16,6 +16,39 @@ class TestBundlerGem < Gem::TestCase
     assert_nil Gem::BUNDLED_GEMS.warning?("csv", specs: {})
   end
 
+  def test_find_gem_plain_name
+    assert_equal ["csv", "csv", false], Gem::BUNDLED_GEMS.find_gem("csv")
+  end
+
+  def test_find_gem_returns_nil_for_non_bundled_gem
+    assert_nil Gem::BUNDLED_GEMS.find_gem("some_gem")
+    assert_nil Gem::BUNDLED_GEMS.find_gem("some/nested/gem")
+  end
+
+  def test_find_gem_exact_mapping
+    # kconv is provided by the nkf gem; the feature keeps its original name
+    assert_equal ["kconv", "nkf", false], Gem::BUNDLED_GEMS.find_gem("kconv")
+  end
+
+  def test_find_gem_dashed_name
+    # resolv/replace is provided by the resolv-replace gem
+    assert_equal ["resolv/replace", "resolv-replace", false], Gem::BUNDLED_GEMS.find_gem("resolv/replace")
+  end
+
+  def test_find_gem_subfeature
+    assert_equal ["benchmark/ips", "benchmark", true], Gem::BUNDLED_GEMS.find_gem("benchmark/ips")
+  end
+
+  def test_find_gem_strips_libdir_prefix
+    path = File.join(::RbConfig::CONFIG.fetch("rubylibdir"), "csv.rb")
+    assert_equal ["csv", "csv", false], Gem::BUNDLED_GEMS.find_gem(path)
+  end
+
+  def test_find_gem_strips_archdir_prefix
+    path = File.join(::RbConfig::CONFIG.fetch("rubyarchdir"), "syslog.so")
+    assert_equal ["syslog", "syslog", false], Gem::BUNDLED_GEMS.find_gem(path)
+  end
+
   def test_no_warning_warning
     assert_nil Gem::BUNDLED_GEMS.warning?("some_gem", specs: {})
     assert_nil Gem::BUNDLED_GEMS.warning?("/path/to/some_gem.rb", specs: {})


### PR DESCRIPTION
`lib/bundled_gems.rb` accumulated its require-detection logic as a series of point fixes and had become hard to follow.

This is a behavior-preserving cleanup that extracts the feature-to-gem resolution into a side-effect-free, unit-testable `find_gem`, records the frame-walking heuristics and cross-file contracts that previously lived only in commit history, and separates the unrelated `force_activate`.

Verified with `spec/bundled_gems_spec.rb` and `test/test_bundled_gems.rb.`