### PR TITLE
[3.4] Fix ar_find_entry_hint() to handle #eql? or another thread changing bound or converting to st_table

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -411,6 +411,7 @@ typedef st_index_t st_hash_t;
  */
 
 #define RHASH_AR_TABLE_MAX_BOUND     RHASH_AR_TABLE_MAX_SIZE
+#define RHASH_AR_TABLE_CONVERTED_TO_ST_TABLE (RHASH_AR_TABLE_MAX_BOUND + 1)
 
 #define RHASH_AR_TABLE_REF(hash, n) (&RHASH_AR_TABLE(hash)->pairs[n])
 #define RHASH_AR_CLEARED_HINT 0xff
@@ -658,18 +659,22 @@ ar_equal(VALUE x, VALUE y)
     return rb_any_cmp(x, y) == 0;
 }
 
+// Returns the bin index if found, RHASH_AR_TABLE_MAX_BOUND if not found,
+// or RHASH_AR_TABLE_CONVERTED_TO_ST_TABLE if #eql? or a Thread converted the hash to st_table.
 static unsigned
 ar_find_entry_hint(VALUE hash, ar_hint_t hint, st_data_t key)
 {
-    unsigned i, bound = RHASH_AR_TABLE_BOUND(hash);
-    const ar_hint_t *hints = RHASH_AR_TABLE(hash)->ar_hint.ary;
-
     /* if table is NULL, then bound also should be 0 */
 
-    for (i = 0; i < bound; i++) {
+    for (unsigned i = 0; i < RHASH_AR_TABLE_BOUND(hash); i++) {
+        const ar_hint_t *hints = RHASH_AR_TABLE(hash)->ar_hint.ary;
         if (hints[i] == hint) {
             ar_table_pair *pair = RHASH_AR_TABLE_REF(hash, i);
-            if (ar_equal(key, pair->key)) {
+            int eq = ar_equal(key, pair->key);
+            if (UNLIKELY(!RHASH_AR_TABLE_P(hash))) {
+                return RHASH_AR_TABLE_CONVERTED_TO_ST_TABLE;
+            }
+            if (eq) {
                 RB_DEBUG_COUNTER_INC(artable_hint_hit);
                 return i;
             }
@@ -950,6 +955,9 @@ ar_foreach_check(VALUE hash, st_foreach_check_callback_func *func, st_data_t arg
                 pair = RHASH_AR_TABLE_REF(hash, i);
                 if (pair->key == never) break;
                 ret = ar_find_entry_hint(hash, hint, key);
+                if (UNLIKELY(ret == RHASH_AR_TABLE_CONVERTED_TO_ST_TABLE)) {
+                    ensure_ar_table(hash);
+                }
                 if (ret == RHASH_AR_TABLE_MAX_BOUND) {
                     (*func)(0, 0, arg, 1);
                     return 2;
@@ -989,6 +997,9 @@ ar_update(VALUE hash, st_data_t key,
 
     if (RHASH_AR_TABLE_SIZE(hash) > 0) {
         bin = ar_find_entry(hash, hash_value, key);
+        if (UNLIKELY(bin == RHASH_AR_TABLE_CONVERTED_TO_ST_TABLE)) {
+            return -1;
+        }
         existing = (bin != RHASH_AR_TABLE_MAX_BOUND) ? TRUE : FALSE;
     }
     else {
@@ -1042,6 +1053,9 @@ ar_insert(VALUE hash, st_data_t key, st_data_t value)
     }
 
     bin = ar_find_entry(hash, hash_value, key);
+    if (UNLIKELY(bin == RHASH_AR_TABLE_CONVERTED_TO_ST_TABLE)) {
+        return -1;
+    }
     if (bin == RHASH_AR_TABLE_MAX_BOUND) {
         if (RHASH_AR_TABLE_SIZE(hash) >= RHASH_AR_TABLE_MAX_SIZE) {
             return -1;
@@ -1075,6 +1089,9 @@ ar_lookup(VALUE hash, st_data_t key, st_data_t *value)
             return st_lookup(RHASH_ST_TABLE(hash), key, value);
         }
         unsigned bin = ar_find_entry(hash, hash_value, key);
+        if (UNLIKELY(bin == RHASH_AR_TABLE_CONVERTED_TO_ST_TABLE)) {
+            return st_lookup(RHASH_ST_TABLE(hash), key, value);
+        }
 
         if (bin == RHASH_AR_TABLE_MAX_BOUND) {
             return 0;
@@ -1101,6 +1118,9 @@ ar_delete(VALUE hash, st_data_t *key, st_data_t *value)
     }
 
     bin = ar_find_entry(hash, hash_value, *key);
+    if (UNLIKELY(bin == RHASH_AR_TABLE_CONVERTED_TO_ST_TABLE)) {
+        return st_delete(RHASH_ST_TABLE(hash), key, value);
+    }
 
     if (bin == RHASH_AR_TABLE_MAX_BOUND) {
         if (value != 0) *value = 0;

--- a/test/ruby/test_hash.rb
+++ b/test/ruby/test_hash.rb
@@ -2427,4 +2427,33 @@ class TestHashOnly < Test::Unit::TestCase
     end
     assert_equal values, hash.values, "[ruby-core:121239] [Bug #21170]"
   end
+
+  def test_ar_find_entry_hint_eql_mutates_hash
+    # ar_find_entry_hint caches bound and hints, then calls #eql? which
+    # can mutate the hash. If #eql? triggers AR->ST conversion the loop
+    # would read st_table memory as ar_table pairs.
+    key_class = Class.new do
+      attr_reader :v
+      def initialize(v, h = nil)
+        @v = v
+        @h = h
+      end
+      def hash; 0; end
+      def eql?(other)
+        if @h
+          # Trigger AR->ST conversion
+          @h[42] = 42
+        end
+        other.is_a?(self.class) && @v == other.v
+      end
+    end
+
+    h = {}
+    8.times { |i| h[key_class.new(i)] = i }
+
+    # Not in the hash, so ar_find_entry_hint checks every entry.
+    lookup_key = key_class.new(-1, h)
+
+    assert_equal nil, h[lookup_key]
+  end
 end


### PR DESCRIPTION
* While perusing code in hash.c I found it suspicious that ar_find_entry_hint() didn't reread bound in the loop and yet called arbitrary code through #eql?.
* ar_find_entry_hint() before this commit would not check if bound or the storage (AR->ST) changed and would return a bin index which is not correct to access.
* Check bound in the loop so it's always up-to-date.
* Return RHASH_AR_TABLE_CONVERTED_TO_ST_TABLE when converted to st_table and make callers retry the operation as a st_table.

[Bug #22120]


(cherry picked from commit c88430e1878fe8d219a239259728a90098e014d2)