### PR TITLE
ZJIT: Add quick checks to bail out of inlining early

### DIFF
--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -4465,6 +4465,19 @@ impl Function {
     /// Inline method calls by replacing eligible SendDirect instructions with the
     /// callee's HIR body. Returns true if any inlining occurred.
     fn inline_methods(&mut self) -> bool {
+        // Bail early if inlining is disabled.
+        if get_option!(inline_threshold) == 0 {
+            return false;
+        }
+
+        // Fail fast if inlining is enabled but we've exhausted our inlining budget.
+        // Otherwise, `can_inline` and `should_inline` will make local inlining decisions.
+        let budget = get_option!(inline_budget);
+        if budget != INLINE_BUDGET_UNLIMITED && self.insns.len() > budget {
+            incr_counter!(inline_reject_budget_exceeded);
+            return false;
+        }
+
         let mut did_inline = false;
 
         // Worklist of blocks left to scan for inlinable SendDirects. Seeded with

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -43,6 +43,7 @@ macro_rules! hir_comment {
 
 #[allow(unused_imports)]
 pub(crate) use hir_comment;
+use crate::options::INLINE_BUDGET_UNLIMITED;
 
 /// An index of an [`Insn`] in a [`Function`]. This is a popular
 /// type since this effectively acts as a pointer to an [`Insn`].
@@ -4424,9 +4425,9 @@ impl Function {
         // allocated for this function — not the final compiled size. Once that count
         // crosses the budget, every further callee is rejected and the optimization
         // fixed-point loop reaches its terminal iteration. See `Options::inline_budget`
-        // for the full unit/semantics caveat. Budget == 0 disables this cap.
+        // for the full unit/semantics caveat.
         let budget = get_option!(inline_budget);
-        if budget != 0 && self.insns.len() > budget {
+        if budget != INLINE_BUDGET_UNLIMITED && self.insns.len() > budget {
             incr_counter!(inline_reject_budget_exceeded);
             return false;
         }

--- a/zjit/src/options.rs
+++ b/zjit/src/options.rs
@@ -30,6 +30,7 @@ pub type InlineThreshold = usize;
 
 /// Default --zjit-inline-budget
 pub const DEFAULT_INLINE_BUDGET: InlineBudget = 500;
+pub const INLINE_BUDGET_UNLIMITED: InlineBudget = 0;
 pub type InlineBudget = usize;
 
 /// Default --zjit-inline-max-iterations
@@ -145,8 +146,8 @@ pub struct Options {
     /// `inline_methods` inside the `optimize()` fixed-point loop). Once a caller has
     /// grown past this many HIR instructions, `should_inline` rejects further callees,
     /// bounding runaway code-size growth from depth-N inlining (and providing the
-    /// optimization fixed-point loop's effective terminating condition). 0 disables
-    /// the budget.
+    /// optimization fixed-point loop's effective terminating condition).
+    /// `INLINE_BUDGET_UNLIMITED` disables the budget.
     ///
     /// Caveat on the unit: `self.insns` is append-only across the whole pipeline —
     /// `InsnId`s are stable indices into it, so passes never shrink it. `len()` is

--- a/zjit/src/stats.rs
+++ b/zjit/src/stats.rs
@@ -465,8 +465,10 @@ make_counters! {
     invokeblock_handler_megamorphic,
     invokeblock_handler_no_profiles,
 
-    // HIR-level method inliner (inline_methods) counters. These are incremented
-    // at compile time, once per SendDirect the inliner considers.
+    // HIR-level method inliner counters. Most rejection counters are incremented
+    // once per SendDirect the inliner considers. inline_reject_budget_exceeded may
+    // be incremented only once, rather than once per SendDirect, if the caller
+    // already exceeds the budget before scanning for its SendDirects.
     inline_method_count,
     inline_reject_too_large,
     inline_reject_complex_params,


### PR DESCRIPTION
While these checks were already being performed, they did so after scanning the caller's blocks. We want to avoid that work when we know inlining cannot be performed.