### PR TITLE
rb_define_method: allow compilers to precompute strlen

### DIFF
--- a/include/ruby/internal/anyargs.h
+++ b/include/ruby/internal/anyargs.h
@@ -281,14 +281,14 @@ RBIMPL_ANYARGS_DECL(rb_define_method, VALUE, const char *)
 /** @endcond */
 
 /**
- * @brief  Defines klass\#mid.
- * @see    ::rb_define_method
- * @param  klass  Where the method lives.
- * @param  mid    Name of the defining method.
- * @param  func   Implementation of klass\#mid.
- * @param  arity  Arity of klass\#mid.
- */
-#define rb_define_method(klass, mid, func, arity)           RBIMPL_ANYARGS_DISPATCH_rb_define_method((arity), (func))((klass), (mid), (func), (arity))
+* @brief  Defines klass\#mid.
+* @see    ::rb_define_method
+* @param  klass  Where the method lives.
+* @param  mid    Name of the defining method.
+* @param  func   Implementation of klass\#mid.
+* @param  arity  Arity of klass\#mid.
+*/
+#define rb_define_method(klass, mid, func, arity)           RBIMPL_ANYARGS_DISPATCH_rb_define_method_id((arity), (func))((klass), rb_intern_const(mid), (func), (arity))
 
 /**
  * @brief  Defines klass\#mid.


### PR DESCRIPTION
By inlining the `rb_intern()` call, we allow it to be replaced by `rb_intern_const()` which with most compiler will allow to save the `strlen` call when invoked with a string literal.

This is a small optimization, but during program boot, `rb_define_method` is called thousands of times.

Other `rb_define_*` function could benefit from the same treatment, but that require exposing an `_id` versionm, which most of them lack.