### PR TITLE
Fix flaky TCPSocket#local_address implicit-hostname spec

### DIFF
--- a/spec/ruby/library/socket/tcpsocket/local_address_spec.rb
+++ b/spec/ruby/library/socket/tcpsocket/local_address_spec.rb
@@ -65,7 +65,13 @@ describe 'TCPSocket#local_address' do
 
       describe 'the returned Addrinfo' do
         it 'uses the correct IP address' do
-          @sock.local_address.ip_address.should == @host
+          # An implicit (nil) hostname resolves to the loopback of either family
+          # and Happy Eyeballs prefers IPv6, so the connection is not guaranteed
+          # to land on @host: under parallel runs an unrelated listener on
+          # ::1:<same ephemeral port> can be reached instead, making @host a
+          # flaky expectation (local_address would be ::1). The local end always
+          # matches the family actually connected, so compare against the peer.
+          @sock.local_address.ip_address.should == @sock.remote_address.ip_address
         end
       end
     end


### PR DESCRIPTION
The "using an implicit hostname" example connects with TCPSocket.new(nil, port) to a server bound to the IPv4 loopback, then asserts that local_address.ip_address equals @host ("127.0.0.1"). This is flaky.

A nil hostname resolves to the loopback of both families, and Happy Eyeballs prefers IPv6, so the connection is not guaranteed to reach the IPv4 test server. IPv4 and IPv6 can share the same ephemeral port number (v6only), so under parallel runs (-j20) an unrelated listener on ::1:<same port> can be reached instead. local_address then comes back as "::1" and the spec fails.

The invariant the example actually wants to check is that local_address reflects the connection's family, which always matches the peer. Compare against remote_address.ip_address instead of @host: deterministic in a clean environment and robust to the cross-family ephemeral-port collision.

Verified: the spec passes normally, and with a forced ::1 listener on the same port the old `== @host` assertion fails while `== remote` holds.

(Imported from ruby/spec; should be upstreamed there.)

Error:
  TCPSocket#local_address using IPv4 using an implicit hostname the returned
  Addrinfo uses the correct IP address FAILED
  Expected "::1" == "127.0.0.1" to be truthy but was false
  spec/ruby/library/socket/tcpsocket/local_address_spec.rb:68

CI: https://ci.rvm.jp/results/trunk@ruby-sp3/6380323
Log: https://ci.rvm.jp/logfiles/brlog.trunk.20260616-071309