### PR TITLE
Make Dir.mktmpdir cleanup tolerate missing paths

### DIFF
--- a/lib/tmpdir.rb
+++ b/lib/tmpdir.rb
@@ -73,7 +73,7 @@ class Dir
   # If a block is given,
   # it is yielded with the path of the directory.
   # The directory and its contents are removed
-  # using FileUtils.remove_entry before Dir.mktmpdir returns.
+  # using FileUtils.remove_entry with force before Dir.mktmpdir returns.
   # The value of the block is returned.
   #
   #  Dir.mktmpdir {|dir|
@@ -111,7 +111,7 @@ class Dir
             raise ArgumentError, "parent directory is world writable but not sticky: #{base}"
           end
         end
-        FileUtils.remove_entry path
+        FileUtils.remove_entry path, true
       end
     else
       path

--- a/spec/ruby/library/tmpdir/dir/mktmpdir_spec.rb
+++ b/spec/ruby/library/tmpdir/dir/mktmpdir_spec.rb
@@ -57,7 +57,7 @@ describe "Dir.mktmpdir when passed a block" do
     Dir.stub!(:mkdir)
     Dir.mktmpdir do |path|
       @tmpdir = path
-      FileUtils.should_receive(:remove_entry).with(path)
+      FileUtils.should_receive(:remove_entry).with(path, true)
     end
   end
 

--- a/test/test_tmpdir.rb
+++ b/test/test_tmpdir.rb
@@ -77,6 +77,17 @@ class TestTmpdir < Test::Unit::TestCase
     }
   end
 
+  def test_mktmpdir_tolerates_removed_directory
+    dir = nil
+    assert_nothing_raised do
+      Dir.mktmpdir do |d|
+        dir = d
+        FileUtils.remove_entry(d)
+      end
+    end
+    assert_file.not_exist?(dir)
+  end
+
   def test_mktmpdir_mutate
     bug16918 = '[ruby-core:98563]'
     assert_nothing_raised(bug16918) do


### PR DESCRIPTION
## Summary

`Dir.mktmpdir` currently removes block-created temporary directories with `FileUtils.remove_entry(path)`, which uses strict cleanup semantics. If the directory or one of its children has already been removed before teardown, cleanup can raise even though the requested final state has already been reached.

This changes block cleanup to use `FileUtils.remove_entry(path, true)`, matching forceful recursive removal semantics used by `FileUtils.rm_rf`.

## Testing

- `/Users/samuel/.local/state/tec/toolchain/base_profile/bin/ruby --disable-gems -Ilib -e 'require "tmpdir"; dir = nil; Dir.mktmpdir {|path| dir = path; FileUtils.remove_entry(path)}; abort "still exists" if File.exist?(dir); puts "ok"'`

I could not run `test/test_tmpdir.rb` directly in this worktree because CRuby is not configured/built here, and external Ruby runners either require in-tree Rubygems/rbconfig or lack `test/unit` with gems disabled.