### PR TITLE
io.c: read files in a single pass

### DIFF
--- a/io.c
+++ b/io.c
@@ -3411,7 +3411,16 @@ read_all(rb_io_t *fptr, long siz, VALUE str)
     enc = io_read_encoding(fptr);
     cr = 0;
 
-    if (siz == 0) siz = BUFSIZ;
+    if (siz == 0) {
+        siz = BUFSIZ;
+    }
+    else {
+        // If `siz` is set, we got it from `stat(2)`.
+        // We attempt to read one extra byte because:
+        //  - If the file was appended to since then, we'll continue reading.
+        //  - If the file is still the same length, we won't issue a second `io_fread`.
+        siz++;
+    }
     shrinkable = io_setstrbuf(&str, siz);
     for (;;) {
         READ_CHECK(fptr);


### PR DESCRIPTION
`read_all` receives the file size when known, and does all the work to allocate a string of the right size and issue a single `read` call.

However since the condition to check for EOF is `read_bytes < size`, on the happy path we end up:

  - Enlarging the buffer by `BUFSIZ`
  - Issuing a second `read`

Instead we can always attempt to read one extra byte, so that on the happy path we can read the entire file in a single pass and not over allocate the returned string.

repro:

```ruby
require "objspace"
path = "/tmp/test.txt"
File.write(path, "a" * 10)
p ObjectSpace.memsize_of(File.read(path))
```

before: `1075`
after: `40`