### PR TITLE
Add fast path for ASCII-8BIT in `String#downcase` / `String#upcase`

### DIFF
--- a/benchmark/string_downcase.yml
+++ b/benchmark/string_downcase.yml
@@ -7,6 +7,10 @@ prelude: |
   nonascii10 = nonascii1 * 10
   nonascii100 = nonascii10 * 10
   nonascii1000 = nonascii100 * 10
+  ascii8bit256 = (0..255).to_a.pack("C*")
+  ascii8bit2560 = ascii8bit256 * 10
+  ascii8bit25600 = ascii8bit2560 * 10
+  ascii8bit256000 = ascii8bit25600 * 10
 benchmark:
   downcase-1: str1.upcase
   downcase-10: str10.upcase
@@ -16,3 +20,7 @@ benchmark:
   downcase-nonascii10: nonascii10.downcase
   downcase-nonascii100: nonascii100.downcase
   downcase-nonascii1000: nonascii1000.downcase
+  downcase-ascii8bit-256: ascii8bit256.downcase
+  downcase-ascii8bit-2560: ascii8bit2560.downcase
+  downcase-ascii8bit-25600: ascii8bit25600.downcase
+  downcase-ascii8bit-256000: ascii8bit256000.downcase

--- a/benchmark/string_upcase.yml
+++ b/benchmark/string_upcase.yml
@@ -7,6 +7,10 @@ prelude: |
   nonascii10 = nonascii1 * 10
   nonascii100 = nonascii10 * 10
   nonascii1000 = nonascii100 * 10
+  ascii8bit256 = (0..255).to_a.pack("C*")
+  ascii8bit2560 = ascii8bit256 * 10
+  ascii8bit25600 = ascii8bit2560 * 10
+  ascii8bit256000 = ascii8bit25600 * 10
 benchmark:
   upcase-1: str1.upcase
   upcase-10: str10.upcase
@@ -16,3 +20,7 @@ benchmark:
   upcase-nonascii10: nonascii10.upcase
   upcase-nonascii100: nonascii100.upcase
   upcase-nonascii1000: nonascii1000.upcase
+  upcase-ascii8bit-256: ascii8bit256.upcase
+  upcase-ascii8bit-2560: ascii8bit2560.upcase
+  upcase-ascii8bit-25600: ascii8bit25600.upcase
+  upcase-ascii8bit-256000: ascii8bit256000.upcase

--- a/string.c
+++ b/string.c
@@ -7836,7 +7836,8 @@ case_option_single_p(OnigCaseFoldType flags, rb_encoding *enc, VALUE str)
 {
     if ((flags & ONIGENC_CASE_ASCII_ONLY) && (enc==rb_utf8_encoding() || rb_enc_mbmaxlen(enc) == 1))
         return true;
-    return !(flags & ONIGENC_CASE_FOLD_TURKISH_AZERI) && ENC_CODERANGE(str) == ENC_CODERANGE_7BIT;
+    return !(flags & ONIGENC_CASE_FOLD_TURKISH_AZERI) &&
+           (ENC_CODERANGE(str) == ENC_CODERANGE_7BIT || rb_is_ascii8bit_enc(enc));
 }
 
 /* 16 should be long enough to absorb any kind of single character length increase */

--- a/test/ruby/enc/test_case_mapping.rb
+++ b/test/ruby/enc/test_case_mapping.rb
@@ -60,6 +60,31 @@ class TestCaseMappingPreliminary < Test::Unit::TestCase
     check_swapcase_properties   'yUKIHIRO matsumoto (MAtz)', 'Yukihiro MATSUMOTO (maTZ)'
   end
 
+  def test_ascii_8bit_case_mapping_all_bytes
+    bytes = (0..255).to_a.pack("C*")
+    upper_ascii = "A".ord.."Z".ord
+    lower_ascii = "a".ord.."z".ord
+    downcase_expected = (0..255).map {|byte| upper_ascii.cover?(byte) ? byte + 32 : byte }.pack("C*")
+    upcase_expected = (0..255).map {|byte| lower_ascii.cover?(byte) ? byte - 32 : byte }.pack("C*")
+
+    assert_equal Encoding::ASCII_8BIT, bytes.encoding
+    assert_equal downcase_expected, bytes.downcase
+    assert_equal downcase_expected, bytes.downcase(:fold)
+    assert_equal upcase_expected, bytes.upcase
+
+    downcased = bytes.dup
+    assert_same downcased, downcased.downcase!
+    assert_equal downcase_expected, downcased
+
+    folded = bytes.dup
+    assert_same folded, folded.downcase!(:fold)
+    assert_equal downcase_expected, folded
+
+    upcased = bytes.dup
+    assert_same upcased, upcased.upcase!
+    assert_equal upcase_expected, upcased
+  end
+
   def test_invalid
     assert_raise(ArgumentError, "Should not be possible to upcase invalid string.") { "\xEB".dup.force_encoding('UTF-8').upcase }
     assert_raise(ArgumentError, "Should not be possible to downcase invalid string.") { "\xEB".dup.force_encoding('UTF-8').downcase }


### PR DESCRIPTION
## Background

`String#downcase` already has a fast path for case mappings that can be handled one byte at a time.

ASCII-8BIT strings should be able to use this path too. Case mapping for ASCII-8BIT only changes ASCII letters, and all non-ASCII bytes are preserved as bytes.

Before this change, ASCII-8BIT strings that contained bytes outside the 7-bit range missed the single-byte case mapping path.

## Proposal

Allow ASCII-8BIT strings to use the single-byte case mapping path, even when their coderange is not 7-bit.

```diff
-    return !(flags & ONIGENC_CASE_FOLD_TURKISH_AZERI) && ENC_CODERANGE(str) == ENC_CODERANGE_7BIT;
+    return !(flags & ONIGENC_CASE_FOLD_TURKISH_AZERI) &&
+           (ENC_CODERANGE(str) == ENC_CODERANGE_7BIT || rb_is_ascii8bit_enc(enc));
```

Add a parity test that checks all 256 byte values for `downcase`/`downcase!`, `upcase`/`upcase!`, and `downcase` with the `:fold` option which now goes through the fast path.

## Justification

ASCII-8BIT is a single-byte encoding, and its default case mapping only changes ASCII uppercase bytes (`A-Z`) to lowercase (`a-z`) and vice-versa. Bytes outside that range are unchanged.

## Tradeoffs

This broadens the single-byte case mapping path for ASCII-8BIT strings. The parity test checks every byte value to make sure the optimized path preserves existing behavior.

## Results

| Benchmark | Operation | base i/s | head fast path i/s | Speedup |
|---|---|---:|---:|---:|
| `ascii8bit-256` | `downcase` | 2.185M | 17.241M | 7.89x |
| `ascii8bit-2560` | `downcase` | 232.986k | 1.618M | 6.94x |
| `ascii8bit-25600` | `downcase` | 24.278k | 209.422k | 8.63x |
| `ascii8bit-256000` | `downcase` | 2.474k | 20.477k | 8.28x |
| `ascii8bit-256` | `upcase` | 2.229M | 17.070M | 7.66x |
| `ascii8bit-2560` | `upcase` | 234.680k | 1.616M | 6.89x |
| `ascii8bit-25600` | `upcase` | 24.600k | 207.370k | 8.43x |
| `ascii8bit-256000` | `upcase` | 2.482k | 20.434k | 8.23x |

The new parity test passes both before and after the fast path change.

## Methodology

- Built and tested the parity-test commit without the fast path.
- Built and tested `HEAD` with the fast path.
- Used `benchmark-driver` with 30 repeats, averaged.