### PR TITLE
Raise SYNTAX_SUGGEST_TIMEOUT on emulated ppc64le/s390x runners

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -139,9 +139,13 @@ jobs:
 
       # Emulated ppc64le/s390x runners are slow enough that subprocess
       # assertion timeouts (e.g. assert_separately) flake. Scale them up, as
-      # macos.yml does for slower/contended runners.
+      # macos.yml does for slower/contended runners. SYNTAX_SUGGEST_TIMEOUT
+      # covers syntax_suggest's own internal search timeout, which
+      # RUBY_TEST_TIMEOUT_SCALE does not affect.
       - name: Set timeout scale for emulated runners
-        run: echo "RUBY_TEST_TIMEOUT_SCALE=10" >> $GITHUB_ENV
+        run: |
+          echo "RUBY_TEST_TIMEOUT_SCALE=10" >> $GITHUB_ENV
+          echo "SYNTAX_SUGGEST_TIMEOUT=10" >> $GITHUB_ENV
         if: ${{ endsWith(matrix.os, 'ppc64le') || endsWith(matrix.os, 's390x') }}
 
       - name: make ${{ matrix.test_task }}


### PR DESCRIPTION
syntax_suggest's internal search timeout defaults to 1 second, which is too short on the emulated ppc64le/s390x runners. The integration spec issues/95 prints "Search timed out" instead of the expected diagnostic and flakes intermittently. Over the last 60 Ubuntu runs on master, this accounted for 7 of 8 make-ibm failures.

RUBY_TEST_TIMEOUT_SCALE does not affect syntax_suggest's own timeout, so set SYNTAX_SUGGEST_TIMEOUT alongside it in the same emulated-runner step.
