### PR TITLE
Fix YJIT test to actually test invalid call_threshold

### DIFF
--- a/test/ruby/test_yjit.rb
+++ b/test/ruby/test_yjit.rb
@@ -151,7 +151,7 @@ class TestYJIT < Test::Unit::TestCase
   end
 
   def test_yjit_enable_with_invalid_runtime_call_threshold_option
-    assert_in_out_err(['--yjit-disable', '-e', 'RubyVM::YJIT.enable(mem_size: 0)']) do |stdout, stderr, status|
+    assert_in_out_err(['--yjit-disable', '-e', 'RubyVM::YJIT.enable(call_threshold: 0)']) do |stdout, stderr, status|
       assert_not_empty stderr
       assert_match(/ArgumentError/, stderr.join)
       assert_equal 1, status.exitstatus


### PR DESCRIPTION
`test_yjit_enable_with_invalid_runtime_call_threshold_option` was passing `mem_size: 0`, which is identical to the `mem_size` test right below it. Invalid `call_threshold` was never actually tested. Pass `call_threshold: 0` instead.