### PR TITLE
Use an isolated prefix with `check` job on macos-15-intel

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -53,6 +53,11 @@ jobs:
 
     env:
       GITPULLOPTIONS: --no-tags origin ${{ github.ref }}
+      # The macos-15-intel runner image ships a pre-installed Ruby under
+      # /usr/local whose default-gem dir collides with the build's on the
+      # 3.3.0 ABI path. Build under an isolated prefix so Gem.default_dir does
+      # not scan that stale bundler default-gem stub during rake autoload.
+      PREFIX: ${{ matrix.os == 'macos-15-intel' && '/tmp/ruby-prefix' || '' }}
 
     runs-on: ${{ matrix.os }}
 
@@ -99,7 +104,7 @@ jobs:
         continue-on-error: true
 
       - name: Run configure
-        run: ../src/configure -C --disable-install-doc ${ruby_configure_args} ${{ matrix.configure_args }}
+        run: ../src/configure -C --disable-install-doc ${PREFIX:+--prefix="$PREFIX"} ${ruby_configure_args} ${{ matrix.configure_args }}
 
       - run: make prepare-gems
         if: ${{ matrix.test_task == 'test-bundled-gems' }}


### PR DESCRIPTION
We need to handle `/usr/local` of `macos-15-intel` same as https://github.com/ruby/ruby/pull/17335