### PR TITLE
IO::Buffer: Check freed in block of #each and #each_byte

### DIFF
--- a/io_buffer.c
+++ b/io_buffer.c
@@ -2285,10 +2285,10 @@ io_buffer_each(int argc, VALUE *argv, VALUE self)
 {
     RETURN_ENUMERATOR_KW(self, argc, argv, RB_NO_KEYWORDS);
 
+    struct rb_io_buffer *buffer = get_io_buffer(self);
     const void *base;
     size_t size;
-
-    rb_io_buffer_get_bytes_for_reading(self, &base, &size);
+    io_buffer_get_bytes_for_reading(buffer, &base, &size);
 
     ID buffer_type;
     if (argc >= 1) {
@@ -2303,7 +2303,13 @@ io_buffer_each(int argc, VALUE *argv, VALUE self)
 
     for (size_t i = 0; i < count; i++) {
         size_t current_offset = offset;
-        VALUE value = rb_io_buffer_get_value(base, size, buffer_type, &offset);
+        VALUE value;
+
+        io_buffer_get_bytes_for_reading(buffer, &base, &size);
+        if (!base) {
+            rb_raise(rb_eIOBufferInvalidatedError, "Buffer has been freed!");
+        }
+        value = rb_io_buffer_get_value(base, size, buffer_type, &offset);
         rb_yield_values(2, SIZET2NUM(current_offset), value);
     }
 
@@ -2369,10 +2375,11 @@ io_buffer_each_byte(int argc, VALUE *argv, VALUE self)
 {
     RETURN_ENUMERATOR_KW(self, argc, argv, RB_NO_KEYWORDS);
 
+    struct rb_io_buffer *buffer = get_io_buffer(self);
     const void *base;
     size_t size;
 
-    rb_io_buffer_get_bytes_for_reading(self, &base, &size);
+    io_buffer_get_bytes_for_reading(buffer, &base, &size);
 
     size_t offset, count;
     io_buffer_extract_offset_count(RB_IO_BUFFER_DATA_TYPE_U8, size, argc, argv, &offset, &count);
@@ -2382,7 +2389,12 @@ io_buffer_each_byte(int argc, VALUE *argv, VALUE self)
     }
 
     for (size_t i = 0; i < count; i++) {
-        unsigned char *value = (unsigned char *)base + i + offset;
+        unsigned char *value;
+        io_buffer_get_bytes_for_reading(buffer, &base, &size);
+        if (!base) {
+            rb_raise(rb_eIOBufferInvalidatedError, "Buffer has been freed!");
+        }
+        value = (unsigned char *)base + i + offset;
         rb_yield(RB_INT2FIX(*value));
     }
 
@@ -3946,7 +3958,9 @@ Init_IO_Buffer(void)
     /* Raised when you try to write to a read-only buffer, or resize an external buffer. */
     rb_eIOBufferAccessError = rb_define_class_under(rb_cIOBuffer, "AccessError", rb_eRuntimeError);
 
-    /* Raised if you try to access a buffer slice which no longer references a valid memory range of the underlying source. */
+    /* Raised if you try to access a buffer slice which no longer
+       references a valid memory range of the underlying source or a
+       buffer which is already freed. */
     rb_eIOBufferInvalidatedError = rb_define_class_under(rb_cIOBuffer, "InvalidatedError", rb_eRuntimeError);
 
     /* Raised if the mask given to a binary operation is invalid, e.g. zero length or overlaps the target buffer. */

--- a/test/ruby/test_io_buffer.rb
+++ b/test/ruby/test_io_buffer.rb
@@ -543,6 +543,15 @@ class TestIOBuffer < Test::Unit::TestCase
     end
   end
 
+  def test_each_free_in_block
+    buffer = IO::Buffer.new(128)
+    assert_raise(IO::Buffer::InvalidatedError) do
+      buffer.each(:U64) do
+        buffer.free
+      end
+    end
+  end
+
   def test_zero_length_each
     buffer = IO::Buffer.new(0)
 
@@ -563,6 +572,15 @@ class TestIOBuffer < Test::Unit::TestCase
     assert_raise(ArgumentError) { buffer.each_byte(0, 2).to_a }
     assert_raise(ArgumentError) { buffer.each_byte(1, 1).to_a }
     assert_raise(ArgumentError) { buffer.each_byte(SIZE_MAX, 0).to_a }
+  end
+
+  def test_each_byte_free_in_block
+    buffer = IO::Buffer.new(128)
+    assert_raise(IO::Buffer::InvalidatedError) do
+      buffer.each_byte do
+        buffer.free
+      end
+    end
   end
 
   def test_zero_length_each_byte


### PR DESCRIPTION
If a user call `#free` in block of `#each` and `#each_byte`, `#each` and `#each_byte` touch invalid address. It may cause a crash or return a broken data.

This checks whether `#free` is called in block or not. If `#free` is called, `IO::Buffer::InvalidatedError` is raised.