### PR TITLE
ZJIT: Centralize stack index management in StackState

### DIFF
--- a/zjit/src/backend/arm64/mod.rs
+++ b/zjit/src/backend/arm64/mod.rs
@@ -680,14 +680,14 @@ impl Assembler {
         }
 
         /// If opnd is Opnd::Mem with MemBase::Stack, lower it to Opnd::Mem with MemBase::Reg, and split a large disp.
-        fn split_stack_membase(asm: &mut Assembler, opnd: Opnd, scratch_opnd: Opnd, stack_state: &StackState) -> Opnd {
-            let opnd = split_only_stack_membase(asm, opnd, scratch_opnd, stack_state);
+        fn split_stack_membase(asm: &mut Assembler, opnd: Opnd, scratch_opnd: Opnd) -> Opnd {
+            let opnd = split_only_stack_membase(asm, opnd, scratch_opnd);
             split_large_disp(asm, opnd, scratch_opnd)
         }
 
         /// split_stack_membase but without split_large_disp. This should be used only by lea,
         /// whose lowering already handles large displacements in arm64_emit.
-        fn split_only_stack_membase(asm: &mut Assembler, opnd: Opnd, scratch_opnd: Opnd, stack_state: &StackState) -> Opnd {
+        fn split_only_stack_membase(asm: &mut Assembler, opnd: Opnd, scratch_opnd: Opnd) -> Opnd {
             match opnd {
                 Opnd::Mem(Mem { base: stack_membase @ MemBase::Stack { .. }, disp: opnd_disp, num_bits: opnd_num_bits }) => {
                     // Convert MemBase::Stack to MemBase::Reg(NATIVE_BASE_PTR) with the
@@ -695,13 +695,13 @@ impl Assembler {
                     // [NATIVE_BASE_PTR + stack_disp], so we just adjust the base and
                     // combine displacements -- no indirection needed. Large
                     // displacements are handled by split_stack_membase().
-                    let Mem { base, disp: stack_disp, .. } = stack_state.stack_membase_to_mem(stack_membase);
+                    let Mem { base, disp: stack_disp, .. } = asm.stack_state.stack_membase_to_mem(stack_membase);
                     Opnd::Mem(Mem { base, disp: stack_disp + opnd_disp, num_bits: opnd_num_bits })
                 }
                 Opnd::Mem(Mem { base: MemBase::StackIndirect { stack_idx }, disp: opnd_disp, num_bits: opnd_num_bits }) => {
                     // The spilled value (a pointer) lives at a stack slot. Load it
                     // into a scratch register, then use the register as the base.
-                    let stack_mem = stack_state.stack_membase_to_mem(MemBase::Stack { stack_idx, num_bits: 64 });
+                    let stack_mem = asm.stack_state.stack_membase_to_mem(MemBase::Stack { stack_idx, num_bits: 64 });
                     let stack_opnd = split_large_disp(asm, Opnd::Mem(stack_mem), scratch_opnd);
                     asm.load_into(scratch_opnd, stack_opnd);
                     Opnd::Mem(Mem {
@@ -715,9 +715,9 @@ impl Assembler {
         }
 
         /// If opnd is Opnd::Mem, lower it to scratch_opnd. You should use this when `opnd` is read by the instruction, not written.
-        fn split_memory_read(asm: &mut Assembler, opnd: Opnd, scratch_opnd: Opnd, stack_state: &StackState) -> Opnd {
+        fn split_memory_read(asm: &mut Assembler, opnd: Opnd, scratch_opnd: Opnd) -> Opnd {
             if let Opnd::Mem(_) = opnd {
-                let opnd = split_stack_membase(asm, opnd, scratch_opnd, stack_state);
+                let opnd = split_stack_membase(asm, opnd, scratch_opnd);
                 let scratch_opnd = opnd.num_bits().map(|num_bits| scratch_opnd.with_num_bits(num_bits)).unwrap_or(scratch_opnd);
                 asm.load_into(scratch_opnd, opnd);
                 scratch_opnd
@@ -737,14 +737,8 @@ impl Assembler {
             }
         }
 
-        // Prepare StackState to lower MemBase::Stack
-        let stack_state = StackState::new(self.stack_base_idx);
-
-        let mut asm_local = Assembler::new();
+        let mut asm_local = Assembler::new_with_asm_without_blocks(&self);
         asm_local.accept_scratch_reg = true;
-        asm_local.stack_base_idx = self.stack_base_idx;
-        asm_local.label_names = self.label_names.clone();
-        asm_local.num_vregs = self.num_vregs;
 
         // Create one giant block to linearize everything into
         asm_local.new_block_without_id("linearized");
@@ -771,27 +765,27 @@ impl Assembler {
                 Insn::CSelLE { truthy: left, falsy: right, out } |
                 Insn::CSelG  { truthy: left, falsy: right, out } |
                 Insn::CSelGE { truthy: left, falsy: right, out } => {
-                    *left = split_memory_read(asm, *left, SCRATCH0_OPND, &stack_state);
-                    *right = split_memory_read(asm, *right, SCRATCH1_OPND, &stack_state);
+                    *left = split_memory_read(asm, *left, SCRATCH0_OPND);
+                    *right = split_memory_read(asm, *right, SCRATCH1_OPND);
                     let mem_out = split_memory_write(out, SCRATCH0_OPND);
 
                     asm.push_insn(insn);
 
                     if let Some(mem_out) = mem_out {
-                        let mem_out = split_stack_membase(asm, mem_out, SCRATCH1_OPND, &stack_state);
+                        let mem_out = split_stack_membase(asm, mem_out, SCRATCH1_OPND);
                         asm.store(mem_out, SCRATCH0_OPND);
                     }
                 }
                 Insn::Mul { left, right, out } => {
-                    *left = split_memory_read(asm, *left, SCRATCH0_OPND, &stack_state);
-                    *right = split_memory_read(asm, *right, SCRATCH1_OPND, &stack_state);
+                    *left = split_memory_read(asm, *left, SCRATCH0_OPND);
+                    *right = split_memory_read(asm, *right, SCRATCH1_OPND);
                     let mem_out = split_memory_write(out, SCRATCH0_OPND);
                     let reg_out = out.clone();
 
                     asm.push_insn(insn);
 
                     if let Some(mem_out) = mem_out {
-                        let mem_out = split_stack_membase(asm, mem_out, SCRATCH1_OPND, &stack_state);
+                        let mem_out = split_stack_membase(asm, mem_out, SCRATCH1_OPND);
                         asm.store(mem_out, SCRATCH0_OPND);
                     };
 
@@ -804,20 +798,20 @@ impl Assembler {
                 }
                 Insn::LShift { opnd, out, .. } |
                 Insn::RShift { opnd, out, .. } => {
-                    *opnd = split_memory_read(asm, *opnd, SCRATCH0_OPND, &stack_state);
+                    *opnd = split_memory_read(asm, *opnd, SCRATCH0_OPND);
                     let mem_out = split_memory_write(out, SCRATCH0_OPND);
 
                     asm.push_insn(insn);
 
                     if let Some(mem_out) = mem_out {
-                        let mem_out = split_stack_membase(asm, mem_out, SCRATCH1_OPND, &stack_state);
+                        let mem_out = split_stack_membase(asm, mem_out, SCRATCH1_OPND);
                         asm.store(mem_out, SCRATCH0_OPND);
                     }
                 }
                 Insn::Cmp { left, right } |
                 Insn::Test { left, right } => {
-                    *left = split_memory_read(asm, *left, SCRATCH0_OPND, &stack_state);
-                    *right = split_memory_read(asm, *right, SCRATCH1_OPND, &stack_state);
+                    *left = split_memory_read(asm, *left, SCRATCH0_OPND);
+                    *right = split_memory_read(asm, *right, SCRATCH1_OPND);
                     asm.push_insn(insn);
                 }
                 // For compile_exits, support splitting simple C arguments here
@@ -837,20 +831,20 @@ impl Assembler {
                     asm.cret(C_RET_OPND);
                 }
                 Insn::Lea { opnd, out } => {
-                    *opnd = split_only_stack_membase(asm, *opnd, SCRATCH0_OPND, &stack_state);
+                    *opnd = split_only_stack_membase(asm, *opnd, SCRATCH0_OPND);
                     let mem_out = split_memory_write(out, SCRATCH0_OPND);
 
                     asm.push_insn(insn);
 
                     if let Some(mem_out) = mem_out {
-                        let mem_out = split_stack_membase(asm, mem_out, SCRATCH1_OPND, &stack_state);
+                        let mem_out = split_stack_membase(asm, mem_out, SCRATCH1_OPND);
                         asm.store(mem_out, SCRATCH0_OPND);
                     }
                 }
                 Insn::Load { opnd, out } |
                 Insn::LoadInto { opnd, dest: out } => {
-                    *opnd = split_stack_membase(asm, *opnd, SCRATCH0_OPND, &stack_state);
-                    *out = split_stack_membase(asm, *out, SCRATCH1_OPND, &stack_state);
+                    *opnd = split_stack_membase(asm, *opnd, SCRATCH0_OPND);
+                    *out = split_stack_membase(asm, *out, SCRATCH1_OPND);
 
                     if let Opnd::Mem(_) = out {
                         // If NATIVE_STACK_PTR is used as a source for Store, it's handled as xzr, storeing zero.
@@ -883,13 +877,13 @@ impl Assembler {
                     asm.push_insn(Insn::Jne(label));
                 }
                 Insn::Store { dest, src } => {
-                    *dest = split_stack_membase(asm, *dest, SCRATCH0_OPND, &stack_state);
-                    *src = split_stack_membase(asm, *src, SCRATCH1_OPND, &stack_state);
+                    *dest = split_stack_membase(asm, *dest, SCRATCH0_OPND);
+                    *src = split_stack_membase(asm, *src, SCRATCH1_OPND);
                     asm.push_insn(insn);
                 }
                 Insn::Mov { dest, src } => {
-                    *src = split_stack_membase(asm, *src, SCRATCH0_OPND, &stack_state);
-                    *dest = split_stack_membase(asm, *dest, SCRATCH1_OPND, &stack_state);
+                    *src = split_stack_membase(asm, *src, SCRATCH0_OPND);
+                    *dest = split_stack_membase(asm, *dest, SCRATCH1_OPND);
                     match dest {
                         Opnd::Reg(_) => asm.load_into(*dest, *src),
                         Opnd::Mem(_) => asm.store(*dest, *src),
@@ -1643,7 +1637,7 @@ impl Assembler {
             let preferred_registers = trace_compile_phase("preferred_registers", || asm.preferred_register_assignments(&intervals));
             let (assignments, num_stack_slots) = trace_compile_phase("linear_scan", || asm.linear_scan(intervals.clone(), regs.len(), &preferred_registers));
 
-            let total_stack_slots = asm.stack_base_idx + num_stack_slots;
+            let total_stack_slots = asm.stack_state.stack_base_idx + num_stack_slots;
             if total_stack_slots > Self::MAX_FRAME_STACK_SLOTS {
                 return Err(CompileError::NativeStackTooLarge);
             }
@@ -1770,7 +1764,7 @@ mod tests {
 
         let mut asm = Assembler::new();
         asm.new_block_without_id("test");
-        asm.stack_base_idx = 1;
+        asm.stack_state.stack_base_idx = 1;
 
         let label = asm.new_label("bb0");
         asm.write_label(label.clone());
@@ -1970,7 +1964,7 @@ mod tests {
         // Test 3 preserved regs (odd), odd slot_count
         let cb1 = {
             let (mut asm, mut cb) = setup_asm();
-            asm.stack_base_idx = 3;
+            asm.stack_state.stack_base_idx = 3;
             asm.frame_setup(THREE_REGS);
             asm.frame_teardown(THREE_REGS);
             asm.compile_with_num_regs(&mut cb, 0);
@@ -1980,7 +1974,7 @@ mod tests {
         // Test 3 preserved regs (odd), even slot_count
         let cb2 = {
             let (mut asm, mut cb) = setup_asm();
-            asm.stack_base_idx = 4;
+            asm.stack_state.stack_base_idx = 4;
             asm.frame_setup(THREE_REGS);
             asm.frame_teardown(THREE_REGS);
             asm.compile_with_num_regs(&mut cb, 0);
@@ -1991,7 +1985,7 @@ mod tests {
         let cb3 = {
             static FOUR_REGS: &[Opnd] = &[Opnd::Reg(X19_REG), Opnd::Reg(X20_REG), Opnd::Reg(X21_REG), Opnd::Reg(X22_REG)];
             let (mut asm, mut cb) = setup_asm();
-            asm.stack_base_idx = 3;
+            asm.stack_state.stack_base_idx = 3;
             asm.frame_setup(FOUR_REGS);
             asm.frame_teardown(FOUR_REGS);
             asm.compile_with_num_regs(&mut cb, 0);

--- a/zjit/src/backend/arm64/mod.rs
+++ b/zjit/src/backend/arm64/mod.rs
@@ -1637,8 +1637,9 @@ impl Assembler {
             let preferred_registers = trace_compile_phase("preferred_registers", || asm.preferred_register_assignments(&intervals));
             let (assignments, num_stack_slots) = trace_compile_phase("linear_scan", || asm.linear_scan(intervals.clone(), regs.len(), &preferred_registers));
 
-            let total_stack_slots = asm.stack_state.stack_base_idx + num_stack_slots;
-            if total_stack_slots > Self::MAX_FRAME_STACK_SLOTS {
+            asm.stack_state.num_spill_slots = num_stack_slots;
+            let stack_slot_count = asm.stack_state.stack_slot_count();
+            if stack_slot_count > Self::MAX_FRAME_STACK_SLOTS {
                 return Err(CompileError::NativeStackTooLarge);
             }
 
@@ -1662,21 +1663,20 @@ impl Assembler {
                 }
             }
 
-            // Update FrameSetup slot_count to account for:
-            // 1) stack slots reserved for block params (stack_base_idx), and
-            // 2) register allocator spills (num_stack_slots).
+            // Update FrameSetup slot_count now that StackState knows the
+            // register allocator spill count.
             trace_compile_phase("count_stack_slots", || {
                 for block in asm.basic_blocks.iter_mut() {
                     for insn in block.insns.iter_mut() {
                         if let Insn::FrameSetup { slot_count, .. } = insn {
-                            *slot_count = total_stack_slots;
+                            *slot_count = stack_slot_count;
                         }
                     }
                 }
             });
 
             trace_compile_phase("resolve_ssa", || {
-                asm.handle_caller_saved_regs(&intervals, &assignments, &C_ARG_REGREGS, total_stack_slots);
+                asm.handle_caller_saved_regs(&intervals, &assignments, &C_ARG_REGREGS);
                 asm.resolve_ssa(&intervals, &assignments);
             });
 

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -1368,17 +1368,45 @@ impl Allocation {
 pub struct StackState {
     /// The number of stack slots reserved before register allocator spills.
     pub(crate) stack_base_idx: usize,
+
+    /// The number of stack slots needed by register allocator spills.
+    pub(crate) num_spill_slots: usize,
 }
 
 impl StackState {
     /// Initialize an empty stack state.
     fn new() -> Self {
-        StackState { stack_base_idx: 0 }
+        StackState { stack_base_idx: 0, num_spill_slots: 0 }
     }
 
     /// Initialize a stack state with a fixed number of reserved stack slots.
     fn new_with_stack_slots(stack_base_idx: usize) -> Self {
-        StackState { stack_base_idx }
+        StackState { stack_base_idx, num_spill_slots: 0 }
+    }
+
+    /// Return the total number of native stack slots used for the frame's
+    /// reserved data and register allocator spills.
+    pub(crate) fn stack_slot_count(&self) -> usize {
+        self.stack_base_idx + self.num_spill_slots
+    }
+
+    /// Return the stack-map index for a VReg stored in an allocator spill slot.
+    /// rb_zjit_materialize_frames() reads this as cfp->jit_return[-index].
+    fn stack_map_index_for_spill(&self, stack_idx: usize) -> usize {
+        self.stack_base_idx
+            .checked_add(1)
+            .expect("StackMap requires a JITFrame slot")
+            + stack_idx
+    }
+
+    /// Return the stack-map index for a VReg saved by handle_caller_saved_regs().
+    /// rb_zjit_materialize_frames() reads this as cfp->jit_return[-index].
+    fn stack_map_index_for_caller_saved_reg(&self, position: usize) -> usize {
+        let frame_alignment_slots = self.stack_slot_count() % 2;
+        (self.stack_slot_count() + frame_alignment_slots)
+            .checked_add(1)
+            .expect("StackMap requires a JITFrame slot")
+            + position
     }
 
     /// Convert a stack index to the `disp` of the stack slot
@@ -2137,7 +2165,6 @@ impl Assembler
         intervals: &[Interval],
         assignments: &[Option<Allocation>],
         regs: &[Reg],
-        total_stack_slots: usize,
     ) {
         use crate::backend::parcopy;
         use crate::backend::current::{C_RET_OPND, SCRATCH_REG, ALLOC_REGS};
@@ -2217,33 +2244,13 @@ impl Assembler
                                     value
                                 }
                                 Opnd::VReg { idx: VRegId(vreg_id), .. } => {
-                                    // Calculate the offset from NATIVE_BASE_PTR to the stack slot for this VReg.
                                     let vreg_stack_index = match assignments[*vreg_id].expect("StackMap VReg should have an allocation") {
                                         Allocation::Reg(_) | Allocation::Fixed(_) => {
                                             let position = survivors.iter().position(|&survivor_id| survivor_id == *vreg_id).unwrap();
-                                            // See Assembler::alloc_stack's native stack diagram. rb_zjit_materialize_frames()
-                                            // reads vreg_stack_index as cfp->jit_return[-vreg_stack_index].
-                                            // For both arches, FrameSetup may add one native stack slot for
-                                            // alignment before these CPushPairs.
-                                            // TODO: Centralize stack slot offset calculation in StackState.
-                                            let frame_alignment_slots = if total_stack_slots % 2 == 1 {
-                                                1
-                                            } else {
-                                                0
-                                            };
-                                            (total_stack_slots + frame_alignment_slots)
-                                                .checked_add(1)
-                                                .expect("StackMap requires a JITFrame slot")
-                                                + position
+                                            self.stack_state.stack_map_index_for_caller_saved_reg(position)
                                         }
                                         Allocation::Stack(stack_idx) => {
-                                            // StackState places allocator spills at:
-                                            //   cfp->jit_return[-(self.stack_base_idx + stack_idx + 1)]
-                                            // so encode the matching materializer index.
-                                            self.stack_state.stack_base_idx
-                                                .checked_add(1)
-                                                .expect("StackMap requires a JITFrame slot")
-                                                + stack_idx
+                                            self.stack_state.stack_map_index_for_spill(stack_idx)
                                         }
                                     };
 
@@ -3482,7 +3489,7 @@ impl Assembler {
     }
 
     pub fn frame_setup(&mut self, preserved_regs: &'static [Opnd]) {
-        let slot_count = self.stack_state.stack_base_idx;
+        let slot_count = self.stack_state.stack_slot_count();
         self.push_insn(Insn::FrameSetup { preserved: preserved_regs, slot_count });
     }
 
@@ -4538,7 +4545,8 @@ mod tests {
         let intervals = asm.build_intervals(live_in);
         let num_regs = 2;
         let preferred_registers = asm.preferred_register_assignments(&intervals);
-        let (assignments, _) = asm.linear_scan(intervals.clone(), num_regs, &preferred_registers);
+        let (assignments, num_stack_slots) = asm.linear_scan(intervals.clone(), num_regs, &preferred_registers);
+        asm.stack_state.num_spill_slots = num_stack_slots;
 
         let regs = &ALLOC_REGS[..num_regs];
 
@@ -4550,7 +4558,7 @@ mod tests {
             "v1 should be in a register");
 
         // Run the pipeline: handle_caller_saved_regs then resolve_ssa
-        asm.handle_caller_saved_regs(&intervals, &assignments, regs, 0);
+        asm.handle_caller_saved_regs(&intervals, &assignments, regs);
         asm.resolve_ssa(&intervals, &assignments);
 
         let insns = &asm.basic_blocks[b1.0].insns;

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -1362,15 +1362,22 @@ impl Allocation {
     }
 }
 
-/// StackState converts abstract stack slots into concrete stack addresses.
+/// StackState tracks the native stack layout and converts abstract stack slots
+/// into concrete stack addresses.
+#[derive(Clone)]
 pub struct StackState {
-    /// Copy of Assembler::stack_base_idx. Used for calculating stack slot offsets.
-    stack_base_idx: usize,
+    /// The number of stack slots reserved before register allocator spills.
+    pub(crate) stack_base_idx: usize,
 }
 
 impl StackState {
-    /// Initialize a stack allocator
-    pub(super) fn new(stack_base_idx: usize) -> Self {
+    /// Initialize an empty stack state.
+    fn new() -> Self {
+        StackState { stack_base_idx: 0 }
+    }
+
+    /// Initialize a stack state with a fixed number of reserved stack slots.
+    fn new_with_stack_slots(stack_base_idx: usize) -> Self {
         StackState { stack_base_idx }
     }
 
@@ -1426,9 +1433,8 @@ pub struct Assembler {
     /// On `compile`, it also disables the backend's use of them.
     pub(super) accept_scratch_reg: bool,
 
-    /// The maximum number of stack slots that have been reserved
-    /// by Assembler::alloc_stack().
-    pub stack_base_idx: usize,
+    /// Native stack layout state.
+    pub(crate) stack_state: StackState,
 
     /// If Some, the next ccall should verify its leafness
     leaf_ccall_stack_size: Option<usize>,
@@ -1449,7 +1455,7 @@ impl Assembler
         Self {
             label_names: Vec::default(),
             accept_scratch_reg: false,
-            stack_base_idx: 0,
+            stack_state: StackState::new(),
             leaf_ccall_stack_size: None,
             basic_blocks: Vec::default(),
             current_block_id: BlockId(0),
@@ -1461,7 +1467,7 @@ impl Assembler
 
     /// Create an Assembler, reserving a specified number of stack slots
     pub fn new_with_stack_slots(stack_base_idx: usize) -> Self {
-        Self { stack_base_idx, ..Self::new() }
+        Self { stack_state: StackState::new_with_stack_slots(stack_base_idx), ..Self::new() }
     }
 
     /// Create an Assembler that allows the use of scratch registers.
@@ -1473,18 +1479,25 @@ impl Assembler
     /// Create an Assembler with parameters of another Assembler and empty instructions.
     /// Compiler passes build a next Assembler with this API and insert new instructions to it.
     pub(super) fn new_with_asm(old_asm: &Assembler) -> Self {
-        let mut asm = Self {
-            label_names: old_asm.label_names.clone(),
-            accept_scratch_reg: old_asm.accept_scratch_reg,
-            stack_base_idx: old_asm.stack_base_idx,
-            ..Self::new()
-        };
+        let mut asm = Self::new_with_asm_without_blocks(old_asm);
 
         // Initialize basic blocks from the old assembler, preserving hir_block_id and entry flag
         // but with empty instruction lists
         for old_block in &old_asm.basic_blocks {
             asm.new_block_from_old_block(&old_block);
         }
+
+        asm
+    }
+
+    /// Create an Assembler with parameters of another Assembler, but without basic blocks.
+    pub(super) fn new_with_asm_without_blocks(old_asm: &Assembler) -> Self {
+        let mut asm = Self {
+            label_names: old_asm.label_names.clone(),
+            accept_scratch_reg: old_asm.accept_scratch_reg,
+            stack_state: old_asm.stack_state.clone(),
+            ..Self::new()
+        };
 
         // Initialize num_vregs to match the old assembler's size
         // This allows reusing VRegs from the old assembler
@@ -2227,7 +2240,7 @@ impl Assembler
                                             // StackState places allocator spills at:
                                             //   cfp->jit_return[-(self.stack_base_idx + stack_idx + 1)]
                                             // so encode the matching materializer index.
-                                            self.stack_base_idx
+                                            self.stack_state.stack_base_idx
                                                 .checked_add(1)
                                                 .expect("StackMap requires a JITFrame slot")
                                                 + stack_idx
@@ -3469,7 +3482,7 @@ impl Assembler {
     }
 
     pub fn frame_setup(&mut self, preserved_regs: &'static [Opnd]) {
-        let slot_count = self.stack_base_idx;
+        let slot_count = self.stack_state.stack_base_idx;
         self.push_insn(Insn::FrameSetup { preserved: preserved_regs, slot_count });
     }
 
@@ -3648,11 +3661,7 @@ impl Assembler {
     /// This is used for trampolines that don't allow scratch registers.
     /// Linearizes all blocks into a single giant block.
     pub fn resolve_parallel_mov_pass(self) -> Assembler {
-        let mut asm_local = Assembler::new();
-        asm_local.accept_scratch_reg = self.accept_scratch_reg;
-        asm_local.stack_base_idx = self.stack_base_idx;
-        asm_local.label_names = self.label_names.clone();
-        asm_local.num_vregs = self.num_vregs;
+        let mut asm_local = Assembler::new_with_asm_without_blocks(&self);
 
         // Create one giant block to linearize everything into
         asm_local.new_block_without_id("linearized");

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -1384,6 +1384,40 @@ impl StackState {
         StackState { stack_base_idx, num_spill_slots: 0 }
     }
 
+    /// Reserve native stack slots for JITFrame storage and stack-allocated operands.
+    /// Returns the total number of reserved slots for the current allocation.
+    ///
+    /// Native stack layout:
+    ///
+    ///         high addr
+    /// +------------------------+
+    /// | return address         |
+    /// +------------------------+
+    /// | previous frame pointer | <- NATIVE_BASE_PTR (== depth-0 cfp->jit_return)
+    /// +------------------------+
+    /// | JITFrame slot depth 0  | <- [NATIVE_BASE_PTR - 8]; read by CFP_ZJIT_FRAME for the top-level frame
+    /// +------------------------+
+    /// |          ...           |    one slot per inlining depth (jit_frame_size slots total)
+    /// +------------------------+
+    /// | JITFrame slot depth N  | <- innermost inlined frame's slot
+    /// +------------------------+
+    /// | opnds.last()           |
+    /// +------------------------+
+    /// |          ...           |
+    /// +------------------------+
+    /// | opnds.first()          | <- pointer returned by Assembler::alloc_stack()
+    /// +------------------------+
+    /// | register spill slots   | if any
+    /// +------------------------+
+    /// | FrameSetup align slot  | if needed
+    /// +------------------------+
+    ///         low addr
+    pub(crate) fn reserve_stack_slots(&mut self, jit_frame_size: usize, stack_size: usize) -> usize {
+        let total_stack_size = jit_frame_size + stack_size;
+        self.stack_base_idx = self.stack_base_idx.max(total_stack_size);
+        total_stack_size
+    }
+
     /// Return the total number of native stack slots used for the frame's
     /// reserved data and register allocator spills.
     pub(crate) fn stack_slot_count(&self) -> usize {

--- a/zjit/src/backend/x86_64/mod.rs
+++ b/zjit/src/backend/x86_64/mod.rs
@@ -350,14 +350,14 @@ impl Assembler {
 
         /// If a given operand is Opnd::Mem and it uses MemBase::Stack, lower it to MemBase::Reg(NATIVE_BASE_PTR).
         /// In general, `out` operand is a `VReg`, so it may use MemBase::Stack, but not MemBase::StackIndirect.
-        fn lower_stack_membase(opnd: Opnd, stack_state: &StackState) -> Opnd {
+        fn lower_stack_membase(asm: &Assembler, opnd: Opnd) -> Opnd {
             match opnd {
                 Opnd::Mem(Mem { base: stack_membase @ MemBase::Stack { .. }, disp: opnd_disp, num_bits: opnd_num_bits }) => {
                     // Convert MemBase::Stack to MemBase::Reg(NATIVE_BASE_PTR) with the
                     // correct stack displacement. The stack slot value lives directly at
                     // [NATIVE_BASE_PTR + stack_disp], so we just adjust the base and
                     // combine displacements -- no indirection needed.
-                    let Mem { base, disp: stack_disp, .. } = stack_state.stack_membase_to_mem(stack_membase);
+                    let Mem { base, disp: stack_disp, .. } = asm.stack_state.stack_membase_to_mem(stack_membase);
                     Opnd::Mem(Mem { base, disp: stack_disp + opnd_disp, num_bits: opnd_num_bits })
                 }
                 Opnd::Mem(Mem { base: MemBase::StackIndirect { .. }, .. }) => {
@@ -369,13 +369,13 @@ impl Assembler {
 
         /// If a given operand is Opnd::Mem and it uses MemBase::Stack, lower it to MemBase::Reg(NATIVE_BASE_PTR).
         /// For MemBase::StackIndirect, load the pointer from the stack slot into a scratch register.
-        fn split_stack_membase(asm: &mut Assembler, opnd: Opnd, scratch_opnd: Opnd, stack_state: &StackState) -> Opnd {
+        fn split_stack_membase(asm: &mut Assembler, opnd: Opnd, scratch_opnd: Opnd) -> Opnd {
             match opnd {
-                Opnd::Mem(Mem { base: MemBase::Stack { .. }, .. }) => lower_stack_membase(opnd, stack_state),
+                Opnd::Mem(Mem { base: MemBase::Stack { .. }, .. }) => lower_stack_membase(asm, opnd),
                 Opnd::Mem(Mem { base: MemBase::StackIndirect { stack_idx }, disp: opnd_disp, num_bits: opnd_num_bits }) => {
                     // The spilled value (a pointer) lives at a stack slot. Load it
                     // into a scratch register, then use the register as the base.
-                    let stack_mem = stack_state.stack_membase_to_mem(MemBase::Stack { stack_idx, num_bits: 64 });
+                    let stack_mem = asm.stack_state.stack_membase_to_mem(MemBase::Stack { stack_idx, num_bits: 64 });
                     asm.load_into(scratch_opnd, Opnd::Mem(stack_mem));
                     Opnd::Mem(Mem {
                         base: MemBase::Reg(scratch_opnd.unwrap_reg().reg_no),
@@ -434,14 +434,8 @@ impl Assembler {
             }
         }
 
-        // Prepare StackState to lower MemBase::Stack
-        let stack_state = StackState::new(self.stack_base_idx);
-
-        let mut asm_local = Assembler::new();
+        let mut asm_local = Assembler::new_with_asm_without_blocks(&self);
         asm_local.accept_scratch_reg = true;
-        asm_local.stack_base_idx = self.stack_base_idx;
-        asm_local.label_names = self.label_names.clone();
-        asm_local.num_vregs = self.num_vregs;
 
         // Create one giant block to linearize everything into
         asm_local.new_block_without_id("linearized");
@@ -468,16 +462,16 @@ impl Assembler {
                     // since we'll overwrite out when moving left into it.
                     // Compare before lowering (Stack membases change during lowering).
                     let right_eq_out = out == right;
-                    *out = lower_stack_membase(*out, &stack_state);
+                    *out = lower_stack_membase(asm, *out);
                     if right_eq_out {
                         asm.mov(SCRATCH1_OPND, *out);
                         *right = SCRATCH1_OPND;
                     }
 
                     // Phase 2: Lower stack memory bases
-                    *left = split_stack_membase(asm, *left, SCRATCH0_OPND, &stack_state);
+                    *left = split_stack_membase(asm, *left, SCRATCH0_OPND);
                     if !right_eq_out {
-                        *right = split_stack_membase(asm, *right, SCRATCH1_OPND, &stack_state);
+                        *right = split_stack_membase(asm, *right, SCRATCH1_OPND);
                     }
 
                     // Phase 3: If right is a Mem whose base register equals the out
@@ -512,11 +506,11 @@ impl Assembler {
                 Insn::Mul { left, right, out } => {
                     assert_out_is_phys_reg_or_stack_mem(*out);
 
-                    *left = split_stack_membase(asm, *left, SCRATCH0_OPND, &stack_state);
+                    *left = split_stack_membase(asm, *left, SCRATCH0_OPND);
                     *left = split_if_both_memory(asm, *left, *right, SCRATCH0_OPND);
-                    *right = split_stack_membase(asm, *right, SCRATCH1_OPND, &stack_state);
+                    *right = split_stack_membase(asm, *right, SCRATCH1_OPND);
                     *right = split_64bit_immediate(asm, *right, SCRATCH1_OPND);
-                    *out = lower_stack_membase(*out, &stack_state);
+                    *out = lower_stack_membase(asm, *out);
 
                     // imul doesn't have (Mem, Reg) encoding. Swap left and right in that case.
                     if let (Opnd::Mem(_), Opnd::Reg(_)) = (&left, &right) {
@@ -536,8 +530,8 @@ impl Assembler {
                 }
                 Insn::Test { left, right } |
                 Insn::Cmp { left, right } => {
-                    *left = split_stack_membase(asm, *left, SCRATCH1_OPND, &stack_state);
-                    *right = split_stack_membase(asm, *right, SCRATCH0_OPND, &stack_state);
+                    *left = split_stack_membase(asm, *left, SCRATCH1_OPND);
+                    *right = split_stack_membase(asm, *right, SCRATCH0_OPND);
                     *right = split_if_both_memory(asm, *right, *left, SCRATCH0_OPND);
 
                     let num_bits = match right {
@@ -574,10 +568,10 @@ impl Assembler {
                 Insn::CSelLE { truthy: left, falsy: right, out } |
                 Insn::CSelG { truthy: left, falsy: right, out } |
                 Insn::CSelGE { truthy: left, falsy: right, out } => {
-                    *left = split_stack_membase(asm, *left, SCRATCH1_OPND, &stack_state);
-                    *right = split_stack_membase(asm, *right, SCRATCH0_OPND, &stack_state);
+                    *left = split_stack_membase(asm, *left, SCRATCH1_OPND);
+                    *right = split_stack_membase(asm, *right, SCRATCH0_OPND);
                     *right = split_if_both_memory(asm, *right, *left, SCRATCH0_OPND);
-                    *out = lower_stack_membase(*out, &stack_state);
+                    *out = lower_stack_membase(asm, *out);
                     let mem_out = split_memory_write(out, SCRATCH0_OPND);
                     asm.push_insn(insn);
                     if let Some(mem_out) = mem_out {
@@ -585,8 +579,8 @@ impl Assembler {
                     }
                 }
                 Insn::Lea { opnd, out } => {
-                    *opnd = split_stack_membase(asm, *opnd, SCRATCH0_OPND, &stack_state);
-                    *out = lower_stack_membase(*out, &stack_state);
+                    *opnd = split_stack_membase(asm, *opnd, SCRATCH0_OPND);
+                    *out = lower_stack_membase(asm, *out);
                     let mem_out = split_memory_write(out, SCRATCH0_OPND);
                     asm.push_insn(insn);
                     if let Some(mem_out) = mem_out {
@@ -601,9 +595,9 @@ impl Assembler {
                 }
                 Insn::Load { out, opnd } |
                 Insn::LoadInto { dest: out, opnd } => {
-                    *opnd = split_stack_membase(asm, *opnd, SCRATCH0_OPND, &stack_state);
+                    *opnd = split_stack_membase(asm, *opnd, SCRATCH0_OPND);
                     // Split stack membase on out before checking for memory write
-                    *out = lower_stack_membase(*out, &stack_state);
+                    *out = lower_stack_membase(asm, *out);
                     let mem_out = split_memory_write(out, SCRATCH0_OPND);
                     asm.push_insn(insn);
                     if let Some(mem_out) = mem_out {
@@ -618,15 +612,15 @@ impl Assembler {
                     asm.incr_counter(Opnd::mem(64, SCRATCH0_OPND, 0), value);
                 }
                 &mut Insn::Mov { dest, src } => {
-                    let dest = split_stack_membase(asm, dest, SCRATCH1_OPND, &stack_state);
-                    let src = split_stack_membase(asm, src, SCRATCH0_OPND, &stack_state);
+                    let dest = split_stack_membase(asm, dest, SCRATCH1_OPND);
+                    let src = split_stack_membase(asm, src, SCRATCH0_OPND);
                     asm_mov(asm, dest, src, SCRATCH0_OPND);
                 }
                 // Handle various operand combinations for spills on compile_exits.
                 &mut Insn::Store { dest, src } => {
                     let num_bits = dest.rm_num_bits();
-                    let src = split_stack_membase(asm, src, SCRATCH0_OPND, &stack_state);
-                    let dest = split_stack_membase(asm, dest, SCRATCH1_OPND, &stack_state);
+                    let src = split_stack_membase(asm, src, SCRATCH0_OPND);
+                    let dest = split_stack_membase(asm, dest, SCRATCH1_OPND);
 
                     let src = match src {
                         Opnd::Reg(_) => src,
@@ -1156,7 +1150,7 @@ impl Assembler {
             let preferred_registers = trace_compile_phase("preferred_registers", || asm.preferred_register_assignments(&intervals));
             let (assignments, num_stack_slots) = trace_compile_phase("linear_scan", || asm.linear_scan(intervals.clone(), regs.len(), &preferred_registers));
 
-            let total_stack_slots = asm.stack_base_idx + num_stack_slots;
+            let total_stack_slots = asm.stack_state.stack_base_idx + num_stack_slots;
             if total_stack_slots > Self::MAX_FRAME_STACK_SLOTS {
                 return Err(CompileError::NativeStackTooLarge);
             }
@@ -1384,7 +1378,7 @@ mod tests {
 
         let mut asm = Assembler::new();
         asm.new_block_without_id("test");
-        asm.stack_base_idx = 1;
+        asm.stack_state.stack_base_idx = 1;
 
         let label = asm.new_label("bb0");
         asm.write_label(label.clone());
@@ -2123,7 +2117,7 @@ mod tests {
     #[test]
     fn frame_setup_teardown_stack_base_idx() {
         let (mut asm, mut cb) = setup_asm();
-        asm.stack_base_idx = 5;
+        asm.stack_state.stack_base_idx = 5;
         asm.frame_setup(&[]);
         asm.frame_teardown(&[]);
         asm.compile_with_num_regs(&mut cb, 0);

--- a/zjit/src/backend/x86_64/mod.rs
+++ b/zjit/src/backend/x86_64/mod.rs
@@ -1150,8 +1150,9 @@ impl Assembler {
             let preferred_registers = trace_compile_phase("preferred_registers", || asm.preferred_register_assignments(&intervals));
             let (assignments, num_stack_slots) = trace_compile_phase("linear_scan", || asm.linear_scan(intervals.clone(), regs.len(), &preferred_registers));
 
-            let total_stack_slots = asm.stack_state.stack_base_idx + num_stack_slots;
-            if total_stack_slots > Self::MAX_FRAME_STACK_SLOTS {
+            asm.stack_state.num_spill_slots = num_stack_slots;
+            let stack_slot_count = asm.stack_state.stack_slot_count();
+            if stack_slot_count > Self::MAX_FRAME_STACK_SLOTS {
                 return Err(CompileError::NativeStackTooLarge);
             }
 
@@ -1175,21 +1176,20 @@ impl Assembler {
                 }
             }
 
-            // Update FrameSetup slot_count to account for:
-            // 1) stack slots reserved for block params (stack_base_idx), and
-            // 2) register allocator spills (num_stack_slots).
+            // Update FrameSetup slot_count now that StackState knows the
+            // register allocator spill count.
             trace_compile_phase("count_stack_slots", || {
                 for block in asm.basic_blocks.iter_mut() {
                     for insn in block.insns.iter_mut() {
                         if let Insn::FrameSetup { slot_count, .. } = insn {
-                            *slot_count = total_stack_slots;
+                            *slot_count = stack_slot_count;
                         }
                     }
                 }
             });
 
             trace_compile_phase("resolve_ssa", || {
-                asm.handle_caller_saved_regs(&intervals, &assignments, &C_ARG_REGREGS, total_stack_slots);
+                asm.handle_caller_saved_regs(&intervals, &assignments, &C_ARG_REGREGS);
                 asm.resolve_ssa(&intervals, &assignments);
             });
 

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -3710,31 +3710,7 @@ impl Assembler {
     /// Allocate stack space on top of the stack slots reserved for JITFrame,
     /// and return a pointer to the allocated space.
     fn alloc_stack(&mut self, jit: &JITState, stack_size: usize) -> Opnd {
-        let total_stack_size = jit.jit_frame_size + stack_size;
-        self.stack_state.stack_base_idx = self.stack_state.stack_base_idx.max(total_stack_size);
-        //         high addr
-        // +------------------------+
-        // | return address         |
-        // +------------------------+
-        // | previous frame pointer | <- NATIVE_BASE_PTR (== depth-0 cfp->jit_return)
-        // +------------------------+
-        // | JITFrame slot depth 0  | <- [NATIVE_BASE_PTR - 8]; read by CFP_ZJIT_FRAME for the top-level frame
-        // +------------------------+
-        // |          ...           |    one slot per inlining depth (jit.jit_frame_size slots total)
-        // +------------------------+
-        // | JITFrame slot depth N  | <- innermost inlined frame's slot
-        // +------------------------+
-        // | opnds.last()           |
-        // +------------------------+
-        // |          ...           |
-        // +------------------------+
-        // | opnds.first()          | <- pointer returned by alloc_stack()
-        // +------------------------+
-        // | register spill slots   | if any
-        // +------------------------+
-        // | FrameSetup align slot  | if needed
-        // +------------------------+
-        //         low addr
+        let total_stack_size = self.stack_state.reserve_stack_slots(jit.jit_frame_size, stack_size);
         self.sub(NATIVE_BASE_PTR, (SIZEOF_VALUE * total_stack_size).into())
     }
 

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -3711,7 +3711,7 @@ impl Assembler {
     /// and return a pointer to the allocated space.
     fn alloc_stack(&mut self, jit: &JITState, stack_size: usize) -> Opnd {
         let total_stack_size = jit.jit_frame_size + stack_size;
-        self.stack_base_idx = self.stack_base_idx.max(total_stack_size);
+        self.stack_state.stack_base_idx = self.stack_state.stack_base_idx.max(total_stack_size);
         //         high addr
         // +------------------------+
         // | return address         |


### PR DESCRIPTION
Currently, a register allocator pass (`handle_caller_saved_regs`) is doing a stack offset calculation for stack maps, which needs to account for low-level details like an alignment slot created by `FrameSetup`. 

To make it easier to maintain, this PR moves the responsibility of such stack offset calculation from LIR passes to the `StackState` module by doing:

* Embed `StackState` in `Assembler`, instead of instantiating it in the `scratch_split` pass.
    * The source of truth for `stack_base_idx` is moved from `Assembler` to `StackState`.
* Always ask `StackState` to calculate stack slot offsets.
    * Other LIR passes no longer need to be aware of the native stack layout, such as an alignment slot.