### PR TITLE
Drop `--no-llvm-bc` to test if Rust still needs it

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -332,10 +332,6 @@ AC_CHECK_TOOLS([STRIP],   [gstrip strip], [:])
 
 FIRSTMAKEFILE=""
 
-# nm errors with Rust's LLVM bitcode when Rust uses a newer LLVM version than nm.
-# In case we're working with llvm-nm, tell it to not worry about the bitcode.
-AS_IF([${NM} --help 2>&1 | grep -q 'llvm-bc'], [NM="$NM --no-llvm-bc"])
-
 AS_IF([test ! $rb_test_CFLAGS], [AS_UNSET(CFLAGS)]); AS_UNSET(rb_test_CFLAGS)
 AS_IF([test ! $rb_test_CXXFLAGS], [AS_UNSET(CXXFLAGS)]); AS_UNSET(rb_save_CXXFLAGS)
 
@@ -4163,7 +4159,7 @@ AC_SUBST(JIT_CARGO_SUPPORT)dnl "no" or the cargo profile of the rust code
 [begin]_group "build section" && {
 AC_CACHE_CHECK([for prefix of external symbols], rb_cv_symbol_prefix, [
     AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[extern void conftest_external(void) {}]], [[]])],[
-	rb_cv_symbol_prefix=`$NM conftest.$ac_objext 2>/dev/null |
+	rb_cv_symbol_prefix=`$NM conftest.$ac_objext |
 			     sed -n ['/.*T[ 	]\([^ 	]*\)conftest_external.*/!d;s//\1/p;q']`
 	],
 	[rb_cv_symbol_prefix=''])

--- a/tool/leaked-globals
+++ b/tool/leaked-globals
@@ -60,23 +60,6 @@ end
 # extern, so we allow the Rust one.
 REPLACE.push("rust_eh_personality") if RUBY_PLATFORM.include?("darwin")
 
-# Under LTO the compiler emits raw LLVM bitcode objects (magic "BC\xC0\xDE", or
-# the bitcode wrapper magic).  nm carries --no-llvm-bc (added in configure so it
-# ignores Rust's newer-version bitcode) and so cannot read them, only emitting
-# "not recognized" noise.  Drop them; leaked symbols are still checked on the
-# linked library and any non-bitcode objects.
-if defined?(NM) and NM.include?("--no-llvm-bc")
-  bitcode = 0
-  ARGV.reject! do |n|
-    next false unless File.file?(n)
-    case File.binread(n, 4)&.bytes
-    when [0x42, 0x43, 0xC0, 0xDE], [0xDE, 0xC0, 0x17, 0x0B]
-      bitcode += 1
-    end
-  end
-  puts "Skip #{col.skip("#{bitcode} LLVM bitcode object(s)")}" if bitcode > 0
-end
-
 print "Checking leaked global symbols..."
 STDOUT.flush
 if soext
@@ -122,7 +105,7 @@ Pipe.new(NM + ARGV).each do |line|
   puts col.fail("leaked") if count.zero?
   count += 1
   puts "  #{n}"
-end unless ARGV.empty?
+end
 case count
 when 0
   puts col.pass("none")


### PR DESCRIPTION
Remove the flag entirely along with the #17374 compensation (leaked-globals bitcode skip and the configure symbol-prefix stderr redirect), reverting to the state before the flag existed.

`--no-llvm-bc` is appended to NM in configure to turn off llvm-nm's bitcode reader. On Linux the Rust JIT libraries never go through nm (they use `ld -r --whole-archive` plus objcopy), so the flag only matters for the `clang-22 LTO` build, where it makes `llvm-nm` reject the raw bitcode objects with the "not recognized" noise #17374 worked around.

On macOS the flag is consumed in exactly one place, the darwin-only `RUST_LIB_SYMBOLS` recipe that runs nm over the Rust archive, where the members are Mach-O and read fine with or without it.

The goal is to verify in CI whether the macOS Rust nm path still builds the exported symbol list without the flag, and whether dropping it keeps the Linux clang-22 LTO leaked-globals check green.