### PR TITLE
Cache bundled gem sources to survive transient clone failures

### DIFF
--- a/.github/actions/setup/directories/action.yml
+++ b/.github/actions/setup/directories/action.yml
@@ -109,6 +109,18 @@ runs:
         path: ${{ inputs.srcdir }}/.downloaded-cache
         key: ${{ runner.os }}-${{ runner.arch }}-downloaded-cache
 
+    # Cache cloned bundled gem sources so a transient DNS/network failure
+    # while cloning from github.com (e.g. "Could not resolve host") does not
+    # abort the build. The key is invalidated when gems/bundled_gems changes,
+    # and restore-keys falls back to the latest cache so only bumped gems are
+    # re-fetched.
+    - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: ${{ inputs.srcdir }}/gems/src
+        key: ${{ runner.os }}-${{ runner.arch }}-bundled-gems-src-${{ hashFiles(format('{0}/gems/bundled_gems', inputs.srcdir)) }}
+        restore-keys: |
+          ${{ runner.os }}-${{ runner.arch }}-bundled-gems-src-
+
     - if: steps.which.outputs.autoreconf
       shell: bash
       working-directory: ${{ inputs.srcdir }}


### PR DESCRIPTION
CI jobs frequently abort while cloning bundled gems from github.com when the runner momentarily fails to resolve the host. The clone in defs/gmake.mk has no retry, so a single transient "Could not resolve host" error fails the whole build with `make: *** [gems/src/<gem>/.git] Error 128`.

This caches gems/src in the shared setup/directories composite action, keyed on gems/bundled_gems. When the bundled gem set is unchanged the build reuses the cached clones and touches no network. restore-keys falls back to the latest cache so only bumped gems are re-fetched. Placing it in the shared action covers every workflow that builds from a checkout in a single change.

This does not remove the cold-cache path, where a clone can still fail, but it drops the clone from the common case where most of these failures happen.
