### PR TITLE
Avoid `-C` with miniruby

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -1585,10 +1585,10 @@ no-test-bundled-gems-precheck:
 yes-update-default-gemspecs no-update-default-gemspecs: update-default-gemspecs
 update-default-gemspecs: $(PREP) $(RBCONFIG)
 	@$(MAKEDIRS) $(srcdir)/.bundle/specifications
-	$(Q)$(MINIRUBY) -W0 -C "$(srcdir)" -I tool/lib -roptparse -routput -rbundled_gem \
+	$(Q)$(MINIRUBY) -W0 -I "$(srcdir)/tool/lib" -roptparse -routput -rbundled_gem \
 	    -e "(out = Output.new).def_options(ARGV.options)" \
 	    -e "BundledGem.update_default_gemspecs(ARGV.parse!, out, quiet: $(V).zero?)" \
-	    -- -c -o .bundle/specifications lib ext
+	    -- -c -o "$(srcdir)/.bundle/specifications" "$(srcdir)/lib" "$(srcdir)/ext"
 
 install-for-test-bundled-gems: $(TEST_RUNNABLE)-install-for-test-bundled-gems
 no-install-for-test-bundled-gems: no-update-default-gemspecs


### PR DESCRIPTION
If `load-relative` is specified, the system uses `dladdr` to locate the executable file path when initializing the load path; however, on some platforms (at least OpenBSD), `dladdr` fails under certain conditions (such as when debug information is missing).  In that case, the system falls back to using `argv[0]`; however, if this is a relative path, the executable cannot be found after changing the working directory with the `-C` option, resulting in an error.