### PR TITLE
Avoid timeout in `test_dump_all_with_ractors`

### DIFF
--- a/test/objspace/test_objspace.rb
+++ b/test/objspace/test_objspace.rb
@@ -849,7 +849,7 @@ class TestObjSpace < Test::Unit::TestCase
           Tempfile.create do |f|
             ObjectSpace.dump_all(output: f)
             f.close
-            File.readlines(f.path).each do |line|
+            File.foreach(f.path) do |line|
               JSON.parse(line)
             end
           end


### PR DESCRIPTION
`File.readlines` slurps each Ractor's whole ~8MB dump into memory at once. Because `dump_all` dumps the shared heap, the concurrent Ractors' readlines buffers feed back into each other's dumps, so peak memory grows superlinearly and the stop-the-world barrier thrashes past the 100s timeout on macOS.

`File.foreach` keeps peak memory flat (NR=16: 2.96GB -> 47MB) while still parsing every line.