### PR TITLE
If malloc_increase reaches the limit don't immediately gc_rest

### DIFF
--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -4360,6 +4360,26 @@ gc_sweep_continue(rb_objspace_t *objspace, rb_heap_t *sweep_heap)
     gc_sweeping_exit(objspace);
 }
 
+static void
+gc_sweep_step_for_malloc(rb_objspace_t *objspace)
+{
+    GC_ASSERT(is_lazy_sweeping(objspace));
+
+    unsigned int lock_lev;
+    gc_enter(objspace, gc_enter_event_continue, &lock_lev);
+
+    gc_sweeping_enter(objspace);
+
+    for (int i = 0; i < HEAP_COUNT; i++) {
+        rb_heap_t *heap = &heaps[i];
+        gc_sweep_step(objspace, heap);
+    }
+
+    gc_sweeping_exit(objspace);
+
+    gc_exit(objspace, gc_enter_event_continue, &lock_lev);
+}
+
 VALUE
 rb_gc_impl_location(void *objspace_ptr, VALUE value)
 {
@@ -8503,7 +8523,7 @@ objspace_malloc_increase_body(rb_objspace_t *objspace, void *mem, size_t new_siz
       retry:
         if (malloc_increase > malloc_limit && ruby_native_thread_p() && !dont_gc_val()) {
             if (ruby_thread_has_gvl_p() && is_lazy_sweeping(objspace)) {
-                gc_rest(objspace); /* gc_rest can reduce malloc_increase */
+                gc_sweep_step_for_malloc(objspace); /* sweeping frees may reduce malloc_increase */
                 goto retry;
             }
             garbage_collect_with_gvl(objspace, GPR_FLAG_MALLOC);


### PR DESCRIPTION
Instead lets run a single sweep step per heap and see if we can reduce malloc_increase enough to carry on without requiring a complete sweep finish and a big pause.

A quick smoke test on railsbench shows that this change results in less time spend in GC overall, and a slightly increased number of minor GC's vs majors

```
ubuntu@ip-172-31-30-75:~/src/ruby-bench$ ./run_benchmarks.rb railsbench --harness=gc  --chruby="master::ruby-base --yjit" --chruby="experiment::ruby-test --yjit" --interleave --rss

+ sudo -S sh -c 'echo 100 > /sys/devices/system/cpu/intel_pstate/min_perf_pct'
Running benchmark "railsbench" [master] (1/1)
+ setarch x86_64 -R taskset -c 31 /home/ubuntu/.rubies/ruby-base/bin/ruby --yjit -I harness-gc /home/ubuntu/src/ruby-bench/benchmarks/railsbench/benchmark.rb
ruby 4.1.0dev (2026-06-17T10:00:21Z master 45fd5d58f1) +YJIT +PRISM [x86_64-linux]

itr:   time   marking  sweeping  gc_count     major     minor  maj/min
 #1: 2035ms   190.0ms    53.0ms        22         5        17     0.29
 #2: 1504ms   133.0ms    48.0ms        17         4        13     0.31
 #3: 1530ms   149.0ms    47.0ms        16         4        12     0.33
 #4: 1490ms   135.0ms    45.0ms        13         4         9     0.44
 #5: 1451ms   102.0ms    44.0ms        13         3        10     0.30
 #6: 1447ms   103.0ms    42.0ms        12         3         9     0.33
 #7: 1436ms    84.0ms    46.0ms        12         2        10     0.20
 #8: 1447ms   104.0ms    42.0ms        11         3         8     0.38
 #9: 1404ms    70.0ms    41.0ms        10         2         8     0.25
#10: 1404ms    70.0ms    40.0ms        10         2         8     0.25
#11: 1427ms   105.0ms    39.0ms        10         3         7     0.43
#12: 1423ms    85.0ms    47.0ms         9         2         7     0.29
#13: 1395ms    70.0ms    39.0ms         9         2         7     0.29
#14: 1393ms    71.0ms    39.0ms         9         2         7     0.29
#15: 1393ms    71.0ms    38.0ms         8         2         6     0.33
#16: 1395ms    71.0ms    40.0ms         9         2         7     0.29
#17: 1394ms    71.0ms    41.0ms         8         2         6     0.33
#18: 1392ms    71.0ms    38.0ms         8         2         6     0.33
#19: 1355ms    37.0ms    39.0ms         8         1         7     0.14
#20: 1394ms    71.0ms    40.0ms         8         2         6     0.33
#21: 1391ms    72.0ms    37.0ms         8         2         6     0.33
#22: 1354ms    37.0ms    39.0ms         7         1         6     0.17
#23: 1348ms    36.0ms    35.0ms         7         1         6     0.17
#24: 1353ms    38.0ms    38.0ms         8         1         7     0.14
#25: 1311ms     1.0ms    36.0ms         7         0         7     0.00

RSS: 144.5MiB
RSS sampled (n=10): median 143.0MiB ± 1.2MiB (MAD), range [141.0, 144.5]MiB
Average of last 10, non-warmup iters: 1369ms
Average marking time: 50.0ms
Average sweeping time: 38.0ms

Running benchmark "railsbench" [experiment] (1/1)
+ setarch x86_64 -R taskset -c 31 /home/ubuntu/.rubies/ruby-test/bin/ruby --yjit -I harness-gc /home/ubuntu/src/ruby-bench/benchmarks/railsbench/benchmark.rb
ruby 4.1.0dev (2026-06-17T14:34:54Z mvh-obspace-malloc.. cbf9c41cfd) +YJIT +PRISM [x86_64-linux]

itr:   time   marking  sweeping  gc_count     major     minor  maj/min
 #1: 2045ms   193.0ms    51.0ms        20         5        15     0.33
 #2: 1511ms   134.0ms    48.0ms        16         4        12     0.33
 #3: 1500ms   116.0ms    47.0ms        14         3        11     0.27
 #4: 1460ms   102.0ms    44.0ms        13         3        10     0.30
 #5: 1462ms   103.0ms    43.0ms        13         3        10     0.30
 #6: 1423ms    70.0ms    42.0ms        11         2         9     0.22
 #7: 1483ms   118.0ms    46.0ms        11         3         8     0.38
 #8: 1415ms    70.0ms    42.0ms        11         2         9     0.22
 #9: 1455ms   104.0ms    41.0ms        10         3         7     0.43
#10: 1415ms    72.0ms    40.0ms        10         2         8     0.25
#11: 1438ms   104.0ms    40.0ms        10         3         7     0.43
#12: 1433ms    85.0ms    44.0ms         9         2         7     0.29
#13: 1405ms    70.0ms    39.0ms         9         2         7     0.29
#14: 1402ms    71.0ms    38.0ms         9         2         7     0.29
#15: 1406ms    71.0ms    40.0ms         8         2         6     0.33
#16: 1359ms    37.0ms    36.0ms         8         1         7     0.14
#17: 1405ms    71.0ms    40.0ms         9         2         7     0.29
#18: 1404ms    71.0ms    41.0ms         8         2         6     0.33
#19: 1401ms    72.0ms    37.0ms         8         2         6     0.33
#20: 1396ms    72.0ms    38.0ms         7         2         5     0.40
#21: 1364ms    36.0ms    39.0ms         8         1         7     0.14
#22: 1356ms    37.0ms    35.0ms         7         1         6     0.17
#23: 1363ms    37.0ms    38.0ms         8         1         7     0.14
#24: 1319ms     1.0ms    36.0ms         7         0         7     0.00
#25: 1316ms     1.0ms    34.0ms         7         0         7     0.00

RSS: 144.3MiB
RSS sampled (n=10): median 143.2MiB ± 1.0MiB (MAD), range [141.0, 144.3]MiB
Average of last 10, non-warmup iters: 1368ms
Average marking time: 43.0ms
Average sweeping time: 37.0ms

master: ruby 4.1.0dev (2026-06-17T10:00:21Z master 45fd5d58f1) +YJIT +PRISM [x86_64-linux]
experiment: ruby 4.1.0dev (2026-06-17T14:34:54Z mvh-obspace-malloc.. cbf9c41cfd) +YJIT +PRISM [x86_64-linux]

----------  -------------  ------------  ---------------  ------------  ------------------  -----------------  ---------------------
bench         master (ms)     RSS (MiB)  experiment (ms)     RSS (MiB)  experiment 1st itr  master/experiment  RSS master/experiment
railsbench  1369.2 ± 2.0%  142.9 ± 0.9%    1368.7 ± 2.3%  142.9 ± 0.8%               0.995              1.000                  1.000
----------  -------------  ------------  ---------------  ------------  ------------------  -----------------  ---------------------

GC summary:
----------  ---------------  ----------------  -------------  --------------  -------------  -------------  -------------
bench       mark/iter ratio  sweep/iter ratio  mark/GC ratio  sweep/GC ratio     major/iter     minor/iter     minor GC %
railsbench            1.161             1.024          1.146           1.011   1.4  →   1.2   6.4  →   6.5   82%  →   84%
----------  ---------------  ----------------  -------------  --------------  -------------  -------------  -------------
```