### PR TITLE
Implement copy-on-write Hash dup

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -3038,6 +3038,8 @@ mark_hash(VALUE hash)
 {
     if (RHASH_SHARED_TABLE_P(hash)) {
         gc_mark_internal(RHASH_SHARED_ROOT(hash));
+        gc_mark_internal(RHASH(hash)->ifnone);
+        return;
     }
 
     if (rb_hash_compare_by_id_p(hash)) {

--- a/gc.c
+++ b/gc.c
@@ -1425,7 +1425,7 @@ rb_gc_obj_needs_cleanup_p(VALUE obj)
         return rb_shape_has_fields(shape_id);
 
       case T_HASH:
-        if (flags & (RHASH_ST_TABLE_FLAG | RHASH_SHARED_TABLE_FLAG)) return true;
+        if (flags & RHASH_ST_TABLE_FLAG) return true;
         return rb_shape_has_fields(shape_id);
 
       case T_MATCH:

--- a/gc.c
+++ b/gc.c
@@ -1425,7 +1425,7 @@ rb_gc_obj_needs_cleanup_p(VALUE obj)
         return rb_shape_has_fields(shape_id);
 
       case T_HASH:
-        if (flags & RHASH_ST_TABLE_FLAG) return true;
+        if (flags & (RHASH_ST_TABLE_FLAG | RHASH_SHARED_TABLE_FLAG)) return true;
         return rb_shape_has_fields(shape_id);
 
       case T_MATCH:
@@ -2621,6 +2621,9 @@ rb_obj_memsize_of(VALUE obj)
         size += rb_ary_memsize(obj);
         break;
       case T_HASH:
+        if (RHASH_SHARED_TABLE_P(obj)) {
+            break;
+        }
         if (RHASH_ST_TABLE_P(obj)) {
             VM_ASSERT(RHASH_ST_TABLE(obj) != NULL);
             /* st_table is in the slot */
@@ -3033,6 +3036,10 @@ pin_key_mark_value(st_data_t key, st_data_t value, st_data_t data)
 static void
 mark_hash(VALUE hash)
 {
+    if (RHASH_SHARED_TABLE_P(hash)) {
+        gc_mark_internal(RHASH_SHARED_ROOT(hash));
+    }
+
     if (rb_hash_compare_by_id_p(hash)) {
         rb_hash_stlike_foreach(hash, pin_key_mark_value, 0);
     }
@@ -3939,6 +3946,11 @@ rb_gc_update_set_refs(st_table *tbl)
 static void
 gc_ref_update_hash(void *objspace, VALUE v)
 {
+    if (RHASH_SHARED_TABLE_P(v)) {
+        UPDATE_IF_MOVED(objspace, *RHASH_SHARED_ROOT_REF(v));
+        return;
+    }
+
     rb_hash_stlike_foreach_with_replace(v, hash_foreach_replace, hash_replace_ref, (st_data_t)objspace);
 }
 
@@ -5056,7 +5068,7 @@ rb_raw_obj_info_buitin_type(char *const buff, const size_t buff_size, const VALU
           }
           case T_HASH: {
             APPEND_F("[%c] %"PRIdSIZE,
-                     RHASH_AR_TABLE_P(obj) ? 'A' : 'S',
+                     RHASH_SHARED_TABLE_P(obj) ? 'H' : RHASH_AR_TABLE_P(obj) ? 'A' : 'S',
                      RHASH_SIZE(obj));
             break;
           }

--- a/hash.c
+++ b/hash.c
@@ -519,13 +519,44 @@ RHASH_TABLE_EMPTY_P(VALUE hash)
     return RHASH_SIZE(hash) == 0;
 }
 
-#define RHASH_SET_ST_FLAG(h)          FL_SET_RAW(h, RHASH_ST_TABLE_FLAG)
+#define RHASH_SET_ST_FLAG(h) do { \
+    FL_UNSET_RAW((h), RHASH_SHARED_TABLE_FLAG); \
+    FL_SET_RAW((h), RHASH_ST_TABLE_FLAG); \
+} while (0)
 #define RHASH_UNSET_ST_FLAG(h)        FL_UNSET_RAW(h, RHASH_ST_TABLE_FLAG)
+
+static void
+hash_set_shared_table(VALUE hash, VALUE root)
+{
+    HASH_ASSERT(RB_TYPE_P(root, T_HASH));
+    HASH_ASSERT(RHASH_ST_TABLE_P(root));
+    HASH_ASSERT(!RHASH_SHARED_TABLE_P(root));
+
+    RBASIC(hash)->flags &= ~(RHASH_ST_TABLE_FLAG | RHASH_AR_TABLE_SIZE_MASK | RHASH_AR_TABLE_BOUND_MASK);
+    FL_SET_RAW(hash, RHASH_SHARED_TABLE_FLAG);
+    RB_OBJ_WRITE(hash, RHASH_SHARED_ROOT_REF(hash), root);
+}
+
+static void
+hash_materialize_shared_table(VALUE hash)
+{
+    if (!RHASH_SHARED_TABLE_P(hash)) return;
+
+    VALUE root = RHASH_SHARED_ROOT(hash);
+    st_table tab;
+
+    st_replace(&tab, RHASH_ST_TABLE(root));
+    RBASIC(hash)->flags &= ~(RHASH_SHARED_TABLE_FLAG | RHASH_AR_TABLE_SIZE_MASK | RHASH_AR_TABLE_BOUND_MASK);
+    RHASH_SET_ST_FLAG(hash);
+    *RHASH_ST_TABLE_RAW(hash) = tab;
+    rb_gc_writebarrier_remember(hash);
+    hash_verify(hash);
+}
 
 static void
 hash_st_table_init(VALUE hash, const struct st_hash_type *type, st_index_t size)
 {
-    st_init_existing_table_with_size(RHASH_ST_TABLE(hash), type, size);
+    st_init_existing_table_with_size(RHASH_ST_TABLE_RAW(hash), type, size);
     RHASH_SET_ST_FLAG(hash);
 }
 
@@ -535,7 +566,7 @@ rb_hash_st_table_set(VALUE hash, st_table *st)
     HASH_ASSERT(st != NULL);
     RHASH_SET_ST_FLAG(hash);
 
-    *RHASH_ST_TABLE(hash) = *st;
+    *RHASH_ST_TABLE_RAW(hash) = *st;
 }
 
 static inline void
@@ -701,6 +732,10 @@ ar_each_key(ar_table *ar, int max, enum ar_each_key_type type, st_data_t *dst_ke
 static st_table *
 ar_force_convert_table(VALUE hash, const char *file, int line)
 {
+    if (RHASH_SHARED_TABLE_P(hash)) {
+        hash_materialize_shared_table(hash);
+        return RHASH_ST_TABLE_RAW(hash);
+    }
     if (RHASH_ST_TABLE_P(hash)) {
         return RHASH_ST_TABLE(hash);
     }
@@ -1182,8 +1217,9 @@ static void
 hash_st_free(VALUE hash)
 {
     HASH_ASSERT(RHASH_ST_TABLE_P(hash));
+    HASH_ASSERT(!RHASH_SHARED_TABLE_P(hash));
 
-    rb_st_free_embedded_table(RHASH_ST_TABLE(hash));
+    rb_st_free_embedded_table(RHASH_ST_TABLE_RAW(hash));
 }
 
 static void
@@ -1196,6 +1232,9 @@ hash_st_free_and_clear_table(VALUE hash)
 void
 rb_hash_free(VALUE hash)
 {
+    if (RHASH_SHARED_TABLE_P(hash)) {
+        return;
+    }
     if (RHASH_ST_TABLE_P(hash)) {
         hash_st_free(hash);
     }
@@ -1381,6 +1420,8 @@ rb_hash_stlike_foreach(VALUE hash, st_foreach_callback_func *func, st_data_t arg
 int
 rb_hash_stlike_foreach_with_replace(VALUE hash, st_foreach_check_callback_func *func, st_update_callback_func *replace, st_data_t arg)
 {
+    hash_materialize_shared_table(hash);
+
     if (RHASH_AR_TABLE_P(hash)) {
         return ar_foreach_with_replace(hash, func, replace, arg);
     }
@@ -1513,10 +1554,46 @@ rb_hash_alloc_fixed_size(VALUE klass, st_index_t size)
 }
 
 static VALUE
-hash_copy(VALUE ret, VALUE hash)
+hash_make_shared_root(VALUE hash)
+{
+    HASH_ASSERT(RHASH_ST_TABLE_P(hash));
+
+    if (RHASH_SHARED_TABLE_P(hash)) {
+        return RHASH_SHARED_ROOT(hash);
+    }
+
+    if (RB_OBJ_FROZEN_RAW(hash)) {
+        return hash;
+    }
+
+    VALUE root = hash_alloc_flags(0, 0, Qnil, true);
+    rb_obj_hide(root);
+    RHASH_SET_ST_FLAG(root);
+
+    if (hash_iterating_p(hash)) {
+        st_replace(RHASH_ST_TABLE_RAW(root), RHASH_ST_TABLE_RAW(hash));
+    }
+    else {
+        *RHASH_ST_TABLE_RAW(root) = *RHASH_ST_TABLE_RAW(hash);
+        RHASH_ST_CLEAR(hash);
+        hash_set_shared_table(hash, root);
+    }
+
+    rb_gc_writebarrier_remember(root);
+    return root;
+}
+
+static VALUE
+hash_copy(VALUE ret, VALUE hash, bool shared)
 {
     if (rb_hash_compare_by_id_p(hash)) {
         rb_gc_register_pinning_obj(ret);
+    }
+
+    if (shared && RHASH_ST_TABLE_P(hash) && !RHASH_EMPTY_P(hash)) {
+        VALUE root = hash_make_shared_root(hash);
+        hash_set_shared_table(ret, root);
+        return ret;
     }
 
     if (RHASH_AR_TABLE_P(hash)) {
@@ -1542,7 +1619,7 @@ hash_copy(VALUE ret, VALUE hash)
         HASH_ASSERT(sizeof(st_table) <= sizeof(ar_table));
 
         RHASH_SET_ST_FLAG(ret);
-        st_replace(RHASH_ST_TABLE(ret), RHASH_ST_TABLE(hash));
+        st_replace(RHASH_ST_TABLE_RAW(ret), RHASH_ST_TABLE(hash));
 
         rb_gc_writebarrier_remember(ret);
     }
@@ -1560,14 +1637,14 @@ hash_dup_with_compare_by_id(VALUE hash)
         RHASH_UNSET_ST_FLAG(dup);
     }
 
-    return hash_copy(dup, hash);
+    return hash_copy(dup, hash, false);
 }
 
 static VALUE
 hash_dup(VALUE hash, VALUE klass, VALUE flags)
 {
     return hash_copy(hash_alloc_flags(klass, flags, RHASH_IFNONE(hash), !RHASH_EMPTY_P(hash) && RHASH_ST_TABLE_P(hash)),
-                     hash);
+                     hash, true);
 }
 
 VALUE
@@ -1578,6 +1655,17 @@ rb_hash_dup(VALUE hash)
 
     rb_copy_generic_ivar(ret, hash);
 
+    return ret;
+}
+
+static VALUE
+rb_hash_dup_modify(VALUE hash)
+{
+    const VALUE flags = RBASIC(hash)->flags;
+    VALUE ret = hash_copy(hash_alloc_flags(rb_obj_class(hash), flags & RHASH_PROC_DEFAULT, RHASH_IFNONE(hash), RHASH_ST_TABLE_P(hash)),
+                          hash, false);
+
+    rb_copy_generic_ivar(ret, hash);
     return ret;
 }
 
@@ -1611,6 +1699,7 @@ static void
 rb_hash_modify(VALUE hash)
 {
     rb_hash_modify_check(hash);
+    hash_materialize_shared_table(hash);
 }
 
 NORETURN(static void no_new_key(void));
@@ -1652,6 +1741,8 @@ typedef int (*tbl_update_func)(st_data_t *, st_data_t *, st_data_t, int);
 int
 rb_hash_stlike_update(VALUE hash, st_data_t key, st_update_callback_func *func, st_data_t arg)
 {
+    hash_materialize_shared_table(hash);
+
     if (RHASH_AR_TABLE_P(hash)) {
         int result = ar_update(hash, key, func, arg);
         if (result == -1) {
@@ -1821,7 +1912,7 @@ rb_hash_s_create(int argc, VALUE *argv, VALUE klass)
             else {
                 hash = hash_alloc(klass);
                 if (!RHASH_EMPTY_P(tmp))
-                    hash_copy(hash, tmp);
+                    hash_copy(hash, tmp, false);
                 return hash;
             }
         }
@@ -1988,7 +2079,7 @@ rb_hash_rehash(VALUE hash)
     if (hash_iterating_p(hash)) {
         rb_raise(rb_eRuntimeError, "rehash during iteration");
     }
-    rb_hash_modify_check(hash);
+    rb_hash_modify(hash);
     if (RHASH_AR_TABLE_P(hash)) {
         tmp = hash_alloc(0);
         rb_hash_foreach(hash, rb_hash_rehash_i, (VALUE)tmp);
@@ -2343,6 +2434,8 @@ rb_hash_key(VALUE hash, VALUE value)
 int
 rb_hash_stlike_delete(VALUE hash, st_data_t *pkey, st_data_t *pval)
 {
+    hash_materialize_shared_table(hash);
+
     if (RHASH_AR_TABLE_P(hash)) {
         return ar_delete(hash, pkey, pval);
     }
@@ -2426,7 +2519,7 @@ rb_hash_delete_m(VALUE hash, VALUE key)
 {
     VALUE val;
 
-    rb_hash_modify_check(hash);
+    rb_hash_modify(hash);
     val = rb_hash_delete_entry(hash, key);
 
     if (!UNDEF_P(val)) {
@@ -2479,7 +2572,7 @@ rb_hash_shift(VALUE hash)
 {
     struct shift_var var;
 
-    rb_hash_modify_check(hash);
+    rb_hash_modify(hash);
     if (RHASH_AR_TABLE_P(hash)) {
         var.key = Qundef;
         if (!hash_iterating_p(hash)) {
@@ -2550,7 +2643,7 @@ VALUE
 rb_hash_delete_if(VALUE hash)
 {
     RETURN_SIZED_ENUMERATOR(hash, 0, 0, hash_enum_size);
-    rb_hash_modify_check(hash);
+    rb_hash_modify(hash);
     if (!RHASH_TABLE_EMPTY_P(hash)) {
         rb_hash_foreach(hash, delete_if_i, hash);
         compact_after_delete(hash);
@@ -2820,7 +2913,7 @@ rb_hash_select_bang(VALUE hash)
     st_index_t n;
 
     RETURN_SIZED_ENUMERATOR(hash, 0, 0, hash_enum_size);
-    rb_hash_modify_check(hash);
+    rb_hash_modify(hash);
     n = RHASH_SIZE(hash);
     if (!n) return Qnil;
     rb_hash_foreach(hash, keep_if_i, hash);
@@ -2849,7 +2942,7 @@ static VALUE
 rb_hash_keep_if(VALUE hash)
 {
     RETURN_SIZED_ENUMERATOR(hash, 0, 0, hash_enum_size);
-    rb_hash_modify_check(hash);
+    rb_hash_modify(hash);
     if (!RHASH_TABLE_EMPTY_P(hash)) {
         rb_hash_foreach(hash, keep_if_i, hash);
     }
@@ -2874,7 +2967,7 @@ clear_i(VALUE key, VALUE value, VALUE dummy)
 VALUE
 rb_hash_clear(VALUE hash)
 {
-    rb_hash_modify_check(hash);
+    rb_hash_modify(hash);
 
     if (hash_iterating_p(hash)) {
         rb_hash_foreach(hash, clear_i, 0);
@@ -2989,7 +3082,7 @@ rb_hash_aset(VALUE hash, VALUE key, VALUE val)
 static VALUE
 rb_hash_replace(VALUE hash, VALUE hash2)
 {
-    rb_hash_modify_check(hash);
+    rb_hash_modify(hash);
     if (hash == hash2) return hash;
     if (hash_iterating_p(hash)) {
         rb_raise(rb_eRuntimeError, "can't replace hash during iteration");
@@ -3005,7 +3098,7 @@ rb_hash_replace(VALUE hash, VALUE hash2)
         hash_st_free_and_clear_table(hash);
     }
 
-    hash_copy(hash, hash2);
+    hash_copy(hash, hash2, true);
 
     return hash;
 }
@@ -3058,6 +3151,17 @@ each_value_i(VALUE key, VALUE value, VALUE _)
     return ST_CONTINUE;
 }
 
+static void
+hash_prepare_for_user_iteration(VALUE hash)
+{
+    if (RHASH_SHARED_TABLE_P(hash) && !RB_OBJ_FROZEN(hash)) {
+        /* If mutating during Hash#each was an error, shared hashes could keep
+         * iterating the root table. Since Ruby permits deletes and clears, the
+         * iterator and mutator need to operate on the same table. */
+        hash_materialize_shared_table(hash);
+    }
+}
+
 /*
  *  call-seq:
  *    each_value {|value| ... } -> self
@@ -3082,6 +3186,7 @@ static VALUE
 rb_hash_each_value(VALUE hash)
 {
     RETURN_SIZED_ENUMERATOR(hash, 0, 0, hash_enum_size);
+    hash_prepare_for_user_iteration(hash);
     rb_hash_foreach(hash, each_value_i, 0);
     return hash;
 }
@@ -3116,6 +3221,7 @@ static VALUE
 rb_hash_each_key(VALUE hash)
 {
     RETURN_SIZED_ENUMERATOR(hash, 0, 0, hash_enum_size);
+    hash_prepare_for_user_iteration(hash);
     rb_hash_foreach(hash, each_key_i, 0);
     return hash;
 }
@@ -3162,6 +3268,7 @@ static VALUE
 rb_hash_each_pair(VALUE hash)
 {
     RETURN_SIZED_ENUMERATOR(hash, 0, 0, hash_enum_size);
+    hash_prepare_for_user_iteration(hash);
     if (rb_block_pair_yield_optimizable())
         rb_hash_foreach(hash, each_pair_i_fast, 0);
     else
@@ -3425,7 +3532,7 @@ rb_hash_transform_keys_bang(int argc, VALUE *argv, VALUE hash)
     else {
         RETURN_SIZED_ENUMERATOR(hash, 0, 0, hash_enum_size);
     }
-    rb_hash_modify_check(hash);
+    rb_hash_modify(hash);
     if (!RHASH_TABLE_EMPTY_P(hash)) {
         long i;
         VALUE new_keys = hash_alloc(0);
@@ -3550,7 +3657,7 @@ static VALUE
 rb_hash_transform_values_bang(VALUE hash)
 {
     RETURN_SIZED_ENUMERATOR(hash, 0, 0, hash_enum_size);
-    rb_hash_modify_check(hash);
+    rb_hash_modify(hash);
 
     if (!RHASH_TABLE_EMPTY_P(hash)) {
         transform_values(hash);
@@ -4590,7 +4697,7 @@ delete_if_nil(VALUE key, VALUE value, VALUE hash)
 static VALUE
 rb_hash_compact(VALUE hash)
 {
-    VALUE result = rb_hash_dup(hash);
+    VALUE result = rb_hash_dup_modify(hash);
     if (!RHASH_EMPTY_P(hash)) {
         rb_hash_foreach(result, delete_if_nil, result);
         compact_after_delete(result);
@@ -4621,7 +4728,7 @@ static VALUE
 rb_hash_compact_bang(VALUE hash)
 {
     st_index_t n;
-    rb_hash_modify_check(hash);
+    rb_hash_modify(hash);
     n = RHASH_SIZE(hash);
     if (n) {
         rb_hash_foreach(hash, delete_if_nil, hash);
@@ -4665,7 +4772,7 @@ rb_hash_compare_by_id(VALUE hash)
 
     if (rb_hash_compare_by_id_p(hash)) return hash;
 
-    rb_hash_modify_check(hash);
+    rb_hash_modify(hash);
     if (hash_iterating_p(hash)) {
         rb_raise(rb_eRuntimeError, "compare_by_identity during iteration");
     }

--- a/hash.c
+++ b/hash.c
@@ -1299,6 +1299,24 @@ hash_iter_status_check(int status)
 }
 
 static int
+hash_iter_readonly_status_check(int status)
+{
+    switch (status) {
+      case ST_CONTINUE:
+        return ST_CHECK;
+      case ST_STOP:
+        return ST_STOP;
+      case ST_DELETE:
+      case ST_REPLACE:
+        rb_raise(rb_eRuntimeError, "can't modify hash during read-only iteration");
+      default:
+        rb_raise(rb_eRuntimeError, "unexpected hash iteration status: %d", status);
+    }
+
+    UNREACHABLE_RETURN(ST_STOP);
+}
+
+static int
 hash_ar_foreach_iter(st_data_t key, st_data_t value, st_data_t argp, int error)
 {
     struct hash_foreach_arg *arg = (struct hash_foreach_arg *)argp;
@@ -1311,6 +1329,18 @@ hash_ar_foreach_iter(st_data_t key, st_data_t value, st_data_t argp, int error)
 }
 
 static int
+hash_ar_foreach_readonly_iter(st_data_t key, st_data_t value, st_data_t argp, int error)
+{
+    struct hash_foreach_arg *arg = (struct hash_foreach_arg *)argp;
+
+    if (error) return ST_STOP;
+
+    int status = (*arg->func)((VALUE)key, (VALUE)value, arg->arg);
+
+    return hash_iter_readonly_status_check(status);
+}
+
+static int
 hash_foreach_iter(st_data_t key, st_data_t value, st_data_t argp, int error)
 {
     struct hash_foreach_arg *arg = (struct hash_foreach_arg *)argp;
@@ -1320,6 +1350,18 @@ hash_foreach_iter(st_data_t key, st_data_t value, st_data_t argp, int error)
     int status = (*arg->func)((VALUE)key, (VALUE)value, arg->arg);
 
     return hash_iter_status_check(status);
+}
+
+static int
+hash_foreach_readonly_iter(st_data_t key, st_data_t value, st_data_t argp, int error)
+{
+    struct hash_foreach_arg *arg = (struct hash_foreach_arg *)argp;
+
+    if (error) return ST_STOP;
+
+    int status = (*arg->func)((VALUE)key, (VALUE)value, arg->arg);
+
+    return hash_iter_readonly_status_check(status);
 }
 
 static unsigned long
@@ -1449,6 +1491,25 @@ hash_foreach_call(VALUE arg)
     return Qnil;
 }
 
+static VALUE
+hash_foreach_readonly_call(VALUE arg)
+{
+    VALUE hash = ((struct hash_foreach_arg *)arg)->hash;
+    int ret = 0;
+    if (RHASH_AR_TABLE_P(hash)) {
+        ret = ar_foreach_check(hash, hash_ar_foreach_readonly_iter,
+                               (st_data_t)arg, (st_data_t)Qundef);
+    }
+    else if (RHASH_ST_TABLE_P(hash)) {
+        ret = st_foreach_check(RHASH_ST_TABLE(hash), hash_foreach_readonly_iter,
+                               (st_data_t)arg, (st_data_t)Qundef);
+    }
+    if (ret) {
+        rb_raise(rb_eRuntimeError, "ret: %d, hash modified during read-only iteration", ret);
+    }
+    return Qnil;
+}
+
 void
 rb_hash_foreach(VALUE hash, rb_foreach_func *func, VALUE farg)
 {
@@ -1456,6 +1517,7 @@ rb_hash_foreach(VALUE hash, rb_foreach_func *func, VALUE farg)
 
     if (RHASH_TABLE_EMPTY_P(hash))
         return;
+    hash_materialize_shared_table(hash);
     arg.hash = hash;
     arg.func = (rb_foreach_func *)func;
     arg.arg  = farg;
@@ -1465,6 +1527,26 @@ rb_hash_foreach(VALUE hash, rb_foreach_func *func, VALUE farg)
     else {
         hash_iter_lev_inc(hash);
         rb_ensure(hash_foreach_call, (VALUE)&arg, hash_foreach_ensure, hash);
+    }
+    hash_verify(hash);
+}
+
+static void
+rb_hash_foreach_readonly(VALUE hash, rb_foreach_func *func, VALUE farg)
+{
+    struct hash_foreach_arg arg;
+
+    if (RHASH_TABLE_EMPTY_P(hash))
+        return;
+    arg.hash = hash;
+    arg.func = (rb_foreach_func *)func;
+    arg.arg  = farg;
+    if (RB_OBJ_FROZEN(hash)) {
+        hash_foreach_readonly_call((VALUE)&arg);
+    }
+    else {
+        hash_iter_lev_inc(hash);
+        rb_ensure(hash_foreach_readonly_call, (VALUE)&arg, hash_foreach_ensure, hash);
     }
     hash_verify(hash);
 }
@@ -3692,7 +3774,7 @@ rb_hash_to_a(VALUE hash)
     VALUE ary;
 
     ary = rb_ary_new_capa(RHASH_SIZE(hash));
-    rb_hash_foreach(hash, to_a_i, ary);
+    rb_hash_foreach_readonly(hash, to_a_i, ary);
 
     return ary;
 }
@@ -3916,7 +3998,7 @@ rb_hash_keys(VALUE hash)
         rb_ary_set_len(keys, size);
     }
     else {
-        rb_hash_foreach(hash, keys_i, keys);
+        rb_hash_foreach_readonly(hash, keys_i, keys);
     }
 
     return keys;
@@ -3967,7 +4049,7 @@ rb_hash_values(VALUE hash)
         rb_ary_set_len(values, size);
     }
     else {
-        rb_hash_foreach(hash, values_i, values);
+        rb_hash_foreach_readonly(hash, values_i, values);
     }
 
     return values;
@@ -4653,7 +4735,7 @@ rb_hash_flatten(int argc, VALUE *argv, VALUE hash)
         if (level == 0) return rb_hash_to_a(hash);
 
         ary = rb_ary_new_capa(RHASH_SIZE(hash) * 2);
-        rb_hash_foreach(hash, flatten_i, ary);
+        rb_hash_foreach_readonly(hash, flatten_i, ary);
         level--;
 
         if (level > 0) {
@@ -4667,7 +4749,7 @@ rb_hash_flatten(int argc, VALUE *argv, VALUE hash)
     }
     else {
         ary = rb_ary_new_capa(RHASH_SIZE(hash) * 2);
-        rb_hash_foreach(hash, flatten_i, ary);
+        rb_hash_foreach_readonly(hash, flatten_i, ary);
     }
 
     return ary;

--- a/internal/hash.h
+++ b/internal/hash.h
@@ -20,6 +20,7 @@ struct ar_table_struct;
 typedef unsigned char ar_hint_t;
 
 enum ruby_rhash_flags {
+    RHASH_SHARED_TABLE_FLAG = FL_USER0,                                  /* FL 0 */
     RHASH_PASS_AS_KEYWORDS = FL_USER1,                                   /* FL 1 */
     RHASH_PROC_DEFAULT = FL_USER2,                                       /* FL 2 */
     RHASH_ST_TABLE_FLAG = FL_USER3,                                      /* FL 3 */
@@ -49,6 +50,10 @@ typedef struct ar_table_struct {
     /* 64bit CPU: 8B * 2 * 8 = 128B */
     ar_table_pair pairs[RHASH_AR_TABLE_MAX_SIZE];
 } ar_table;
+
+typedef struct hash_shared_table_struct {
+    VALUE root;
+} hash_shared_table;
 
 struct RHash {
     struct RBasic basic;
@@ -98,7 +103,12 @@ static inline size_t RHASH_SIZE(VALUE h);
 static inline bool RHASH_EMPTY_P(VALUE h);
 static inline bool RHASH_AR_TABLE_P(VALUE h);
 static inline bool RHASH_ST_TABLE_P(VALUE h);
+static inline bool RHASH_SHARED_TABLE_P(VALUE h);
 static inline struct ar_table_struct *RHASH_AR_TABLE(VALUE h);
+static inline hash_shared_table *RHASH_SHARED_TABLE(VALUE h);
+static inline VALUE *RHASH_SHARED_ROOT_REF(VALUE h);
+static inline VALUE RHASH_SHARED_ROOT(VALUE h);
+static inline st_table *RHASH_ST_TABLE_RAW(VALUE h);
 static inline st_table *RHASH_ST_TABLE(VALUE h);
 static inline size_t RHASH_ST_SIZE(VALUE h);
 static inline void RHASH_ST_CLEAR(VALUE h);
@@ -126,7 +136,7 @@ VALUE rb_hash_compare_by_id(VALUE hash);
 static inline bool
 RHASH_AR_TABLE_P(VALUE h)
 {
-    return ! FL_TEST_RAW(h, RHASH_ST_TABLE_FLAG);
+    return ! FL_TEST_RAW(h, RHASH_ST_TABLE_FLAG | RHASH_SHARED_TABLE_FLAG);
 }
 
 RBIMPL_ATTR_RETURNS_NONNULL()
@@ -137,10 +147,46 @@ RHASH_AR_TABLE(VALUE h)
 }
 
 RBIMPL_ATTR_RETURNS_NONNULL()
+static inline hash_shared_table *
+RHASH_SHARED_TABLE(VALUE h)
+{
+    return (hash_shared_table *)((uintptr_t)h + sizeof(struct RHash));
+}
+
+static inline VALUE *
+RHASH_SHARED_ROOT_REF(VALUE h)
+{
+    return &RHASH_SHARED_TABLE(h)->root;
+}
+
+static inline bool
+RHASH_SHARED_TABLE_P(VALUE h)
+{
+    return FL_TEST_RAW(h, RHASH_SHARED_TABLE_FLAG);
+}
+
+static inline VALUE
+RHASH_SHARED_ROOT(VALUE h)
+{
+    RUBY_ASSERT(RHASH_SHARED_TABLE_P(h));
+    return *RHASH_SHARED_ROOT_REF(h);
+}
+
+RBIMPL_ATTR_RETURNS_NONNULL()
+static inline st_table *
+RHASH_ST_TABLE_RAW(VALUE h)
+{
+    return (st_table *)((uintptr_t)h + sizeof(struct RHash));
+}
+
+RBIMPL_ATTR_RETURNS_NONNULL()
 static inline st_table *
 RHASH_ST_TABLE(VALUE h)
 {
-    return (st_table *)((uintptr_t)h + sizeof(struct RHash));
+    if (RHASH_SHARED_TABLE_P(h)) {
+        return RHASH_ST_TABLE(RHASH_SHARED_ROOT(h));
+    }
+    return RHASH_ST_TABLE_RAW(h);
 }
 
 static inline VALUE
@@ -169,7 +215,7 @@ RHASH_EMPTY_P(VALUE h)
 static inline bool
 RHASH_ST_TABLE_P(VALUE h)
 {
-    return ! RHASH_AR_TABLE_P(h);
+    return FL_TEST_RAW(h, RHASH_ST_TABLE_FLAG | RHASH_SHARED_TABLE_FLAG);
 }
 
 static inline size_t
@@ -181,7 +227,8 @@ RHASH_ST_SIZE(VALUE h)
 static inline void
 RHASH_ST_CLEAR(VALUE h)
 {
-    memset(RHASH_ST_TABLE(h), 0, sizeof(st_table));
+    RUBY_ASSERT(!RHASH_SHARED_TABLE_P(h));
+    memset(RHASH_ST_TABLE_RAW(h), 0, sizeof(st_table));
 }
 
 static inline unsigned

--- a/ractor.c
+++ b/ractor.c
@@ -1170,6 +1170,13 @@ rb_obj_set_shareable_no_assert(VALUE obj)
 {
     FL_SET_RAW(obj, FL_SHAREABLE);
 
+    if (RB_TYPE_P(obj, T_HASH) && RHASH_SHARED_TABLE_P(obj)) {
+        VALUE root = RHASH_SHARED_ROOT(obj);
+        if (!RB_OBJ_SHAREABLE_P(root)) {
+            rb_obj_set_shareable_no_assert(root);
+        }
+    }
+
     if (rb_obj_gen_fields_p(obj)) {
         VALUE fields = rb_obj_fields_no_ractor_check(obj);
         if (imemo_type_p(fields, imemo_fields)) {

--- a/spec/ruby/optional/capi/hash_spec.rb
+++ b/spec/ruby/optional/capi/hash_spec.rb
@@ -190,6 +190,17 @@ describe "C-API Hash function" do
       out.should == {name: "Evan", sign: :libra}
       hsh.should == {}
     end
+
+    it "deletes via the callback without mutating the source of a shared dup" do
+      hsh = {}
+      20.times { |i| hsh[i] = i }
+      dup = hsh.dup
+
+      out = @s.rb_hash_foreach_delete(dup)
+      out.should == hsh
+      dup.should == {}
+      hsh.should == 20.times.to_h { |i| [i, i] }
+    end
   end
 
   describe "rb_hash_bulk_insert" do

--- a/test/ruby/test_hash.rb
+++ b/test/ruby/test_hash.rb
@@ -394,6 +394,15 @@ class TestHash < Test::Unit::TestCase
     h = @cls[a: 1, b: nil, c: false, d: true, e: nil]
     assert_equal({a: 1, c: false, d: true}, h.compact)
     assert_equal({a: 1, b: nil, c: false, d: true, e: nil}, h)
+
+    h = @cls[]
+    (1..20).each {|i| h[i] = i.even? ? nil : i}
+    assert_equal((1..20).select(&:odd?), h.compact.keys)
+    assert_equal(20, h.size)
+    assert_nil(h[2])
+    assert_equal(1, h[1])
+
+    h = @cls[a: 1, b: nil, c: false, d: true, e: nil]
     assert_same(h, h.compact!)
     assert_equal({a: 1, c: false, d: true}, h)
     assert_nil(h.compact!)
@@ -409,6 +418,37 @@ class TestHash < Test::Unit::TestCase
       assert_not_same(a, b)
       assert_equal(false, b.frozen?)
     end
+  end
+
+  def test_dup_large_hash_mutation_isolation
+    h = @cls[]
+    (1..20).each {|i| h[i] = i}
+
+    dup = h.dup
+    h[:source] = :source
+    dup[:dup] = :dup
+
+    assert_equal(:source, h[:source])
+    assert_nil(h[:dup])
+    assert_nil(dup[:source])
+    assert_equal(:dup, dup[:dup])
+    assert_equal((1..20).to_a, (1..20).select {|i| dup[i] == i})
+  end
+
+  def test_dup_large_compare_by_identity_hash_mutation_isolation
+    h = @cls[].compare_by_identity
+    (1..20).each {|i| h[i] = i}
+
+    dup = h.dup
+    source_key = +"key"
+    dup_key = +"key"
+    h[source_key] = :source
+    dup[dup_key] = :dup
+
+    assert_predicate(h, :compare_by_identity?)
+    assert_predicate(dup, :compare_by_identity?)
+    assert_nil(h[dup_key])
+    assert_nil(dup[source_key])
   end
 
   def test_dup_equality
@@ -436,6 +476,23 @@ class TestHash < Test::Unit::TestCase
     h[1] = 1
     h[2] = 2
     assert_equal([[1,1],[2,2]], h.each.to_a)
+
+    (1..9).each {|i| h[i] = i}
+    h.dup.each do |k, v|
+      assert_equal(v, h.delete(k))
+    end
+    assert_equal(@cls[], h)
+
+    h = @cls[]
+    (1..20).each {|i| h[i] = i}
+    h = h.dup
+    count = 0
+    h.each do
+      count += 1
+      h.clear
+    end
+    assert_equal(1, count)
+    assert_empty(h)
   end
 
   def test_each_key
@@ -448,6 +505,23 @@ class TestHash < Test::Unit::TestCase
       h.delete(k)
     end
     assert_equal(@cls[], h)
+
+    (1..9).each {|i| h[i] = i}
+    h.dup.each_key do |k|
+      assert_equal(k, h.delete(k))
+    end
+    assert_equal(@cls[], h)
+
+    h = @cls[]
+    (1..20).each {|i| h[i] = i}
+    h = h.dup
+    count = 0
+    h.each_key do
+      count += 1
+      h.clear
+    end
+    assert_equal(1, count)
+    assert_empty(h)
   end
 
   def test_each_pair
@@ -460,6 +534,23 @@ class TestHash < Test::Unit::TestCase
       assert_equal(v, h.delete(k))
     end
     assert_equal(@cls[], h)
+
+    (1..9).each {|i| h[i] = i}
+    h.dup.each_pair do |k, v|
+      assert_equal(v, h.delete(k))
+    end
+    assert_equal(@cls[], h)
+
+    h = @cls[]
+    (1..20).each {|i| h[i] = i}
+    h = h.dup
+    count = 0
+    h.each_pair do
+      count += 1
+      h.clear
+    end
+    assert_equal(1, count)
+    assert_empty(h)
   end
 
   def test_each_value
@@ -475,6 +566,17 @@ class TestHash < Test::Unit::TestCase
 
     assert_equal([], expected - res)
     assert_equal([], res - expected)
+
+    h = @cls[]
+    (1..20).each {|i| h[i] = i}
+    h = h.dup
+    count = 0
+    h.each_value do
+      count += 1
+      h.clear
+    end
+    assert_equal(1, count)
+    assert_empty(h)
   end
 
   def test_empty?

--- a/test/ruby/test_ractor.rb
+++ b/test/ruby/test_ractor.rb
@@ -229,6 +229,18 @@ class TestRactor < Test::Unit::TestCase
     RUBY
   end
 
+  def test_shareable_frozen_hash_dup
+    hash = 40.times.to_h { |i| [i, i] }
+    dup = hash.dup.freeze
+
+    assert_predicate dup, :frozen?
+    assert Ractor.shareable?(dup)
+    assert_nil GC.verify_internal_consistency
+
+    hash[0] = :changed
+    assert_equal 0, dup[0]
+  end
+
   def test_fork_raise_isolation_error
     assert_ractor(<<~'RUBY')
       ractor = Ractor.new do

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -680,6 +680,7 @@ pub struct rb_call_data {
 }
 pub const RSTRING_CHILLED: ruby_rstring_private_flags = 49152;
 pub type ruby_rstring_private_flags = u32;
+pub const RHASH_SHARED_TABLE_FLAG: ruby_rhash_flags = 4096;
 pub const RHASH_PASS_AS_KEYWORDS: ruby_rhash_flags = 8192;
 pub const RHASH_PROC_DEFAULT: ruby_rhash_flags = 16384;
 pub const RHASH_ST_TABLE_FLAG: ruby_rhash_flags = 32768;

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -1554,6 +1554,7 @@ pub struct rb_call_data {
 }
 pub const RSTRING_CHILLED: ruby_rstring_private_flags = 49152;
 pub type ruby_rstring_private_flags = u32;
+pub const RHASH_SHARED_TABLE_FLAG: ruby_rhash_flags = 4096;
 pub const RHASH_PASS_AS_KEYWORDS: ruby_rhash_flags = 8192;
 pub const RHASH_PROC_DEFAULT: ruby_rhash_flags = 16384;
 pub const RHASH_ST_TABLE_FLAG: ruby_rhash_flags = 32768;


### PR DESCRIPTION
This revives copy-on-write Hash duplication using a hidden shared root rather than a per-table refcount (https://github.com/ruby/ruby/pull/6613).

The implementation adds a third Hash table representation for shared hashes. Large ST-backed hashes can be duplicated by pointing the duplicate at a hidden root hash that owns the real `st_table`. Reads treat the shared representation as ST-like and follow the root. Mutating operations materialize the shared hash into a private ST table before changing entries.

Some deliberate design choices:

- Only ST-backed hashes are shared. AR-backed small hashes continue to be copied normally because they are cheap and have a different inline representation.
- Mutable source hashes are allowed to remain mutable after `dup`. When possible, the original table is moved into a hidden root and both source and duplicate point at it.
- If the source hash is currently being iterated, the source keeps its table and the hidden root receives a copied table, so active iterators are not invalidated.
- Frozen ST-backed hashes can act as the root directly.
- Shared children do not own the table memory. The hidden root accounts for and frees the `st_table`, matching Array's owner-accounting model for shared buffers.
- GC marking and compaction update shared-root references explicitly.

### Destructive foreach on a freshly duplicated hash

Some non-bang methods duplicate a hash and then immediately mutate the duplicate during traversal. `Hash#compact` is one example: it duplicates, then removes nil-valued entries from the result.

Using a shared duplicate there would let `ST_DELETE` operate on the shared root table, which also changes the source hash. To avoid that, this change adds `rb_hash_dup_modify`, which creates a private duplicate directly via `hash_copy(..., false)` instead of making a shared duplicate and immediately materializing it. `Hash#compact` now uses that helper.

### Mutation while iterating a shared hash

Ruby permits some mutation while iterating a Hash, including deleting entries and clearing the hash. With a shared hash, starting iteration over the root table and then materializing on mutation would leave the active iterator walking the old root table while the receiver has moved to a private table.

To preserve existing behavior, public user-yielding iteration entrypoints (`each`, `each_key`, `each_value`, and `each_pair`) now materialize mutable shared hashes before yielding. If mutation during Hash iteration were an error, this could be more efficient: shared hashes could continue iterating the root table without copying. Since Ruby allows deletes and clears, the iterator and mutator need to operate on the same table.

### Performance notes

I compared this branch against a clean `upstream/master` build at the same base revision (`46128b15d5`) using a standalone microbenchmark that times best-of-5 samples with GC disabled inside each sample.

The results match the expected shape of the design:

| benchmark | baseline | this branch | change |
|---|---:|---:|---:|
| `dup ar/8` | 11.6M/s | 11.7M/s | unchanged |
| `dup st/20` | 8.6M/s | 11.9M/s | 1.4x faster |
| `dup st/1000` | 2.3M/s | 13.0M/s | 5.6x faster |
| `dup st/10000` | 183.6k/s | 13.7M/s | 74x faster |
| `dup st/100000` | 7.1k/s | 13.3M/s | 1870x faster |
| `dup identity st/1000` | 2.3M/s | 12.3M/s | 5.2x faster |
| `dup+read st/1000` | 1.9M/s | 10.4M/s | 5.5x faster |
| `dup+mutate dup st/1000` | 2.0M/s | 1.9M/s | roughly neutral |
| `dup+mutate dup st/10000` | 183.0k/s | 191.4k/s | roughly neutral |
| `dup+each st/1000` | 34.6k/s | 34.9k/s | unchanged |

Small AR hashes are unchanged because they are still copied normally. ST-backed `Hash#dup` becomes effectively constant-time. Immediate mutation after `dup` is roughly neutral because the copy cost is paid at materialization. `dup.each` is also neutral because mutable shared hashes are materialized before public user-yielding iteration to preserve Ruby's existing mutation-during-iteration behavior.
