### PR TITLE
Keep curry's argument array alive across the inner call

### DIFF
--- a/proc.c
+++ b/proc.c
@@ -3875,7 +3875,15 @@ curry(RB_BLOCK_CALL_FUNC_ARGLIST(_, args))
         return arity;
     }
     else {
-        return rb_proc_call_with_block(proc, check_argc(RARRAY_LEN(passed)), RARRAY_CONST_PTR(passed), blockarg);
+        // `passed` is the only reference keeping this array (and thus the
+        // buffer that RARRAY_CONST_PTR points into) alive, but it is otherwise
+        // unused after this point. Without RB_GC_GUARD the compiler may drop it
+        // before the call returns, so conservative stack marking misses it and
+        // GC can reclaim the array while it is still being read as argv,
+        // crashing with "try to mark T_NONE object".
+        VALUE result = rb_proc_call_with_block(proc, check_argc(RARRAY_LEN(passed)), RARRAY_CONST_PTR(passed), blockarg);
+        RB_GC_GUARD(passed);
+        return result;
     }
 }
 

--- a/test/ruby/test_proc.rb
+++ b/test/ruby/test_proc.rb
@@ -342,6 +342,25 @@ class TestProc < Test::Unit::TestCase
     assert_equal(9, b)
   end
 
+  # Not named test_curry_* so that test_curry_with_trace does not re-run it
+  # under set_trace_func (which would be needlessly slow with GC.stress).
+  def test_proc_curry_keeps_args_alive
+    # The argument array passed down by `curry` must stay alive across the
+    # inner call; otherwise GC may reclaim it while it is still read as argv
+    # and crash with "try to mark T_NONE object". See the RB_GC_GUARD in `curry`.
+    assert_separately([], "#{<<~"begin;"}\n#{<<~'end;'}", timeout: 60)
+    begin;
+      GC.stress = true
+      l = ->(a, b, c) { a + b + c }
+      30.times do
+        l1 = l.curry.call(1)
+        l2 = l1.curry.call(2)
+        assert_equal(6, l2.curry.call(3))
+        assert_equal(6, l1.curry.call(2, 3))
+      end
+    end;
+  end
+
   def test_lambda?
     l = proc {}
     assert_equal(false, l.lambda?)


### PR DESCRIPTION
In the call branch of `curry`, `passed` is the only reference keeping the freshly built argument array alive, yet its backing buffer is handed to `rb_proc_call_with_block` as `argv` via `RARRAY_CONST_PTR(passed)`. After taking that pointer `passed` is otherwise unused, so the compiler may drop it before the call returns. Conservative stack marking then fails to find the array, and a GC triggered during the call (e.g. under GC.stress) can reclaim it while `argv` still points into its (embedded) buffer, crashing with:

  [BUG] try to mark T_NONE object (... parent: T_ARRAY ...)

It also shows up as silent argument corruption, e.g. a curried proc raising "false can't be coerced into Integer", which is how it surfaced as a flaky Proc#curry spec failure in CI.

Add RB_GC_GUARD(passed) to keep the array live until the call returns. Note that `curry` calls with kw_splat == 0, so the argv-rewriting path in invoke_block_from_c_proc (the rb_proc_call_kw / bd16973b85 case) is not reached here; this is purely a liveness issue, not a write-barrier one.

The added test reproduces the crash deterministically under GC.stress.