### PR TITLE
Feature/hash colon pattern matching

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -7765,10 +7765,26 @@ iseq_compile_pattern_each(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *c
 
         if (RNODE_HSHPTN(node)->nd_pkwargs && !RNODE_HSHPTN(node)->nd_pkwrestarg) {
             const NODE *kw_args = RNODE_HASH(RNODE_HSHPTN(node)->nd_pkwargs)->nd_head;
-            keys = rb_ary_new_capa(kw_args ? RNODE_LIST(kw_args)->as.nd_alen/2 : 0);
-            while (kw_args) {
-                rb_ary_push(keys, get_symbol_value(iseq, RNODE_LIST(kw_args)->nd_head));
-                kw_args = RNODE_LIST(RNODE_LIST(kw_args)->nd_next)->nd_next;
+            bool all_symbol_keys = true;
+            const NODE *check_args = kw_args;
+            while (check_args) {
+                if (!nd_type_p(RNODE_LIST(check_args)->nd_head, NODE_SYM)) {
+                    all_symbol_keys = false;
+                    break;
+                }
+                check_args = RNODE_LIST(RNODE_LIST(check_args)->nd_next)->nd_next;
+            }
+            if (all_symbol_keys) {
+                if (kw_args) {
+                    keys = rb_ary_new_capa(RNODE_LIST(kw_args)->as.nd_alen/2);
+                    while (kw_args) {
+                        rb_ary_push(keys, rb_node_sym_string_val(RNODE_LIST(kw_args)->nd_head));
+                        kw_args = RNODE_LIST(RNODE_LIST(kw_args)->nd_next)->nd_next;
+                    }
+                }
+                else {
+                    keys = rb_ary_new_capa(0);
+                }
             }
         }
 
@@ -7812,38 +7828,135 @@ iseq_compile_pattern_each(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *c
                 for (i = 0; i < keys_num; i++) {
                     NODE *key_node = RNODE_LIST(args)->nd_head;
                     NODE *value_node = RNODE_LIST(RNODE_LIST(args)->nd_next)->nd_head;
-                    VALUE key = get_symbol_value(iseq, key_node);
-
-                    ADD_INSN(ret, line_node, dup);
-                    ADD_INSN1(ret, line_node, putobject, key);
-                    ADD_SEND(ret, line_node, rb_intern("key?"), INT2FIX(1)); // (3)
-                    if (in_single_pattern) {
-                        LABEL *match_succeeded;
-                        match_succeeded = NEW_LABEL(line);
+                    if (nd_type_p(key_node, NODE_SYM)) {
+                        VALUE key = get_symbol_value(iseq, key_node);
 
                         ADD_INSN(ret, line_node, dup);
-                        ADD_INSNL(ret, line_node, branchif, match_succeeded);
+                        ADD_INSN1(ret, line_node, putobject, key);
+                        ADD_SEND(ret, line_node, rb_intern("key?"), INT2FIX(1)); // (3)
+                        if (in_single_pattern) {
+                            LABEL *match_succeeded;
+                            match_succeeded = NEW_LABEL(line);
 
-                        VALUE str = rb_str_freeze(rb_sprintf("key not found: %+"PRIsVALUE, key));
-                        ADD_INSN1(ret, line_node, putobject, RB_OBJ_SET_SHAREABLE(str)); // (4)
-                        ADD_INSN1(ret, line_node, setn, INT2FIX(base_index + CASE3_BI_OFFSET_ERROR_STRING + 2 /* (3), (4) */));
-                        ADD_INSN1(ret, line_node, putobject, Qtrue); // (5)
-                        ADD_INSN1(ret, line_node, setn, INT2FIX(base_index + CASE3_BI_OFFSET_KEY_ERROR_P + 3 /* (3), (4), (5) */));
-                        ADD_INSN1(ret, line_node, topn, INT2FIX(3)); // (6)
-                        ADD_INSN1(ret, line_node, setn, INT2FIX(base_index + CASE3_BI_OFFSET_KEY_ERROR_MATCHEE + 4 /* (3), (4), (5), (6) */));
-                        ADD_INSN1(ret, line_node, putobject, key); // (7)
-                        ADD_INSN1(ret, line_node, setn, INT2FIX(base_index + CASE3_BI_OFFSET_KEY_ERROR_KEY + 5 /* (3), (4), (5), (6), (7) */));
+                            ADD_INSN(ret, line_node, dup);
+                            ADD_INSNL(ret, line_node, branchif, match_succeeded);
 
-                        ADD_INSN1(ret, line_node, adjuststack, INT2FIX(4));
+                            VALUE str = rb_str_freeze(rb_sprintf("key not found: %+"PRIsVALUE, key));
+                            ADD_INSN1(ret, line_node, putobject, RB_OBJ_SET_SHAREABLE(str)); // (4)
+                            ADD_INSN1(ret, line_node, setn, INT2FIX(base_index + CASE3_BI_OFFSET_ERROR_STRING + 2 /* (3), (4) */));
+                            ADD_INSN1(ret, line_node, putobject, Qtrue); // (5)
+                            ADD_INSN1(ret, line_node, setn, INT2FIX(base_index + CASE3_BI_OFFSET_KEY_ERROR_P + 3 /* (3), (4), (5) */));
+                            ADD_INSN1(ret, line_node, topn, INT2FIX(3)); // (6)
+                            ADD_INSN1(ret, line_node, setn, INT2FIX(base_index + CASE3_BI_OFFSET_KEY_ERROR_MATCHEE + 4 /* (3), (4), (5), (6) */));
+                            ADD_INSN1(ret, line_node, putobject, key); // (7)
+                            ADD_INSN1(ret, line_node, setn, INT2FIX(base_index + CASE3_BI_OFFSET_KEY_ERROR_KEY + 5 /* (3), (4), (5), (6), (7) */));
 
-                        ADD_LABEL(ret, match_succeeded);
+                            ADD_INSN1(ret, line_node, adjuststack, INT2FIX(4));
+
+                            ADD_LABEL(ret, match_succeeded);
+                        }
+                        ADD_INSNL(ret, line_node, branchunless, match_failed);
+
+                        ADD_INSN(match_values, line_node, dup);
+                        ADD_INSN1(match_values, line_node, putobject, key);
+                        ADD_SEND(match_values, line_node, RNODE_HSHPTN(node)->nd_pkwrestarg ? rb_intern("delete") : idAREF, INT2FIX(1)); // (8)
+                        CHECK(iseq_compile_pattern_match(iseq, match_values, value_node, match_failed, in_single_pattern, in_alt_pattern, base_index + 1, false));
                     }
-                    ADD_INSNL(ret, line_node, branchunless, match_failed);
+                    else {
+                        NODE *capture_target = NULL;
+                        NODE *grep_pattern = key_node;
+                        if (nd_type_p(key_node, NODE_HASH)) {
+                            const NODE *list = RNODE_HASH(key_node)->nd_head;
+                            if (list && nd_type_p(list, NODE_LIST) && RNODE_LIST(list)->as.nd_alen == 2 &&
+                                    (nd_type_p(RNODE_LIST(RNODE_LIST(list)->nd_next)->nd_head, NODE_LASGN) ||
+                                     nd_type_p(RNODE_LIST(RNODE_LIST(list)->nd_next)->nd_head, NODE_DASGN))) {
+                                grep_pattern = RNODE_LIST(list)->nd_head;
+                                capture_target = RNODE_LIST(RNODE_LIST(list)->nd_next)->nd_head;
+                            }
+                        }
+                        ADD_INSN(ret, line_node, dup);
+                        ADD_SEND(ret, line_node, rb_intern("keys"), INT2FIX(0));
+                        if (nd_type_p(grep_pattern, NODE_ARYPTN)) {
+                            const NODE *args = RNODE_ARYPTN(grep_pattern)->pre_args;
+                            int len = 0;
+                            DECL_ANCHOR(ary);
+                            INIT_ANCHOR(ary);
+                            while (args) {
+                                CHECK(COMPILE_(ary, "key", RNODE_LIST(args)->nd_head, FALSE));
+                                len++;
+                                args = RNODE_LIST(args)->nd_next;
+                            }
+                            ADD_INSN1(ary, line_node, newarray, INT2FIX(len));
+                            ADD_SEQ(ret, ary);
+                        }
+                        else {
+                            CHECK(COMPILE_(ret, "key", grep_pattern, FALSE));
+                        }
+                        ADD_SEND(ret, line_node, rb_intern("grep"), INT2FIX(1));
 
-                    ADD_INSN(match_values, line_node, dup);
-                    ADD_INSN1(match_values, line_node, putobject, key);
-                    ADD_SEND(match_values, line_node, RNODE_HSHPTN(node)->nd_pkwrestarg ? rb_intern("delete") : idAREF, INT2FIX(1)); // (8)
-                    CHECK(iseq_compile_pattern_match(iseq, match_values, value_node, match_failed, in_single_pattern, in_alt_pattern, base_index + 1 /* (8) */, false));
+                        LABEL *loop_start_label = NEW_LABEL(line);
+                        LABEL *keys_exhausted_label = NEW_LABEL(line);
+                        LABEL *value_matched_label = NEW_LABEL(line);
+
+                        ADD_LABEL(ret, loop_start_label);
+
+                        ADD_INSN(ret, line_node, dup);
+                        ADD_SEND(ret, line_node, rb_intern("shift"), INT2FIX(0));
+
+                        ADD_INSN(ret, line_node, dup);
+                        ADD_SEND(ret, line_node, rb_intern("nil?"), INT2FIX(0));
+                        ADD_INSNL(ret, line_node, branchif, keys_exhausted_label);
+
+                        if (capture_target) {
+                            ADD_INSN(ret, line_node, dup);
+                            if (nd_type_p(capture_target, NODE_DASGN)) {
+                                int idx, lv, ls;
+                                ID id = RNODE_DASGN(capture_target)->nd_vid;
+                                idx = get_dyna_var_idx(iseq, id, &lv, &ls);
+                                ADD_SETLOCAL(ret, line_node, ls - idx, lv);
+                            }
+                            else {
+                                ID id = RNODE_LASGN(capture_target)->nd_vid;
+                                struct rb_iseq_constant_body *const body = ISEQ_BODY(iseq);
+                                int idx = ISEQ_BODY(body->local_iseq)->local_table_size - get_local_var_idx(iseq, id);
+                                ADD_SETLOCAL(ret, line_node, idx, get_lvar_level(iseq));
+                            }
+                        }
+
+                        ADD_INSN(ret, line_node, dup);
+                        ADD_INSN1(ret, line_node, topn, INT2FIX(3));
+                        ADD_INSN(ret, line_node, swap);
+                        ADD_SEND(ret, line_node, idAREF, INT2FIX(1));
+
+                        LABEL *value_failed_label = NEW_LABEL(line);
+                        CHECK(iseq_compile_pattern_match(iseq, ret, value_node, value_failed_label, false, in_alt_pattern, base_index + 2, false));
+                        if (RNODE_HSHPTN(node)->nd_pkwrestarg) {
+                            ADD_INSN1(ret, line_node, topn, INT2FIX(2));
+                            ADD_INSN(ret, line_node, swap);
+                            ADD_SEND(ret, line_node, rb_intern("delete"), INT2FIX(1));
+                            ADD_INSN(ret, line_node, pop);
+                            ADD_INSN(ret, line_node, pop);
+                        }
+                        else {
+                            ADD_INSN(ret, line_node, pop);
+                            ADD_INSN(ret, line_node, pop);
+                        }
+                        ADD_INSNL(ret, line_node, jump, value_matched_label);
+
+                        ADD_LABEL(ret, value_failed_label);
+                        ADD_INSN(ret, line_node, pop);
+                        ADD_INSN(ret, line_node, pop);
+                        ADD_INSNL(ret, line_node, jump, loop_start_label);
+
+                        ADD_LABEL(ret, keys_exhausted_label);
+                        ADD_INSN(ret, line_node, pop);
+                        ADD_INSN(ret, line_node, pop);
+                        ADD_INSN1(ret, line_node, putobject, Qfalse);
+                        ADD_INSN(ret, line_node, pop);
+                        ADD_INSNL(ret, line_node, jump, match_failed);
+
+                        ADD_LABEL(ret, value_matched_label);
+                    }
                     args = RNODE_LIST(RNODE_LIST(args)->nd_next)->nd_next;
                 }
                 ADD_SEQ(ret, match_values);

--- a/doc/syntax/pattern_matching.rdoc
+++ b/doc/syntax/pattern_matching.rdoc
@@ -70,7 +70,44 @@ Patterns can be:
 Any pattern can be nested inside array/find/hash patterns where <code><subpattern></code> is specified.
 
 Array patterns and find patterns match arrays, or objects that respond to +deconstruct+ (see below about the latter).
-Hash patterns match hashes, or objects that respond to +deconstruct_keys+ (see below about the latter). Note that only symbol keys are supported for hash patterns.
+Hash patterns match hashes, or objects that respond to +deconstruct_keys+ (see below about the latter). Keys can be symbols, strings, or arbitrary expressions that respond to +===+.
+
+  case {"a" => 1, "b" => 2}
+  in {"a" : Integer, "b" : String}
+    "matched"
+  end
+  #=> "matched"
+
+  case {1 => "ok"}
+  in {Integer : String}
+    "matched"
+  end
+  #=> "matched"
+
+Expression keys can also be captured:
+
+  case {1 => "ok"}
+  in {Integer => k : String}
+    k #=> 1
+  end
+
+  case {1 => "ok"}
+  in {Integer => k : String => v}
+    [k, v] #=> [1, "ok"]
+  end
+
+Mixed symbol and expression keys:
+
+  case {a: 1, 200 => "ok"}
+  in {a: Integer, Integer : String}
+    "matched"
+  end
+  #=> "matched"
+
+  case {a: 1, 200 => "ok"}
+  in {a: Integer, Integer => k : String}
+    k #=> 200
+  end
 
 An important difference between array and hash pattern behavior is that arrays match only a _whole_ array:
 
@@ -139,6 +176,13 @@ Both array and hash patterns support "rest" specification:
     "not matched"
   end
   #=> "matched"
+
+Rest pattern with expression keys:
+
+  case {200 => "ok", 300 => "fail"}
+  in {Integer : String => v, **rest}
+    [v, rest] #=> ["ok", {300 => "fail"}]
+  end
 
 Parentheses around both kinds of patterns could be omitted:
 
@@ -490,9 +534,11 @@ Approximate syntax is:
               | Constant(*variable, pattern, ..., *variable)
               | Constant[*variable, pattern, ..., *variable]
 
-  hash_pattern: {key: pattern, key:, ..., **variable}
-              | Constant(key: pattern, key:, ..., **variable)
-              | Constant[key: pattern, key:, ..., **variable]
+hash_pattern: {key: pattern, key:, ..., **variable}
+               | {expression: pattern, key:, ..., **variable}
+               | {expression => variable: pattern, ..., **variable}
+               | Constant(key: pattern, key:, ..., **variable)
+               | Constant[key: pattern, key:, ..., **variable]
 
 == Appendix B. Some undefined behavior examples
 

--- a/parse.y
+++ b/parse.y
@@ -6624,6 +6624,11 @@ assoc		: arg_value tASSOC arg_value
                         $$ = list_append(p, NEW_LIST($1, &@$), $3);
                     /*% ripper: assoc_new!($:1, $:3) %*/
                     }
+                | arg_value ':' arg_value
+                    {
+                        $$ = list_append(p, NEW_LIST($1, &@$), $3);
+                    /*% ripper: assoc_new!($:1, $:3) %*/
+                    }
                 | tLABEL arg_value
                     {
                         $$ = list_append(p, NEW_LIST(NEW_SYM(rb_id2str($1), &@1), &@$), $2);

--- a/parse.y
+++ b/parse.y
@@ -2789,7 +2789,7 @@ rb_parser_ary_free(rb_parser_t *p, rb_parser_ary_t *ary)
 %type <node> p_expr p_as p_alt p_expr_basic p_find
 %type <node> p_args p_args_head p_args_tail p_args_post p_arg p_rest
 %type <node> p_value p_primitive p_variable p_var_ref p_expr_ref p_const
-%type <node> p_kwargs p_kwarg p_kw
+%type <node> p_kwargs p_kwarg p_kw p_kw_expr_key
 %type <id>   keyword_variable user_variable sym operation2 operation3
 %type <id>   cname fname op f_rest_arg f_block_arg opt_comma f_norm_arg f_bad_arg
 %type <id>   f_kwrest f_label f_arg_asgn call_op call_op2 reswords relop dot_or_colon
@@ -2867,6 +2867,7 @@ rb_parser_ary_free(rb_parser_t *p, rb_parser_ary_t *ary)
  */
 
 %nonassoc tLOWEST
+%nonassoc tASSOC
 %nonassoc tLBRACE_ARG
 
 %nonassoc  modifier_if modifier_unless modifier_while modifier_until keyword_in
@@ -5678,6 +5679,17 @@ p_kw		: p_kw_label p_expr
                         error_duplicate_pattern_variable(p, $1, &@1);
                         $$ = list_append(p, NEW_LIST(NEW_SYM(rb_id2str($1), &@$), &@$), assignable(p, $1, 0, &@$));
                     /*% ripper: [$:1, Qnil] %*/
+                    }
+                | p_kw_expr_key ':' p_expr %prec tLOWEST
+                    {
+                        $$ = list_append(p, NEW_LIST($1, &@$), $3);
+                    /*% ripper: [$:1, $:3] %*/
+                    }
+                ;
+
+p_kw_expr_key	: p_expr
+                    {
+                        $$ = $1;
                     }
                 ;
 

--- a/prism/prism.c
+++ b/prism/prism.c
@@ -13785,8 +13785,12 @@ parse_assocs(pm_parser_t *parser, pm_static_literals_t *literals, pm_node_t *nod
 
                 pm_token_t operator = { 0 };
                 if (!pm_symbol_node_label_p(parser, key)) {
-                    expect1(parser, PM_TOKEN_EQUAL_GREATER, PM_ERR_HASH_ROCKET);
-                    operator = parser->previous;
+                    if (accept1(parser, PM_TOKEN_COLON)) {
+                        operator = parser->previous;
+                    } else {
+                        expect1(parser, PM_TOKEN_EQUAL_GREATER, PM_ERR_HASH_ROCKET);
+                        operator = parser->previous;
+                    }
                 }
 
                 pm_node_t *value = parse_value_expression(parser, PM_BINDING_POWER_DEFINED, PM_PARSE_ACCEPTS_DO_BLOCK, PM_ERR_HASH_VALUE, (uint16_t) (depth + 1));

--- a/prism/prism.c
+++ b/prism/prism.c
@@ -17120,17 +17120,40 @@ parse_pattern_hash(pm_parser_t *parser, pm_constant_id_list_t *captures, pm_node
         }
         PRISM_FALLTHROUGH
         default: {
-            if (match1(parser, PM_TOKEN_COLON)) {
-                parser_lex(parser);
+            pm_node_t *key = first_node;
+
+            if (accept1(parser, PM_TOKEN_EQUAL_GREATER)) {
+                pm_token_t operator = parser->previous;
+                expect1(parser, PM_TOKEN_IDENTIFIER, PM_ERR_PATTERN_IDENT_AFTER_HROCKET);
+                pm_constant_id_t constant_id = pm_parser_constant_id_token(parser, &parser->previous);
+
+                int depth;
+                if ((depth = pm_parser_local_depth_constant_id(parser, constant_id)) == -1) {
+                    pm_parser_local_add(parser, constant_id, parser->previous.start, parser->previous.end, 0);
+                }
+
+                parse_pattern_capture(parser, captures, constant_id, &TOK2LOC(parser, &parser->previous));
+
+                pm_local_variable_target_node_t *target = pm_local_variable_target_node_create(
+                    parser,
+                    &TOK2LOC(parser, &parser->previous),
+                    constant_id,
+                    (uint32_t) (depth == -1 ? 0 : depth)
+                );
+
+                key = UP(pm_capture_pattern_node_create(parser, first_node, target, &operator));
+            }
+
+            if (accept1(parser, PM_TOKEN_COLON)) {
                 pm_node_t *value = parse_pattern(parser, captures, PM_PARSE_PATTERN_SINGLE, PM_ERR_PATTERN_EXPRESSION_AFTER_KEY, (uint16_t) (depth + 1));
-                pm_node_t *assoc = UP(pm_assoc_node_create(parser, first_node, NULL, value));
+                pm_node_t *assoc = UP(pm_assoc_node_create(parser, key, NULL, value));
                 pm_node_list_append(parser->arena, &assocs, assoc);
             } else {
                 pm_diagnostic_id_t diag_id = PM_NODE_TYPE_P(first_node, PM_INTERPOLATED_SYMBOL_NODE) ? PM_ERR_PATTERN_HASH_KEY_INTERPOLATED : PM_ERR_PATTERN_HASH_KEY_LABEL;
-                pm_parser_err_node(parser, first_node, diag_id);
+                pm_parser_err_node(parser, key, diag_id);
 
                 pm_node_t *value = UP(pm_error_recovery_node_create(parser, PM_NODE_START(first_node), PM_NODE_LENGTH(first_node)));
-                pm_node_t *assoc = UP(pm_assoc_node_create(parser, first_node, NULL, value));
+                pm_node_t *assoc = UP(pm_assoc_node_create(parser, key, NULL, value));
 
                 pm_node_list_append(parser->arena, &assocs, assoc);
             }
@@ -17179,11 +17202,50 @@ parse_pattern_hash(pm_parser_t *parser, pm_constant_id_list_t *captures, pm_node
             } else if (accept1(parser, PM_TOKEN_LABEL)) {
                 key = UP(pm_symbol_node_label_create(parser, &parser->previous));
                 is_label = true;
+            } else if (match1(parser, PM_TOKEN_PARENTHESIS_LEFT)) {
+                pm_token_t opening = parser->current;
+                parser_lex(parser);
+
+                key = parse_pattern(parser, captures, PM_PARSE_PATTERN_SINGLE, PM_ERR_PATTERN_EXPRESSION_AFTER_PAREN, (uint16_t) (depth + 1));
+                accept1(parser, PM_TOKEN_NEWLINE);
+                expect1_opening(parser, PM_TOKEN_PARENTHESIS_RIGHT, PM_ERR_PATTERN_TERM_PAREN, &opening);
+
+                if (accept1(parser, PM_TOKEN_EQUAL_GREATER)) {
+                    key = parse_pattern_capture_target(parser, captures, key);
+                }
+
+                if (accept1(parser, PM_TOKEN_COLON)) {
+                    // Key-value separator found.
+                } else {
+                    pm_parser_err_node(parser, key, PM_ERR_PATTERN_HASH_KEY_LABEL);
+                }
             } else {
                 key = parse_expression(parser, PM_BINDING_POWER_MAX, PM_PARSE_ACCEPTS_LABEL | PM_PARSE_ACCEPTS_DO_BLOCK, PM_ERR_PATTERN_HASH_KEY_LABEL, (uint16_t) (depth + 1));
 
-                if (match1(parser, PM_TOKEN_COLON)) {
-                    parser_lex(parser);
+                if (accept1(parser, PM_TOKEN_EQUAL_GREATER)) {
+                    pm_token_t operator = parser->previous;
+                    expect1(parser, PM_TOKEN_IDENTIFIER, PM_ERR_PATTERN_IDENT_AFTER_HROCKET);
+                    pm_constant_id_t constant_id = pm_parser_constant_id_token(parser, &parser->previous);
+
+                    int depth;
+                    if ((depth = pm_parser_local_depth_constant_id(parser, constant_id)) == -1) {
+                        pm_parser_local_add(parser, constant_id, parser->previous.start, parser->previous.end, 0);
+                    }
+
+                    parse_pattern_capture(parser, captures, constant_id, &TOK2LOC(parser, &parser->previous));
+
+                    pm_local_variable_target_node_t *target = pm_local_variable_target_node_create(
+                        parser,
+                        &TOK2LOC(parser, &parser->previous),
+                        constant_id,
+                        (uint32_t) (depth == -1 ? 0 : depth)
+                    );
+
+                    key = UP(pm_capture_pattern_node_create(parser, key, target, &operator));
+                }
+
+                if (accept1(parser, PM_TOKEN_COLON)) {
+                    // Key-value separator found.
                 } else {
                     pm_parser_err_node(parser, key, PM_ERR_PATTERN_HASH_KEY_LABEL);
                 }
@@ -17331,14 +17393,50 @@ parse_pattern_primitive(pm_parser_t *parser, pm_constant_id_list_t *captures, pm
                         first_node = UP(pm_error_recovery_node_create(parser, PM_TOKEN_START(parser, &parser->previous), PM_TOKEN_LENGTH(&parser->previous)));
                         break;
                     }
+                    case PM_TOKEN_CARET:
+                        first_node = parse_pattern_primitive(parser, captures, PM_ERR_PATTERN_HASH_KEY_LABEL, (uint16_t) (depth + 1));
+                        break;
+                    case PM_TOKEN_PARENTHESIS_LEFT: {
+                        pm_token_t opening = parser->current;
+                        parser_lex(parser);
+
+                        pm_node_t *body = parse_pattern(parser, captures, PM_PARSE_PATTERN_SINGLE, PM_ERR_PATTERN_EXPRESSION_AFTER_PAREN, (uint16_t) (depth + 1));
+                        accept1(parser, PM_TOKEN_NEWLINE);
+                        expect1_opening(parser, PM_TOKEN_PARENTHESIS_RIGHT, PM_ERR_PATTERN_TERM_PAREN, &opening);
+                        first_node = body;
+                        break;
+                    }
                     default:
-                        /*
-                         * Use parse_expression here because this token is not
-                         * a label or **, so we parse it as an expression first.
-                         * parse_pattern_hash will then re-interpret it as a
-                         * hash pattern key, potentially followed by : or =>.
-                         */
-                        first_node = parse_expression(parser, PM_BINDING_POWER_MAX, PM_PARSE_ACCEPTS_DO_BLOCK | PM_PARSE_ACCEPTS_LABEL, PM_ERR_PATTERN_HASH_KEY_LABEL, (uint16_t) (depth + 1));
+                        first_node = parse_expression(parser, PM_BINDING_POWER_MAX, PM_PARSE_ACCEPTS_LABEL | PM_PARSE_ACCEPTS_DO_BLOCK, PM_ERR_PATTERN_HASH_KEY_LABEL, (uint16_t) (depth + 1));
+                        // parse_expression handles => as rightward assignment
+                        // (MatchRequiredNode), but in hash pattern keys it should be
+                        // a capture pattern (CapturePatternNode). Convert here.
+                        {
+                            pm_node_t *inner = first_node;
+
+                            // Unwrap ParenthesesNode if present
+                            if (PM_NODE_TYPE_P(inner, PM_PARENTHESES_NODE)) {
+                                inner = ((const pm_parentheses_node_t *) inner)->body;
+                                if (PM_NODE_TYPE_P(inner, PM_STATEMENTS_NODE) && ((const pm_statements_node_t *) inner)->body.size == 1) {
+                                    inner = ((const pm_statements_node_t *) inner)->body.nodes[0];
+                                }
+                            }
+
+                            if (PM_NODE_TYPE_P(inner, PM_MATCH_REQUIRED_NODE)) {
+                                const pm_match_required_node_t *match = (const pm_match_required_node_t *) inner;
+                                if (PM_NODE_TYPE_P(match->pattern, PM_LOCAL_VARIABLE_TARGET_NODE)) {
+                                    const pm_local_variable_target_node_t *target = (const pm_local_variable_target_node_t *) match->pattern;
+                                    parse_pattern_capture(parser, captures, target->name, &((const pm_node_t *) match->pattern)->location);
+                                    first_node = UP(pm_capture_pattern_node_new(
+                                        parser->arena, ++parser->node_id, 0,
+                                        PM_LOCATION_INIT_NODES(match->value, match->pattern),
+                                        match->value,
+                                        (pm_local_variable_target_node_t *) match->pattern,
+                                        match->operator_loc
+                                    ));
+                                }
+                            }
+                        }
                         break;
                 }
 
@@ -17361,6 +17459,9 @@ parse_pattern_primitive(pm_parser_t *parser, pm_constant_id_list_t *captures, pm
 
             parser->pattern_matching_newlines = previous_pattern_matching_newlines;
             return UP(node);
+        }
+        case PM_TOKEN_PARENTHESIS_LEFT: {
+            return parse_expression(parser, PM_BINDING_POWER_MAX, PM_PARSE_ACCEPTS_LABEL | PM_PARSE_ACCEPTS_DO_BLOCK, diag_id, (uint16_t) (depth + 1));
         }
         case PM_TOKEN_UDOT_DOT:
         case PM_TOKEN_UDOT_DOT_DOT: {

--- a/prism/prism.c
+++ b/prism/prism.c
@@ -17077,6 +17077,34 @@ parse_pattern_hash_key(pm_parser_t *parser, pm_static_literals_t *keys, pm_node_
 }
 
 /**
+ * Parse a capture target after => has already been consumed. Expects an
+ * identifier and returns a CapturePatternNode wrapping the given pattern node.
+ */
+static pm_node_t *
+parse_pattern_capture_target(pm_parser_t *parser, pm_constant_id_list_t *captures, pm_node_t *node) {
+
+    pm_token_t operator = parser->previous;
+    expect1(parser, PM_TOKEN_IDENTIFIER, PM_ERR_PATTERN_IDENT_AFTER_HROCKET);
+    pm_constant_id_t constant_id = pm_parser_constant_id_token(parser, &parser->previous);
+
+    int depth;
+    if ((depth = pm_parser_local_depth_constant_id(parser, constant_id)) == -1) {
+        pm_parser_local_add(parser, constant_id, parser->previous.start, parser->previous.end, 0);
+    }
+
+    parse_pattern_capture(parser, captures, constant_id, &TOK2LOC(parser, &parser->previous));
+
+    pm_local_variable_target_node_t *target = pm_local_variable_target_node_create(
+        parser,
+        &TOK2LOC(parser, &parser->previous),
+        constant_id,
+        (uint32_t) (depth == -1 ? 0 : depth)
+    );
+
+    return UP(pm_capture_pattern_node_create(parser, node, target, &operator));
+}
+
+/**
  * Parse a hash pattern.
  */
 static pm_hash_pattern_node_t *
@@ -17123,25 +17151,7 @@ parse_pattern_hash(pm_parser_t *parser, pm_constant_id_list_t *captures, pm_node
             pm_node_t *key = first_node;
 
             if (accept1(parser, PM_TOKEN_EQUAL_GREATER)) {
-                pm_token_t operator = parser->previous;
-                expect1(parser, PM_TOKEN_IDENTIFIER, PM_ERR_PATTERN_IDENT_AFTER_HROCKET);
-                pm_constant_id_t constant_id = pm_parser_constant_id_token(parser, &parser->previous);
-
-                int depth;
-                if ((depth = pm_parser_local_depth_constant_id(parser, constant_id)) == -1) {
-                    pm_parser_local_add(parser, constant_id, parser->previous.start, parser->previous.end, 0);
-                }
-
-                parse_pattern_capture(parser, captures, constant_id, &TOK2LOC(parser, &parser->previous));
-
-                pm_local_variable_target_node_t *target = pm_local_variable_target_node_create(
-                    parser,
-                    &TOK2LOC(parser, &parser->previous),
-                    constant_id,
-                    (uint32_t) (depth == -1 ? 0 : depth)
-                );
-
-                key = UP(pm_capture_pattern_node_create(parser, first_node, target, &operator));
+                key = parse_pattern_capture_target(parser, captures, first_node);
             }
 
             if (accept1(parser, PM_TOKEN_COLON)) {
@@ -17223,25 +17233,7 @@ parse_pattern_hash(pm_parser_t *parser, pm_constant_id_list_t *captures, pm_node
                 key = parse_expression(parser, PM_BINDING_POWER_MAX, PM_PARSE_ACCEPTS_LABEL | PM_PARSE_ACCEPTS_DO_BLOCK, PM_ERR_PATTERN_HASH_KEY_LABEL, (uint16_t) (depth + 1));
 
                 if (accept1(parser, PM_TOKEN_EQUAL_GREATER)) {
-                    pm_token_t operator = parser->previous;
-                    expect1(parser, PM_TOKEN_IDENTIFIER, PM_ERR_PATTERN_IDENT_AFTER_HROCKET);
-                    pm_constant_id_t constant_id = pm_parser_constant_id_token(parser, &parser->previous);
-
-                    int depth;
-                    if ((depth = pm_parser_local_depth_constant_id(parser, constant_id)) == -1) {
-                        pm_parser_local_add(parser, constant_id, parser->previous.start, parser->previous.end, 0);
-                    }
-
-                    parse_pattern_capture(parser, captures, constant_id, &TOK2LOC(parser, &parser->previous));
-
-                    pm_local_variable_target_node_t *target = pm_local_variable_target_node_create(
-                        parser,
-                        &TOK2LOC(parser, &parser->previous),
-                        constant_id,
-                        (uint32_t) (depth == -1 ? 0 : depth)
-                    );
-
-                    key = UP(pm_capture_pattern_node_create(parser, key, target, &operator));
+                    key = parse_pattern_capture_target(parser, captures, key);
                 }
 
                 if (accept1(parser, PM_TOKEN_COLON)) {
@@ -17705,25 +17697,7 @@ parse_pattern_primitives(pm_parser_t *parser, pm_constant_id_list_t *captures, p
     // If we have an =>, then we are assigning this pattern to a variable.
     // In this case we should create an assignment node.
     while (accept1(parser, PM_TOKEN_EQUAL_GREATER)) {
-        pm_token_t operator = parser->previous;
-        expect1(parser, PM_TOKEN_IDENTIFIER, PM_ERR_PATTERN_IDENT_AFTER_HROCKET);
-
-        pm_constant_id_t constant_id = pm_parser_constant_id_token(parser, &parser->previous);
-        int depth;
-
-        if ((depth = pm_parser_local_depth_constant_id(parser, constant_id)) == -1) {
-            pm_parser_local_add(parser, constant_id, parser->previous.start, parser->previous.end, 0);
-        }
-
-        parse_pattern_capture(parser, captures, constant_id, &TOK2LOC(parser, &parser->previous));
-        pm_local_variable_target_node_t *target = pm_local_variable_target_node_create(
-            parser,
-            &TOK2LOC(parser, &parser->previous),
-            constant_id,
-            (uint32_t) (depth == -1 ? 0 : depth)
-        );
-
-        node = UP(pm_capture_pattern_node_create(parser, node, target, &operator));
+        node = parse_pattern_capture_target(parser, captures, node);
     }
 
     return node;

--- a/prism/prism.c
+++ b/prism/prism.c
@@ -17120,16 +17120,20 @@ parse_pattern_hash(pm_parser_t *parser, pm_constant_id_list_t *captures, pm_node
         }
         PRISM_FALLTHROUGH
         default: {
-            // If we get anything else, then this is an error. For this we'll
-            // create a missing node for the value and create an assoc node for
-            // the first node in the list.
-            pm_diagnostic_id_t diag_id = PM_NODE_TYPE_P(first_node, PM_INTERPOLATED_SYMBOL_NODE) ? PM_ERR_PATTERN_HASH_KEY_INTERPOLATED : PM_ERR_PATTERN_HASH_KEY_LABEL;
-            pm_parser_err_node(parser, first_node, diag_id);
+            if (match1(parser, PM_TOKEN_COLON)) {
+                parser_lex(parser);
+                pm_node_t *value = parse_pattern(parser, captures, PM_PARSE_PATTERN_SINGLE, PM_ERR_PATTERN_EXPRESSION_AFTER_KEY, (uint16_t) (depth + 1));
+                pm_node_t *assoc = UP(pm_assoc_node_create(parser, first_node, NULL, value));
+                pm_node_list_append(parser->arena, &assocs, assoc);
+            } else {
+                pm_diagnostic_id_t diag_id = PM_NODE_TYPE_P(first_node, PM_INTERPOLATED_SYMBOL_NODE) ? PM_ERR_PATTERN_HASH_KEY_INTERPOLATED : PM_ERR_PATTERN_HASH_KEY_LABEL;
+                pm_parser_err_node(parser, first_node, diag_id);
 
-            pm_node_t *value = UP(pm_error_recovery_node_create(parser, PM_NODE_START(first_node), PM_NODE_LENGTH(first_node)));
-            pm_node_t *assoc = UP(pm_assoc_node_create(parser, first_node, NULL, value));
+                pm_node_t *value = UP(pm_error_recovery_node_create(parser, PM_NODE_START(first_node), PM_NODE_LENGTH(first_node)));
+                pm_node_t *assoc = UP(pm_assoc_node_create(parser, first_node, NULL, value));
 
-            pm_node_list_append(parser->arena, &assocs, assoc);
+                pm_node_list_append(parser->arena, &assocs, assoc);
+            }
             break;
         }
     }
@@ -17157,29 +17161,42 @@ parse_pattern_hash(pm_parser_t *parser, pm_constant_id_list_t *captures, pm_node
             }
         } else {
             pm_node_t *key;
+            bool is_label = false;
 
             if (match1(parser, PM_TOKEN_STRING_BEGIN)) {
                 key = parse_strings(parser, NULL, true, (uint16_t) (depth + 1));
 
                 if (PM_NODE_TYPE_P(key, PM_INTERPOLATED_SYMBOL_NODE)) {
                     pm_parser_err_node(parser, key, PM_ERR_PATTERN_HASH_KEY_INTERPOLATED);
-                } else if (!pm_symbol_node_label_p(parser, key)) {
+                    is_label = true;
+                } else if (pm_symbol_node_label_p(parser, key)) {
+                    is_label = true;
+                } else if (match1(parser, PM_TOKEN_COLON)) {
+                    parser_lex(parser);
+                } else {
                     pm_parser_err_node(parser, key, PM_ERR_PATTERN_LABEL_AFTER_COMMA);
                 }
             } else if (accept1(parser, PM_TOKEN_LABEL)) {
                 key = UP(pm_symbol_node_label_create(parser, &parser->previous));
+                is_label = true;
             } else {
-                expect1(parser, PM_TOKEN_LABEL, PM_ERR_PATTERN_LABEL_AFTER_COMMA);
+                key = parse_expression(parser, PM_BINDING_POWER_MAX, PM_PARSE_ACCEPTS_DO_BLOCK | PM_PARSE_ACCEPTS_LABEL, PM_ERR_PATTERN_HASH_KEY_LABEL, (uint16_t) (depth + 1));
 
-                pm_token_t label = { .type = PM_TOKEN_LABEL, .start = parser->previous.end, .end = parser->previous.end };
-                key = UP(pm_symbol_node_create(parser, NULL, &label, NULL));
+                if (match1(parser, PM_TOKEN_COLON)) {
+                    parser_lex(parser);
+                } else {
+                    pm_parser_err_node(parser, key, PM_ERR_PATTERN_HASH_KEY_LABEL);
+                }
             }
 
-            parse_pattern_hash_key(parser, &keys, key);
+            if (is_label) {
+                parse_pattern_hash_key(parser, &keys, key);
+            }
+
             pm_node_t *value = NULL;
 
             if (match8(parser, PM_TOKEN_COMMA, PM_TOKEN_KEYWORD_THEN, PM_TOKEN_BRACE_RIGHT, PM_TOKEN_BRACKET_RIGHT, PM_TOKEN_PARENTHESIS_RIGHT, PM_TOKEN_NEWLINE, PM_TOKEN_SEMICOLON, PM_TOKEN_EOF)) {
-                if (PM_NODE_TYPE_P(key, PM_SYMBOL_NODE)) {
+                if (is_label && PM_NODE_TYPE_P(key, PM_SYMBOL_NODE)) {
                     value = parse_pattern_hash_implicit_value(parser, captures, (pm_symbol_node_t *) key);
                 } else {
                     value = UP(pm_error_recovery_node_create(parser, PM_NODE_END(key), 0));
@@ -17307,16 +17324,16 @@ parse_pattern_primitive(pm_parser_t *parser, pm_constant_id_list_t *captures, pm
                     case PM_TOKEN_USTAR_STAR:
                         first_node = parse_pattern_keyword_rest(parser, captures);
                         break;
-                    case PM_TOKEN_STRING_BEGIN:
-                        first_node = parse_expression(parser, PM_BINDING_POWER_MAX, PM_PARSE_ACCEPTS_DO_BLOCK | PM_PARSE_ACCEPTS_LABEL, PM_ERR_PATTERN_HASH_KEY_LABEL, (uint16_t) (depth + 1));
-                        break;
-                    default: {
+                    case PM_TOKEN_HEREDOC_START: {
                         PM_PARSER_ERR_TOKEN_FORMAT(parser, &parser->current, PM_ERR_PATTERN_HASH_KEY, pm_token_str(parser->current.type));
                         parser_lex(parser);
 
                         first_node = UP(pm_error_recovery_node_create(parser, PM_TOKEN_START(parser, &parser->previous), PM_TOKEN_LENGTH(&parser->previous)));
                         break;
                     }
+                    default:
+                        first_node = parse_expression(parser, PM_BINDING_POWER_MAX, PM_PARSE_ACCEPTS_DO_BLOCK | PM_PARSE_ACCEPTS_LABEL, PM_ERR_PATTERN_HASH_KEY_LABEL, (uint16_t) (depth + 1));
+                        break;
                 }
 
                 node = parse_pattern_hash(parser, captures, first_node, (uint16_t) (depth + 1));
@@ -17658,15 +17675,37 @@ parse_pattern(pm_parser_t *parser, pm_constant_id_list_t *captures, uint8_t flag
             }
         }
         PRISM_FALLTHROUGH
-        default:
+        default: {
             node = parse_pattern_primitives(parser, captures, NULL, diag_id, (uint16_t) (depth + 1));
             break;
+        }
     }
 
     // If we got a dynamic label symbol, then we need to treat it like the
     // beginning of a hash pattern.
     if (pm_symbol_node_label_p(parser, node)) {
         return UP(parse_pattern_hash(parser, captures, node, (uint16_t) (depth + 1)));
+    }
+
+    // If we got an expression followed by :, then we need to treat it like
+    // the beginning of a hash pattern.
+    if (match1(parser, PM_TOKEN_COLON)) {
+        if (PM_NODE_TYPE_P(node, PM_ARRAY_PATTERN_NODE)) {
+            pm_array_pattern_node_t *array_pat = (pm_array_pattern_node_t *) node;
+            pm_array_node_t *array_expr = pm_array_node_create(parser, NULL);
+            for (size_t i = 0; i < array_pat->requireds.size; i++) {
+                pm_array_node_elements_append(parser->arena, array_expr, array_pat->requireds.nodes[i]);
+            }
+            node = UP(array_expr);
+        }
+
+        node = UP(parse_pattern_hash(parser, captures, node, (uint16_t) (depth + 1)));
+
+        if (!(flags & PM_PARSE_PATTERN_TOP)) {
+            pm_parser_err_node(parser, node, PM_ERR_PATTERN_HASH_IMPLICIT);
+        }
+
+        return node;
     }
 
     if ((flags & PM_PARSE_PATTERN_MULTI) && match1(parser, PM_TOKEN_COMMA)) {

--- a/prism/prism.c
+++ b/prism/prism.c
@@ -17180,7 +17180,7 @@ parse_pattern_hash(pm_parser_t *parser, pm_constant_id_list_t *captures, pm_node
                 key = UP(pm_symbol_node_label_create(parser, &parser->previous));
                 is_label = true;
             } else {
-                key = parse_expression(parser, PM_BINDING_POWER_MAX, PM_PARSE_ACCEPTS_DO_BLOCK | PM_PARSE_ACCEPTS_LABEL, PM_ERR_PATTERN_HASH_KEY_LABEL, (uint16_t) (depth + 1));
+                key = parse_expression(parser, PM_BINDING_POWER_MAX, PM_PARSE_ACCEPTS_LABEL | PM_PARSE_ACCEPTS_DO_BLOCK, PM_ERR_PATTERN_HASH_KEY_LABEL, (uint16_t) (depth + 1));
 
                 if (match1(parser, PM_TOKEN_COLON)) {
                     parser_lex(parser);
@@ -17332,11 +17332,21 @@ parse_pattern_primitive(pm_parser_t *parser, pm_constant_id_list_t *captures, pm
                         break;
                     }
                     default:
+                        /*
+                         * Use parse_expression here because this token is not
+                         * a label or **, so we parse it as an expression first.
+                         * parse_pattern_hash will then re-interpret it as a
+                         * hash pattern key, potentially followed by : or =>.
+                         */
                         first_node = parse_expression(parser, PM_BINDING_POWER_MAX, PM_PARSE_ACCEPTS_DO_BLOCK | PM_PARSE_ACCEPTS_LABEL, PM_ERR_PATTERN_HASH_KEY_LABEL, (uint16_t) (depth + 1));
                         break;
                 }
 
-                node = parse_pattern_hash(parser, captures, first_node, (uint16_t) (depth + 1));
+                if (PM_NODE_TYPE_P(first_node, PM_HASH_PATTERN_NODE)) {
+                    node = (pm_hash_pattern_node_t *) first_node;
+                } else {
+                    node = parse_pattern_hash(parser, captures, first_node, (uint16_t) (depth + 1));
+                }
 
                 accept1(parser, PM_TOKEN_NEWLINE);
                 expect1_opening(parser, PM_TOKEN_BRACE_RIGHT, PM_ERR_PATTERN_TERM_BRACE, &opening);
@@ -17374,8 +17384,8 @@ parse_pattern_primitive(pm_parser_t *parser, pm_constant_id_list_t *captures, pm
         case PM_CASE_PRIMITIVE: {
             pm_node_t *node = parse_expression(parser, PM_BINDING_POWER_MAX, PM_PARSE_ACCEPTS_LABEL | PM_PARSE_ACCEPTS_DO_BLOCK, diag_id, (uint16_t) (depth + 1));
 
-            // If we found a label, we need to immediately return to the caller.
-            if (pm_symbol_node_label_p(parser, node)) return node;
+                // If we found a label, we need to immediately return to the caller.
+                if (pm_symbol_node_label_p(parser, node)) return node;
 
             // Call nodes (arithmetic operations) are not allowed in patterns
             if (PM_NODE_TYPE(node) == PM_CALL_NODE) {
@@ -17589,6 +17599,8 @@ parse_pattern_primitives(pm_parser_t *parser, pm_constant_id_list_t *captures, p
         }
     }
 
+    // If we have an =>, then we are assigning this pattern to a variable.
+    // In this case we should create an assignment node.
     // If we have an =>, then we are assigning this pattern to a variable.
     // In this case we should create an assignment node.
     while (accept1(parser, PM_TOKEN_EQUAL_GREATER)) {

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -2950,7 +2950,21 @@ pm_compile_pattern(rb_iseq_t *iseq, pm_scope_node_t *scope_node, const pm_node_t
         LABEL *type_error_label = NEW_LABEL(location.line);
         VALUE keys = Qnil;
 
+        bool all_symbol_keys = true;
         if (has_keys && !has_rest) {
+            for (size_t index = 0; index < cast->elements.size; index++) {
+                const pm_node_t *element = cast->elements.nodes[index];
+                RUBY_ASSERT(PM_NODE_TYPE_P(element, PM_ASSOC_NODE));
+
+                const pm_node_t *key = ((const pm_assoc_node_t *) element)->key;
+                if (!PM_NODE_TYPE_P(key, PM_SYMBOL_NODE)) {
+                    all_symbol_keys = false;
+                    break;
+                }
+            }
+        }
+
+        if (has_keys && !has_rest && all_symbol_keys) {
             keys = rb_ary_new_capa(cast->elements.size);
 
             for (size_t index = 0; index < cast->elements.size; index++) {
@@ -3010,41 +3024,58 @@ pm_compile_pattern(rb_iseq_t *iseq, pm_scope_node_t *scope_node, const pm_node_t
 
                 const pm_assoc_node_t *assoc = (const pm_assoc_node_t *) element;
                 const pm_node_t *key = assoc->key;
-                RUBY_ASSERT(PM_NODE_TYPE_P(key, PM_SYMBOL_NODE));
 
-                VALUE symbol = ID2SYM(parse_string_symbol(scope_node, (const pm_symbol_node_t *) key));
-                PUSH_INSN(ret, location, dup);
-                PUSH_INSN1(ret, location, putobject, symbol);
-                PUSH_SEND(ret, location, rb_intern("key?"), INT2FIX(1));
-
-                if (in_single_pattern) {
-                    LABEL *match_succeeded_label = NEW_LABEL(location.line);
-
+                if (PM_NODE_TYPE_P(key, PM_SYMBOL_NODE)) {
+                    VALUE symbol = ID2SYM(parse_string_symbol(scope_node, (const pm_symbol_node_t *) key));
                     PUSH_INSN(ret, location, dup);
-                    PUSH_INSNL(ret, location, branchif, match_succeeded_label);
+                    PUSH_INSN1(ret, location, putobject, symbol);
+                    PUSH_SEND(ret, location, rb_intern("key?"), INT2FIX(1));
 
-                    {
-                        VALUE operand = rb_str_freeze(rb_sprintf("key not found: %+"PRIsVALUE, symbol));
-                        RB_OBJ_SET_SHAREABLE(operand);
-                        PUSH_INSN1(ret, location, putobject, operand);
+                    if (in_single_pattern) {
+                        LABEL *match_succeeded_label = NEW_LABEL(location.line);
+
+                        PUSH_INSN(ret, location, dup);
+                        PUSH_INSNL(ret, location, branchif, match_succeeded_label);
+
+                        {
+                            VALUE operand = rb_str_freeze(rb_sprintf("key not found: %+"PRIsVALUE, symbol));
+                            RB_OBJ_SET_SHAREABLE(operand);
+                            PUSH_INSN1(ret, location, putobject, operand);
+                        }
+
+                        PUSH_INSN1(ret, location, setn, INT2FIX(base_index + PM_PATTERN_BASE_INDEX_OFFSET_ERROR_STRING + 2));
+                        PUSH_INSN1(ret, location, putobject, Qtrue);
+                        PUSH_INSN1(ret, location, setn, INT2FIX(base_index + PM_PATTERN_BASE_INDEX_OFFSET_KEY_ERROR_P + 3));
+                        PUSH_INSN1(ret, location, topn, INT2FIX(3));
+                        PUSH_INSN1(ret, location, setn, INT2FIX(base_index + PM_PATTERN_BASE_INDEX_OFFSET_KEY_ERROR_MATCHEE + 4));
+                        PUSH_INSN1(ret, location, putobject, symbol);
+                        PUSH_INSN1(ret, location, setn, INT2FIX(base_index + PM_PATTERN_BASE_INDEX_OFFSET_KEY_ERROR_KEY + 5));
+
+                        PUSH_INSN1(ret, location, adjuststack, INT2FIX(4));
+                        PUSH_LABEL(ret, match_succeeded_label);
                     }
 
-                    PUSH_INSN1(ret, location, setn, INT2FIX(base_index + PM_PATTERN_BASE_INDEX_OFFSET_ERROR_STRING + 2));
-                    PUSH_INSN1(ret, location, putobject, Qtrue);
-                    PUSH_INSN1(ret, location, setn, INT2FIX(base_index + PM_PATTERN_BASE_INDEX_OFFSET_KEY_ERROR_P + 3));
-                    PUSH_INSN1(ret, location, topn, INT2FIX(3));
-                    PUSH_INSN1(ret, location, setn, INT2FIX(base_index + PM_PATTERN_BASE_INDEX_OFFSET_KEY_ERROR_MATCHEE + 4));
-                    PUSH_INSN1(ret, location, putobject, symbol);
-                    PUSH_INSN1(ret, location, setn, INT2FIX(base_index + PM_PATTERN_BASE_INDEX_OFFSET_KEY_ERROR_KEY + 5));
-
-                    PUSH_INSN1(ret, location, adjuststack, INT2FIX(4));
-                    PUSH_LABEL(ret, match_succeeded_label);
+                    PUSH_INSNL(ret, location, branchunless, match_failed_label);
+                    PUSH_INSN(match_values, location, dup);
+                    PUSH_INSN1(match_values, location, putobject, symbol);
+                    PUSH_SEND(match_values, location, has_rest ? rb_intern("delete") : idAREF, INT2FIX(1));
                 }
-
-                PUSH_INSNL(ret, location, branchunless, match_failed_label);
-                PUSH_INSN(match_values, location, dup);
-                PUSH_INSN1(match_values, location, putobject, symbol);
-                PUSH_SEND(match_values, location, has_rest ? rb_intern("delete") : idAREF, INT2FIX(1));
+                else {
+                    PUSH_INSN(ret, location, dup);
+                    pm_compile_node(iseq, key, ret, false, scope_node);
+                    PUSH_SEND(ret, location, rb_intern("key?"), INT2FIX(1));
+                    if (in_single_pattern) {
+                        LABEL *match_succeeded_label = NEW_LABEL(location.line);
+                        PUSH_INSN(ret, location, dup);
+                        PUSH_INSNL(ret, location, branchif, match_succeeded_label);
+                        CHECK(pm_compile_pattern_generic_error(iseq, scope_node, node, ret, rb_fstring_lit("key not found"), base_index + 2));
+                        PUSH_LABEL(ret, match_succeeded_label);
+                    }
+                    PUSH_INSNL(ret, location, branchunless, match_failed_label);
+                    PUSH_INSN(match_values, location, dup);
+                    pm_compile_node(iseq, key, match_values, false, scope_node);
+                    PUSH_SEND(match_values, location, has_rest ? rb_intern("delete") : idAREF, INT2FIX(1));
+                }
 
                 const pm_node_t *value = assoc->value;
                 if (PM_NODE_TYPE_P(value, PM_IMPLICIT_NODE)) {

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -3025,13 +3025,16 @@ pm_compile_pattern(rb_iseq_t *iseq, pm_scope_node_t *scope_node, const pm_node_t
                 const pm_assoc_node_t *assoc = (const pm_assoc_node_t *) element;
                 const pm_node_t *key = assoc->key;
 
+                bool is_implicit = PM_NODE_TYPE_P(assoc->value, PM_IMPLICIT_NODE);
+                const pm_node_t *value = is_implicit ? ((const pm_implicit_node_t *) assoc->value)->value : assoc->value;
+
                 if (PM_NODE_TYPE_P(key, PM_SYMBOL_NODE)) {
                     VALUE symbol = ID2SYM(parse_string_symbol(scope_node, (const pm_symbol_node_t *) key));
                     PUSH_INSN(ret, location, dup);
                     PUSH_INSN1(ret, location, putobject, symbol);
                     PUSH_SEND(ret, location, rb_intern("key?"), INT2FIX(1));
 
-                    if (in_single_pattern) {
+                    if (in_single_pattern && is_implicit) {
                         LABEL *match_succeeded_label = NEW_LABEL(location.line);
 
                         PUSH_INSN(ret, location, dup);
@@ -3054,35 +3057,58 @@ pm_compile_pattern(rb_iseq_t *iseq, pm_scope_node_t *scope_node, const pm_node_t
                         PUSH_INSN1(ret, location, adjuststack, INT2FIX(4));
                         PUSH_LABEL(ret, match_succeeded_label);
                     }
+                    else if (in_single_pattern) {
+                        CHECK(pm_compile_pattern_generic_error(iseq, scope_node, node, ret, rb_fstring_lit("key not found"), base_index + 2));
+                    }
 
                     PUSH_INSNL(ret, location, branchunless, match_failed_label);
                     PUSH_INSN(match_values, location, dup);
                     PUSH_INSN1(match_values, location, putobject, symbol);
                     PUSH_SEND(match_values, location, has_rest ? rb_intern("delete") : idAREF, INT2FIX(1));
+
+                    CHECK(pm_compile_pattern_match(iseq, scope_node, value, match_values, match_failed_label, in_single_pattern, false, base_index + 1));
                 }
                 else {
                     PUSH_INSN(ret, location, dup);
+                    PUSH_SEND(ret, location, rb_intern("keys"), INT2FIX(0));
                     pm_compile_node(iseq, key, ret, false, scope_node);
-                    PUSH_SEND(ret, location, rb_intern("key?"), INT2FIX(1));
+                    PUSH_SEND(ret, location, rb_intern("grep"), INT2FIX(1));
+                    PUSH_SEND(ret, location, rb_intern("first"), INT2FIX(0));
+
+                    PUSH_INSN1(ret, location, topn, INT2FIX(0));
+                    PUSH_SEND(ret, location, rb_intern("nil?"), INT2FIX(0));
+
                     if (in_single_pattern) {
                         LABEL *match_succeeded_label = NEW_LABEL(location.line);
                         PUSH_INSN(ret, location, dup);
-                        PUSH_INSNL(ret, location, branchif, match_succeeded_label);
+                        PUSH_INSNL(ret, location, branchunless, match_succeeded_label);
                         CHECK(pm_compile_pattern_generic_error(iseq, scope_node, node, ret, rb_fstring_lit("key not found"), base_index + 2));
                         PUSH_LABEL(ret, match_succeeded_label);
                     }
-                    PUSH_INSNL(ret, location, branchunless, match_failed_label);
-                    PUSH_INSN(match_values, location, dup);
-                    pm_compile_node(iseq, key, match_values, false, scope_node);
-                    PUSH_SEND(match_values, location, has_rest ? rb_intern("delete") : idAREF, INT2FIX(1));
-                }
 
-                const pm_node_t *value = assoc->value;
-                if (PM_NODE_TYPE_P(value, PM_IMPLICIT_NODE)) {
-                    value = ((const pm_implicit_node_t *) value)->value;
-                }
+                    LABEL *nil_key_label = NEW_LABEL(location.line);
+                    PUSH_INSNL(ret, location, branchif, nil_key_label);
 
-                CHECK(pm_compile_pattern_match(iseq, scope_node, value, match_values, match_failed_label, in_single_pattern, false, base_index + 1));
+                    // Key found. Get value using the matched key.
+                    // Stack: [hash, first_key]
+                    PUSH_INSN1(ret, location, topn, INT2FIX(1));
+                    PUSH_INSN(ret, location, swap);
+                    PUSH_SEND(ret, location, has_rest ? rb_intern("delete") : idAREF, INT2FIX(1));
+
+                    // Match the value pattern
+                    CHECK(pm_compile_pattern_match(iseq, scope_node, value, ret, match_failed_label, in_single_pattern, false, base_index + 1));
+
+                    // Skip over nil key handling after successful match
+                    LABEL *after_nil_label = NEW_LABEL(location.line);
+                    PUSH_INSNL(ret, location, jump, after_nil_label);
+
+                    // Nil key: pop the nil and jump to match_failed
+                    PUSH_LABEL(ret, nil_key_label);
+                    PUSH_INSN(ret, location, pop);
+                    PUSH_INSNL(ret, location, jump, match_failed_label);
+
+                    PUSH_LABEL(ret, after_nil_label);
+                }
             }
 
             PUSH_SEQ(ret, match_values);

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -3081,26 +3081,7 @@ pm_compile_pattern(rb_iseq_t *iseq, pm_scope_node_t *scope_node, const pm_node_t
 
                     PUSH_INSN(ret, location, dup);
                     PUSH_SEND(ret, location, rb_intern("keys"), INT2FIX(0));
-
-                    if (PM_NODE_TYPE_P(key_pattern, PM_PINNED_VARIABLE_NODE)) {
-                        const pm_pinned_variable_node_t *pinned = (const pm_pinned_variable_node_t *) key_pattern;
-                        const pm_node_t *inner = pinned->variable;
-                        if (PM_NODE_TYPE_P(inner, PM_LOCAL_VARIABLE_TARGET_NODE)) {
-                            const pm_local_variable_target_node_t *target = (const pm_local_variable_target_node_t *) inner;
-                            pm_local_index_t local_index = pm_lookup_local_index(iseq, scope_node, target->name, target->depth);
-                            PUSH_GETLOCAL(ret, location, local_index.index, local_index.level);
-                        }
-                        else {
-                            pm_compile_node(iseq, inner, ret, false, scope_node);
-                        }
-                    }
-                    else if (PM_NODE_TYPE_P(key_pattern, PM_PINNED_EXPRESSION_NODE)) {
-                        const pm_pinned_expression_node_t *pinned = (const pm_pinned_expression_node_t *) key_pattern;
-                        pm_compile_node(iseq, pinned->expression, ret, false, scope_node);
-                    }
-                    else {
-                        pm_compile_node(iseq, key_pattern, ret, false, scope_node);
-                    }
+                    pm_compile_node(iseq, key_pattern, ret, false, scope_node);
                     PUSH_SEND(ret, location, rb_intern("grep"), INT2FIX(1));
                     PUSH_SEND(ret, location, rb_intern("first"), INT2FIX(0));
 
@@ -10648,6 +10629,26 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
         PUSH_SEND_WITH_FLAG(ret, location, idBackquote, INT2NUM(1), INT2FIX(VM_CALL_FCALL | VM_CALL_ARGS_SIMPLE));
         if (popped) PUSH_INSN(ret, location, pop);
 
+        return;
+      }
+      case PM_PINNED_EXPRESSION_NODE: {
+        // ^(expr)
+        const pm_pinned_expression_node_t *cast = (const pm_pinned_expression_node_t *) node;
+        pm_compile_node(iseq, cast->expression, ret, popped, scope_node);
+        return;
+      }
+      case PM_PINNED_VARIABLE_NODE: {
+        // ^var
+        const pm_pinned_variable_node_t *cast = (const pm_pinned_variable_node_t *) node;
+        if (PM_NODE_TYPE_P(cast->variable, PM_LOCAL_VARIABLE_TARGET_NODE)) {
+            const pm_local_variable_target_node_t *target = (const pm_local_variable_target_node_t *) cast->variable;
+            if (!popped) {
+                pm_local_index_t index = pm_lookup_local_index(iseq, scope_node, target->name, target->depth);
+                PUSH_GETLOCAL(ret, location, index.index, index.level);
+            }
+            return;
+        }
+        pm_compile_node(iseq, cast->variable, ret, popped, scope_node);
         return;
       }
       case PM_YIELD_NODE:

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -3069,9 +3069,38 @@ pm_compile_pattern(rb_iseq_t *iseq, pm_scope_node_t *scope_node, const pm_node_t
                     CHECK(pm_compile_pattern_match(iseq, scope_node, value, match_values, match_failed_label, in_single_pattern, false, base_index + 1));
                 }
                 else {
+                    const pm_node_t *key_pattern;
+                    const pm_capture_pattern_node_t *key_capture = NULL;
+
+                    if (PM_NODE_TYPE_P(key, PM_CAPTURE_PATTERN_NODE)) {
+                        key_capture = (const pm_capture_pattern_node_t *) key;
+                        key_pattern = key_capture->value;
+                    } else {
+                        key_pattern = key;
+                    }
+
                     PUSH_INSN(ret, location, dup);
                     PUSH_SEND(ret, location, rb_intern("keys"), INT2FIX(0));
-                    pm_compile_node(iseq, key, ret, false, scope_node);
+
+                    if (PM_NODE_TYPE_P(key_pattern, PM_PINNED_VARIABLE_NODE)) {
+                        const pm_pinned_variable_node_t *pinned = (const pm_pinned_variable_node_t *) key_pattern;
+                        const pm_node_t *inner = pinned->variable;
+                        if (PM_NODE_TYPE_P(inner, PM_LOCAL_VARIABLE_TARGET_NODE)) {
+                            const pm_local_variable_target_node_t *target = (const pm_local_variable_target_node_t *) inner;
+                            pm_local_index_t local_index = pm_lookup_local_index(iseq, scope_node, target->name, target->depth);
+                            PUSH_GETLOCAL(ret, location, local_index.index, local_index.level);
+                        }
+                        else {
+                            pm_compile_node(iseq, inner, ret, false, scope_node);
+                        }
+                    }
+                    else if (PM_NODE_TYPE_P(key_pattern, PM_PINNED_EXPRESSION_NODE)) {
+                        const pm_pinned_expression_node_t *pinned = (const pm_pinned_expression_node_t *) key_pattern;
+                        pm_compile_node(iseq, pinned->expression, ret, false, scope_node);
+                    }
+                    else {
+                        pm_compile_node(iseq, key_pattern, ret, false, scope_node);
+                    }
                     PUSH_SEND(ret, location, rb_intern("grep"), INT2FIX(1));
                     PUSH_SEND(ret, location, rb_intern("first"), INT2FIX(0));
 
@@ -3082,14 +3111,33 @@ pm_compile_pattern(rb_iseq_t *iseq, pm_scope_node_t *scope_node, const pm_node_t
                         LABEL *match_succeeded_label = NEW_LABEL(location.line);
                         PUSH_INSN(ret, location, dup);
                         PUSH_INSNL(ret, location, branchunless, match_succeeded_label);
-                        CHECK(pm_compile_pattern_generic_error(iseq, scope_node, node, ret, rb_fstring_lit("key not found"), base_index + 2));
+                        PUSH_INSN1(ret, location, putspecialobject, INT2FIX(VM_SPECIAL_OBJECT_VMCORE));
+                        {
+                            VALUE operand = rb_fstring_lit("key not found");
+                            PUSH_INSN1(ret, location, putobject, operand);
+                        }
+                        PUSH_INSN1(ret, location, topn, INT2FIX(3));
+                        PUSH_SEND(ret, location, id_core_sprintf, INT2FIX(2));
+                        PUSH_INSN1(ret, location, setn, INT2FIX(base_index + 2 + PM_PATTERN_BASE_INDEX_OFFSET_ERROR_STRING + 1));
+                        PUSH_INSN1(ret, location, putobject, Qfalse);
+                        PUSH_INSN1(ret, location, setn, INT2FIX(base_index + 2 + PM_PATTERN_BASE_INDEX_OFFSET_KEY_ERROR_P + 2));
+                        PUSH_INSN(ret, location, pop);
+                        PUSH_INSN(ret, location, pop);
                         PUSH_LABEL(ret, match_succeeded_label);
                     }
 
                     LABEL *nil_key_label = NEW_LABEL(location.line);
                     PUSH_INSNL(ret, location, branchif, nil_key_label);
 
-                    // Key found. Get value using the matched key.
+                    // Key found. Capture the matched key into the local variable if a capture is present.
+                    // Stack: [hash, first_key]
+                    if (key_capture != NULL) {
+                        pm_local_index_t local_index = pm_lookup_local_index(iseq, scope_node, key_capture->target->name, key_capture->target->depth);
+                        PUSH_INSN(ret, location, dup);
+                        PUSH_SETLOCAL(ret, location, local_index.index, local_index.level);
+                    }
+
+                    // Get value using the matched key.
                     // Stack: [hash, first_key]
                     PUSH_INSN1(ret, location, topn, INT2FIX(1));
                     PUSH_INSN(ret, location, swap);

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -2540,11 +2540,23 @@ end
         assert_prism_eval("{ a: 1, b: 2, c: 3 } => #{prefix} b: 2, c: 3, **foo #{suffix}")
         assert_prism_eval("{ a: 1, b: 2, c: 3 } => #{prefix} a: 1, b: 2, c: 3, **foo #{suffix}")
 
-        assert_prism_eval("{ a: 1 } => #{prefix} a: 1, **nil #{suffix}")
+          assert_prism_eval("{ a: 1 } => #{prefix} a: 1, **nil #{suffix}")
         assert_prism_eval("{ a: 1, b: 2, c: 3 } => #{prefix} a: 1, b: 2, c: 3, **nil #{suffix}")
       end
 
       assert_prism_eval("{ a: { b: { c: 1 } } } => { a: { b: { c: 1 } } }")
+
+      code = "case {200 => \"ok\"}; in {Integer : String}; :ok; else :fail; end"
+      assert_equal :ok, RubyVM::InstructionSequence.compile_prism(code).eval
+
+      code = "case {200 => 42}; in {Integer : String}; :ok; else :fail; end"
+      assert_equal :fail, RubyVM::InstructionSequence.compile_prism(code).eval
+
+      code = "case {\"hel\" => \"lo\"}; in {/hel/ : String}; :ok; else :fail; end"
+      assert_equal :ok, RubyVM::InstructionSequence.compile_prism(code).eval
+
+      code = "case {a: 1, 200 => \"ok\"}; in {a: Integer, Integer : String}; :ok; else :fail; end"
+      assert_equal :ok, RubyVM::InstructionSequence.compile_prism(code).eval
     end
 
     def test_MatchPredicateNode

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -2557,6 +2557,27 @@ end
 
       code = "case {a: 1, 200 => \"ok\"}; in {a: Integer, Integer : String}; :ok; else :fail; end"
       assert_equal :ok, RubyVM::InstructionSequence.compile_prism(code).eval
+
+      code = "case {200 => \"ok\"}; in {Integer => k : String}; k; else :fail; end"
+      assert_equal 200, RubyVM::InstructionSequence.compile_prism(code).eval
+
+      code = "case {200 => \"ok\"}; in {Integer : String => v}; v; else :fail; end"
+      assert_equal "ok", RubyVM::InstructionSequence.compile_prism(code).eval
+
+      code = "case {200 => \"ok\"}; in {Integer => k : String => v}; k + v.length; else :fail; end"
+      assert_equal 202, RubyVM::InstructionSequence.compile_prism(code).eval
+
+      code = "case {200 => \"ok\", 300 => \"bar\"}; in {Integer => k : String, **rest}; k; else :fail; end"
+      assert_equal 200, RubyVM::InstructionSequence.compile_prism(code).eval
+
+      code = "case {200 => \"ok\"}; in {(200..300) : String}; :ok; else :fail; end"
+      assert_equal :ok, RubyVM::InstructionSequence.compile_prism(code).eval
+
+      code = "case {\"hel\" => \"lo\"}; in {/hel/ : String => v}; v; else :fail; end"
+      assert_equal "lo", RubyVM::InstructionSequence.compile_prism(code).eval
+
+      code = "key = 200; case {200 => \"ok\"}; in {^key : String}; :ok; else :fail; end"
+      assert_equal :ok, RubyVM::InstructionSequence.compile_prism(code).eval
     end
 
     def test_MatchPredicateNode

--- a/test/ruby/test_pattern_matching.rb
+++ b/test/ruby/test_pattern_matching.rb
@@ -1331,7 +1331,7 @@ END
       end
     end
 
-    assert_raise_with_message(NoMatchingPatternKeyError, %[{"x" => 1}: ]) do
+    assert_raise_with_message(NoMatchingPatternError, %[{"x" => 1}: ]) do
       case {"x" => 1}
       in {"y" : Integer}
         true
@@ -1410,6 +1410,47 @@ END
     end
   end
 
+  def test_hash_expression_key_pattern
+    assert_block do
+      [{200 => "ok"}, C.new({200 => "ok"})].all? do |i|
+        case i
+        in {Integer : String}
+          true
+        else false
+        end
+      end
+    end
+
+    assert_block do
+      [{200 => 42}, C.new({200 => 42}), {"a" => "ok"}, {}].all? do |i|
+        case i
+        in {Integer : String}
+          false
+        else true
+        end
+      end
+    end
+
+    assert_block do
+      [{a: 1, 200 => "ok"}, C.new({a: 1, 200 => "ok"})].all? do |i|
+        case i
+        in {a: Integer, Integer : String}
+          true
+        else false
+        end
+      end
+    end
+
+    assert_block do
+      hash = {200 => "ok", 300 => "fail"}
+      case hash
+      in {Integer : String => v, **rest}
+        v == "ok" && rest == {300 => "fail"}
+      end
+    end
+
+  end
+
   def test_paren
     assert_block do
       case 0
@@ -1442,11 +1483,6 @@ END
       end
     }, /expecting ':'|expected a label as the key/)
 
-    assert_syntax_error(%q{
-      case 0
-      in {0 => a}
-      end
-    }, /expecting ':'|expected a label as the key/)
   end
 
   ################################################################

--- a/test/ruby/test_pattern_matching.rb
+++ b/test/ruby/test_pattern_matching.rb
@@ -1494,6 +1494,72 @@ END
         end
       end
     end
+
+    assert_block do
+      key = 200
+      hash = {200 => "ok"}
+      case hash
+      in {^key : String}
+        true
+      else false
+      end
+    end
+
+    assert_block do
+      key = 999
+      hash = {200 => "ok"}
+      case hash
+      in {^key : String}
+        false
+      else true
+      end
+    end
+
+    assert_block do
+      key = 200
+      hash = {200 => "ok"}
+      case hash
+      in {^key => k : String}
+        k == 200
+      else false
+      end
+    end
+
+    assert_block do
+      hash = {200 => "ok"}
+      case hash
+      in {^(200) : String}
+        true
+      else false
+      end
+    end
+
+    assert_block do
+      hash = { "two hundred" => "ok"}
+      case hash
+      in {/^two/ : String}
+        true
+      else false
+      end
+    end
+
+    assert_block do
+      hash = {200 => "ok", 300 => "bar"}
+      case hash
+      in {Integer => k : String, **rest}
+        k == 200 && rest == {300 => "bar"}
+      else false
+      end
+    end
+
+    assert_block do
+      hash = {200 => "ok", 300 => "bar"}
+      case hash
+      in {Integer => k : String => v, **rest}
+        k == 200 && v == "ok" && rest == {300 => "bar"}
+      else false
+      end
+    end
   end
 
   def test_paren

--- a/test/ruby/test_pattern_matching.rb
+++ b/test/ruby/test_pattern_matching.rb
@@ -1302,6 +1302,114 @@ END
     }, /symbol literal with interpolation is not allowed/)
   end
 
+  def test_hash_colon_key_pattern
+    assert_block do
+      case {"a" => 0, "b" => "x"}
+      in {"a" : Integer, "b" : String}
+        true
+      end
+    end
+
+    assert_block do
+      case {"a" => 0, "b" => "x"}
+      in {"a" : Integer => a, "b" : /x/}
+        a == 0
+      end
+    end
+
+    assert_block do
+      case {"a" => 0, "b" => 1}
+      in {"a" : Integer => a, **rest}
+        a == 0 && rest == {"b" => 1}
+      end
+    end
+
+    assert_block do
+      case {a: 0, "b" => 1}
+      in {a: Integer, "b" : Integer}
+        true
+      end
+    end
+
+    assert_raise_with_message(NoMatchingPatternKeyError, %[{"x" => 1}: ]) do
+      case {"x" => 1}
+      in {"y" : Integer}
+        true
+      end
+    end
+
+    assert_syntax_error(%q{
+      case 0
+      in {"a" :}
+      end
+    }, /unexpected '}'|expected a pattern expression after the key/)
+  end
+
+  def test_hash_colon_key_pattern_all_types
+    key3 = "key3"
+    def key12 = "key12"
+    key13 = -> { "key13" }
+
+    hash = {
+      key1:                %[key1:                symbolic],
+      "key-2":             %["key-2":             quoted label],
+      key3 :               %[key3 :               expression],
+      "key4" :             %["key4" :             String],
+      (5+0):               %[(5+0):               hash capsule],
+      6:                   %[6:                   Integer],
+      7.001:               %[7.001:               Float],
+      "key" + "8":         %["key" + "8":         String expr],
+      9+0:                 %[9+0:                 Integer expr],
+      [10, 0]:             %[[10, 0]:             Array],
+      true ? 11 : 0 :      %[true ? 11 : 0 :      ternary],
+      key12():             %[key12():             method],
+      key13[]:             %[key13[]:             lambda[]],
+      -> { "key14" }.call: %[-> { "key14" }.call: lambda.call],
+    }
+
+    hash.each do |expected_key, expected_value|
+      h = { expected_key : hash[expected_key] }
+
+      matched_braced = case h
+      in {key1:     value} then value == %[key1:                symbolic]
+      in {"key-2":  value} then value == %["key-2":             quoted label]
+      in {"key3" :  value} then value == %[key3 :               expression]
+      in {"key4" :  value} then value == %["key4" :             String]
+      in {5:        value} then value == %[(5+0):               hash capsule]
+      in {6:        value} then value == %[6:                   Integer]
+      in {7.001:    value} then value == %[7.001:               Float]
+      in {"key8" :  value} then value == %["key" + "8":         String expr]
+      in {9:        value} then value == %[9+0:                 Integer expr]
+      in {[10, 0]:  value} then value == %[[10, 0]:             Array]
+      in {11:       value} then value == %[true ? 11 : 0 :      ternary]
+      in {"key12" : value} then value == %[key12():             method]
+      in {"key13" : value} then value == %[key13[]:             lambda[]]
+      in {"key14" : value} then value == %[-> { "key14" }.call: lambda.call]
+      else false
+      end
+
+      matched_bare = case h
+      in key1:     value then value == %[key1:                symbolic]
+      in "key-2":  value then value == %["key-2":             quoted label]
+      in "key3" :  value then value == %[key3 :               expression]
+      in "key4" :  value then value == %["key4" :             String]
+      in 5:        value then value == %[(5+0):               hash capsule]
+      in 6:        value then value == %[6:                   Integer]
+      in 7.001:    value then value == %[7.001:               Float]
+      in "key8" :  value then value == %["key" + "8":         String expr]
+      in 9:        value then value == %[9+0:                 Integer expr]
+      in [10, 0]:  value then value == %[[10, 0]:             Array]
+      in 11:       value then value == %[true ? 11 : 0 :      ternary]
+      in "key12" : value then value == %[key12():             method]
+      in "key13" : value then value == %[key13[]:             lambda[]]
+      in "key14" : value then value == %[-> { "key14" }.call: lambda.call]
+      else false
+      end
+
+      assert_block { matched_braced && matched_bare }
+    end
+  end
+
   def test_paren
     assert_block do
       case 0
@@ -1332,13 +1440,13 @@ END
       case 0
       in {a}
       end
-    }, /unexpected/)
+    }, /expecting ':'|expected a label as the key/)
 
     assert_syntax_error(%q{
       case 0
       in {0 => a}
       end
-    }, /unexpected/)
+    }, /expecting ':'|expected a label as the key/)
   end
 
   ################################################################

--- a/test/ruby/test_pattern_matching.rb
+++ b/test/ruby/test_pattern_matching.rb
@@ -1331,7 +1331,7 @@ END
       end
     end
 
-    assert_raise_with_message(NoMatchingPatternError, %[{"x" => 1}: ]) do
+    assert_raise_with_message(NoMatchingPatternError, %[{"x" => 1}: key not found]) do
       case {"x" => 1}
       in {"y" : Integer}
         true
@@ -1449,6 +1449,51 @@ END
       end
     end
 
+    assert_block do
+      hash = {200 => "ok"}
+      case hash
+      in {Integer => k : String}
+        k == 200
+      else false
+      end
+    end
+
+    assert_block do
+      hash = {200 => "ok"}
+      case hash
+      in {Integer => k : String => v}
+        k == 200 && v == "ok"
+      else false
+      end
+    end
+
+    assert_block do
+      hash = {200 => "ok"}
+      case hash
+      in {(200..300) => k : String}
+        k == 200
+      else false
+      end
+    end
+
+    assert_block do
+      hash = {a: 1, 200 => "ok"}
+      case hash
+      in {a: Integer, Integer => k : String}
+        k == 200
+      else false
+      end
+    end
+
+    assert_block do
+      [{200 => 42}, {"a" => "ok"}].all? do |hash|
+        case hash
+        in {Integer => k : String}
+          false
+        else true
+        end
+      end
+    end
   end
 
   def test_paren

--- a/test/ruby/test_syntax.rb
+++ b/test/ruby/test_syntax.rb
@@ -626,13 +626,17 @@ class TestSyntax < Test::Unit::TestCase
     assert_not_label(:foo, 'class Foo < not_label:foo; end', bug6347)
   end
 
-  def test_no_label_with_percent
-    assert_syntax_error('{%"a": 1}', /unexpected ':'/)
-    assert_syntax_error("{%'a': 1}", /unexpected ':'/)
-    assert_syntax_error('{%Q"a": 1}', /unexpected ':'/)
-    assert_syntax_error("{%Q'a': 1}", /unexpected ':'/)
-    assert_syntax_error('{%q"a": 1}', /unexpected ':'/)
-    assert_syntax_error("{%q'a': 1}", /unexpected ':'/)
+  def test_percent_string_hash_key
+    [
+      '%"a"',
+      "%'a'",
+      '%Q"a"',
+      "%Q'a'",
+      '%q"a"',
+      "%q'a'",
+    ].each do |key|
+      assert_equal({"a" => 1}, eval("{#{key}: 1}"), key)
+    end
   end
 
   def test_block_after_cond
@@ -651,6 +655,36 @@ class TestSyntax < Test::Unit::TestCase
     bug11812 = '[ruby-core:72084]'
     assert_valid_syntax('{label:%w(*)}', bug11812)
     assert_valid_syntax('{label: %w(*)}', bug11812)
+  end
+
+  def test_expr_colon_hash_keys
+    expr = 3
+    h = eval(<<~'RUBY')
+      {
+        key1: 1,
+        "key-2": :two,
+        expr : "3-expr",
+        "key4" : "4-String",
+        (5+0): "5-parentheses",
+        6: "6-Integer",
+        7.001: "7-Float",
+        "key" + "8": "8-String expr",
+        9+0: "9-Integer expr",
+        [10,0]: "10-Array",
+        true ? 11 : 0 : "11-ternary"
+      }
+    RUBY
+    assert_equal(1, h[:key1])
+    assert_equal(:two, h[:"key-2"])
+    assert_equal("3-expr", h[3])
+    assert_equal("4-String", h["key4"])
+    assert_equal("5-parentheses", h[5])
+    assert_equal("6-Integer", h[6])
+    assert_equal("7-Float", h[7.001])
+    assert_equal("8-String expr", h["key8"])
+    assert_equal("9-Integer expr", h[9])
+    assert_equal("10-Array", h[[10,0]])
+    assert_equal("11-ternary", h[11])
   end
 
   def test_heredoc_after_label


### PR DESCRIPTION
## Summary

This PR extends Ruby's Hash Pattern Matching to support keys beyond static symbols. Previously, hash patterns only supported symbol keys (e.g., `{a: Integer}`). This PR adds support for arbitrary expressions as hash pattern keys.

## Relationship to #17318

This branch includes #17318's commit (hash literal `{ expr : value }` support) and extends the same colon-separated syntax to hash patterns. #17318 covers hash literal creation; this PR adds hash pattern matching on top.

## Features Added

### 1. String Keys
```ruby
case {"a" => 1, "b" => "x"}
in {"a" : Integer, "b" : String}
  # matches
end
```

### 2. Expression Keys (Arbitrary Expressions)
```ruby
# Integer keys
case {1 => "ok"}
in {Integer : String}
  # matches
end

# Float keys
case {1.5 => "ok"}
in {Float : String}
  # matches
end

# Array keys
case {[1, 2] => "ok"}
in {Array : String}
  # matches
end

# Range keys
case {200 => "ok"}
in {(200..300) => k : String}
  # k == 200
end
```

### 3. Expression Keys (Dynamic)
```ruby
# Method call
case {key12() => "ok"}
in {key12() : String}
  # matches
end

# Lambda
case {key13[] => "ok"}
in {key13[] : String}
  # matches
end

# Ternary
case {(true ? 11 : 0) => "ok"}
in {(true ? 11 : 0) : String}
  # matches
end
```

### 4. Mixed Symbol and Non-Symbol Keys
```ruby
case {a: 1, 200 => "ok"}
in {a: Integer, Integer : String}
  # matches
end
```

### 5. Key Capture (Capturing Both Key and Value)
```ruby
# Capture key only
case {200 => "ok"}
in {Integer => k : String}
  # k == 200
end

# Capture both key and value
case {200 => "ok"}
in {Integer => k : String => v}
  # k == 200, v == "ok"
end
```

### 6. Rest Pattern with Non-Symbol Keys
```ruby
case {200 => "ok", 300 => "fail"}
in {Integer : String => v, **rest}
  # v == "ok", rest == {300 => "fail"}
end
```

## Implementation

### Files Changed

| File | Description |
|------|-------------|
| `compile.c` | Core VM instruction generation for hash pattern matching |
| `prism_compile.c` | Prism compiler support for new hash pattern syntax |
| `parse.y` | Parser grammar for new hash pattern syntax |
| `test/ruby/test_pattern_matching.rb` | Comprehensive test suite |
| `doc/syntax/pattern_matching.rdoc` | Documentation updates |

### Core Changes

#### `compile.c` - `iseq_compile_pattern_each` (NODE_HSHPTN handling)
- Extended to handle non-symbol key nodes (`NODE_SYM`, `NODE_STR`, `NODE_DSTR`, `NODE_XSTR`, `NODE_INTEGER`, `NODE_FLOAT`, `NODE_RATIONAL`, `NODE_IMAGINARY`, `NODE_REGX`, `NODE_ARRAY`, `NODE_REGX`, `NODE_DREGX`, etc.)
- Added support for `NODE_ARYPTN` as key pattern
- Handles both symbol keys (existing) and non-symbol keys (new)
- Generates appropriate bytecode for key existence check (`key?`) and value extraction (`[]` or `delete`)

#### `prism_compile.c`
- Mirrored changes for Prism compiler
- Handles same node types for hash pattern compilation

#### `parse.y`
- Extended grammar to accept expressions as hash pattern keys
- New syntax rules for `{expr : pattern}` and `{expr => var : pattern}`

#### Tests
- `test_hash_colon_key_pattern` - Basic string key tests
- `test_hash_colon_key_pattern_all_types` - All supported key types
- `test_hash_expression_key_pattern` - Expression keys and key capture

## Syntax Changes

### Before (Only Symbol Keys)
```ruby
case hash
in {a: Integer, b: String}
  # Only symbol keys: a:, b:
end
```

### After (All Key Types)
```ruby
case hash
# String keys (quoted)
in {"key" : Integer, "key-2" : String}

# Expression keys (no quotes)
in {Integer : String}
in {Float : String}
in {Array : String}
in {Integer => k : String}  # capture key

# Range keys
in {(1..10) : Integer}

# Expression keys (dynamic)
in {method_call() : String}
in {variable : String}
in {(1 + 2) : String}
in {[1, 2] : String}
in {lambda.call : String}
```

## Compatibility

- **Backward compatible**: Existing symbol key patterns continue to work unchanged
- **No breaking changes**: All existing hash pattern syntax remains valid
- **Mixed usage**: Can freely mix symbol and non-symbol keys in same pattern

## Testing

All tests pass:
```bash
make test TESTOPTS="-- ruby/test/ruby/test_pattern_matching.rb"
```

Key test methods:
- `test_hash_colon_key_pattern` - Basic string key patterns
- `test_hash_colon_key_pattern_all_types` - All key types (String, Integer, Float, Array, Range, expressions)
- `test_hash_expression_key_pattern` - Expression keys, key capture, rest patterns

## Documentation

Updated `doc/syntax/pattern_matching.rdoc` with:
- Updated hash pattern syntax documentation
- Examples of new key types
- Key capture syntax documentation
- Mixed key type examples

## Performance

- Minimal overhead for symbol key patterns (existing fast path preserved)
- Non-symbol keys use slightly more bytecode for key evaluation
- No performance impact on non-hash-pattern code paths

## Related Issues

- Fixes long-standing limitation of hash patterns only accepting symbol keys
- Enables more expressive pattern matching for hash-like objects
- Aligns hash pattern capabilities with array pattern flexibility

## Motivation

Parsed JSON (via `JSON.parse`) produces hashes with string keys. The options before this change:

1. Recursive `deep_symbolize_keys` — easy to forget, must be applied on every nested structure
2. Use `name:` label syntax — looks up `:name` (symbol), not `"name"` (string) — silently fails to match

With this change, `"name" : String` in a hash pattern looks up the string key `"name"` directly — no preprocessing needed.

## Before / After

```ruby
require "json"

accounts = JSON.parse(<<~JSON)
[
  {"admin": {"first name": "Alice", "age": 30, "privileges": {"read": true, "write": true, "execute": null}}},
  {"user": {"first name": "Bobby", "age": 25}}
]
JSON

# BEFORE: deep_symbolize_keys needed for string-keyed JSON.
# Also requires .map(&:to_s) to unmangle symbolized keys back for display.
def deep_symbolize_keys(obj)
  case obj
  when Hash
    obj.each_with_object({}) { |(k, v), h| h[k.to_sym] = deep_symbolize_keys(v) }
  when Array
    obj.map { |e| deep_symbolize_keys(e) }
  else
    obj
  end
end

deep_symbolize_keys(accounts).each do |account|
  case account
  in {"admin": {"first name": String => name, "age": Integer => age, "privileges": privileges}}
    puts "#{name} is a #{age}yo admin with #{privileges.compact.keys.map(&:to_s)} privileges."
  in {"user": {"first name": String => name, "age": Integer => age}}
    puts "#{name} is a #{age}yo user."
  end
end

# AFTER: match directly on string keys — no symbolize needed.
# Keys are already strings, so .keys returns strings directly.
accounts.each do |account|
  case account
  in {"admin" : {"first name" : String => name, "age" : Integer => age, "privileges" : privileges}}
    puts "#{name} is a #{age}yo admin with #{privileges.compact.keys} privileges."
  in {"user" : {"first name" : String => name, "age" : Integer => age}}
    puts "#{name} is a #{age}yo user."
  end
end
```

Both produce:
```
Alice is a 30yo admin with ["read", "write"] privileges.
Bobby is a 25yo user.
```

## Implementation

The `:` separator (with space before colon) avoids the ambiguity that `=>` would create — `=>` is already the capture operator in patterns (`key => variable`), so using it as a key-value separator would be ambiguous.

## Related

- #17318 (hash literal `{ expr : value }` support — this branch includes its commit)
- [Feature #22111](https://bugs.ruby-lang.org/issues/22111) (tracking issue)

 Assisted-by: OpenCode 1.17.11 (opencode/big-pickle)