### PR TITLE
Don't fail CI automation jobs on best-effort steps

### DIFF
--- a/.github/workflows/post_push.yml
+++ b/.github/workflows/post_push.yml
@@ -28,6 +28,7 @@ jobs:
         if: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/ruby_') }}
 
       - name: Fetch changesets on bugs.ruby-lang.org
+        continue-on-error: true
         run: |
           curl "https://bugs.ruby-lang.org/sys/fetch_changesets?key=${REDMINE_SYS_API_KEY}" -s --fail-with-body -w '* status: %{http_code}\n'
         env:

--- a/.github/workflows/pr-playground.yml
+++ b/.github/workflows/pr-playground.yml
@@ -83,7 +83,8 @@ jobs:
               });
               const artifact = artifacts.find(artifact => artifact.name == 'github-pr-info');
               if (!artifact) {
-                throw new Error('Cannot find github-pr-info.txt artifact');
+                core.warning('Cannot find github-pr-info.txt artifact; skipping');
+                return null;
               }
 
               const { data } = await github.rest.actions.downloadArtifact({
@@ -99,6 +100,10 @@ jobs:
             }
 
             const prNumber = await derivePRNumber();
+            if (!prNumber) {
+              core.info(`No PR number could be derived; skipping.`);
+              return;
+            }
 
             const { data: pr } = await github.rest.pulls.get({
               owner: context.repo.owner,


### PR DESCRIPTION
Two automation workflows on master turn red on nearly every run even though the work they exist to do has already succeeded.