### PR TITLE
[Feature #22118] Introduce Basic Bit Operations into String

### DIFF
--- a/doc/string/bit_clear.rdoc
+++ b/doc/string/bit_clear.rdoc
@@ -1,0 +1,16 @@
+Sets the bit at zero-based bit +offset+ to 0; returns +self+:
+
+  s = "\xFF"
+  s.bit_clear(1) # => "\xFD"
+  s              # => "\xFD"
+
+By default, bits within each byte are numbered from least-significant to
+most-significant. If +lsb_first+ is +false+, byte order is unchanged but bits
+within each byte are numbered from most-significant to least-significant:
+
+  s = "\xFF"
+  s.bit_clear(1, lsb_first: false) # => "\xBF"
+
+Raises +IndexError+ if +offset+ is out of range.
+Raises +ArgumentError+ if +offset+ is too large to be represented.
+Raises +ArgumentError+ if +lsb_first+ is neither +true+ nor +false+.

--- a/doc/string/bit_count.rdoc
+++ b/doc/string/bit_count.rdoc
@@ -1,0 +1,8 @@
+Returns the number of set bits in +self+:
+
+  "\x00".bit_count # => 0
+  "\xFF".bit_count # => 8
+  "\xAA".bit_count # => 4
+
+The count is over the bytes of +self+ and is independent of string encoding.
+Raises +ArgumentError+ if any argument is given.

--- a/doc/string/bit_flip.rdoc
+++ b/doc/string/bit_flip.rdoc
@@ -1,0 +1,16 @@
+Flips the bit at zero-based bit +offset+; returns +self+:
+
+  s = "\x00"
+  s.bit_flip(1) # => "\x02"
+  s.bit_flip(1) # => "\x00"
+
+By default, bits within each byte are numbered from least-significant to
+most-significant. If +lsb_first+ is +false+, byte order is unchanged but bits
+within each byte are numbered from most-significant to least-significant:
+
+  s = "\x00"
+  s.bit_flip(1, lsb_first: false) # => "\x40"
+
+Raises +IndexError+ if +offset+ is out of range.
+Raises +ArgumentError+ if +offset+ is too large to be represented.
+Raises +ArgumentError+ if +lsb_first+ is neither +true+ nor +false+.

--- a/doc/string/bit_get.rdoc
+++ b/doc/string/bit_get.rdoc
@@ -1,0 +1,20 @@
+Returns +0+ or +1+ for the bit at zero-based bit +offset+:
+
+  s = "\xAA" # 0b10101010
+  s.bit_get(0) # => 0
+  s.bit_get(1) # => 1
+
+Returns +nil+ if +offset+ is beyond the end of +self+:
+
+  s.bit_get(8) # => nil
+
+By default, bits within each byte are numbered from least-significant to
+most-significant. If +lsb_first+ is +false+, byte order is unchanged but bits
+within each byte are numbered from most-significant to least-significant:
+
+  s.bit_get(0, lsb_first: false) # => 1
+  s.bit_get(1, lsb_first: false) # => 0
+
+Raises +IndexError+ if +offset+ is negative.
+Raises +ArgumentError+ if +offset+ is too large to be represented.
+Raises +ArgumentError+ if +lsb_first+ is neither +true+ nor +false+.

--- a/doc/string/bit_set.rdoc
+++ b/doc/string/bit_set.rdoc
@@ -1,0 +1,16 @@
+Sets the bit at zero-based bit +offset+ to 1; returns +self+:
+
+  s = "\x00"
+  s.bit_set(1) # => "\x02"
+  s            # => "\x02"
+
+By default, bits within each byte are numbered from least-significant to
+most-significant. If +lsb_first+ is +false+, byte order is unchanged but bits
+within each byte are numbered from most-significant to least-significant:
+
+  s = "\x00"
+  s.bit_set(1, lsb_first: false) # => "\x40"
+
+Raises +IndexError+ if +offset+ is out of range.
+Raises +ArgumentError+ if +offset+ is too large to be represented.
+Raises +ArgumentError+ if +lsb_first+ is neither +true+ nor +false+.

--- a/doc/string/bit_set_p.rdoc
+++ b/doc/string/bit_set_p.rdoc
@@ -1,0 +1,20 @@
+Returns +true+ or +false+ for whether the bit at zero-based bit +offset+ is set:
+
+  s = "\xAA" # 0b10101010
+  s.bit_set?(0) # => false
+  s.bit_set?(1) # => true
+
+Returns +nil+ if +offset+ is beyond the end of +self+:
+
+  s.bit_set?(8) # => nil
+
+By default, bits within each byte are numbered from least-significant to
+most-significant. If +lsb_first+ is +false+, byte order is unchanged but bits
+within each byte are numbered from most-significant to least-significant:
+
+  s.bit_set?(0, lsb_first: false) # => true
+  s.bit_set?(1, lsb_first: false) # => false
+
+Raises +IndexError+ if +offset+ is negative.
+Raises +ArgumentError+ if +offset+ is too large to be represented.
+Raises +ArgumentError+ if +lsb_first+ is neither +true+ nor +false+.

--- a/doc/string/bitwise_and.rdoc
+++ b/doc/string/bitwise_and.rdoc
@@ -1,0 +1,7 @@
+Returns a new string whose bytes are the bitwise AND of +self+ and +other+:
+
+  "\xF0".bitwise_and("\xCC") # => "\xC0"
+
++other+ is converted to a string using +to_str+.
+Raises +ArgumentError+ if the two strings have different byte sizes.
+The returned string has BINARY encoding.

--- a/doc/string/bitwise_and_bang.rdoc
+++ b/doc/string/bitwise_and_bang.rdoc
@@ -1,0 +1,10 @@
+Replaces each byte in +self+ with the bitwise AND of that byte and the
+corresponding byte in +other+; returns +self+:
+
+  s = "\xF0"
+  s.bitwise_and!("\xCC") # => "\xC0"
+  s                      # => "\xC0"
+
++other+ is converted to a string using +to_str+.
+Raises +ArgumentError+ if the two strings have different byte sizes.
+The encoding of +self+ is not changed.

--- a/doc/string/bitwise_not.rdoc
+++ b/doc/string/bitwise_not.rdoc
@@ -1,0 +1,5 @@
+Returns a new string whose bytes are the bitwise complement of +self+:
+
+  "\x00\xAA".bitwise_not # => "\xFF\x55"
+
+The returned string has BINARY encoding.

--- a/doc/string/bitwise_not_bang.rdoc
+++ b/doc/string/bitwise_not_bang.rdoc
@@ -1,0 +1,7 @@
+Replaces each byte in +self+ with its bitwise complement; returns +self+:
+
+  s = "\x00\xAA"
+  s.bitwise_not! # => "\xFF\x55"
+  s              # => "\xFF\x55"
+
+The encoding of +self+ is not changed.

--- a/doc/string/bitwise_or.rdoc
+++ b/doc/string/bitwise_or.rdoc
@@ -1,0 +1,7 @@
+Returns a new string whose bytes are the bitwise OR of +self+ and +other+:
+
+  "\xF0".bitwise_or("\x0C") # => "\xFC"
+
++other+ is converted to a string using +to_str+.
+Raises +ArgumentError+ if the two strings have different byte sizes.
+The returned string has BINARY encoding.

--- a/doc/string/bitwise_or_bang.rdoc
+++ b/doc/string/bitwise_or_bang.rdoc
@@ -1,0 +1,10 @@
+Replaces each byte in +self+ with the bitwise OR of that byte and the
+corresponding byte in +other+; returns +self+:
+
+  s = "\xF0"
+  s.bitwise_or!("\x0C") # => "\xFC"
+  s                     # => "\xFC"
+
++other+ is converted to a string using +to_str+.
+Raises +ArgumentError+ if the two strings have different byte sizes.
+The encoding of +self+ is not changed.

--- a/doc/string/bitwise_xor.rdoc
+++ b/doc/string/bitwise_xor.rdoc
@@ -1,0 +1,7 @@
+Returns a new string whose bytes are the bitwise XOR of +self+ and +other+:
+
+  "\xF0".bitwise_xor("\xCC") # => "\x3C"
+
++other+ is converted to a string using +to_str+.
+Raises +ArgumentError+ if the two strings have different byte sizes.
+The returned string has BINARY encoding.

--- a/doc/string/bitwise_xor_bang.rdoc
+++ b/doc/string/bitwise_xor_bang.rdoc
@@ -1,0 +1,10 @@
+Replaces each byte in +self+ with the bitwise XOR of that byte and the
+corresponding byte in +other+; returns +self+:
+
+  s = "\xF0"
+  s.bitwise_xor!("\xCC") # => "\x3C"
+  s                      # => "\x3C"
+
++other+ is converted to a string using +to_str+.
+Raises +ArgumentError+ if the two strings have different byte sizes.
+The encoding of +self+ is not changed.

--- a/spec/ruby/core/string/bit_clear_spec.rb
+++ b/spec/ruby/core/string/bit_clear_spec.rb
@@ -1,0 +1,33 @@
+# encoding: binary
+require_relative '../../spec_helper'
+
+ruby_version_is "4.1" do
+  describe "String#bit_clear" do
+    it "clears a bit in LSB-first order by default and returns self" do
+      str = "\xFF".dup
+      str.bit_clear(1).should.equal?(str)
+      str.should == "\xFD"
+    end
+
+    it "clears a bit in MSB-first order" do
+      str = "\xFF".dup
+      str.bit_clear(1, lsb_first: false)
+      str.should == "\xBF"
+    end
+
+    it "preserves byte order when using MSB-first order" do
+      str = "\xFF\xFF".dup
+      str.bit_clear(8, lsb_first: false)
+      str.should == "\xFF\x7F"
+    end
+
+    it "raises an IndexError for an out of range bit offset" do
+      -> { "\x00".bit_clear(8) }.should.raise(IndexError)
+      -> { "\x00".bit_clear(-1) }.should.raise(IndexError)
+    end
+
+    it "raises a FrozenError if self is frozen" do
+      -> { "\x00".freeze.bit_clear(0) }.should.raise(FrozenError)
+    end
+  end
+end

--- a/spec/ruby/core/string/bit_clear_spec.rb
+++ b/spec/ruby/core/string/bit_clear_spec.rb
@@ -4,19 +4,19 @@ require_relative '../../spec_helper'
 ruby_version_is "4.1" do
   describe "String#bit_clear" do
     it "clears a bit in LSB-first order by default and returns self" do
-      str = "\xFF".dup
+      str = +"\xFF"
       str.bit_clear(1).should.equal?(str)
       str.should == "\xFD"
     end
 
     it "clears a bit in MSB-first order" do
-      str = "\xFF".dup
+      str = +"\xFF"
       str.bit_clear(1, lsb_first: false)
       str.should == "\xBF"
     end
 
     it "preserves byte order when using MSB-first order" do
-      str = "\xFF\xFF".dup
+      str = +"\xFF\xFF"
       str.bit_clear(8, lsb_first: false)
       str.should == "\xFF\x7F"
     end

--- a/spec/ruby/core/string/bit_count_spec.rb
+++ b/spec/ruby/core/string/bit_count_spec.rb
@@ -1,0 +1,18 @@
+# encoding: binary
+require_relative '../../spec_helper'
+
+ruby_version_is "4.1" do
+  describe "String#bit_count" do
+    it "returns the number of set bits in the string" do
+      "".bit_count.should == 0
+      "\x00".bit_count.should == 0
+      "\xFF".bit_count.should == 8
+      "\xAA\xF0".bit_count.should == 8
+    end
+
+    it "raises an ArgumentError when given an argument" do
+      -> { "\x00".bit_count(0) }.should.raise(ArgumentError)
+      -> { "\x00".bit_count(lsb_first: false) }.should.raise(ArgumentError)
+    end
+  end
+end

--- a/spec/ruby/core/string/bit_flip_spec.rb
+++ b/spec/ruby/core/string/bit_flip_spec.rb
@@ -1,0 +1,35 @@
+# encoding: binary
+require_relative '../../spec_helper'
+
+ruby_version_is "4.1" do
+  describe "String#bit_flip" do
+    it "flips a bit in LSB-first order by default and returns self" do
+      str = "\x00".dup
+      str.bit_flip(1).should.equal?(str)
+      str.should == "\x02"
+      str.bit_flip(1)
+      str.should == "\x00"
+    end
+
+    it "flips a bit in MSB-first order" do
+      str = "\x00".dup
+      str.bit_flip(1, lsb_first: false)
+      str.should == "\x40"
+    end
+
+    it "preserves byte order when using MSB-first order" do
+      str = "\x00\x00".dup
+      str.bit_flip(8, lsb_first: false)
+      str.should == "\x00\x80"
+    end
+
+    it "raises an IndexError for an out of range bit offset" do
+      -> { "\x00".bit_flip(8) }.should.raise(IndexError)
+      -> { "\x00".bit_flip(-1) }.should.raise(IndexError)
+    end
+
+    it "raises a FrozenError if self is frozen" do
+      -> { "\x00".freeze.bit_flip(0) }.should.raise(FrozenError)
+    end
+  end
+end

--- a/spec/ruby/core/string/bit_flip_spec.rb
+++ b/spec/ruby/core/string/bit_flip_spec.rb
@@ -4,7 +4,7 @@ require_relative '../../spec_helper'
 ruby_version_is "4.1" do
   describe "String#bit_flip" do
     it "flips a bit in LSB-first order by default and returns self" do
-      str = "\x00".dup
+      str = +"\x00"
       str.bit_flip(1).should.equal?(str)
       str.should == "\x02"
       str.bit_flip(1)
@@ -12,13 +12,13 @@ ruby_version_is "4.1" do
     end
 
     it "flips a bit in MSB-first order" do
-      str = "\x00".dup
+      str = +"\x00"
       str.bit_flip(1, lsb_first: false)
       str.should == "\x40"
     end
 
     it "preserves byte order when using MSB-first order" do
-      str = "\x00\x00".dup
+      str = +"\x00\x00"
       str.bit_flip(8, lsb_first: false)
       str.should == "\x00\x80"
     end

--- a/spec/ruby/core/string/bit_get_spec.rb
+++ b/spec/ruby/core/string/bit_get_spec.rb
@@ -1,0 +1,38 @@
+# encoding: binary
+require_relative '../../spec_helper'
+
+ruby_version_is "4.1" do
+  describe "String#bit_get" do
+    it "returns 0 or 1 for a bit offset in LSB-first order by default" do
+      str = "\xAA"
+      str.bit_get(0).should == 0
+      str.bit_get(1).should == 1
+      str.bit_get(7).should == 1
+    end
+
+    it "returns 0 or 1 for a bit offset in MSB-first order" do
+      str = "\xAA"
+      str.bit_get(0, lsb_first: false).should == 1
+      str.bit_get(1, lsb_first: false).should == 0
+      str.bit_get(7, lsb_first: false).should == 0
+    end
+
+    it "preserves byte order when using MSB-first order" do
+      str = "\x00\x80"
+      str.bit_get(8, lsb_first: false).should == 1
+    end
+
+    it "returns nil for a bit offset beyond the string" do
+      "\x00".bit_get(8).should == nil
+      "".bit_get(0).should == nil
+    end
+
+    it "raises an IndexError for a negative bit offset" do
+      -> { "\x00".bit_get(-1) }.should.raise(IndexError)
+    end
+
+    it "raises an ArgumentError for an invalid lsb_first value" do
+      -> { "\x00".bit_get(0, lsb_first: nil) }.should.raise(ArgumentError)
+    end
+  end
+end

--- a/spec/ruby/core/string/bit_set_p_spec.rb
+++ b/spec/ruby/core/string/bit_set_p_spec.rb
@@ -1,0 +1,38 @@
+# encoding: binary
+require_relative '../../spec_helper'
+
+ruby_version_is "4.1" do
+  describe "String#bit_set?" do
+    it "returns true or false for a bit offset in LSB-first order by default" do
+      str = "\xAA"
+      str.bit_set?(0).should == false
+      str.bit_set?(1).should == true
+      str.bit_set?(7).should == true
+    end
+
+    it "returns true or false for a bit offset in MSB-first order" do
+      str = "\xAA"
+      str.bit_set?(0, lsb_first: false).should == true
+      str.bit_set?(1, lsb_first: false).should == false
+      str.bit_set?(7, lsb_first: false).should == false
+    end
+
+    it "preserves byte order when using MSB-first order" do
+      str = "\x00\x80"
+      str.bit_set?(8, lsb_first: false).should == true
+    end
+
+    it "returns nil for a bit offset beyond the string" do
+      "\x00".bit_set?(8).should == nil
+      "".bit_set?(0).should == nil
+    end
+
+    it "raises an IndexError for a negative bit offset" do
+      -> { "\x00".bit_set?(-1) }.should.raise(IndexError)
+    end
+
+    it "raises an ArgumentError for an invalid lsb_first value" do
+      -> { "\x00".bit_set?(0, lsb_first: nil) }.should.raise(ArgumentError)
+    end
+  end
+end

--- a/spec/ruby/core/string/bit_set_spec.rb
+++ b/spec/ruby/core/string/bit_set_spec.rb
@@ -1,0 +1,33 @@
+# encoding: binary
+require_relative '../../spec_helper'
+
+ruby_version_is "4.1" do
+  describe "String#bit_set" do
+    it "sets a bit in LSB-first order by default and returns self" do
+      str = "\x00".dup
+      str.bit_set(1).should.equal?(str)
+      str.should == "\x02"
+    end
+
+    it "sets a bit in MSB-first order" do
+      str = "\x00".dup
+      str.bit_set(1, lsb_first: false)
+      str.should == "\x40"
+    end
+
+    it "preserves byte order when using MSB-first order" do
+      str = "\x00\x00".dup
+      str.bit_set(8, lsb_first: false)
+      str.should == "\x00\x80"
+    end
+
+    it "raises an IndexError for an out of range bit offset" do
+      -> { "\x00".bit_set(8) }.should.raise(IndexError)
+      -> { "\x00".bit_set(-1) }.should.raise(IndexError)
+    end
+
+    it "raises a FrozenError if self is frozen" do
+      -> { "\x00".freeze.bit_set(0) }.should.raise(FrozenError)
+    end
+  end
+end

--- a/spec/ruby/core/string/bit_set_spec.rb
+++ b/spec/ruby/core/string/bit_set_spec.rb
@@ -4,19 +4,19 @@ require_relative '../../spec_helper'
 ruby_version_is "4.1" do
   describe "String#bit_set" do
     it "sets a bit in LSB-first order by default and returns self" do
-      str = "\x00".dup
+      str = +"\x00"
       str.bit_set(1).should.equal?(str)
       str.should == "\x02"
     end
 
     it "sets a bit in MSB-first order" do
-      str = "\x00".dup
+      str = +"\x00"
       str.bit_set(1, lsb_first: false)
       str.should == "\x40"
     end
 
     it "preserves byte order when using MSB-first order" do
-      str = "\x00\x00".dup
+      str = +"\x00\x00"
       str.bit_set(8, lsb_first: false)
       str.should == "\x00\x80"
     end

--- a/spec/ruby/core/string/bitwise_and_spec.rb
+++ b/spec/ruby/core/string/bitwise_and_spec.rb
@@ -1,0 +1,40 @@
+# encoding: binary
+require_relative '../../spec_helper'
+
+ruby_version_is "4.1" do
+  describe "String#bitwise_and" do
+    it "returns a new string containing the byte-wise AND with another string" do
+      str = "\xF0"
+      result = str.bitwise_and("\xCC")
+      result.should == "\xC0".b
+      result.should_not.equal?(str)
+      str.should == "\xF0"
+    end
+
+    it "converts the argument with to_str" do
+      other = mock("string")
+      other.should_receive(:to_str).and_return("\xCC")
+      "\xF0".bitwise_and(other).should == "\xC0".b
+    end
+
+    it "raises an ArgumentError if byte sizes differ" do
+      -> { "\x00".bitwise_and("\x00\x00") }.should.raise(ArgumentError)
+    end
+
+    it "returns a BINARY string" do
+      "\xF0".dup.force_encoding("UTF-8").bitwise_and("\xCC").encoding.should == Encoding::BINARY
+    end
+  end
+
+  describe "String#bitwise_and!" do
+    it "replaces self with the byte-wise AND and returns self" do
+      str = "\xF0".dup
+      str.bitwise_and!("\xCC").should.equal?(str)
+      str.should == "\xC0"
+    end
+
+    it "raises a FrozenError if self is frozen" do
+      -> { "\x00".freeze.bitwise_and!("\x00") }.should.raise(FrozenError)
+    end
+  end
+end

--- a/spec/ruby/core/string/bitwise_and_spec.rb
+++ b/spec/ruby/core/string/bitwise_and_spec.rb
@@ -22,13 +22,13 @@ ruby_version_is "4.1" do
     end
 
     it "returns a BINARY string" do
-      "\xF0".dup.force_encoding("UTF-8").bitwise_and("\xCC").encoding.should == Encoding::BINARY
+      (+"\xF0").force_encoding("UTF-8").bitwise_and("\xCC").encoding.should == Encoding::BINARY
     end
   end
 
   describe "String#bitwise_and!" do
     it "replaces self with the byte-wise AND and returns self" do
-      str = "\xF0".dup
+      str = +"\xF0"
       str.bitwise_and!("\xCC").should.equal?(str)
       str.should == "\xC0"
     end

--- a/spec/ruby/core/string/bitwise_and_spec.rb
+++ b/spec/ruby/core/string/bitwise_and_spec.rb
@@ -18,7 +18,8 @@ ruby_version_is "4.1" do
     end
 
     it "raises an ArgumentError if byte sizes differ" do
-      -> { "\x00".bitwise_and("\x00\x00") }.should.raise(ArgumentError)
+      -> { "\xF0".bitwise_and("") }.should.raise(ArgumentError)
+      -> { "\xF0".bitwise_and("\x00\x00") }.should.raise(ArgumentError)
     end
 
     it "returns a BINARY string" do

--- a/spec/ruby/core/string/bitwise_not_spec.rb
+++ b/spec/ruby/core/string/bitwise_not_spec.rb
@@ -1,0 +1,31 @@
+# encoding: binary
+require_relative '../../spec_helper'
+
+ruby_version_is "4.1" do
+  describe "String#bitwise_not" do
+    it "returns a new string with every bit inverted" do
+      str = "\x00\xAA"
+      result = str.bitwise_not
+      result.should == "\xFF\x55".b
+      result.should_not.equal?(str)
+      str.should == "\x00\xAA"
+    end
+
+    it "returns a BINARY string" do
+      str = "\x00".dup.force_encoding("US-ASCII")
+      str.bitwise_not.encoding.should == Encoding::BINARY
+    end
+  end
+
+  describe "String#bitwise_not!" do
+    it "inverts every bit in self and returns self" do
+      str = "\x00\xAA".dup
+      str.bitwise_not!.should.equal?(str)
+      str.should == "\xFF\x55"
+    end
+
+    it "raises a FrozenError if self is frozen" do
+      -> { "\x00".freeze.bitwise_not! }.should.raise(FrozenError)
+    end
+  end
+end

--- a/spec/ruby/core/string/bitwise_not_spec.rb
+++ b/spec/ruby/core/string/bitwise_not_spec.rb
@@ -12,14 +12,14 @@ ruby_version_is "4.1" do
     end
 
     it "returns a BINARY string" do
-      str = "\x00".dup.force_encoding("US-ASCII")
+      str = (+"\x00").force_encoding("US-ASCII")
       str.bitwise_not.encoding.should == Encoding::BINARY
     end
   end
 
   describe "String#bitwise_not!" do
     it "inverts every bit in self and returns self" do
-      str = "\x00\xAA".dup
+      str = +"\x00\xAA"
       str.bitwise_not!.should.equal?(str)
       str.should == "\xFF\x55"
     end

--- a/spec/ruby/core/string/bitwise_or_spec.rb
+++ b/spec/ruby/core/string/bitwise_or_spec.rb
@@ -1,0 +1,40 @@
+# encoding: binary
+require_relative '../../spec_helper'
+
+ruby_version_is "4.1" do
+  describe "String#bitwise_or" do
+    it "returns a new string containing the byte-wise OR with another string" do
+      str = "\xF0"
+      result = str.bitwise_or("\x0C")
+      result.should == "\xFC".b
+      result.should_not.equal?(str)
+      str.should == "\xF0"
+    end
+
+    it "converts the argument with to_str" do
+      other = mock("string")
+      other.should_receive(:to_str).and_return("\x0C")
+      "\xF0".bitwise_or(other).should == "\xFC".b
+    end
+
+    it "raises an ArgumentError if byte sizes differ" do
+      -> { "\x00".bitwise_or("\x00\x00") }.should.raise(ArgumentError)
+    end
+
+    it "returns a BINARY string" do
+      "\xF0".dup.force_encoding("UTF-8").bitwise_or("\x0C").encoding.should == Encoding::BINARY
+    end
+  end
+
+  describe "String#bitwise_or!" do
+    it "replaces self with the byte-wise OR and returns self" do
+      str = "\xF0".dup
+      str.bitwise_or!("\x0C").should.equal?(str)
+      str.should == "\xFC"
+    end
+
+    it "raises a FrozenError if self is frozen" do
+      -> { "\x00".freeze.bitwise_or!("\x00") }.should.raise(FrozenError)
+    end
+  end
+end

--- a/spec/ruby/core/string/bitwise_or_spec.rb
+++ b/spec/ruby/core/string/bitwise_or_spec.rb
@@ -18,7 +18,8 @@ ruby_version_is "4.1" do
     end
 
     it "raises an ArgumentError if byte sizes differ" do
-      -> { "\x00".bitwise_or("\x00\x00") }.should.raise(ArgumentError)
+      -> { "\xF0".bitwise_or("") }.should.raise(ArgumentError)
+      -> { "\xF0".bitwise_or("\x00\x00") }.should.raise(ArgumentError)
     end
 
     it "returns a BINARY string" do

--- a/spec/ruby/core/string/bitwise_or_spec.rb
+++ b/spec/ruby/core/string/bitwise_or_spec.rb
@@ -22,13 +22,13 @@ ruby_version_is "4.1" do
     end
 
     it "returns a BINARY string" do
-      "\xF0".dup.force_encoding("UTF-8").bitwise_or("\x0C").encoding.should == Encoding::BINARY
+      (+"\xF0").force_encoding("UTF-8").bitwise_or("\x0C").encoding.should == Encoding::BINARY
     end
   end
 
   describe "String#bitwise_or!" do
     it "replaces self with the byte-wise OR and returns self" do
-      str = "\xF0".dup
+      str = +"\xF0"
       str.bitwise_or!("\x0C").should.equal?(str)
       str.should == "\xFC"
     end

--- a/spec/ruby/core/string/bitwise_xor_spec.rb
+++ b/spec/ruby/core/string/bitwise_xor_spec.rb
@@ -1,0 +1,40 @@
+# encoding: binary
+require_relative '../../spec_helper'
+
+ruby_version_is "4.1" do
+  describe "String#bitwise_xor" do
+    it "returns a new string containing the byte-wise XOR with another string" do
+      str = "\xF0"
+      result = str.bitwise_xor("\xCC")
+      result.should == "\x3C".b
+      result.should_not.equal?(str)
+      str.should == "\xF0"
+    end
+
+    it "converts the argument with to_str" do
+      other = mock("string")
+      other.should_receive(:to_str).and_return("\xCC")
+      "\xF0".bitwise_xor(other).should == "\x3C".b
+    end
+
+    it "raises an ArgumentError if byte sizes differ" do
+      -> { "\x00".bitwise_xor("\x00\x00") }.should.raise(ArgumentError)
+    end
+
+    it "returns a BINARY string" do
+      "\xF0".dup.force_encoding("UTF-8").bitwise_xor("\xCC").encoding.should == Encoding::BINARY
+    end
+  end
+
+  describe "String#bitwise_xor!" do
+    it "replaces self with the byte-wise XOR and returns self" do
+      str = "\xF0".dup
+      str.bitwise_xor!("\xCC").should.equal?(str)
+      str.should == "\x3C"
+    end
+
+    it "raises a FrozenError if self is frozen" do
+      -> { "\x00".freeze.bitwise_xor!("\x00") }.should.raise(FrozenError)
+    end
+  end
+end

--- a/spec/ruby/core/string/bitwise_xor_spec.rb
+++ b/spec/ruby/core/string/bitwise_xor_spec.rb
@@ -18,7 +18,8 @@ ruby_version_is "4.1" do
     end
 
     it "raises an ArgumentError if byte sizes differ" do
-      -> { "\x00".bitwise_xor("\x00\x00") }.should.raise(ArgumentError)
+      -> { "\xF0".bitwise_xor("") }.should.raise(ArgumentError)
+      -> { "\xF0".bitwise_xor("\x00\x00") }.should.raise(ArgumentError)
     end
 
     it "returns a BINARY string" do

--- a/spec/ruby/core/string/bitwise_xor_spec.rb
+++ b/spec/ruby/core/string/bitwise_xor_spec.rb
@@ -22,13 +22,13 @@ ruby_version_is "4.1" do
     end
 
     it "returns a BINARY string" do
-      "\xF0".dup.force_encoding("UTF-8").bitwise_xor("\xCC").encoding.should == Encoding::BINARY
+      (+"\xF0").force_encoding("UTF-8").bitwise_xor("\xCC").encoding.should == Encoding::BINARY
     end
   end
 
   describe "String#bitwise_xor!" do
     it "replaces self with the byte-wise XOR and returns self" do
-      str = "\xF0".dup
+      str = +"\xF0"
       str.bitwise_xor!("\xCC").should.equal?(str)
       str.should == "\x3C"
     end

--- a/string.c
+++ b/string.c
@@ -26,6 +26,7 @@
 #include "id.h"
 #include "internal.h"
 #include "internal/array.h"
+#include "internal/bits.h"
 #include "internal/compar.h"
 #include "internal/compilers.h"
 #include "internal/concurrent_set.h"
@@ -6750,6 +6751,484 @@ rb_str_setbyte(VALUE str, VALUE index, VALUE value)
     return value;
 }
 
+#define STR_BIT_LEN(byte_len) ((uint64_t)(byte_len) * CHAR_BIT)
+
+/*
+ * Keep both the full bit offset and its long representation.  Most calls use a
+ * Fixnum-sized offset and can stay on the original long fast path; only large
+ * Bignum offsets need the uint64_t path below.  This matters on platforms
+ * where long is narrower than the address space, such as 32-bit and LLP64.
+ */
+struct str_bit_offset {
+    uint64_t value;
+    long long_value;
+    bool fits_long;
+};
+
+static inline struct str_bit_offset
+str_bit_offset_from_index(VALUE index)
+{
+    VALUE integer = rb_to_int(index);
+    struct str_bit_offset offset;
+
+    /*
+     * FIXNUM_P only decides whether the common long path is immediately usable.
+     * This covers practically all offsets on LP64 platforms; Bignum offsets
+     * are still accepted below when they fit in uint64_t, mainly for platforms
+     * with 32-bit long where large strings can have Bignum bit offsets.
+     */
+    if (FIXNUM_P(integer)) {
+        offset.long_value = FIX2LONG(integer);
+        if (offset.long_value < 0) {
+            rb_raise(rb_eIndexError, "bit index out of range");
+        }
+        offset.value = (uint64_t)offset.long_value;
+        offset.fits_long = true;
+        return offset;
+    }
+
+    RUBY_ASSERT(RB_TYPE_P(integer, T_BIGNUM));
+    if (rb_int_negative_p(integer)) {
+        rb_raise(rb_eIndexError, "bit index out of range");
+    }
+    if (rb_cmpint(rb_int_cmp(integer, ULL2NUM(UINT64_MAX)), integer, ULL2NUM(UINT64_MAX)) > 0) {
+        rb_raise(rb_eArgError, "bit index out of representable range");
+    }
+
+    offset.value = (uint64_t)NUM2ULL(integer);
+    if (offset.value <= (uint64_t)LONG_MAX) {
+        offset.long_value = (long)offset.value;
+        offset.fits_long = true;
+    }
+    else {
+        offset.long_value = 0;
+        offset.fits_long = false;
+    }
+    return offset;
+}
+
+static bool
+str_lsb_first(int argc, VALUE *argv, VALUE *index)
+{
+    static ID keywords[1];
+    VALUE opts, vlsb_first;
+
+    if (!keywords[0]) {
+        keywords[0] = rb_intern_const("lsb_first");
+    }
+
+    rb_scan_args(argc, argv, "1:", index, &opts);
+    rb_get_kwargs(opts, keywords, 0, 1, &vlsb_first);
+    if (vlsb_first == Qundef || vlsb_first == Qtrue) {
+        return true;
+    }
+    if (vlsb_first == Qfalse) {
+        return false;
+    }
+    rb_raise(rb_eArgError, "lsb_first must be true or false");
+    UNREACHABLE_RETURN(false);
+}
+
+static inline uint64_t
+str_logical_to_physical_bit64(uint64_t logical, bool lsb_first)
+{
+    return lsb_first ? logical : ((logical & ~(uint64_t)7) | (7 - (logical & 7)));
+}
+
+static inline long
+str_logical_to_physical_bit(long logical, bool lsb_first)
+{
+    return lsb_first ? logical : ((logical & ~7L) | (7 - (logical & 7L)));
+}
+
+struct str_bit_location {
+    long byte_index;
+    unsigned int bit_offset;
+};
+
+static inline struct str_bit_location
+str_bit_location_from_offset(uint64_t logical, bool lsb_first)
+{
+    /*
+     * When long is 32-bit, a bit offset for a large string can be a Bignum
+     * while the byte index still fits in long, which is RSTRING_LEN's type.
+     */
+    uint64_t physical = str_logical_to_physical_bit64(logical, lsb_first);
+    struct str_bit_location location;
+    location.byte_index = (long)(physical / CHAR_BIT);
+    location.bit_offset = (unsigned int)(physical % CHAR_BIT);
+    return location;
+}
+
+static inline int
+str_get_bit(const char *ptr, long bit_index)
+{
+    return (((unsigned char)ptr[bit_index / CHAR_BIT]) >> (bit_index % CHAR_BIT)) & 1;
+}
+
+static inline int
+str_get_bit_location(const char *ptr, struct str_bit_location location)
+{
+    return (((unsigned char)ptr[location.byte_index]) >> location.bit_offset) & 1;
+}
+
+static int
+str_bit_get(int argc, VALUE *argv, VALUE str)
+{
+    VALUE index;
+    bool lsb_first = str_lsb_first(argc, argv, &index);
+    struct str_bit_offset offset = str_bit_offset_from_index(index);
+
+    if (STR_BIT_LEN(RSTRING_LEN(str)) <= offset.value) {
+        return -1;
+    }
+
+    if (offset.fits_long) {
+        return str_get_bit(RSTRING_PTR(str), str_logical_to_physical_bit(offset.long_value, lsb_first));
+    }
+    else {
+        return str_get_bit_location(RSTRING_PTR(str), str_bit_location_from_offset(offset.value, lsb_first));
+    }
+}
+
+/*
+ *  call-seq:
+ *    bit_get(offset, lsb_first: true) -> 0, 1, or nil
+ *
+ *  :include: doc/string/bit_get.rdoc
+ *
+ */
+static VALUE
+rb_str_bit_get(int argc, VALUE *argv, VALUE str)
+{
+    int bit = str_bit_get(argc, argv, str);
+    return bit < 0 ? Qnil : INT2FIX(bit);
+}
+
+/*
+ *  call-seq:
+ *    bit_set?(offset, lsb_first: true) -> true, false, or nil
+ *
+ *  :include: doc/string/bit_set_p.rdoc
+ *
+ */
+static VALUE
+rb_str_bit_set_p(int argc, VALUE *argv, VALUE str)
+{
+    int bit = str_bit_get(argc, argv, str);
+    return bit < 0 ? Qnil : RBOOL(bit);
+}
+
+enum str_bit_mutation {
+    STR_BIT_SET,
+    STR_BIT_CLEAR,
+    STR_BIT_FLIP
+};
+
+static VALUE
+str_mutate_bit(int argc, VALUE *argv, VALUE str, enum str_bit_mutation mutation)
+{
+    VALUE index;
+    bool lsb_first = str_lsb_first(argc, argv, &index);
+    struct str_bit_offset offset = str_bit_offset_from_index(index);
+    struct str_bit_location location;
+    long bit_index;
+    unsigned char *ptr;
+    unsigned char mask;
+
+    if (STR_BIT_LEN(RSTRING_LEN(str)) <= offset.value) {
+        rb_raise(rb_eIndexError, "bit index out of range");
+    }
+
+    rb_str_modify(str);
+    ptr = (unsigned char *)RSTRING_PTR(str);
+    if (offset.fits_long) {
+        bit_index = str_logical_to_physical_bit(offset.long_value, lsb_first);
+        mask = (unsigned char)(1u << (bit_index % CHAR_BIT));
+        location.byte_index = bit_index / CHAR_BIT;
+    }
+    else {
+        location = str_bit_location_from_offset(offset.value, lsb_first);
+        mask = (unsigned char)(1u << location.bit_offset);
+    }
+
+    switch (mutation) {
+      case STR_BIT_SET:
+        ptr[location.byte_index] |= mask;
+        break;
+      case STR_BIT_CLEAR:
+        ptr[location.byte_index] &= (unsigned char)~mask;
+        break;
+      case STR_BIT_FLIP:
+        ptr[location.byte_index] ^= mask;
+        break;
+    }
+
+    return str;
+}
+
+/*
+ *  call-seq:
+ *    bit_set(offset, lsb_first: true) -> self
+ *
+ *  :include: doc/string/bit_set.rdoc
+ *
+ */
+static VALUE
+rb_str_bit_set(int argc, VALUE *argv, VALUE str)
+{
+    return str_mutate_bit(argc, argv, str, STR_BIT_SET);
+}
+
+/*
+ *  call-seq:
+ *    bit_clear(offset, lsb_first: true) -> self
+ *
+ *  :include: doc/string/bit_clear.rdoc
+ *
+ */
+static VALUE
+rb_str_bit_clear(int argc, VALUE *argv, VALUE str)
+{
+    return str_mutate_bit(argc, argv, str, STR_BIT_CLEAR);
+}
+
+/*
+ *  call-seq:
+ *    bit_flip(offset, lsb_first: true) -> self
+ *
+ *  :include: doc/string/bit_flip.rdoc
+ *
+ */
+static VALUE
+rb_str_bit_flip(int argc, VALUE *argv, VALUE str)
+{
+    return str_mutate_bit(argc, argv, str, STR_BIT_FLIP);
+}
+
+static uint64_t
+str_count_bits(const unsigned char *ptr, long len)
+{
+    uint64_t count = 0;
+    long off = 0;
+    long unrolled_end = len & ~31L;
+    long aligned_end = len & ~7L;
+
+    // 32 bytes (256 bits) at a time
+    for (; off < unrolled_end; off += 32) {
+        uint64_t w0, w1, w2, w3;
+        memcpy(&w0, ptr + off, 8);
+        memcpy(&w1, ptr + off + 8, 8);
+        memcpy(&w2, ptr + off + 16, 8);
+        memcpy(&w3, ptr + off + 24, 8);
+        count += rb_popcount64(w0);
+        count += rb_popcount64(w1);
+        count += rb_popcount64(w2);
+        count += rb_popcount64(w3);
+    }
+
+    // 8 bytes (64 bits) at a time
+    for (; off < aligned_end; off += 8) {
+        uint64_t word;
+        memcpy(&word, ptr + off, 8);
+        count += rb_popcount64(word);
+    }
+
+    // remaining bytes
+    if (off < len) {
+        uint64_t word = 0;
+        int shift = 0;
+        for (; off < len; off++, shift += CHAR_BIT) {
+            word |= (uint64_t)ptr[off] << shift;
+        }
+        count += rb_popcount64(word);
+    }
+
+    return count;
+}
+
+/*
+ *  call-seq:
+ *    bit_count -> integer
+ *
+ *  :include: doc/string/bit_count.rdoc
+ *
+ */
+static VALUE
+rb_str_bit_count(VALUE str)
+{
+    return ULL2NUM(str_count_bits((const unsigned char *)RSTRING_PTR(str), RSTRING_LEN(str)));
+}
+
+static void
+str_check_bitwise_length(VALUE str, VALUE other)
+{
+    if (RSTRING_LEN(str) != RSTRING_LEN(other)) {
+        rb_raise(rb_eArgError, "operands must have the same length (%ld vs %ld)",
+                 RSTRING_LEN(str), RSTRING_LEN(other));
+    }
+}
+
+static VALUE
+str_bitwise_result(VALUE str)
+{
+    long len = RSTRING_LEN(str);
+    VALUE result = rb_str_buf_new(len);
+    rb_str_resize(result, len);
+    rb_enc_associate(result, rb_ascii8bit_encoding());
+    ENC_CODERANGE_CLEAR(result);
+    return result;
+}
+
+#define STR_DEFINE_UNARY_BITWISE_KERNEL(name, expr_word, expr_byte)         \
+    static void                                                             \
+    name(unsigned char *dst, const unsigned char *src, long len)            \
+    {                                                                       \
+        long off = 0;                                                       \
+        long unrolled_end = len & ~31L;                                     \
+        long aligned_end = len & ~7L;                                       \
+        for (; off < unrolled_end; off += 32) {                             \
+            uint64_t s0, s1, s2, s3;                                        \
+            memcpy(&s0, src + off, 8);                                      \
+            memcpy(&s1, src + off + 8, 8);                                  \
+            memcpy(&s2, src + off + 16, 8);                                 \
+            memcpy(&s3, src + off + 24, 8);                                 \
+            s0 = (expr_word(s0));                                           \
+            s1 = (expr_word(s1));                                           \
+            s2 = (expr_word(s2));                                           \
+            s3 = (expr_word(s3));                                           \
+            memcpy(dst + off, &s0, 8);                                      \
+            memcpy(dst + off + 8, &s1, 8);                                  \
+            memcpy(dst + off + 16, &s2, 8);                                 \
+            memcpy(dst + off + 24, &s3, 8);                                 \
+        }                                                                   \
+        for (; off < aligned_end; off += 8) {                               \
+            uint64_t word;                                                  \
+            memcpy(&word, src + off, 8);                                    \
+            word = (expr_word(word));                                       \
+            memcpy(dst + off, &word, 8);                                    \
+        }                                                                   \
+        for (; off < len; off++) dst[off] = (expr_byte(src[off]));          \
+    }
+
+#define STR_DEFINE_BINARY_BITWISE_KERNEL(name, expr_word, expr_byte)        \
+    static void                                                             \
+    name(unsigned char *dst, const unsigned char *lhs,                      \
+         const unsigned char *rhs, long len)                                \
+    {                                                                       \
+        long off = 0;                                                       \
+        long unrolled_end = len & ~31L;                                     \
+        long aligned_end = len & ~7L;                                       \
+        for (; off < unrolled_end; off += 32) {                             \
+            uint64_t l0, l1, l2, l3, r0, r1, r2, r3;                        \
+            memcpy(&l0, lhs + off, 8); memcpy(&r0, rhs + off, 8);           \
+            memcpy(&l1, lhs + off + 8, 8); memcpy(&r1, rhs + off + 8, 8);   \
+            memcpy(&l2, lhs + off + 16, 8); memcpy(&r2, rhs + off + 16, 8); \
+            memcpy(&l3, lhs + off + 24, 8); memcpy(&r3, rhs + off + 24, 8); \
+            l0 = expr_word(l0, r0);                                         \
+            l1 = expr_word(l1, r1);                                         \
+            l2 = expr_word(l2, r2);                                         \
+            l3 = expr_word(l3, r3);                                         \
+            memcpy(dst + off, &l0, 8);                                      \
+            memcpy(dst + off + 8, &l1, 8);                                  \
+            memcpy(dst + off + 16, &l2, 8);                                 \
+            memcpy(dst + off + 24, &l3, 8);                                 \
+        }                                                                   \
+        for (; off < aligned_end; off += 8) {                               \
+            uint64_t lhs_word, rhs_word;                                    \
+            memcpy(&lhs_word, lhs + off, 8);                                \
+            memcpy(&rhs_word, rhs + off, 8);                                \
+            lhs_word = expr_word(lhs_word, rhs_word);                       \
+            memcpy(dst + off, &lhs_word, 8);                                \
+        }                                                                   \
+        for (; off < len; off++) dst[off] = expr_byte(lhs[off], rhs[off]);  \
+    }
+
+#define STR_BITWISE_NOT_WORD(x)    (~(x))
+#define STR_BITWISE_NOT_BYTE(x)    ((unsigned char)~(x))
+#define STR_BITWISE_AND_WORD(x, y) ((x) & (y))
+#define STR_BITWISE_AND_BYTE(x, y) ((unsigned char)((x) & (y)))
+#define STR_BITWISE_OR_WORD(x, y)  ((x) | (y))
+#define STR_BITWISE_OR_BYTE(x, y)  ((unsigned char)((x) | (y)))
+#define STR_BITWISE_XOR_WORD(x, y) ((x) ^ (y))
+#define STR_BITWISE_XOR_BYTE(x, y) ((unsigned char)((x) ^ (y)))
+
+STR_DEFINE_UNARY_BITWISE_KERNEL(str_bitwise_not, STR_BITWISE_NOT_WORD, STR_BITWISE_NOT_BYTE)
+STR_DEFINE_BINARY_BITWISE_KERNEL(str_bitwise_and, STR_BITWISE_AND_WORD, STR_BITWISE_AND_BYTE)
+STR_DEFINE_BINARY_BITWISE_KERNEL(str_bitwise_or,  STR_BITWISE_OR_WORD,  STR_BITWISE_OR_BYTE)
+STR_DEFINE_BINARY_BITWISE_KERNEL(str_bitwise_xor, STR_BITWISE_XOR_WORD, STR_BITWISE_XOR_BYTE)
+
+/*
+ *  call-seq:
+ *    bitwise_not -> string
+ *
+ *  :include: doc/string/bitwise_not.rdoc
+ *
+ */
+static VALUE
+rb_str_bitwise_not(VALUE str)
+{
+    long len = RSTRING_LEN(str);
+    VALUE result = str_bitwise_result(str);
+    str_bitwise_not((unsigned char *)RSTRING_PTR(result),
+                    (const unsigned char *)RSTRING_PTR(str), len);
+    return result;
+}
+
+/*
+ *  call-seq:
+ *    bitwise_not! -> self
+ *
+ *  :include: doc/string/bitwise_not_bang.rdoc
+ *
+ */
+static VALUE
+rb_str_bitwise_not_bang(VALUE str)
+{
+    long len;
+    unsigned char *ptr;
+
+    rb_str_modify(str);
+    len = RSTRING_LEN(str);
+    ptr = (unsigned char *)RSTRING_PTR(str);
+    str_bitwise_not(ptr, ptr, len);
+    return str;
+}
+
+#define STR_DEFINE_BINARY_BITWISE_METHOD(name)                              \
+    static VALUE                                                            \
+    rb_str_bitwise_##name(VALUE str, VALUE other)                           \
+    {                                                                       \
+        long len;                                                           \
+        VALUE result;                                                       \
+        StringValue(other);                                                 \
+        str_check_bitwise_length(str, other);                               \
+        len = RSTRING_LEN(str);                                             \
+        result = str_bitwise_result(str);                                   \
+        str_bitwise_##name((unsigned char *)RSTRING_PTR(result),            \
+                           (const unsigned char *)RSTRING_PTR(str),         \
+                           (const unsigned char *)RSTRING_PTR(other), len); \
+        return result;                                                      \
+    }                                                                       \
+    static VALUE                                                            \
+    rb_str_bitwise_##name##_bang(VALUE str, VALUE other)                    \
+    {                                                                       \
+        long len;                                                           \
+        unsigned char *ptr;                                                 \
+        StringValue(other);                                                 \
+        str_check_bitwise_length(str, other);                               \
+        rb_str_modify(str);                                                 \
+        len = RSTRING_LEN(str);                                             \
+        ptr = (unsigned char *)RSTRING_PTR(str);                            \
+        str_bitwise_##name(ptr, ptr,                                        \
+                           (const unsigned char *)RSTRING_PTR(other), len); \
+        return str;                                                         \
+    }
+
+STR_DEFINE_BINARY_BITWISE_METHOD(and)
+STR_DEFINE_BINARY_BITWISE_METHOD(or)
+STR_DEFINE_BINARY_BITWISE_METHOD(xor)
+
 static VALUE
 str_byte_substr(VALUE str, long beg, long len, int empty)
 {
@@ -12924,6 +13403,20 @@ Init_String(void)
     rb_define_method(rb_cString, "chr", rb_str_chr, 0);
     rb_define_method(rb_cString, "getbyte", rb_str_getbyte, 1);
     rb_define_method(rb_cString, "setbyte", rb_str_setbyte, 2);
+    rb_define_method(rb_cString, "bit_get", rb_str_bit_get, -1);
+    rb_define_method(rb_cString, "bit_set?", rb_str_bit_set_p, -1);
+    rb_define_method(rb_cString, "bit_set", rb_str_bit_set, -1);
+    rb_define_method(rb_cString, "bit_clear", rb_str_bit_clear, -1);
+    rb_define_method(rb_cString, "bit_flip", rb_str_bit_flip, -1);
+    rb_define_method(rb_cString, "bit_count", rb_str_bit_count, 0);
+    rb_define_method(rb_cString, "bitwise_not", rb_str_bitwise_not, 0);
+    rb_define_method(rb_cString, "bitwise_not!", rb_str_bitwise_not_bang, 0);
+    rb_define_method(rb_cString, "bitwise_and", rb_str_bitwise_and, 1);
+    rb_define_method(rb_cString, "bitwise_and!", rb_str_bitwise_and_bang, 1);
+    rb_define_method(rb_cString, "bitwise_or", rb_str_bitwise_or, 1);
+    rb_define_method(rb_cString, "bitwise_or!", rb_str_bitwise_or_bang, 1);
+    rb_define_method(rb_cString, "bitwise_xor", rb_str_bitwise_xor, 1);
+    rb_define_method(rb_cString, "bitwise_xor!", rb_str_bitwise_xor_bang, 1);
     rb_define_method(rb_cString, "byteslice", rb_str_byteslice, -1);
     rb_define_method(rb_cString, "bytesplice", rb_str_bytesplice, -1);
     rb_define_method(rb_cString, "scrub", str_scrub, -1);

--- a/string.c
+++ b/string.c
@@ -6751,7 +6751,12 @@ rb_str_setbyte(VALUE str, VALUE index, VALUE value)
     return value;
 }
 
-#define STR_BIT_LEN(byte_len) ((uint64_t)(byte_len) * CHAR_BIT)
+static inline bool
+str_bit_offset_out_of_range(long byte_len, uint64_t bit_offset)
+{
+    /* Compare byte indexes to avoid overflowing byte_len * CHAR_BIT. */
+    return bit_offset / CHAR_BIT >= (uint64_t)byte_len;
+}
 
 /*
  * Keep both the full bit offset and its long representation.  Most calls use a
@@ -6879,7 +6884,7 @@ str_bit_get(int argc, VALUE *argv, VALUE str)
     bool lsb_first = str_lsb_first(argc, argv, &index);
     struct str_bit_offset offset = str_bit_offset_from_index(index);
 
-    if (STR_BIT_LEN(RSTRING_LEN(str)) <= offset.value) {
+    if (str_bit_offset_out_of_range(RSTRING_LEN(str), offset.value)) {
         return -1;
     }
 
@@ -6936,7 +6941,7 @@ str_mutate_bit(int argc, VALUE *argv, VALUE str, enum str_bit_mutation mutation)
     unsigned char *ptr;
     unsigned char mask;
 
-    if (STR_BIT_LEN(RSTRING_LEN(str)) <= offset.value) {
+    if (str_bit_offset_out_of_range(RSTRING_LEN(str), offset.value)) {
         rb_raise(rb_eIndexError, "bit index out of range");
     }
 

--- a/test/ruby/test_string.rb
+++ b/test/ruby/test_string.rb
@@ -1026,6 +1026,119 @@ CODE
     assert_raise(FrozenError) { S('foo').freeze.setbyte(0, 0x61) }
   end
 
+  def test_bit_get
+    s = S("\xAA\x80")
+    assert_equal(0, s.bit_get(0))
+    assert_equal(1, s.bit_get(1))
+    assert_equal(1, s.bit_get(7))
+    assert_equal(1, s.bit_get(0, lsb_first: false))
+    assert_equal(0, s.bit_get(1, lsb_first: false))
+    assert_equal(1, s.bit_get(8, lsb_first: false))
+    assert_nil(s.bit_get(16))
+    assert_raise(IndexError) { s.bit_get(-1) }
+    assert_raise(ArgumentError) { s.bit_get(2**100) }
+    assert_raise(ArgumentError) { s.bit_get(0, lsb_first: nil) }
+  end
+
+  def test_bit_set_p
+    s = S("\xAA\x80")
+    assert_equal(false, s.bit_set?(0))
+    assert_equal(true, s.bit_set?(1))
+    assert_equal(true, s.bit_set?(7))
+    assert_equal(true, s.bit_set?(0, lsb_first: false))
+    assert_equal(false, s.bit_set?(1, lsb_first: false))
+    assert_equal(true, s.bit_set?(8, lsb_first: false))
+    assert_nil(s.bit_set?(16))
+    assert_raise(IndexError) { s.bit_set?(-1) }
+    assert_raise(ArgumentError) { s.bit_set?(2**100) }
+    assert_raise(ArgumentError) { s.bit_set?(0, lsb_first: nil) }
+  end
+
+  def test_bit_set_clear_flip
+    s = S("\x00")
+    assert_same(s, s.bit_set(1))
+    assert_equal(S("\x02"), s)
+    assert_same(s, s.bit_clear(1))
+    assert_equal(S("\x00"), s)
+    assert_same(s, s.bit_flip(1))
+    assert_equal(S("\x02"), s)
+    assert_same(s, s.bit_flip(1))
+    assert_equal(S("\x00"), s)
+
+    s.bit_set(1, lsb_first: false)
+    assert_equal(S("\x40"), s)
+    s.bit_clear(1, lsb_first: false)
+    assert_equal(S("\x00"), s)
+
+    s = S("\x00\x00")
+    s.bit_set(8, lsb_first: false)
+    assert_equal(S("\x00\x80"), s)
+    s.bit_clear(8, lsb_first: false)
+    assert_equal(S("\x00\x00"), s)
+    s.bit_flip(8, lsb_first: false)
+    assert_equal(S("\x00\x80"), s)
+
+    assert_raise(IndexError) { S("\x00").bit_set(8) }
+    assert_raise(IndexError) { S("\x00").bit_set(-1) }
+    assert_raise(IndexError) { S("\x00").bit_clear(8) }
+    assert_raise(IndexError) { S("\x00").bit_clear(-1) }
+    assert_raise(IndexError) { S("\x00").bit_flip(8) }
+    assert_raise(IndexError) { S("\x00").bit_flip(-1) }
+    assert_raise(ArgumentError) { S("\x00").bit_set(0, lsb_first: nil) }
+    assert_raise(FrozenError) { S("\x00").freeze.bit_set(0) }
+
+    shared = S("fooXbar").split(S("X")).last
+    shared.bit_set(0)
+    assert_equal(S("car"), shared)
+  end
+
+  def test_bit_count
+    assert_equal(0, S("").bit_count)
+    assert_equal(0, S("\x00").bit_count)
+    assert_equal(8, S("\xFF").bit_count)
+    assert_equal(8, S("\xAA\xF0").bit_count)
+    assert_raise(ArgumentError) { S("\x00").bit_count(0) }
+    assert_raise(ArgumentError) { S("\x00").bit_count(lsb_first: false) }
+  end
+
+  def test_bitwise
+    s = S("\x00\xAA")
+    result = s.bitwise_not
+    assert_equal(S("\xFF\x55").b, result)
+    assert_not_same(s, result)
+    assert_equal(S("\x00\xAA"), s)
+    assert_equal(Encoding::BINARY, result.encoding)
+
+    assert_same(s, s.bitwise_not!)
+    assert_equal(S("\xFF\x55"), s)
+
+    assert_equal(S("\xC0").b, S("\xF0").bitwise_and(S("\xCC")))
+    assert_equal(S("\xFC").b, S("\xF0").bitwise_or(S("\x0C")))
+    assert_equal(S("\x3C").b, S("\xF0").bitwise_xor(S("\xCC")))
+    assert_equal(Encoding::BINARY, S("\xF0").force_encoding("UTF-8").bitwise_and(S("\xCC")).encoding)
+    assert_equal(Encoding::BINARY, S("\xF0").force_encoding("UTF-8").bitwise_or(S("\x0C")).encoding)
+    assert_equal(Encoding::BINARY, S("\xF0").force_encoding("UTF-8").bitwise_xor(S("\xCC")).encoding)
+
+    s = S("\xF0")
+    assert_same(s, s.bitwise_and!(S("\xCC")))
+    assert_equal(S("\xC0"), s)
+    assert_same(s, s.bitwise_or!(S("\x0C")))
+    assert_equal(S("\xCC"), s)
+    assert_same(s, s.bitwise_xor!(S("\xFF")))
+    assert_equal(S("\x33"), s)
+
+    other = Object.new
+    def other.to_str
+      "\xCC"
+    end
+    assert_equal(S("\xC0").b, S("\xF0").bitwise_and(other))
+
+    assert_raise(ArgumentError) { S("\x00").bitwise_and(S("\x00\x00")) }
+    assert_raise(TypeError) { S("\x00").bitwise_or(Object.new) }
+    assert_raise(FrozenError) { S("\x00").freeze.bitwise_not! }
+    assert_raise(FrozenError) { S("\x00").freeze.bitwise_xor!(S("\x00")) }
+  end
+
   def test_each_codepoint
     # Single byte optimization
     assert_equal 65, S("ABC").each_codepoint.next


### PR DESCRIPTION
This patch adds the following methods to String class:

* String#bit_get(offset, lsb_first: true) -> 1 | 0 | nil
* String#bit_set?(offset, lsb_first: true) -> true | false | nil
* String#bit_set(offset, lsb_first: true) -> self
* String#bit_clear(offset, lsb_first: true) -> self
* String#bit_flip(offset, lsb_first: true) -> self
* String#bit_count -> Integer
* String#bitwise_not -> String
* String#bitwise_not! -> self
* String#bitwise_and(other) -> String
* String#bitwise_and!(other) -> self
* String#bitwise_or(other) -> String
* String#bitwise_or!(other) -> self
* String#bitwise_xor(other) -> String
* String#bitwise_xor!(other) -> self

Other than implementation, tests, specs, and docs are added.

Link: [Feature #22118]

## Note

In `string.c`, I wrote some big macros that create method functions and helper functions for `bitwise_*` methods:

* STR_DEFINE_BINARY_BITWISE_METHOD
* STR_DEFINE_UNARY_BITWISE_KERNEL
* STR_DEFINE_BINARY_BITWISE_KERNEL

While using macros like this may reduce maintainability, I think it's acceptable because there are no plans to extend the `bitwise_*` methods beyond this proposal, and the logic is stable.

On the other hand, other methods such as `bit_at` and `bit_count` are planned to have argument extensions in the future.