### PR TITLE
Retry transient crates.io download failures on all Rust CI

### DIFF
--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -27,6 +27,11 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  # Work around transient crates.io download failures (curl HTTP/2 framing / partial transfer)
+  CARGO_NET_RETRY: 10
+  CARGO_HTTP_MULTIPLEXING: false
+
 # Each job is split so that they roughly take 30min to run through.
 jobs:
   compile-if:

--- a/.github/workflows/modgc.yml
+++ b/.github/workflows/modgc.yml
@@ -20,6 +20,11 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  # Work around transient crates.io download failures (curl HTTP/2 framing / partial transfer)
+  CARGO_NET_RETRY: 10
+  CARGO_HTTP_MULTIPLEXING: false
+
 jobs:
   check:
     strategy:

--- a/.github/workflows/rust-warnings.yml
+++ b/.github/workflows/rust-warnings.yml
@@ -20,6 +20,11 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  # Work around transient crates.io download failures (curl HTTP/2 framing / partial transfer)
+  CARGO_NET_RETRY: 10
+  CARGO_HTTP_MULTIPLEXING: false
+
 jobs:
   rust-warnings:
     env:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -20,6 +20,11 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  # Work around transient crates.io download failures (curl HTTP/2 framing / partial transfer)
+  CARGO_NET_RETRY: 10
+  CARGO_HTTP_MULTIPLEXING: false
+
 jobs:
   make:
     strategy:

--- a/.github/workflows/yjit-macos.yml
+++ b/.github/workflows/yjit-macos.yml
@@ -26,6 +26,11 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  # Work around transient crates.io download failures (curl HTTP/2 framing / partial transfer)
+  CARGO_NET_RETRY: 10
+  CARGO_HTTP_MULTIPLEXING: false
+
 jobs:
   cargo:
     name: cargo test

--- a/.github/workflows/yjit-ubuntu.yml
+++ b/.github/workflows/yjit-ubuntu.yml
@@ -20,6 +20,11 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  # Work around transient crates.io download failures (curl HTTP/2 framing / partial transfer)
+  CARGO_NET_RETRY: 10
+  CARGO_HTTP_MULTIPLEXING: false
+
 jobs:
   cargo:
     name: cargo test

--- a/.github/workflows/zjit-macos.yml
+++ b/.github/workflows/zjit-macos.yml
@@ -26,6 +26,11 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  # Work around transient crates.io download failures (curl HTTP/2 framing / partial transfer)
+  CARGO_NET_RETRY: 10
+  CARGO_HTTP_MULTIPLEXING: false
+
 jobs:
   make:
     strategy:

--- a/.github/workflows/zjit-ubuntu.yml
+++ b/.github/workflows/zjit-ubuntu.yml
@@ -26,6 +26,11 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  # Work around transient crates.io download failures (curl HTTP/2 framing / partial transfer)
+  CARGO_NET_RETRY: 10
+  CARGO_HTTP_MULTIPLEXING: false
+
 jobs:
   lint:
     name: cargo clippy
@@ -100,9 +105,6 @@ jobs:
       BUNDLE_JOBS: 8 # for yjit-bench
       RUST_BACKTRACE: 1
       ZJIT_RB_BUG: 1
-      # Work around transient crates.io download failures (curl [16] HTTP/2 framing layer)
-      CARGO_NET_RETRY: 10
-      CARGO_HTTP_MULTIPLEXING: false
 
     runs-on: ${{ matrix.runs-on || 'ubuntu-22.04' }}
 


### PR DESCRIPTION
The ZJIT Ubuntu ruby-bench job failed when cargo could not finish downloading a crate from crates.io. curl reported a truncated transfer ([18] partial file), the same class of transient failure that the zjit-ubuntu make job already works around with CARGO_NET_RETRY and CARGO_HTTP_MULTIPLEXING=false ([16] HTTP/2 framing layer).

That workaround only covered one job. Every workflow that compiles YJIT, ZJIT, or any Rust code is exposed to the same flakiness. This sets CARGO_NET_RETRY and disables HTTP/2 multiplexing at the workflow level across all of them so cargo retries instead of failing the build, and consolidates the existing per-job settings in zjit-ubuntu into the workflow-level env.

https://github.com/ruby/ruby/actions/runs/28014276636/job/82914636268
