### PR TITLE
compile.c: reject negative object index in the IBF loader (pinned_list_store / pinned_list_fetch)

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -12647,7 +12647,7 @@ pinned_list_fetch(VALUE list, long offset)
 
     TypedData_Get_Struct(list, struct pinned_list, &pinned_list_type, ptr);
 
-    if (offset >= ptr->size) {
+    if (offset < 0 || offset >= ptr->size) {
         rb_raise(rb_eIndexError, "object index out of range: %ld", offset);
     }
 
@@ -12661,7 +12661,7 @@ pinned_list_store(VALUE list, long offset, VALUE object)
 
     TypedData_Get_Struct(list, struct pinned_list, &pinned_list_type, ptr);
 
-    if (offset >= ptr->size) {
+    if (offset < 0 || offset >= ptr->size) {
         rb_raise(rb_eIndexError, "object index out of range: %ld", offset);
     }
 


### PR DESCRIPTION
## compile.c: reject negative object index in the IBF loader (pinned_list_store / pinned_list_fetch)

`pinned_list_store` and `pinned_list_fetch` in `compile.c` validate only the upper bound
of the object index (a signed `long`):

```c
if (offset >= ptr->size) {
    rb_raise(rb_eIndexError, "object index out of range: %ld", offset);
}
```

They accept negative offsets, so a malformed or truncated IBF blob whose object index
(e.g. the `TS_CDHASH` operand in `ibf_load_code`) is negative causes an out-of-bounds
write (`pinned_list_store`) or read (`pinned_list_fetch`) through `ptr->buffer[negative]`
instead of failing cleanly.

This is not a security boundary (`load_from_binary` is documented as requiring trusted
input, per https://hackerone.com/reports/3816955), but in practice the loader is reached by
caching layers (e.g. Bootsnap) on possibly-corrupted on-disk caches, so a clean exception is
much friendlier than an OOB access when debugging a corrupted cache, and is consistent with
the existing upper-bound check.

The fix adds a lower-bound check to both functions, turning the OOB access into the same
`IndexError` already raised for the upper bound:

```c
if (offset < 0 || offset >= ptr->size) {
    rb_raise(rb_eIndexError, "object index out of range: %ld", offset);
}
```

Verification: `test/ruby/test_iseq.rb` passes with the change, and a crafted IBF blob with a
negative object index now raises `IndexError` instead of performing a silent out-of-bounds
write.

(I initially included a regression test using a fixed crafted blob, but dropped it: IBF
binaries are platform-specific (endianness / word size), so the blob was rejected as
"broken binary format" on big-endian / 32-bit CI before reaching the code path. Happy to add
a regression test that constructs the malformed input at test time if you'd like one.)
