### PR TITLE
Properly test implicit super in test_implicit_super_kwsplat

### DIFF
--- a/test/ruby/test_keyword.rb
+++ b/test/ruby/test_keyword.rb
@@ -615,7 +615,7 @@ class TestKeywordArguments < Test::Unit::TestCase
     sc = Class.new
     c = sc.new
     def c.m(*args, **kw)
-      super(*args, **kw)
+      super
     end
     sc.class_eval do
       def m(*args)


### PR DESCRIPTION
The method used explicit `super(*args, **kw)`, which made the test an exact duplicate of test_explicit_super_kwsplat and never exercised the zsuper code path its name implies. Use bare `super` so it actually tests implicit super.