### PR TITLE
Introduce Parallel Sweep

### DIFF
--- a/box.c
+++ b/box.c
@@ -328,7 +328,7 @@ static const rb_data_type_t rb_box_data_type = {
         box_entry_memsize,
         rb_box_gc_update_references,
     },
-    0, 0, RUBY_TYPED_FREE_IMMEDIATELY // TODO: enable RUBY_TYPED_WB_PROTECTED when inserting write barriers
+    0, 0, RUBY_TYPED_THREAD_SAFE_FREE // TODO: enable RUBY_TYPED_WB_PROTECTED when inserting write barriers
 };
 
 static const rb_data_type_t rb_master_box_data_type = {
@@ -791,7 +791,7 @@ box_ext_cleanup_free(void *p)
 static const rb_data_type_t box_ext_cleanup_type = {
     "box_ext_cleanup",
     {box_ext_cleanup_mark, box_ext_cleanup_free},
-    .flags = RUBY_TYPED_FREE_IMMEDIATELY,
+    .flags = RUBY_TYPED_THREAD_SAFE_FREE,
 };
 
 void

--- a/concurrent_set.c
+++ b/concurrent_set.c
@@ -4,14 +4,24 @@
 #include "ruby/atomic.h"
 #include "vm_sync.h"
 
-#define CONCURRENT_SET_CONTINUATION_BIT ((VALUE)1 << (sizeof(VALUE) * CHAR_BIT - 1))
-#define CONCURRENT_SET_HASH_MASK (~CONCURRENT_SET_CONTINUATION_BIT)
+// insertion probes have gone past this slot
+#define CONCURRENT_SET_CONTINUATION_BIT ((VALUE)0x2)
+#define CONCURRENT_SET_KEY_MASK (~CONCURRENT_SET_CONTINUATION_BIT)
+// This slot's hash can be reclaimed if and only if the key is EMPTY and it doesn't have a continuation bit. If the key is something
+// else, this bit on the hash has no meaning and is ignored.
+#define CONCURRENT_SET_HASH_RECLAIMABLE_BIT ((VALUE)1 << (sizeof(VALUE) * CHAR_BIT - 1))
+#define CONCURRENT_SET_HASH_MASK (~CONCURRENT_SET_HASH_RECLAIMABLE_BIT)
+
+#define CONCURRENT_SET_DEBUG 0
+#define CONCURRENT_SET_DEBUG_STATS 0
+#define CONCURRENT_SET_DEBUG_DUPLICATES 0
+#define CONCURRENT_SET_DEBUG_BAD_HASH_FN 0
 
 enum concurrent_set_special_values {
-    CONCURRENT_SET_EMPTY,
-    CONCURRENT_SET_DELETED,
-    CONCURRENT_SET_MOVED,
-    CONCURRENT_SET_SPECIAL_VALUE_COUNT
+    CONCURRENT_SET_EMPTY = 0,
+    CONCURRENT_SET_TOMBSTONE = 1,
+    CONCURRENT_SET_MOVED = 5, // continuation bit is 0x02, so 0x05 doesn't have bits in conflict with it
+    CONCURRENT_SET_SPECIAL_VALUE_COUNT = 6
 };
 
 struct concurrent_set_entry {
@@ -22,38 +32,53 @@ struct concurrent_set_entry {
 struct concurrent_set {
     rb_atomic_t size;
     unsigned int capacity;
-    unsigned int deleted_entries;
+    rb_atomic_t deleted_entries;
     const struct rb_concurrent_set_funcs *funcs;
     struct concurrent_set_entry *entries;
+    int key_type;
+#if CONCURRENT_SET_DEBUG_STATS
+    rb_atomic_t find_count;
+    rb_atomic_t find_probe_total;
+    rb_atomic_t find_probe_max;
+    rb_atomic_t insert_count;
+    rb_atomic_t insert_probe_total;
+    rb_atomic_t insert_probe_max;
+#endif
 };
 
-static void
-concurrent_set_mark_continuation(struct concurrent_set_entry *entry, VALUE curr_hash_and_flags)
+static bool
+concurrent_set_mark_continuation(struct concurrent_set_entry *entry, VALUE raw_key)
 {
-    if (curr_hash_and_flags & CONCURRENT_SET_CONTINUATION_BIT) return;
+    if (raw_key & CONCURRENT_SET_CONTINUATION_BIT) return true;
 
-    RUBY_ASSERT((curr_hash_and_flags & CONCURRENT_SET_HASH_MASK) != 0);
+    VALUE new_key = raw_key | CONCURRENT_SET_CONTINUATION_BIT; // NOTE: raw_key can be CONCURRENT_SET_EMPTY
+    VALUE prev_key = rbimpl_atomic_value_cas(&entry->key, raw_key, new_key, RBIMPL_ATOMIC_RELEASE, RBIMPL_ATOMIC_ACQUIRE);
 
-    VALUE new_hash = curr_hash_and_flags | CONCURRENT_SET_CONTINUATION_BIT;
-    VALUE prev_hash = rbimpl_atomic_value_cas(&entry->hash, curr_hash_and_flags, new_hash, RBIMPL_ATOMIC_RELEASE, RBIMPL_ATOMIC_RELAXED);
-
-    // At the moment we only expect to be racing concurrently against another
-    // thread also setting the continuation bit.
-    // In the future if deletion is concurrent this will need adjusting
-    RUBY_ASSERT(prev_hash == curr_hash_and_flags || prev_hash == new_hash);
-    (void)prev_hash;
+    if (prev_key == raw_key || prev_key == new_key) {
+        return true;
+    }
+    else if ((prev_key & CONCURRENT_SET_KEY_MASK) == CONCURRENT_SET_TOMBSTONE) {
+        return true;
+    }
+    else {
+        // * key could have been made EMPTY, and anything could have happened to this slot since then. Need to retry.
+        // * key could have been moved during resize
+        return false;
+    }
 }
 
 static VALUE
 concurrent_set_hash(const struct concurrent_set *set, VALUE key)
 {
     VALUE hash = set->funcs->hash(key);
+#if CONCURRENT_SET_DEBUG_BAD_HASH_FN
+    hash = hash % 1024;
+    if (hash == 0) hash = 1;
+#endif
     hash &= CONCURRENT_SET_HASH_MASK;
-    if (hash == 0) {
-        hash ^= CONCURRENT_SET_HASH_MASK;
-    }
+    if (hash == 0) hash = ~(VALUE)0 & CONCURRENT_SET_HASH_MASK;
     RUBY_ASSERT(hash != 0);
-    RUBY_ASSERT(!(hash & CONCURRENT_SET_CONTINUATION_BIT));
+    RUBY_ASSERT(!(hash & CONCURRENT_SET_HASH_RECLAIMABLE_BIT));
     return hash;
 }
 
@@ -91,18 +116,29 @@ static const rb_data_type_t concurrent_set_type = {
         .dsize = concurrent_set_size,
     },
     /* Hack: NOT WB_PROTECTED on purpose (see above) */
-    .flags = RUBY_TYPED_THREAD_SAFE_FREE | RUBY_TYPED_EMBEDDABLE
+    /* NOTE: don't make embedded due to compaction */
+    .flags = RUBY_TYPED_THREAD_SAFE_FREE
 };
 
 VALUE
-rb_concurrent_set_new(const struct rb_concurrent_set_funcs *funcs, int capacity)
+rb_concurrent_set_new(const struct rb_concurrent_set_funcs *funcs, int capacity, int key_type)
 {
     struct concurrent_set *set;
     VALUE obj = TypedData_Make_Struct(0, struct concurrent_set, &concurrent_set_type, set);
     set->funcs = funcs;
     set->entries = ZALLOC_N(struct concurrent_set_entry, capacity);
     set->capacity = capacity;
+    (void)key_type;
+#if CONCURRENT_SET_DEBUG
+    set->key_type = key_type;
+#endif
     return obj;
+}
+
+void *
+rb_concurrent_set_get_data(VALUE set_obj)
+{
+    return RTYPEDDATA_GET_DATA(set_obj);
 }
 
 rb_atomic_t
@@ -112,6 +148,50 @@ rb_concurrent_set_size(VALUE set_obj)
 
     return RUBY_ATOMIC_LOAD(set->size);
 }
+
+unsigned int
+rb_concurrent_set_capacity(VALUE set_obj)
+{
+    struct concurrent_set *set = RTYPEDDATA_GET_DATA(set_obj);
+
+    return set->capacity;
+}
+
+void
+rb_concurrent_set_probe_stats(VALUE set_obj,
+                              rb_atomic_t *find_count, rb_atomic_t *find_probe_total, rb_atomic_t *find_probe_max,
+                              rb_atomic_t *insert_count, rb_atomic_t *insert_probe_total, rb_atomic_t *insert_probe_max)
+{
+#if CONCURRENT_SET_DEBUG_STATS
+    struct concurrent_set *set = RTYPEDDATA_GET_DATA(set_obj);
+    *find_count = RUBY_ATOMIC_LOAD(set->find_count);
+    *find_probe_total = RUBY_ATOMIC_LOAD(set->find_probe_total);
+    *find_probe_max = RUBY_ATOMIC_LOAD(set->find_probe_max);
+    *insert_count = RUBY_ATOMIC_LOAD(set->insert_count);
+    *insert_probe_total = RUBY_ATOMIC_LOAD(set->insert_probe_total);
+    *insert_probe_max = RUBY_ATOMIC_LOAD(set->insert_probe_max);
+#else
+    *find_count = 0;
+    *find_probe_total = 0;
+    *find_probe_max = 0;
+    *insert_count = 0;
+    *insert_probe_total = 0;
+    *insert_probe_max = 0;
+#endif
+}
+
+#if CONCURRENT_SET_DEBUG_STATS
+static void
+concurrent_set_atomic_max(rb_atomic_t *target, rb_atomic_t val)
+{
+    rb_atomic_t cur = RUBY_ATOMIC_LOAD(*target);
+    while (val > cur) {
+        rb_atomic_t prev = rbimpl_atomic_cas(target, cur, val, RBIMPL_ATOMIC_RELAXED, RBIMPL_ATOMIC_RELAXED);
+        if (prev == cur) break;
+        cur = prev;
+    }
+}
+#endif
 
 struct concurrent_set_probe {
     int idx;
@@ -137,68 +217,61 @@ concurrent_set_probe_next(struct concurrent_set_probe *probe)
     return probe->idx;
 }
 
+// NOTE: must not allocate or cause GC
 static void
-concurrent_set_try_resize_without_locking(VALUE old_set_obj, VALUE *set_obj_ptr)
+concurrent_set_try_resize_locked(VALUE old_set_obj, VALUE *set_obj_ptr, VALUE new_set_obj, int old_capacity)
 {
-    // Check if another thread has already resized.
-    if (rbimpl_atomic_value_load(set_obj_ptr, RBIMPL_ATOMIC_ACQUIRE) != old_set_obj) {
-        return;
-    }
-
     struct concurrent_set *old_set = RTYPEDDATA_GET_DATA(old_set_obj);
-
-    // This may overcount by up to the number of threads concurrently attempting to insert
-    // GC may also happen between now and the set being rebuilt
-    int expected_size = rbimpl_atomic_load(&old_set->size, RBIMPL_ATOMIC_RELAXED) - old_set->deleted_entries;
-
-    // NOTE: new capacity must make sense with load factor, don't change one without checking the other.
     struct concurrent_set_entry *old_entries = old_set->entries;
-    int old_capacity = old_set->capacity;
-    int new_capacity = old_capacity * 2;
-    if (new_capacity > expected_size * 8) {
-        new_capacity = old_capacity / 2;
-    }
-    else if (new_capacity > expected_size * 4) {
-        new_capacity = old_capacity;
-    }
-
-    // May cause GC and therefore deletes, so must happen first.
-    VALUE new_set_obj = rb_concurrent_set_new(old_set->funcs, new_capacity);
     struct concurrent_set *new_set = RTYPEDDATA_GET_DATA(new_set_obj);
 
     for (int i = 0; i < old_capacity; i++) {
         struct concurrent_set_entry *old_entry = &old_entries[i];
-        VALUE key = rbimpl_atomic_value_exchange(&old_entry->key, CONCURRENT_SET_MOVED, RBIMPL_ATOMIC_ACQUIRE);
-        RUBY_ASSERT(key != CONCURRENT_SET_MOVED);
+        VALUE prev_key_raw = rbimpl_atomic_value_exchange(&old_entry->key, CONCURRENT_SET_MOVED, RBIMPL_ATOMIC_ACQUIRE);
+        VALUE prev_key = prev_key_raw & CONCURRENT_SET_KEY_MASK;
+        RUBY_ASSERT(prev_key != CONCURRENT_SET_MOVED);
 
-        if (key < CONCURRENT_SET_SPECIAL_VALUE_COUNT) continue;
-        if (!RB_SPECIAL_CONST_P(key) && rb_objspace_garbage_object_p(key)) continue;
+        if (prev_key < CONCURRENT_SET_SPECIAL_VALUE_COUNT) continue;
 
-        VALUE hash = rbimpl_atomic_value_load(&old_entry->hash, RBIMPL_ATOMIC_RELAXED) & CONCURRENT_SET_HASH_MASK;
-        RUBY_ASSERT(hash != 0);
-        RUBY_ASSERT(hash == concurrent_set_hash(old_set, key));
+        if (!RB_SPECIAL_CONST_P(prev_key) && rb_objspace_garbage_object_p(prev_key)) continue;
+
+#if CONCURRENT_SET_DEBUG
+        if (new_set->key_type == T_STRING) {
+            RUBY_ASSERT(BUILTIN_TYPE(prev_key) == T_STRING);
+            RUBY_ASSERT(FL_TEST(prev_key, RSTRING_FSTR));
+        }
+        else {
+            RUBY_ASSERT(STATIC_SYM_P(prev_key));
+        }
+#endif
+
+        VALUE hash = rbimpl_atomic_value_load(&old_entry->hash, RBIMPL_ATOMIC_ACQUIRE) & CONCURRENT_SET_HASH_MASK;
+        if (hash == 0) continue;
+        RUBY_ASSERT(concurrent_set_hash(old_set, prev_key) == hash);
 
         // Insert key into new_set.
         struct concurrent_set_probe probe;
         int idx = concurrent_set_probe_start(&probe, new_set, hash);
+        MAYBE_UNUSED(int start_idx) = idx;
 
         while (true) {
             struct concurrent_set_entry *entry = &new_set->entries[idx];
 
-            if (entry->hash == CONCURRENT_SET_EMPTY) {
+            if (entry->hash == 0) {
                 RUBY_ASSERT(entry->key == CONCURRENT_SET_EMPTY);
 
                 new_set->size++;
                 RUBY_ASSERT(new_set->size <= new_set->capacity / 2);
 
-                entry->key = key;
+                entry->key = prev_key; // no continuation bit
                 entry->hash = hash;
                 break;
             }
 
             RUBY_ASSERT(entry->key >= CONCURRENT_SET_SPECIAL_VALUE_COUNT);
-            entry->hash |= CONCURRENT_SET_CONTINUATION_BIT;
+            entry->key |= CONCURRENT_SET_CONTINUATION_BIT;
             idx = concurrent_set_probe_next(&probe);
+            RUBY_ASSERT(idx != start_idx);
         }
     }
 
@@ -207,12 +280,80 @@ concurrent_set_try_resize_without_locking(VALUE old_set_obj, VALUE *set_obj_ptr)
     RB_GC_GUARD(old_set_obj);
 }
 
+#if USE_PARALLEL_SWEEP
+static pthread_mutex_t resize_lock = PTHREAD_MUTEX_INITIALIZER;
+static pthread_t resize_lock_owner;
+
+static inline void
+resize_lock_lock(void)
+{
+    int r;
+#if VM_CHECK_MODE > 0
+    RUBY_ASSERT(resize_lock_owner != pthread_self());
+#endif
+    if ((r = pthread_mutex_lock(&resize_lock))) {
+        rb_bug_errno("pthread_mute_lock", r);
+    }
+#if VM_CHECK_MODE > 0
+    resize_lock_owner = pthread_self();
+#endif
+}
+
+static inline void
+resize_lock_unlock(void)
+{
+    int r;
+#if VM_CHECK_MODE > 0
+    RUBY_ASSERT(resize_lock_owner == pthread_self());
+    resize_lock_owner = 0;
+#endif
+    if ((r = pthread_mutex_unlock(&resize_lock))) {
+        rb_bug_errno("pthread_mutex_unlock", r);
+    }
+}
+
+#else
+#define resize_lock_lock() (void)0
+#define resize_lock_unlock() (void)0
+#endif // USE_PARALLEL_SWEEP
+
 static void
 concurrent_set_try_resize(VALUE old_set_obj, VALUE *set_obj_ptr)
 {
-    RB_VM_LOCKING() {
-        concurrent_set_try_resize_without_locking(old_set_obj, set_obj_ptr);
+    unsigned int lev;
+    RB_VM_LOCK_ENTER_LEV(&lev);
+    {
+        // Check if another thread has already resized.
+        if (rbimpl_atomic_value_load(set_obj_ptr, RBIMPL_ATOMIC_ACQUIRE) != old_set_obj) {
+            RB_VM_LOCK_LEAVE_LEV(&lev);
+            return;
+        }
+        struct concurrent_set *old_set = RTYPEDDATA_GET_DATA(old_set_obj);
+
+        // This may overcount by up to the number of threads concurrently attempting to insert
+        // GC may also happen between now and the set being rebuilt
+        int expected_size = rbimpl_atomic_load(&old_set->size, RBIMPL_ATOMIC_RELAXED) - old_set->deleted_entries;
+
+        // NOTE: new capacity must make sense with load factor, don't change one without checking the other.
+        int old_capacity = old_set->capacity;
+        int new_capacity = old_capacity * 2;
+        if (new_capacity > expected_size * 8) {
+            new_capacity = old_capacity / 2;
+        }
+        else if (new_capacity > expected_size * 4) {
+            new_capacity = old_capacity;
+        }
+
+        // May cause GC and therefore deletes, so must happen first.
+        VALUE new_set_obj = rb_concurrent_set_new(old_set->funcs, new_capacity, old_set->key_type);
+        // deletes from sweep thread must not happen during resize and sweep thread can't take VM lock so it takes the resize lock
+        resize_lock_lock();
+        {
+            concurrent_set_try_resize_locked(old_set_obj, set_obj_ptr, new_set_obj, old_capacity);
+        }
+        resize_lock_unlock();
     }
+    RB_VM_LOCK_LEAVE_LEV(&lev);
 }
 
 VALUE
@@ -242,29 +383,39 @@ rb_concurrent_set_find(VALUE *set_obj_ptr, VALUE key)
 
     while (true) {
         struct concurrent_set_entry *entry = &set->entries[idx];
-        VALUE curr_hash_and_flags = rbimpl_atomic_value_load(&entry->hash, RBIMPL_ATOMIC_ACQUIRE);
-        VALUE curr_hash = curr_hash_and_flags & CONCURRENT_SET_HASH_MASK;
-        bool continuation = curr_hash_and_flags & CONCURRENT_SET_CONTINUATION_BIT;
+        VALUE curr_hash = rbimpl_atomic_value_load(&entry->hash, RBIMPL_ATOMIC_ACQUIRE) & CONCURRENT_SET_HASH_MASK;
 
-        if (curr_hash_and_flags == CONCURRENT_SET_EMPTY) {
+        if (curr_hash == 0) {
+#if CONCURRENT_SET_DEBUG_STATS
+            rbimpl_atomic_fetch_add(&set->find_count, 1, RBIMPL_ATOMIC_RELAXED);
+            rbimpl_atomic_fetch_add(&set->find_probe_total, probe.d, RBIMPL_ATOMIC_RELAXED);
+            concurrent_set_atomic_max(&set->find_probe_max, probe.d);
+#endif
             return 0;
         }
 
+        VALUE raw_key = rbimpl_atomic_value_load(&entry->key, RBIMPL_ATOMIC_ACQUIRE);
+        VALUE curr_key = raw_key & CONCURRENT_SET_KEY_MASK;
+        bool continuation = raw_key & CONCURRENT_SET_CONTINUATION_BIT;
+
         if (curr_hash != hash) {
             if (!continuation) {
+#if CONCURRENT_SET_DEBUG_STATS
+                rbimpl_atomic_fetch_add(&set->find_count, 1, RBIMPL_ATOMIC_RELAXED);
+                rbimpl_atomic_fetch_add(&set->find_probe_total, probe.d, RBIMPL_ATOMIC_RELAXED);
+                concurrent_set_atomic_max(&set->find_probe_max, probe.d);
+#endif
                 return 0;
             }
             idx = concurrent_set_probe_next(&probe);
             continue;
         }
 
-        VALUE curr_key = rbimpl_atomic_value_load(&entry->key, RBIMPL_ATOMIC_ACQUIRE);
-
         switch (curr_key) {
           case CONCURRENT_SET_EMPTY:
-            // In-progress insert: hash written but key not yet
+            // In-progress insert: hash written but key not yet.
             break;
-          case CONCURRENT_SET_DELETED:
+          case CONCURRENT_SET_TOMBSTONE:
             break;
           case CONCURRENT_SET_MOVED:
             // Wait
@@ -280,11 +431,21 @@ rb_concurrent_set_find(VALUE *set_obj_ptr, VALUE key)
 
             if (set->funcs->cmp(key, curr_key)) {
                 // We've found a match.
+#if CONCURRENT_SET_DEBUG_STATS
+                rbimpl_atomic_fetch_add(&set->find_count, 1, RBIMPL_ATOMIC_RELAXED);
+                rbimpl_atomic_fetch_add(&set->find_probe_total, probe.d, RBIMPL_ATOMIC_RELAXED);
+                concurrent_set_atomic_max(&set->find_probe_max, probe.d);
+#endif
                 RB_GC_GUARD(set_obj);
                 return curr_key;
             }
 
             if (!continuation) {
+#if CONCURRENT_SET_DEBUG_STATS
+                rbimpl_atomic_fetch_add(&set->find_count, 1, RBIMPL_ATOMIC_RELAXED);
+                rbimpl_atomic_fetch_add(&set->find_probe_total, probe.d, RBIMPL_ATOMIC_RELAXED);
+                concurrent_set_atomic_max(&set->find_probe_max, probe.d);
+#endif
                 return 0;
             }
 
@@ -312,7 +473,7 @@ rb_concurrent_set_find_or_insert(VALUE *set_obj_ptr, VALUE key, void *data)
     RUBY_ASSERT(set_obj);
 
     struct concurrent_set *set = RTYPEDDATA_GET_DATA(set_obj);
-    key = set->funcs->create(key, data);
+    key = set->funcs->create(key, data); // this can join GC (takes VM Lock)
     VALUE hash = concurrent_set_hash(set, key);
 
     struct concurrent_set_probe probe;
@@ -333,33 +494,40 @@ start_search:
 
     while (true) {
         struct concurrent_set_entry *entry = &set->entries[idx];
-        VALUE curr_hash_and_flags = rbimpl_atomic_value_load(&entry->hash, RBIMPL_ATOMIC_ACQUIRE);
-        VALUE curr_hash = curr_hash_and_flags & CONCURRENT_SET_HASH_MASK;
-        bool continuation = curr_hash_and_flags & CONCURRENT_SET_CONTINUATION_BIT;
-
-        if (curr_hash_and_flags == CONCURRENT_SET_EMPTY) {
+        bool can_continue_probing;
+        VALUE raw_hash = rbimpl_atomic_value_load(&entry->hash, RBIMPL_ATOMIC_ACQUIRE);
+        VALUE curr_hash = raw_hash & CONCURRENT_SET_HASH_MASK;
+        if (raw_hash == 0) {
             // Reserve this slot for our hash value
-            curr_hash_and_flags = rbimpl_atomic_value_cas(&entry->hash, CONCURRENT_SET_EMPTY, hash, RBIMPL_ATOMIC_RELEASE, RBIMPL_ATOMIC_RELAXED);
-            if (curr_hash_and_flags != CONCURRENT_SET_EMPTY) {
+            raw_hash = rbimpl_atomic_value_cas(&entry->hash, 0, hash, RBIMPL_ATOMIC_RELEASE, RBIMPL_ATOMIC_RELAXED);
+            if (raw_hash != 0) {
                 // Lost race, retry same slot to check winner's hash
                 continue;
             }
-
-            // CAS succeeded, so these are the values stored
-            curr_hash_and_flags = hash;
+            raw_hash = hash;
             curr_hash = hash;
-
             // Fall through to try to claim key
         }
 
-        if (curr_hash != hash) {
-            goto probe_next;
-        }
-
-        VALUE curr_key = rbimpl_atomic_value_load(&entry->key, RBIMPL_ATOMIC_ACQUIRE);
+        VALUE raw_key = rbimpl_atomic_value_load(&entry->key, RBIMPL_ATOMIC_ACQUIRE);
+        VALUE curr_key = raw_key & CONCURRENT_SET_KEY_MASK;
+        bool continuation = raw_key & CONCURRENT_SET_CONTINUATION_BIT;
 
         switch (curr_key) {
           case CONCURRENT_SET_EMPTY: {
+            if ((raw_hash & CONCURRENT_SET_HASH_RECLAIMABLE_BIT) && !continuation) {
+                // Reclaim this reclaimable slot by clearing the reclaimable bit
+                VALUE prev_hash = rbimpl_atomic_value_cas(&entry->hash, raw_hash, hash, RBIMPL_ATOMIC_RELEASE, RBIMPL_ATOMIC_RELAXED);
+                if (prev_hash != raw_hash) {
+                    // Lost race, retry same slot
+                    continue;
+                }
+                curr_hash = hash;
+                raw_hash = hash;
+            }
+            if (curr_hash != hash) {
+                goto probe_next;
+            }
             rb_atomic_t prev_size = rbimpl_atomic_fetch_add(&set->size, 1, RBIMPL_ATOMIC_RELAXED);
 
             // Load_factor reached at 75% full. ex: prev_size: 32, capacity: 64, load_factor: 50%.
@@ -370,9 +538,38 @@ start_search:
                 goto retry;
             }
 
-            VALUE prev_key = rbimpl_atomic_value_cas(&entry->key, CONCURRENT_SET_EMPTY, key, RBIMPL_ATOMIC_RELEASE, RBIMPL_ATOMIC_RELAXED);
-            if (prev_key == CONCURRENT_SET_EMPTY) {
-                RUBY_ASSERT(rb_concurrent_set_find(set_obj_ptr, key) == key);
+            VALUE prev_raw_key = rbimpl_atomic_value_cas(&entry->key, raw_key, key | (continuation ? CONCURRENT_SET_CONTINUATION_BIT : 0), RBIMPL_ATOMIC_RELEASE, RBIMPL_ATOMIC_RELAXED);
+            if (prev_raw_key == raw_key) {
+#if CONCURRENT_SET_DEBUG_STATS
+                rbimpl_atomic_fetch_add(&set->insert_count, 1, RBIMPL_ATOMIC_RELAXED);
+                rbimpl_atomic_fetch_add(&set->insert_probe_total, probe.d, RBIMPL_ATOMIC_RELAXED);
+                concurrent_set_atomic_max(&set->insert_probe_max, probe.d);
+#endif
+#if CONCURRENT_SET_DEBUG_DUPLICATES
+                {
+                    // Probe further to verify no duplicate of our key exists
+                    struct concurrent_set_probe dup_probe = probe;
+                    int dup_idx = concurrent_set_probe_next(&dup_probe);
+                    int dup_idx_start = dup_idx;
+                    while (true) {
+                        struct concurrent_set_entry *dup_entry = &set->entries[dup_idx];
+                        VALUE dup_raw_key = rbimpl_atomic_value_load(&dup_entry->key, RBIMPL_ATOMIC_ACQUIRE);
+                        VALUE dup_key = dup_raw_key & CONCURRENT_SET_KEY_MASK;
+
+                        if (dup_key == CONCURRENT_SET_EMPTY) break;
+                        if (dup_key == CONCURRENT_SET_MOVED) break;
+
+                        if (dup_key >= CONCURRENT_SET_SPECIAL_VALUE_COUNT && dup_key == key) {
+                            rb_bug("concurrent_set_find_or_insert: duplicate key %p found at index %d after inserting at index %d",
+                                   (void *)key, dup_idx, idx);
+                        }
+                        int next_dup_idx = concurrent_set_probe_next(&dup_probe);
+                        if (dup_idx < dup_idx_start && next_dup_idx >= dup_idx_start) break;
+                        if (next_dup_idx == dup_idx_start) break;
+                        dup_idx = next_dup_idx;
+                    }
+                }
+#endif
                 RB_GC_GUARD(set_obj);
                 return key;
             }
@@ -380,36 +577,45 @@ start_search:
                 // Entry was not inserted.
                 rbimpl_atomic_sub(&set->size, 1, RBIMPL_ATOMIC_RELAXED);
 
-                // Another thread won the race, try again at the same location.
+                // * Another thread with the same hash could have won the race, try again at the same location, we might find it.
+                // * A resize could also be underway, and `prev_raw_key` could be CONCURRENT_SET_MOVED.
+                // * The continuation bit could also have been set on the key just now, in which case we'll retry
                 continue;
             }
           }
-          case CONCURRENT_SET_DELETED:
+          case CONCURRENT_SET_TOMBSTONE:
             break;
           case CONCURRENT_SET_MOVED:
             // Wait
             RB_VM_LOCKING();
             goto retry;
           default:
-            // We're never GC during our search
+            if (curr_hash != hash) {
+                goto probe_next;
+            }
             // If the continuation bit wasn't set at the start of our search,
-            // any concurrent find with the same hash value would also look at
+            // any concurrent find_or_insert with the same hash value would also look at
             // this location and try to swap curr_key
             if (UNLIKELY(!RB_SPECIAL_CONST_P(curr_key) && rb_objspace_garbage_object_p(curr_key))) {
                 if (continuation) {
                     goto probe_next;
                 }
                 {
-                    VALUE prev = rbimpl_atomic_value_cas(&entry->key, curr_key, CONCURRENT_SET_EMPTY, RBIMPL_ATOMIC_RELEASE, RBIMPL_ATOMIC_RELAXED);
-                    if (prev == curr_key) {
+                    VALUE prev = rbimpl_atomic_value_cas(&entry->key, raw_key, CONCURRENT_SET_EMPTY, RBIMPL_ATOMIC_RELEASE, RBIMPL_ATOMIC_RELAXED);
+                    if (prev == raw_key) {
                         rbimpl_atomic_sub(&set->size, 1, RBIMPL_ATOMIC_RELAXED);
                     }
                 }
-                continue;
+                continue; // try to reclaim same slot, because the hash is the same and it's now EMPTY
             }
 
             if (set->funcs->cmp(key, curr_key)) {
                 // We've found a live match.
+#if CONCURRENT_SET_DEBUG_STATS
+                rbimpl_atomic_fetch_add(&set->insert_count, 1, RBIMPL_ATOMIC_RELAXED);
+                rbimpl_atomic_fetch_add(&set->insert_probe_total, probe.d, RBIMPL_ATOMIC_RELAXED);
+                concurrent_set_atomic_max(&set->insert_probe_max, probe.d);
+#endif
                 RB_GC_GUARD(set_obj);
 
                 // We created key using set->funcs->create, but we didn't end
@@ -423,8 +629,10 @@ start_search:
         }
 
       probe_next:
-        RUBY_ASSERT(curr_hash_and_flags != CONCURRENT_SET_EMPTY);
-        concurrent_set_mark_continuation(entry, curr_hash_and_flags);
+        can_continue_probing =  concurrent_set_mark_continuation(entry, raw_key);
+        if (!can_continue_probing) {
+            continue;
+        }
         idx = concurrent_set_probe_next(&probe);
     }
 }
@@ -434,22 +642,21 @@ concurrent_set_delete_entry_locked(struct concurrent_set *set, struct concurrent
 {
     ASSERT_vm_locking_with_barrier();
 
-    if (entry->hash & CONCURRENT_SET_CONTINUATION_BIT) {
-        entry->hash = CONCURRENT_SET_CONTINUATION_BIT;
-        entry->key = CONCURRENT_SET_DELETED;
+    if (entry->key & CONCURRENT_SET_CONTINUATION_BIT) {
+        entry->key = CONCURRENT_SET_TOMBSTONE | CONCURRENT_SET_CONTINUATION_BIT;
         set->deleted_entries++;
     }
     else {
-        entry->hash = CONCURRENT_SET_EMPTY;
+        entry->hash = 0;
         entry->key = CONCURRENT_SET_EMPTY;
         set->size--;
     }
 }
 
-VALUE
-rb_concurrent_set_delete_by_identity(VALUE set_obj, VALUE key)
+
+static VALUE
+rb_concurrent_set_delete_by_identity_locked(VALUE set_obj, VALUE key)
 {
-    ASSERT_vm_locking_with_barrier();
 
     struct concurrent_set *set = RTYPEDDATA_GET_DATA(set_obj);
 
@@ -457,25 +664,70 @@ rb_concurrent_set_delete_by_identity(VALUE set_obj, VALUE key)
 
     struct concurrent_set_probe probe;
     int idx = concurrent_set_probe_start(&probe, set, hash);
+    bool hash_cleared = false;
+    MAYBE_UNUSED(VALUE prev_hash) = 0;
 
     while (true) {
         struct concurrent_set_entry *entry = &set->entries[idx];
-        VALUE curr_key = entry->key;
+        VALUE raw_key = rbimpl_atomic_value_load(&entry->key, RBIMPL_ATOMIC_ACQUIRE);
+        VALUE loaded_hash_raw = rbimpl_atomic_value_load(&entry->hash, RBIMPL_ATOMIC_ACQUIRE);
+        MAYBE_UNUSED(VALUE loaded_hash) = loaded_hash_raw & CONCURRENT_SET_HASH_MASK;
+        bool continuation = raw_key & CONCURRENT_SET_CONTINUATION_BIT;
+        VALUE curr_key = raw_key & CONCURRENT_SET_KEY_MASK;
 
         switch (curr_key) {
           case CONCURRENT_SET_EMPTY:
-            // We didn't find our entry to delete.
-            return 0;
-          case CONCURRENT_SET_DELETED:
+            if (!continuation) {
+                return 0;
+            }
+            break;
+          case CONCURRENT_SET_TOMBSTONE:
             break;
           case CONCURRENT_SET_MOVED:
             rb_bug("rb_concurrent_set_delete_by_identity: moved entry");
             break;
           default:
             if (key == curr_key) {
-                RUBY_ASSERT((entry->hash & CONCURRENT_SET_HASH_MASK) == hash);
-                concurrent_set_delete_entry_locked(set, entry);
-                return curr_key;
+                VALUE new_key;
+                RUBY_ASSERT(hash_cleared || loaded_hash == hash);
+                if (continuation) {
+                    new_key = CONCURRENT_SET_TOMBSTONE | CONCURRENT_SET_CONTINUATION_BIT;
+                }
+                else {
+                    new_key = CONCURRENT_SET_EMPTY;
+                }
+
+                if (!hash_cleared) {
+                    // Hashes only change here and they get reclaimed in find_or_insert
+                    prev_hash = rbimpl_atomic_value_cas(&entry->hash, loaded_hash_raw, hash | CONCURRENT_SET_HASH_RECLAIMABLE_BIT, RBIMPL_ATOMIC_RELEASE, RBIMPL_ATOMIC_RELAXED);
+                    RUBY_ASSERT(prev_hash == hash || prev_hash == (hash | CONCURRENT_SET_HASH_RECLAIMABLE_BIT));
+                    hash_cleared = true;
+                }
+                VALUE prev_key = rbimpl_atomic_value_cas(&entry->key, raw_key, new_key, RBIMPL_ATOMIC_RELEASE, RBIMPL_ATOMIC_ACQUIRE);
+                if (prev_key == raw_key) {
+                    if (continuation) {
+                        rbimpl_atomic_add(&set->deleted_entries, 1, RBIMPL_ATOMIC_RELAXED);
+                    }
+                    else {
+                        rbimpl_atomic_sub(&set->size, 1, RBIMPL_ATOMIC_RELAXED);
+                    }
+                    return curr_key;
+                }
+                else if (!continuation && prev_key == (raw_key | CONCURRENT_SET_CONTINUATION_BIT)) {
+                    continue; // try again, the continuation bit was just set on this key so we can tombstone it
+                }
+                else if ((prev_key & CONCURRENT_SET_KEY_MASK) == CONCURRENT_SET_EMPTY || (prev_key & CONCURRENT_SET_KEY_MASK) == CONCURRENT_SET_TOMBSTONE) {
+                    return curr_key; // the key was deleted by another thread
+                }
+                else {
+                    // the key was changed to EMPTY by being garbage during find_or_insert and then a new key was put at the same slot. It's okay
+                    // that the hash was marked reclaimable above.
+                    RUBY_ASSERT(prev_hash != 0);
+                    return curr_key;
+                }
+            }
+            else if (!continuation) {
+                return 0;
             }
             break;
         }
@@ -484,8 +736,43 @@ rb_concurrent_set_delete_by_identity(VALUE set_obj, VALUE key)
     }
 }
 
-void
-rb_concurrent_set_foreach_with_replace(VALUE set_obj, int (*callback)(VALUE *key, void *data), void *data)
+// This can be called concurrently by a ruby GC thread and the sweep thread.
+VALUE
+rb_concurrent_set_delete_by_identity(VALUE *set_obj_ptr, VALUE key)
+{
+    VALUE result;
+
+    VALUE set_obj = rbimpl_atomic_value_load(set_obj_ptr, RBIMPL_ATOMIC_ACQUIRE);
+
+#if USE_PARALLEL_SWEEP
+    if (is_sweep_thread_p()) {
+        while (1) {
+            resize_lock_lock();
+            {
+                VALUE current_set_obj = rbimpl_atomic_value_load(set_obj_ptr, RBIMPL_ATOMIC_ACQUIRE);
+                if (current_set_obj != set_obj) {
+                    set_obj = current_set_obj;
+                    // retry - resize happened
+                }
+                else {
+                    result = rb_concurrent_set_delete_by_identity_locked(set_obj, key);
+                    resize_lock_unlock();
+                    break;
+                }
+            }
+            resize_lock_unlock();
+        }
+    }
+    else
+#endif
+    {
+        result = rb_concurrent_set_delete_by_identity_locked(set_obj, key);
+    }
+    return result;
+}
+
+static void
+rb_concurrent_set_foreach_with_replace_locked(VALUE set_obj, int (*callback)(VALUE *key, void *data), void *data)
 {
     ASSERT_vm_locking_with_barrier();
 
@@ -493,26 +780,51 @@ rb_concurrent_set_foreach_with_replace(VALUE set_obj, int (*callback)(VALUE *key
 
     for (unsigned int i = 0; i < set->capacity; i++) {
         struct concurrent_set_entry *entry = &set->entries[i];
-        VALUE key = entry->key;
+        VALUE raw_key = entry->key;
+        bool continuation = raw_key & CONCURRENT_SET_CONTINUATION_BIT;
+        VALUE key = raw_key & CONCURRENT_SET_KEY_MASK;
 
         switch (key) {
           case CONCURRENT_SET_EMPTY:
-          case CONCURRENT_SET_DELETED:
+          case CONCURRENT_SET_TOMBSTONE:
             continue;
           case CONCURRENT_SET_MOVED:
             rb_bug("rb_concurrent_set_foreach_with_replace: moved entry");
             break;
           default: {
-            int ret = callback(&entry->key, data);
+            VALUE cb_key = key;
+            int ret = callback(&cb_key, data);
             switch (ret) {
               case ST_STOP:
                 return;
               case ST_DELETE:
                 concurrent_set_delete_entry_locked(set, entry);
                 break;
+              case ST_CONTINUE:
+                if (cb_key != key) {
+                    // Key was replaced by callback
+                    entry->key = cb_key | (continuation ? CONCURRENT_SET_CONTINUATION_BIT : 0);
+                }
+                break;
+              case ST_REPLACE:
+                rb_bug("unexpected concurrent_set callback return value: ST_REPLACE");
             }
             break;
           }
         }
+    }
+}
+
+// NOTE: `callback` must not cause GC
+void
+rb_concurrent_set_foreach_with_replace(VALUE set_obj, int (*callback)(VALUE *key, void *data), void *data)
+{
+    RB_VM_LOCKING() {
+        // Don't allow concurrent deletes from sweep thread during this time.
+        resize_lock_lock();
+        {
+            rb_concurrent_set_foreach_with_replace_locked(set_obj, callback, data);
+        }
+        resize_lock_unlock();
     }
 }

--- a/configure.ac
+++ b/configure.ac
@@ -4296,6 +4296,19 @@ AC_ARG_ENABLE(debug-env,
        AS_HELP_STRING([--enable-debug-env], [enable RUBY_DEBUG environment variable]),
        [AC_SUBST(ENABLE_DEBUG_ENV, yes)])
 
+AC_ARG_ENABLE(parallel-sweep,
+       AS_HELP_STRING([--enable-parallel-sweep],
+                      [enable background sweep thread in the default GC (requires pthread target, [[disabled by default]])]),
+       [parallel_sweep=$enableval], [parallel_sweep=no])
+AS_IF([test "x$parallel_sweep" = xyes], [
+    AS_IF([test "x$THREAD_MODEL" != xpthread], [
+        AC_MSG_ERROR([--enable-parallel-sweep requires the pthread thread model (got: $THREAD_MODEL)])
+    ])
+    RUBY_APPEND_OPTIONS(CPPFLAGS, -DUSE_PARALLEL_SWEEP=1)
+], [
+    RUBY_APPEND_OPTIONS(CPPFLAGS, -DUSE_PARALLEL_SWEEP=0)
+])
+
 AS_IF([test "$gnumake" = yes], [ NULLCMD=: ], [
     AC_MSG_CHECKING([for safe null command for ${MAKE-make}])
     mkdir conftest.dir

--- a/cont.c
+++ b/cont.c
@@ -291,12 +291,73 @@ rb_free_shared_fiber_pool(void)
     struct fiber_pool_allocation *allocations = shared_fiber_pool.allocations;
     while (allocations) {
         struct fiber_pool_allocation *next = allocations->next;
-        SIZED_FREE(allocations);
+        ruby_mimfree(allocations);
         allocations = next;
     }
 }
 
 static ID fiber_initialize_keywords[3] = {0};
+
+#if USE_PARALLEL_SWEEP
+// We don't use the VM lock to protect the shared fiber pool because the sweep
+// thread frees fibers and it can't take the VM lock.
+static rb_nativethread_lock_t fiber_lock;
+static pthread_t fiber_pool_lock_owner;
+
+MAYBE_UNUSED(static inline bool
+fiber_pool_locked_p(void))
+{
+    return pthread_self() == fiber_pool_lock_owner;
+}
+
+static inline void
+ASSERT_fiber_pool_locked(void)
+{
+    VM_ASSERT(fiber_pool_locked_p());
+}
+
+static inline void
+ASSERT_fiber_pool_unlocked(void)
+{
+    VM_ASSERT(!fiber_pool_locked_p());
+}
+
+static inline void
+fiber_pool_lock_lev(unsigned int *levp) {
+    (void)levp;
+    ASSERT_fiber_pool_unlocked();
+    rb_native_mutex_lock(&fiber_lock);
+#if VM_CHECK_MODE > 0
+    fiber_pool_lock_owner = pthread_self();
+#endif
+}
+
+static inline void
+fiber_pool_unlock_lev(unsigned int *levp) {
+    (void)levp;
+    ASSERT_fiber_pool_locked();
+#if VM_CHECK_MODE > 0
+    fiber_pool_lock_owner = 0;
+#endif
+    rb_native_mutex_unlock(&fiber_lock);
+}
+
+void
+fiber_pool_lock_reset(void)
+{
+    rb_native_mutex_initialize(&fiber_lock);
+}
+#else
+#define fiber_pool_lock_lev(levp) RB_VM_LOCK_ENTER_LEV(levp)
+#define fiber_pool_unlock_lev(levp) RB_VM_LOCK_LEAVE_LEV(levp)
+#define fiber_pool_locked_p() (!rb_multi_ractor_p() || RB_VM_LOCKED_P())
+static inline void
+ASSERT_fiber_pool_locked(void)
+{
+    VM_ASSERT(fiber_pool_locked_p());
+}
+#endif // USE_PARALLEL_SWEEP
+
 
 /*
  * FreeBSD require a first (i.e. addr) argument of mmap(2) is not NULL
@@ -394,6 +455,7 @@ fiber_pool_vacancy_reset(struct fiber_pool_vacancy * vacancy)
 inline static struct fiber_pool_vacancy *
 fiber_pool_vacancy_push(struct fiber_pool_vacancy * vacancy, struct fiber_pool_vacancy * head)
 {
+    ASSERT_fiber_pool_locked();
     vacancy->next = head;
 
 #ifdef FIBER_POOL_ALLOCATION_FREE
@@ -426,6 +488,7 @@ fiber_pool_vacancy_remove(struct fiber_pool_vacancy * vacancy)
 inline static struct fiber_pool_vacancy *
 fiber_pool_vacancy_pop(struct fiber_pool * pool)
 {
+    ASSERT_fiber_pool_locked();
     struct fiber_pool_vacancy * vacancy = pool->vacancies;
 
     if (vacancy) {
@@ -438,6 +501,7 @@ fiber_pool_vacancy_pop(struct fiber_pool * pool)
 inline static struct fiber_pool_vacancy *
 fiber_pool_vacancy_pop(struct fiber_pool * pool)
 {
+    ASSERT_fiber_pool_locked();
     struct fiber_pool_vacancy * vacancy = pool->vacancies;
 
     if (vacancy) {
@@ -525,115 +589,146 @@ fiber_pool_allocate_memory(size_t * count, size_t stride)
 // fiber_pool_initialize before the pool is shared across threads.
 // @sa fiber_pool_allocation_free
 static struct fiber_pool_allocation *
-fiber_pool_expand(struct fiber_pool * fiber_pool, size_t count)
+fiber_pool_expand(struct fiber_pool * fiber_pool, size_t count, bool needs_lock, bool unlock_before_raise, struct fiber_pool_vacancy **vacancy_out)
 {
     if (count == 0) {
         errno = EAGAIN;
         return NULL;
     }
 
-    STACK_GROW_DIR_DETECTION;
+    struct fiber_pool_allocation * allocation = ruby_mimmalloc(sizeof(struct fiber_pool_allocation));
 
-    size_t size = fiber_pool->size;
-    size_t stride = size + RB_PAGE_SIZE;
+    unsigned int lev;
+    if (needs_lock) fiber_pool_lock_lev(&lev);
+    {
+        STACK_GROW_DIR_DETECTION;
 
-    // If the maximum number of stacks is set, and we have reached it, return NULL.
-    if (fiber_pool->maximum_count > 0) {
-        if (fiber_pool->count >= fiber_pool->maximum_count) {
-            errno = EAGAIN;
+        size_t size = fiber_pool->size;
+        size_t stride = size + RB_PAGE_SIZE;
+
+        // If the maximum number of stacks is set, and we have reached it, return NULL.
+        if (fiber_pool->maximum_count > 0) {
+            if (fiber_pool->count >= fiber_pool->maximum_count) {
+                if (unlock_before_raise) fiber_pool_unlock_lev(&lev);
+                errno = EAGAIN;
+                return NULL;
+            }
+            size_t remaining = fiber_pool->maximum_count - fiber_pool->count;
+            if (count > remaining) {
+                count = remaining;
+            }
+        }
+
+
+        // Allocate the memory required for the stacks:
+        void * base = fiber_pool_allocate_memory(&count, stride);
+
+        if (base == NULL) {
+            int saved_errno = errno;
+            if (!saved_errno) saved_errno = ENOMEM;
+            if (unlock_before_raise) fiber_pool_unlock_lev(&lev);
+            ruby_mimfree(allocation);
+            errno = saved_errno;
             return NULL;
         }
-        size_t remaining = fiber_pool->maximum_count - fiber_pool->count;
-        if (count > remaining) {
-            count = remaining;
+
+        struct fiber_pool_vacancy * vacancies = fiber_pool->vacancies;
+
+        // Initialize fiber pool allocation:
+        allocation->base = base;
+        allocation->size = size;
+        allocation->stride = stride;
+        allocation->count = count;
+#ifdef FIBER_POOL_ALLOCATION_FREE
+        allocation->used = 0;
+#endif
+        allocation->pool = fiber_pool;
+
+        if (DEBUG_EXPAND) {
+            fprintf(stderr, "fiber_pool_expand(%"PRIuSIZE"): %p, %"PRIuSIZE"/%"PRIuSIZE" x [%"PRIuSIZE":%"PRIuSIZE"]\n",
+                    count, (void*)fiber_pool, fiber_pool->used, fiber_pool->count, size, fiber_pool->vm_stack_size);
         }
+
+        // Iterate over all stacks, initializing the vacancy list:
+        for (size_t i = 0; i < count; i += 1) {
+            void * base = (char*)allocation->base + (stride * i);
+            void * page = (char*)base + STACK_DIR_UPPER(size, 0);
+#if defined(_WIN32)
+            DWORD old_protect;
+
+            if (!VirtualProtect(page, RB_PAGE_SIZE, PAGE_READWRITE | PAGE_GUARD, &old_protect)) {
+                int error = rb_w32_map_errno(GetLastError());
+                if (unlock_before_raise) fiber_pool_unlock_lev(&lev);
+                VirtualFree(allocation->base, 0, MEM_RELEASE);
+                ruby_mimfree(allocation);
+                errno = error;
+                return NULL;
+            }
+#elif defined(__wasi__)
+            // wasi-libc's mprotect emulation doesn't support PROT_NONE.
+            (void)page;
+#else
+            if (mprotect(page, RB_PAGE_SIZE, PROT_NONE) < 0) {
+                int error = errno;
+                if (!error) error = ENOMEM;
+                if (unlock_before_raise) fiber_pool_unlock_lev(&lev);
+                munmap(allocation->base, count*stride);
+                ruby_mimfree(allocation);
+                errno = error;
+                return NULL;
+            }
+#endif
+
+            vacancies = fiber_pool_vacancy_initialize(
+                fiber_pool, vacancies,
+                (char*)base + STACK_DIR_UPPER(0, RB_PAGE_SIZE),
+                size
+            );
+
+#ifdef FIBER_POOL_ALLOCATION_FREE
+            vacancies->stack.allocation = allocation;
+#endif
+        }
+
+        // Insert the allocation into the head of the pool:
+        allocation->next = fiber_pool->allocations;
+
+#ifdef FIBER_POOL_ALLOCATION_FREE
+        if (allocation->next) {
+            allocation->next->previous = allocation;
+        }
+
+        allocation->previous = NULL;
+#endif
+
+        fiber_pool->allocations = allocation;
+        fiber_pool->vacancies = vacancies;
+        fiber_pool->count += count;
+
+        if (vacancy_out) {
+           *vacancy_out = fiber_pool_vacancy_pop(fiber_pool);
+        }
+
+        if (needs_lock) fiber_pool_unlock_lev(&lev);
     }
 
-    // Allocate metadata before mmap: ruby_xmalloc (RB_ALLOC) raises on failure and
-    // must not run after base is mapped, or the region would leak.
-    struct fiber_pool_allocation * allocation = RB_ALLOC(struct fiber_pool_allocation);
+    return allocation;
+}
 
-    // Allocate the memory required for the stacks:
-    void * base = fiber_pool_allocate_memory(&count, stride);
-
-    if (base == NULL) {
-        if (!errno) errno = ENOMEM;
-        ruby_xfree(allocation);
+static struct fiber_pool_vacancy *
+fiber_pool_expand_and_pop(struct fiber_pool * fiber_pool, size_t count, bool needs_lock, bool unlock_before_raise)
+{
+    RUBY_ASSERT(needs_lock || (!needs_lock && fiber_pool_locked_p()));
+    struct fiber_pool_vacancy *vacancy_out = NULL;
+    struct fiber_pool_allocation *allocation = fiber_pool_expand(fiber_pool, count, needs_lock, unlock_before_raise, &vacancy_out);
+    if (allocation) {
+        RUBY_ASSERT(vacancy_out);
+        return vacancy_out;
+    }
+    else {
         return NULL;
     }
 
-    struct fiber_pool_vacancy * vacancies = fiber_pool->vacancies;
-
-    // Initialize fiber pool allocation:
-    allocation->base = base;
-    allocation->size = size;
-    allocation->stride = stride;
-    allocation->count = count;
-#ifdef FIBER_POOL_ALLOCATION_FREE
-    allocation->used = 0;
-#endif
-    allocation->pool = fiber_pool;
-
-    if (DEBUG_EXPAND) {
-        fprintf(stderr, "fiber_pool_expand(%"PRIuSIZE"): %p, %"PRIuSIZE"/%"PRIuSIZE" x [%"PRIuSIZE":%"PRIuSIZE"]\n",
-                count, (void*)fiber_pool, fiber_pool->used, fiber_pool->count, size, fiber_pool->vm_stack_size);
-    }
-
-    // Iterate over all stacks, initializing the vacancy list:
-    for (size_t i = 0; i < count; i += 1) {
-        void * base = (char*)allocation->base + (stride * i);
-        void * page = (char*)base + STACK_DIR_UPPER(size, 0);
-#if defined(_WIN32)
-        DWORD old_protect;
-
-        if (!VirtualProtect(page, RB_PAGE_SIZE, PAGE_READWRITE | PAGE_GUARD, &old_protect)) {
-            int error = rb_w32_map_errno(GetLastError());
-            VirtualFree(allocation->base, 0, MEM_RELEASE);
-            ruby_xfree(allocation);
-            errno = error;
-            return NULL;
-        }
-#elif defined(__wasi__)
-        // wasi-libc's mprotect emulation doesn't support PROT_NONE.
-        (void)page;
-#else
-        if (mprotect(page, RB_PAGE_SIZE, PROT_NONE) < 0) {
-            int error = errno;
-            if (!error) error = ENOMEM;
-            munmap(allocation->base, count*stride);
-            ruby_xfree(allocation);
-            errno = error;
-            return NULL;
-        }
-#endif
-
-        vacancies = fiber_pool_vacancy_initialize(
-            fiber_pool, vacancies,
-            (char*)base + STACK_DIR_UPPER(0, RB_PAGE_SIZE),
-            size
-        );
-
-#ifdef FIBER_POOL_ALLOCATION_FREE
-        vacancies->stack.allocation = allocation;
-#endif
-    }
-
-    // Insert the allocation into the head of the pool:
-    allocation->next = fiber_pool->allocations;
-
-#ifdef FIBER_POOL_ALLOCATION_FREE
-    if (allocation->next) {
-        allocation->next->previous = allocation;
-    }
-
-    allocation->previous = NULL;
-#endif
-
-    fiber_pool->allocations = allocation;
-    fiber_pool->vacancies = vacancies;
-    fiber_pool->count += count;
-
-    return allocation;
 }
 
 // Initialize the specified fiber pool with the given number of stacks.
@@ -654,7 +749,7 @@ fiber_pool_initialize(struct fiber_pool * fiber_pool, size_t size, size_t minimu
     fiber_pool->vm_stack_size = vm_stack_size;
 
     if (fiber_pool->minimum_count > 0) {
-        if (RB_UNLIKELY(!fiber_pool_expand(fiber_pool, fiber_pool->minimum_count))) {
+        if (RB_UNLIKELY(!fiber_pool_expand(fiber_pool, fiber_pool->minimum_count, true, true, NULL))) {
             rb_raise(rb_eFiberError, "can't allocate initial fiber stacks (%"PRIuSIZE" x %"PRIuSIZE" bytes): %s", fiber_pool->minimum_count, fiber_pool->size, strerror(errno));
         }
     }
@@ -701,7 +796,7 @@ fiber_pool_allocation_free(struct fiber_pool_allocation * allocation)
 
     allocation->pool->count -= allocation->count;
 
-    SIZED_FREE(allocation);
+    ruby_mimfree(allocation);
 }
 #endif
 
@@ -709,6 +804,7 @@ fiber_pool_allocation_free(struct fiber_pool_allocation * allocation)
 static size_t
 fiber_pool_stack_expand_count(const struct fiber_pool *pool)
 {
+    ASSERT_fiber_pool_locked();
     const size_t maximum_allocations = FIBER_POOL_MAXIMUM_ALLOCATIONS;
     const size_t minimum_count = FIBER_POOL_MINIMUM_COUNT;
 
@@ -737,21 +833,26 @@ fiber_pool_stack_expand_count(const struct fiber_pool *pool)
 // When the vacancy list is empty, grow the pool (and run GC only if mmap fails). Caller holds the VM lock.
 // Returns NULL if expansion failed after GC + retry; errno is set. Otherwise returns a vacancy.
 static struct fiber_pool_vacancy *
-fiber_pool_stack_acquire_expand(struct fiber_pool *fiber_pool)
+fiber_pool_stack_acquire_expand(struct fiber_pool *fiber_pool, unsigned int *levp)
 {
+    // fiber_pool_lock acquired
     size_t count = fiber_pool_stack_expand_count(fiber_pool);
 
     if (DEBUG_ACQUIRE) fprintf(stderr, "fiber_pool_stack_acquire: expanding fiber pool by %"PRIuSIZE" stacks\n", count);
 
     struct fiber_pool_vacancy *vacancy = NULL;
 
-    if (RB_LIKELY(fiber_pool_expand(fiber_pool, count))) {
-        return fiber_pool_vacancy_pop(fiber_pool);
+    if (RB_LIKELY((vacancy = fiber_pool_expand_and_pop(fiber_pool, count, false, true)))) {
+        return vacancy;
     }
     else {
         if (DEBUG_ACQUIRE) fprintf(stderr, "fiber_pool_stack_acquire: expand failed (%s), collecting garbage\n", strerror(errno));
 
-        rb_gc();
+        fiber_pool_unlock_lev(levp);
+        {
+            rb_gc();
+        }
+        fiber_pool_lock_lev(levp);
 
         // After running GC, the vacancy list may have some stacks:
         vacancy = fiber_pool_vacancy_pop(fiber_pool);
@@ -763,8 +864,8 @@ fiber_pool_stack_acquire_expand(struct fiber_pool *fiber_pool)
         count = fiber_pool_stack_expand_count(fiber_pool);
 
         // Try to expand the fiber pool again:
-        if (RB_LIKELY(fiber_pool_expand(fiber_pool, count))) {
-            return fiber_pool_vacancy_pop(fiber_pool);
+        if (RB_LIKELY((vacancy = fiber_pool_expand_and_pop(fiber_pool, count, false, true)))) {
+            return vacancy;
         }
         else {
             // Okay, we really failed to acquire a stack. Give up and return NULL with errno set:
@@ -780,7 +881,7 @@ fiber_pool_stack_acquire(struct fiber_pool * fiber_pool)
     struct fiber_pool_vacancy * vacancy;
 
     unsigned int lev;
-    RB_VM_LOCK_ENTER_LEV(&lev);
+    fiber_pool_lock_lev(&lev);
     {
         // Fast path: try to acquire a stack from the vacancy list:
         vacancy = fiber_pool_vacancy_pop(fiber_pool);
@@ -789,11 +890,11 @@ fiber_pool_stack_acquire(struct fiber_pool * fiber_pool)
 
         // Slow path: If the pool has no vacancies, expand first. Only run GC when expansion fails (e.g. mmap), so we can reclaim stacks from dead fibers before retrying:
         if (RB_UNLIKELY(!vacancy)) {
-            vacancy = fiber_pool_stack_acquire_expand(fiber_pool);
+            vacancy = fiber_pool_stack_acquire_expand(fiber_pool, &lev);
 
             // If expansion failed, raise an error:
             if (RB_UNLIKELY(!vacancy)) {
-                RB_VM_LOCK_LEAVE_LEV(&lev);
+                fiber_pool_unlock_lev(&lev);
                 rb_raise(rb_eFiberError, "can't allocate fiber stack: %s", strerror(errno));
             }
         }
@@ -811,10 +912,9 @@ fiber_pool_stack_acquire(struct fiber_pool * fiber_pool)
 #ifdef FIBER_POOL_ALLOCATION_FREE
         vacancy->stack.allocation->used += 1;
 #endif
-
         fiber_pool_stack_reset(&vacancy->stack);
     }
-    RB_VM_LOCK_LEAVE_LEV(&lev);
+    fiber_pool_unlock_lev(&lev);
 
     return vacancy->stack;
 }
@@ -880,10 +980,11 @@ fiber_pool_stack_free(struct fiber_pool_stack * stack)
 #endif
 }
 
-// Release and return a stack to the vacancy list.
+// Release and return a stack to the vacancy list. fiber_lock is acquired upon entry.
 static void
 fiber_pool_stack_release(struct fiber_pool_stack * stack)
 {
+    ASSERT_fiber_pool_locked();
     struct fiber_pool * pool = stack->pool;
     struct fiber_pool_vacancy * vacancy = fiber_pool_vacancy_pointer(stack->base, stack->size);
 
@@ -1029,17 +1130,6 @@ fiber_stack_release(rb_fiber_t * fiber)
 
     // The stack is no longer associated with this execution context:
     rb_ec_clear_vm_stack(ec);
-}
-
-static void
-fiber_stack_release_locked(rb_fiber_t *fiber)
-{
-    if (!ruby_vm_during_cleanup) {
-        // We can't try to acquire the VM lock here because MMTK calls free in its own native thread which has no ec.
-        // This assertion will fail on MMTK but we currently don't have CI for debug releases of MMTK, so we can assert for now.
-        ASSERT_vm_locking_with_barrier();
-    }
-    fiber_stack_release(fiber);
 }
 
 static const char *
@@ -1204,7 +1294,12 @@ cont_free(void *ptr)
     else {
         rb_fiber_t *fiber = (rb_fiber_t*)cont;
         coroutine_destroy(&fiber->context);
-        fiber_stack_release_locked(fiber);
+        unsigned int lev;
+        fiber_pool_lock_lev(&lev);
+        {
+            fiber_stack_release(fiber);
+        }
+        fiber_pool_unlock_lev(&lev);
     }
 
     SIZED_FREE_N(cont->saved_vm_stack.ptr, cont->saved_vm_stack.size);
@@ -1373,7 +1468,7 @@ cont_handle_weak_references(void *ptr)
 static const rb_data_type_t rb_cont_data_type = {
     "continuation",
     {cont_mark, cont_free, cont_memsize, cont_compact, cont_handle_weak_references},
-    0, 0, RUBY_TYPED_FREE_IMMEDIATELY
+    0, 0, RUBY_TYPED_THREAD_SAFE_FREE
 };
 
 static inline void
@@ -2134,7 +2229,7 @@ fiber_handle_weak_references(void *ptr)
 static const rb_data_type_t rb_fiber_data_type = {
     "fiber",
     {fiber_mark, fiber_free, fiber_memsize, fiber_compact, fiber_handle_weak_references},
-    0, 0, RUBY_TYPED_FREE_IMMEDIATELY
+    0, 0, RUBY_TYPED_THREAD_SAFE_FREE
 };
 
 static VALUE
@@ -2892,9 +2987,12 @@ fiber_switch(rb_fiber_t *fiber, int argc, const VALUE *argv, int kw_splat, rb_fi
     // We cannot free the stack until the pthread is joined:
 #ifndef COROUTINE_PTHREAD_CONTEXT
     if (FIBER_TERMINATED_P(fiber)) {
-        RB_VM_LOCKING() {
+        unsigned int lev;
+        fiber_pool_lock_lev(&lev);
+        {
             fiber_stack_release(fiber);
         }
+        fiber_pool_unlock_lev(&lev);
     }
 #endif
 
@@ -3540,7 +3638,7 @@ fiber_pool_memsize(const void *ptr)
 static const rb_data_type_t FiberPoolDataType = {
     "fiber_pool",
     {NULL, fiber_pool_free, fiber_pool_memsize,},
-    0, 0, RUBY_TYPED_FREE_IMMEDIATELY
+    0, 0, RUBY_TYPED_THREAD_SAFE_FREE
 };
 
 static VALUE
@@ -3653,6 +3751,9 @@ Init_Cont(void)
 
     rb_eFiberError = rb_define_class("FiberError", rb_eStandardError);
 
+#if USE_PARALLEL_SWEEP
+    rb_native_mutex_initialize(&fiber_lock);
+#endif
     size_t minimum_count = shared_fiber_pool_minimum_count();
     size_t maximum_count = shared_fiber_pool_maximum_count();
     fiber_pool_initialize(&shared_fiber_pool, stack_size, minimum_count, maximum_count, vm_stack_size);

--- a/ext/stringio/stringio.c
+++ b/ext/stringio/stringio.c
@@ -119,7 +119,7 @@ static const rb_data_type_t strio_data_type = {
 	strio_free,
 	strio_memsize,
     },
-    0, 0, RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED
+    0, 0, RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED // uses reference count, not concurrent free safe
 };
 
 #define check_strio(self) ((struct StringIO*)rb_check_typeddata((self), &strio_data_type))

--- a/gc.c
+++ b/gc.c
@@ -151,9 +151,22 @@ rb_gc_vm_unlock(unsigned int lev, const char *file, int line)
     rb_vm_lock_leave(&lev, file, line);
 }
 
+#if USE_PARALLEL_SWEEP
+bool
+is_sweep_thread_p(void)
+{
+    rb_vm_t *vm = GET_VM();
+    if (!vm) return false;
+    return vm->gc.sweep_thread == pthread_self();
+}
+#endif
+
 unsigned int
 rb_gc_cr_lock(const char *file, int line)
 {
+#if USE_PARALLEL_SWEEP
+    GC_ASSERT(!is_sweep_thread_p());
+#endif
     unsigned int lev;
     rb_vm_lock_enter_cr(GET_RACTOR(), &lev, file, line);
     return lev;
@@ -162,6 +175,9 @@ rb_gc_cr_lock(const char *file, int line)
 void
 rb_gc_cr_unlock(unsigned int lev, const char *file, int line)
 {
+#if USE_PARALLEL_SWEEP
+    GC_ASSERT(!is_sweep_thread_p());
+#endif
     rb_vm_lock_leave_cr(GET_RACTOR(), &lev, file, line);
 }
 
@@ -981,6 +997,20 @@ rb_objspace_free(void *objspace)
     rb_gc_impl_objspace_free(objspace);
 }
 
+void rb_gc_impl_parallel_sweep_start(void *objspace_ptr);
+
+#if USE_PARALLEL_SWEEP
+void
+rb_gc_parallel_sweep_start(void)
+{
+#if USE_MODULAR_GC
+    /* Parallel sweep is a feature of the default GC only. */
+    if (rb_gc_modular_gc_loaded_p()) return;
+#endif
+    rb_gc_impl_parallel_sweep_start(rb_gc_get_objspace());
+}
+#endif
+
 size_t
 rb_gc_obj_slot_size(VALUE obj)
 {
@@ -1345,7 +1375,8 @@ rb_gc_imemo_needs_cleanup_p(VALUE obj)
         return ((rb_imemo_tmpbuf_t *)obj)->ptr != NULL;
 
       case imemo_fields:
-        return FL_TEST_RAW(obj, OBJ_FIELD_HEAP) || (id2ref_tbl && rb_obj_shape_has_id(obj));
+        return FL_TEST_RAW(obj, OBJ_FIELD_HEAP) ||
+            (rbimpl_atomic_ptr_load((void**)&id2ref_tbl, RBIMPL_ATOMIC_ACQUIRE) && rb_obj_shape_has_id(obj));
     }
     UNREACHABLE_RETURN(true);
 }
@@ -1396,9 +1427,6 @@ rb_gc_obj_needs_cleanup_p(VALUE obj)
         return true;
     }
 
-    shape_id_t shape_id = RBASIC_SHAPE_ID(obj);
-    if (id2ref_tbl && rb_shape_has_object_id(shape_id)) return true;
-
     switch (flags & RUBY_T_MASK) {
       case T_OBJECT:
         if (flags & ROBJECT_HEAP) return true;
@@ -1418,36 +1446,39 @@ rb_gc_obj_needs_cleanup_p(VALUE obj)
 
       case T_STRING:
         if (flags & (RSTRING_NOEMBED | RSTRING_FSTR)) return true;
-        return rb_shape_has_fields(shape_id);
+        return false;
 
       case T_ARRAY:
         if (!(flags & RARRAY_EMBED_FLAG)) return true;
-        return rb_shape_has_fields(shape_id);
+        return false;
 
       case T_HASH:
         if (flags & RHASH_ST_TABLE_FLAG) return true;
-        return rb_shape_has_fields(shape_id);
+        return false;
 
       case T_MATCH:
         if ((flags & (RMATCH_ONIG | RMATCH_OFFSETS_EXTERNAL)) || USE_DEBUG_COUNTER) return true;
-        return rb_shape_has_fields(shape_id);
+        return false;
 
       case T_BIGNUM:
         if (!(flags & BIGNUM_EMBED_FLAG)) return true;
-        return rb_shape_has_fields(shape_id);
+        return false;
 
       case T_STRUCT:
         if (!(flags & RSTRUCT_EMBED_LEN_MASK)) return true;
-        if (flags & RSTRUCT_GEN_FIELDS) return rb_shape_has_fields(shape_id);
         return false;
 
       case T_FLOAT:
       case T_RATIONAL:
       case T_COMPLEX:
-        return rb_shape_has_fields(shape_id);
+        return false;
+
+      case T_ZOMBIE:
+        RUBY_ASSERT(flags & FL_FREEZE);
+        return true;
 
       default:
-        UNREACHABLE_RETURN(true);
+        rb_bug("bad object type in needs_cleanup_p: %lu", flags & RUBY_T_MASK);
     }
 }
 
@@ -1464,6 +1495,7 @@ make_io_zombie(void *objspace, VALUE obj)
     rb_gc_impl_make_zombie(objspace, obj, io_fptr_finalize, fptr);
 }
 
+// Returns whether or not we can add `obj` back to the page's freelist.
 static bool
 rb_data_free(void *objspace, VALUE obj)
 {
@@ -1526,6 +1558,7 @@ classext_iclass_free(rb_classext_t *ext, bool is_prime, VALUE box_value, void *a
     rb_iclass_classext_free(args->klass, ext, is_prime);
 }
 
+// Returns whether or not we can add `obj` back to the page's freelist.
 bool
 rb_gc_obj_free(void *objspace, VALUE obj)
 {
@@ -1630,7 +1663,7 @@ rb_gc_obj_free(void *objspace, VALUE obj)
         }
         break;
       case T_DATA:
-        if (!rb_data_free(objspace, obj)) return false;
+        if (!RB_LIKELY(rb_data_free(objspace, obj))) return FALSE;
         break;
       case T_MATCH:
         {
@@ -1718,12 +1751,19 @@ rb_gc_obj_free(void *objspace, VALUE obj)
         rb_imemo_free((VALUE)obj);
         break;
 
+      case T_ZOMBIE:
+        GC_ASSERT(FL_TEST(obj, FL_FREEZE));
+        GC_ASSERT(!FL_TEST(obj, FL_FINALIZE));
+        void rb_gc_impl_free_zombie(rb_objspace_t *, VALUE);
+        rb_gc_impl_free_zombie(objspace, obj);
+        return TRUE;
       default:
         rb_bug("gc_sweep(): unknown data type 0x%x(%p) 0x%"PRIxVALUE,
                BUILTIN_TYPE(obj), (void*)obj, RBASIC(obj)->flags);
     }
 
     if (FL_TEST_RAW(obj, FL_FINALIZE)) {
+        GC_ASSERT(BUILTIN_TYPE(obj) !=  T_ZOMBIE);
         rb_gc_impl_make_zombie(objspace, obj, 0, 0);
         return FALSE;
     }
@@ -2190,7 +2230,7 @@ object_id0(VALUE obj)
     RUBY_ASSERT(RBASIC_SHAPE_ID(obj) == object_id_shape_id);
     RUBY_ASSERT(rb_obj_shape_has_id(obj));
 
-    if (RB_UNLIKELY(id2ref_tbl)) {
+    if (RB_UNLIKELY(rbimpl_atomic_ptr_load((void**)&id2ref_tbl, RBIMPL_ATOMIC_ACQUIRE))) {
         RB_VM_LOCKING() {
             st_insert(id2ref_tbl, (st_data_t)id, (st_data_t)obj);
         }
@@ -2274,13 +2314,12 @@ object_id_to_ref(void *objspace_ptr, VALUE object_id)
 
         // build_id2ref_i will most certainly malloc, which could trigger GC and sweep
         // objects we just added to the table.
-        // By calling rb_gc_disable() we also save having to handle potentially garbage objects.
         bool gc_disabled = RTEST(rb_gc_disable());
         {
-            id2ref_tbl = tmp_id2ref_tbl;
             id2ref_value = tmp_id2ref_value;
 
-            rb_gc_impl_each_object(objspace, build_id2ref_i, (void *)id2ref_tbl);
+            rb_gc_impl_each_object(objspace, build_id2ref_i, (void *)tmp_id2ref_tbl);
+            rbimpl_atomic_ptr_store((volatile void**)&id2ref_tbl, tmp_id2ref_tbl, RBIMPL_ATOMIC_RELEASE);
         }
         if (!gc_disabled) rb_gc_enable();
     }
@@ -2302,57 +2341,31 @@ object_id_to_ref(void *objspace_ptr, VALUE object_id)
     }
 }
 
-static inline void
-obj_free_object_id(VALUE obj)
+#if USE_PARALLEL_SWEEP
+void
+rb_gc_obj_free_concurrency_safe_vm_weak_references(VALUE obj)
 {
-    VALUE obj_id = 0;
-    if (RB_UNLIKELY(id2ref_tbl)) {
-        switch (BUILTIN_TYPE(obj)) {
-          case T_CLASS:
-          case T_MODULE:
-            obj_id = RCLASS(obj)->object_id;
-            break;
-          case T_IMEMO:
-            if (!IMEMO_TYPE_P(obj, imemo_fields)) {
-                return;
-            }
-            // fallthrough
-          case T_OBJECT:
-            {
-            shape_id_t shape_id = RBASIC_SHAPE_ID(obj);
-            if (rb_shape_has_object_id(shape_id)) {
-                obj_id = object_id_get(obj, shape_id);
-            }
-            break;
-          }
-          default:
-            // For generic_fields, the T_IMEMO/fields is responsible for freeing the id.
-            return;
-        }
+    ASSUME(!RB_SPECIAL_CONST_P(obj));
 
-        if (RB_UNLIKELY(obj_id)) {
-            RUBY_ASSERT(FIXNUM_P(obj_id) || RB_TYPE_P(obj_id, T_BIGNUM));
-
-            if (!st_delete(id2ref_tbl, (st_data_t *)&obj_id, NULL)) {
-                // The the object is a T_IMEMO/fields, then it's possible the actual object
-                // has been garbage collected already.
-                if (!RB_TYPE_P(obj, T_IMEMO)) {
-                    rb_bug("Object ID seen, but not in _id2ref table: object_id=%llu object=%s", NUM2ULL(obj_id), rb_obj_info(obj));
-                }
-            }
+    switch (BUILTIN_TYPE(obj)) {
+      case T_STRING:
+        if (FL_TEST_RAW(obj, RSTRING_FSTR)) {
+            rb_gc_free_fstring(obj);
         }
+        break;
+      case T_SYMBOL:
+        rb_gc_free_dsymbol(obj);
+        break;
+      default:
+        break;
     }
 }
+#endif
 
 void
 rb_gc_obj_free_vm_weak_references(VALUE obj)
 {
     ASSUME(!RB_SPECIAL_CONST_P(obj));
-    obj_free_object_id(obj);
-
-    if (rb_obj_gen_fields_p(obj)) {
-        rb_free_generic_ivar(obj);
-    }
 
     switch (BUILTIN_TYPE(obj)) {
       case T_STRING:
@@ -2709,7 +2722,14 @@ count_objects_i(VALUE obj, void *d)
     struct count_objects_data *data = (struct count_objects_data *)d;
 
     if (RBASIC(obj)->flags) {
-        data->counts[BUILTIN_TYPE(obj)]++;
+        // This will make sure the count is like the old behavior when we used to turn a zombie into
+        // T_NONE right after the finalizer and/or free function ran.
+        if (BUILTIN_TYPE(obj) == T_ZOMBIE && FL_TEST(obj, FL_FREEZE)) {
+            data->freed++;
+        }
+        else {
+            data->counts[BUILTIN_TYPE(obj)]++;
+        }
     }
     else {
         data->freed++;
@@ -4268,13 +4288,28 @@ vm_weak_table_frozen_strings_foreach(VALUE *str, void *data)
     }
 
     if (retval == ST_DELETE) {
-        FL_UNSET(*str, RSTRING_FSTR);
+        FL_UNSET_RAW(*str, RSTRING_FSTR);
     }
 
     return retval;
 }
 
 void rb_fstring_foreach_with_replace(int (*callback)(VALUE *str, void *data), void *data);
+
+// Whether this table must be cleaned every GC after marking.
+// Other tables may be skipped cleaned up per-object via rb_gc_obj_free_vm_weak_references.
+bool
+rb_gc_vm_weak_table_essential_p(enum rb_gc_vm_weak_tables table)
+{
+    switch (table) {
+      case RB_GC_VM_ID2REF_TABLE:
+      case RB_GC_VM_GENERIC_FIELDS_TABLE:
+        return true;
+      default:
+        return false;
+    }
+}
+
 void
 rb_gc_vm_weak_table_foreach(vm_table_foreach_callback_func callback,
                             vm_table_update_callback_func update_callback,
@@ -4902,7 +4937,7 @@ rb_method_type_name(rb_method_type_t type)
 static void
 rb_raw_iseq_info(char *const buff, const size_t buff_size, const rb_iseq_t *iseq)
 {
-    if (buff_size > 0 && ISEQ_BODY(iseq) && ISEQ_BODY(iseq)->location.label && !RB_TYPE_P(ISEQ_BODY(iseq)->location.pathobj, T_MOVED)) {
+    if (buff_size > 0 && ISEQ_BODY(iseq) && ISEQ_BODY(iseq)->location.label && !rb_objspace_garbage_object_p(ISEQ_BODY(iseq)->location.pathobj)) {
         VALUE path = rb_iseq_path(iseq);
         int n = ISEQ_BODY(iseq)->location.first_lineno;
         snprintf(buff, buff_size, " %s@%s:%d",
@@ -4933,7 +4968,7 @@ str_len_no_raise(VALUE str)
 #define C(c, s) ((c) != 0 ? (s) : " ")
 
 static size_t
-rb_raw_obj_info_common(char *const buff, const size_t buff_size, const VALUE obj)
+rb_raw_obj_info_common(char *const buff, const size_t buff_size, const VALUE obj, bool *is_garbage_out)
 {
     size_t pos = 0;
 
@@ -4975,6 +5010,10 @@ rb_raw_obj_info_common(char *const buff, const size_t buff_size, const VALUE obj
         }
         else if (RBASIC(obj)->klass == 0) {
             APPEND_S("(temporary internal)");
+        }
+        else if (rb_objspace_garbage_object_p(RBASIC(obj)->klass)) {
+            APPEND_S("(garbage class)");
+            *is_garbage_out = true;
         }
         else if (RTEST(RBASIC(obj)->klass)) {
             VALUE class_path = rb_mod_name(RBASIC(obj)->klass);
@@ -5074,9 +5113,14 @@ rb_raw_obj_info_buitin_type(char *const buff, const size_t buff_size, const VALU
             }
           case T_ICLASS:
             {
-                VALUE class_path = rb_mod_name(RBASIC_CLASS(obj));
-                if (!NIL_P(class_path)) {
-                    APPEND_F("src:%s", RSTRING_PTR(class_path));
+                if (rb_objspace_garbage_object_p(RBASIC_CLASS(obj))) {
+                    APPEND_S("src: garbage");
+                }
+                else {
+                    VALUE class_path = rb_mod_name(RBASIC_CLASS(obj));
+                    if (!NIL_P(class_path)) {
+                        APPEND_F("src:%s", RSTRING_PTR(class_path));
+                    }
                 }
                 break;
             }
@@ -5217,8 +5261,11 @@ rb_asan_poisoned_object_p(VALUE obj)
 static void
 raw_obj_info(char *const buff, const size_t buff_size, VALUE obj)
 {
-    size_t pos = rb_raw_obj_info_common(buff, buff_size, obj);
-    pos = rb_raw_obj_info_buitin_type(buff, buff_size, obj, pos);
+    bool is_garbage = false;
+    size_t pos = rb_raw_obj_info_common(buff, buff_size, obj, &is_garbage);
+    if (!is_garbage) {
+        pos = rb_raw_obj_info_buitin_type(buff, buff_size, obj, pos);
+    }
     if (pos >= buff_size) {} // truncated
 }
 
@@ -5233,11 +5280,9 @@ rb_raw_obj_info(char *const buff, const size_t buff_size, VALUE obj)
     else if (!rb_gc_impl_live_object_p(objspace, (const void *)obj)) {
         snprintf(buff, buff_size, "out-of-heap:%p", (void *)obj);
     }
-#if 0 // maybe no need to check it?
-    else if (0 && rb_gc_impl_garbage_object_p(objspace, obj)) {
+    else if (rb_gc_impl_garbage_object_p(objspace, obj)) {
         snprintf(buff, buff_size, "garbage:%p", (void *)obj);
     }
-#endif
     else {
         asan_unpoisoning_object(obj) {
             raw_obj_info(buff, buff_size, obj);

--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -26,6 +26,7 @@
 #include "ruby_atomic.h"
 #include "ruby/debug.h"
 #include "ruby/thread.h"
+#include "ruby/thread_native.h"
 #include "ruby/util.h"
 #include "ruby/vm.h"
 #include "ruby/internal/encoding/string.h"
@@ -139,6 +140,11 @@ rb_hrtime_sub(rb_hrtime_t a, rb_hrtime_t b)
 #ifndef GC_HEAP_INIT_BYTES
 #define GC_HEAP_INIT_BYTES (2560 * 1024)
 #endif
+
+#ifndef PSWEEP_COLLECT_TIMINGS
+#define PSWEEP_COLLECT_TIMINGS 0
+#endif
+
 #ifndef GC_HEAP_FREE_SLOTS
 #define GC_HEAP_FREE_SLOTS  4096
 #endif
@@ -202,6 +208,13 @@ static RB_THREAD_LOCAL_SPECIFIER int malloc_increase_local;
 #else
 # define GC_CAN_COMPILE_COMPACTION 1
 #endif
+#endif
+
+#ifdef HAVE_SYS_PRCTL_H
+#include <sys/prctl.h>
+#endif
+#if !defined(SET_CURRENT_THREAD_NAME) && defined(__linux__) && defined(PR_SET_NAME)
+# define SET_CURRENT_THREAD_NAME(name) prctl(PR_SET_NAME, name)
 #endif
 
 #ifndef PRINT_ENTER_EXIT_TICK
@@ -316,6 +329,8 @@ static ruby_gc_params_t gc_params = {
 # define RGENGC_DEBUG_ENABLED(level) 0
 #endif
 int ruby_rgengc_debug;
+
+extern int ruby_parallel_sweep_enabled;
 
 /* RGENGC_PROFILE
  * 0: disable RGenGC profiling
@@ -525,6 +540,29 @@ typedef struct rb_heap_struct {
     size_t total_pages;      /* total page count in a heap */
     size_t total_slots;      /* total slot count */
 
+#if USE_PARALLEL_SWEEP
+    rb_nativethread_cond_t sweep_page_cond; // associated with global sweep lock
+    rb_nativethread_lock_t swept_pages_lock;
+    size_t pre_swept_bg_slots;
+    bool is_finished_sweeping;
+    bool done_background_sweep;
+    bool skip_sweep_continue;
+
+    // Snapshot of pages to sweep. Both threads claim pages off this list
+    rb_darray(struct heap_page *) sweep_pages;
+    struct heap_page *drained_local;
+    size_t claimed_local_start;
+    size_t claimed_local_end;
+    size_t ruby_th_claimed;
+    size_t in_flight_processed;
+    size_t sweep_claim_overshoot;
+    size_t worker_cache_start;
+    size_t worker_cache_end;
+    rb_atomic_t background_sweep_steps; // only incremented/checked by sweep thread
+    rb_atomic_t foreground_sweep_steps; // incremented by ruby thread, checked by sweep thread
+    RUBY_ALIGNAS(64) size_t sweep_claim_index; // cross-thread atomic
+    RUBY_ALIGNAS(64) struct heap_page *pre_swept_head; // cross-thread atomic
+#endif
 } rb_heap_t;
 
 enum {
@@ -582,23 +620,40 @@ typedef struct rb_objspace {
 
     struct {
         unsigned int mode : 2;
-        unsigned int immediate_sweep : 1;
-        unsigned int dont_gc : 1;
-        unsigned int dont_incremental : 1;
-        unsigned int during_gc : 1;
-        unsigned int during_compacting : 1;
         unsigned int during_reference_updating : 1;
-        unsigned int gc_stressful: 1;
-        unsigned int during_minor_gc : 1;
-        unsigned int during_incremental_marking : 1;
         unsigned int measure_gc : 1;
     } flags;
+    bool during_incremental_marking;
+    bool immediate_sweep;
+    bool dont_incremental;
+    bool during_compacting;
+    bool during_lazy_sweeping;
+    bool during_minor_gc;
+    bool during_gc;
+    bool dont_gc;
+    bool gc_stressful;
 
     rb_event_flag_t hook_events;
 
     rb_heap_t heaps[HEAP_COUNT];
     size_t empty_pages_count;
     struct heap_page *empty_pages;
+
+#if USE_PARALLEL_SWEEP
+    rb_nativethread_lock_t sweep_lock;
+    rb_nativethread_cond_t sweep_cond;
+    pthread_t sweep_thread;
+    bool sweep_thread_running;
+    bool sweep_thread_sweep_requested;
+    bool sweep_thread_sweep_exited;
+    bool sweep_thread_waiting_request;
+    bool sweep_thread_sweeping;
+    bool use_background_sweep_thread;
+    bool background_sweep_mode;
+    bool background_sweep_restart_heaps;
+    unsigned int heaps_done_background_sweep;
+    bool sweep_rest;
+#endif
 
     struct {
         rb_atomic_t finalizing;
@@ -680,9 +735,26 @@ typedef struct rb_objspace {
         unsigned long long sweeping_time_ns;
         struct timespec sweeping_start_time;
 
+#if PSWEEP_COLLECT_TIMINGS > 0
+        /* Ruby thread sweep time tracking (always collected) */
+        unsigned long long ruby_thread_sweep_cpu_time_ns;
+        unsigned long long ruby_thread_sweep_wall_time_ns;
+        struct timespec ruby_thread_sweep_cpu_start_time;
+        struct timespec ruby_thread_sweep_wall_start_time;
+#endif
+
         /* Weak references */
         size_t weak_references_count;
     } profile;
+
+#if USE_PARALLEL_SWEEP
+    /* Cumulative sweep counters that persist across GC cycles (never reset) */
+    struct {
+        size_t pages_swept_by_sweep_thread;
+        size_t pages_swept_by_sweep_thread_had_deferred_free_objects;
+        size_t pages_swept_by_ruby_thread;
+    } sweep_stats;
+#endif
 
     VALUE gc_stress_mode;
 
@@ -737,6 +809,10 @@ typedef struct rb_objspace {
     int fork_vm_lock_lev;
 
     struct rb_gc_vm_context vm_context;
+
+#if USE_PARALLEL_SWEEP
+    rb_atomic_t background_sweep_abort; // set by Ruby thread, read by sweep thread
+#endif
 } rb_objspace_t;
 
 #ifndef HEAP_PAGE_ALIGN_LOG
@@ -883,12 +959,12 @@ struct heap_page {
     unsigned short final_slots;
     unsigned short pinned_slots;
     struct {
-        unsigned int before_sweep : 1;
         unsigned int has_remembered_objects : 1;
         unsigned int has_uncollectible_wb_unprotected_objects : 1;
     } flags;
 
     rb_heap_t *heap;
+    bool before_sweep; // ruby thread sets
 
     struct heap_page *free_next;
     struct heap_page_body *body;
@@ -905,6 +981,15 @@ struct heap_page {
     /* If set, the object is not movable */
     bits_t pinned_bits[HEAP_PAGE_BITMAP_LIMIT];
     bits_t age_bits[HEAP_PAGE_BITMAP_LIMIT * RVALUE_AGE_BIT_COUNT];
+#if USE_PARALLEL_SWEEP
+    bits_t deferred_free_bits[HEAP_PAGE_BITMAP_LIMIT]; // both threads set when they own page
+    // both threads set when they own the page
+    unsigned short pre_freed_slots;
+    unsigned short pre_empty_slots;
+    unsigned short pre_deferred_free_slots;
+    unsigned short pre_final_slots;
+    unsigned short pre_zombie_slots;
+#endif
 };
 
 /*
@@ -1117,10 +1202,10 @@ gc_malloc_counters_snapshot(rb_objspace_t *objspace, struct gc_malloc_bytes *c)
 #define heap_pages_freeable_pages	objspace->heap_pages.freeable_pages
 #define heap_pages_deferred_final	objspace->heap_pages.deferred_final
 #define heaps              objspace->heaps
-#define during_gc		objspace->flags.during_gc
+#define during_gc		objspace->during_gc
 #define finalizing		objspace->atomic_flags.finalizing
 #define finalizer_table 	objspace->finalizer_table
-#define ruby_gc_stressful	objspace->flags.gc_stressful
+#define ruby_gc_stressful	objspace->gc_stressful
 #define ruby_gc_stress_mode     objspace->gc_stress_mode
 #if GC_DEBUG_STRESS_TO_CLASS
 #define stress_to_class         objspace->stress_to_class
@@ -1130,16 +1215,22 @@ gc_malloc_counters_snapshot(rb_objspace_t *objspace, struct gc_malloc_bytes *c)
 #define set_stress_to_class(c)  ((void)objspace, (c))
 #endif
 
-#if 0
-#define dont_gc_on()          (fprintf(stderr, "dont_gc_on@%s:%d\n",      __FILE__, __LINE__), objspace->flags.dont_gc = 1)
-#define dont_gc_off()         (fprintf(stderr, "dont_gc_off@%s:%d\n",     __FILE__, __LINE__), objspace->flags.dont_gc = 0)
-#define dont_gc_set(b)        (fprintf(stderr, "dont_gc_set(%d)@%s:%d\n", __FILE__, __LINE__), objspace->flags.dont_gc = (int)(b))
-#define dont_gc_val()         (objspace->flags.dont_gc)
+#if USE_PARALLEL_SWEEP
+# define SET_DONT_GC_ON_PRE(o) wait_for_background_sweeping_to_finish((o), false, "dont_gc_on")
 #else
-#define dont_gc_on()          (objspace->flags.dont_gc = 1)
-#define dont_gc_off()         (objspace->flags.dont_gc = 0)
-#define dont_gc_set(b)        (objspace->flags.dont_gc = (int)(b))
-#define dont_gc_val()         (objspace->flags.dont_gc)
+# define SET_DONT_GC_ON_PRE(o) ((void)(o))
+#endif
+
+#if 0
+#define dont_gc_on()          (fprintf(stderr, "dont_gc_on@%s:%d\n",      __FILE__, __LINE__), SET_DONT_GC_ON_PRE(objspace), objspace->dont_gc = 1)
+#define dont_gc_off()         (fprintf(stderr, "dont_gc_off@%s:%d\n",     __FILE__, __LINE__), objspace->dont_gc = 0)
+#define dont_gc_set(b)        (fprintf(stderr, "dont_gc_set(%d)@%s:%d\n", __FILE__, __LINE__), objspace->dont_gc = (int)(b))
+#define dont_gc_val()         (objspace->dont_gc)
+#else
+#define dont_gc_on()          (SET_DONT_GC_ON_PRE(objspace), objspace->dont_gc = 1)
+#define dont_gc_off()         (objspace->dont_gc = 0)
+#define dont_gc_set(b)        (objspace->dont_gc = (bool)(b))
+#define dont_gc_val()         (objspace->dont_gc)
 #endif
 
 #define gc_config_full_mark_set(b) (objspace->gc_config.full_mark = (int)(b))
@@ -1174,10 +1265,149 @@ gc_mode_verify(enum gc_mode mode)
     return mode;
 }
 
-static inline bool
+
+#if USE_PARALLEL_SWEEP
+static pthread_t sweep_lock_owner = 0;
+
+static inline void
+sweep_lock_lock_impl(rb_objspace_t *objspace, const char *function, int line)
+{
+    if (!ruby_parallel_sweep_enabled) return;
+    GC_ASSERT(sweep_lock_owner != pthread_self());
+    rb_native_mutex_lock(&objspace->sweep_lock);
+    GC_ASSERT(sweep_lock_owner == 0);
+#if VM_CHECK_MODE > 0
+    sweep_lock_owner = pthread_self();
+#endif
+}
+
+#define sweep_lock_lock(objspace) \
+    sweep_lock_lock_impl(objspace, __FUNCTION__, __LINE__)
+
+static inline void
+sweep_lock_unlock(rb_objspace_t *objspace)
+{
+    if (!ruby_parallel_sweep_enabled) return;
+#if VM_CHECK_MODE > 0
+    GC_ASSERT(sweep_lock_owner == pthread_self());
+    sweep_lock_owner = 0;
+#endif
+    rb_native_mutex_unlock(&objspace->sweep_lock);
+}
+
+static inline void
+sweep_lock_set_locked(rb_objspace_t *objspace)
+{
+    if (!ruby_parallel_sweep_enabled) return;
+    GC_ASSERT(sweep_lock_owner == 0);
+#if VM_CHECK_MODE > 0
+    sweep_lock_owner = pthread_self();
+#endif
+}
+
+static inline void
+sweep_lock_set_unlocked(rb_objspace_t *objspace)
+{
+    if (!ruby_parallel_sweep_enabled) return;
+#if VM_CHECK_MODE > 0
+    GC_ASSERT(sweep_lock_owner == pthread_self());
+    sweep_lock_owner = 0;
+#endif
+}
+#else
+#define sweep_lock_lock(objspace) (void)0
+#define sweep_lock_unlock(objspace) (void)0
+#endif // USE_PARALLEL_SWEEP
+
+#if USE_PARALLEL_SWEEP
+/* Load page claim_index atomically. */
+static inline size_t
+sweep_claim_index_load(rb_heap_t *heap)
+{
+    return rbimpl_atomic_size_load(&heap->sweep_claim_index, RBIMPL_ATOMIC_ACQUIRE);
+}
+
+/* Pages claimed by sweep thread */
+MAYBE_UNUSED(static inline size_t
+sweep_in_flight_load(rb_heap_t *heap))
+{
+    return sweep_claim_index_load(heap) - heap->ruby_th_claimed;
+}
+
+/* Pages the sweep thread claimed but the Ruby thread has not yet finished processing. */
+static inline size_t
+sweep_true_in_flight(rb_heap_t *heap)
+{
+    size_t total = rb_darray_size(heap->sweep_pages);
+    size_t claim_idx = sweep_claim_index_load(heap);
+    size_t in_flight = claim_idx - heap->ruby_th_claimed;
+    size_t worker_overshoot = 0;
+    if (claim_idx > total) {
+        size_t total_overshoot = claim_idx - total;
+        worker_overshoot = (total_overshoot > heap->sweep_claim_overshoot)
+                           ? total_overshoot - heap->sweep_claim_overshoot
+                           : 0;
+    }
+    GC_ASSERT(in_flight >= heap->in_flight_processed + worker_overshoot);
+    return in_flight - heap->in_flight_processed - worker_overshoot;
+}
+
+static inline void
+sweep_claim_state_reset(rb_heap_t *heap)
+{
+    heap->sweep_claim_index = 0;
+    heap->sweep_claim_overshoot = 0;
+    heap->in_flight_processed = 0;
+    heap->ruby_th_claimed = 0;
+}
+
+MAYBE_UNUSED(static inline bool
+sweep_claim_state_is_reset(rb_heap_t *heap))
+{
+    return rbimpl_atomic_size_load(&heap->sweep_claim_index, RBIMPL_ATOMIC_ACQUIRE) == 0 &&
+           heap->sweep_claim_overshoot == 0 &&
+           heap->in_flight_processed == 0 &&
+           heap->ruby_th_claimed == 0;
+}
+#endif // USE_PARALLEL_SWEEP
+
+// Returns true when the sweep thread and Ruby thread have finished processing all the pages for that heap.
+static bool
+heap_is_sweep_done(rb_objspace_t *objspace, rb_heap_t *heap)
+{
+#if USE_PARALLEL_SWEEP
+    if (heap->is_finished_sweeping) {
+        return true;
+    }
+
+    /* Local caches owned by the Ruby thread count as not-yet-done work. */
+    if (heap->drained_local) return false;
+    if (heap->claimed_local_start < heap->claimed_local_end) return false;
+
+    size_t total = rb_darray_size(heap->sweep_pages);
+    size_t claim_idx = sweep_claim_index_load(heap);
+    size_t in_flight = claim_idx - heap->ruby_th_claimed;
+
+    if (claim_idx < total) {
+        return false;
+    }
+    /* Every chunk handed out AND every worker-claimed page committed. */
+    size_t total_overshoot = claim_idx - total;
+    size_t worker_overshoot = (total_overshoot > heap->sweep_claim_overshoot)
+                              ? total_overshoot - heap->sweep_claim_overshoot
+                              : 0;
+    GC_ASSERT(in_flight >= heap->in_flight_processed + worker_overshoot);
+    bool done = in_flight == heap->in_flight_processed + worker_overshoot;
+    return done;
+#else
+    return !heap->sweeping_page;
+#endif
+}
+
+static bool
 has_sweeping_pages(rb_objspace_t *objspace)
 {
-    return objspace->sweeping_heap_count != 0;
+    return objspace->sweeping_heap_count > 0;
 }
 
 static inline size_t
@@ -1218,7 +1448,7 @@ total_final_slots_count(rb_objspace_t *objspace)
     size_t count = 0;
     for (int i = 0; i < HEAP_COUNT; i++) {
         rb_heap_t *heap = &heaps[i];
-        count += heap->final_slots_count;
+        count += (size_t)RUBY_ATOMIC_VALUE_LOAD(heap->final_slots_count);
     }
     return count;
 }
@@ -1229,8 +1459,8 @@ total_final_slots_count(rb_objspace_t *objspace)
 
 #define is_marking(objspace)             (gc_mode(objspace) == gc_mode_marking)
 #define is_sweeping(objspace)            (gc_mode(objspace) == gc_mode_sweeping)
-#define is_full_marking(objspace)        ((objspace)->flags.during_minor_gc == FALSE)
-#define is_incremental_marking(objspace) ((objspace)->flags.during_incremental_marking != FALSE)
+#define is_full_marking(objspace)        ((objspace)->during_minor_gc == FALSE)
+#define is_incremental_marking(objspace) ((objspace)->during_incremental_marking != FALSE)
 #define will_be_incremental_marking(objspace) ((objspace)->rgengc.need_major_gc != GPR_FLAG_NONE)
 /*
  * Byte budget for incremental sweep steps. Each step sweeps at most
@@ -1244,8 +1474,7 @@ total_final_slots_count(rb_objspace_t *objspace)
  */
 #define GC_INCREMENTAL_SWEEP_BYTES           (2048 * RVALUE_SLOT_SIZE)
 #define GC_INCREMENTAL_SWEEP_POOL_BYTES      (1024 * RVALUE_SLOT_SIZE)
-#define is_lazy_sweeping(objspace)           (GC_ENABLE_LAZY_SWEEP && has_sweeping_pages(objspace))
-/* In lazy sweeping or the previous incremental marking finished and did not yield a free page. */
+#define is_lazy_sweeping(objspace)           (GC_ENABLE_LAZY_SWEEP && (objspace)->during_lazy_sweeping)
 #define needs_continue_sweeping(objspace, heap) \
     ((heap)->free_pages == NULL && is_lazy_sweeping(objspace))
 
@@ -1277,6 +1506,8 @@ static int garbage_collect(rb_objspace_t *, unsigned int reason);
 
 static int  gc_start(rb_objspace_t *objspace, unsigned int reason);
 static void gc_rest(rb_objspace_t *objspace);
+static inline void atomic_sub_nounderflow(size_t *var, size_t sub);
+static void malloc_increase_local_flush(rb_objspace_t *objspace);
 
 enum gc_enter_event {
     gc_enter_event_start,
@@ -1496,6 +1727,10 @@ check_rvalue_consistency_force(rb_objspace_t *objspace, const VALUE obj, int ter
 {
     int err = 0;
 
+
+    rb_execution_context_t *ec = rb_current_execution_context(false);
+    if (!ec) return 0; // sweep thread
+
     int lev = RB_GC_VM_LOCK_NO_BARRIER();
     {
         if (SPECIAL_CONST_P(obj)) {
@@ -1535,8 +1770,8 @@ check_rvalue_consistency_force(rb_objspace_t *objspace, const VALUE obj, int ter
                 fprintf(stderr, "check_rvalue_consistency: %s is T_NONE.\n", rb_obj_info(obj));
                 err++;
             }
-            if (BUILTIN_TYPE(obj) == T_ZOMBIE) {
-                fprintf(stderr, "check_rvalue_consistency: %s is T_ZOMBIE.\n", rb_obj_info(obj));
+            if (BUILTIN_TYPE(obj) == T_ZOMBIE && FL_TEST(obj, FL_FREEZE)) {
+                fprintf(stderr, "check_rvalue_consistency: %s is freeable T_ZOMBIE.\n", rb_obj_info(obj));
                 err++;
             }
 
@@ -1787,6 +2022,12 @@ rb_gc_impl_get_measure_total_time(void *objspace_ptr)
     return objspace->flags.measure_gc;
 }
 
+#define ZOMBIE_OBJ_KEPT_FLAGS (FL_FINALIZE)
+// Zombie needs to be put back on the freelist later (during GC) and finalizer has ran
+#define ZOMBIE_NEEDS_FREE_FLAG (FL_FREEZE)
+#define ZOMBIE_NEEDS_FREE_P(zombie) (FL_TEST(zombie, ZOMBIE_NEEDS_FREE_FLAG))
+#define ZOMBIE_SET_NEEDS_FREE_FLAG(zombie) (FL_SET(zombie, ZOMBIE_NEEDS_FREE_FLAG))
+
 /* garbage objects will be collected soon. */
 bool
 rb_gc_impl_garbage_object_p(void *objspace_ptr, VALUE ptr)
@@ -1803,7 +2044,7 @@ rb_gc_impl_garbage_object_p(void *objspace_ptr, VALUE ptr)
         GC_ASSERT(BUILTIN_TYPE(ptr) != T_ZOMBIE);
     }
 
-    return is_lazy_sweeping(objspace) && GET_HEAP_PAGE(ptr)->flags.before_sweep &&
+    return is_lazy_sweeping(objspace) && GET_HEAP_PAGE(ptr)->before_sweep &&
         !RVALUE_MARKED(objspace, ptr);
 }
 
@@ -1901,6 +2142,7 @@ heap_allocatable_bytes_expand(rb_objspace_t *objspace,
     objspace->heap_pages.allocatable_bytes += extend_slot_count * slot_size;
 }
 
+/* Add a `page` with some free slots to the beginning of `heap->free_pages` */
 static inline void
 heap_add_freepage(rb_heap_t *heap, struct heap_page *page)
 {
@@ -1934,7 +2176,10 @@ static void
 heap_unlink_page(rb_objspace_t *objspace, rb_heap_t *heap, struct heap_page *page)
 {
     ccan_list_del(&page->page_node);
+    GC_ASSERT(heap->total_pages > 0);
     heap->total_pages--;
+    GC_ASSERT(heap->total_slots >= page->total_slots);
+    GC_ASSERT(page->total_slots > 0);
     heap->total_slots -= page->total_slots;
 }
 
@@ -2116,6 +2361,7 @@ heap_page_body_allocate(void)
     return page_body;
 }
 
+/* Try to "resurrect" an empty page by removing it from the global empty pages list */
 static struct heap_page *
 heap_page_resurrect(rb_objspace_t *objspace)
 {
@@ -2181,11 +2427,12 @@ heap_page_allocate(rb_objspace_t *objspace)
     return page;
 }
 
+/* Add either an empty page or a newly allocated page to a heap. */
 static void
 heap_add_page(rb_objspace_t *objspace, rb_heap_t *heap, struct heap_page *page)
 {
     /* Adding to eden heap during incremental sweeping is forbidden */
-    GC_ASSERT(!heap->sweeping_page);
+    GC_ASSERT(heap_is_sweep_done(objspace, heap));
     GC_ASSERT(heap_page_in_global_empty_pages_pool(objspace, page));
 
     /* Align start to slot_size boundary */
@@ -2228,7 +2475,9 @@ heap_add_page(rb_objspace_t *objspace, rb_heap_t *heap, struct heap_page *page)
     heap->total_allocated_pages++;
 
     ccan_list_add_tail(&heap->pages, &page->page_node);
+
     heap->total_pages++;
+    GC_ASSERT(page->total_slots == page->free_slots);
     heap->total_slots += page->total_slots;
 }
 
@@ -2277,6 +2526,7 @@ heap_page_allocate_and_initialize_force(rb_objspace_t *objspace, rb_heap_t *heap
     objspace->heap_pages.allocatable_bytes = prev_allocatable_bytes;
 }
 
+// Run incremental marking and/or sweeping, if in incremental marking or sweeping mode
 static void
 gc_continue(rb_objspace_t *objspace, rb_heap_t *heap)
 {
@@ -2305,12 +2555,21 @@ heap_prepare(rb_objspace_t *objspace, rb_heap_t *heap)
 {
     GC_ASSERT(heap->free_pages == NULL);
 
-    if (heap->total_slots < gc_params.heap_init_bytes / heap->slot_size &&
+#if USE_PARALLEL_SWEEP
+    if (heap->total_slots < (gc_params.heap_init_bytes / heap->slot_size) &&
+         (objspace->sweeping_heap_count == 0 || heap_is_sweep_done(objspace, heap))) {
+        heap_page_allocate_and_initialize_force(objspace, heap);
+        GC_ASSERT(heap->free_pages != NULL);
+        return;
+    }
+#else
+    if (heap->total_slots < (gc_params.heap_init_bytes / heap->slot_size) &&
             heap->sweeping_page == NULL) {
         heap_page_allocate_and_initialize_force(objspace, heap);
         GC_ASSERT(heap->free_pages != NULL);
         return;
     }
+#endif
 
     /* Continue incremental marking or lazy sweeping, if in any of those steps. */
     gc_continue(objspace, heap);
@@ -2388,6 +2647,7 @@ static inline VALUE
 newobj_init(VALUE klass, VALUE flags, int wb_protected, rb_objspace_t *objspace, VALUE obj)
 {
     GC_ASSERT(BUILTIN_TYPE(obj) == T_NONE);
+    GC_ASSERT(RVALUE_AGE_GET(obj) == 0);
     GC_ASSERT((flags & FL_WB_PROTECTED) == 0);
     RBASIC(obj)->flags = flags;
     *((VALUE *)&RBASIC(obj)->klass) = klass;
@@ -2514,6 +2774,7 @@ ractor_cache_allocate_slot(rb_objspace_t *objspace, rb_ractor_newobj_cache_t *ca
         cache->incremental_mark_step_allocated_slots++;
     }
 
+
     VALUE obj = (VALUE)cursor;
     rb_asan_unpoison_object(obj, true);
     heap_cache->cursor = cursor + pool_slot_sizes[heap_idx];
@@ -2544,8 +2805,7 @@ heap_next_free_page(rb_objspace_t *objspace, rb_heap_t *heap)
 
     page = heap->free_pages;
     heap->free_pages = page->free_next;
-
-    GC_ASSERT(page->free_slots != 0);
+    GC_ASSERT(page->free_slots > 0);
 
     asan_unlock_freelist(page);
 
@@ -2685,6 +2945,8 @@ newobj_alloc(rb_objspace_t *objspace, rb_ractor_newobj_cache_t *cache, size_t he
 
 ALWAYS_INLINE(static VALUE newobj_slowpath(VALUE klass, VALUE flags, rb_objspace_t *objspace, rb_ractor_newobj_cache_t *cache, int wb_protected, size_t heap_idx));
 
+static const char *type_name(int type, VALUE obj);
+
 static inline VALUE
 newobj_slowpath(VALUE klass, VALUE flags, rb_objspace_t *objspace, rb_ractor_newobj_cache_t *cache, int wb_protected, size_t heap_idx)
 {
@@ -2700,7 +2962,7 @@ newobj_slowpath(VALUE klass, VALUE flags, rb_objspace_t *objspace, rb_ractor_new
                 if (rb_memerror_reentered()) {
                     rb_memerror();
                 }
-                rb_bug("object allocation during garbage collection phase");
+                rb_bug("object allocation during garbage collection phase for klass %s\n", type_name(flags & T_MASK, 0));
             }
 
             if (ruby_gc_stressful) {
@@ -2865,26 +3127,24 @@ rb_gc_impl_live_object_p(void *objspace_ptr, const void *ptr)
     return live;
 }
 
-#define ZOMBIE_OBJ_KEPT_FLAGS (FL_FINALIZE)
-
 void
 rb_gc_impl_make_zombie(void *objspace_ptr, VALUE obj, void (*dfree)(void *), void *data)
 {
     rb_objspace_t *objspace = objspace_ptr;
 
+    struct heap_page *page = GET_HEAP_PAGE(obj);
     struct RZombie *zombie = RZOMBIE(obj);
     zombie->flags = T_ZOMBIE | (zombie->flags & ZOMBIE_OBJ_KEPT_FLAGS);
     zombie->dfree = dfree;
     zombie->data = data;
-    VALUE prev, next = heap_pages_deferred_final;
+    VALUE prev, next = rbimpl_atomic_value_load(&heap_pages_deferred_final, RBIMPL_ATOMIC_RELAXED);
+    GC_ASSERT(page == GET_HEAP_PAGE(zombie));
     do {
         zombie->next = prev = next;
         next = RUBY_ATOMIC_VALUE_CAS(heap_pages_deferred_final, prev, obj);
     } while (next != prev);
-
-    struct heap_page *page = GET_HEAP_PAGE(obj);
-    page->final_slots++;
-    page->heap->final_slots_count++;
+    page->final_slots++; // NOTE: not synchronized, but either background thread or user thread owns page during free
+    RUBY_ATOMIC_SIZE_INC(page->heap->final_slots_count);
 }
 
 typedef int each_obj_callback(void *, void *, size_t, void *);
@@ -2910,7 +3170,7 @@ objspace_each_objects_ensure(VALUE arg)
 
     /* Reenable incremental GC */
     if (data->reenable_incremental) {
-        objspace->flags.dont_incremental = FALSE;
+        objspace->dont_incremental = FALSE;
     }
 
     for (int i = 0; i < HEAP_COUNT; i++) {
@@ -2992,10 +3252,10 @@ objspace_each_exec(bool protected, struct each_obj_data *each_obj_data)
     rb_objspace_t *objspace = each_obj_data->objspace;
     bool reenable_incremental = FALSE;
     if (protected) {
-        reenable_incremental = !objspace->flags.dont_incremental;
+        reenable_incremental = !objspace->dont_incremental;
 
         gc_rest(objspace);
-        objspace->flags.dont_incremental = TRUE;
+        objspace->dont_incremental = TRUE;
     }
 
     each_obj_data->reenable_incremental = reenable_incremental;
@@ -3008,6 +3268,9 @@ objspace_each_exec(bool protected, struct each_obj_data *each_obj_data)
 static void
 objspace_each_objects(rb_objspace_t *objspace, each_obj_callback *callback, void *data, bool protected)
 {
+#if USE_PARALLEL_SWEEP
+    wait_for_background_sweeping_to_finish(objspace, false, "objspace_each_objects");
+#endif
     struct each_obj_data each_obj_data = {
         .objspace = objspace,
         .each_obj_callback = callback,
@@ -3155,30 +3418,34 @@ run_final(rb_objspace_t *objspace, VALUE zombie, unsigned int lev)
     return lev;
 }
 
+void
+rb_gc_impl_free_zombie(rb_objspace_t *objspace, VALUE obj)
+{
+#if USE_PARALLEL_SWEEP
+    GC_ASSERT(!is_sweep_thread_p());
+#endif
+    struct heap_page *page = GET_HEAP_PAGE(obj);
+    GC_ASSERT(RUBY_ATOMIC_VALUE_LOAD(page->heap->final_slots_count) > 0);
+    RUBY_ATOMIC_SIZE_DEC(page->heap->final_slots_count);
+    GC_ASSERT(page->final_slots > 0);
+    page->final_slots--;
+}
+
 static void
 finalize_list(rb_objspace_t *objspace, VALUE zombie)
 {
     while (zombie) {
         VALUE next_zombie;
-        struct heap_page *page;
         rb_asan_unpoison_object(zombie, false);
         next_zombie = RZOMBIE(zombie)->next;
-        page = GET_HEAP_PAGE(zombie);
 
         unsigned int lev = RB_GC_VM_LOCK();
 
         lev = run_final(objspace, zombie, lev);
         {
             GC_ASSERT(BUILTIN_TYPE(zombie) == T_ZOMBIE);
-            GC_ASSERT(page->heap->final_slots_count > 0);
-            GC_ASSERT(page->final_slots > 0);
-
-            page->heap->final_slots_count--;
-            page->final_slots--;
-            page->free_slots++;
-            RVALUE_AGE_SET_BITMAP(zombie, 0);
-            heap_page_add_free_region(objspace, page, zombie);
-            page->heap->total_freed_objects++;
+            GC_ASSERT(!FL_TEST(zombie, FL_FINALIZE));
+            ZOMBIE_SET_NEEDS_FREE_FLAG(zombie);
         }
         RB_GC_VM_UNLOCK(lev);
 
@@ -3222,6 +3489,10 @@ gc_finalize_deferred_register(rb_objspace_t *objspace)
 
 static int pop_mark_stack(mark_stack_t *stack, VALUE *data);
 
+#if USE_PARALLEL_SWEEP
+static void clear_pre_sweep_fields(rb_objspace_t *objspace, struct heap_page *page);
+#endif
+
 static void
 gc_abort(void *objspace_ptr)
 {
@@ -3232,19 +3503,43 @@ gc_abort(void *objspace_ptr)
         VALUE obj;
         while (pop_mark_stack(&objspace->mark_stack, &obj));
 
-        objspace->flags.during_incremental_marking = FALSE;
+        objspace->during_incremental_marking = FALSE;
     }
+
+#if USE_PARALLEL_SWEEP
+    wait_for_background_sweeping_to_finish(objspace, false, "gc_abort");
+#endif
 
     if (is_lazy_sweeping(objspace)) {
         objspace->sweeping_heap_count = 0;
         for (int i = 0; i < HEAP_COUNT; i++) {
             rb_heap_t *heap = &heaps[i];
-
             heap->sweeping_page = NULL;
+#if USE_PARALLEL_SWEEP
+            heap->background_sweep_steps = heap->foreground_sweep_steps;
+
+            /* Pages that were pre-swept but never committed have non-zero
+             * pre_* counters and possibly dirty deferred_free_bits.
+             * Two places hold uncommitted pages at this point: the worker's
+             * pre_swept_head stack and the Ruby thread's drained_local list. */
+            for (struct heap_page *page = heap->pre_swept_head, *next; page; page = next) {
+                next = page->free_next;
+                page->free_next = NULL;
+                clear_pre_sweep_fields(objspace, page);
+            }
+            for (struct heap_page *page = heap->drained_local, *next; page; page = next) {
+                next = page->free_next;
+                page->free_next = NULL;
+                clear_pre_sweep_fields(objspace, page);
+            }
+            heap->pre_swept_head = NULL;
+            heap->drained_local = NULL;
+#endif
+
             struct heap_page *page = NULL;
 
             ccan_list_for_each(&heap->pages, page, page_node) {
-                page->flags.before_sweep = false;
+                page->before_sweep = false;
             }
         }
     }
@@ -3307,8 +3602,12 @@ rb_gc_impl_shutdown_call_finalizer(void *objspace_ptr)
     gc_verify_internal_consistency(objspace);
 #endif
 
+#if USE_PARALLEL_SWEEP
+    wait_for_background_sweeping_to_finish(objspace, false, "shutdown_call_finalizer");
+#endif
+
     /* prohibit incremental GC */
-    objspace->flags.dont_incremental = 1;
+    objspace->dont_incremental = 1;
 
     if (RUBY_ATOMIC_EXCHANGE(finalizing, 1)) {
         /* Abort incremental marking and lazy sweeping to speed up shutdown. */
@@ -3760,7 +4059,7 @@ gc_compact_finish(rb_objspace_t *objspace)
         gc_profile_record *record = gc_prof_record(objspace);
         record->moved_objects = objspace->rcompactor.total_moved - record->moved_objects;
     }
-    objspace->flags.during_compacting = FALSE;
+    objspace->during_compacting = FALSE;
 }
 
 struct gc_sweep_context {
@@ -3768,9 +4067,12 @@ struct gc_sweep_context {
     int final_slots;
     int freed_slots;
     int empty_slots;
+    int zombie_slots; /* pre-existing zombies not yet ready to free */
 
     struct free_region *free_region;
 };
+
+bool rb_gc_obj_needs_cleanup_p(VALUE obj);
 
 static inline void
 gc_sweep_register_free_slot(rb_objspace_t *objspace, struct heap_page *page, struct gc_sweep_context *ctx, uintptr_t p, short slot_size)
@@ -3791,7 +4093,6 @@ gc_sweep_register_free_slot(rb_objspace_t *objspace, struct heap_page *page, str
 
         ctx->free_region = free_region;
     }
-
     if (existing_region) rb_asan_poison_object((VALUE)existing_region);
     rb_asan_poison_object(p);
 }
@@ -3810,7 +4111,7 @@ gc_sweep_plane(rb_objspace_t *objspace, rb_heap_t *heap, uintptr_t p, bits_t bit
         if (bitset & 1) {
             switch (BUILTIN_TYPE(vp)) {
               case T_MOVED:
-                if (objspace->flags.during_compacting) {
+                if (RB_UNLIKELY(objspace->during_compacting)) {
                     /* The sweep cursor shouldn't have made it to any
                      * T_MOVED slots while the compact flag is enabled.
                      * The sweep cursor and compact cursor move in
@@ -3823,7 +4124,11 @@ gc_sweep_plane(rb_objspace_t *objspace, rb_heap_t *heap, uintptr_t p, bits_t bit
                 gc_sweep_register_free_slot(objspace, sweep_page, ctx, p, slot_size);
                 break;
               case T_ZOMBIE:
-                /* already counted */
+                if (ZOMBIE_NEEDS_FREE_P(vp)) {
+                    goto free_object;
+                }
+                /* already counted as final slot */
+                ctx->zombie_slots++;
                 break;
               case T_NONE:
                 ctx->empty_slots++; /* already freed */
@@ -3831,10 +4136,11 @@ gc_sweep_plane(rb_objspace_t *objspace, rb_heap_t *heap, uintptr_t p, bits_t bit
                 break;
 
               default:
+              free_object:
 #if RGENGC_CHECK_MODE
                 if (!is_full_marking(objspace)) {
-                    if (RVALUE_OLD_P(objspace, vp)) rb_bug("page_sweep: %p - old while minor GC.", (void *)p);
-                    if (RVALUE_REMEMBERED(objspace, vp)) rb_bug("page_sweep: %p - remembered.", (void *)p);
+                    if (RVALUE_OLD_P(objspace, vp)) rb_bug("page_sweep: %p - old while minor GC.", (void *)vp);
+                    if (RVALUE_REMEMBERED(objspace, vp)) rb_bug("page_sweep: %p - remembered.", (void *)vp);
                 }
 #endif
 
@@ -3854,8 +4160,7 @@ gc_sweep_plane(rb_objspace_t *objspace, rb_heap_t *heap, uintptr_t p, bits_t bit
                     ctx->freed_slots++;
                 }
                 else {
-                    gc_report(2, objspace, "page_sweep: free %p\n", (void *)p);
-
+                    gc_report(2, objspace, "page_sweep: free %p\n", (void *)vp);
                     rb_gc_obj_free_vm_weak_references(vp);
                     if (rb_gc_obj_free(objspace, vp)) {
                         (void)VALGRIND_MAKE_MEM_UNDEFINED((void*)p, slot_size);
@@ -3870,11 +4175,131 @@ gc_sweep_plane(rb_objspace_t *objspace, rb_heap_t *heap, uintptr_t p, bits_t bit
                 break;
             }
         }
+        else {
+            GC_ASSERT(RVALUE_MARKED(objspace, vp));
+        }
         p += slot_size;
         bitset >>= 1;
     } while (bitset);
 }
 
+#if USE_PARALLEL_SWEEP
+void
+wait_for_background_sweeping_to_finish(rb_objspace_t *objspace, bool exit_sweep_thread, const char *from_fn)
+{
+    if (!objspace->sweep_thread) {
+        return;
+    }
+    sweep_lock_lock(objspace);
+    rbimpl_atomic_store(&objspace->background_sweep_abort, 1, RBIMPL_ATOMIC_RELEASE);
+    objspace->background_sweep_restart_heaps = false;
+    objspace->sweep_thread_sweep_requested = false;
+    while (objspace->sweep_thread_running && objspace->sweep_thread_sweeping) {
+        rb_native_cond_signal(&objspace->sweep_cond);
+        sweep_lock_set_unlocked(objspace);
+        rb_native_cond_wait(&objspace->sweep_cond, &objspace->sweep_lock);
+        sweep_lock_set_locked(objspace);
+    }
+    for (int i = 0; i < HEAP_COUNT; i++) {
+        heaps[i].skip_sweep_continue = false;
+        heaps[i].pre_swept_bg_slots = 0;
+        heaps[i].background_sweep_steps = heaps[i].foreground_sweep_steps;
+    }
+    if (exit_sweep_thread) {
+        objspace->sweep_thread_running = false;
+        while (!objspace->sweep_thread_sweep_exited) {
+            rb_native_cond_signal(&objspace->sweep_cond);
+            sweep_lock_set_unlocked(objspace);
+            rb_native_cond_wait(&objspace->sweep_cond, &objspace->sweep_lock);
+            sweep_lock_set_locked(objspace);
+        }
+        pthread_join(objspace->sweep_thread, NULL);
+        GET_VM()->gc.sweep_thread = 0;
+        objspace->sweep_thread = 0;
+    }
+    rbimpl_atomic_store(&objspace->background_sweep_abort, 0, RBIMPL_ATOMIC_RELEASE);
+    objspace->background_sweep_mode = false;
+    sweep_lock_unlock(objspace);
+}
+
+// Free the object in a Ruby thread. Return whether or not we put the slot back on the page's freelist.
+static bool
+deferred_free(rb_objspace_t *objspace, VALUE obj, struct gc_sweep_context *ctx)
+{
+    ASSERT_vm_locking_with_barrier();
+    bool result;
+    rb_gc_obj_free_vm_weak_references(obj);
+    if (rb_gc_obj_free(objspace, obj)) {
+        struct heap_page *page = GET_HEAP_PAGE(obj);
+        gc_sweep_register_free_slot(objspace, page, ctx, obj, page->slot_size);
+        (void)VALGRIND_MAKE_MEM_UNDEFINED((void*)obj, page->slot_size);
+        result = true;
+    }
+    else {
+#if RUBY_DEBUG
+        if (!(BUILTIN_TYPE(obj) == T_ZOMBIE && !FL_TEST(obj, FL_FREEZE))) {
+            rb_bug("should be unfreeable zombie");
+        }
+#endif
+        result = false;
+        MAYBE_UNUSED(struct heap_page *page) = GET_HEAP_PAGE(obj);
+    }
+    return result;
+}
+
+// Clear bits for the page that was swept by the background thread.
+static inline void
+gc_post_sweep_page(rb_objspace_t *objspace, rb_heap_t *heap, struct heap_page *sweep_page)
+{
+    GC_ASSERT(sweep_page->heap == heap);
+
+    bits_t *bits;
+
+    gc_report(2, objspace, "post_page_sweep: start.\n");
+
+#if RGENGC_CHECK_MODE
+    if (!objspace->immediate_sweep) {
+        GC_ASSERT(sweep_page->before_sweep);
+    }
+#endif
+    GC_ASSERT(sweep_page->before_sweep);
+    sweep_page->before_sweep = false;
+
+    bits = sweep_page->mark_bits;
+
+    int total_slots = sweep_page->total_slots;
+    int bitmap_plane_count = CEILDIV(total_slots, BITS_BITLENGTH);
+
+    int out_of_range_bits = total_slots % BITS_BITLENGTH;
+    if (out_of_range_bits != 0) {
+        bits[bitmap_plane_count - 1] |= ~(((bits_t)1 << out_of_range_bits) - 1);
+    }
+
+    // Clear wb_unprotected and age bits for all unmarked slots
+    {
+        bits_t *wb_unprotected_bits = sweep_page->wb_unprotected_bits;
+        bits_t *age_bits = sweep_page->age_bits;
+        for (int i = 0; i < bitmap_plane_count; i++) {
+            bits_t unmarked = ~bits[i];
+            wb_unprotected_bits[i] &= ~unmarked;
+            age_bits[i * 2] &= ~unmarked;
+            age_bits[i * 2 + 1] &= ~unmarked;
+        }
+    }
+
+    if (!heap->compact_cursor) {
+        gc_setup_mark_bits(sweep_page);
+    }
+
+    if (rbimpl_atomic_value_load(&heap_pages_deferred_final, RBIMPL_ATOMIC_ACQUIRE) && !finalizing) {
+        gc_finalize_deferred_register(objspace);
+    }
+
+    gc_report(2, objspace, "post_page_sweep: end.\n");
+}
+#endif // USE_PARALLEL_SWEEP
+
+// Sweep a page by the Ruby thread (synchronous freeing).
 static inline void
 gc_sweep_page(rb_objspace_t *objspace, rb_heap_t *heap, struct gc_sweep_context *ctx)
 {
@@ -3887,11 +4312,14 @@ gc_sweep_page(rb_objspace_t *objspace, rb_heap_t *heap, struct gc_sweep_context 
     gc_report(2, objspace, "page_sweep: start.\n");
 
 #if RGENGC_CHECK_MODE
-    if (!objspace->flags.immediate_sweep) {
-        GC_ASSERT(sweep_page->flags.before_sweep == TRUE);
+    if (!objspace->immediate_sweep) {
+        GC_ASSERT(sweep_page->before_sweep);
     }
 #endif
-    sweep_page->flags.before_sweep = FALSE;
+    sweep_page->before_sweep = false;
+#if USE_PARALLEL_SWEEP
+    objspace->sweep_stats.pages_swept_by_ruby_thread++;
+#endif
     sweep_page->free_slots = 0;
 
     asan_unlock_freelist(sweep_page);
@@ -3950,10 +4378,10 @@ gc_sweep_page(rb_objspace_t *objspace, rb_heap_t *heap, struct gc_sweep_context 
                    sweep_page->total_slots,
                    ctx->freed_slots, ctx->empty_slots, ctx->final_slots);
 
-    sweep_page->free_slots += ctx->freed_slots + ctx->empty_slots;
     sweep_page->heap->total_freed_objects += ctx->freed_slots;
+    sweep_page->free_slots = ctx->freed_slots + ctx->empty_slots;
 
-    if (heap_pages_deferred_final && !finalizing) {
+    if (rbimpl_atomic_value_load(&heap_pages_deferred_final, RBIMPL_ATOMIC_ACQUIRE) && !finalizing) {
         gc_finalize_deferred_register(objspace);
     }
 
@@ -4049,6 +4477,571 @@ heap_page_flush_cache_regions(struct heap_page *page, rb_ractor_newobj_heap_cach
     }
 }
 
+#if USE_PARALLEL_SWEEP
+static inline void
+sweep_in_ruby_thread(rb_objspace_t *objspace, struct heap_page *page, VALUE obj)
+{
+    page->pre_deferred_free_slots += 1;
+    GC_ASSERT(BUILTIN_TYPE(obj) != T_NONE);
+    MARK_IN_BITMAP(page->deferred_free_bits, obj);
+}
+
+static inline bool
+zombie_needs_deferred_free(VALUE zombie)
+{
+    return ZOMBIE_NEEDS_FREE_P(zombie);
+}
+#endif // USE_PARALLEL_SWEEP
+
+#if RUBY_DEBUG && USE_PARALLEL_SWEEP
+static void
+debug_free_check(rb_objspace_t *objspace, VALUE vp)
+{
+    if (!is_full_marking(objspace)) {
+        if (RVALUE_OLD_P(objspace, vp)) rb_bug("page_sweep: %p - old while minor GC.", (void *)vp);
+        if (RVALUE_REMEMBERED(objspace, vp)) rb_bug("page_sweep: %p - remembered.", (void *)vp);
+    }
+#define CHECK(x) if (x(objspace, vp) != FALSE) rb_bug("obj_free: " #x "(%s) != FALSE", rb_obj_info(vp))
+    CHECK(RVALUE_MARKED);
+    CHECK(RVALUE_MARKING);
+    CHECK(RVALUE_UNCOLLECTIBLE);
+#undef CHECK
+}
+#else
+#define debug_free_check(...) (void)0
+#endif
+
+#if USE_PARALLEL_SWEEP
+static inline void
+gc_pre_sweep_plane(rb_objspace_t *objspace, rb_heap_t *heap, struct heap_page *page, uintptr_t p, bits_t bitset, short slot_size, struct gc_sweep_context *ctx)
+{
+    unsigned short freed = 0;
+    unsigned short empties = 0;
+    unsigned short finals = 0;
+    unsigned short zombies = 0;
+    do {
+        VALUE vp = (VALUE)p;
+        GC_ASSERT(GET_HEAP_PAGE(vp) == page);
+
+        rb_asan_unpoison_object(vp, false);
+        if (bitset & 1) {
+            GC_ASSERT(!RVALUE_MARKED(objspace, vp));
+            switch (BUILTIN_TYPE(vp)) {
+              case T_MOVED: {
+                empties++;
+                gc_sweep_register_free_slot(objspace, page, ctx, vp, page->slot_size);
+                (void)VALGRIND_MAKE_MEM_UNDEFINED((void*)vp, page->slot_size);
+                break;
+              }
+              case T_NONE:
+                empties++; // already in freelist
+                gc_sweep_register_free_slot(objspace, page, ctx, p, slot_size);
+                break;
+              case T_ZOMBIE:
+                if (zombie_needs_deferred_free(vp)) {
+                    sweep_in_ruby_thread(objspace, page, vp);
+                }
+                else {
+                    // already counted as final_slot when made into a zombie
+                    zombies++;
+                }
+                break;
+              case T_DATA: {
+                debug_free_check(objspace, vp);
+                void *data = RTYPEDDATA_P(vp) ? RTYPEDDATA_GET_DATA(vp) : DATA_PTR(vp);
+                if (!data) {
+                    goto free;
+                }
+                // NOTE: this repeats int found in `rb_data_free`.
+                void (*dfree)(void *);
+                int free_immediately = (RTYPEDDATA_TYPE(vp)->flags & RUBY_TYPED_THREAD_SAFE_FREE) != 0;
+                dfree = RTYPEDDATA_TYPE(vp)->function.dfree;
+
+                if (!dfree || dfree == RUBY_DEFAULT_FREE || free_immediately) {
+                    goto free;
+                }
+                else {
+                    sweep_in_ruby_thread(objspace, page, vp);
+                    break;
+                }
+                break;
+              }
+              case T_IMEMO: {
+                debug_free_check(objspace, vp);
+                switch (imemo_type(vp)) {
+                    case imemo_callcache:
+                    case imemo_constcache:
+                    case imemo_cref:
+                    case imemo_env:
+                    case imemo_ifunc:
+                    case imemo_memo:
+                    case imemo_svar:
+                    case imemo_throw_data:
+                    case imemo_tmpbuf:
+                    case imemo_fields:
+                    case imemo_cvar_entry:
+                    case imemo_subclasses:
+                    case imemo_cdhash:
+                        goto free;
+                    case imemo_callinfo:
+                    case imemo_iseq:
+                    case imemo_ment:
+                        sweep_in_ruby_thread(objspace, page, vp);
+                        break;
+                    default:
+                        rb_bug("Unknown imemo type: %d\n", imemo_type(vp));
+                }
+                break;
+              }
+              case T_COMPLEX:
+              case T_RATIONAL:
+              case T_FLOAT:
+              case T_BIGNUM:
+              case T_OBJECT:
+              case T_STRING:
+              case T_SYMBOL:
+              case T_ARRAY:
+              case T_HASH:
+              case T_STRUCT:
+              case T_MATCH:
+              case T_REGEXP:
+              case T_FILE:
+              case T_CLASS:
+              case T_MODULE:
+              case T_ICLASS: {
+                goto free;
+              }
+              free: {
+                debug_free_check(objspace, vp);
+                if (!rb_gc_obj_needs_cleanup_p(vp)) {
+                    gc_sweep_register_free_slot(objspace, page, ctx, vp, page->slot_size);
+                    (void)VALGRIND_MAKE_MEM_UNDEFINED((void*)vp, page->slot_size);
+                    freed++;
+                }
+                else {
+                    rb_gc_obj_free_concurrency_safe_vm_weak_references(vp);
+                    bool can_put_back_on_freelist = rb_gc_obj_free(objspace, vp);
+                    if (can_put_back_on_freelist) {
+                        gc_sweep_register_free_slot(objspace, page, ctx, vp, page->slot_size);
+                        freed++;
+                        (void)VALGRIND_MAKE_MEM_UNDEFINED((void*)vp, page->slot_size);
+                    }
+                    else {
+                        RUBY_ASSERT(BUILTIN_TYPE(vp) == T_ZOMBIE);
+                        finals++;
+                    }
+                }
+                break;
+              }
+              default:
+                rb_bug("unexpected type: %d\n", BUILTIN_TYPE(vp));
+            }
+        }
+        else {
+            GC_ASSERT(RVALUE_MARKED(objspace, vp));
+        }
+
+        p += slot_size;
+        bitset >>= 1;
+    } while (bitset);
+
+    page->pre_freed_slots += freed;
+    page->pre_empty_slots += empties;
+    page->pre_final_slots += finals;
+    page->pre_zombie_slots += zombies;
+}
+
+static void
+gc_pre_sweep_page(rb_objspace_t *objspace, rb_heap_t *heap, struct heap_page *page)
+{
+    uintptr_t p = (uintptr_t)page->start;
+    bits_t *bits = page->mark_bits;
+    bits_t bitset;
+    short slot_size = page->slot_size;
+    int total_slots = page->total_slots;
+    GC_ASSERT(page->heap == heap);
+    GC_ASSERT(page->pre_deferred_free_slots == 0);
+    asan_unlock_freelist(page);
+    page->free_region = NULL;
+
+    int bitmap_plane_count = CEILDIV(total_slots, BITS_BITLENGTH);
+    int out_of_range_bits = total_slots % BITS_BITLENGTH;
+
+    if (out_of_range_bits != 0) {
+        bits[bitmap_plane_count - 1] |= ~(((bits_t)1 << out_of_range_bits) - 1);
+    }
+
+    struct gc_sweep_context ctx = { .page = page, .free_region = 0 };
+    for (int i = 0; i < bitmap_plane_count; i++) {
+        bitset = ~bits[i];
+        if (bitset) {
+            gc_pre_sweep_plane(objspace, heap, page, p, bitset, slot_size, &ctx);
+        }
+        p += BITS_BITLENGTH * slot_size;
+    }
+#if USE_PARALLEL_SWEEP
+    objspace->sweep_stats.pages_swept_by_sweep_thread++;
+    if (page->pre_deferred_free_slots > 0) {
+        objspace->sweep_stats.pages_swept_by_sweep_thread_had_deferred_free_objects++;
+    }
+#endif
+    page->free_region = ctx.free_region;
+    asan_lock_freelist(page);
+}
+
+static inline bool
+done_worker_incremental_sweep_steps_p(rb_objspace_t *objspace, rb_heap_t *heap)
+{
+    if (rbimpl_atomic_load(&heap->foreground_sweep_steps, RBIMPL_ATOMIC_ACQUIRE) != heap->background_sweep_steps) {
+        GC_ASSERT(ATOMIC_LOAD_RELAXED(heap->foreground_sweep_steps) > heap->background_sweep_steps);
+        return true;
+    }
+    return false;
+}
+#endif // USE_PARALLEL_SWEEP
+
+MAYBE_UNUSED(static bool)
+bitmap_is_all_zero(bits_t *bits, size_t count)
+{
+    for (size_t i = 0; i < count; i++) {
+        if (bits[i] != 0) return false;
+    }
+    return true;
+}
+
+static void
+move_to_empty_pages(rb_objspace_t *objspace, rb_heap_t *heap, struct heap_page *page)
+{
+    GC_ASSERT(bitmap_is_all_zero(page->mark_bits, HEAP_PAGE_BITMAP_LIMIT));
+    GC_ASSERT(bitmap_is_all_zero(page->uncollectible_bits, HEAP_PAGE_BITMAP_LIMIT));
+    GC_ASSERT(bitmap_is_all_zero(page->wb_unprotected_bits, HEAP_PAGE_BITMAP_LIMIT));
+    GC_ASSERT(bitmap_is_all_zero(page->marking_bits, HEAP_PAGE_BITMAP_LIMIT));
+    GC_ASSERT(bitmap_is_all_zero(page->remembered_bits, HEAP_PAGE_BITMAP_LIMIT));
+    GC_ASSERT(bitmap_is_all_zero(page->age_bits, HEAP_PAGE_BITMAP_LIMIT * RVALUE_AGE_BIT_COUNT));
+#if USE_PARALLEL_SWEEP
+    GC_ASSERT(bitmap_is_all_zero(page->deferred_free_bits, HEAP_PAGE_BITMAP_LIMIT));
+#endif
+    // NOTE: pinned bits can still be set, but it's okay because they are cleared when compaction starts
+
+    heap_unlink_page(objspace, heap, page);
+
+    page->start = 0;
+    page->total_slots = 0;
+    page->slot_size = 0;
+    page->heap = NULL;
+    page->free_slots = 0;
+
+    asan_unlock_freelist(page);
+    page->free_region = NULL;
+    asan_lock_freelist(page);
+
+    asan_poison_memory_region(page->body, HEAP_PAGE_SIZE);
+
+    objspace->empty_pages_count++;
+    page->free_next = objspace->empty_pages;
+    objspace->empty_pages = page;
+}
+
+static void malloc_increase_commit(rb_objspace_t *objspace, size_t new_size, size_t old_size);
+
+#if USE_PARALLEL_SWEEP
+static void
+clear_pre_sweep_fields(rb_objspace_t *objspace, struct heap_page *page)
+{
+    page->pre_freed_slots = 0;
+    page->pre_deferred_free_slots = 0;
+    memset(page->deferred_free_bits, 0, sizeof(page->deferred_free_bits));
+    page->pre_empty_slots = 0;
+    page->pre_final_slots = 0;
+    page->pre_zombie_slots = 0;
+}
+
+#define SWEEP_CHUNK 4
+
+/* Atomically claim a chunk of page indices to sweep. Returns true and writes [start, end)
+ * into out params on success. Returns false when there is no more work to claim. */
+static bool
+sweep_claim_chunk(rb_heap_t *heap, size_t *out_start, size_t *out_end, int chunk_sz, bool is_sweep_thread)
+{
+    size_t total = rb_darray_size(heap->sweep_pages);
+    if (total == 0) return false;
+
+    size_t prev = rbimpl_atomic_size_fetch_add(&heap->sweep_claim_index, (size_t)chunk_sz, RBIMPL_ATOMIC_ACQ_REL);
+    if (!is_sweep_thread) heap->ruby_th_claimed += chunk_sz;
+    size_t start = prev;
+    if (start >= total) {
+        if (!is_sweep_thread) {
+            heap->sweep_claim_overshoot += chunk_sz;
+        }
+        return false;
+    }
+    size_t end = start + chunk_sz;
+    if (end > total) {
+        /* Partial-chunk overshoot. */
+        if (!is_sweep_thread) {
+            heap->sweep_claim_overshoot += end - total;
+        }
+        end = total;
+    }
+    *out_start = start;
+    *out_end = end;
+    return true;
+}
+
+/* Lock-free bulk push of a pre-linked chain of pages onto heap->pre_swept_head. */
+static void
+sweep_stack_push_bulk(rb_heap_t *heap, struct heap_page *head, struct heap_page *tail)
+{
+    struct heap_page *old;
+    do {
+        old = rbimpl_atomic_ptr_load((void**)&heap->pre_swept_head, RBIMPL_ATOMIC_RELAXED);
+        tail->free_next = old;
+    } while ((struct heap_page *)rbimpl_atomic_ptr_cas((void**)&heap->pre_swept_head, old, head,
+                                                        RBIMPL_ATOMIC_RELEASE, RBIMPL_ATOMIC_RELAXED) != old);
+}
+
+/* Atomically detach the entire pre-swept stack and return its head, or NULL.
+ * Caller iterates via page->free_next. */
+static struct heap_page *
+sweep_stack_drain(rb_heap_t *heap)
+{
+    struct heap_page *chain = rbimpl_atomic_ptr_exchange((void**)&heap->pre_swept_head, NULL, RBIMPL_ATOMIC_ACQ_REL);
+    struct heap_page *prev = NULL;
+    // Reverse the stack so we process them in pre-swept order
+    while (chain != NULL) {
+        struct heap_page *next = chain->free_next;
+        chain->free_next = prev;
+        prev = chain;
+        chain = next;
+    }
+    return prev;
+}
+
+static void
+sweep_thread_signal_enqueued_pages(rb_objspace_t *objspace, rb_heap_t *heap)
+{
+    if (!objspace->background_sweep_mode) {
+        rb_native_cond_signal(&heap->sweep_page_cond);
+    }
+}
+
+enum sweep_step_worker_state {
+    WORKER_SKIP_HEAP,
+    WORKER_NEXT_HEAP_FG,
+    WORKER_NEXT_HEAP_BG,
+    WORKER_DONE_HEAP,
+    WORKER_DONE_ALL_HEAPS,
+    WORKER_ABORT_SWEEP_HEAPS,
+    WORKER_RESTART_SWEEP_HEAPS,
+};
+
+// Perform incremental (lazy) sweep on a heap by the background sweep thread.
+static enum sweep_step_worker_state
+gc_sweep_step_worker(rb_objspace_t *objspace, rb_heap_t *heap)
+{
+    // sweep_lock is acquired
+
+    GC_ASSERT(heap->background_sweep_steps <= ATOMIC_LOAD_RELAXED(heap->foreground_sweep_steps));
+    if (heap->done_background_sweep) {
+        return WORKER_DONE_HEAP;
+    }
+    /* In foreground mode, honor the per-heap throttle the worker set during the prior background phase. */
+    if (!objspace->background_sweep_mode && heap->skip_sweep_continue) {
+        return WORKER_SKIP_HEAP;
+    }
+    int chunk_sz = SWEEP_CHUNK;
+    size_t sweep_budget = GC_INCREMENTAL_SWEEP_BYTES / heap->slot_size;
+    size_t pool_budget = GC_INCREMENTAL_SWEEP_POOL_BYTES / heap->slot_size;
+    size_t slot_budget = sweep_budget + pool_budget;
+    while (1) {
+        /* Claim work via atomic fetch_add. The claim itself is lock-free, so we drop sweep_lock */
+        bool was_bg_mode = objspace->background_sweep_mode;
+        sweep_lock_unlock(objspace);
+
+        /* Accumulate up to SWEEP_CHUNK pre-swept pages in a local linked list then push the whole batch onto
+         * pre_swept_head with a single CAS. */
+        struct heap_page *batch_head = NULL;
+        struct heap_page *batch_tail = NULL;
+        int batch_count = 0;
+        bool no_more_work = false;
+        size_t batch_bg_slots = 0;
+
+        while (batch_count < chunk_sz) {
+            if (heap->worker_cache_start >= heap->worker_cache_end) {
+                /* Leave the last chunk for the Ruby thread. If at most one chunk's worth of pages remains
+                 * unclaimed, bail so the Ruby thread can claim them instead of waiting on the condvar */
+                size_t cur_idx = sweep_claim_index_load(heap);
+                size_t total = rb_darray_size(heap->sweep_pages);
+                if (cur_idx < total && total - cur_idx <= SWEEP_CHUNK) {
+                    no_more_work = true;
+                    break;
+                } else if (chunk_sz == SWEEP_CHUNK && cur_idx < total && total - cur_idx <= (SWEEP_CHUNK * 2)) {
+                    chunk_sz = SWEEP_CHUNK/2;
+                }
+
+                size_t chunk_start, chunk_end;
+                if (!sweep_claim_chunk(heap, &chunk_start, &chunk_end, chunk_sz, true)) {
+                    no_more_work = true;
+                    break;
+                }
+                heap->worker_cache_start = chunk_start;
+                heap->worker_cache_end = chunk_end;
+            }
+
+            size_t i = heap->worker_cache_start++;
+            GC_ASSERT(i < rb_darray_size(heap->sweep_pages));
+            struct heap_page *page = heap->sweep_pages->data[i];
+            GC_ASSERT(page->before_sweep);
+            page->free_next = NULL;
+            gc_pre_sweep_page(objspace, heap, page);
+
+            if (was_bg_mode) {
+                size_t page_free_slots = (size_t)page->pre_freed_slots + (size_t)page->pre_empty_slots;
+                bool page_will_be_empty =
+                    page->pre_final_slots == 0 &&
+                    page->pre_zombie_slots == 0 &&
+                    page_free_slots == (size_t)page->total_slots;
+                if (!page_will_be_empty) {
+                    batch_bg_slots += page_free_slots;
+                }
+            }
+
+            page->free_next = batch_head;
+            batch_head = page;
+            if (batch_tail == NULL) {
+                batch_tail = page;
+            }
+            batch_count++;
+        }
+
+        if (batch_head != NULL) {
+            sweep_stack_push_bulk(heap, batch_head, batch_tail);
+        }
+
+        sweep_lock_lock(objspace);
+
+        if (batch_bg_slots > 0 && objspace->background_sweep_mode && !objspace->background_sweep_abort && !objspace->background_sweep_restart_heaps) {
+            heap->pre_swept_bg_slots += batch_bg_slots;
+            if (!no_more_work && heap->pre_swept_bg_slots > slot_budget) {
+                heap->skip_sweep_continue = true;
+                return WORKER_NEXT_HEAP_BG;
+            }
+        }
+
+        if (no_more_work) {
+            GC_ASSERT(!heap->done_background_sweep);
+            GC_ASSERT(objspace->heaps_done_background_sweep < HEAP_COUNT);
+            heap->done_background_sweep = true;
+            objspace->heaps_done_background_sweep++;
+            sweep_thread_signal_enqueued_pages(objspace, heap);
+            if (objspace->heaps_done_background_sweep == HEAP_COUNT) {
+                return WORKER_DONE_ALL_HEAPS;
+            }
+            else {
+                return WORKER_DONE_HEAP;
+            }
+        }
+
+        if (RB_UNLIKELY(objspace->background_sweep_abort)) {
+            sweep_thread_signal_enqueued_pages(objspace, heap);
+            return WORKER_ABORT_SWEEP_HEAPS;
+        }
+
+        if (!objspace->background_sweep_mode) {
+            if (!objspace->sweep_rest && done_worker_incremental_sweep_steps_p(objspace, heap)) {
+                heap->background_sweep_steps = ATOMIC_LOAD_RELAXED(heap->foreground_sweep_steps);
+                sweep_thread_signal_enqueued_pages(objspace, heap);
+                return WORKER_NEXT_HEAP_FG;
+            }
+        }
+        else {
+            if (objspace->background_sweep_restart_heaps) {
+                return WORKER_RESTART_SWEEP_HEAPS;
+            }
+        }
+        // notify of newly swept pages in case Ruby thread is waiting on us
+        sweep_thread_signal_enqueued_pages(objspace, heap);
+    }
+    // sweep_lock is acquired
+}
+
+static void *
+gc_sweep_thread_func(void *ptr)
+{
+    rb_objspace_t *objspace = ptr;
+
+#ifdef SET_CURRENT_THREAD_NAME
+    SET_CURRENT_THREAD_NAME("Ruby VM Sweep");
+#endif
+
+    sweep_lock_lock(objspace);
+    objspace->sweep_thread_sweep_exited = false;
+
+    while (objspace->sweep_thread_running) {
+        while (objspace->sweep_thread_running && !objspace->sweep_thread_sweep_requested) {
+            objspace->sweep_thread_waiting_request = true;
+            sweep_lock_set_unlocked(objspace);
+            rb_native_cond_wait(&objspace->sweep_cond, &objspace->sweep_lock);
+            sweep_lock_set_locked(objspace);
+            objspace->sweep_thread_waiting_request = false;
+        }
+        objspace->sweep_thread_sweep_requested = false;
+        if (!objspace->sweep_thread_running || objspace->background_sweep_abort) {
+            break;
+        }
+
+        objspace->background_sweep_restart_heaps = false;
+        objspace->sweep_thread_sweeping = true;
+
+        bool done_all;
+        bool restart;
+        bool abort;
+    restart_heaps:
+        done_all = false;
+        restart = false;
+        abort = false;
+        for (int i = 0; i < HEAP_COUNT; i++) {
+            rb_heap_t *heap = &heaps[i];
+            enum sweep_step_worker_state state = gc_sweep_step_worker(objspace, heap);
+            switch (state) {
+                case WORKER_SKIP_HEAP:
+                case WORKER_NEXT_HEAP_FG:
+                case WORKER_NEXT_HEAP_BG:
+                case WORKER_DONE_HEAP:
+                    break;
+                case WORKER_DONE_ALL_HEAPS:
+                    done_all = true;
+                    break;
+                case WORKER_RESTART_SWEEP_HEAPS:
+                    restart = true;
+                    break;
+                case WORKER_ABORT_SWEEP_HEAPS:
+                    abort = true;
+                    break;
+            }
+            if (abort || done_all) {
+                break;
+            } else if (restart) {
+                objspace->background_sweep_restart_heaps = false;
+                goto restart_heaps;
+            }
+        }
+#if USE_MALLOC_INCREASE_LOCAL
+        malloc_increase_local_flush(objspace);
+#endif
+
+        objspace->sweep_thread_sweeping = false;
+        rb_native_cond_signal(&objspace->sweep_cond); // signal done sweeping this iteration
+    }
+    objspace->sweep_thread_sweep_requested = false;
+    objspace->sweep_thread_sweep_exited = true;
+    sweep_lock_unlock(objspace);
+    rb_native_cond_signal(&objspace->sweep_cond); // signal exited
+
+    return NULL;
+}
+#endif // USE_PARALLEL_SWEEP
+
 static void
 gc_sweep_start_heap(rb_objspace_t *objspace, rb_heap_t *heap)
 {
@@ -4058,14 +5051,83 @@ gc_sweep_start_heap(rb_objspace_t *objspace, rb_heap_t *heap)
     }
     heap->free_pages = NULL;
     heap->pooled_pages = NULL;
-    if (!objspace->flags.immediate_sweep) {
-        struct heap_page *page = NULL;
+    GC_ASSERT(heap->freed_slots == 0);
+    GC_ASSERT(heap->empty_slots == 0);
 
-        ccan_list_for_each(&heap->pages, page, page_node) {
-            page->flags.before_sweep = TRUE;
+#if USE_PARALLEL_SWEEP
+    heap->background_sweep_steps = heap->foreground_sweep_steps;
+    heap->is_finished_sweeping = false;
+    heap->done_background_sweep = false;
+    heap->skip_sweep_continue = false;
+    heap->pre_swept_bg_slots = 0;
+
+    /* Build the page snapshot for this sweep cycle. Pages can't be added during the
+     * sweeping of a heap, so this is stable. This is an optimization to allow a lock-free queue
+     * of pre-swept pages between the worker and the ruby GC thread */
+    rb_darray_clear(heap->sweep_pages);
+    sweep_claim_state_reset(heap);
+    heap->pre_swept_head = NULL;
+    heap->drained_local = NULL;
+    heap->claimed_local_start = 0;
+    heap->claimed_local_end = 0;
+    heap->worker_cache_start = 0;
+    heap->worker_cache_end = 0;
+#endif
+    heap->freed_slots = 0;
+    heap->empty_slots = 0;
+
+    struct heap_page *page = NULL;
+
+#if USE_PARALLEL_SWEEP
+    /* During compaction we defer building the snapshot until gc_sweep_compact has finished */
+    const bool build_snapshot = !objspace->during_compacting;
+
+    if (build_snapshot) {
+        if (rb_darray_capa(heap->sweep_pages) < heap->total_pages) {
+            rb_darray_resize_capa_without_gc(&heap->sweep_pages, heap->total_pages);
+        }
+        else if (rb_darray_capa(heap->sweep_pages) > heap->total_pages * 4) {
+            rb_darray_resize_capa_without_gc(&heap->sweep_pages, rb_darray_capa(heap->sweep_pages) / 2);
         }
     }
+#endif
+
+    ccan_list_for_each(&heap->pages, page, page_node) {
+        page->before_sweep = true;
+#if USE_PARALLEL_SWEEP
+        GC_ASSERT(page->pre_deferred_free_slots == 0);
+        if (build_snapshot) {
+            rb_darray_append_without_gc(&heap->sweep_pages, page);
+        }
+#endif
+    }
 }
+
+#if USE_PARALLEL_SWEEP
+/* NOTE: Build the sweep_pages snapshot after gc_sweep_compact has run. */
+static void
+gc_sweep_start_heap_snapshot(rb_objspace_t *objspace, rb_heap_t *heap)
+{
+    if (heap->is_finished_sweeping) return;
+
+    GC_ASSERT(rb_darray_size(heap->sweep_pages) == 0);
+    GC_ASSERT(heap->pre_swept_head == NULL);
+    GC_ASSERT(heap->drained_local == NULL);
+    GC_ASSERT(heap->claimed_local_start == 0 && heap->claimed_local_end == 0);
+    GC_ASSERT(sweep_claim_state_is_reset(heap));
+
+    if (rb_darray_capa(heap->sweep_pages) < heap->total_pages) {
+        rb_darray_resize_capa_without_gc(&heap->sweep_pages, heap->total_pages);
+    }
+
+    struct heap_page *page = NULL;
+    ccan_list_for_each(&heap->pages, page, page_node) {
+        if (!page->before_sweep) continue; // compacted page
+        GC_ASSERT(page->pre_deferred_free_slots == 0);
+        rb_darray_append_without_gc(&heap->sweep_pages, page);
+    }
+}
+#endif
 
 #if defined(__GNUC__) && __GNUC__ == 4 && __GNUC_MINOR__ == 4
 __attribute__((noinline))
@@ -4104,6 +5166,15 @@ gc_ractor_newobj_cache_clear(void *c, void *data)
         cache->cursor_end = 0;
         cache->next_region = NULL;
     }
+}
+
+static int
+gc_sweep_weak_table_i(VALUE val, void *data)
+{
+    rb_objspace_t *objspace = data;
+    if (RB_SPECIAL_CONST_P(val)) return ST_CONTINUE;
+    if (RVALUE_MARKED(objspace, val)) return ST_CONTINUE;
+    return ST_DELETE;
 }
 
 static void
@@ -4166,14 +5237,38 @@ static void
 gc_sweep_start(rb_objspace_t *objspace)
 {
     gc_mode_transition(objspace, gc_mode_sweeping);
+#if GC_ENABLE_LAZY_SWEEP
+    objspace->during_lazy_sweeping = true;
+#endif
     objspace->rincgc.pooled_slots = 0;
+
+#if USE_PARALLEL_SWEEP
+    objspace->heaps_done_background_sweep = 0;
+#if VM_CHECK_MODE > 0
+    // Background sweeping cannot be happening
+    sweep_lock_lock(objspace);
+    GC_ASSERT(!objspace->sweep_thread_sweeping && !objspace->sweep_thread_sweep_requested);
+    sweep_lock_unlock(objspace);
+#endif
+#endif // PARALLEL_SWEEP
 
     if (RB_UNLIKELY(objspace->hook_events & RUBY_INTERNAL_EVENT_FREEOBJ)) {
         gc_sweep_freeobj_hooks(objspace);
     }
 
+    for (int table = 0; table < RB_GC_VM_WEAK_TABLE_COUNT; table++) {
+        if (!rb_gc_vm_weak_table_essential_p(table)) continue;
+        rb_gc_vm_weak_table_foreach(
+            gc_sweep_weak_table_i,
+            NULL,
+            objspace,
+            true,
+            table
+        );
+    }
+
 #if GC_CAN_COMPILE_COMPACTION
-    if (objspace->flags.during_compacting) {
+    if (objspace->during_compacting) {
         gc_sort_heap_by_compare_func(
             objspace,
             objspace->rcompactor.compare_func ? objspace->rcompactor.compare_func : compare_pinned_slots
@@ -4194,6 +5289,25 @@ gc_sweep_start(rb_objspace_t *objspace)
     }
 
     rb_gc_ractor_newobj_cache_foreach(gc_ractor_newobj_cache_clear, NULL);
+
+#if USE_PARALLEL_SWEEP
+    bool do_signal = false;
+    if (objspace->sweep_thread && !objspace->during_compacting) {
+        objspace->use_background_sweep_thread = true;
+        sweep_lock_lock(objspace);
+        {
+            objspace->sweep_thread_sweep_requested = true;
+            do_signal = true;
+        }
+        sweep_lock_unlock(objspace);
+        if (do_signal) {
+            rb_native_cond_signal(&objspace->sweep_cond);
+        }
+    }
+    else {
+        objspace->use_background_sweep_thread = false;
+    }
+#endif
 }
 
 static void
@@ -4201,9 +5315,23 @@ gc_sweep_finish_heap(rb_objspace_t *objspace, rb_heap_t *heap)
 {
     size_t total_slots = heap->total_slots;
     size_t swept_slots = heap->freed_slots + heap->empty_slots;
+    GC_ASSERT(total_slots >= swept_slots);
 
     size_t init_slots = gc_params.heap_init_bytes / heap->slot_size;
     size_t min_free_slots = (size_t)(MAX(total_slots, init_slots) * gc_params.heap_free_slots_min_ratio);
+
+#if USE_PARALLEL_SWEEP
+    GC_ASSERT(heap->background_sweep_steps <= ATOMIC_LOAD_RELAXED(heap->foreground_sweep_steps));
+    GC_ASSERT(!heap->is_finished_sweeping);
+    heap->is_finished_sweeping = true;
+    heap->sweeping_page = NULL;
+#if RUBY_DEBUG
+    for (size_t i = 0; i < rb_darray_size(heap->sweep_pages); i++) {
+        struct heap_page *page = rb_darray_get(heap->sweep_pages, i);
+        GC_ASSERT(!page->before_sweep);
+    }
+#endif
+#endif // USE_PARALLEL_SWEEP
 
     if (swept_slots < min_free_slots &&
             /* The heap is a growth heap if it freed more slots than had empty slots. */
@@ -4244,14 +5372,23 @@ gc_sweep_finish(rb_objspace_t *objspace)
 {
     gc_report(1, objspace, "gc_sweep_finish\n");
 
+#if USE_PARALLEL_SWEEP
+    objspace->use_background_sweep_thread = false;
+#endif
+
     gc_prof_set_heap_info(objspace);
     heap_pages_free_unused_pages(objspace);
 
     for (int i = 0; i < HEAP_COUNT; i++) {
         rb_heap_t *heap = &heaps[i];
-
         heap->freed_slots = 0;
         heap->empty_slots = 0;
+#if USE_PARALLEL_SWEEP
+        GC_ASSERT(heap->is_finished_sweeping);
+        if (heap->background_sweep_steps < heap->foreground_sweep_steps) {
+            heap->background_sweep_steps = heap->foreground_sweep_steps;
+        }
+#endif
 
         if (!will_be_incremental_marking(objspace)) {
             struct heap_page *end_page = heap->free_pages;
@@ -4269,60 +5406,246 @@ gc_sweep_finish(rb_objspace_t *objspace)
 
     rb_gc_event_hook(0, RUBY_INTERNAL_EVENT_GC_END_SWEEP);
     gc_mode_transition(objspace, gc_mode_none);
+#if GC_ENABLE_LAZY_SWEEP
+    objspace->during_lazy_sweeping = false;
+#endif
 
 #if RGENGC_CHECK_MODE >= 2
     gc_verify_internal_consistency(objspace);
 #endif
 }
 
+#if USE_PARALLEL_SWEEP
+// Dequeue a page for the Ruby GC thread to process. Returns NULL when no work is
+// available for this heap. When the returned page came from our own claim (not the
+// worker's pre-sweep stack), *dequeued_unswept_page is set to true and the caller
+// must do the full sweep.
+static struct heap_page *
+gc_sweep_dequeue_page(rb_objspace_t *objspace, rb_heap_t *heap, bool free_in_user_thread, bool *dequeued_unswept_page)
+{
+
+    /* 1) Local drain cache from a previous bulk grab. */
+retry:
+    if (heap->drained_local) {
+        struct heap_page *page = heap->drained_local;
+        heap->drained_local = page->free_next;
+        page->free_next = NULL;
+        GC_ASSERT(page->before_sweep);
+        return page;
+    }
+retry_drain:
+
+    /* 2) Bulk-drain the worker's pre-swept stack with one xchg. */
+    heap->drained_local = sweep_stack_drain(heap);
+    if (heap->drained_local) goto retry;
+
+    /* 3) Resume an outstanding claimed range. */
+    if (heap->claimed_local_start < heap->claimed_local_end) {
+        GC_ASSERT(heap->claimed_local_end <= rb_darray_size(heap->sweep_pages));
+        GC_ASSERT(heap->claimed_local_start < rb_darray_size(heap->sweep_pages));
+        struct heap_page *page = heap->sweep_pages->data[heap->claimed_local_start++];
+        *dequeued_unswept_page = true;
+        return page;
+    }
+
+    /* 4) Claim a fresh chunk. */
+    if (sweep_claim_chunk(heap, &heap->claimed_local_start, &heap->claimed_local_end, SWEEP_CHUNK, false)) {
+        GC_ASSERT(heap->claimed_local_end <= rb_darray_size(heap->sweep_pages));
+        GC_ASSERT(heap->claimed_local_start < rb_darray_size(heap->sweep_pages));
+        struct heap_page *page = heap->sweep_pages->data[heap->claimed_local_start++];
+        *dequeued_unswept_page = true;
+        return page;
+    }
+
+    /* 5) Nothing left to claim. If the worker still has pages in flight, wait for
+     *    them to land on the stack and retry the drain. */
+    if (sweep_true_in_flight(heap) > 0) {
+        sweep_lock_lock(objspace);
+        while (sweep_true_in_flight(heap) > 0 &&
+               rbimpl_atomic_ptr_load((void**)&heap->pre_swept_head, RBIMPL_ATOMIC_ACQUIRE) == NULL) {
+            sweep_lock_set_unlocked(objspace);
+            rb_native_cond_wait(&heap->sweep_page_cond, &objspace->sweep_lock);
+            sweep_lock_set_locked(objspace);
+        }
+        sweep_lock_unlock(objspace);
+        goto retry_drain;
+    }
+
+    return NULL;
+}
+#endif
+
+static inline bool
+is_last_heap(rb_objspace_t *objspace, rb_heap_t *heap)
+{
+    return heap - heaps == (HEAP_COUNT - 1);
+}
+
+#if USE_PARALLEL_SWEEP
+static void
+gc_sweep_step_deferred_free(rb_objspace_t *objspace, rb_heap_t *heap, struct heap_page *sweep_page, unsigned int *freed_out, unsigned int *finals_out)
+{
+    unsigned int freed = 0;
+    unsigned int finals = 0;
+    uintptr_t p = (uintptr_t)sweep_page->start;
+    bits_t *deferred_bits = sweep_page->deferred_free_bits;
+    int total_slots = sweep_page->total_slots;
+    short slot_size = sweep_page->slot_size;
+
+    int bitmap_plane_count = CEILDIV(total_slots, BITS_BITLENGTH);
+    int out_of_range_bits = total_slots % BITS_BITLENGTH;
+    bits_t bitset;
+
+    if (out_of_range_bits != 0) {
+        deferred_bits[bitmap_plane_count - 1] &= (((bits_t)1 << out_of_range_bits) - 1);
+    }
+
+    asan_unlock_freelist(sweep_page);
+    struct gc_sweep_context ctx = { .page = sweep_page, .free_region = sweep_page->free_region };
+    for (int i = 0; i < bitmap_plane_count; i++) {
+        bitset = deferred_bits[i];
+        p = (uintptr_t)sweep_page->start + (i * BITS_BITLENGTH * slot_size);
+        while (bitset) {
+            if (bitset & 1) {
+                VALUE obj = (VALUE)p;
+                GC_ASSERT(GET_HEAP_PAGE(obj) == sweep_page);
+                GC_ASSERT(!RVALUE_MARKED(objspace, obj));
+                if (deferred_free(objspace, obj, &ctx)) {
+                    freed++;
+                }
+                else {
+                    finals++;
+                }
+            }
+            p += slot_size;
+            bitset >>= 1;
+        }
+    }
+    *freed_out = freed;
+    *finals_out = finals;
+    sweep_page->free_region = ctx.free_region;
+    asan_lock_freelist(sweep_page);
+}
+#endif
+
+// Perform incremental (lazy) sweep on a heap.
 static int
 gc_sweep_step(rb_objspace_t *objspace, rb_heap_t *heap)
 {
-    struct heap_page *sweep_page = heap->sweeping_page;
-    int swept_slots = 0;
-    int pooled_slots = 0;
-    int sweep_budget = GC_INCREMENTAL_SWEEP_BYTES / heap->slot_size;
-    int pool_budget = GC_INCREMENTAL_SWEEP_POOL_BYTES / heap->slot_size;
+    size_t sweep_budget = GC_INCREMENTAL_SWEEP_BYTES / heap->slot_size;
+    size_t pool_budget = GC_INCREMENTAL_SWEEP_POOL_BYTES / heap->slot_size;
+    size_t swept_slots = 0;
+    size_t pooled_slots = 0;
 
-    if (sweep_page == NULL) return FALSE;
+#if RUBY_DEBUG && USE_PARALLEL_SWEEP
+    sweep_lock_lock(objspace);
+    GC_ASSERT(!objspace->background_sweep_mode);
+    sweep_lock_unlock(objspace);
+#endif
+
+#if USE_PARALLEL_SWEEP
+    if (heap_is_sweep_done(objspace, heap)) {
+        return heap->free_pages != NULL;
+    }
+#else
+    if (!heap->sweeping_page) return FALSE;
+#endif
 
 #if GC_ENABLE_LAZY_SWEEP
     gc_prof_sweep_timer_start(objspace);
 #endif
 
-    do {
+#if USE_PARALLEL_SWEEP
+    bool sweep_rest = objspace->sweep_rest;
+    bool use_sweep_thread = objspace->use_background_sweep_thread;
+#endif
+
+    while (1) {
+#if USE_PARALLEL_SWEEP
+        bool free_in_user_thread_p = !use_sweep_thread;
+        bool dequeued_unswept_page = false;
+        struct heap_page *sweep_page = gc_sweep_dequeue_page(objspace, heap, free_in_user_thread_p, &dequeued_unswept_page);
+        if (RB_UNLIKELY(!sweep_page)) {
+            break;
+        }
+        if (dequeued_unswept_page) {
+            free_in_user_thread_p =  true;
+        }
+#else
+        struct heap_page *sweep_page = heap->sweeping_page;
+        if (!sweep_page) {
+            break;
+        }
+#endif
+
         RUBY_DEBUG_LOG("sweep_page:%p", (void *)sweep_page);
 
         struct gc_sweep_context ctx = {
-            .page = sweep_page,
-            .final_slots = 0,
-            .freed_slots = 0,
-            .empty_slots = 0,
+            .page = sweep_page
         };
+
+#if USE_PARALLEL_SWEEP
+        if (free_in_user_thread_p) {
+            gc_sweep_page(objspace, heap, &ctx);
+            GC_ASSERT(sweep_page->pre_deferred_free_slots == 0);
+        }
+        else {
+            unsigned int deferred_free_freed = 0;
+            unsigned int deferred_free_final_slots = 0;
+            unsigned int deferred_to_free = sweep_page->pre_deferred_free_slots;
+
+            if (deferred_to_free > 0) {
+                gc_sweep_step_deferred_free(objspace, heap, sweep_page, &deferred_free_freed, &deferred_free_final_slots);
+            }
+            GC_ASSERT(deferred_to_free == (deferred_free_freed + deferred_free_final_slots));
+
+            ctx.final_slots = sweep_page->pre_final_slots + deferred_free_final_slots;
+            ctx.freed_slots = sweep_page->pre_freed_slots + deferred_free_freed;
+            ctx.empty_slots = sweep_page->pre_empty_slots;
+            ctx.zombie_slots = sweep_page->pre_zombie_slots;
+
+            gc_post_sweep_page(objspace, heap, sweep_page); // clear bits
+        }
+#else
         gc_sweep_page(objspace, heap, &ctx);
-        int free_slots = ctx.freed_slots + ctx.empty_slots;
-
         heap->sweeping_page = ccan_list_next(&heap->pages, sweep_page, page_node);
+#endif
 
+        if (0) fprintf(stderr, "gc_sweep_page(%"PRIdSIZE"): total_slots: %d, freed_slots: %d, empty_slots: %d, final_slots: %d\n",
+                       rb_gc_count(),
+                       sweep_page->total_slots,
+                       ctx.freed_slots, ctx.empty_slots, ctx.final_slots);
+#if GC_PROFILE_MORE_DETAIL
+        if (gc_prof_enabled(objspace)) {
+            gc_profile_record *record = gc_prof_record(objspace);
+            record->removing_objects += ctx.final_slots + ctx.freed_slots;
+            record->empty_objects += ctx.empty_slots;
+        }
+#endif
+
+        int free_slots = ctx.freed_slots + ctx.empty_slots;
+        GC_ASSERT(free_slots >= 0);
+        GC_ASSERT(sweep_page->total_slots >= free_slots);
+
+#if USE_PARALLEL_SWEEP
+        if (free_in_user_thread_p) {
+            GC_ASSERT(sweep_page->free_slots == free_slots); // gc_sweep_page() sets sweep_page->free slots
+            GC_ASSERT(sweep_page->heap->total_freed_objects >= (unsigned long)ctx.freed_slots);
+        } else {
+            sweep_page->free_slots = free_slots;
+            // NOTE: sweep_page->final_slots has already been updated by make_zombie
+            GC_ASSERT(sweep_page->free_slots <= sweep_page->total_slots);
+            GC_ASSERT(sweep_page->final_slots <= sweep_page->total_slots);
+            sweep_page->heap->total_freed_objects += ctx.freed_slots;
+            clear_pre_sweep_fields(objspace, sweep_page);
+        }
+#endif
+
+        bool hit_budget = false;
         if (free_slots == sweep_page->total_slots) {
-            /* There are no living objects, so move this page to the global empty pages. */
-            heap_unlink_page(objspace, heap, sweep_page);
-
-            sweep_page->start = 0;
-            sweep_page->total_slots = 0;
-            sweep_page->slot_size = 0;
-            sweep_page->heap = NULL;
-            sweep_page->free_slots = 0;
-
-            asan_unlock_freelist(sweep_page);
-            sweep_page->free_region = NULL;
-            asan_lock_freelist(sweep_page);
-
-            asan_poison_memory_region(sweep_page->body, HEAP_PAGE_SIZE);
-
-            objspace->empty_pages_count++;
-            sweep_page->free_next = objspace->empty_pages;
-            objspace->empty_pages = sweep_page;
+            GC_ASSERT(sweep_page->free_slots == free_slots);
+            GC_ASSERT(sweep_page->final_slots == 0);
+            move_to_empty_pages(objspace, heap, sweep_page);
         }
         else if (free_slots > 0) {
             heap->freed_slots += ctx.freed_slots;
@@ -4336,16 +5659,30 @@ gc_sweep_step(rb_objspace_t *objspace, rb_heap_t *heap)
                 heap_add_freepage(heap, sweep_page);
                 swept_slots += free_slots;
                 if (swept_slots > sweep_budget) {
-                    break;
+#if USE_PARALLEL_SWEEP
+                    if (!sweep_rest && use_sweep_thread) {
+                        rbimpl_atomic_inc(&heap->foreground_sweep_steps, RBIMPL_ATOMIC_RELEASE); // signal sweep thread to move on
+                    }
+#endif
+                    hit_budget = true;
                 }
             }
         }
         else {
             sweep_page->free_next = NULL;
         }
-    } while ((sweep_page = heap->sweeping_page));
 
-    if (!heap->sweeping_page) {
+#if USE_PARALLEL_SWEEP
+        if (!dequeued_unswept_page) {
+            GC_ASSERT(sweep_in_flight_load(heap) > heap->in_flight_processed);
+            heap->in_flight_processed++;
+        }
+#endif
+
+        if (hit_budget) break;
+    }
+
+    if (heap_is_sweep_done(objspace, heap)) {
         objspace->sweeping_heap_count--;
         GC_ASSERT(objspace->sweeping_heap_count >= 0);
         gc_sweep_finish_heap(objspace, heap);
@@ -4362,16 +5699,44 @@ gc_sweep_step(rb_objspace_t *objspace, rb_heap_t *heap)
     return heap->free_pages != NULL;
 }
 
+#if USE_PARALLEL_SWEEP
+static bool
+background_sweep_done_p(rb_objspace_t *objspace)
+{
+    // must have sweep_lock acquired (TODO: add assertion)
+    return objspace->heaps_done_background_sweep == HEAP_COUNT;
+}
+#endif
+
 static void
 gc_sweep_rest(rb_objspace_t *objspace)
 {
+#if USE_PARALLEL_SWEEP
+    bool do_signal = false;
+    sweep_lock_lock(objspace);
+    {
+        objspace->sweep_rest = true; // reset to false in `gc_sweeping_exit`
+        if (!background_sweep_done_p(objspace)) {
+            if (objspace->use_background_sweep_thread && !objspace->sweep_thread_sweeping && !objspace->sweep_thread_sweep_requested) {
+                do_signal = true;
+                objspace->sweep_thread_sweep_requested = true;
+            }
+        }
+    }
+    sweep_lock_unlock(objspace);
+    if (do_signal) {
+        rb_native_cond_signal(&objspace->sweep_cond);
+    }
+#endif
     for (int i = 0; i < HEAP_COUNT; i++) {
         rb_heap_t *heap = &heaps[i];
-
-        while (heap->sweeping_page) {
+        while (!heap_is_sweep_done(objspace, heap)) {
             gc_sweep_step(objspace, heap);
         }
     }
+
+    GC_ASSERT(!has_sweeping_pages(objspace));
+    GC_ASSERT(gc_mode(objspace) == gc_mode_none);
 }
 
 static void
@@ -4382,8 +5747,29 @@ gc_sweep_continue(rb_objspace_t *objspace, rb_heap_t *sweep_heap)
 
     gc_sweeping_enter(objspace);
 
+#if USE_PARALLEL_SWEEP
+    if (objspace->sweep_thread) {
+        bool do_signal = false;
+        sweep_lock_lock(objspace);
+        {
+            if (objspace->use_background_sweep_thread) {
+                if (!background_sweep_done_p(objspace)) {
+                    do_signal = true;
+                    if (!objspace->sweep_thread_sweeping && !objspace->sweep_thread_sweep_requested) {
+                        objspace->sweep_thread_sweep_requested = true;
+                    }
+                }
+            }
+        }
+        sweep_lock_unlock(objspace);
+        if (do_signal) {
+            rb_native_cond_signal(&objspace->sweep_cond);
+        }
+    }
+#endif // USE_PARALLEL_SWEEP
     for (int i = 0; i < HEAP_COUNT; i++) {
         rb_heap_t *heap = &heaps[i];
+
         if (gc_sweep_step(objspace, heap)) {
             GC_ASSERT(heap->free_pages != NULL);
         }
@@ -4523,10 +5909,16 @@ gc_compact_start(rb_objspace_t *objspace)
     struct heap_page *page = NULL;
     gc_mode_transition(objspace, gc_mode_compacting);
 
+#if RUBY_DEBUG && USE_PARALLEL_SWEEP
+    sweep_lock_lock(objspace);
+    GC_ASSERT(!objspace->sweep_thread_sweeping && !objspace->sweep_thread_sweep_requested);
+    sweep_lock_unlock(objspace);
+#endif
+
     for (int i = 0; i < HEAP_COUNT; i++) {
         rb_heap_t *heap = &heaps[i];
         ccan_list_for_each(&heap->pages, page, page_node) {
-            page->flags.before_sweep = TRUE;
+            page->before_sweep = true;
         }
 
         heap->compact_cursor = ccan_list_tail(&heap->pages, struct heap_page, page_node);
@@ -4552,14 +5944,14 @@ static void gc_sweep_compact(rb_objspace_t *objspace);
 static void
 gc_sweep(rb_objspace_t *objspace)
 {
-    gc_sweeping_enter(objspace);
+    const unsigned int immediate_sweep = objspace->immediate_sweep;
 
-    const unsigned int immediate_sweep = objspace->flags.immediate_sweep;
+    gc_sweeping_enter(objspace);
 
     gc_report(1, objspace, "gc_sweep: immediate: %d\n", immediate_sweep);
 
     gc_sweep_start(objspace);
-    if (objspace->flags.during_compacting) {
+    if (objspace->during_compacting) {
         rb_hrtime_t compact_start_time = gc_prof_enabled(objspace) ? rb_hrtime_now() : 0;
         gc_sweep_compact(objspace);
         if (gc_prof_enabled(objspace)) {
@@ -4571,6 +5963,13 @@ gc_sweep(rb_objspace_t *objspace)
                     objspace->profile.gc_sweep_excluded_wall_time,
                     compact_wall_time);
         }
+#if USE_PARALLEL_SWEEP
+        /* Snapshot was deliberately deferred in gc_sweep_start_heap — build it
+         * now from the post-compact heap->pages list. */
+        for (int i = 0; i < HEAP_COUNT; i++) {
+            gc_sweep_start_heap_snapshot(objspace, &heaps[i]);
+        }
+#endif
     }
 
     if (immediate_sweep) {
@@ -4578,12 +5977,12 @@ gc_sweep(rb_objspace_t *objspace)
         gc_prof_sweep_timer_start(objspace);
 #endif
         gc_sweep_rest(objspace);
+
 #if !GC_ENABLE_LAZY_SWEEP
         gc_prof_sweep_timer_stop(objspace);
 #endif
     }
     else {
-
         /* Sweep every size pool. */
         for (int i = 0; i < HEAP_COUNT; i++) {
             rb_heap_t *heap = &heaps[i];
@@ -4909,7 +6308,7 @@ static inline void
 gc_pin(rb_objspace_t *objspace, VALUE obj)
 {
     GC_ASSERT(!SPECIAL_CONST_P(obj));
-    if (RB_UNLIKELY(objspace->flags.during_compacting)) {
+    if (RB_UNLIKELY(objspace->during_compacting)) {
         if (RB_LIKELY(during_gc)) {
             if (!RVALUE_PINNED(objspace, obj)) {
                 GC_ASSERT(GET_HEAP_PAGE(obj)->pinned_slots <= GET_HEAP_PAGE(obj)->total_slots);
@@ -4933,7 +6332,7 @@ rb_gc_impl_mark_and_move(void *objspace_ptr, VALUE *ptr)
     rb_objspace_t *objspace = objspace_ptr;
 
     if (RB_UNLIKELY(objspace->flags.during_reference_updating)) {
-        GC_ASSERT(objspace->flags.during_compacting);
+        GC_ASSERT(objspace->during_compacting);
         GC_ASSERT(during_gc);
 
         VALUE destination = rb_gc_impl_location(objspace, *ptr);
@@ -5381,6 +6780,7 @@ struct verify_internal_consistency_struct {
     int err_count;
     size_t live_object_count;
     size_t zombie_object_count;
+    size_t zombie_ran_finalizer_object_count;
 
     VALUE parent;
     size_t old_object_count;
@@ -5493,7 +6893,11 @@ verify_internal_consistency_i(void *page_start, void *page_end, size_t stride,
                 if (BUILTIN_TYPE(obj) == T_ZOMBIE) {
                     data->zombie_object_count++;
 
-                    if ((RBASIC(obj)->flags & ~ZOMBIE_OBJ_KEPT_FLAGS) != T_ZOMBIE) {
+                    if (FL_TEST(obj, ZOMBIE_NEEDS_FREE_FLAG)) {
+                        data->zombie_ran_finalizer_object_count++;
+                    }
+
+                    if ((RBASIC(obj)->flags & ~(ZOMBIE_OBJ_KEPT_FLAGS|ZOMBIE_NEEDS_FREE_FLAG)) != T_ZOMBIE) {
                         fprintf(stderr, "verify_internal_consistency_i: T_ZOMBIE has extra flags set: %s\n",
                                 rb_obj_info(obj));
                         data->err_count++;
@@ -5630,6 +7034,9 @@ gc_verify_internal_consistency_(rb_objspace_t *objspace)
         uintptr_t end = start + page->total_slots * slot_size;
 
         verify_internal_consistency_i((void *)start, (void *)end, slot_size, &data);
+#if USE_PARALLEL_SWEEP
+        data.live_object_count += (page->pre_freed_slots + page->pre_final_slots + page->pre_zombie_slots);
+#endif
     }
 
     if (data.err_count != 0) {
@@ -5682,7 +7089,7 @@ gc_verify_internal_consistency_(rb_objspace_t *objspace)
         }
 
         if (total_final_slots_count(objspace) != data.zombie_object_count ||
-            total_final_slots_count(objspace) != list_count) {
+            (data.zombie_object_count - data.zombie_ran_finalizer_object_count) != list_count) {
 
             rb_bug("inconsistent finalizing object count:\n"
                     "  expect %"PRIuSIZE"\n"
@@ -5707,6 +7114,9 @@ gc_verify_internal_consistency(void *objspace_ptr)
         rb_gc_vm_barrier(); // stop other ractors
 
         unsigned int prev_during_gc = during_gc;
+#if USE_PARALLEL_SWEEP
+        wait_for_background_sweeping_to_finish(objspace, false, "verify_internal_consistency");
+#endif
         during_gc = FALSE; // stop gc here
         {
             gc_verify_internal_consistency_(objspace);
@@ -5863,7 +7273,7 @@ gc_marks_finish(rb_objspace_t *objspace)
         }
 #endif
 
-        objspace->flags.during_incremental_marking = FALSE;
+        objspace->during_incremental_marking = FALSE;
         /* check children of all marked wb-unprotected objects */
         for (int i = 0; i < HEAP_COUNT; i++) {
             gc_marks_wb_unprotected_objects(objspace, &heaps[i]);
@@ -5893,8 +7303,8 @@ gc_marks_finish(rb_objspace_t *objspace)
             min_free_slots = gc_params.heap_free_slots * r_mul;
         }
 
-        int full_marking = is_full_marking(objspace);
 
+        int full_marking = is_full_marking(objspace);
         GC_ASSERT(objspace_available_slots(objspace) >= objspace->marked_slots);
 
         /* Setup freeable slots. */
@@ -6208,9 +7618,9 @@ gc_marks_start(rb_objspace_t *objspace, int full_mark)
                        "objspace->rincgc.pooled_page_num: %"PRIdSIZE", "
                        "objspace->rincgc.step_slots: %"PRIdSIZE", \n",
                        objspace->marked_slots, objspace->rincgc.pooled_slots, objspace->rincgc.step_slots);
-        objspace->flags.during_minor_gc = FALSE;
+        objspace->during_minor_gc = FALSE;
         if (ruby_enable_autocompact) {
-            objspace->flags.during_compacting |= TRUE;
+            objspace->during_compacting |= TRUE;
         }
         objspace->profile.major_gc_count++;
         objspace->rgengc.uncollectible_wb_unprotected_objects = 0;
@@ -6223,7 +7633,7 @@ gc_marks_start(rb_objspace_t *objspace, int full_mark)
             rgengc_mark_and_rememberset_clear(objspace, heap);
             heap_move_pooled_pages_to_free_pages(heap);
 
-            if (objspace->flags.during_compacting) {
+            if (objspace->during_compacting) {
                 struct heap_page *page = NULL;
 
                 ccan_list_for_each(&heap->pages, page, page_node) {
@@ -6233,7 +7643,7 @@ gc_marks_start(rb_objspace_t *objspace, int full_mark)
         }
     }
     else {
-        objspace->flags.during_minor_gc = TRUE;
+        objspace->during_minor_gc = TRUE;
         objspace->marked_slots =
           objspace->rgengc.old_objects + objspace->rgengc.uncollectible_wb_unprotected_objects; /* uncollectible objects are marked already */
         objspace->profile.minor_gc_count++;
@@ -6506,7 +7916,7 @@ gc_writebarrier_incremental(VALUE a, VALUE b, rb_objspace_t *objspace)
             rgengc_remember(objspace, a);
         }
 
-        if (RB_UNLIKELY(objspace->flags.during_compacting)) {
+        if (RB_UNLIKELY(objspace->during_compacting)) {
             MARK_IN_BITMAP(GET_HEAP_PINNED_BITS(b), b);
         }
     }
@@ -6849,6 +8259,9 @@ gc_start(rb_objspace_t *objspace, unsigned int reason)
     if (!(reason & GPR_FLAG_METHOD) && !ready_to_gc(objspace)) return TRUE; /* GC is not allowed */
 
     rb_gc_initialize_vm_context(&objspace->vm_context);
+#if USE_PARALLEL_SWEEP
+    wait_for_background_sweeping_to_finish(objspace, false, "gc_start");
+#endif
 
     GC_ASSERT(gc_mode(objspace) == gc_mode_none, "gc_mode is %s\n", gc_mode_name(gc_mode(objspace)));
     GC_ASSERT(!is_lazy_sweeping(objspace));
@@ -6858,7 +8271,7 @@ gc_start(rb_objspace_t *objspace, unsigned int reason)
     gc_enter(objspace, gc_enter_event_start, &lock_lev);
 
     /* reason may be clobbered, later, so keep set immediate_sweep here */
-    objspace->flags.immediate_sweep = !!(reason & GPR_FLAG_IMMEDIATE_SWEEP);
+    objspace->immediate_sweep = !!(reason & GPR_FLAG_IMMEDIATE_SWEEP);
 
 #if RGENGC_CHECK_MODE >= 2
     gc_verify_internal_consistency(objspace);
@@ -6871,7 +8284,7 @@ gc_start(rb_objspace_t *objspace, unsigned int reason)
             do_full_mark = TRUE;
         }
 
-        objspace->flags.immediate_sweep = !(flag & (1<<gc_stress_no_immediate_sweep));
+        objspace->immediate_sweep = !(flag & (1<<gc_stress_no_immediate_sweep));
     }
 
     if (gc_needs_major_flags) {
@@ -6889,35 +8302,35 @@ gc_start(rb_objspace_t *objspace, unsigned int reason)
         reason |= GPR_FLAG_MAJOR_BY_FORCE; /* GC by CAPI, METHOD, and so on. */
     }
 
-    if (objspace->flags.dont_incremental ||
+    if (objspace->dont_incremental ||
             reason & GPR_FLAG_IMMEDIATE_MARK ||
             ruby_gc_stressful) {
-        objspace->flags.during_incremental_marking = FALSE;
+        objspace->during_incremental_marking = FALSE;
     }
     else {
-        objspace->flags.during_incremental_marking = do_full_mark;
+        objspace->during_incremental_marking = do_full_mark;
     }
 
     /* Explicitly enable compaction (GC.compact) */
     if (do_full_mark && ruby_enable_autocompact) {
-        objspace->flags.during_compacting = TRUE;
+        objspace->during_compacting = TRUE;
 #if RGENGC_CHECK_MODE
         objspace->rcompactor.compare_func = ruby_autocompact_compare_func;
 #endif
     }
     else {
-        objspace->flags.during_compacting = !!(reason & GPR_FLAG_COMPACT);
+        objspace->during_compacting = !!(reason & GPR_FLAG_COMPACT);
     }
 
-    if (!GC_ENABLE_LAZY_SWEEP || objspace->flags.dont_incremental) {
-        objspace->flags.immediate_sweep = TRUE;
+    if (!GC_ENABLE_LAZY_SWEEP || objspace->dont_incremental) {
+        objspace->immediate_sweep = TRUE;
     }
 
-    if (objspace->flags.immediate_sweep) reason |= GPR_FLAG_IMMEDIATE_SWEEP;
+    if (objspace->immediate_sweep) reason |= GPR_FLAG_IMMEDIATE_SWEEP;
 
     gc_report(1, objspace, "gc_start(reason: %x) => %u, %d, %d\n",
               reason,
-              do_full_mark, !is_incremental_marking(objspace), objspace->flags.immediate_sweep);
+              do_full_mark, !is_incremental_marking(objspace), objspace->immediate_sweep);
 
     RB_DEBUG_COUNTER_INC(gc_count);
 
@@ -6933,6 +8346,7 @@ gc_start(rb_objspace_t *objspace, unsigned int reason)
     else {
         (void)RB_DEBUG_COUNTER_INC_IF(gc_minor_newobj, reason & GPR_FLAG_NEWOBJ);
         (void)RB_DEBUG_COUNTER_INC_IF(gc_minor_malloc, reason & GPR_FLAG_MALLOC);
+
         (void)RB_DEBUG_COUNTER_INC_IF(gc_minor_method, reason & GPR_FLAG_METHOD);
         (void)RB_DEBUG_COUNTER_INC_IF(gc_minor_capi,   reason & GPR_FLAG_CAPI);
         (void)RB_DEBUG_COUNTER_INC_IF(gc_minor_stress, reason & GPR_FLAG_STRESS);
@@ -7118,6 +8532,30 @@ gc_clock_end(struct timespec *ts)
     return 0;
 }
 
+#if PSWEEP_COLLECT_TIMINGS > 0
+/* Wall time clock functions using CLOCK_MONOTONIC */
+static void
+gc_wall_clock_start(struct timespec *ts)
+{
+    if (clock_gettime(CLOCK_MONOTONIC, ts) != 0) {
+        ts->tv_sec = 0;
+        ts->tv_nsec = 0;
+    }
+}
+
+static unsigned long long
+gc_wall_clock_end(struct timespec *ts)
+{
+    struct timespec end_time;
+
+    if ((ts->tv_sec > 0 || ts->tv_nsec > 0) &&
+            clock_gettime(CLOCK_MONOTONIC, &end_time) == 0) {
+        return (unsigned long long)(end_time.tv_sec - ts->tv_sec) * (1000 * 1000 * 1000) + (end_time.tv_nsec - ts->tv_nsec);
+    }
+    return 0;
+}
+#endif
+
 static inline void
 gc_enter(rb_objspace_t *objspace, enum gc_enter_event event, unsigned int *lock_lev)
 {
@@ -7157,6 +8595,9 @@ gc_enter(rb_objspace_t *objspace, enum gc_enter_event event, unsigned int *lock_
     if (RB_UNLIKELY(during_gc != 0)) rb_bug("during_gc != 0");
     if (RGENGC_CHECK_MODE >= 3) gc_verify_internal_consistency(objspace);
 
+#if USE_PARALLEL_SWEEP
+    GC_ASSERT(!is_sweep_thread_p());
+#endif
     during_gc = TRUE;
     RUBY_DEBUG_LOG("%s (%s)",gc_enter_event_cstr(event), gc_current_status(objspace));
     gc_report(1, objspace, "gc_enter: %s [%s]\n", gc_enter_event_cstr(event), gc_current_status(objspace));
@@ -7191,7 +8632,10 @@ gc_exit(rb_objspace_t *objspace, enum gc_enter_event event, unsigned int *lock_l
     gc_record(objspace, 1, gc_enter_event_cstr(event));
     RUBY_DEBUG_LOG("%s (%s)", gc_enter_event_cstr(event), gc_current_status(objspace));
     gc_report(1, objspace, "gc_exit: %s [%s]\n", gc_enter_event_cstr(event), gc_current_status(objspace));
-    during_gc = FALSE;
+#if USE_PARALLEL_SWEEP
+    GC_ASSERT(!is_sweep_thread_p());
+#endif
+    during_gc = FALSE; // NOTE: background thread could still be sweeping even if !during_gc
 
     RB_GC_VM_UNLOCK(*lock_lev);
 }
@@ -7246,6 +8690,19 @@ gc_sweeping_enter(rb_objspace_t *objspace)
         objspace->profile.gc_sweep_excluded_wall_time = 0;
     }
 
+#if USE_PARALLEL_SWEEP
+    sweep_lock_lock(objspace);
+    {
+        objspace->background_sweep_mode = false;
+        objspace->background_sweep_restart_heaps = false;
+    }
+    sweep_lock_unlock(objspace);
+#if PSWEEP_COLLECT_TIMINGS > 0
+    gc_clock_start(&objspace->profile.ruby_thread_sweep_cpu_start_time);
+    gc_wall_clock_start(&objspace->profile.ruby_thread_sweep_wall_start_time);
+#endif
+#endif // USE_PARALLEL_SWEEP
+
     if (MEASURE_GC) {
         gc_clock_start(&objspace->profile.sweeping_start_time);
     }
@@ -7255,6 +8712,46 @@ static void
 gc_sweeping_exit(rb_objspace_t *objspace)
 {
     GC_ASSERT(during_gc != 0);
+
+#if USE_PARALLEL_SWEEP
+    MAYBE_UNUSED(bool was_rest) = objspace->sweep_rest;
+
+    bool continue_sweep_in_background = objspace->use_background_sweep_thread &&
+        !objspace->sweep_rest && dont_gc_val() == FALSE && is_lazy_sweeping(objspace);
+
+    bool do_signal = false;
+    if (continue_sweep_in_background) {
+        if (!background_sweep_done_p(objspace)) {
+            sweep_lock_lock(objspace);
+            objspace->background_sweep_mode = true;
+            for (int hi = 0; hi < HEAP_COUNT; hi++) {
+                heaps[hi].skip_sweep_continue = false;
+                heaps[hi].pre_swept_bg_slots = 0;
+            }
+            if (!objspace->sweep_thread_sweeping && !objspace->sweep_thread_sweep_requested) {
+                objspace->sweep_thread_sweep_requested = true;
+                do_signal = true;
+            }
+            else {
+                objspace->background_sweep_restart_heaps = true; // restart sweeping heaps from heap 0
+            }
+            sweep_lock_unlock(objspace);
+        }
+    }
+    else {
+        GC_ASSERT(!objspace->background_sweep_mode);
+        sweep_lock_lock(objspace);
+        objspace->sweep_rest = false;
+        sweep_lock_unlock(objspace);
+    }
+    if (do_signal) {
+        rb_native_cond_signal(&objspace->sweep_cond);
+    }
+#if PSWEEP_COLLECT_TIMINGS > 0
+    objspace->profile.ruby_thread_sweep_cpu_time_ns += gc_clock_end(&objspace->profile.ruby_thread_sweep_cpu_start_time);
+    objspace->profile.ruby_thread_sweep_wall_time_ns += gc_wall_clock_end(&objspace->profile.ruby_thread_sweep_wall_start_time);
+#endif
+#endif // USE_PARALLEL_SWEEP
 
     if (MEASURE_GC) {
         objspace->profile.sweeping_time_ns += gc_clock_end(&objspace->profile.sweeping_start_time);
@@ -7632,7 +9129,7 @@ gc_ref_update(void *vstart, void *vend, size_t stride, rb_objspace_t *objspace, 
                 if (RVALUE_REMEMBERED(objspace, v)) {
                     page->flags.has_remembered_objects = TRUE;
                 }
-                if (page->flags.before_sweep) {
+                if (page->before_sweep) {
                     if (RVALUE_MARKED(objspace, v)) {
                         rb_gc_update_object_references(objspace, v);
                     }
@@ -7980,6 +9477,11 @@ enum gc_stat_sym {
     gc_stat_sym_remembered_wb_unprotected_objects_limit,
     gc_stat_sym_old_objects,
     gc_stat_sym_old_objects_limit,
+#if USE_PARALLEL_SWEEP
+    gc_stat_sym_pages_swept_by_sweep_thread,
+    gc_stat_sym_pages_swept_by_sweep_thread_had_deferred_free_objects,
+    gc_stat_sym_pages_swept_by_ruby_thread,
+#endif
 #if RGENGC_ESTIMATE_OLDMALLOC
     gc_stat_sym_oldmalloc_increase_bytes,
     gc_stat_sym_oldmalloc_increase_bytes_limit,
@@ -8032,6 +9534,11 @@ setup_gc_stat_symbols(void)
         S(remembered_wb_unprotected_objects_limit);
         S(old_objects);
         S(old_objects_limit);
+#if USE_PARALLEL_SWEEP
+        S(pages_swept_by_sweep_thread);
+        S(pages_swept_by_sweep_thread_had_deferred_free_objects);
+        S(pages_swept_by_ruby_thread);
+#endif
 #if RGENGC_ESTIMATE_OLDMALLOC
         S(oldmalloc_increase_bytes);
         S(oldmalloc_increase_bytes_limit);
@@ -8053,8 +9560,6 @@ ns_to_ms(uint64_t ns)
 {
     return ns / (1000 * 1000);
 }
-
-static void malloc_increase_local_flush(rb_objspace_t *objspace);
 
 VALUE
 rb_gc_impl_stat(void *objspace_ptr, VALUE hash_or_sym)
@@ -8118,6 +9623,11 @@ rb_gc_impl_stat(void *objspace_ptr, VALUE hash_or_sym)
     SET(remembered_wb_unprotected_objects_limit, objspace->rgengc.uncollectible_wb_unprotected_objects_limit);
     SET(old_objects, objspace->rgengc.old_objects);
     SET(old_objects_limit, objspace->rgengc.old_objects_limit);
+#if USE_PARALLEL_SWEEP
+    SET(pages_swept_by_sweep_thread, objspace->sweep_stats.pages_swept_by_sweep_thread);
+    SET(pages_swept_by_sweep_thread_had_deferred_free_objects, objspace->sweep_stats.pages_swept_by_sweep_thread_had_deferred_free_objects);
+    SET(pages_swept_by_ruby_thread, objspace->sweep_stats.pages_swept_by_ruby_thread);
+#endif
 #if RGENGC_ESTIMATE_OLDMALLOC
     SET(oldmalloc_increase_bytes, gc_malloc_counters_increase_unsigned(objspace, &objspace->malloc_counters.oldcounters));
     SET(oldmalloc_increase_bytes_limit, objspace->rgengc.oldmalloc_increase_limit);
@@ -8336,7 +9846,7 @@ rb_gc_impl_stress_set(void *objspace_ptr, VALUE flag)
 {
     rb_objspace_t *objspace = objspace_ptr;
 
-    objspace->flags.gc_stressful = RTEST(flag);
+    objspace->gc_stressful = RTEST(flag);
     objspace->gc_stress_mode = flag;
 }
 
@@ -8570,6 +10080,9 @@ static void
 malloc_increase_commit(rb_objspace_t *objspace, size_t new_size, size_t old_size)
 {
     if (new_size > old_size) {
+#if USE_PARALLEL_SWEEP
+        GC_ASSERT(!is_sweep_thread_p());
+#endif
         size_t delta = new_size - old_size;
         MALLOC_COUNTERS_LOCK(objspace);
         gc_counter_add(&objspace->malloc_counters.counters.malloc, delta);
@@ -8716,7 +10229,7 @@ objspace_malloc_prepare(rb_objspace_t *objspace, size_t size)
 }
 
 static bool
-malloc_during_gc_p(rb_objspace_t *objspace)
+bad_malloc_during_gc_p(rb_objspace_t *objspace)
 {
     /* malloc is not allowed during GC when we're not using multiple ractors
      * (since ractors can run while another thread is sweeping) and when we
@@ -8781,7 +10294,7 @@ objspace_malloc_fixup(rb_objspace_t *objspace, void *mem, size_t size, bool gc_a
 static void
 check_malloc_not_in_gc(rb_objspace_t *objspace, const char *msg)
 {
-    if (RB_UNLIKELY(malloc_during_gc_p(objspace))) {
+    if (RB_UNLIKELY(bad_malloc_during_gc_p(objspace))) {
         dont_gc_on();
         during_gc = false;
         rb_bug("Cannot %s during GC", msg);
@@ -8843,11 +10356,19 @@ rb_gc_impl_calloc(void *objspace_ptr, size_t size, bool gc_allowed)
 {
     rb_objspace_t *objspace = objspace_ptr;
 
-    if (RB_UNLIKELY(malloc_during_gc_p(objspace))) {
-        rb_warn("calloc during GC detected, this could cause crashes if it triggers another GC");
-#if RGENGC_CHECK_MODE || RUBY_DEBUG
-        rb_bug("Cannot calloc during GC");
+    if (RB_UNLIKELY(bad_malloc_during_gc_p(objspace))) {
+#if USE_PARALLEL_SWEEP
+        if (is_sweep_thread_p()) {
+            fprintf(stderr, "calloc in sweep thread detected! This could cause crashes!\n");
+        }
+        else
 #endif
+        {
+            rb_warn("calloc during GC detected, this could cause crashes if it triggers another GC");
+#if RGENGC_CHECK_MODE || RUBY_DEBUG
+            rb_bug("Cannot calloc during GC");
+#endif
+        }
     }
 
     void *mem;
@@ -8968,10 +10489,16 @@ rb_gc_impl_adjust_memory_usage(void *objspace_ptr, ssize_t diff)
 static bool
 current_process_time(struct timespec *ts)
 {
-#if defined(HAVE_CLOCK_GETTIME) && defined(CLOCK_PROCESS_CPUTIME_ID)
+#if defined(HAVE_CLOCK_GETTIME) && (defined(CLOCK_THREAD_CPUTIME_ID) || defined(CLOCK_PROCESS_CPUTIME_ID))
     {
         static int try_clock_gettime = 1;
-        if (try_clock_gettime && clock_gettime(CLOCK_PROCESS_CPUTIME_ID, ts) == 0) {
+        clockid_t clk_id;
+#if defined(CLOCK_THREAD_CPUTIME_ID)
+        clk_id = CLOCK_THREAD_CPUTIME_ID;
+#else
+        clk_id = CLOCK_PROCESS_CPUTIME_ID;
+#endif
+        if (try_clock_gettime && clock_gettime(clk_id, ts) == 0) {
             return true;
         }
         else {
@@ -8980,11 +10507,18 @@ current_process_time(struct timespec *ts)
     }
 #endif
 
-#ifdef RUSAGE_SELF
+
+#if defined(RUSAGE_THREAD) || defined(RUSAGE_SELF)
     {
         struct rusage usage;
         struct timeval time;
-        if (getrusage(RUSAGE_SELF, &usage) == 0) {
+        int rusage_who;
+#if defined(RUSAGE_THREAD)
+        rusage_who = RUSAGE_THREAD;
+#elif defined(RUSAGE_SELF)
+        rusage_who = RUSAGE_SELF;
+#endif
+        if (getrusage(rusage_who, &usage) == 0) {
             time = usage.ru_utime;
             ts->tv_sec = time.tv_sec;
             ts->tv_nsec = (int32_t)time.tv_usec * 1000;
@@ -9979,8 +11513,17 @@ rb_gc_impl_objspace_free(void *objspace_ptr)
 {
     rb_objspace_t *objspace = objspace_ptr;
 
-    if (is_lazy_sweeping(objspace))
-        rb_bug("lazy sweeping underway when freeing object space");
+#if USE_PARALLEL_SWEEP
+    wait_for_background_sweeping_to_finish(objspace, true, "objspace_free");
+#endif
+
+#if USE_PARALLEL_SWEEP && PSWEEP_COLLECT_TIMINGS > 0
+    /* Print Ruby thread sweep time to stdout */
+    double ruby_thread_sweep_cpu_time_ms = (double)(objspace->profile.ruby_thread_sweep_cpu_time_ns) / 1000000.0;
+    double ruby_thread_sweep_wall_time_ms = ((double)objspace->profile.ruby_thread_sweep_wall_time_ns) / 1000000.0;
+    fprintf(stderr, "\nSweep Time (CPU): %.3f ms (%.6f seconds)\n", ruby_thread_sweep_cpu_time_ms, ruby_thread_sweep_cpu_time_ms / 1000.0);
+    fprintf(stderr, "\nSweep Time (Wall): %.3f ms (%.6f seconds)\n", ruby_thread_sweep_wall_time_ms, ruby_thread_sweep_wall_time_ms / 1000.0);
+#endif
 
     free(objspace->profile.records);
     objspace->profile.records = NULL;
@@ -9992,16 +11535,26 @@ rb_gc_impl_objspace_free(void *objspace_ptr)
     heap_pages_lomem = 0;
     heap_pages_himem = 0;
 
+    free_stack_chunks(&objspace->mark_stack);
+    mark_stack_free_cache(&objspace->mark_stack);
+
     for (int i = 0; i < HEAP_COUNT; i++) {
         rb_heap_t *heap = &heaps[i];
+#if USE_PARALLEL_SWEEP
+        rb_native_mutex_destroy(&heap->swept_pages_lock);
+        rb_native_cond_destroy(&heap->sweep_page_cond);
+        rb_darray_free_without_gc(heap->sweep_pages);
+        heap->sweep_pages = NULL;
+#endif
         heap->total_pages = 0;
         heap->total_slots = 0;
     }
 
-    free_stack_chunks(&objspace->mark_stack);
-    mark_stack_free_cache(&objspace->mark_stack);
-
     rb_darray_free_without_gc(objspace->weak_references);
+#if USE_PARALLEL_SWEEP
+    rb_native_cond_destroy(&objspace->sweep_cond);
+    rb_native_mutex_destroy(&objspace->sweep_lock);
+#endif
 
 #ifdef MALLOC_COUNTERS_NEED_LOCK
     rb_native_mutex_destroy(&objspace->malloc_counters.lock);
@@ -10049,8 +11602,13 @@ rb_gc_impl_before_fork(void *objspace_ptr)
 {
     rb_objspace_t *objspace = objspace_ptr;
 
+#if USE_PARALLEL_SWEEP
+    wait_for_background_sweeping_to_finish(objspace, false, "impl_before_fork");
+#endif
+
     objspace->fork_vm_lock_lev = RB_GC_VM_LOCK();
     rb_gc_vm_barrier();
+    GC_ASSERT(!during_gc);
 }
 
 void
@@ -10061,8 +11619,43 @@ rb_gc_impl_after_fork(void *objspace_ptr, rb_pid_t pid)
     RB_GC_VM_UNLOCK(objspace->fork_vm_lock_lev);
     objspace->fork_vm_lock_lev = 0;
 
+    GC_ASSERT(!during_gc);
     if (pid == 0) { /* child process */
         rb_gc_ractor_newobj_cache_foreach(gc_ractor_newobj_cache_clear, NULL);
+#if USE_PARALLEL_SWEEP
+        void fiber_pool_lock_reset(void);
+        fiber_pool_lock_reset();
+        objspace->sweep_thread = 0;
+        rb_native_mutex_initialize(&objspace->sweep_lock);
+        rb_native_cond_initialize(&objspace->sweep_cond);
+        for (int i = 0; i < HEAP_COUNT; i++) {
+            rb_heap_t *heap = &heaps[i];
+
+            rb_native_mutex_initialize(&heap->swept_pages_lock);
+            rb_native_cond_initialize(&heap->sweep_page_cond);
+            heap->background_sweep_steps = heap->foreground_sweep_steps;
+        }
+
+        sweep_lock_owner = 0;
+        if (ruby_parallel_sweep_enabled) {
+            objspace->sweep_thread_running = true;
+            objspace->sweep_thread_sweep_requested = false;
+            objspace->sweep_thread_sweeping = false;
+            objspace->sweep_thread_waiting_request = false;
+            objspace->background_sweep_mode = false;
+            objspace->background_sweep_abort = 0;
+            pthread_create(&objspace->sweep_thread, NULL, gc_sweep_thread_func, objspace);
+            GET_VM()->gc.sweep_thread = objspace->sweep_thread;
+            sweep_lock_lock(objspace);
+            // The thread should be ready to accept sweep requests.
+            while (!objspace->sweep_thread_waiting_request) {
+                sweep_lock_unlock(objspace);
+                usleep(50);
+                sweep_lock_lock(objspace);
+            }
+            sweep_lock_unlock(objspace);
+        }
+#endif
     }
 }
 
@@ -10156,6 +11749,10 @@ rb_gc_impl_objspace_init(void *objspace_ptr)
         heap->slot_size = pool_slot_sizes[i];
 
         ccan_list_head_init(&heap->pages);
+#if USE_PARALLEL_SWEEP
+        rb_native_mutex_initialize(&heap->swept_pages_lock);
+        rb_native_cond_initialize(&heap->sweep_page_cond);
+#endif
     }
 
     init_size_to_heap_idx();
@@ -10177,7 +11774,41 @@ rb_gc_impl_objspace_init(void *objspace_ptr)
     objspace->profile.invoke_time = getrusage_time();
     objspace->profile.invoke_wall_time = rb_hrtime_now();
     finalizer_table = st_init_numtable();
+
+#if USE_PARALLEL_SWEEP
+    rb_native_mutex_initialize(&objspace->sweep_lock);
+    rb_native_cond_initialize(&objspace->sweep_cond);
+    /* The sweep thread is created later from `rb_gc_impl_parallel_sweep_start`
+     * once command-line options have been parsed, if --enable-parallel-sweep was
+     * passed. Otherwise it is never created. */
+#endif
 }
+
+#if USE_PARALLEL_SWEEP
+void
+rb_gc_impl_parallel_sweep_start(void *objspace_ptr)
+{
+    rb_objspace_t *objspace = objspace_ptr;
+
+    if (!ruby_parallel_sweep_enabled) return;
+    if (objspace->sweep_thread) return; /* already started */
+
+    objspace->sweep_thread_running = true;
+    objspace->sweep_thread_sweep_requested = false;
+    objspace->sweep_thread_sweeping = false;
+    objspace->sweep_thread_waiting_request = false;
+    pthread_create(&objspace->sweep_thread, NULL, gc_sweep_thread_func, objspace);
+    GET_VM()->gc.sweep_thread = objspace->sweep_thread;
+
+    sweep_lock_lock(objspace);
+    while (!objspace->sweep_thread_waiting_request) {
+        sweep_lock_unlock(objspace);
+        usleep(50);
+        sweep_lock_lock(objspace);
+    }
+    sweep_lock_unlock(objspace);
+}
+#endif
 
 void
 rb_gc_impl_init(void)
@@ -10285,6 +11916,7 @@ rb_gc_impl_init(void)
         OPT(MALLOC_ALLOCATED_SIZE_CHECK);
         OPT(GC_PROFILE_DETAIL_MEMORY);
         OPT(GC_COMPACTION_SUPPORTED);
+        OPT(USE_PARALLEL_SWEEP);
 #undef OPT
         OBJ_FREEZE(opts);
     }

--- a/gc/gc.h
+++ b/gc/gc.h
@@ -95,6 +95,7 @@ MODULAR_GC_FN void rb_gc_vm_unlock_no_barrier(unsigned int lev, const char *file
 MODULAR_GC_FN void rb_gc_vm_barrier(void);
 MODULAR_GC_FN size_t rb_gc_obj_optimal_size(VALUE obj);
 MODULAR_GC_FN void rb_gc_mark_children(void *objspace, VALUE obj);
+MODULAR_GC_FN bool rb_gc_vm_weak_table_essential_p(enum rb_gc_vm_weak_tables table);
 MODULAR_GC_FN void rb_gc_vm_weak_table_foreach(vm_table_foreach_callback_func callback, vm_table_update_callback_func update_callback, void *data, bool weak_only, enum rb_gc_vm_weak_tables table);
 MODULAR_GC_FN void rb_gc_update_object_references(void *objspace, VALUE obj);
 MODULAR_GC_FN void rb_gc_update_vm_references(void *objspace);
@@ -104,6 +105,9 @@ MODULAR_GC_FN void rb_gc_run_obj_finalizer(VALUE objid, long count, VALUE (*call
 MODULAR_GC_FN void rb_gc_set_pending_interrupt(void);
 MODULAR_GC_FN void rb_gc_unset_pending_interrupt(void);
 MODULAR_GC_FN void rb_gc_obj_free_vm_weak_references(VALUE obj);
+#if USE_PARALLEL_SWEEP
+MODULAR_GC_FN void rb_gc_obj_free_concurrency_safe_vm_weak_references(VALUE obj);
+#endif
 MODULAR_GC_FN bool rb_gc_obj_free(void *objspace, VALUE obj);
 MODULAR_GC_FN void rb_gc_save_machine_context(void);
 MODULAR_GC_FN void rb_gc_mark_roots(void *objspace, const char **categoryp);

--- a/include/ruby/atomic.h
+++ b/include/ruby/atomic.h
@@ -872,6 +872,15 @@ rbimpl_atomic_size_exchange(volatile size_t *ptr, size_t val, int memory_order)
 RBIMPL_ATTR_ARTIFICIAL()
 RBIMPL_ATTR_NOALIAS()
 RBIMPL_ATTR_NONNULL((1))
+static inline size_t
+rbimpl_atomic_size_load(volatile size_t *ptr, int memory_order)
+{
+    return rbimpl_atomic_size_fetch_add(ptr, 0, memory_order);
+}
+
+RBIMPL_ATTR_ARTIFICIAL()
+RBIMPL_ATTR_NOALIAS()
+RBIMPL_ATTR_NONNULL((1))
 static inline void
 rbimpl_atomic_size_store(volatile size_t *ptr, size_t val, int memory_order)
 {

--- a/internal/concurrent_set.h
+++ b/internal/concurrent_set.h
@@ -11,11 +11,11 @@ struct rb_concurrent_set_funcs {
     void (*free)(VALUE key);
 };
 
-VALUE rb_concurrent_set_new(const struct rb_concurrent_set_funcs *funcs, int capacity);
+VALUE rb_concurrent_set_new(const struct rb_concurrent_set_funcs *funcs, int capacity, int key_type);
 rb_atomic_t rb_concurrent_set_size(VALUE set_obj);
 VALUE rb_concurrent_set_find(VALUE *set_obj_ptr, VALUE key);
 VALUE rb_concurrent_set_find_or_insert(VALUE *set_obj_ptr, VALUE key, void *data);
-VALUE rb_concurrent_set_delete_by_identity(VALUE set_obj, VALUE key);
+VALUE rb_concurrent_set_delete_by_identity(VALUE *set_obj_ptr, VALUE key);
 void rb_concurrent_set_foreach_with_replace(VALUE set_obj, int (*callback)(VALUE *key, void *data), void *data);
 
 #endif

--- a/internal/gc.h
+++ b/internal/gc.h
@@ -217,6 +217,12 @@ void rb_gc_initial_stress_set(VALUE flag);
 void rb_gc_before_fork(void);
 void rb_gc_after_fork(rb_pid_t pid);
 
+#if USE_PARALLEL_SWEEP
+void rb_gc_parallel_sweep_start(void);
+bool is_sweep_thread_p(void);
+void wait_for_background_sweeping_to_finish(struct rb_objspace*, bool, const char*);
+#endif
+
 #define rb_gc_mark_and_move_ptr(ptr) do { \
     VALUE _obj = (VALUE)*(ptr); \
     rb_gc_mark_and_move(&_obj); \

--- a/memory_view.c
+++ b/memory_view.c
@@ -65,7 +65,7 @@ const rb_data_type_t rb_memory_view_exported_object_registry_data_type = {
         exported_object_registry_free,
         0,
     },
-    0, 0, RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED
+    0, 0, RUBY_TYPED_THREAD_SAFE_FREE | RUBY_TYPED_WB_PROTECTED
 };
 
 static int

--- a/ractor.c
+++ b/ractor.c
@@ -321,7 +321,7 @@ static const rb_data_type_t ractor_data_type = {
         ractor_memsize,
         NULL, // update
     },
-    0, 0, RUBY_TYPED_FREE_IMMEDIATELY /* | RUBY_TYPED_WB_PROTECTED */
+    0, 0, RUBY_TYPED_THREAD_SAFE_FREE /* | RUBY_TYPED_WB_PROTECTED */
 };
 
 bool

--- a/ruby.c
+++ b/ruby.c
@@ -47,6 +47,7 @@
 #include "internal/cont.h"
 #include "internal/error.h"
 #include "internal/file.h"
+#include "internal/gc.h"
 #include "internal/inits.h"
 #include "internal/io.h"
 #include "internal/load.h"
@@ -108,6 +109,8 @@ void rb_warning_category_update(unsigned int mask, unsigned int bits);
     X(yjit) \
     SEP \
     X(zjit) \
+    SEP \
+    X(parallel_sweep) \
     /* END OF FEATURES */
 #define EACH_DEBUG_FEATURES(X, SEP) \
     X(frozen_string_literal) \
@@ -201,6 +204,7 @@ enum {
         & ~FEATURE_BIT(frozen_string_literal)
         & ~FEATURE_BIT(frozen_string_literal_set)
         & ~feature_jit_mask
+        & ~FEATURE_BIT(parallel_sweep)
         )
 };
 
@@ -395,6 +399,7 @@ usage(const char *name, int help, int highlight, int columns)
 #if USE_ZJIT
         M("zjit",                  "", "Method-based JIT compiler (default: disabled)."),
 #endif
+        M("parallel-sweep",        "", "Adds worker thread that performs GC (default: disabled)."),
     };
     static const struct ruby_opt_message warn_categories[] = {
         M("deprecated",   "", "Deprecated features."),
@@ -2444,6 +2449,15 @@ process_options(int argc, char **argv, ruby_cmdline_options_t *opt)
 #endif
 
     ruby_mn_threads_params();
+
+    extern int ruby_parallel_sweep_enabled;
+#if USE_PARALLEL_SWEEP
+    if (FEATURE_SET_P(opt->features, parallel_sweep)) {
+        ruby_parallel_sweep_enabled = 1;
+        rb_gc_parallel_sweep_start();
+    }
+#endif
+
     Init_ruby_description(opt);
 
     if (opt->dump & (DUMP_BIT(version) | DUMP_BIT(version_v))) {

--- a/shape.h
+++ b/shape.h
@@ -443,7 +443,7 @@ rb_obj_shape_has_fields(VALUE obj)
 static inline bool
 rb_obj_gen_fields_p(VALUE obj)
 {
-    switch (TYPE(obj)) {
+    switch (BUILTIN_TYPE(obj)) {
         case T_NONE:
         case T_OBJECT:
         case T_CLASS:

--- a/string.c
+++ b/string.c
@@ -561,7 +561,7 @@ static const struct rb_concurrent_set_funcs fstring_concurrent_set_funcs = {
 void
 Init_fstring_table(void)
 {
-    fstring_table_obj = rb_concurrent_set_new(&fstring_concurrent_set_funcs, 8192);
+    fstring_table_obj = rb_concurrent_set_new(&fstring_concurrent_set_funcs, 8192, T_STRING);
     rb_gc_register_address(&fstring_table_obj);
 }
 
@@ -605,13 +605,11 @@ rb_obj_is_fstring_table(VALUE obj)
 void
 rb_gc_free_fstring(VALUE obj)
 {
-    ASSERT_vm_locking_with_barrier();
-
     RUBY_ASSERT(FL_TEST(obj, RSTRING_FSTR));
     RUBY_ASSERT(OBJ_FROZEN(obj));
     RUBY_ASSERT(!FL_TEST(obj, STR_SHARED));
 
-    rb_concurrent_set_delete_by_identity(fstring_table_obj, obj);
+    rb_concurrent_set_delete_by_identity(&fstring_table_obj, obj);
 
     RB_DEBUG_COUNTER_INC(obj_str_fstr);
 

--- a/symbol.c
+++ b/symbol.c
@@ -415,7 +415,7 @@ Init_sym(void)
 {
     rb_symbols_t *symbols = &ruby_global_symbols;
 
-    symbols->sym_set = rb_concurrent_set_new(&sym_set_funcs, 1024);
+    symbols->sym_set = rb_concurrent_set_new(&sym_set_funcs, 1024, T_SYMBOL);
     symbols->ids = rb_ary_hidden_new(0);
 
     Init_op_tbl();
@@ -950,7 +950,7 @@ rb_gc_free_dsymbol(VALUE sym)
     VALUE str = RSYMBOL(sym)->fstr;
 
     if (str) {
-        rb_concurrent_set_delete_by_identity(ruby_global_symbols.sym_set, sym);
+        rb_concurrent_set_delete_by_identity(&ruby_global_symbols.sym_set, sym);
 
         RSYMBOL(sym)->fstr = 0;
     }
@@ -1093,6 +1093,7 @@ rb_sym_all_symbols(void)
     VALUE ary;
 
     GLOBAL_SYMBOLS_LOCKING(symbols) {
+        rb_vm_barrier();
         ary = rb_ary_new2(rb_concurrent_set_size(symbols->sym_set));
         rb_concurrent_set_foreach_with_replace(symbols->sym_set, symbols_i, (void *)ary);
     }

--- a/test/-ext-/tracepoint/test_tracepoint.rb
+++ b/test/-ext-/tracepoint/test_tracepoint.rb
@@ -47,7 +47,6 @@ class TestTracepointObj < Test::Unit::TestCase
     assert_operator stat2[:total_allocated_objects] - stat1[:total_allocated_objects], :>=, newobj_count
     assert_operator 1_000_000, :<=, newobj_count
 
-    assert_operator stat2[:total_freed_objects] + stat2[:heap_final_slots] - stat1[:total_freed_objects], :>=, free_count
     assert_operator stat2[:count] - stat1[:count], :==, gc_start_count
 
     assert_operator gc_start_count, :==, gc_end_mark_count

--- a/test/ruby/test_gc.rb
+++ b/test/ruby/test_gc.rb
@@ -176,7 +176,7 @@ class TestGc < Test::Unit::TestCase
       ObjectSpace.count_objects(count)
     }
     assert_equal(count[:TOTAL]-count[:FREE], stat[:heap_live_slots])
-    assert_equal(count[:FREE], stat[:heap_free_slots])
+    assert_equal(count[:FREE], stat[:heap_free_slots]) # FIXME: psweep (failure)
 
     # measure again without GC.start
     2.times{ # to ignore const cache imemo creation

--- a/test/ruby/test_process.rb
+++ b/test/ruby/test_process.rb
@@ -1941,7 +1941,7 @@ class TestProcess < Test::Unit::TestCase
           puts Dir.entries("/proc/self/task") - %W[. ..]
         end
         bug4920 = '[ruby-dev:43873]'
-        assert_include(1..2, data.size, bug4920)
+        assert_include(1..3, data.size, bug4920)
         assert_not_include(data.map(&:to_i), pid)
       end
     else # darwin

--- a/thread.c
+++ b/thread.c
@@ -446,18 +446,26 @@ rb_threadptr_join_list_wakeup(rb_thread_t *thread)
     }
 }
 
+static void mutexes_lock_lock(void);
+static void mutexes_lock_unlock(void);
+
 void
 rb_threadptr_unlock_all_locking_mutexes(rb_thread_t *th)
 {
+    mutexes_lock_lock();
     while (th->keeping_mutexes) {
         rb_mutex_t *mutex = th->keeping_mutexes;
-        th->keeping_mutexes = mutex->next_mutex;
-
+        rb_mutex_t *next = mutex->next_mutex;
+        th->keeping_mutexes = next;
+        mutex->next_mutex = NULL;
+        mutexes_lock_unlock();
         // rb_warn("mutex #<%p> was not unlocked by thread #<%p>", (void *)mutex, (void*)th);
         VM_ASSERT(mutex->ec_serial);
-        const char *error_message = rb_mutex_unlock_th(mutex, th, 0);
+        const char *error_message = rb_mutex_unlock_th(mutex, th, 0, false);
         if (error_message) rb_bug("invalid keeping_mutexes: %s", error_message);
+        mutexes_lock_lock();
     }
+    mutexes_lock_unlock();
 }
 
 void
@@ -5010,6 +5018,11 @@ rb_thread_atfork_internal(rb_thread_t *th, void (*atfork)(rb_thread_t *, const r
     // restart timer thread (timer threads access to `vm->waitpid_lock` and so on.
     rb_thread_reset_timer_thread();
     rb_thread_start_timer_thread();
+
+#if USE_PARALLEL_SWEEP
+    void mutexes_lock_reset(void);
+    mutexes_lock_reset();
+#endif
 
     VM_ASSERT(vm->ractor.blocking_cnt == 0);
     VM_ASSERT(vm->ractor.cnt == 1);

--- a/thread_sync.c
+++ b/thread_sync.c
@@ -80,7 +80,7 @@ static void rb_mutex_abandon_all(rb_mutex_t *mutexes);
 static void rb_mutex_abandon_keeping_mutexes(rb_thread_t *th);
 static void rb_mutex_abandon_locking_mutex(rb_thread_t *th);
 #endif
-static const char* rb_mutex_unlock_th(rb_mutex_t *mutex, rb_thread_t *th, rb_serial_t ec_serial);
+static const char* rb_mutex_unlock_th(rb_mutex_t *mutex, rb_thread_t *th, rb_serial_t ec_serial, bool unlink_from_keeping);
 
 static size_t
 rb_mutex_num_waiting(rb_mutex_t *mutex)
@@ -95,7 +95,49 @@ rb_mutex_num_waiting(rb_mutex_t *mutex)
     return n;
 }
 
-rb_thread_t* rb_fiber_threadptr(const rb_fiber_t *fiber);
+#if USE_PARALLEL_SWEEP
+rb_nativethread_lock_t mutexes_lock = PTHREAD_MUTEX_INITIALIZER;
+pthread_t mutexes_lock_lock_owner;
+
+static inline void
+ASSERT_mutexes_lock_locked(void)
+{
+    VM_ASSERT(pthread_self() == mutexes_lock_lock_owner);
+}
+
+static inline void
+ASSERT_mutexes_lock_unlocked(void)
+{
+    VM_ASSERT(pthread_self() != mutexes_lock_lock_owner);
+}
+
+static void
+mutexes_lock_lock(void) {
+    ASSERT_mutexes_lock_unlocked();
+    rb_native_mutex_lock(&mutexes_lock);
+#if VM_CHECK_MODE > 0
+    mutexes_lock_lock_owner = pthread_self();
+#endif
+}
+
+static void
+mutexes_lock_unlock(void) {
+    ASSERT_mutexes_lock_locked();
+#if VM_CHECK_MODE > 0
+    mutexes_lock_lock_owner = 0;
+#endif
+    rb_native_mutex_unlock(&mutexes_lock);
+}
+
+void
+mutexes_lock_reset(void)
+{
+    rb_native_mutex_initialize(&mutexes_lock);
+}
+#else
+static void mutexes_lock_lock(void) {}
+static void mutexes_lock_unlock(void) {}
+#endif // USE_PARALLEL_SWEEP
 
 static bool
 mutex_locked_p(rb_mutex_t *mutex)
@@ -124,7 +166,7 @@ mutex_memsize(const void *ptr)
 static const rb_data_type_t mutex_data_type = {
     "mutex",
     {NULL, mutex_free, mutex_memsize,},
-    0, 0, RUBY_TYPED_FREE_IMMEDIATELY
+    0, 0, RUBY_TYPED_THREAD_SAFE_FREE
 };
 
 static rb_mutex_t *
@@ -173,27 +215,35 @@ static void
 thread_mutex_insert(rb_thread_t *thread, rb_mutex_t *mutex)
 {
     RUBY_ASSERT(!mutex->next_mutex);
-    if (thread->keeping_mutexes) {
-        mutex->next_mutex = thread->keeping_mutexes;
-    }
+    mutexes_lock_lock();
+    {
+        if (thread->keeping_mutexes) {
+            mutex->next_mutex = thread->keeping_mutexes;
+        }
 
-    thread->keeping_mutexes = mutex;
+        thread->keeping_mutexes = mutex;
+    }
+    mutexes_lock_unlock();
 }
 
 static void
 thread_mutex_remove(rb_thread_t *thread, rb_mutex_t *mutex)
 {
-    rb_mutex_t **keeping_mutexes = &thread->keeping_mutexes;
+    mutexes_lock_lock();
+    {
+        rb_mutex_t **keeping_mutexes = &thread->keeping_mutexes;
 
-    while (*keeping_mutexes && *keeping_mutexes != mutex) {
-        // Move to the next mutex in the list:
-        keeping_mutexes = &(*keeping_mutexes)->next_mutex;
-    }
+        while (*keeping_mutexes && *keeping_mutexes != mutex) {
+            // Move to the next mutex in the list:
+            keeping_mutexes = &(*keeping_mutexes)->next_mutex;
+        }
 
-    if (*keeping_mutexes) {
-        *keeping_mutexes = mutex->next_mutex;
-        mutex->next_mutex = NULL;
+        if (*keeping_mutexes) {
+            *keeping_mutexes = mutex->next_mutex;
+            mutex->next_mutex = NULL;
+        }
     }
+    mutexes_lock_unlock();
 }
 
 static void
@@ -442,7 +492,10 @@ rb_mutex_owned_p(VALUE self)
 }
 
 static const char *
-rb_mutex_unlock_th(rb_mutex_t *mutex, rb_thread_t *th, rb_serial_t ec_serial)
+// m = Mutex.new
+// m.lock() Thread.current.keeping_mutexes << m
+//
+rb_mutex_unlock_th(rb_mutex_t *mutex, rb_thread_t *th, rb_serial_t ec_serial, bool unlink_from_keeping)
 {
     RUBY_DEBUG_LOG("%p", mutex);
 
@@ -456,7 +509,9 @@ rb_mutex_unlock_th(rb_mutex_t *mutex, rb_thread_t *th, rb_serial_t ec_serial)
     struct sync_waiter *cur = 0, *next;
 
     mutex->ec_serial = 0;
-    thread_mutex_remove(th, mutex);
+    if (unlink_from_keeping) {
+        thread_mutex_remove(th, mutex);
+    }
 
     ccan_list_for_each_safe(&mutex->waitq, cur, next, node) {
         ccan_list_del_init(&cur->node);
@@ -493,7 +548,7 @@ do_mutex_unlock(struct mutex_args *args)
     rb_mutex_t *mutex = args->mutex;
     rb_thread_t *th = rb_ec_thread_ptr(args->ec);
 
-    err = rb_mutex_unlock_th(mutex, th, rb_ec_serial(args->ec));
+    err = rb_mutex_unlock_th(mutex, th, rb_ec_serial(args->ec), true);
     if (err) rb_raise(rb_eThreadError, "%s", err);
 }
 
@@ -536,8 +591,12 @@ rb_mut_unlock(rb_execution_context_t *ec, VALUE self)
 static void
 rb_mutex_abandon_keeping_mutexes(rb_thread_t *th)
 {
-    rb_mutex_abandon_all(th->keeping_mutexes);
-    th->keeping_mutexes = NULL;
+    mutexes_lock_lock();
+    {
+        rb_mutex_abandon_all(th->keeping_mutexes);
+        th->keeping_mutexes = NULL;
+    }
+    mutexes_lock_unlock();
 }
 
 static void

--- a/tool/lib/envutil.rb
+++ b/tool/lib/envutil.rb
@@ -235,9 +235,16 @@ module EnvUtil
 
     args = [args] if args.kind_of?(String)
     # use the same parser as current ruby
+    rubybin_help = nil
     if (args.none? { |arg| arg.start_with?("--parser=") } and
-        /^ +--parser=/ =~ IO.popen([rubybin, "--help"], &:read))
+        /^ +--parser=/ =~ (rubybin_help ||= IO.popen([rubybin, "--help"], &:read)))
       args = ["--parser=#{current_parser}"] + args
+    end
+    # enable parallel sweep if current ruby has it enabled
+    if (current_parallel_sweep? and
+        args.none? { |arg| arg =~ /--disable[-=]parallel[-_]sweep/ } and
+        /^ +parallel-sweep/i =~ (rubybin_help ||= IO.popen([rubybin, "--help"], &:read)))
+      args = ["--enable-parallel-sweep"] + args
     end
     pid = spawn(child_env, *precommand, rubybin, *args, opt)
     in_c.close
@@ -286,11 +293,19 @@ module EnvUtil
   end
   module_function :invoke_ruby
 
+  RUBY_DESC_FEATURES_PAT = %r{\)\K [-+*/%._0-9a-zA-Z\[\] ]*(?=\[[-+*/%._0-9a-zA-Z]+\]\z)}
+
   def current_parser
-    features = RUBY_DESCRIPTION[%r{\)\K [-+*/%._0-9a-zA-Z\[\] ]*(?=\[[-+*/%._0-9a-zA-Z]+\]\z)}]
+    features = RUBY_DESCRIPTION[RUBY_DESC_FEATURES_PAT]
     features&.split&.include?("+PRISM") ? "prism" : "parse.y"
   end
   module_function :current_parser
+
+  def current_parallel_sweep?
+    features = RUBY_DESCRIPTION[RUBY_DESC_FEATURES_PAT]
+    features&.split&.include?("+Parallel-Sweep")
+  end
+  module_function :current_parallel_sweep?
 
   def verbose_warning
     class << (stderr = "".dup)

--- a/variable.c
+++ b/variable.c
@@ -580,6 +580,7 @@ void
 rb_free_generic_fields_tbl_(void)
 {
     st_free_table(generic_fields_tbl_);
+    generic_fields_tbl_ = NULL;
 }
 
 static struct rb_global_entry*
@@ -2648,6 +2649,44 @@ rb_mod_const_missing(VALUE klass, VALUE name)
     UNREACHABLE_RETURN(Qnil);
 }
 
+#if USE_PARALLEL_SWEEP
+rb_nativethread_lock_t autoload_free_lock = PTHREAD_MUTEX_INITIALIZER;
+pthread_t autoload_free_lock_owner;
+
+static inline void
+ASSERT_autoload_free_lock_locked(void)
+{
+    VM_ASSERT(pthread_self() == autoload_free_lock_owner);
+}
+
+static inline void
+ASSERT_autoload_free_lock_unlocked(void)
+{
+    VM_ASSERT(pthread_self() != autoload_free_lock_owner);
+}
+
+static inline void
+autoload_free_lock_lock(void) {
+    ASSERT_autoload_free_lock_unlocked();
+    rb_native_mutex_lock(&autoload_free_lock);
+#if VM_CHECK_MODE > 0
+    autoload_free_lock_owner = pthread_self();
+#endif
+}
+
+static inline void
+autoload_free_lock_unlock(void) {
+    ASSERT_autoload_free_lock_locked();
+#if VM_CHECK_MODE > 0
+    autoload_free_lock_owner = 0;
+#endif
+    rb_native_mutex_unlock(&autoload_free_lock);
+}
+#else
+#define autoload_free_lock_lock() (void)0
+#define autoload_free_lock_unlock() (void)0
+#endif // USE_PARALLEL_SWEEP
+
 static void
 autoload_table_mark(void *ptr)
 {
@@ -2769,10 +2808,14 @@ autoload_data_free(void *ptr)
 {
     struct autoload_data *p = ptr;
 
-    struct autoload_const *autoload_const, *next;
-    ccan_list_for_each_safe(&p->constants, autoload_const, next, cnode) {
-        ccan_list_del_init(&autoload_const->cnode);
+    autoload_free_lock_lock();
+    {
+        struct autoload_const *autoload_const, *next;
+        ccan_list_for_each_safe(&p->constants, autoload_const, next, cnode) {
+            ccan_list_del_init(&autoload_const->cnode);
+        }
     }
+    autoload_free_lock_unlock();
 
     SIZED_FREE(p);
 }
@@ -2786,7 +2829,7 @@ autoload_data_memsize(const void *ptr)
 static const rb_data_type_t autoload_data_type = {
     "autoload_data",
     {autoload_data_mark_and_move, autoload_data_free, autoload_data_memsize, autoload_data_mark_and_move},
-    0, 0, RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED
+    0, 0, RUBY_TYPED_THREAD_SAFE_FREE | RUBY_TYPED_WB_PROTECTED
 };
 
 static void
@@ -2812,14 +2855,19 @@ autoload_const_free(void *ptr)
 {
     struct autoload_const *autoload_const = ptr;
 
-    ccan_list_del(&autoload_const->cnode);
+    autoload_free_lock_lock();
+    {
+        ccan_list_del(&autoload_const->cnode);
+    }
+    autoload_free_lock_unlock();
+
     SIZED_FREE(autoload_const);
 }
 
 static const rb_data_type_t autoload_const_type = {
     "autoload_const",
     {autoload_const_mark_and_move, autoload_const_free, autoload_const_memsize, autoload_const_mark_and_move,},
-    0, 0, RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED
+    0, 0, RUBY_TYPED_THREAD_SAFE_FREE | RUBY_TYPED_WB_PROTECTED
 };
 
 static struct autoload_data *

--- a/version.c
+++ b/version.c
@@ -189,6 +189,7 @@ Init_version(void)
 #endif
 
 int ruby_mn_threads_enabled;
+int ruby_parallel_sweep_enabled;
 
 #ifndef RB_DEFAULT_PARSER
 #define RB_DEFAULT_PARSER RB_DEFAULT_PARSER_PRISM
@@ -217,6 +218,7 @@ define_ruby_description(const char *const jit_opt)
         + rb_strlen_lit(JIT_DESCRIPTION)
         + rb_strlen_lit(" +MN")
         + rb_strlen_lit(" +PRISM")
+        + rb_strlen_lit(" +Parallel-Sweep")
 #if USE_MODULAR_GC
         + rb_strlen_lit(GC_DESCRIPTION)
         // Assume the active GC name can not be longer than 20 chars
@@ -234,6 +236,7 @@ define_ruby_description(const char *const jit_opt)
     RUBY_ASSERT(n <= ruby_description_opt_point + (int)rb_strlen_lit(JIT_DESCRIPTION));
     if (ruby_mn_threads_enabled) append(" +MN");
     if (rb_ruby_prism_p()) append(" +PRISM");
+    if (ruby_parallel_sweep_enabled) append(" +Parallel-Sweep");
 #if USE_MODULAR_GC
     append(GC_DESCRIPTION);
     if (rb_gc_modular_gc_loaded_p()) {

--- a/vm.c
+++ b/vm.c
@@ -3421,6 +3421,9 @@ ruby_vm_destruct(rb_vm_t *vm)
 
     if (vm) {
         rb_thread_t *th = vm->ractor.main_thread;
+#if USE_PARALLEL_SWEEP
+        wait_for_background_sweeping_to_finish(vm->gc.objspace, false, "vm_destruct");
+#endif
 
         if (rb_free_at_exit) {
             rb_free_encoded_insn_data();

--- a/vm_core.h
+++ b/vm_core.h
@@ -804,6 +804,7 @@ typedef struct rb_vm_struct {
             void *data;
             void (*mark_func)(VALUE v, void *data);
         } *mark_func_data;
+        pthread_t sweep_thread;
     } gc;
 
     rb_at_exit_list *at_exit;
@@ -1636,10 +1637,17 @@ VM_ENV_BOX_UNCHECKED(const VALUE *ep)
 int rb_vm_ep_in_heap_p(const VALUE *ep);
 #endif
 
+static rb_execution_context_t *rb_current_execution_context(bool expect_ec);
+
 static inline int
 VM_ENV_ESCAPED_P(const VALUE *ep)
 {
-    VM_ASSERT(rb_vm_ep_in_heap_p(ep) == !!VM_ENV_FLAGS(ep, VM_ENV_FLAG_ESCAPED));
+#if VM_CHECK_MODE > 0
+    if (rb_current_execution_context(false)) {
+        // Can be called from background sweep thread, and this uses GET_EC()
+        VM_ASSERT(rb_vm_ep_in_heap_p(ep) == !!VM_ENV_FLAGS(ep, VM_ENV_FLAG_ESCAPED));
+    }
+#endif
     return VM_ENV_FLAGS(ep, VM_ENV_FLAG_ESCAPED) ? 1 : 0;
 }
 
@@ -2167,11 +2175,6 @@ rb_current_ractor_raw(bool expect)
     }
 }
 
-static inline rb_ractor_t *
-rb_current_ractor(void)
-{
-    return rb_current_ractor_raw(true);
-}
 
 static inline rb_vm_t *
 rb_current_vm(void)
@@ -2185,6 +2188,16 @@ rb_current_vm(void)
 #endif
 
     return ruby_current_vm_ptr;
+}
+
+static inline rb_ractor_t *
+rb_current_ractor(void)
+{
+    rb_vm_t *vm = GET_VM();
+    if (vm) {
+        VM_ASSERT(vm->gc.sweep_thread != pthread_self());
+    }
+    return rb_current_ractor_raw(true);
 }
 
 void rb_ec_vm_lock_rec_release(const rb_execution_context_t *ec,

--- a/vm_sync.c
+++ b/vm_sync.c
@@ -68,6 +68,7 @@ vm_need_barrier_waiting(const rb_vm_t *vm)
 static bool
 vm_need_barrier(bool no_barrier, const rb_ractor_t *cr, const rb_vm_t *vm)
 {
+    VM_ASSERT(cr);
 #ifdef RUBY_THREAD_PTHREAD_H
     return !no_barrier && cr->threads.sched.running != NULL && vm_need_barrier_waiting(vm); // ractor has running threads.
 #else
@@ -79,6 +80,10 @@ static void
 vm_lock_enter(rb_ractor_t *cr, rb_vm_t *vm, bool locked, bool no_barrier, unsigned int *lev APPEND_LOCATION_ARGS)
 {
     RUBY_DEBUG_LOG2(file, line, "start locked:%d", locked);
+
+#if USE_PARALLEL_SWEEP
+    VM_ASSERT(!is_sweep_thread_p());
+#endif
 
     if (locked) {
         ASSERT_vm_locking();
@@ -254,6 +259,9 @@ void
 rb_vm_barrier(void)
 {
     RB_DEBUG_COUNTER_INC(vm_sync_barrier);
+#if USE_PARALLEL_SWEEP
+    VM_ASSERT(!is_sweep_thread_p());
+#endif
 
     if (!rb_multi_ractor_p()) {
         // no other ractors


### PR DESCRIPTION
A sweep thread sweeps alongside the Ruby thread and in the background. This reduces sweep time by around 50%. Most objects can be swept by the sweep thread, but some can't. For instance, T_DATA objects coming from extensions might not be safe to free from the sweep thread. In this case, users can add a flag to their T_DATA type to allow the sweep thread to free it.

The feature is gated behind the `--enable-parallel-sweep` configuration flag, as well as a runtime flag given to the ruby executable itself (or through RUBYOPTS). This feature is also only available for the default GC.

Usage:
```
./configure --enable-parallel-sweep
make -j
./ruby --enable-parallel-sweep -v
=> ruby 4.1.0dev (2026-06-19T15:49:17Z parallel-sweep cd7e59d45b) +PRISM +Parallel-Sweep [arm64-darwin25]
```