### PR TITLE
Add specs for __dir__ with eval filenames

### DIFF
--- a/spec/ruby/core/kernel/__dir___spec.rb
+++ b/spec/ruby/core/kernel/__dir___spec.rb
@@ -17,6 +17,17 @@ describe "Kernel#__dir__" do
       eval("__dir__", nil, "foo.rb").should == "."
       eval("__dir__", nil, "foo/bar.rb").should == "foo"
     end
+
+    it "returns File.dirname(filename) when used in instance_eval" do
+      Object.new.instance_eval("__dir__", "foo/bar.rb").should == "foo"
+    end
+
+    it "returns File.dirname(filename) in methods defined by eval" do
+      klass = Class.new
+      klass.class_eval("def evaluated_dir; __dir__; end", "foo/bar.rb")
+
+      klass.new.evaluated_dir.should == "foo"
+    end
   end
 
   context "when used in eval with top level binding" do


### PR DESCRIPTION
Add RubySpec coverage for `Kernel#__dir__` when evaluated code is given an explicit filename through `instance_eval` and when methods are defined inside eval.

## Context
The existing RubySpec coverage already checks that `eval("__dir__", nil, "foo/bar.rb")` returns `"foo"` and that eval without an explicit filename returns `nil` for `__dir__`.

This adds coverage for two related cases where the same explicit filename semantics should hold:

- `instance_eval("__dir__", "foo/bar.rb")`
- a method defined via eval/class_eval with an explicit filename, then called after eval returns

These cases help implementations preserve CRuby-compatible behavior beyond the immediate `eval` call frame.

## Changes
- Added two examples to `spec/ruby/core/kernel/__dir___spec.rb`.
- No implementation changes.