### PR TITLE
Add RUBY_TYPED_THREAD_SAFE_FREE flag

### DIFF
--- a/doc/extension.rdoc
+++ b/doc/extension.rdoc
@@ -735,13 +735,29 @@ are not sure.
 
 +RUBY_TYPED_FREE_IMMEDIATELY+ ::
 
-  This flag makes the garbage collector immediately invoke <tt>dfree()</tt>
-  during GC when it need to free your struct.
+  This flag allows the garbage collector to immediately invoke <tt>dfree()</tt>
+  during GC when it needs to free your struct.
   You can specify this flag if the <tt>dfree</tt> never unlocks Ruby's
   internal lock (GVL).
 
   If this flag is not set, Ruby defers invocation of <tt>dfree()</tt>
   and invokes <tt>dfree()</tt> at the same time as finalizers.
+
++RUBY_TYPED_THREAD_SAFE_FREE+ ::
+
+  This flag declares that the <tt>dfree()</tt> function is thread-safe.
+
+  With this flag set the garbage collector MAY invoke <tt>dfree()</tt>
+    * On any thread, whether a Ruby Thread or a native thread
+    * In parallel with calls to the same or other <tt>dfree</tt> functions
+    * Concurrently with other Ruby code
+
+  This should NOT be set on <tt>dfree()</tt> functions which access shared state
+  in a thread-unsafe way. A <tt>dfree()</tt> function which uses only
+  <tt>xfree()</tt> on the struct and memory it exclusively owns is thread-safe.
+
+  This flag implies +RUBY_TYPED_FREE_IMMEDIATELY+, since a thread-safe
+  <tt>dfree()</tt> is also safe to invoke immediately.
 
 +RUBY_TYPED_WB_PROTECTED+ ::
 

--- a/gc.c
+++ b/gc.c
@@ -1193,7 +1193,7 @@ VALUE
 rb_data_typed_object_zalloc(VALUE klass, size_t size, const rb_data_type_t *type)
 {
     if (RB_DATA_TYPE_EMBEDDABLE_P(type)) {
-        if (!(type->flags & RUBY_TYPED_FREE_IMMEDIATELY)) {
+        if (!(type->flags & (RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_THREAD_SAFE_FREE))) {
             rb_raise(rb_eTypeError, "Embeddable TypedData must be freed immediately");
         }
 
@@ -1474,7 +1474,7 @@ rb_data_free(void *objspace, VALUE obj)
 
         if (dfree) {
             bool embedded = RTYPEDDATA_EMBEDDED_P(obj);
-            int free_immediately = (type->flags & RUBY_TYPED_FREE_IMMEDIATELY) != 0;
+            int free_immediately = (type->flags & (RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_THREAD_SAFE_FREE)) != 0;
             bool free_embeddable_data = RB_DATA_TYPE_EMBEDDABLE_P(type) && !embedded;
 
             if (dfree == RUBY_DEFAULT_FREE) {

--- a/include/ruby/internal/core/rtypeddata.h
+++ b/include/ruby/internal/core/rtypeddata.h
@@ -120,6 +120,7 @@ static inline VALUE rbimpl_check_external_typeddata(VALUE obj);
  * Macros to see if each corresponding flag is defined.
  */
 #define RUBY_TYPED_FREE_IMMEDIATELY  RUBY_TYPED_FREE_IMMEDIATELY
+#define RUBY_TYPED_THREAD_SAFE_FREE  RUBY_TYPED_THREAD_SAFE_FREE
 #define RUBY_TYPED_FROZEN_SHAREABLE  RUBY_TYPED_FROZEN_SHAREABLE
 #define RUBY_TYPED_WB_PROTECTED      RUBY_TYPED_WB_PROTECTED
 #define RUBY_TYPED_EMBEDDABLE        RUBY_TYPED_EMBEDDABLE
@@ -147,6 +148,19 @@ rbimpl_typeddata_flags {
      * would better leave it unspecified.
      */
     RUBY_TYPED_FREE_IMMEDIATELY = 1,
+
+    /**
+     * This flag declares that the dfree function is thread-safe.  With it set,
+     * the garbage collector MAY invoke dfree on any thread (Ruby or native), in
+     * parallel with calls to the same or other dfree functions, and
+     * concurrently with other Ruby code.  Do not set it on dfree functions that
+     * touch shared state in a thread-unsafe way; a dfree that only calls xfree
+     * on the struct and memory it exclusively owns is thread-safe.
+     *
+     * This implies RUBY_TYPED_FREE_IMMEDIATELY, since a thread-safe dfree is
+     * also safe to invoke immediately.
+     */
+    RUBY_TYPED_THREAD_SAFE_FREE = 4,
 
     /**
      * This flag indicate to Ruby that the associated C struct may be embedded

--- a/zjit/bindgen/src/main.rs
+++ b/zjit/bindgen/src/main.rs
@@ -84,7 +84,6 @@ fn main() {
         .allowlist_type("RBasic")
 
         .allowlist_type("ruby_rstring_flags")
-        .allowlist_type("rbimpl_typeddata_flags")
 
         // This function prints info about a value and is useful for debugging
         .allowlist_function("rb_raw_obj_info")

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -344,12 +344,6 @@ pub const RMODULE_IS_REFINEMENT: ruby_rmodule_flags = 8192;
 pub type ruby_rmodule_flags = u32;
 pub const ROBJECT_HEAP: ruby_robject_flags = 65536;
 pub type ruby_robject_flags = u32;
-pub const RUBY_TYPED_FREE_IMMEDIATELY: rbimpl_typeddata_flags = 1;
-pub const RUBY_TYPED_EMBEDDABLE: rbimpl_typeddata_flags = 2;
-pub const RUBY_TYPED_FROZEN_SHAREABLE: rbimpl_typeddata_flags = 256;
-pub const RUBY_TYPED_WB_PROTECTED: rbimpl_typeddata_flags = 32;
-pub const RUBY_TYPED_DECL_MARKING: rbimpl_typeddata_flags = 16384;
-pub type rbimpl_typeddata_flags = u32;
 pub type rb_event_flag_t = u32;
 pub type rb_block_call_func = ::std::option::Option<
     unsafe extern "C" fn(


### PR DESCRIPTION
Lets a TypedData type declare its dfree as thread-safe, so the GC may run it on any thread, in parallel, and concurrently with Ruby code. Implies RUBY_TYPED_FREE_IMMEDIATELY.