### PR TITLE
Retry connection errors when downloading gems

### DIFF
--- a/tool/downloader.rb
+++ b/tool/downloader.rb
@@ -328,7 +328,10 @@ class Downloader
     times = 0
     begin
       block.call
-    rescue Errno::ETIMEDOUT, SocketError, OpenURI::HTTPError, Net::ReadTimeout, Net::OpenTimeout, ArgumentError => e
+    # Retry transient network failures.  SystemCallError covers the
+    # Errno::* family (e.g. ECONNRESET "Connection reset by peer" raised
+    # during SSL_connect), which is otherwise not caught by SocketError.
+    rescue SystemCallError, SocketError, OpenSSL::SSL::SSLError, OpenURI::HTTPError, Net::ReadTimeout, Net::OpenTimeout, ArgumentError => e
       raise if e.is_a?(OpenURI::HTTPError) && e.message !~ /^50[023] / # retry only 500, 502, 503 for http error
       times += 1
       if times <= max_times


### PR DESCRIPTION
Downloading bundled gems from rubygems.org sometimes fails in CI with Errno::ECONNRESET ("Connection reset by peer") raised during SSL_connect. tool/downloader.rb already wraps the download in with_retry, but its rescue list did not cover the Errno::* family, so a single transient reset aborted the build without any retry.

This catches SystemCallError so all Errno::* network errors are retried like the other transient failures. OpenSSL::SSL::SSLError is also added for handshake errors.

https://github.com/ruby/ruby/actions/runs/27928507724/job/82635651528
