### PR TITLE
Ruby 3.3: Use macos-26 and old versions with related fixes

### DIFF
--- a/.github/actions/setup/macos/action.yml
+++ b/.github/actions/setup/macos/action.yml
@@ -13,12 +13,12 @@ runs:
     - name: brew
       shell: bash
       run: |
-        brew install --quiet gmp libffi openssl@1.1 zlib autoconf automake libtool readline
+        brew install --quiet gmp libffi openssl@3 zlib autoconf automake libtool readline
 
     - name: Set ENV
       shell: bash
       run: |
-        for lib in openssl@1.1 readline; do
+        for lib in openssl@3 readline; do
           CONFIGURE_ARGS="${CONFIGURE_ARGS:+$CONFIGURE_ARGS }--with-${lib%@*}-dir=$(brew --prefix $lib)"
         done
         echo CONFIGURE_ARGS="${CONFIGURE_ARGS}" >> $GITHUB_ENV

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         test_task: ['check']
         configure: ['']
-        os: ['macos-14', 'macos-15', 'macos-15-intel']
+        os: ['macos-26', 'macos-15', 'macos-15-intel', 'macos-14']
         include:
           - test_task: test-all TESTS=--repeat-count=2
             os: macos-14

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -41,6 +41,11 @@ jobs:
 
     env:
       GITPULLOPTIONS: --no-tags origin ${{ github.ref }}
+      # The macos-15-intel runner image ships a pre-installed Ruby under
+      # /usr/local whose default-gem dir collides with the build's on the
+      # 3.3.0 ABI path. Build under an isolated prefix so Gem.default_dir does
+      # not scan that stale bundler default-gem stub during rake autoload.
+      PREFIX: ${{ matrix.os == 'macos-15-intel' && '/tmp/ruby-prefix' || '' }}
 
     runs-on: ${{ matrix.os }}
 
@@ -69,7 +74,7 @@ jobs:
           dummy-files: ${{ matrix.test_task == 'check' }}
 
       - name: Run configure
-        run: ../src/configure -C --disable-install-doc ${{ matrix.configure }}
+        run: ../src/configure -C --disable-install-doc ${PREFIX:+--prefix="$PREFIX"} ${{ matrix.configure }}
 
       - run: make prepare-gems
         if: ${{ matrix.test_task == 'test-bundled-gems' }}

--- a/.github/workflows/tarball-macos.yml
+++ b/.github/workflows/tarball-macos.yml
@@ -30,10 +30,15 @@ jobs:
         include:
           - os: macos-15-intel
             test_task: check
+            # The runner image ships a pre-installed Ruby under /usr/local whose
+            # gems dir collides with the default prefix on Intel. Use an isolated
+            # prefix so RDoc generation does not scan that stale default-gem stub.
+            prefix: /tmp/ruby-prefix
       fail-fast: false
     runs-on: ${{ matrix.os }}
     env:
       ARCHNAME: ${{ inputs.archname }}
+      PREFIX: ${{ matrix.prefix || '/usr/local' }}
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -52,7 +57,7 @@ jobs:
         run: |
           echo "JOBS=-j$((1 + $(sysctl -n hw.activecpu)))" >> $GITHUB_ENV
       - name: configure
-        run: cd "$ARCHNAME/" && ./configure --with-openssl-dir=$(brew --prefix openssl) --with-libyaml-dir=$(brew --prefix libyaml)
+        run: cd "$ARCHNAME/" && ./configure --prefix="$PREFIX" --with-openssl-dir=$(brew --prefix openssl) --with-libyaml-dir=$(brew --prefix libyaml)
       - name: make
         run: cd "$ARCHNAME/" && make $JOBS
       - name: Tests
@@ -72,9 +77,9 @@ jobs:
         if: matrix.test_task == 'check'
       - name: Verify installed binaries
         run: |
-          /usr/local/bin/ruby -v
-          /usr/local/bin/gem -v
-          /usr/local/bin/bundle -v
+          "$PREFIX/bin/ruby" -v
+          "$PREFIX/bin/gem" -v
+          "$PREFIX/bin/bundle" -v
         if: matrix.test_task == 'check'
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
Make `macos-26` as default and added old versions into matrix, backport https://github.com/ruby/ruby/pull/17335 and https://github.com/ruby/ruby/pull/17339.