### PR TITLE
Work around flaky crates.io downloads in ZJIT Ubuntu CI

### DIFF
--- a/.github/workflows/zjit-ubuntu.yml
+++ b/.github/workflows/zjit-ubuntu.yml
@@ -100,6 +100,9 @@ jobs:
       BUNDLE_JOBS: 8 # for yjit-bench
       RUST_BACKTRACE: 1
       ZJIT_RB_BUG: 1
+      # Work around transient crates.io download failures (curl [16] HTTP/2 framing layer)
+      CARGO_NET_RETRY: 10
+      CARGO_HTTP_MULTIPLEXING: false
 
     runs-on: ${{ matrix.runs-on || 'ubuntu-22.04' }}
 


### PR DESCRIPTION
The ZJIT Ubuntu build sometimes fails while cargo downloads dependencies from crates.io, with curl reporting `[16] Error in the HTTP2 framing layer`. This is a transient transport-level failure unrelated to the change under test, yet it fails the whole job and forces a manual re-run.

Setting `CARGO_HTTP_MULTIPLEXING=false` avoids the HTTP/2 framing bug and raising `CARGO_NET_RETRY` to 10 keeps a single hiccup from aborting the build. The impact on total job time is negligible since the download phase is small relative to compilation.

Scoped to the ZJIT Ubuntu workflow where the failure was observed. Other Rust workflows can adopt the same variables if they hit the same error.
