### PR TITLE
ZJIT: Support inlining methods that dispatch to blocks

### DIFF
--- a/zjit/src/codegen_tests.rs
+++ b/zjit/src/codegen_tests.rs
@@ -6058,6 +6058,65 @@ fn test_inlined_method_with_keyword_default_using_prior_param() {
 }
 
 #[test]
+fn test_inlined_method_with_invokeblock() {
+    with_inlining(|| {
+        assert_snapshot!(assert_inlines("
+            def callee(x)
+              yield x
+            end
+            def test(n)
+              callee(n) { |x| x + 2 }
+            end
+
+            test(10)
+            test(10)
+            test(10)
+        "), @"12");
+    });
+}
+
+#[test]
+fn test_inlined_method_with_block_param() {
+    with_inlining(|| {
+        assert_snapshot!(assert_inlines("
+            def callee(x, &block)
+              block.call(x)
+            end
+            def test(n)
+              callee(n) { |x| x + 2 }
+            end
+
+            test(10)
+            test(10)
+            test(10)
+        "), @"12");
+    });
+}
+
+#[test]
+fn test_inlined_method_that_forwards_block_arg() {
+    // The callee captures a literal block in `&block` and forwards it on to
+    // `inner`. While `callee` is inlined, the forwarded call stays a dynamic send.
+    with_inlining(|| {
+        assert_snapshot!(assert_inlines("
+            def inner(x)
+              yield x
+            end
+            def callee(x, &block)
+              inner(x, &block)
+            end
+            def test(n)
+              callee(n) { |x| x + 2 }
+            end
+
+            test(10)
+            test(10)
+            test(10)
+        "), @"12");
+    });
+}
+
+#[test]
 fn test_inlined_method_with_rescue_caught_in_callee() {
     // The callee's begin/rescue catches an exception raised inside the same
     // callee. The runtime exception walker must find the rescue clause via the

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -4388,13 +4388,12 @@ impl Function {
 
     /// Check whether a callee ISEQ can be inlined.
     fn can_inline(callee_iseq: IseqPtr) -> bool {
-        // Inline callees with required, optional, post-required positional, and keyword
-        // parameters. Rest params, double-splat (kwrest), and forwardable params are rejected
-        // because `can_direct_send` rejects them -- we only inline direct sends.
-        // TODO (nirvdrum 2026-06-12) Block params should be supported by the inliner.
+        // Inline callees with required, optional, post-required positional, keyword, and
+        // block parameters, including callees that dispatch to a passed block with `yield`.
+        // Rest params, double-splat (kwrest), and forwardable params are rejected because
+        // `can_direct_send` rejects them -- we only inline direct sends.
         let params = unsafe { callee_iseq.params() };
         if params.flags.has_rest() != 0
-            || params.flags.has_block() != 0
             || params.flags.forwardable() != 0
             || params.flags.has_kwrest() != 0
         {
@@ -4407,32 +4406,6 @@ impl Function {
         if iseq_ep_starts_escaped(callee_iseq) || iseq_seen_ep_escape(callee_iseq) {
             incr_counter!(inline_reject_ep_escapes);
             return false;
-        }
-
-        // Reject callees that use yield/invokeblock (block inlining is future work).
-        // TODO (nirvdrum 2026-06-12) Work through this list, adding support for each rejected instruction.
-        let callee_encoded_size = unsafe { get_iseq_encoded_size(callee_iseq) };
-        let mut pc_idx: u32 = 0;
-        while pc_idx < callee_encoded_size {
-            let pc = unsafe { rb_iseq_pc_at_idx(callee_iseq, pc_idx) };
-            let opcode: u32 = unsafe { rb_iseq_bare_opcode_at_pc(callee_iseq, pc) }
-                .try_into()
-                .unwrap();
-            if opcode == YARVINSN_invokeblock {
-                incr_counter!(inline_reject_invokeblock);
-                return false;
-            }
-
-            // Reject callees that use block params. The codegen for getblockparam
-            // and getblockparamproxy uses jit.iseq to compute the block param level,
-            // which would be wrong for inlined code.
-            if opcode == YARVINSN_getblockparam || opcode == YARVINSN_getblockparamproxy {
-                incr_counter!(inline_reject_blockparam);
-                return false;
-            }
-
-            let insn_len = insn_len(opcode as usize);
-            pc_idx += insn_len;
         }
 
         true
@@ -8985,8 +8958,10 @@ fn add_iseq_to_hir(
                         });
 
                     let result = if is_ifunc {
-                        // Load the block handler from LEP
-                        let level = get_lvar_level(fun.iseq);
+                        // Load the block handler from the current frame's LEP. In inlined
+                        // code, the function ISEQ is the caller while `exit_state.iseq` is the
+                        // callee containing this `invokeblock`.
+                        let level = get_lvar_level(exit_state.iseq);
                         let lep = fun.push_insn(block, Insn::GetEP { level });
                         let block_handler = fun.push_insn(block, Insn::LoadField {
                             recv: lep,

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -18673,6 +18673,189 @@ mod hir_opt_tests {
     }
 
     #[test]
+    fn test_inline_method_with_invokeblock() {
+        // The callee dispatches to the caller-supplied literal block via `yield`.
+        // The block handler is established by the SPECVAL written into the inlined
+        // frame by PushInlineFrame, and the `yield` lowers to an InvokeBlock that
+        // reads it off the live CFP at runtime.
+        eval("
+            def with_yield(x)
+              yield x
+            end
+            def test(n)
+              with_yield(n) { |x| x + 2 }
+            end
+            test(1)
+            test(1)
+        ");
+        let counters = crate::state::ZJITState::get_counters();
+        let inline_count_before = counters.inline_method_count;
+
+        let result = hir_string_with_inlining("test");
+
+        assert!(counters.inline_method_count > inline_count_before,
+            "Expected with_yield to be inlined, inline_method_count did not increment.\nHIR:\n{result}");
+        assert!(result.contains("PushInlineFrame"),
+            "Expected PushInlineFrame in inlined HIR:\n{result}");
+        assert!(!result.contains("SendDirect"),
+            "Expected SendDirect to be replaced after inlining:\n{result}");
+
+        assert_snapshot!(result, @"
+        fn test@<compiled>:6:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          v2:CPtr = LoadSP
+          v3:BasicObject = LoadField v2, :n@0x1000
+          Jump bb3(v1, v3)
+        bb2():
+          EntryPoint JIT(0)
+          v6:BasicObject = LoadArg :self@0
+          v7:BasicObject = LoadArg :n@1
+          Jump bb3(v6, v7)
+        bb3(v9:BasicObject, v10:BasicObject):
+          PatchPoint MethodRedefined(Object@0x1008, with_yield@0x1010, cme:0x1018)
+          v27:ObjectSubclass[class_exact*:Object@VALUE(0x1008)] = GuardType v9, ObjectSubclass[class_exact*:Object@VALUE(0x1008)] recompile
+          PushInlineFrame v27 (0x1040), v10
+          v35:BasicObject = InvokeBlock, v10 # SendFallbackReason: InvokeBlock: not yet specialized
+          CheckInterrupts
+          PopInlineFrame
+          PatchPoint NoEPEscape(test)
+          Return v35
+        ");
+    }
+
+    #[test]
+    fn test_inline_method_with_block_param() {
+        // The callee captures the caller-supplied literal block in a `&block`
+        // parameter and invokes it with `block.call`. Inlining must preserve the
+        // block handler so the reified Proc dispatches to the right block.
+        eval("
+            def with_block_param(x, &block)
+              block.call(x)
+            end
+            def test(n)
+              with_block_param(n) { |x| x + 2 }
+            end
+            test(1)
+            test(1)
+        ");
+        let counters = crate::state::ZJITState::get_counters();
+        let inline_count_before = counters.inline_method_count;
+
+        let result = hir_string_with_inlining("test");
+
+        assert!(counters.inline_method_count > inline_count_before,
+            "Expected with_block_param to be inlined, inline_method_count did not increment.\nHIR:\n{result}");
+        assert!(result.contains("PushInlineFrame"),
+            "Expected PushInlineFrame in inlined HIR:\n{result}");
+        assert!(!result.contains("SendDirect"),
+            "Expected SendDirect to be replaced after inlining:\n{result}");
+
+        assert_snapshot!(result, @"
+        fn test@<compiled>:6:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          v2:CPtr = LoadSP
+          v3:BasicObject = LoadField v2, :n@0x1000
+          Jump bb3(v1, v3)
+        bb2():
+          EntryPoint JIT(0)
+          v6:BasicObject = LoadArg :self@0
+          v7:BasicObject = LoadArg :n@1
+          Jump bb3(v6, v7)
+        bb3(v9:BasicObject, v10:BasicObject):
+          PatchPoint MethodRedefined(Object@0x1008, with_block_param@0x1010, cme:0x1018)
+          v27:ObjectSubclass[class_exact*:Object@VALUE(0x1008)] = GuardType v9, ObjectSubclass[class_exact*:Object@VALUE(0x1008)] recompile
+          v54:NilClass = Const Value(nil)
+          PushInlineFrame v27 (0x1040), v10
+          v37:CPtr = GetEP 0
+          v38:CUInt64 = LoadField v37, :VM_ENV_DATA_INDEX_FLAGS@0x1048
+          v39:CBool = IsBlockParamModified v38
+          CondBranch v39, bb6(), bb7()
+        bb6():
+          v41:BasicObject = LoadField v37, :block@0x1049
+          Jump bb8(v41, v41)
+        bb7():
+          v43:CInt64 = LoadField v37, :VM_ENV_DATA_INDEX_SPECVAL@0x104a
+          v44:CInt64 = GuardAnyBitSet v43, CUInt64(1)
+          v45:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1050))
+          Jump bb8(v45, v54)
+        bb8(v35:BasicObject, v36:BasicObject):
+          v49:BasicObject = Send v35, :call, v10 # SendFallbackReason: SendWithoutBlock: unsupported optimized method type BlockCall
+          CheckInterrupts
+          PopInlineFrame
+          PatchPoint NoEPEscape(test)
+          Return v49
+        ");
+    }
+
+    #[test]
+    fn test_inline_method_that_forwards_block_arg() {
+        eval("
+            def inner(x)
+              yield x
+            end
+            def callee(x, &block)
+              inner(x, &block)
+            end
+            def test(n)
+              callee(n) { |x| x + 2 }
+            end
+            test(1)
+            test(1)
+        ");
+        let counters = crate::state::ZJITState::get_counters();
+        let inline_count_before = counters.inline_method_count;
+
+        let result = hir_string_with_inlining("test");
+
+        assert!(counters.inline_method_count > inline_count_before,
+            "Expected callee to be inlined despite forwarding its block.\nHIR:\n{result}");
+        assert_eq!(result.matches("PushInlineFrame").count(), 1,
+            "Expected only `callee` to be inlined, not `inner`:\n{result}");
+
+        assert_snapshot!(result, @"
+        fn test@<compiled>:9:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          v2:CPtr = LoadSP
+          v3:BasicObject = LoadField v2, :n@0x1000
+          Jump bb3(v1, v3)
+        bb2():
+          EntryPoint JIT(0)
+          v6:BasicObject = LoadArg :self@0
+          v7:BasicObject = LoadArg :n@1
+          Jump bb3(v6, v7)
+        bb3(v9:BasicObject, v10:BasicObject):
+          PatchPoint MethodRedefined(Object@0x1008, callee@0x1010, cme:0x1018)
+          v27:ObjectSubclass[class_exact*:Object@VALUE(0x1008)] = GuardType v9, ObjectSubclass[class_exact*:Object@VALUE(0x1008)] recompile
+          v55:NilClass = Const Value(nil)
+          PushInlineFrame v27 (0x1040), v10
+          v39:CPtr = GetEP 0
+          v40:CUInt64 = LoadField v39, :VM_ENV_DATA_INDEX_FLAGS@0x1048
+          v41:CBool = IsBlockParamModified v40
+          CondBranch v41, bb6(), bb7()
+        bb6():
+          v43:BasicObject = LoadField v39, :block@0x1049
+          Jump bb8(v43, v43)
+        bb7():
+          v45:CInt64 = LoadField v39, :VM_ENV_DATA_INDEX_SPECVAL@0x104a
+          v46:CInt64 = GuardAnyBitSet v45, CUInt64(1)
+          v47:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1050))
+          Jump bb8(v47, v55)
+        bb8(v37:BasicObject, v38:BasicObject):
+          v50:BasicObject = Send v27, &block, :inner, v10, v37 # SendFallbackReason: Complex argument passing
+          CheckInterrupts
+          PopInlineFrame
+          PatchPoint NoEPEscape(test)
+          Return v50
+        ");
+    }
+
+    #[test]
     fn test_inline_object_new_no_escape() {
         // Mirrors the object-new-no-escape benchmark from ruby-bench.
         eval("

--- a/zjit/src/stats.rs
+++ b/zjit/src/stats.rs
@@ -471,8 +471,6 @@ make_counters! {
     inline_reject_too_large,
     inline_reject_complex_params,
     inline_reject_ep_escapes,
-    inline_reject_invokeblock,
-    inline_reject_blockparam,
     inline_reject_denied,
     inline_reject_compile_failure,
     inline_reject_no_returns,


### PR DESCRIPTION
Previously, the inliner conservatively refused any callee that interacted with a block. `can_inline` rejected callees whose parameters included a block parameter, and separately scanned the callee bytecode and bailed on `invokeblock`, `getblockparam`, and `getblockparamproxy`. Together these excluded the common case of a small method that simply yields to a passed block.

This lifts those restrictions so such a method can itself be inlined. Only the enclosing method is inlined; the block body is still invoked through the normal block-dispatch path rather than being inlined in turn.

Removing the bytecode scan exposed a latent bug in the `invokeblock` lowering. The block-handler level was computed with `get_lvar_level(fun.iseq)`, but `fun.iseq` is the outer compiled function rather than the callee that contains the `invokeblock`. Under inlining the two diverge, so the level could be computed against the wrong frame. It now uses `exit_state.iseq`: the ISEQ of the frame actually executing the instruction.