### PR TITLE
Move RB_GC_GUARD(src) in pm_iseq_compile_with_option

### DIFF
--- a/iseq.c
+++ b/iseq.c
@@ -1460,8 +1460,6 @@ pm_iseq_compile_with_option(VALUE src, VALUE file, VALUE realpath, VALUE line, V
         error = pm_parse_string(&result, src, file, ruby_vm_keep_script_lines ? &script_lines : NULL);
     }
 
-    RB_GC_GUARD(src);
-
     if (error == Qnil) {
         int error_state;
         iseq_new_setup_coverage(file, (int) (pm_parser_line_offsets(result.node.parser)->size - 1));
@@ -1478,6 +1476,7 @@ pm_iseq_compile_with_option(VALUE src, VALUE file, VALUE realpath, VALUE line, V
         pm_parse_result_free(&result);
         rb_exc_raise(error);
     }
+    RB_GC_GUARD(src);
 
     return iseq;
 }


### PR DESCRIPTION
`src`'s buffer is saved into `result` by `pm_parse_string()`. Then, `pm_iseq_new_with_opt` points into this buffer. The string could be unrooted if `src` is a newly created string through `str = StringValue(str)`.

Note that `StringValue(str)` actually calls a function in a different translation unit and gives it the address of `str`, so `str` must therefore be on the stack throughout the function. But, that relies on Ruby not being compiled with LTO.