### PR TITLE
ZJIT: Rename iseq_escapes_ep helpers

### DIFF
--- a/zjit/src/cruby.rs
+++ b/zjit/src/cruby.rs
@@ -320,11 +320,11 @@ pub fn iseq_opcode_at_idx(iseq: IseqPtr, insn_idx: u32) -> u32 {
     unsafe { rb_iseq_opcode_at_pc(iseq, pc) as u32 }
 }
 
-/// Return true if a given ISEQ is known to escape EP to the heap on entry.
+/// Return true if a given ISEQ starts with EP escaped to the heap on entry.
 ///
 /// As of vm_push_frame(), EP is always equal to BP. However, after pushing
 /// a frame, some ISEQ setups call vm_bind_update_env(), which redirects EP.
-pub fn iseq_escapes_ep(iseq: IseqPtr) -> bool {
+pub fn iseq_ep_starts_escaped(iseq: IseqPtr) -> bool {
     match unsafe { get_iseq_body_type(iseq) } {
         // The EP of the <main> frame points to TOPLEVEL_BINDING
         ISEQ_TYPE_MAIN |

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -7,7 +7,7 @@
 #![allow(clippy::match_like_matches_macro)]
 use crate::{
     backend::lir::C_ARG_OPNDS,
-    cast::IntoUsize, codegen::{local_idx_to_ep_offset, max_iseq_versions}, cruby::*, invariants::{self, iseq_has_escaped_ep}, payload::get_or_create_iseq_payload, options::{debug, get_option, DumpHIR, InlineDepth}, state::ZJITState, json::Json,
+    cast::IntoUsize, codegen::{local_idx_to_ep_offset, max_iseq_versions}, cruby::*, invariants::{self, iseq_seen_ep_escape}, payload::get_or_create_iseq_payload, options::{debug, get_option, DumpHIR, InlineDepth}, state::ZJITState, json::Json,
     state,
 };
 use std::{
@@ -4404,7 +4404,7 @@ impl Function {
 
         // Reject callees whose environment pointer can escape (e.g., via binding).
         // TODO (nirvdrum 2026-04-15) The interaction between inlined frames and EP escape hasn't been verified.
-        if iseq_ep_starts_escaped(callee_iseq) || iseq_has_escaped_ep(callee_iseq) {
+        if iseq_ep_starts_escaped(callee_iseq) || iseq_seen_ep_escape(callee_iseq) {
             incr_counter!(inline_reject_ep_escapes);
             return false;
         }
@@ -7466,8 +7466,8 @@ fn add_iseq_to_hir(
     let ep_starts_escaped = iseq_ep_starts_escaped(iseq);
     // Check if the EP has been escaped at some point in the ISEQ. If it has, then we assume that
     // its EP is shared with other frames.
-    let iseq_has_escaped_ep = iseq_has_escaped_ep(iseq);
-    let ep_escaped = ep_starts_escaped || iseq_has_escaped_ep;
+    let seen_ep_escape = iseq_seen_ep_escape(iseq);
+    let ep_escaped = ep_starts_escaped || seen_ep_escape;
 
     // Iteratively fill out basic blocks using a queue.
     // TODO(max): Basic block arguments at edges
@@ -9426,10 +9426,10 @@ fn compile_jit_entry_state(fun: &mut Function, jit_entry_block: BlockId, jit_ent
     let opt_num: usize = params.opt_num.try_into().expect("iseq param opt_num >= 0");
     let lead_num: usize = params.lead_num.try_into().expect("iseq param lead_num >= 0");
     let passed_opt_num = jit_entry_idx;
-    // We don't need to check crate::cruby::iseq_ep_starts_escaped because we
+    // We don't need to check iseq_ep_starts_escaped() because we
     // don't enter ISEQ_TYPE_MAIN/ISEQ_TYPE_EVAL using JIT-to-JIT calls.
     // TODO: Stop compiling such JIT entries (Shopify/ruby#992)
-    let iseq_has_escaped_ep = iseq_has_escaped_ep(iseq);
+    let seen_ep_escape = iseq_seen_ep_escape(iseq);
 
     // If the iseq has keyword parameters, the keyword bits local will be appended to the local table.
     let kw_bits_idx: Option<usize> = if unsafe { rb_get_iseq_flags_has_kw(iseq) } {
@@ -9485,7 +9485,7 @@ fn compile_jit_entry_state(fun: &mut Function, jit_entry_block: BlockId, jit_ent
         // Once an ISEQ has escaped EP, HIR getlocal may need to read from the
         // VM frame instead of FrameState. Direct JIT-to-JIT entry passes locals
         // as C arguments, so initialize the frame slots here before such reads.
-        if iseq_has_escaped_ep {
+        if seen_ep_escape {
             let ep_offset = local_idx_to_ep_offset(iseq, local_idx);
             let local_id = unsafe { rb_zjit_local_id(iseq, local_idx.try_into().unwrap()) };
             let ep = *ep.get_or_insert_with(|| fun.push_insn(jit_entry_block, Insn::GetEP { level: 0 }));

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -7,7 +7,7 @@
 #![allow(clippy::match_like_matches_macro)]
 use crate::{
     backend::lir::C_ARG_OPNDS,
-    cast::IntoUsize, codegen::{local_idx_to_ep_offset, max_iseq_versions}, cruby::*, invariants::{self}, payload::get_or_create_iseq_payload, options::{debug, get_option, DumpHIR, InlineDepth}, state::ZJITState, json::Json,
+    cast::IntoUsize, codegen::{local_idx_to_ep_offset, max_iseq_versions}, cruby::*, invariants::{self, iseq_has_escaped_ep}, payload::get_or_create_iseq_payload, options::{debug, get_option, DumpHIR, InlineDepth}, state::ZJITState, json::Json,
     state,
 };
 use std::{
@@ -4404,7 +4404,7 @@ impl Function {
 
         // Reject callees whose environment pointer can escape (e.g., via binding).
         // TODO (nirvdrum 2026-04-15) The interaction between inlined frames and EP escape hasn't been verified.
-        if iseq_escapes_ep(callee_iseq) || crate::invariants::iseq_escapes_ep(callee_iseq) {
+        if iseq_ep_starts_escaped(callee_iseq) || iseq_has_escaped_ep(callee_iseq) {
             incr_counter!(inline_reject_ep_escapes);
             return false;
         }
@@ -7463,11 +7463,11 @@ fn add_iseq_to_hir(
 
     // Check if the EP is escaped for the ISEQ from the beginning. We give up
     // optimizing locals in that case because they're shared with other frames.
-    let ep_starts_escaped = iseq_escapes_ep(iseq);
+    let ep_starts_escaped = iseq_ep_starts_escaped(iseq);
     // Check if the EP has been escaped at some point in the ISEQ. If it has, then we assume that
     // its EP is shared with other frames.
-    let ep_has_been_escaped = crate::invariants::iseq_escapes_ep(iseq);
-    let ep_escaped = ep_starts_escaped || ep_has_been_escaped;
+    let iseq_has_escaped_ep = iseq_has_escaped_ep(iseq);
+    let ep_escaped = ep_starts_escaped || iseq_has_escaped_ep;
 
     // Iteratively fill out basic blocks using a queue.
     // TODO(max): Basic block arguments at edges
@@ -9374,7 +9374,7 @@ fn compile_entry_state(fun: &mut Function) -> (InsnId, FrameState) {
     // If the ISEQ does not escape EP, we can assume EP + 1 == SP
     // TODO: This should maybe also consider if the EP has historically been escaped in this iseq.
     // (see: https://github.com/Shopify/ruby/issues/774)
-    let use_sp = !iseq_escapes_ep(iseq);
+    let use_sp = !iseq_ep_starts_escaped(iseq);
     let mut base: Option<InsnId> = None;
     for local_idx in 0..num_locals(iseq) {
         if local_idx < param_size {
@@ -9426,10 +9426,10 @@ fn compile_jit_entry_state(fun: &mut Function, jit_entry_block: BlockId, jit_ent
     let opt_num: usize = params.opt_num.try_into().expect("iseq param opt_num >= 0");
     let lead_num: usize = params.lead_num.try_into().expect("iseq param lead_num >= 0");
     let passed_opt_num = jit_entry_idx;
-    // We don't need to check crate::cruby::iseq_escapes_ep because we
+    // We don't need to check crate::cruby::iseq_ep_starts_escaped because we
     // don't enter ISEQ_TYPE_MAIN/ISEQ_TYPE_EVAL using JIT-to-JIT calls.
     // TODO: Stop compiling such JIT entries (Shopify/ruby#992)
-    let iseq_escapes_ep = crate::invariants::iseq_escapes_ep(iseq);
+    let iseq_has_escaped_ep = iseq_has_escaped_ep(iseq);
 
     // If the iseq has keyword parameters, the keyword bits local will be appended to the local table.
     let kw_bits_idx: Option<usize> = if unsafe { rb_get_iseq_flags_has_kw(iseq) } {
@@ -9485,7 +9485,7 @@ fn compile_jit_entry_state(fun: &mut Function, jit_entry_block: BlockId, jit_ent
         // Once an ISEQ has escaped EP, HIR getlocal may need to read from the
         // VM frame instead of FrameState. Direct JIT-to-JIT entry passes locals
         // as C arguments, so initialize the frame slots here before such reads.
-        if iseq_escapes_ep {
+        if iseq_has_escaped_ep {
             let ep_offset = local_idx_to_ep_offset(iseq, local_idx);
             let local_id = unsafe { rb_zjit_local_id(iseq, local_idx.try_into().unwrap()) };
             let ep = *ep.get_or_insert_with(|| fun.push_insn(jit_entry_block, Insn::GetEP { level: 0 }));

--- a/zjit/src/invariants.rs
+++ b/zjit/src/invariants.rs
@@ -263,7 +263,7 @@ pub fn track_no_ep_escape_assumption(
 }
 
 /// Returns true if a given ISEQ has previously escaped environment pointer.
-pub fn iseq_has_escaped_ep(iseq: IseqPtr) -> bool {
+pub fn iseq_seen_ep_escape(iseq: IseqPtr) -> bool {
     ZJITState::get_invariants().ep_escape_iseqs.contains(&iseq)
 }
 

--- a/zjit/src/invariants.rs
+++ b/zjit/src/invariants.rs
@@ -263,7 +263,7 @@ pub fn track_no_ep_escape_assumption(
 }
 
 /// Returns true if a given ISEQ has previously escaped environment pointer.
-pub fn iseq_escapes_ep(iseq: IseqPtr) -> bool {
+pub fn iseq_has_escaped_ep(iseq: IseqPtr) -> bool {
     ZJITState::get_invariants().ep_escape_iseqs.contains(&iseq)
 }
 


### PR DESCRIPTION
`crate::cruby::iseq_escapes_ep` and `crate::invariants::iseq_escapes_ep` have the same function name while they check different things.

This PR renames them to clarify what they mean.