### PR TITLE
load.c: rewind stack on exception

### DIFF
--- a/load.c
+++ b/load.c
@@ -1313,6 +1313,7 @@ require_internal(rb_execution_context_t *ec, VALUE fname, int exception, bool wa
     saved_path = path;
 
     EC_PUSH_TAG(ec);
+    rb_control_frame_t *volatile saved_cfp = ec->cfp;
     ec->errinfo = Qnil; /* ensure */
     th->top_wrapper = 0;
     if ((state = EC_EXEC_TAG()) == TAG_NONE) {
@@ -1354,6 +1355,9 @@ require_internal(rb_execution_context_t *ec, VALUE fname, int exception, bool wa
                 result = TAG_RETURN;
             }
         }
+    }
+    else {
+        rb_vm_rewind_cfp(ec, saved_cfp);
     }
     EC_POP_TAG();
 


### PR DESCRIPTION
[[Bug #21967]](https://bugs.ruby-lang.org/issues/21967)

As suggested by @composerinteralia. I must admit I'm not familiar enough with this to really know if it's the best fix (likely isn't), but it does indeed prevent the crash:

```ruby
fork do
  10.times do
    sleep 0.01
    Process.kill(:SIGTERM, Process.ppid)
  end
end

now = Time.now
Encoding.list.each do
  p _1.name
  Encoding.find(_1.name).ascii_compatible?
end
p (Time.now.to_f - now.to_f).round(2)
```