### PR TITLE
Add timeout scale to macOS ModGC CI jobs

### DIFF
--- a/.github/workflows/modgc.yml
+++ b/.github/workflows/modgc.yml
@@ -131,6 +131,10 @@ jobs:
           echo "TESTS=${TESTS}" >> $GITHUB_ENV
         if: ${{ matrix.test_task == 'check' && matrix.skipped_tests }}
 
+      - name: Set timeout scale
+        run: echo "RUBY_TEST_TIMEOUT_SCALE=10" >> $GITHUB_ENV # subprocess assertion timeouts flake on slower/contended macOS runners, especially with the slower MMTk GC
+        if: ${{ contains(matrix.os, 'macos') }}
+
       - name: Set up Launchable
         id: launchable
         uses: ./.github/actions/launchable/setup


### PR DESCRIPTION
Same fix as commit 8e8682fc2312164c49d3bf4a15d1f464d2644598