### PR TITLE
[Bug #22126] Fix partial DCE with loop back-edges

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -3149,41 +3149,56 @@ find_destination(INSN *i)
 static int
 remove_unreachable_chunk(rb_iseq_t *iseq, LINK_ELEMENT *i)
 {
-    LINK_ELEMENT *first = i, *end;
+    LINK_ELEMENT *first = i, *end, *scan;
     int *unref_counts = 0, nlabels = ISEQ_COMPILE_DATA(iseq)->label_no;
 
     if (!i) return 0;
     unref_counts = ALLOCA_N(int, nlabels);
     MEMZERO(unref_counts, int, nlabels);
-    end = i;
+
+    scan = i;
     do {
         LABEL *lab;
-        if (IS_INSN(i)) {
-            if (IS_INSN_ID(i, leave)) {
-                end = i;
+        if (IS_INSN(scan)) {
+            if (IS_INSN_ID(scan, leave)) {
                 break;
             }
-            else if ((lab = find_destination((INSN *)i)) != 0) {
+            else if ((lab = find_destination((INSN *)scan)) != 0) {
                 unref_counts[lab->label_no]++;
             }
         }
-        else if (IS_LABEL(i)) {
-            lab = (LABEL *)i;
+        else if (IS_LABEL(scan)) {
+            lab = (LABEL *)scan;
             if (lab->unremovable) return 0;
+        }
+        else if (IS_ADJUST(scan)) {
+            return 0;
+        }
+    } while ((scan = scan->next) != 0);
+
+    end = i;
+    scan = i;
+    do {
+        LABEL *lab;
+        if (IS_INSN(scan)) {
+            if (IS_INSN_ID(scan, leave)) {
+                end = scan;
+                break;
+            }
+        }
+        else if (IS_LABEL(scan)) {
+            lab = (LABEL *)scan;
             if (lab->refcnt > unref_counts[lab->label_no]) {
-                if (i == first) return 0;
+                if (scan == first) return 0;
                 break;
             }
             continue;
         }
-        else if (IS_TRACE(i)) {
-            /* do nothing */
-        }
-        else if (IS_ADJUST(i)) {
+        else if (IS_ADJUST(scan)) {
             return 0;
         }
-        end = i;
-    } while ((i = i->next) != 0);
+        end = scan;
+    } while ((scan = scan->next) != 0);
     i = first;
     do {
         if (IS_INSN(i)) {

--- a/test/ruby/test_iseq.rb
+++ b/test/ruby/test_iseq.rb
@@ -953,6 +953,10 @@ class TestISeq < Test::Unit::TestCase
     end
   end
 
+  def test_unreachable_find_pattern_in_else_branch
+    assert_in_out_err([], "if []; else; a => [*, 42, *]; end")
+  end
+
   def test_serialize_anonymous_outer_variables
     iseq = RubyVM::InstructionSequence.compile(<<~'RUBY')
       obj = Object.new


### PR DESCRIPTION
ref: https://bugs.ruby-lang.org/issues/22126

The old `remove_unreachable_chunk` walked the dead code once and tried to do two things at the same time -- count label references inside that chunk and figure out what exactly to delete.

That breaks for loops -- the loop label comes before the jump back to it; on the first walk, the label looks like it has no references inside the chunk yet, so the optimizer thinks something outside the dead code still needs it. It stops there and deletes only the setup code before the loop, leaving the loop body behind.

The implementation is changed to use two passes to mitigate the issue; I believe the performance overhead is neglible

```shell
$ ruby --parser parse.y -e 'if []; else; a => [*, 42, *]; end'
$ ruby --parser prism -e   'if []; else; a => [*, 42, *]; end'
-- raw disasm--------
   trace: 1
   0000 putnil                                                           (   1)
   0001 leave                                                            (   1)
 <L018> [sp: 1, unremovable: 0, refcnt: 1]
   0002 dup                                                              (   1)
   0003 topn                 2                                           (   1)
   0005 opt_le               <calldata:<=, 1>                            (   1)
   0007 branchunless         <L021>                                      (   1)
   0009 topn                 3                                           (   1)
   0011 topn                 1                                           (   1)
   0013 opt_aref             <calldata:[], 1>                            (   1)
   0015 putobject            42                                          (   1)
   0017 dupn                 2                                           (   1)
   0019 checkmatch           2                                           (   1)
   0021 dup                                                              (   1)
   0022 branchif             <L023>                                      (   1)
   0024 putspecialobject     1                                           (   1)
   0026 putobject            "%p === %p does not return true"            (   1)
   0028 topn                 3                                           (   1)
   0030 topn                 5                                           (   1)
   0032 opt_send_without_block <calldata:core#sprintf, 3>                (   1)
   0034 setn                 10                                          (   1)
   0036 putobject            false                                       (   1)
   0038 setn                 12                                          (   1)
   0040 pop                                                              (   1)
   0041 pop                                                              (   1)
 <L023> [sp: 4, unremovable: 0, refcnt: 1]
   0042 setn                 2                                           (   1)
   0044 pop                                                              (   1)
   0045 pop                                                              (   1)
   0046 branchif             <L020>                                      (   1)
   0048 putobject_INT2FIX_1_                                             (   1)
   0049 opt_plus             <calldata:+, 1>                             (   1)
   0051 jump                 <L018>                                      (   1)
 <L021> [sp: 1, unremovable: 0, refcnt: 1]
*  0053 adjuststack          3                                           (   1)
   0055 putspecialobject     1                                           (   1)
   0057 putobject            "%p does not match to find pattern"         (   1)
   0059 topn                 2                                           (   1)
   0061 opt_send_without_block <calldata:core#sprintf, 2>                (   1)
   0063 setn                 4                                           (   1)
   0065 putobject            false                                       (   1)
   0067 setn                 6                                           (   1)
   0069 pop                                                              (   1)
   0070 pop                                                              (   1)
   0071 jump                 <L012>                                      (   1)
 <L020> [sp: 1, unremovable: 0, refcnt: 1]
   0073 adjuststack          3                                           (   1)
   0075 pop                                                              (   1)
   0076 jump                 <L003>                                      (   1)
 <L012> [sp: -1, unremovable: 0, refcnt: 1]
   0078 pop                                                              (   1)
   0079 putspecialobject     1                                           (   1)
   0081 topn                 4                                           (   1)
   0083 branchif             <L024>                                      (   1)
   0085 putobject            NoMatchingPatternError                      (   1)
   0087 putspecialobject     1                                           (   1)
   0089 putobject            "%p: %s"                                    (   1)
   0091 topn                 4                                           (   1)
   0093 topn                 7                                           (   1)
   0095 opt_send_without_block <calldata:core#sprintf, 3>                (   1)
   0097 opt_send_without_block <calldata:core#raise, 2>                  (   1)
   0099 jump                 <L025>                                      (   1)
 <L024> [sp: -1, unremovable: 0, refcnt: 1]
   0101 putobject            NoMatchingPatternKeyError                   (   1)
   0103 putspecialobject     1                                           (   1)
   0105 putobject            "%p: %s"                                    (   1)
   0107 topn                 4                                           (   1)
   0109 topn                 7                                           (   1)
   0111 opt_send_without_block <calldata:core#sprintf, 3>                (   1)
   0113 topn                 7                                           (   1)
   0115 topn                 9                                           (   1)
   0117 opt_send_without_block <calldata:new, 3>                         (   1)
   0119 opt_send_without_block <calldata:core#raise, 1>                  (   1)
 <L025> [sp: -1, unremovable: 0, refcnt: 1]
   0121 adjuststack          7                                           (   1)
   0123 putnil                                                           (   1)
   0124 leave                                                            (   1)
 <L003> [sp: -1, unremovable: 0, refcnt: 1]
   0125 adjuststack          6                                           (   1)
   0127 putnil                                                           (   1)
   0128 leave                                                            (   1)
---------------------
-e:1: argument stack underflow (-2)
-e: compile error (SyntaxError)
```

Reproducible on every version since `3.4.0-preview2` (`docker run -e ALL_RUBY_SHOW_DUP=yes -e ALL_RUBY_SINCE=3.4 --rm rubylang/all-ruby ./all-ruby -We 'if []; else; a => [*, 42, *]; end'`)

There seem to be another issue related to Prism's DCE & loops:

```shell
$ ruby --parser parse.y --dump insn -e 'if []; else; while true; end; end'
== disasm: #<ISeq:<main>@-e:1 (1,0)-(1,33)>
0000 putnil                                                           (   1)[Li]
0001 leave
$ ruby --parser prism --dump insn -e 'if []; else; while true; end; end'
== disasm: #<ISeq:<main>@-e:1 (1,0)-(1,33)>
0000 newarray                               0                         (   1)[Li]
0002 branchunless                           11
0004 putnil
0005 leave
0006 pop
0007 jump                                   11
0009 putnil
0010 pop
0011 jump                                   11
0013 putnil
0014 leave
```

the reason `branchunless` is not eliminated is that prism does not emit `NODE_ZLIST` like `parse.y` does and instead emits `PM_ARRAY_NODE-0` while is not treated as a truthy value by the peephole-optmizer. LMK if it should be addressed as well