### PR TITLE
Make mkmf have_func honor provided headers

### DIFF
--- a/lib/mkmf.rb
+++ b/lib/mkmf.rb
@@ -852,6 +852,7 @@ int main() {printf("%"PRI_CONFTEST_PREFIX"#{neg ? 'd' : 'u'}\\n", conftest_const
   # [+headers+] a String or an Array of strings which contains names of header
   #             files.
   def try_func(func, libs, headers = nil, opt = "", &b)
+    include_headers = headers
     headers = cpp_include(headers)
     prepare = String.new
     case func
@@ -890,7 +891,7 @@ extern int t(void);
 #{MAIN_DOES_NOTHING 't'}
 int t(void) { #{decltype["volatile p"]}; p = (#{decltype[]})#{func}; return !p; }
 SRC
-    call && try_link(<<"SRC", opt, &b)
+    call && !(decltype && include_headers) && try_link(<<"SRC", opt, &b)
 #{headers}
 /*top*/
 extern int t(void);

--- a/test/mkmf/test_have_func.rb
+++ b/test/mkmf/test_have_func.rb
@@ -8,8 +8,35 @@ class TestMkmfHaveFunc < TestMkmf
     assert_include($defs, '-DHAVE_RUBY_INIT')
   end
 
+  def test_have_func_without_headers_uses_link_fallback
+    object = create_link_only_func("mkmf_link_only")
+    assert_equal(true, have_func("mkmf_link_only", nil, object), MKMFLOG)
+    assert_include($defs, '-DHAVE_MKMF_LINK_ONLY')
+  end
+
+  def test_have_func_with_headers_requires_declaration
+    object = create_link_only_func("mkmf_link_only")
+    assert_equal(false, have_func("mkmf_link_only", "stdio.h", object), MKMFLOG)
+    assert_not_include($defs, '-DHAVE_MKMF_LINK_ONLY')
+  end
+
+  def test_have_func_with_headers_accepts_declaration
+    assert_equal(true, have_func("printf", "stdio.h"), MKMFLOG)
+    assert_include($defs, '-DHAVE_PRINTF')
+  end
+
   def test_not_have_func
     assert_equal(false, have_func("no_ruby_init"), MKMFLOG)
     assert_not_include($defs, '-DHAVE_RUBY_INIT')
+  end
+
+  private
+
+  def create_link_only_func(name)
+    object = "#{name}.#{$OBJEXT}"
+    create_tmpsrc("void #{name}(void) {}\n")
+    assert(xsystem(cc_command), "compile failed: #{cc_command}")
+    File.rename("#{CONFTEST}.#{$OBJEXT}", object)
+    object
   end
 end


### PR DESCRIPTION
When `have_func` is called with explicit headers, avoid falling back to a synthesized `extern void func();` declaration after the header-based probe fails.

This makes calls like:

```ruby
have_func("foo", "foo.h")
```

answer whether `foo` is declared by the supplied headers, rather than whether a linkable symbol named `foo` exists somewhere.

## Background

The current fallback can report success even when the requested header does not declare the function. That is too weak for extensions compiled as C99 or newer, where later extension code can fail with an implicit function declaration error despite `have_func` having defined `HAVE_FOO`.

A concrete downstream case is Android/Termux exposing an `epoll_pwait2` symbol while `<sys/epoll.h>` does not declare `epoll_pwait2`; a bare `have_func("epoll_pwait2", "sys/epoll.h")` can succeed, but compiling the extension fails when calling `epoll_pwait2`.

This keeps the legacy link-symbol fallback for calls without explicit headers:

```ruby
have_func("foo")
```

so existing bare symbol probes keep their current behavior (although that too is a bit questionable).

## Changes

* Track whether `headers` was explicitly supplied to `try_func`.
* Skip the fallback declaration probe for bare function names when headers were supplied.
* Add tests covering:
  * no-header probes still use the link fallback;
  * header-specific probes require a declaration;
  * header-specific probes still succeed for declared functions.