### PR TITLE
[DOC] Harmonize symlink methods

### DIFF
--- a/file.c
+++ b/file.c
@@ -1837,14 +1837,23 @@ rb_file_pipe_p(VALUE obj, VALUE fname)
 }
 
 /*
+ * :markup: markdown
+ *
  * call-seq:
- *   File.symlink?(filepath) -> true or false
+ *   File.symlink?(path) -> true or false
  *
- * Returns +true+ if +filepath+ points to a symbolic link, +false+ otherwise:
+ * Returns whether the entry at `path` is a symbolic link:
  *
- *   symlink = File.symlink('t.txt', 'symlink')
- *   File.symlink?('symlink') # => true
- *   File.symlink?('t.txt')   # => false
+ * ```ruby
+ * path = 'doc/t.tmp'
+ * link_path = 'lib/u.tmp'
+ * File.write(path, 'foo')
+ * File.symlink?(path)      # => false
+ * File.symlink(path, link_path)
+ * File.symlink?(link_path) # => true
+ * File.delete(path)
+ * File.delete(link_path)
+ * ```
  *
  */
 
@@ -6347,18 +6356,24 @@ rb_stat_p(VALUE obj)
 }
 
 /*
+ *  :markup: markdown
+ *
  *  call-seq:
- *     stat.symlink?    -> true or false
+ *    symlink? -> true or false
  *
- *  Returns <code>true</code> if <i>stat</i> is a symbolic link,
- *  <code>false</code> if it isn't or if the operating system doesn't
- *  support this feature. As File::stat automatically follows symbolic
- *  links, #symlink? will always be <code>false</code> for an object
- *  returned by File::stat.
+ *  Returns whether the entry in `self` is a symbolic link:
  *
- *     File.symlink("testfile", "alink")   #=> 0
- *     File.stat("alink").symlink?         #=> false
- *     File.lstat("alink").symlink?        #=> true
+ *  ```ruby
+ *  path = 'doc/t.tmp'
+ *  link_path = 'lib/u.tmp'
+ *  File.write(path, 'foo')
+ *  File.symlink(path, link_path)
+ *  File.stat(path).symlink?       # => false
+ *  File.stat(link_path).symlink?  # Raises Errno::NOENT; entry is not a file.
+ *  File.lstat(link_path).symlink? # => true
+ *  File.delete(path)
+ *  File.delete(link_path)
+ *  ```
  *
  */
 

--- a/file.c
+++ b/file.c
@@ -1842,8 +1842,19 @@ rb_file_pipe_p(VALUE obj, VALUE fname)
  * call-seq:
  *   File.symlink?(path) -> true or false
  *
- * Returns whether the entry at `path` is a symbolic link;
- * see ::symlink.
+ * Returns whether the entry at `path` is a symbolic link:
+ *
+ * ```ruby
+ * # Create paths.
+ * file_path = 'doc/extension.rdoc'         # => "doc/extension.rdoc"
+ * target_path = File.join('..', file_path) # => "../doc/extension.rdoc"
+ * link_path = 'lib/u.tmp'                  # => "lib/u.tmp"
+ * File.symlink?(link_path)                 # => false
+ * # Create link and verify.
+ * File.symlink(target_path, link_path)
+ * File.symlink?(link_path)                 # => true
+ * File.delete(link_path)                   # Clean up.
+ * ```
  *
  */
 
@@ -3503,8 +3514,18 @@ rb_file_s_symlink(VALUE klass, VALUE from, VALUE to)
  *  call-seq:
  *     File.readlink(link_path) -> path
  *
- *  Returns the string path to the entry referenced by the given `link_path`;
- *  see ::symlink.
+ *  Returns the string path to the entry referenced by the given `link_path`:
+ *
+ *  ```ruby
+ *  # Create paths.
+ *  file_path = 'doc/extension.rdoc'         # => "doc/extension.rdoc"
+ *  target_path = File.join('..', file_path) # => "../doc/extension.rdoc"
+ *  link_path = 'lib/u.tmp'                  # => "lib/u.tmp"
+ *  File.symlink(target_path, link_path)
+ *  File.readlink(link_path)                 # => "../doc/extension.rdoc"
+ *  File.delete(link_path)                   # Clean up.
+ *  ```
+ *
  */
 
 static VALUE

--- a/file.c
+++ b/file.c
@@ -1842,18 +1842,8 @@ rb_file_pipe_p(VALUE obj, VALUE fname)
  * call-seq:
  *   File.symlink?(path) -> true or false
  *
- * Returns whether the entry at `path` is a symbolic link:
- *
- * ```ruby
- * path = 'doc/t.tmp'
- * link_path = 'lib/u.tmp'
- * File.write(path, 'foo')
- * File.symlink?(path)      # => false
- * File.symlink(path, link_path)
- * File.symlink?(link_path) # => true
- * File.delete(path)
- * File.delete(link_path)
- * ```
+ * Returns whether the entry at `path` is a symbolic link;
+ * see ::symlink.
  *
  */
 
@@ -3476,16 +3466,29 @@ rb_file_s_link(VALUE klass, VALUE from, VALUE to)
  *  Creates a symbolic link at `link_path` to the entry at `path`:
  *
  *  ```ruby
- *  path = 'doc/t.tmp'
- *  link_path = 'lib/u.tmp'
- *  File.write(path, 'foo')
- *  File.symlink(path, link_path)
+ *  # Create paths.
+ *  file_path = 'doc/t.tmp'                  # => "doc/t.tmp"
+ *  target_path = File.join('..', file_path) # => "../doc/t.tmp"
+ *  link_path = 'lib/u.tmp'                  # => "lib/u.tmp"
+ *  # Create target file.
+ *  File.write(file_path, 'foo')
+ *  # Check state.
+ *  File.exist?(link_path)   # => false
+ *  File.symlink?(link_path) # => false
+ *  File.read(link_path)     # Raises Errno::ENOENT, No such file or directory.
+ *  File.readlink(link_path) # Raises Errno::ENOENT, No such file or directory.
+ *  # Make symlink and check state.
+ *  File.symlink(target_path, link_path)
+ *  File.exist?(link_path)   # => true
  *  File.symlink?(link_path) # => true
- *  File.file?(link_path)    # => false
- *  File.delete(path)
+ *  File.read(link_path)     # => "foo"
+ *  File.readlink(link_path) # => "../doc/t.tmp"
+ *  # Clean up.
+ *  File.delete(file_path)
  *  File.delete(link_path)
  *  ```
  *
+ *  See also: ::read, ::readlink, ::symlink?.
  */
 
 static VALUE

--- a/file.c
+++ b/file.c
@@ -3510,14 +3510,13 @@ rb_file_s_symlink(VALUE klass, VALUE from, VALUE to)
 
 #ifdef HAVE_READLINK
 /*
+ *  :markup: markdown
+ *
  *  call-seq:
- *     File.readlink(link_name)  ->  file_name
+ *     File.readlink(link_path) -> path
  *
- *  Returns the name of the file referenced by the given link.
- *  Not available on all platforms.
- *
- *     File.symlink("testfile", "link2test")   #=> 0
- *     File.readlink("link2test")              #=> "testfile"
+ *  Returns the string path to the entry referenced by the given `link_path`;
+ *  see ::symlink.
  */
 
 static VALUE

--- a/file.c
+++ b/file.c
@@ -3457,14 +3457,25 @@ rb_file_s_link(VALUE klass, VALUE from, VALUE to)
 
 #ifdef HAVE_SYMLINK
 /*
+ * :markup: markdown
+ *
  *  call-seq:
- *     File.symlink(old_name, new_name)   -> 0
+ *    File.symlink(path, link_path) -> 0
  *
- *  Creates a symbolic link called <i>new_name</i> for the existing file
- *  <i>old_name</i>. Raises a NotImplemented exception on
- *  platforms that do not support symbolic links.
+ *  Not supported on some platforms.
  *
- *     File.symlink("testfile", "link2test")   #=> 0
+ *  Creates a symbolic link at `link_path` to the entry at `path`:
+ *
+ *  ```ruby
+ *  path = 'doc/t.tmp'
+ *  link_path = 'lib/u.tmp'
+ *  File.write(path, 'foo')
+ *  File.symlink(path, link_path)
+ *  File.symlink?(link_path) # => true
+ *  File.file?(link_path)    # => false
+ *  File.delete(path)
+ *  File.delete(link_path)
+ *  ```
  *
  */
 

--- a/file.c
+++ b/file.c
@@ -3470,6 +3470,7 @@ rb_file_s_link(VALUE klass, VALUE from, VALUE to)
  *  file_path = 'doc/extension.rdoc'             # => "doc/extension.rdoc"
  *  target_path = File.join('..', file_path)     # => "../doc/extension.rdoc"
  *  link_path = 'lib/u.tmp'                      # => "lib/u.tmp"
+ *  # Create link and verify.
  *  File.symlink(target_path, link_path)
  *  File.read(file_path) == File.read(link_path) # => true
  *  File.delete(link_path)                       # Clean up.

--- a/file.c
+++ b/file.c
@@ -3467,25 +3467,12 @@ rb_file_s_link(VALUE klass, VALUE from, VALUE to)
  *
  *  ```ruby
  *  # Create paths.
- *  file_path = 'doc/t.tmp'                  # => "doc/t.tmp"
- *  target_path = File.join('..', file_path) # => "../doc/t.tmp"
- *  link_path = 'lib/u.tmp'                  # => "lib/u.tmp"
- *  # Create target file.
- *  File.write(file_path, 'foo')
- *  # Check state.
- *  File.exist?(link_path)   # => false
- *  File.symlink?(link_path) # => false
- *  File.read(link_path)     # Raises Errno::ENOENT, No such file or directory.
- *  File.readlink(link_path) # Raises Errno::ENOENT, No such file or directory.
- *  # Make symlink and check state.
+ *  file_path = 'doc/extension.rdoc'             # => "doc/extension.rdoc"
+ *  target_path = File.join('..', file_path)     # => "../doc/extension.rdoc"
+ *  link_path = 'lib/u.tmp'                      # => "lib/u.tmp"
  *  File.symlink(target_path, link_path)
- *  File.exist?(link_path)   # => true
- *  File.symlink?(link_path) # => true
- *  File.read(link_path)     # => "foo"
- *  File.readlink(link_path) # => "../doc/t.tmp"
- *  # Clean up.
- *  File.delete(file_path)
- *  File.delete(link_path)
+ *  File.read(file_path) == File.read(link_path) # => true
+ *  File.delete(link_path)                       # Clean up.
  *  ```
  *
  *  See also: ::read, ::readlink, ::symlink?.

--- a/file.c
+++ b/file.c
@@ -6372,7 +6372,7 @@ rb_stat_p(VALUE obj)
  *  File.write(path, 'foo')
  *  File.symlink(path, link_path)
  *  File.stat(path).symlink?       # => false
- *  File.stat(link_path).symlink?  # Raises Errno::NOENT; entry is not a file.
+ *  File.stat(link_path).symlink?  # Raises Errno::ENOENT; entry is not a file.
  *  File.lstat(link_path).symlink? # => true
  *  File.delete(path)
  *  File.delete(link_path)

--- a/pathname_builtin.rb
+++ b/pathname_builtin.rb
@@ -1449,8 +1449,18 @@ class Pathname    # * File *
   # call-seq:
   #   readlink -> new_pathname
   #
-  # Returns a new pathname containing the string path to the entry referenced by `self`;
-  # see #make_symlink.
+  # Returns a new pathname containing the string path to the entry referenced by `self`:
+  #
+  # ```ruby
+  # # Create Pathnames.
+  # file_pn = Pathname('doc/extension.rdoc') # => #<Pathname:doc/extension.rdoc>
+  # target_pn = Pathname('..').join(file_pn) # => #<Pathname:../doc/extension.rdoc>
+  # link_pn = Pathname('lib/u.tmp')          # => #<Pathname:lib/u.tmp>
+  # link_pn.make_symlink(target_pn)
+  # link_pn.readlink                         # => #<Pathname:../doc/extension.rdoc>
+  # link_pn.delete
+  # ```
+  #
   def readlink() self.class.new(File.readlink(@path)) end
 
   # See <tt>File.rename</tt>.  Rename the file.
@@ -1501,7 +1511,7 @@ class Pathname    # * File *
   # # Create link and verify.
   # link_pn.make_symlink(target_pn)
   # file_pn.read == link_pn.read             # => true
-  # link_pn.delete
+  # link_pn.delete                           # Clean up.
   # ```
   #
   # See also: #read, #readlink, #symlink?.
@@ -1854,8 +1864,20 @@ class Pathname    # * FileTest *
   # call-seq:
   #   symlink? -> true or false
   #
-  # Returns whether the entry at the path in `self` is a symbolic link;
-  # see #make_symlink.
+  # Returns whether the entry at the path in `self` is a symbolic link:
+  #
+  # ```ruby
+  # # Create Pathnames.
+  # file_pn = Pathname('doc/extension.rdoc') # => #<Pathname:doc/extension.rdoc>
+  # target_pn = Pathname('..').join(file_pn) # => #<Pathname:../doc/extension.rdoc>
+  # link_pn = Pathname('lib/u.tmp')          # => #<Pathname:lib/u.tmp>
+  # link_pn.symlink?                         # => false
+  # # Create link.
+  # link_pn.make_symlink(target_pn)
+  # link_pn.symlink?                         # => true
+  # link_pn.delete                           # Clean up.
+  # ```
+  #
   def symlink?() FileTest.symlink?(@path) end
 
   # See <tt>FileTest.writable?</tt>.

--- a/pathname_builtin.rb
+++ b/pathname_builtin.rb
@@ -1480,7 +1480,24 @@ class Pathname    # * File *
   #
   def lstat() File.lstat(@path) end
 
-  # See <tt>File.symlink</tt>.  Creates a symbolic link.
+  # :markup: markdown
+  #
+  # call-seq:
+  #   make_symlink(path) -> 0
+  #
+  # Creates a symbolic link at the path in `self` to the entry at `path`:
+  #
+  # ```ruby
+  # path = 'doc/t.tmp'
+  # link_path = 'lib/u.tmp'
+  # File.write(path, 'foo')
+  # Pathname(link_path).make_symlink(path)
+  # File.symlink?(link_path) # => true
+  # File.file?(link_path)    # => false
+  # File.delete(path)
+  # File.delete(link_path)
+  # ```
+  #
   def make_symlink(old) File.symlink(old, @path) end
 
   # See <tt>File.truncate</tt>.  Truncate the file to +length+ bytes.

--- a/pathname_builtin.rb
+++ b/pathname_builtin.rb
@@ -1495,24 +1495,12 @@ class Pathname    # * File *
   #
   # ```ruby
   # # Create Pathnames.
-  # file_pn = Pathname('doc/t.tmp')          # => #<Pathname:doc/t.tmp>
-  # target_pn = Pathname('..').join(file_pn) # => #<Pathname:../doc/t.tmp>
+  # file_pn = Pathname('doc/extension.rdoc') # => #<Pathname:doc/extension.rdoc>
+  # target_pn = Pathname('..').join(file_pn) # => #<Pathname:../doc/extension.rdoc>
   # link_pn = Pathname('lib/u.tmp')          # => #<Pathname:lib/u.tmp>
-  # # Create target file.
-  # file_pn.write('foo')
-  # # Check state.
-  # link_pn.exist?   # => false
-  # link_pn.symlink? # => false
-  # link_pn.read     # Raises Errno::ENOENT, No such file or directory.
-  # link_pn.readlink # Raises Errno::ENOENT, No such file or directory.
-  # # Make symlink and check state.
+  # # Create link and verify.
   # link_pn.make_symlink(target_pn)
-  # link_pn.exist?   # => true
-  # link_pn.symlink? # => true
-  # link_pn.read     # => "foo"
-  # link_pn.readlink # => #<Pathname:../doc/t.tmp>
-  # # Clean up.
-  # file_pn.delete
+  # file_pn.read == link_pn.read             # => true
   # link_pn.delete
   # ```
   #

--- a/pathname_builtin.rb
+++ b/pathname_builtin.rb
@@ -1488,16 +1488,24 @@ class Pathname    # * File *
   # Creates a symbolic link at the path in `self` to the entry at `path`:
   #
   # ```ruby
-  # path = 'doc/t.tmp'
-  # link_path = 'lib/u.tmp'
-  # File.write(path, 'foo')
-  # Pathname(link_path).make_symlink(path)
-  # File.symlink?(link_path) # => true
-  # File.file?(link_path)    # => false
-  # File.delete(path)
-  # File.delete(link_path)
+  # # Create target file.
+  # File.write('doc/t.tmp', 'foo')
+  # # Create Pathnames.
+  # target_pn = Pathname('../doc/t.tmp')
+  # link_pn = Pathname('lib/u.tmp')
+  # link_pn.symlink? # => false
+  # # Make symlink and check state.
+  # link_pn.make_symlink(target_pn)
+  # link_pn.symlink? # => true
+  # link_pn.readlink # => #<Pathname:../doc/t.tmp>
+  # link_pn.exist?   # => true
+  # link_pn.read     # => "foo"
+  # # Clean up.
+  # link_pn.delete
+  # File.delete('doc/t.tmp')
   # ```
   #
+  # See also: #read, #readlink, #symlink?.
   def make_symlink(old) File.symlink(old, @path) end
 
   # See <tt>File.truncate</tt>.  Truncate the file to +length+ bytes.
@@ -1847,19 +1855,8 @@ class Pathname    # * FileTest *
   # call-seq:
   #   symlink? -> true or false
   #
-  # Returns whether the entry at the path in `self` is a symbolic link:
-  #
-  # ```ruby
-  # path = 'doc/t.tmp'
-  # link_path = 'lib/u.tmp'
-  # File.write(path, 'foo')
-  # File.symlink?(path)      # => false
-  # Pathname(link_path).make_symlink(path)
-  # File.symlink?(link_path) # => true
-  # File.delete(path)
-  # File.delete(link_path)
-  # ```
-  #
+  # Returns whether the entry at the path in `self` is a symbolic link;
+  # see #make_symlink.
   def symlink?() FileTest.symlink?(@path) end
 
   # See <tt>FileTest.writable?</tt>.

--- a/pathname_builtin.rb
+++ b/pathname_builtin.rb
@@ -1444,7 +1444,13 @@ class Pathname    # * File *
     File.open(@path, ...)
   end
 
-  # See <tt>File.readlink</tt>.  Read symbolic link.
+  # :markup: markdown
+  #
+  # call-seq:
+  #   readlink -> new_pathname
+  #
+  # Returns a new pathname containing the string path to the entry referenced by `self`;
+  # see #make_symlink.
   def readlink() self.class.new(File.readlink(@path)) end
 
   # See <tt>File.rename</tt>.  Rename the file.

--- a/pathname_builtin.rb
+++ b/pathname_builtin.rb
@@ -1488,21 +1488,26 @@ class Pathname    # * File *
   # Creates a symbolic link at the path in `self` to the entry at `path`:
   #
   # ```ruby
-  # # Create target file.
-  # File.write('doc/t.tmp', 'foo')
   # # Create Pathnames.
-  # target_pn = Pathname('../doc/t.tmp')
-  # link_pn = Pathname('lib/u.tmp')
+  # file_pn = Pathname('doc/t.tmp')          # => #<Pathname:doc/t.tmp>
+  # target_pn = Pathname('..').join(file_pn) # => #<Pathname:../doc/t.tmp>
+  # link_pn = Pathname('lib/u.tmp')          # => #<Pathname:lib/u.tmp>
+  # # Create target file.
+  # file_pn.write('foo')
+  # # Check state.
+  # link_pn.exist?   # => false
   # link_pn.symlink? # => false
+  # link_pn.read     # Raises Errno::ENOENT, No such file or directory.
+  # link_pn.readlink # Raises Errno::ENOENT, No such file or directory.
   # # Make symlink and check state.
   # link_pn.make_symlink(target_pn)
-  # link_pn.symlink? # => true
-  # link_pn.readlink # => #<Pathname:../doc/t.tmp>
   # link_pn.exist?   # => true
+  # link_pn.symlink? # => true
   # link_pn.read     # => "foo"
+  # link_pn.readlink # => #<Pathname:../doc/t.tmp>
   # # Clean up.
+  # file_pn.delete
   # link_pn.delete
-  # File.delete('doc/t.tmp')
   # ```
   #
   # See also: #read, #readlink, #symlink?.

--- a/pathname_builtin.rb
+++ b/pathname_builtin.rb
@@ -1839,11 +1839,27 @@ class Pathname    # * FileTest *
 
   # See <tt>FileTest.size?</tt>.
   def size?() FileTest.size?(@path) end
-
   # See <tt>FileTest.sticky?</tt>.
   def sticky?() FileTest.sticky?(@path) end
 
-  # See <tt>FileTest.symlink?</tt>.
+  # :markup: markdown
+  #
+  # call-seq:
+  #   symlink? -> true or false
+  #
+  # Returns whether the entry at the path in `self` is a symbolic link:
+  #
+  # ```ruby
+  # path = 'doc/t.tmp'
+  # link_path = 'lib/u.tmp'
+  # File.write(path, 'foo')
+  # File.symlink?(path)      # => false
+  # Pathname(link_path).make_symlink(path)
+  # File.symlink?(link_path) # => true
+  # File.delete(path)
+  # File.delete(link_path)
+  # ```
+  #
   def symlink?() FileTest.symlink?(@path) end
 
   # See <tt>FileTest.writable?</tt>.


### PR DESCRIPTION
Treats:

- File::symlink
- File::symlink?
- File::readlink
- Pathname#make_symlink
- Pathname#symlink?
- Pathname#readlink

Does not treat:

- FileUtils::symlink, FileUtils::ln_s
- FileUtils::symlink
- File::Stat#symlink?
