### PR TITLE
Add wall-clock times to GC Profiler

### DIFF
--- a/depend
+++ b/depend
@@ -5965,6 +5965,7 @@ gc.$(OBJEXT): $(top_srcdir)/internal/string.h
 gc.$(OBJEXT): $(top_srcdir)/internal/struct.h
 gc.$(OBJEXT): $(top_srcdir)/internal/symbol.h
 gc.$(OBJEXT): $(top_srcdir)/internal/thread.h
+gc.$(OBJEXT): $(top_srcdir)/internal/time.h
 gc.$(OBJEXT): $(top_srcdir)/internal/variable.h
 gc.$(OBJEXT): $(top_srcdir)/internal/vm.h
 gc.$(OBJEXT): $(top_srcdir)/internal/warnings.h
@@ -6026,6 +6027,7 @@ gc.$(OBJEXT): {$(VPATH)}encoding.h
 gc.$(OBJEXT): {$(VPATH)}eval_intern.h
 gc.$(OBJEXT): {$(VPATH)}gc.c
 gc.$(OBJEXT): {$(VPATH)}gc.rbinc
+gc.$(OBJEXT): {$(VPATH)}hrtime.h
 gc.$(OBJEXT): {$(VPATH)}id.h
 gc.$(OBJEXT): {$(VPATH)}id_table.h
 gc.$(OBJEXT): {$(VPATH)}intern.h

--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -10103,7 +10103,13 @@ rb_gc_impl_init(void)
      *
      *    GC::Profiler.report
      *
+     *    pp GC::Profiler.raw_data
+     *
      *    GC::Profiler.disable
+     *
+     *  GC::Profiler.raw_data returns one Hash per GC run, including CPU time
+     *  fields such as +:GC_TIME+ and wall-clock fields such as +:GC_WALL_TIME+
+     *  and +:GC_PAUSE_TIME+.
      *
      *  See also GC.count, GC.malloc_allocated_size and GC.malloc_allocations
      */

--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -33,7 +33,43 @@
 #include "darray.h"
 #include "gc/gc.h"
 #include "gc/gc_impl.h"
-#include "hrtime.h"
+
+#ifdef BUILDING_MODULAR_GC
+/* hrtime.h transitively includes internal/time.h -> internal/bits.h, which are
+ * not available to out-of-tree modular GC builds.  We only use a monotonic
+ * clock plus saturating add/sub, so provide that subset locally with the same
+ * semantics as hrtime.h. */
+# include <time.h>
+typedef uint64_t rb_hrtime_t;
+# define RB_HRTIME_PER_SEC ((rb_hrtime_t)1000000000)
+
+static inline rb_hrtime_t
+rb_hrtime_now(void)
+{
+# if defined(HAVE_CLOCK_GETTIME) && defined(CLOCK_MONOTONIC)
+    struct timespec ts;
+    if (clock_gettime(CLOCK_MONOTONIC, &ts) == 0) {
+        return (rb_hrtime_t)ts.tv_sec * RB_HRTIME_PER_SEC + (rb_hrtime_t)ts.tv_nsec;
+    }
+# endif
+    return 0;
+}
+
+static inline rb_hrtime_t
+rb_hrtime_add(rb_hrtime_t a, rb_hrtime_t b)
+{
+    rb_hrtime_t c = a + b;
+    return c < a ? UINT64_MAX : c; /* saturate on overflow */
+}
+
+static inline rb_hrtime_t
+rb_hrtime_sub(rb_hrtime_t a, rb_hrtime_t b)
+{
+    return a < b ? 0 : a - b;
+}
+#else
+# include "hrtime.h"
+#endif
 
 #include "probes.h"
 

--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -385,6 +385,7 @@ typedef struct gc_profile_record {
     rb_hrtime_t gc_stw_time;
     rb_hrtime_t gc_mark_wall_time;
     rb_hrtime_t gc_sweep_wall_time;
+    rb_hrtime_t gc_compact_wall_time;
 
     size_t heap_total_objects;
     size_t heap_use_size;
@@ -1269,6 +1270,7 @@ NO_SANITIZE("memory", static inline bool is_pointer_to_heap(rb_objspace_t *objsp
 static void gc_verify_internal_consistency(void *objspace_ptr);
 
 static double getrusage_time(void);
+static inline rb_hrtime_t elapsed_hrtime_from(rb_hrtime_t start);
 static inline void gc_prof_setup_new_record(rb_objspace_t *objspace, unsigned int reason);
 static inline void gc_prof_timer_start(rb_objspace_t *);
 static inline void gc_prof_timer_stop(rb_objspace_t *);
@@ -4521,7 +4523,13 @@ gc_sweep(rb_objspace_t *objspace)
 
     gc_sweep_start(objspace);
     if (objspace->flags.during_compacting) {
+        rb_hrtime_t compact_start_time = gc_prof_enabled(objspace) ? rb_hrtime_now() : 0;
         gc_sweep_compact(objspace);
+        if (gc_prof_enabled(objspace)) {
+            gc_profile_record *record = gc_prof_record(objspace);
+            record->gc_compact_wall_time = rb_hrtime_add(record->gc_compact_wall_time,
+                    elapsed_hrtime_from(compact_start_time));
+        }
     }
 
     if (immediate_sweep) {
@@ -7044,7 +7052,6 @@ gc_enter_count(enum gc_enter_event event)
 }
 
 static bool current_process_time(struct timespec *ts);
-static inline rb_hrtime_t elapsed_hrtime_from(rb_hrtime_t start);
 
 static void
 gc_clock_start(struct timespec *ts)
@@ -9222,6 +9229,7 @@ gc_profile_clear(VALUE _)
  *	   :GC_STW_TIME=>1.4000000000000001e-05,
  *	   :GC_MARK_WALL_TIME=>9.0000000000000002e-06,
  *	   :GC_SWEEP_WALL_TIME=>5.0000000000000004e-06,
+ *	   :GC_COMPACT_WALL_TIME=>0.0000000000000000e+00,
  *	   :HEAP_USE_SIZE=>289640,
  *	   :HEAP_TOTAL_SIZE=>588960,
  *	   :HEAP_TOTAL_OBJECTS=>14724,
@@ -9259,7 +9267,14 @@ gc_profile_clear(VALUE _)
  *	record, accumulated across incremental marking continuations.
  *  +:GC_SWEEP_WALL_TIME+::
  *	Monotonic wall-clock time elapsed in seconds spent sweeping for this GC
- *	record, accumulated across lazy sweeping continuations.
+ *	record, accumulated across lazy sweeping continuations.  This includes any
+ *	compaction time, which is also reported separately as
+ *	+:GC_COMPACT_WALL_TIME+.
+ *  +:GC_COMPACT_WALL_TIME+::
+ *	Monotonic wall-clock time elapsed in seconds spent compacting for this GC
+ *	record, or +0.0+ if this GC did not compact.  Compaction runs within the
+ *	sweep phase, so this time is nested inside +:GC_SWEEP_WALL_TIME+ and must
+ *	not be added to it.
  *  +:HEAP_USE_SIZE+::
  *	Total bytes of heap used
  *  +:HEAP_TOTAL_SIZE+::
@@ -9325,6 +9340,8 @@ gc_profile_record_get(VALUE _)
                 DBL2NUM(hrtime_to_sec(record->gc_mark_wall_time)));
         rb_hash_aset(prof, ID2SYM(rb_intern("GC_SWEEP_WALL_TIME")),
                 DBL2NUM(hrtime_to_sec(record->gc_sweep_wall_time)));
+        rb_hash_aset(prof, ID2SYM(rb_intern("GC_COMPACT_WALL_TIME")),
+                DBL2NUM(hrtime_to_sec(record->gc_compact_wall_time)));
         rb_hash_aset(prof, ID2SYM(rb_intern("HEAP_USE_SIZE")), SIZET2NUM(record->heap_use_size));
         rb_hash_aset(prof, ID2SYM(rb_intern("HEAP_TOTAL_SIZE")), SIZET2NUM(record->heap_total_size));
         rb_hash_aset(prof, ID2SYM(rb_intern("HEAP_TOTAL_OBJECTS")), SIZET2NUM(record->heap_total_objects));

--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -381,6 +381,8 @@ typedef struct gc_profile_record {
     rb_hrtime_t gc_wall_time;
     rb_hrtime_t gc_invoke_wall_time;
     rb_hrtime_t gc_pause_time;
+    rb_hrtime_t gc_stop_time;
+    rb_hrtime_t gc_stw_time;
 
     size_t heap_total_objects;
     size_t heap_use_size;
@@ -623,6 +625,8 @@ typedef struct rb_objspace {
         rb_hrtime_t gc_wall_start_time;
         rb_hrtime_t gc_sweep_wall_start_time;
         rb_hrtime_t gc_pause_start_time;
+        rb_hrtime_t gc_stw_start_time;
+        rb_hrtime_t gc_stop_time;
         size_t total_allocated_objects_at_gc_start;
         size_t heap_used_at_gc_start;
         size_t heap_total_slots_at_gc_start;
@@ -7090,6 +7094,13 @@ gc_enter(rb_objspace_t *objspace, enum gc_enter_event event, unsigned int *lock_
         break;
     }
 
+    if (objspace->profile.gc_pause_start_time) {
+        objspace->profile.gc_stw_start_time = rb_hrtime_now();
+        objspace->profile.gc_stop_time = rb_hrtime_sub(
+                objspace->profile.gc_stw_start_time,
+                objspace->profile.gc_pause_start_time);
+    }
+
     gc_enter_count(event);
     if (RB_UNLIKELY(during_gc != 0)) rb_bug("during_gc != 0");
     if (RGENGC_CHECK_MODE >= 3) gc_verify_internal_consistency(objspace);
@@ -7111,11 +7122,18 @@ gc_exit(rb_objspace_t *objspace, enum gc_enter_event event, unsigned int *lock_l
 
     if (objspace->profile.gc_pause_start_time) {
         if (gc_prof_enabled(objspace)) {
+            rb_hrtime_t now = rb_hrtime_now();
             gc_profile_record *record = gc_prof_record(objspace);
             record->gc_pause_time = rb_hrtime_add(record->gc_pause_time,
-                    elapsed_hrtime_from(objspace->profile.gc_pause_start_time));
+                    rb_hrtime_sub(now, objspace->profile.gc_pause_start_time));
+            record->gc_stop_time = rb_hrtime_add(record->gc_stop_time,
+                    objspace->profile.gc_stop_time);
+            record->gc_stw_time = rb_hrtime_add(record->gc_stw_time,
+                    rb_hrtime_sub(now, objspace->profile.gc_stw_start_time));
         }
         objspace->profile.gc_pause_start_time = 0;
+        objspace->profile.gc_stw_start_time = 0;
+        objspace->profile.gc_stop_time = 0;
     }
 
     gc_record(objspace, 1, gc_enter_event_cstr(event));
@@ -9176,6 +9194,8 @@ gc_profile_clear(VALUE _)
  *	   :GC_WALL_TIME=>1.4000000000000001e-05,
  *	   :GC_INVOKE_WALL_TIME=>0.010640000000000000,
  *	   :GC_PAUSE_TIME=>1.5000000000000000e-05,
+ *	   :GC_STOP_TIME=>1.0000000000000000e-06,
+ *	   :GC_STW_TIME=>1.4000000000000001e-05,
  *	   :HEAP_USE_SIZE=>289640,
  *	   :HEAP_TOTAL_SIZE=>588960,
  *	   :HEAP_TOTAL_OBJECTS=>14724,
@@ -9192,14 +9212,22 @@ gc_profile_clear(VALUE _)
  *  +:GC_INVOKE_TIME+::
  *	CPU time elapsed in seconds from startup to when the GC was invoked.
  *  +:GC_WALL_TIME+::
- *	Monotonic wall-clock time elapsed in seconds for this GC run.
+ *	Monotonic wall-clock time elapsed in seconds spent doing collector work
+ *	for this GC record.  This does not include time spent stopping other
+ *	ractors before the VM enters GC.
  *  +:GC_INVOKE_WALL_TIME+::
  *	Monotonic wall-clock time elapsed in seconds from startup to when the GC
  *	was invoked.
  *  +:GC_PAUSE_TIME+::
- *	Monotonic wall-clock time elapsed in seconds while the VM was in GC,
- *	including time to stop other ractors.  This may include time from
- *	incremental marking or lazy sweeping continuation charged to this record.
+ *	Monotonic wall-clock time elapsed in seconds while user execution was
+ *	blocked by this GC entry, including time to stop other ractors.  This
+ *	may include time from incremental marking or lazy sweeping continuation
+ *	charged to this record.
+ *  +:GC_STOP_TIME+::
+ *	Monotonic wall-clock time elapsed in seconds stopping other ractors.
+ *  +:GC_STW_TIME+::
+ *	Monotonic wall-clock time elapsed in seconds after other ractors have
+ *	stopped and before the VM exits GC.
  *  +:HEAP_USE_SIZE+::
  *	Total bytes of heap used
  *  +:HEAP_TOTAL_SIZE+::
@@ -9208,6 +9236,15 @@ gc_profile_clear(VALUE _)
  *	Total number of objects
  *  +:GC_IS_MARKED+::
  *	Returns +true+ if the GC is in mark phase
+ *
+ *  The wall-clock timing fields relate to each other as follows:
+ *
+ *    GC_PAUSE_TIME == GC_STOP_TIME + GC_STW_TIME
+ *
+ *  +:GC_WALL_TIME+ measures collector work and is nested inside
+ *  +:GC_STW_TIME+, so it must not be added to +:GC_STW_TIME+.  The difference
+ *  +GC_STW_TIME - GC_WALL_TIME+ is VM overhead inside the stopped interval
+ *  (GC event hooks, bookkeeping, consistency checks, and continuation work).
  *
  *  If ruby was built with +GC_PROFILE_MORE_DETAIL+, you will also have access
  *  to the following hash keys:
@@ -9248,6 +9285,10 @@ gc_profile_record_get(VALUE _)
                 DBL2NUM(hrtime_to_sec(record->gc_invoke_wall_time)));
         rb_hash_aset(prof, ID2SYM(rb_intern("GC_PAUSE_TIME")),
                 DBL2NUM(hrtime_to_sec(record->gc_pause_time)));
+        rb_hash_aset(prof, ID2SYM(rb_intern("GC_STOP_TIME")),
+                DBL2NUM(hrtime_to_sec(record->gc_stop_time)));
+        rb_hash_aset(prof, ID2SYM(rb_intern("GC_STW_TIME")),
+                DBL2NUM(hrtime_to_sec(record->gc_stw_time)));
         rb_hash_aset(prof, ID2SYM(rb_intern("HEAP_USE_SIZE")), SIZET2NUM(record->heap_use_size));
         rb_hash_aset(prof, ID2SYM(rb_intern("HEAP_TOTAL_SIZE")), SIZET2NUM(record->heap_total_size));
         rb_hash_aset(prof, ID2SYM(rb_intern("HEAP_TOTAL_OBJECTS")), SIZET2NUM(record->heap_total_objects));
@@ -10108,8 +10149,10 @@ rb_gc_impl_init(void)
      *    GC::Profiler.disable
      *
      *  GC::Profiler.raw_data returns one Hash per GC run, including CPU time
-     *  fields such as +:GC_TIME+ and wall-clock fields such as +:GC_WALL_TIME+
-     *  and +:GC_PAUSE_TIME+.
+     *  fields such as +:GC_TIME+ and wall-clock fields such as +:GC_WALL_TIME+,
+     *  +:GC_PAUSE_TIME+, +:GC_STOP_TIME+, and +:GC_STW_TIME+.  +:GC_WALL_TIME+
+     *  measures collector work for the record, while +:GC_PAUSE_TIME+ measures
+     *  how long user execution was blocked by the GC entry.
      *
      *  See also GC.count, GC.malloc_allocated_size and GC.malloc_allocations
      */

--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -663,6 +663,7 @@ typedef struct rb_objspace {
         double gc_sweep_start_time;
         rb_hrtime_t gc_wall_start_time;
         rb_hrtime_t gc_sweep_wall_start_time;
+        rb_hrtime_t gc_sweep_excluded_wall_time;
         rb_hrtime_t gc_pause_start_time;
         rb_hrtime_t gc_stw_start_time;
         rb_hrtime_t gc_stop_time;
@@ -4562,9 +4563,13 @@ gc_sweep(rb_objspace_t *objspace)
         rb_hrtime_t compact_start_time = gc_prof_enabled(objspace) ? rb_hrtime_now() : 0;
         gc_sweep_compact(objspace);
         if (gc_prof_enabled(objspace)) {
+            rb_hrtime_t compact_wall_time = elapsed_hrtime_from(compact_start_time);
             gc_profile_record *record = gc_prof_record(objspace);
             record->gc_compact_wall_time = rb_hrtime_add(record->gc_compact_wall_time,
-                    elapsed_hrtime_from(compact_start_time));
+                    compact_wall_time);
+            objspace->profile.gc_sweep_excluded_wall_time = rb_hrtime_add(
+                    objspace->profile.gc_sweep_excluded_wall_time,
+                    compact_wall_time);
         }
     }
 
@@ -7238,6 +7243,7 @@ gc_sweeping_enter(rb_objspace_t *objspace)
 
     if (gc_prof_enabled(objspace)) {
         objspace->profile.gc_sweep_phase_wall_start_time = rb_hrtime_now();
+        objspace->profile.gc_sweep_excluded_wall_time = 0;
     }
 
     if (MEASURE_GC) {
@@ -7255,9 +7261,13 @@ gc_sweeping_exit(rb_objspace_t *objspace)
     }
 
     if (gc_prof_enabled(objspace)) {
+        rb_hrtime_t sweep_wall_time = elapsed_hrtime_from(objspace->profile.gc_sweep_phase_wall_start_time);
         gc_profile_record *record = gc_prof_record(objspace);
+        sweep_wall_time = rb_hrtime_sub(sweep_wall_time,
+                objspace->profile.gc_sweep_excluded_wall_time);
         record->gc_sweep_wall_time = rb_hrtime_add(record->gc_sweep_wall_time,
-                elapsed_hrtime_from(objspace->profile.gc_sweep_phase_wall_start_time));
+                sweep_wall_time);
+        objspace->profile.gc_sweep_excluded_wall_time = 0;
     }
 }
 
@@ -9282,9 +9292,10 @@ gc_profile_clear(VALUE _)
  *  +:GC_INVOKE_TIME+::
  *	CPU time elapsed in seconds from startup to when the GC was invoked.
  *  +:GC_WALL_TIME+::
- *	Monotonic wall-clock time elapsed in seconds spent doing collector work
- *	for this GC record.  This does not include time spent stopping other
- *	ractors before the VM enters GC.
+ *	Monotonic wall-clock counterpart to +:GC_TIME+ for this GC record.
+ *	This does not include time spent stopping other ractors before the VM
+ *	enters GC.  Use the phase wall-clock fields below for mark, sweep, and
+ *	compaction attribution.
  *  +:GC_INVOKE_WALL_TIME+::
  *	Monotonic wall-clock time elapsed in seconds from startup to when the GC
  *	was invoked.
@@ -9303,14 +9314,12 @@ gc_profile_clear(VALUE _)
  *	record, accumulated across incremental marking continuations.
  *  +:GC_SWEEP_WALL_TIME+::
  *	Monotonic wall-clock time elapsed in seconds spent sweeping for this GC
- *	record, accumulated across lazy sweeping continuations.  This includes any
- *	compaction time, which is also reported separately as
+ *	record, accumulated across lazy sweeping continuations.  This does not
+ *	include compaction time, which is reported separately as
  *	+:GC_COMPACT_WALL_TIME+.
  *  +:GC_COMPACT_WALL_TIME+::
  *	Monotonic wall-clock time elapsed in seconds spent compacting for this GC
- *	record, or +0.0+ if this GC did not compact.  Compaction runs within the
- *	sweep phase, so this time is nested inside +:GC_SWEEP_WALL_TIME+ and must
- *	not be added to it.
+ *	record, or +0.0+ if this GC did not compact.
  *  +:HEAP_USE_SIZE+::
  *	Total bytes of heap used
  *  +:HEAP_TOTAL_SIZE+::
@@ -9324,8 +9333,11 @@ gc_profile_clear(VALUE _)
  *
  *    GC_PAUSE_TIME == GC_STOP_TIME + GC_STW_TIME
  *
- *  +:GC_WALL_TIME+ measures collector work and is nested inside
- *  +:GC_STW_TIME+, so it must not be added to +:GC_STW_TIME+.  The difference
+ *  +:GC_MARK_WALL_TIME+, +:GC_SWEEP_WALL_TIME+, and +:GC_COMPACT_WALL_TIME+
+ *  report separate phase timings and must not be added to +:GC_WALL_TIME+.
+ *
+ *  +:GC_WALL_TIME+ is the wall-clock counterpart to +:GC_TIME+ and is nested
+ *  inside +:GC_STW_TIME+, so it must not be added to +:GC_STW_TIME+.  The difference
  *  +GC_STW_TIME - GC_WALL_TIME+ is VM overhead inside the stopped interval
  *  (GC event hooks, bookkeeping, consistency checks, and continuation work).
  *
@@ -10240,8 +10252,8 @@ rb_gc_impl_init(void)
      *  GC::Profiler.raw_data returns one Hash per GC run, including CPU time
      *  fields such as +:GC_TIME+ and wall-clock fields such as +:GC_WALL_TIME+,
      *  +:GC_PAUSE_TIME+, +:GC_STOP_TIME+, and +:GC_STW_TIME+.  +:GC_WALL_TIME+
-     *  measures collector work for the record, while +:GC_PAUSE_TIME+ measures
-     *  how long user execution was blocked by the GC entry.
+     *  is the wall-clock counterpart to +:GC_TIME+, while +:GC_PAUSE_TIME+
+     *  measures how long user execution was blocked by the GC entry.
      *
      *  See also GC.count, GC.malloc_allocated_size and GC.malloc_allocations
      */

--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -383,6 +383,8 @@ typedef struct gc_profile_record {
     rb_hrtime_t gc_pause_time;
     rb_hrtime_t gc_stop_time;
     rb_hrtime_t gc_stw_time;
+    rb_hrtime_t gc_mark_wall_time;
+    rb_hrtime_t gc_sweep_wall_time;
 
     size_t heap_total_objects;
     size_t heap_use_size;
@@ -627,6 +629,8 @@ typedef struct rb_objspace {
         rb_hrtime_t gc_pause_start_time;
         rb_hrtime_t gc_stw_start_time;
         rb_hrtime_t gc_stop_time;
+        rb_hrtime_t gc_mark_phase_wall_start_time;
+        rb_hrtime_t gc_sweep_phase_wall_start_time;
         size_t total_allocated_objects_at_gc_start;
         size_t heap_used_at_gc_start;
         size_t heap_total_slots_at_gc_start;
@@ -7155,6 +7159,10 @@ gc_marking_enter(rb_objspace_t *objspace)
 
     gc_prof_mark_timer_start(objspace);
 
+    if (gc_prof_enabled(objspace)) {
+        objspace->profile.gc_mark_phase_wall_start_time = rb_hrtime_now();
+    }
+
     if (MEASURE_GC) {
         gc_clock_start(&objspace->profile.marking_start_time);
     }
@@ -7171,6 +7179,12 @@ gc_marking_exit(rb_objspace_t *objspace)
         objspace->profile.marking_time_ns += gc_clock_end(&objspace->profile.marking_start_time);
     }
 
+    if (gc_prof_enabled(objspace)) {
+        gc_profile_record *record = gc_prof_record(objspace);
+        record->gc_mark_wall_time = rb_hrtime_add(record->gc_mark_wall_time,
+                elapsed_hrtime_from(objspace->profile.gc_mark_phase_wall_start_time));
+    }
+
     gc_prof_mark_timer_stop(objspace);
 }
 
@@ -7178,6 +7192,10 @@ static void
 gc_sweeping_enter(rb_objspace_t *objspace)
 {
     GC_ASSERT(during_gc != 0);
+
+    if (gc_prof_enabled(objspace)) {
+        objspace->profile.gc_sweep_phase_wall_start_time = rb_hrtime_now();
+    }
 
     if (MEASURE_GC) {
         gc_clock_start(&objspace->profile.sweeping_start_time);
@@ -7191,6 +7209,12 @@ gc_sweeping_exit(rb_objspace_t *objspace)
 
     if (MEASURE_GC) {
         objspace->profile.sweeping_time_ns += gc_clock_end(&objspace->profile.sweeping_start_time);
+    }
+
+    if (gc_prof_enabled(objspace)) {
+        gc_profile_record *record = gc_prof_record(objspace);
+        record->gc_sweep_wall_time = rb_hrtime_add(record->gc_sweep_wall_time,
+                elapsed_hrtime_from(objspace->profile.gc_sweep_phase_wall_start_time));
     }
 }
 
@@ -9196,6 +9220,8 @@ gc_profile_clear(VALUE _)
  *	   :GC_PAUSE_TIME=>1.5000000000000000e-05,
  *	   :GC_STOP_TIME=>1.0000000000000000e-06,
  *	   :GC_STW_TIME=>1.4000000000000001e-05,
+ *	   :GC_MARK_WALL_TIME=>9.0000000000000002e-06,
+ *	   :GC_SWEEP_WALL_TIME=>5.0000000000000004e-06,
  *	   :HEAP_USE_SIZE=>289640,
  *	   :HEAP_TOTAL_SIZE=>588960,
  *	   :HEAP_TOTAL_OBJECTS=>14724,
@@ -9228,6 +9254,12 @@ gc_profile_clear(VALUE _)
  *  +:GC_STW_TIME+::
  *	Monotonic wall-clock time elapsed in seconds after other ractors have
  *	stopped and before the VM exits GC.
+ *  +:GC_MARK_WALL_TIME+::
+ *	Monotonic wall-clock time elapsed in seconds spent marking for this GC
+ *	record, accumulated across incremental marking continuations.
+ *  +:GC_SWEEP_WALL_TIME+::
+ *	Monotonic wall-clock time elapsed in seconds spent sweeping for this GC
+ *	record, accumulated across lazy sweeping continuations.
  *  +:HEAP_USE_SIZE+::
  *	Total bytes of heap used
  *  +:HEAP_TOTAL_SIZE+::
@@ -9289,6 +9321,10 @@ gc_profile_record_get(VALUE _)
                 DBL2NUM(hrtime_to_sec(record->gc_stop_time)));
         rb_hash_aset(prof, ID2SYM(rb_intern("GC_STW_TIME")),
                 DBL2NUM(hrtime_to_sec(record->gc_stw_time)));
+        rb_hash_aset(prof, ID2SYM(rb_intern("GC_MARK_WALL_TIME")),
+                DBL2NUM(hrtime_to_sec(record->gc_mark_wall_time)));
+        rb_hash_aset(prof, ID2SYM(rb_intern("GC_SWEEP_WALL_TIME")),
+                DBL2NUM(hrtime_to_sec(record->gc_sweep_wall_time)));
         rb_hash_aset(prof, ID2SYM(rb_intern("HEAP_USE_SIZE")), SIZET2NUM(record->heap_use_size));
         rb_hash_aset(prof, ID2SYM(rb_intern("HEAP_TOTAL_SIZE")), SIZET2NUM(record->heap_total_size));
         rb_hash_aset(prof, ID2SYM(rb_intern("HEAP_TOTAL_OBJECTS")), SIZET2NUM(record->heap_total_objects));

--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -33,6 +33,7 @@
 #include "darray.h"
 #include "gc/gc.h"
 #include "gc/gc_impl.h"
+#include "hrtime.h"
 
 #include "probes.h"
 
@@ -377,6 +378,9 @@ typedef struct gc_profile_record {
 
     double gc_time;
     double gc_invoke_time;
+    rb_hrtime_t gc_wall_time;
+    rb_hrtime_t gc_invoke_wall_time;
+    rb_hrtime_t gc_pause_time;
 
     size_t heap_total_objects;
     size_t heap_use_size;
@@ -590,6 +594,7 @@ typedef struct rb_objspace {
         double prepare_time;
 #endif
         double invoke_time;
+        rb_hrtime_t invoke_wall_time;
 
         size_t minor_gc_count;
         size_t major_gc_count;
@@ -615,6 +620,9 @@ typedef struct rb_objspace {
 
         /* temporary profiling space */
         double gc_sweep_start_time;
+        rb_hrtime_t gc_wall_start_time;
+        rb_hrtime_t gc_sweep_wall_start_time;
+        rb_hrtime_t gc_pause_start_time;
         size_t total_allocated_objects_at_gc_start;
         size_t heap_used_at_gc_start;
         size_t heap_total_slots_at_gc_start;
@@ -7028,6 +7036,7 @@ gc_enter_count(enum gc_enter_event event)
 }
 
 static bool current_process_time(struct timespec *ts);
+static inline rb_hrtime_t elapsed_hrtime_from(rb_hrtime_t start);
 
 static void
 gc_clock_start(struct timespec *ts)
@@ -7058,6 +7067,18 @@ gc_enter(rb_objspace_t *objspace, enum gc_enter_event event, unsigned int *lock_
 {
     *lock_lev = RB_GC_VM_LOCK();
 
+    if (objspace->profile.run) {
+        switch (event) {
+          case gc_enter_event_start:
+          case gc_enter_event_continue:
+          case gc_enter_event_rest:
+            objspace->profile.gc_pause_start_time = rb_hrtime_now();
+            break;
+          case gc_enter_event_finalizer:
+            break;
+        }
+    }
+
     switch (event) {
       case gc_enter_event_rest:
       case gc_enter_event_start:
@@ -7087,6 +7108,15 @@ gc_exit(rb_objspace_t *objspace, enum gc_enter_event event, unsigned int *lock_l
     GC_ASSERT(during_gc != 0);
 
     rb_gc_event_hook(0, RUBY_INTERNAL_EVENT_GC_EXIT);
+
+    if (objspace->profile.gc_pause_start_time) {
+        if (gc_prof_enabled(objspace)) {
+            gc_profile_record *record = gc_prof_record(objspace);
+            record->gc_pause_time = rb_hrtime_add(record->gc_pause_time,
+                    elapsed_hrtime_from(objspace->profile.gc_pause_start_time));
+        }
+        objspace->profile.gc_pause_start_time = 0;
+    }
 
     gc_record(objspace, 1, gc_enter_event_cstr(event));
     RUBY_DEBUG_LOG("%s (%s)", gc_enter_event_cstr(event), gc_current_status(objspace));
@@ -8899,6 +8929,18 @@ getrusage_time(void)
     }
 }
 
+static inline double
+hrtime_to_sec(rb_hrtime_t time)
+{
+    return (double)time / (double)RB_HRTIME_PER_SEC;
+}
+
+static inline rb_hrtime_t
+elapsed_hrtime_from(rb_hrtime_t start)
+{
+    return rb_hrtime_sub(rb_hrtime_now(), start);
+}
+
 
 static inline void
 gc_prof_setup_new_record(rb_objspace_t *objspace, unsigned int reason)
@@ -8929,6 +8971,8 @@ gc_prof_setup_new_record(rb_objspace_t *objspace, unsigned int reason)
 
         /* setup before-GC parameter */
         record->flags = reason | (ruby_gc_stressful ? GPR_FLAG_STRESS : 0);
+        record->gc_invoke_wall_time = rb_hrtime_sub(rb_hrtime_now(),
+                objspace->profile.invoke_wall_time);
 #if MALLOC_ALLOCATED_SIZE
         record->allocated_size = malloc_allocated_size;
 #endif
@@ -8957,6 +9001,7 @@ gc_prof_timer_start(rb_objspace_t *objspace)
 #endif
         record->gc_time = 0;
         record->gc_invoke_time = getrusage_time();
+        objspace->profile.gc_wall_start_time = rb_hrtime_now();
     }
 }
 
@@ -8979,6 +9024,7 @@ gc_prof_timer_stop(rb_objspace_t *objspace)
         gc_profile_record *record = gc_prof_record(objspace);
         record->gc_time = elapsed_time_from(record->gc_invoke_time);
         record->gc_invoke_time -= objspace->profile.invoke_time;
+        record->gc_wall_time = elapsed_hrtime_from(objspace->profile.gc_wall_start_time);
     }
 }
 
@@ -9017,6 +9063,7 @@ gc_prof_sweep_timer_start(rb_objspace_t *objspace)
 
         if (record->gc_time > 0 || GC_PROFILE_MORE_DETAIL) {
             objspace->profile.gc_sweep_start_time = getrusage_time();
+            objspace->profile.gc_sweep_wall_start_time = rb_hrtime_now();
         }
     }
 }
@@ -9034,6 +9081,8 @@ gc_prof_sweep_timer_stop(rb_objspace_t *objspace)
             sweep_time = elapsed_time_from(objspace->profile.gc_sweep_start_time);
             /* need to accumulate GC time for lazy sweep after gc() */
             record->gc_time += sweep_time;
+            record->gc_wall_time = rb_hrtime_add(record->gc_wall_time,
+                    elapsed_hrtime_from(objspace->profile.gc_sweep_wall_start_time));
         }
         else if (GC_PROFILE_MORE_DETAIL) {
             sweep_time = elapsed_time_from(objspace->profile.gc_sweep_start_time);
@@ -9124,6 +9173,9 @@ gc_profile_clear(VALUE _)
  *	{
  *	   :GC_TIME=>1.3000000000000858e-05,
  *	   :GC_INVOKE_TIME=>0.010634999999999999,
+ *	   :GC_WALL_TIME=>1.4000000000000001e-05,
+ *	   :GC_INVOKE_WALL_TIME=>0.010640000000000000,
+ *	   :GC_PAUSE_TIME=>1.5000000000000000e-05,
  *	   :HEAP_USE_SIZE=>289640,
  *	   :HEAP_TOTAL_SIZE=>588960,
  *	   :HEAP_TOTAL_OBJECTS=>14724,
@@ -9135,9 +9187,19 @@ gc_profile_clear(VALUE _)
  *  The keys mean:
  *
  *  +:GC_TIME+::
- *	Time elapsed in seconds for this GC run
+ *	CPU time elapsed in seconds for this GC run.  This is process CPU time,
+ *	not elapsed wall-clock time.
  *  +:GC_INVOKE_TIME+::
- *	Time elapsed in seconds from startup to when the GC was invoked
+ *	CPU time elapsed in seconds from startup to when the GC was invoked.
+ *  +:GC_WALL_TIME+::
+ *	Monotonic wall-clock time elapsed in seconds for this GC run.
+ *  +:GC_INVOKE_WALL_TIME+::
+ *	Monotonic wall-clock time elapsed in seconds from startup to when the GC
+ *	was invoked.
+ *  +:GC_PAUSE_TIME+::
+ *	Monotonic wall-clock time elapsed in seconds while the VM was in GC,
+ *	including time to stop other ractors.  This may include time from
+ *	incremental marking or lazy sweeping continuation charged to this record.
  *  +:HEAP_USE_SIZE+::
  *	Total bytes of heap used
  *  +:HEAP_TOTAL_SIZE+::
@@ -9180,6 +9242,12 @@ gc_profile_record_get(VALUE _)
         rb_hash_aset(prof, ID2SYM(rb_intern("GC_FLAGS")), gc_info_decode(objspace, rb_hash_new(), record->flags));
         rb_hash_aset(prof, ID2SYM(rb_intern("GC_TIME")), DBL2NUM(record->gc_time));
         rb_hash_aset(prof, ID2SYM(rb_intern("GC_INVOKE_TIME")), DBL2NUM(record->gc_invoke_time));
+        rb_hash_aset(prof, ID2SYM(rb_intern("GC_WALL_TIME")),
+                DBL2NUM(hrtime_to_sec(record->gc_wall_time)));
+        rb_hash_aset(prof, ID2SYM(rb_intern("GC_INVOKE_WALL_TIME")),
+                DBL2NUM(hrtime_to_sec(record->gc_invoke_wall_time)));
+        rb_hash_aset(prof, ID2SYM(rb_intern("GC_PAUSE_TIME")),
+                DBL2NUM(hrtime_to_sec(record->gc_pause_time)));
         rb_hash_aset(prof, ID2SYM(rb_intern("HEAP_USE_SIZE")), SIZET2NUM(record->heap_use_size));
         rb_hash_aset(prof, ID2SYM(rb_intern("HEAP_TOTAL_SIZE")), SIZET2NUM(record->heap_total_size));
         rb_hash_aset(prof, ID2SYM(rb_intern("HEAP_TOTAL_OBJECTS")), SIZET2NUM(record->heap_total_objects));
@@ -9965,6 +10033,7 @@ rb_gc_impl_objspace_init(void *objspace_ptr)
     init_mark_stack(&objspace->mark_stack);
 
     objspace->profile.invoke_time = getrusage_time();
+    objspace->profile.invoke_wall_time = rb_hrtime_now();
     finalizer_table = st_init_numtable();
 }
 

--- a/test/.excludes-mmtk/TestGc.rb
+++ b/test/.excludes-mmtk/TestGc.rb
@@ -15,6 +15,8 @@ exclude(:test_latest_gc_info_weak_references_count, "testing behaviour specific 
 exclude(:test_old_to_young_reference, "testing behaviour specific to default GC")
 exclude(:test_profiler_enabled, "MMTk does not have GC::Profiler")
 exclude(:test_profiler_raw_data, "MMTk does not have GC::Profiler")
+exclude(:test_profiler_raw_data_includes_compaction_wall_time, "MMTk does not have GC::Profiler")
+exclude(:test_profiler_raw_data_includes_wall_time, "MMTk does not have GC::Profiler")
 exclude(:test_profiler_total_time, "MMTk does not have GC::Profiler")
 exclude(:test_start_full_mark, "testing behaviour specific to default GC")
 exclude(:test_start_immediate_sweep, "testing behaviour specific to default GC")

--- a/test/.excludes-mmtk/TestGc.rb
+++ b/test/.excludes-mmtk/TestGc.rb
@@ -15,7 +15,7 @@ exclude(:test_latest_gc_info_weak_references_count, "testing behaviour specific 
 exclude(:test_old_to_young_reference, "testing behaviour specific to default GC")
 exclude(:test_profiler_enabled, "MMTk does not have GC::Profiler")
 exclude(:test_profiler_raw_data, "MMTk does not have GC::Profiler")
-exclude(:test_profiler_raw_data_includes_compaction_wall_time, "MMTk does not have GC::Profiler")
+exclude(:test_profiler_raw_data_reports_compaction_separately_from_sweep_wall_time, "MMTk does not have GC::Profiler")
 exclude(:test_profiler_raw_data_includes_wall_time, "MMTk does not have GC::Profiler")
 exclude(:test_profiler_total_time, "MMTk does not have GC::Profiler")
 exclude(:test_start_full_mark, "testing behaviour specific to default GC")

--- a/test/ruby/test_gc.rb
+++ b/test/ruby/test_gc.rb
@@ -581,6 +581,9 @@ class TestGc < Test::Unit::TestCase
   end
 
   def test_profiler_raw_data_includes_wall_time
+    auto_compact = GC.auto_compact if GC.respond_to?(:auto_compact)
+    GC.auto_compact = false if GC.respond_to?(:auto_compact=)
+
     GC::Profiler.enable
     GC::Profiler.clear
 
@@ -606,26 +609,28 @@ class TestGc < Test::Unit::TestCase
     assert_operator record[:GC_COMPACT_WALL_TIME], :>=, 0.0
     assert_in_delta record[:GC_PAUSE_TIME], record[:GC_STOP_TIME] + record[:GC_STW_TIME], 0.001
     assert_operator record[:GC_MARK_WALL_TIME] + record[:GC_SWEEP_WALL_TIME], :<=, record[:GC_PAUSE_TIME] + 0.001
-    # No compaction was requested, so compaction time is folded into nothing.
     assert_equal 0.0, record[:GC_COMPACT_WALL_TIME]
   ensure
     GC::Profiler.disable
     GC::Profiler.clear
+    GC.auto_compact = auto_compact if GC.respond_to?(:auto_compact=) && defined?(auto_compact)
   end
 
-  def test_profiler_raw_data_includes_compaction_wall_time
+  def test_profiler_raw_data_reports_compaction_separately_from_sweep_wall_time
     omit "compaction not supported" unless GC.respond_to?(:compact)
 
     GC::Profiler.enable
     GC::Profiler.clear
 
+    objects = 10_000.times.map { Object.new }
     GC.compact
     record = GC::Profiler.raw_data.last
 
     assert_kind_of Float, record[:GC_COMPACT_WALL_TIME]
-    assert_operator record[:GC_COMPACT_WALL_TIME], :>=, 0.0
-    # Compaction runs within the sweep phase, so it is bounded by sweep wall time.
-    assert_operator record[:GC_COMPACT_WALL_TIME], :<=, record[:GC_SWEEP_WALL_TIME] + 0.001
+    assert_operator record[:GC_COMPACT_WALL_TIME], :>, 0.0
+    phase_wall_time = record[:GC_MARK_WALL_TIME] + record[:GC_SWEEP_WALL_TIME] + record[:GC_COMPACT_WALL_TIME]
+    assert_operator phase_wall_time, :<=, record[:GC_PAUSE_TIME] + 0.001
+    objects.clear
   rescue NotImplementedError
     omit "compaction not supported"
   ensure

--- a/test/ruby/test_gc.rb
+++ b/test/ruby/test_gc.rb
@@ -594,6 +594,7 @@ class TestGc < Test::Unit::TestCase
     assert_kind_of Float, record[:GC_STW_TIME]
     assert_kind_of Float, record[:GC_MARK_WALL_TIME]
     assert_kind_of Float, record[:GC_SWEEP_WALL_TIME]
+    assert_kind_of Float, record[:GC_COMPACT_WALL_TIME]
 
     assert_operator record[:GC_WALL_TIME], :>=, 0.0
     assert_operator record[:GC_INVOKE_WALL_TIME], :>=, 0.0
@@ -602,8 +603,31 @@ class TestGc < Test::Unit::TestCase
     assert_operator record[:GC_STW_TIME], :>=, 0.0
     assert_operator record[:GC_MARK_WALL_TIME], :>=, 0.0
     assert_operator record[:GC_SWEEP_WALL_TIME], :>=, 0.0
+    assert_operator record[:GC_COMPACT_WALL_TIME], :>=, 0.0
     assert_in_delta record[:GC_PAUSE_TIME], record[:GC_STOP_TIME] + record[:GC_STW_TIME], 0.001
     assert_operator record[:GC_MARK_WALL_TIME] + record[:GC_SWEEP_WALL_TIME], :<=, record[:GC_PAUSE_TIME] + 0.001
+    # No compaction was requested, so compaction time is folded into nothing.
+    assert_equal 0.0, record[:GC_COMPACT_WALL_TIME]
+  ensure
+    GC::Profiler.disable
+    GC::Profiler.clear
+  end
+
+  def test_profiler_raw_data_includes_compaction_wall_time
+    omit "compaction not supported" unless GC.respond_to?(:compact)
+
+    GC::Profiler.enable
+    GC::Profiler.clear
+
+    GC.compact
+    record = GC::Profiler.raw_data.last
+
+    assert_kind_of Float, record[:GC_COMPACT_WALL_TIME]
+    assert_operator record[:GC_COMPACT_WALL_TIME], :>=, 0.0
+    # Compaction runs within the sweep phase, so it is bounded by sweep wall time.
+    assert_operator record[:GC_COMPACT_WALL_TIME], :<=, record[:GC_SWEEP_WALL_TIME] + 0.001
+  rescue NotImplementedError
+    omit "compaction not supported"
   ensure
     GC::Profiler.disable
     GC::Profiler.clear

--- a/test/ruby/test_gc.rb
+++ b/test/ruby/test_gc.rb
@@ -580,6 +580,25 @@ class TestGc < Test::Unit::TestCase
     GC::Profiler.disable
   end
 
+  def test_profiler_raw_data_includes_wall_time
+    GC::Profiler.enable
+    GC::Profiler.clear
+
+    GC.start
+    record = GC::Profiler.raw_data.last
+
+    assert_kind_of Float, record[:GC_WALL_TIME]
+    assert_kind_of Float, record[:GC_INVOKE_WALL_TIME]
+    assert_kind_of Float, record[:GC_PAUSE_TIME]
+
+    assert_operator record[:GC_WALL_TIME], :>=, 0.0
+    assert_operator record[:GC_INVOKE_WALL_TIME], :>=, 0.0
+    assert_operator record[:GC_PAUSE_TIME], :>=, 0.0
+  ensure
+    GC::Profiler.disable
+    GC::Profiler.clear
+  end
+
   def test_profiler_total_time
     GC::Profiler.enable
     GC::Profiler.clear

--- a/test/ruby/test_gc.rb
+++ b/test/ruby/test_gc.rb
@@ -592,13 +592,18 @@ class TestGc < Test::Unit::TestCase
     assert_kind_of Float, record[:GC_PAUSE_TIME]
     assert_kind_of Float, record[:GC_STOP_TIME]
     assert_kind_of Float, record[:GC_STW_TIME]
+    assert_kind_of Float, record[:GC_MARK_WALL_TIME]
+    assert_kind_of Float, record[:GC_SWEEP_WALL_TIME]
 
     assert_operator record[:GC_WALL_TIME], :>=, 0.0
     assert_operator record[:GC_INVOKE_WALL_TIME], :>=, 0.0
     assert_operator record[:GC_PAUSE_TIME], :>=, 0.0
     assert_operator record[:GC_STOP_TIME], :>=, 0.0
     assert_operator record[:GC_STW_TIME], :>=, 0.0
+    assert_operator record[:GC_MARK_WALL_TIME], :>=, 0.0
+    assert_operator record[:GC_SWEEP_WALL_TIME], :>=, 0.0
     assert_in_delta record[:GC_PAUSE_TIME], record[:GC_STOP_TIME] + record[:GC_STW_TIME], 0.001
+    assert_operator record[:GC_MARK_WALL_TIME] + record[:GC_SWEEP_WALL_TIME], :<=, record[:GC_PAUSE_TIME] + 0.001
   ensure
     GC::Profiler.disable
     GC::Profiler.clear

--- a/test/ruby/test_gc.rb
+++ b/test/ruby/test_gc.rb
@@ -590,10 +590,15 @@ class TestGc < Test::Unit::TestCase
     assert_kind_of Float, record[:GC_WALL_TIME]
     assert_kind_of Float, record[:GC_INVOKE_WALL_TIME]
     assert_kind_of Float, record[:GC_PAUSE_TIME]
+    assert_kind_of Float, record[:GC_STOP_TIME]
+    assert_kind_of Float, record[:GC_STW_TIME]
 
     assert_operator record[:GC_WALL_TIME], :>=, 0.0
     assert_operator record[:GC_INVOKE_WALL_TIME], :>=, 0.0
     assert_operator record[:GC_PAUSE_TIME], :>=, 0.0
+    assert_operator record[:GC_STOP_TIME], :>=, 0.0
+    assert_operator record[:GC_STW_TIME], :>=, 0.0
+    assert_in_delta record[:GC_PAUSE_TIME], record[:GC_STOP_TIME] + record[:GC_STW_TIME], 0.001
   ensure
     GC::Profiler.disable
     GC::Profiler.clear

--- a/tool/gc_sampler.rb
+++ b/tool/gc_sampler.rb
@@ -1,0 +1,372 @@
+#!/usr/bin/env ruby
+# A minimal in-process GC sampler.
+#
+# A background thread wakes on a fixed wall-clock interval, snapshots the GC
+# counters, and records the *delta* since the previous wake. to provide GC
+# activity as a rate over time.
+#
+# When any profiler-backed data is available we tap GC::Profiler, but drain and
+# .clear it every interval so its record buffer never grows unbounded. The raw
+# per-GC records can also be retained for later dumping.
+
+class GCSampler
+  Caps = Struct.new(:rgengc_stat, :malloc_size, :prof_wall, :prof_pause_split, :prof_phase_wall, :prof_detail, :prof_rgengc, keyword_init: true)
+
+  def self.initial_caps
+    stat = GC.stat
+    Caps.new(
+      rgengc_stat: stat.key?(:total_promoted_count),
+      malloc_size: GC.respond_to?(:malloc_allocated_size),
+      prof_wall: false,
+      prof_pause_split: false,
+      prof_phase_wall: false,
+      prof_detail: false,
+      prof_rgengc: false,
+    )
+  end
+
+  Col = Struct.new(:key, :head, :w, :fmt)
+
+  def initialize(interval: 0.02, caps: GCSampler.initial_caps, raw_profile: true)
+    @interval = interval
+    @caps     = caps
+    @samples  = []
+    @profile_records = []
+    @buf      = {}
+    @running  = false
+    @raw_profile = raw_profile
+    @use_profiler = true
+  end
+
+  attr_reader :samples, :profile_records, :caps
+
+  def start
+    @running = true
+    if @use_profiler
+      @prof_was = GC::Profiler.enabled?
+      GC::Profiler.enable
+      GC::Profiler.clear
+    end
+    @t0   = mono
+    @prev = snapshot
+    @thread = Thread.new do
+      while @running
+        sleep @interval
+        record
+      end
+    end
+    self
+  end
+
+  def stop
+    @running = false
+    @thread&.join
+    record
+    if @use_profiler
+      GC::Profiler.clear
+      GC::Profiler.disable unless @prof_was
+    end
+    self
+  end
+
+  def run
+    start
+    yield
+  ensure
+    stop
+  end
+
+  def banner(io = $stdout)
+    io.puts "GC sampler — #{RUBY_DESCRIPTION}"
+    io.puts "optional data sources:"
+    io.printf("  GC::Profiler raw records        : %s\n", yn(@raw_profile))
+    io.printf("  GC::Profiler wall time fields   : %s\n", yn(@caps.prof_wall))
+    io.printf("  GC::Profiler pause split fields : %s\n", yn(@caps.prof_pause_split))
+    io.printf("  GC::Profiler phase wall fields  : %s\n", yn(@caps.prof_phase_wall))
+    io.printf("  RGENGC_PROFILE (stat + profiler) : %s\n", yn(@caps.rgengc_stat || @caps.prof_rgengc))
+    io.printf("  GC_PROFILE_MORE_DETAIL (profiler): %s\n", yn(@caps.prof_detail))
+    io.printf("  MALLOC_ALLOCATED_SIZE (methods)  : %s\n", yn(@caps.malloc_size))
+    io.puts  "  GC_PROFILE_DETAIL_MEMORY         : report-only — not samplable"
+    io.puts
+  end
+
+  def report(io = $stdout)
+    cols = build_columns
+    io.puts(cols.map { |c| c.head.rjust(c.w) }.join(" "))
+    @samples.each do |s|
+      io.puts(cols.map { |c| format_cell(c, s) }.join(" "))
+    end
+  end
+
+  def report_raw_profile(io = $stdout)
+    return if @profile_records.empty?
+
+    io.puts
+    io.puts "raw GC::Profiler records:"
+    @profile_records.each_with_index do |record, index|
+      io.printf("[%d]\n", index)
+      record.each do |key, value|
+        io.printf("  %-26s %s\n", "#{key}:", value.inspect)
+      end
+    end
+  end
+
+  def summary(io = $stdout)
+    return if @samples.empty?
+    wall     = @samples.last[:t]
+    wall_total_ms = wall * 1000.0
+    gc_ms    = @samples.sum { _1[:gc_ms] }
+    minors   = @samples.sum { _1[:minor] }
+    majors   = @samples.sum { _1[:major] }
+    gc_count = minors + majors
+    io.puts
+    io.printf("wall:        %.3f s\n", wall)
+    io.printf("GCs:         %d minor + %d major\n", minors, majors)
+    io.printf("objects:     %d allocated, %d freed\n", @samples.sum { _1[:alloc] }, @samples.sum { _1[:freed] })
+    io.printf("GC CPU time: %.3f ms  (~%.1f%% of wall)\n", gc_ms, pct(gc_ms, wall_total_ms))
+    if @caps.prof_wall
+      wall_ms = @samples.sum { _1[:wall_ms].to_f }
+      pause_ms = @samples.sum { _1[:pause_ms].to_f }
+      max_pause_ms = @samples.filter_map { _1[:max_pause_ms] }.max || 0.0
+      mean_pause = gc_count.zero? ? 0.0 : pause_ms / gc_count
+      io.printf("GC wall:     %.3f ms  (~%.1f%% of wall)\n", wall_ms, pct(wall_ms, wall_total_ms))
+      io.printf("GC pause:    %.3f ms total  (%.3f ms mean, %.3f ms max, per GC)\n", pause_ms, mean_pause, max_pause_ms)
+      if @caps.prof_pause_split
+        stop_ms = @samples.sum { _1[:stop_ms].to_f }
+        stw_ms  = @samples.sum { _1[:stw_ms].to_f }
+        io.printf("  stop/STW:  %.3f ms / %.3f ms  (ractor-stop ~%.1f%% of pause)\n",
+                  stop_ms, stw_ms, pct(stop_ms, pause_ms))
+      end
+      if @caps.prof_phase_wall
+        # Phase wall is bounded by pause; report against pause rather than
+        # GC wall time because incremental-mark continuation lands in mark wall
+        # but not in GC_WALL_TIME.
+        mark_ms    = @samples.sum { _1[:markw_ms].to_f }
+        sweep_ms   = @samples.sum { _1[:sweepw_ms].to_f }
+        compact_ms = @samples.sum { _1[:compactw_ms].to_f }
+        io.printf("  phase wall: mark %.3f ms (~%.1f%%) / sweep %.3f ms (~%.1f%%)",
+                  mark_ms, pct(mark_ms, pause_ms), sweep_ms, pct(sweep_ms, pause_ms))
+        io.printf(" / compact %.3f ms (~%.1f%%)", compact_ms, pct(compact_ms, pause_ms)) if compact_ms > 0.0
+        io.printf("  (of pause)\n")
+      end
+    end
+    if @caps.prof_detail
+      io.printf("mark/sweep CPU: %.3f ms / %.3f ms\n", @samples.sum { _1[:mark_ms].to_f }, @samples.sum { _1[:sweep_ms].to_f })
+    end
+    if @caps.rgengc_stat
+      io.printf("promoted:    %d objects to oldgen\n", @samples.sum { _1[:promoted] })
+    end
+  end
+
+  private
+
+  def yn(bool) = bool ? "yes" : "no"
+  def pct(part, whole) = whole.to_f.zero? ? 0.0 : 100.0 * part / whole
+  def mono = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+  def format_cell(col, row)
+    value = row[col.key]
+    return "-".rjust(col.w) if value.nil?
+
+    format("%#{col.w}#{col.fmt}", value)
+  end
+
+  # Column set adapts to what this build exposes.
+  def build_columns
+    cols = [
+      Col.new(:t,     "t(s)",  8, ".3f"),
+      Col.new(:gc,    "gc",    4, "d"),
+      Col.new(:minor, "minor", 5, "d"),
+      Col.new(:major, "major", 5, "d"),
+      Col.new(:alloc, "alloc", 10, "d"),
+      Col.new(:freed, "freed", 10, "d"),
+      Col.new(:live,  "live",  9, "d"),
+      Col.new(:gc_ms, "gc_ms", 7, ".2f"),
+    ]
+    if @caps.prof_wall
+      cols << Col.new(:wall_ms,  "wall_ms",  8, ".3f")
+      cols << Col.new(:pause_ms, "pause_ms", 8, ".3f")
+    end
+    if @caps.prof_pause_split
+      cols << Col.new(:stop_ms, "stop_ms", 8, ".3f")
+      cols << Col.new(:stw_ms,  "stw_ms",  8, ".3f")
+    end
+    if @caps.prof_phase_wall
+      cols << Col.new(:markw_ms,    "markW_ms",    8, ".3f")
+      cols << Col.new(:sweepw_ms,   "sweepW_ms",   9, ".3f")
+      cols << Col.new(:compactw_ms, "compactW_ms", 11, ".3f")
+    end
+    cols << Col.new(:mallocmb, "mallocMB", 8, ".1f") # total_malloc_bytes (always present)
+    if @caps.prof_detail
+      cols << Col.new(:mark_ms,  "mark_ms",  8, ".3f")
+      cols << Col.new(:sweep_ms, "sweep_ms", 8, ".3f")
+      cols << Col.new(:empty,    "emptyObj", 9, "d")
+    end
+    if @caps.rgengc_stat
+      cols << Col.new(:promoted, "promoted", 9, "d")
+      cols << Col.new(:shade,    "shade",    6, "d")
+      cols << Col.new(:rem,      "remembrd", 9, "d")
+    end
+    if @caps.prof_rgengc && !@caps.rgengc_stat
+      cols << Col.new(:old, "oldObj", 9, "d")
+    end
+    if @caps.malloc_size
+      cols << Col.new(:malloc_live,  "mallocLiveMB", 12, ".2f")
+      cols << Col.new(:malloc_count, "mallocAllocs", 12, "d")
+    end
+    cols << Col.new(:gc_by, "gc_by", 8, "s")
+    cols
+  end
+
+  def snapshot
+    GC.stat(@buf)
+    s = {
+      t:          mono,
+      count:      @buf[:count],
+      minor:      @buf[:minor_gc_count],
+      major:      @buf[:major_gc_count],
+      alloc:      @buf[:total_allocated_objects],
+      freed:      @buf[:total_freed_objects],
+      live:       @buf[:heap_live_slots],
+      total_time: GC.total_time,
+      malloc_b:   @buf[:total_malloc_bytes] || 0,
+    }
+    if @caps.rgengc_stat
+      s[:promoted] = @buf[:total_promoted_count]
+      s[:shade]    = @buf[:total_shade_operation_count]
+      s[:rem]      = @buf[:total_remembered_normal_object_count]
+    end
+    if @caps.malloc_size
+      s[:malloc_live]  = GC.malloc_allocated_size
+      s[:malloc_count] = GC.malloc_allocations
+    end
+    s
+  end
+
+  def record
+    cur  = snapshot
+    gc_delta = cur[:count] - @prev[:count]
+    row = {
+      t:        (cur[:t] - @t0).round(3),
+      gc:       gc_delta,
+      minor:    cur[:minor] - @prev[:minor],
+      major:    cur[:major] - @prev[:major],
+      alloc:    cur[:alloc] - @prev[:alloc],
+      freed:    cur[:freed] - @prev[:freed],
+      live:     cur[:live],
+      gc_ms:    (cur[:total_time] - @prev[:total_time]) / 1_000_000.0,
+      mallocmb: cur[:malloc_b] / (1024.0 * 1024.0),
+      gc_by:    gc_delta.zero? ? "-" : (GC.latest_gc_info[:gc_by] || "-"),
+    }
+    if @caps.rgengc_stat
+      row[:promoted] = cur[:promoted] - @prev[:promoted]
+      row[:shade]    = cur[:shade]    - @prev[:shade]
+      row[:rem]      = cur[:rem]      - @prev[:rem]
+    end
+    if @caps.malloc_size
+      row[:malloc_live]  = cur[:malloc_live] / (1024.0 * 1024.0)
+      row[:malloc_count] = cur[:malloc_count]
+    end
+    drain_profiler(row) if @use_profiler
+    @samples << row
+    @prev = cur
+  end
+
+  # Aggregate the per-GC profiler records that accrued during this interval,
+  # then clear so the buffer stays bounded.
+  def drain_profiler(row)
+    data = GC::Profiler.raw_data
+    GC::Profiler.clear
+    return if data.nil? || data.empty?
+    @profile_records.concat(data.map(&:dup)) if @raw_profile
+    @caps.prof_wall ||= data.any? { _1.key?(:GC_WALL_TIME) }
+    @caps.prof_pause_split ||= data.any? { _1.key?(:GC_STOP_TIME) }
+    @caps.prof_phase_wall ||= data.any? { _1.key?(:GC_MARK_WALL_TIME) }
+    @caps.prof_detail ||= data.any? { _1.key?(:GC_MARK_TIME) }
+    @caps.prof_rgengc ||= data.any? { _1.key?(:OLD_OBJECTS) }
+    if @caps.prof_wall
+      pauses = data.map { _1[:GC_PAUSE_TIME] || 0.0 }
+      row[:wall_ms] = data.sum { _1[:GC_WALL_TIME] || 0.0 } * 1000.0
+      row[:pause_ms] = pauses.sum * 1000.0
+      row[:max_pause_ms] = (pauses.max || 0.0) * 1000.0
+    end
+    if @caps.prof_pause_split
+      row[:stop_ms] = data.sum { _1[:GC_STOP_TIME] || 0.0 } * 1000.0
+      row[:stw_ms] = data.sum { _1[:GC_STW_TIME] || 0.0 } * 1000.0
+    end
+    if @caps.prof_phase_wall
+      row[:markw_ms]    = data.sum { _1[:GC_MARK_WALL_TIME]    || 0.0 } * 1000.0
+      row[:sweepw_ms]   = data.sum { _1[:GC_SWEEP_WALL_TIME]   || 0.0 } * 1000.0
+      row[:compactw_ms] = data.sum { _1[:GC_COMPACT_WALL_TIME] || 0.0 } * 1000.0
+    end
+    if @caps.prof_detail
+      row[:mark_ms]  = data.sum { _1[:GC_MARK_TIME] || 0.0 }  * 1000.0
+      row[:sweep_ms] = data.sum { _1[:GC_SWEEP_TIME] || 0.0 } * 1000.0
+      row[:empty]    = data.sum { _1[:EMPTY_OBJECTS] || 0 }
+    end
+    if @caps.prof_rgengc && !@caps.rgengc_stat
+      row[:old] = data.last[:OLD_OBJECTS]
+    end
+  end
+end
+
+USAGE = <<~USAGE
+  Usage:
+    #{$PROGRAM_NAME} SCRIPT [ARGS...]
+    #{$PROGRAM_NAME} -e CODE [ARGS...]
+USAGE
+
+def parse_target(argv)
+  case argv.first
+  when "-e"
+    abort USAGE if argv.size < 2
+
+    code = argv[1]
+    args = argv.drop(2)
+    -> {
+      ARGV.replace(args)
+      $0 = "-e"
+      eval(code, TOPLEVEL_BINDING, "-e", 1)
+    }
+  when "-h", "--help"
+    puts USAGE
+    exit true
+  when nil
+    abort USAGE
+  else
+    script = argv.first
+    args = argv.drop(1)
+    abort "#{script}: no such file" unless File.file?(script)
+
+    -> {
+      ARGV.replace(args)
+      $0 = script
+      load File.expand_path(script)
+    }
+  end
+end
+
+if __FILE__ == $0
+  target = parse_target(ARGV.dup)
+  GC.measure_total_time = true if GC.respond_to?(:measure_total_time=)
+  dump_raw = ENV["RAW"] == "1"
+  sampler = GCSampler.new(interval: 0.02, raw_profile: dump_raw)
+  failure = nil
+  exit_status = nil
+
+  sampler.banner
+  begin
+    sampler.run { target.call }
+  rescue SystemExit => error
+    exit_status = error.status
+  rescue Exception => error # rubocop:disable Lint/RescueException
+    failure = error
+  ensure
+    sampler.report
+    sampler.report_raw_profile if dump_raw
+    sampler.summary
+  end
+
+  raise failure if failure
+  exit exit_status unless exit_status.nil?
+end


### PR DESCRIPTION
`GC::Profiler.raw_data` currently reports only CPU time which is usually not the right signal for measuring latency, especially as more workloads start utilising more Ractors.

This PR adds some monotonic wall-clock fields to the GC Profiler. These are in addition to the existing CPU time fields to avoid breaking any existing consumers.

## New Keys

| Key | Meaning |
| --- | --- |
| `:GC_WALL_TIME` | Wall-clock time doing collector work excluding the time taken to stop Ractors. |
| `:GC_INVOKE_WALL_TIME` | Wall-clock time from VM startup to when this GC was invoked. |
| `:GC_PAUSE_TIME` | Wall-clock time mutators were paused for this GC entry, **including** stopping other Ractors. |
| `:GC_STOP_TIME` | Wall-clock time spent stopping other ractors. |
| `:GC_STW_TIME` | Wall-clock time after ractors stopped and before the VM exits GC. |
| `:GC_MARK_WALL_TIME` | Wall-clock time marking, summed across incremental mark phases. |
| `:GC_SWEEP_WALL_TIME` | Wall-clock time sweeping, summed across lazy-sweep phases, excludes compaction |
| `:GC_COMPACT_WALL_TIME` | Wall-clock time compacting, or `0.0` if this GC didn't compact. |

## Implementation Notes

- All measurements are gated behind `GC::Profiler` so require `-DRGENGC_PROFILE=1` same as the existing stuff.
- When building with Modular GC we include a small shim to provide `rb_hrtime_t`, `rb_hrtime_{now, add, sub}`. This is because including `hrtime.h` would otherwise pull in `internal/bits.h` which conflicts with the modGC stub of `nlz_int64`. This is only used when building with modular GC, regular builds just include `hrtime.h`.
- Profiler tests are excluded from MMTk

## Examples. 

We built a small script that runs some contrived examples with the Profiler enabled and captures the output in order to test the new implementation. 

Here is what an example `raw_data` entry contains now:

```
GC_TIME:                   0.007354319999999914   # CPU time (unchanged)
GC_INVOKE_TIME:            0.24365519700000002    # CPU time (unchanged)
GC_WALL_TIME:              0.007385827            # wall analogue of GC_TIME
GC_INVOKE_WALL_TIME:       0.244600797
GC_PAUSE_TIME:             0.00741573             # STOP + STW
GC_STOP_TIME:              0.000001442            # ractor stop
GC_STW_TIME:               0.007414288            # stopped interval after ractors stopped
GC_MARK_WALL_TIME:         0.005778167            # phase attribution
GC_SWEEP_WALL_TIME:        0.001627285
GC_COMPACT_WALL_TIME:      0.0                    # no compaction this GC
HEAP_USE_SIZE:             4215584
HEAP_TOTAL_SIZE:           7524304
HEAP_TOTAL_OBJECTS:        99761
GC_IS_MARKED:              true
```

And we can easily combine these fields into a more comprehensive summary of GC timings during the runtime of an application.

```
GC sampler — ruby 4.1.0dev (2026-06-23T13:29:06Z mvh-gc-profiler-im.. 6d860643e2) +PRISM [x86_64-linux]
optional data sources:
  GC::Profiler raw records        : no
  GC::Profiler wall time fields   : yes
  GC::Profiler pause split fields : yes
  GC::Profiler phase wall fields  : yes
  RGENGC_PROFILE (stat + profiler) : no
  GC_PROFILE_MORE_DETAIL (profiler): no
  MALLOC_ALLOCATED_SIZE (methods)  : no
  GC_PROFILE_DETAIL_MEMORY         : report-only — not samplable

    t(s)   gc minor major      alloc      freed      live   gc_ms  wall_ms pause_ms  stop_ms   stw_ms markW_ms sweepW_ms compactW_ms mallocMB    gc_by
   0.223  114   111     3    5986446    5933007     72871   43.86   35.290   44.503    0.022   44.481    9.520    29.797       5.026     13.0   newobj
   0.344   70    69     1    3234652    3232839     74684   24.11   20.930   24.380    0.012   24.368    4.028    18.438       1.819     13.1   newobj
   0.466   67    66     1    3231481    3232128     74037   23.08   19.982   23.353    0.011   23.342    3.967    17.514       1.788     13.1   newobj
   0.587   63    62     1    3218974    3200839     92172   23.57   20.167   23.822    0.014   23.808    4.140    17.671       1.922     13.1   newobj
   0.708   61    60     1    3288518    3291829     88861   22.37   18.963   22.598    0.012   22.586    4.111    16.626       1.775     13.2   newobj
   0.830   62    61     1    3293899    3295099     87661   22.32   19.138   22.634    0.012   22.622    4.052    16.789       1.702     13.2   newobj
   0.951   60    59     1    3321557    3328980     80238   21.77   18.459   21.972    0.012   21.960    4.029    16.194       1.669     13.2   newobj
   1.072   57    56     1    3280096    3270608     89726   22.09   18.750   22.440    0.012   22.428    4.088    16.448       1.820     13.2   newobj
   1.193   57    56     1    3328546    3333017     85255   21.60   18.231   21.905    0.012   21.893    4.080    15.904       1.835     13.3   newobj
   1.300   49    48     1    2935384    2914545    106094   18.97   15.781   19.254    0.010   19.244    3.636    13.818       1.728     13.3   newobj
   1.300    0     0     0        103          0    106197    0.00    0.000    0.000    0.000    0.000    0.000     0.000       0.000     13.3   newobj

wall:        1.300 s
GCs:         648 minor + 12 major
objects:     35119656 allocated, 35032891 freed
GC CPU time: 243.721 ms  (~18.7% of wall)
GC wall:     205.691 ms  (~15.8% of wall)
GC pause:    246.860 ms total  (0.374 ms mean, 3.431 ms max, per GC)
  stop/STW:  0.129 ms / 246.731 ms  (ractor-stop ~0.1% of pause)
  phase wall: mark 45.650 ms (~18.5%) / sweep 179.199 ms (~72.6%) / compact 21.085 ms (~8.5%)  (of pause)
```