### PR TITLE
Fix mktmpdir spec for FileUtils.remove_entry force argument

### DIFF
--- a/spec/ruby/library/tmpdir/dir/mktmpdir_spec.rb
+++ b/spec/ruby/library/tmpdir/dir/mktmpdir_spec.rb
@@ -57,7 +57,12 @@ describe "Dir.mktmpdir when passed a block" do
     Dir.stub!(:mkdir)
     Dir.mktmpdir do |path|
       @tmpdir = path
-      FileUtils.should_receive(:remove_entry).with(path)
+      ruby_version_is ""..."4.1" do
+        FileUtils.should_receive(:remove_entry).with(path)
+      end
+      ruby_version_is "4.1" do
+        FileUtils.should_receive(:remove_entry).with(path, true)
+      end
     end
   end
 


### PR DESCRIPTION
Commit 2b751ac7e35 changed Dir.mktmpdir cleanup to call FileUtils.remove_entry with force enabled, which broke the shared spec that mocked the single-argument call. The spec is now version guarded so Ruby before 4.1 keeps asserting the one-argument form while 4.1 and later expect the force argument.
