### PR TITLE
Make the bundled gem sources cache complete and skip redundant fetches

### DIFF
--- a/.github/actions/setup/directories/action.yml
+++ b/.github/actions/setup/directories/action.yml
@@ -63,6 +63,16 @@ inputs:
     description: >-
       If set to true, clean build directory.
 
+  bundled-gems-src-cache:
+    required: false
+    type: boolean
+    default: ''
+    description: >-
+      If set to true, cache the cloned bundled gem sources (gems/src).
+      Enable only on jobs that clone every bundled gem (test-bundled-gems),
+      so the cache shared by the os/arch is always saved with the complete
+      set of gems instead of the partial set that `make up` leaves behind.
+
 outputs: {} # nothing?
 
 runs:
@@ -113,8 +123,11 @@ runs:
     # while cloning from github.com (e.g. "Could not resolve host") does not
     # abort the build. The key is invalidated when gems/bundled_gems changes,
     # and restore-keys falls back to the latest cache so only bumped gems are
-    # re-fetched.
-    - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+    # re-fetched. Only test-bundled-gems jobs opt in (bundled-gems-src-cache),
+    # because they are the ones that clone the complete set into gems/src; other
+    # jobs would otherwise save a partial gems/src and poison the shared key.
+    - if: inputs.bundled-gems-src-cache == 'true'
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ${{ inputs.srcdir }}/gems/src
         key: ${{ runner.os }}-${{ runner.arch }}-bundled-gems-src-${{ hashFiles(format('{0}/gems/bundled_gems', inputs.srcdir)) }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -86,6 +86,7 @@ jobs:
           makeup: true
           clean: true
           dummy-files: ${{ matrix.test_task == 'check' }}
+          bundled-gems-src-cache: ${{ matrix.test_task == 'test-bundled-gems' }}
           # Set fetch-depth: 0 so that Launchable can receive commits information.
           fetch-depth: 10
 

--- a/.github/workflows/parse_y.yml
+++ b/.github/workflows/parse_y.yml
@@ -71,6 +71,7 @@ jobs:
           makeup: true
           clean: true
           dummy-files: ${{ matrix.test_task == 'check' }}
+          bundled-gems-src-cache: ${{ matrix.test_task == 'test-bundled-gems' }}
 
       - name: Run configure
         run: ../src/configure -C --disable-install-doc cppflags=-DRUBY_DEBUG --with-parser=parse.y

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -89,6 +89,7 @@ jobs:
           makeup: true
           clean: true
           dummy-files: ${{ matrix.test_task == 'check' }}
+          bundled-gems-src-cache: ${{ matrix.test_task == 'test-bundled-gems' }}
           # Set fetch-depth: 10 so that Launchable can receive commits information.
           fetch-depth: 10
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -77,6 +77,7 @@ jobs:
           builddir: build
           make-command: nmake
           clean: true
+          bundled-gems-src-cache: ${{ matrix.test_task == 'test-bundled-gems' }}
 
       - name: Install tools with scoop
         run: |

--- a/.github/workflows/yjit-ubuntu.yml
+++ b/.github/workflows/yjit-ubuntu.yml
@@ -144,6 +144,7 @@ jobs:
           builddir: build
           makeup: true
           dummy-files: ${{ matrix.test_task == 'check' }}
+          bundled-gems-src-cache: ${{ matrix.test_task == 'test-bundled-gems' }}
           # Set fetch-depth: 10 so that Launchable can receive commits information.
           fetch-depth: 10
 

--- a/.github/workflows/zjit-ubuntu.yml
+++ b/.github/workflows/zjit-ubuntu.yml
@@ -139,6 +139,7 @@ jobs:
           builddir: build
           makeup: true
           dummy-files: ${{ matrix.test_task == 'check' }}
+          bundled-gems-src-cache: ${{ matrix.test_task == 'test-bundled-gems' }}
           # Set fetch-depth: 10 so that Launchable can receive commits information.
           fetch-depth: 10
 

--- a/tool/fetch-bundled_gems.rb
+++ b/tool/fetch-bundled_gems.rb
@@ -28,7 +28,15 @@ unless File.exist?("#{n}/.git")
   system(*%W"git clone --depth=1 --no-tags #{u} #{n}") or abort
 end
 
-c = (r ? [r] : ["v#{v}", v]).find do |c|
+candidates = r ? [r] : ["v#{v}", v]
+
+# Skip fetching from the remote when the target ref already exists locally
+# (e.g. restored from cache), so a transient network failure does not abort.
+c = candidates.find do |c|
+  system("git", "rev-parse", "-q", "--verify", "#{c}^{commit}", out: File::NULL, err: File::NULL, chdir: n)
+end
+
+c ||= candidates.find do |c|
   puts "fetching #{n} #{color.notice(c)} ..."
   system("git", "fetch", "origin", r || "refs/tags/#{c}:refs/tags/#{c}", chdir: n)
 end or abort


### PR DESCRIPTION
The gems/src cache added recently is restored on every job but does not protect test-bundled-gems. `make up` clones only the revision-pinned gems (debug and rdoc) into gems/src, and because the cache key is immutable those partial trees win the shared key. The test-bundled-gems job then re-clones the rest from github.com, so a transient connection failure such as the recent typeprof clone timeout still aborts the build.

Gate the gems/src cache on a new directories input and enable it only on test-bundled-gems jobs, which clone the full set, so the shared key is always saved with the complete set instead of the partial one.

Cloning a bundled gem already short-circuits when gems/src is warm, but the tag fetch ran unconditionally and added a github.com round-trip per gem that a transient outage could abort. Resolve the ref locally first and fetch only when it is missing, so a warm cache touches the network only for bumped gems.
