### PR TITLE
Improve performance of `String#capitalize` with a single-byte ASCII fast path

### DIFF
--- a/benchmark/string_capitalize.yml
+++ b/benchmark/string_capitalize.yml
@@ -8,3 +8,6 @@ benchmark:
   capitalize-10: str10.capitalize
   capitalize-100: str100.capitalize
   capitalize-1000: str1000.capitalize
+  capitalize!-1: str1.dup.capitalize!
+  capitalize!-100: str100.dup.capitalize!
+  capitalize!-1000: str1000.dup.capitalize!

--- a/string.c
+++ b/string.c
@@ -8157,6 +8157,33 @@ rb_str_downcase(int argc, VALUE *argv, VALUE str)
     return ret;
 }
 
+static bool
+capitalize_single(VALUE str)
+{
+    char *s = RSTRING_PTR(str), *send = RSTRING_END(str);
+    bool modified = false;
+
+    if (s < send) {
+        unsigned int c = *(unsigned char*)s;
+
+        if ('a' <= c && c <= 'z') {
+            *s = 'A' + (c - 'a');
+            modified = true;
+        }
+        s++;
+    }
+    while (s < send) {
+        unsigned int c = *(unsigned char*)s;
+
+        if ('A' <= c && c <= 'Z') {
+            *s = 'a' + (c - 'A');
+            modified = true;
+        }
+        s++;
+    }
+
+    return modified;
+}
 
 /*
  *  call-seq:
@@ -8180,7 +8207,11 @@ rb_str_capitalize_bang(int argc, VALUE *argv, VALUE str)
     str_modify_keep_cr(str);
     enc = str_true_enc(str);
     if (RSTRING_LEN(str) == 0 || !RSTRING_PTR(str)) return Qnil;
-    if (flags&ONIGENC_CASE_ASCII_ONLY)
+    if (case_option_single_p(flags, enc, str)) {
+        if (capitalize_single(str))
+            flags |= ONIGENC_CASE_MODIFIED;
+    }
+    else if (flags&ONIGENC_CASE_ASCII_ONLY)
         rb_str_ascii_casemap(str, str, &flags, enc);
     else
         str_shared_replace(str, rb_str_casemap(str, &flags, enc));
@@ -8208,7 +8239,12 @@ rb_str_capitalize(int argc, VALUE *argv, VALUE str)
     flags = check_case_options(argc, argv, flags);
     enc = str_true_enc(str);
     if (RSTRING_LEN(str) == 0 || !RSTRING_PTR(str)) return str;
-    if (flags&ONIGENC_CASE_ASCII_ONLY) {
+    if (case_option_single_p(flags, enc, str)) {
+        ret = rb_str_new(RSTRING_PTR(str), RSTRING_LEN(str));
+        str_enc_copy_direct(ret, str);
+        capitalize_single(ret);
+    }
+    else if (flags&ONIGENC_CASE_ASCII_ONLY) {
         ret = rb_str_new(0, RSTRING_LEN(str));
         rb_str_ascii_casemap(str, ret, &flags, enc);
     }

--- a/string.c
+++ b/string.c
@@ -8164,7 +8164,7 @@ capitalize_single(VALUE str)
     bool modified = false;
 
     if (s < send) {
-        unsigned int c = *(unsigned char*)s;
+        unsigned int c = (unsigned char)*s;
 
         if ('a' <= c && c <= 'z') {
             *s = 'A' + (c - 'a');
@@ -8173,7 +8173,7 @@ capitalize_single(VALUE str)
         s++;
     }
     while (s < send) {
-        unsigned int c = *(unsigned char*)s;
+        unsigned int c = (unsigned char)*s;
 
         if ('A' <= c && c <= 'Z') {
             *s = 'a' + (c - 'A');


### PR DESCRIPTION
#upcase/#downcase already case-map ASCII strings with a plain byte loop, but #capitalize/#capitalize! always went through full Unicode case-mapping, making them around 10x slower on the same input. Add capitalize_single (mirroring upcase_single/downcase_single), taken whenever case_option_single_p() holds: it titlecases the first byte and downcases the rest, touching ASCII letters only.

Inspired by #17401. If #17401 is merged, `#capitalize`/`#capitalize!` also get faster on ASCII-8BIT (binary) strings containing high bytes (≥ 0x80), with no further changes needed here, since `capitalize` already calls the same predicate. The speedup measured ~3.6x at 25 KB and ~5.8x at 256 KB.

## Benchmark

`make benchmark COMPARE_RUBY=<master> ARGS=benchmark/string_capitalize.yml`
(Apple M1 Max):

|                  | master | this PR |
|:-----------------|-------:|--------:|
| capitalize-1     | 3.287M | 19.379M (5.89x) |
| capitalize-100   | 51.649k | 569.187k (11.02x) |
| capitalize-1000  | 5.239k | 66.531k (12.70x) |
| capitalize!-1    | 2.925M | 16.042M (5.48x) |
| capitalize!-100  | 51.639k | 535.214k (10.36x) |
| capitalize!-1000 | 5.097k | 60.788k (11.93x) |

`String#swapcase` could also benefit from something like this. 