### PR TITLE
Improve inlineability of `rb_define_class` and `rb_define_module`

### DIFF
--- a/class.c
+++ b/class.c
@@ -1402,12 +1402,18 @@ rb_class_inherited(VALUE super, VALUE klass)
     return rb_funcall(super, inherited, 1, klass);
 }
 
+#ifdef rb_define_class
+#undef rb_define_class
+#endif
 VALUE
 rb_define_class(const char *name, VALUE super)
 {
     return rb_define_class_under(rb_cObject, name, super);
 }
 
+#ifdef rb_define_class_under
+#undef rb_define_class_under
+#endif
 VALUE
 rb_define_class_under(VALUE outer, const char *name, VALUE super)
 {
@@ -1506,12 +1512,18 @@ rb_define_module_id(ID id)
     return rb_module_new();
 }
 
+#ifdef rb_define_module
+#undef rb_define_module
+#endif
 VALUE
 rb_define_module(const char *name)
 {
     return rb_define_module_id_under(rb_cObject, rb_intern(name));
 }
 
+#ifdef rb_define_module_under
+#undef rb_define_module_under
+#endif
 VALUE
 rb_define_module_under(VALUE outer, const char *name)
 {

--- a/class.c
+++ b/class.c
@@ -1509,24 +1509,7 @@ rb_define_module_id(ID id)
 VALUE
 rb_define_module(const char *name)
 {
-    VALUE module;
-    ID id = rb_intern(name);
-
-    if (rb_const_defined(rb_cObject, id)) {
-        module = rb_const_get(rb_cObject, id);
-        if (!RB_TYPE_P(module, T_MODULE)) {
-            rb_raise(rb_eTypeError, "%s is not a module (%"PRIsVALUE")",
-                     name, rb_obj_class(module));
-        }
-        /* Module may have been defined in Ruby and not pin-rooted */
-        rb_vm_register_global_object(module);
-        return module;
-    }
-    module = rb_module_new();
-    rb_vm_register_global_object(module);
-    rb_const_set(rb_cObject, id, module);
-
-    return module;
+    return rb_define_module_id_under(rb_cObject, rb_intern(name));
 }
 
 VALUE
@@ -1543,9 +1526,15 @@ rb_define_module_id_under(VALUE outer, ID id)
     if (rb_const_defined_at(outer, id)) {
         module = rb_const_get_at(outer, id);
         if (!RB_TYPE_P(module, T_MODULE)) {
-            rb_raise(rb_eTypeError, "%"PRIsVALUE"::%"PRIsVALUE" is not a module"
-                     " (%"PRIsVALUE")",
-                     outer, rb_id2str(id), rb_obj_class(module));
+            if (outer == rb_cObject) {
+                rb_raise(rb_eTypeError, "%s is not a module (%"PRIsVALUE")",
+                         rb_id2name(id), rb_obj_class(module));
+            }
+            else {
+                rb_raise(rb_eTypeError, "%"PRIsVALUE"::%"PRIsVALUE" is not a module"
+                         " (%"PRIsVALUE")",
+                         outer, rb_id2str(id), rb_obj_class(module));
+            }
         }
         /* Module may have been defined in Ruby and not pin-rooted */
         rb_vm_register_global_object(module);

--- a/class.c
+++ b/class.c
@@ -1405,32 +1405,7 @@ rb_class_inherited(VALUE super, VALUE klass)
 VALUE
 rb_define_class(const char *name, VALUE super)
 {
-    VALUE klass;
-    ID id = rb_intern(name);
-
-    if (rb_const_defined(rb_cObject, id)) {
-        klass = rb_const_get(rb_cObject, id);
-        if (!RB_TYPE_P(klass, T_CLASS)) {
-            rb_raise(rb_eTypeError, "%s is not a class (%"PRIsVALUE")",
-                     name, rb_obj_class(klass));
-        }
-        if (rb_class_real(RCLASS_SUPER(klass)) != super) {
-            rb_raise(rb_eTypeError, "superclass mismatch for class %s", name);
-        }
-
-        /* Class may have been defined in Ruby and not pin-rooted */
-        rb_vm_register_global_object(klass);
-        return klass;
-    }
-    if (!super) {
-        rb_raise(rb_eArgError, "no super class for '%s'", name);
-    }
-    klass = rb_define_class_id(id, super);
-    rb_vm_register_global_object(klass);
-    rb_const_set(rb_cObject, id, klass);
-    rb_class_inherited(super, klass);
-
-    return klass;
+    return rb_define_class_under(rb_cObject, name, super);
 }
 
 VALUE
@@ -1447,22 +1422,38 @@ rb_define_class_id_under_no_pin(VALUE outer, ID id, VALUE super)
     if (rb_const_defined_at(outer, id)) {
         klass = rb_const_get_at(outer, id);
         if (!RB_TYPE_P(klass, T_CLASS)) {
-            rb_raise(rb_eTypeError, "%"PRIsVALUE"::%"PRIsVALUE" is not a class"
-                     " (%"PRIsVALUE")",
-                     outer, rb_id2str(id), rb_obj_class(klass));
+            if (outer == rb_cObject) {
+                rb_raise(rb_eTypeError, "%s is not a class (%"PRIsVALUE")",
+                         rb_id2name(id), rb_obj_class(klass));
+            }
+            else {
+                rb_raise(rb_eTypeError, "%"PRIsVALUE"::%"PRIsVALUE" is not a class"
+                         " (%"PRIsVALUE")",
+                         outer, rb_id2str(id), rb_obj_class(klass));
+            }
         }
         if (rb_class_real(RCLASS_SUPER(klass)) != super) {
-            rb_raise(rb_eTypeError, "superclass mismatch for class "
-                     "%"PRIsVALUE"::%"PRIsVALUE""
-                     " (%"PRIsVALUE" is given but was %"PRIsVALUE")",
-                     outer, rb_id2str(id), RCLASS_SUPER(klass), super);
+            if (outer == rb_cObject) {
+                rb_raise(rb_eTypeError, "superclass mismatch for class %s", rb_id2name(id));
+            }
+            else {
+                rb_raise(rb_eTypeError, "superclass mismatch for class "
+                         "%"PRIsVALUE"::%"PRIsVALUE""
+                         " (%"PRIsVALUE" is given but was %"PRIsVALUE")",
+                         outer, rb_id2str(id), RCLASS_SUPER(klass), super);
+            }
         }
 
         return klass;
     }
     if (!super) {
-        rb_raise(rb_eArgError, "no super class for '%"PRIsVALUE"::%"PRIsVALUE"'",
+        if (outer == rb_cObject) {
+            rb_raise(rb_eArgError, "no super class for '%"PRIsVALUE"'", rb_id2str(id));
+        }
+        else {
+            rb_raise(rb_eArgError, "no super class for '%"PRIsVALUE"::%"PRIsVALUE"'",
                  rb_class_path(outer), rb_id2str(id));
+        }
     }
     klass = rb_define_class_id(id, super);
     rb_set_class_path_string(klass, outer, rb_id2str(id));

--- a/include/ruby/internal/module.h
+++ b/include/ruby/internal/module.h
@@ -66,6 +66,8 @@ RBIMPL_ATTR_NONNULL(())
  */
 VALUE rb_define_class(const char *name, VALUE super);
 
+#define rb_define_class(name, super) rb_define_class_id_under(rb_cObject, rb_intern_const((name)), (super))
+
 RBIMPL_ATTR_NONNULL(())
 /**
  * Defines a top-level module.
@@ -84,6 +86,8 @@ RBIMPL_ATTR_NONNULL(())
  * use other ways to create one.
  */
 VALUE rb_define_module(const char *name);
+
+#define rb_define_module(name) rb_define_module_id_under(rb_cObject, rb_intern_const((name)))
 
 RBIMPL_ATTR_NONNULL(())
 /**
@@ -108,6 +112,8 @@ RBIMPL_ATTR_NONNULL(())
  */
 VALUE rb_define_class_under(VALUE outer, const char *name, VALUE super);
 
+#define rb_define_class_under(outer, name, super) rb_define_class_id_under((outer), rb_intern_const((name)), (super))
+
 RBIMPL_ATTR_NONNULL(())
 /**
  * Defines a module under the namespace of `outer`.
@@ -122,6 +128,8 @@ RBIMPL_ATTR_NONNULL(())
  *              function. They are immortal.
  */
 VALUE rb_define_module_under(VALUE outer, const char *name);
+
+#define rb_define_module_under(outer, name) rb_define_module_id_under((outer), rb_intern_const((name)))
 
 /**
  * Includes a module to a class.


### PR DESCRIPTION
As well as `rb_define_class_under` and `rb_define_module_under`.

By moving the `rb_intern` to the caller, we allow compilers to precompute the `strlen` part of `rb_intern` which isn't a huge win, but happens quite a lot as part of Ruby's boot process and when requiring native gems.