### PR TITLE
ZJIT: Remove optimize_getivar

### DIFF
--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -3970,13 +3970,22 @@ impl Function {
                             }
 
                             self.push_insn(block, Insn::PatchPoint { invariant: Invariant::MethodRedefined { klass, method: mid, cme }, state });
+                            let id = unsafe { get_cme_def_body_attr_id(cme) };
                             if let Some(profiled_type) = profiled_type {
                                 let argc = unsafe { vm_ci_argc(ci) } as i32;
+                                // TODO: attr_writer SetIvar has a null inline cache and may target a receiver
+                                // operand other than CFP self. Support it with a reprofile strategy that
+                                // profiles the receiver operand even after the send insn has finished profiling.
+                                let recompile = None;
                                 recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: Some(Recompile::ProfileSend{ argc }) });
+                                self.try_emit_optimized_setivar(block, recv, id, val, profiled_type, state, recompile).unwrap_or_else(|counter| {
+                                    self.count(block, counter);
+                                    self.push_insn(block, Insn::SetIvar { self_val: recv, id, ic: std::ptr::null(), val, state });
+                                });
+                            } else {
+                                // No shape information, just static class information
+                                self.push_insn(block, Insn::SetIvar { self_val: recv, id, ic: std::ptr::null(), val, state });
                             }
-                            let id = unsafe { get_cme_def_body_attr_id(cme) };
-
-                            self.push_insn(block, Insn::SetIvar { self_val: recv, id, ic: std::ptr::null(), val, state });
                             self.make_equal_to(insn_id, val);
                         } else if !has_block && def_type == VM_METHOD_TYPE_OPTIMIZED {
                             let opt_type: OptimizedMethodType = unsafe { get_cme_def_body_optimized_type(cme) }.into();
@@ -4986,106 +4995,97 @@ impl Function {
         Ok(self.load_ivar(block, self_val, profiled_type, id))
     }
 
-    fn optimize_getivar(&mut self) {
-        for block in self.reverse_post_order() {
-            let old_insns = std::mem::take(&mut self.blocks[block.0].insns);
-            assert!(self.blocks[block.0].insns.is_empty());
-            for insn_id in old_insns {
-                match self.find(insn_id) {
-                    Insn::SetIvar { self_val, id, val, state, ic } => {
-                        let Some(recv_type) = self.profiled_type_of_at(self_val, state) else {
-                            // No (monomorphic/skewed polymorphic) profile info
-                            self.count(block, Counter::setivar_fallback_not_monomorphic);
-                            self.push_insn_id(block, insn_id); continue;
-                        };
-                        if recv_type.flags().is_immediate() {
-                            // Instance variable lookups on immediate values are always nil
-                            self.count(block, Counter::setivar_fallback_immediate);
-                            self.push_insn_id(block, insn_id); continue;
-                        }
-                        assert!(recv_type.shape().is_valid());
-                        if !recv_type.flags().is_t_object() {
-                            // Check if the receiver is a T_OBJECT
-                            self.count(block, Counter::setivar_fallback_not_t_object);
-                            self.push_insn_id(block, insn_id); continue;
-                        }
-                        if recv_type.shape().is_complex() {
-                            // too-complex shapes can't use index access
-                            self.count(block, Counter::setivar_fallback_complex);
-                            self.push_insn_id(block, insn_id); continue;
-                        }
-                        if recv_type.shape().is_frozen() {
-                            // Can't set ivars on frozen objects
-                            self.count(block, Counter::setivar_fallback_frozen);
-                            self.push_insn_id(block, insn_id); continue;
-                        }
-                        if self.policy.no_side_exits {
-                            // TODO: Support polymorphic SetIvar shape-specialized paths.
-                            // https://github.com/Shopify/ruby/issues/927
-                            // On the final version, keep the SetIvar fallback instead of another shape guard.
-                            self.push_insn_id(block, insn_id); continue;
-                        }
-                        let mut ivar_index: attr_index_t = 0;
-                        let mut next_shape_id = recv_type.shape();
-                        if !unsafe { rb_shape_get_iv_index(recv_type.shape().0, id, &mut ivar_index) } {
-                            // Current shape does not contain this ivar; do a shape transition.
-                            let current_shape_id = recv_type.shape();
-                            let class = recv_type.class();
-                            // We're only looking at T_OBJECT so ignore all of the imemo stuff.
-                            assert!(recv_type.flags().is_t_object());
-                            next_shape_id = ShapeId(unsafe { rb_shape_transition_add_ivar_no_warnings(current_shape_id.0, id, class) });
-                            // If the VM ran out of shapes, or this class generated too many leaf,
-                            // it may be de-optimized into OBJ_COMPLEX_SHAPE (hash-table).
-                            let new_shape_complex = unsafe { rb_jit_shape_complex_p(next_shape_id.0) };
-                            // TODO(max): Is it OK to bail out here after making a shape transition?
-                            if new_shape_complex {
-                                self.count(block, Counter::setivar_fallback_new_shape_complex);
-                                self.push_insn_id(block, insn_id); continue;
-                            }
-                            let ivar_result = unsafe { rb_shape_get_iv_index(next_shape_id.0, id, &mut ivar_index) };
-                            assert!(ivar_result, "New shape must have the ivar index");
-                            let current_capacity = unsafe { rb_jit_shape_capacity(current_shape_id.0) };
-                            let next_capacity = unsafe { rb_jit_shape_capacity(next_shape_id.0) };
-                            // If the new shape has a different capacity, or is COMPLEX, we'll have to
-                            // reallocate it.
-                            let needs_extension = next_capacity != current_capacity;
-                            if needs_extension {
-                                self.count(block, Counter::setivar_fallback_new_shape_needs_extension);
-                                self.push_insn_id(block, insn_id); continue;
-                            }
-                            // Fall through to emitting the ivar write
-                        }
-                        let self_val = self.guard_heap(block, self_val, state);
-                        let shape = self.load_shape(block, self_val);
-                        // TODO: attr_writer SetIvar has a null inline cache and may target a receiver
-                        // operand other than CFP self. Support it with a reprofile strategy that
-                        // profiles the receiver operand even after the send insn has finished profiling.
-                        let recompile = if ic.is_null() { None } else { Some(Recompile::ProfileSelf) };
-                        self.guard_shape(block, shape, recv_type.shape(), state, recompile);
-                        // Current shape contains this ivar
-                        let (ivar_storage, offset) = if recv_type.flags().is_embedded() {
-                            // See ROBJECT_FIELDS() from include/ruby/internal/core/robject.h
-                            let offset = ROBJECT_OFFSET_AS_ARY + (SIZEOF_VALUE * ivar_index.to_usize()) as i32;
-                            (self_val, offset)
-                        } else {
-                            let as_heap = self.push_insn(block, Insn::LoadField { recv: self_val, id: FieldName::as_heap, offset: ROBJECT_OFFSET_AS_HEAP_FIELDS, return_type: types::CPtr });
-                            let offset = SIZEOF_VALUE_I32 * ivar_index as i32;
-                            (as_heap, offset)
-                        };
-                        self.push_insn(block, Insn::StoreField { recv: ivar_storage, id: id.into(), offset, val });
-                        self.push_insn(block, Insn::WriteBarrier { recv: self_val, val });
-                        if next_shape_id != recv_type.shape() {
-                            // Write the new shape ID
-                            let shape_id = self.push_insn(block, Insn::Const { val: Const::CShape(next_shape_id) });
-                            let shape_id_offset = unsafe { rb_shape_id_offset() };
-                            self.push_insn(block, Insn::StoreField { recv: self_val, id: FieldName::shape_id, offset: shape_id_offset, val: shape_id });
-                        }
-                    }
-                    _ => { self.push_insn_id(block, insn_id); }
-                }
-            }
+    fn try_emit_optimized_setivar(&mut self, block: BlockId, self_val: InsnId, id: ID, val: InsnId, profiled_type: ProfiledType, state: InsnId, recompile: Option<Recompile>) -> Result<(), Counter> {
+        if profiled_type.flags().is_immediate() {
+            // Instance variable lookups on immediate values are always nil
+            return Err(Counter::setivar_fallback_immediate);
         }
-        crate::stats::trace_compile_phase("infer_types", || self.infer_types());
+        if !profiled_type.flags().is_t_object() {
+            // Check if the receiver is a T_OBJECT
+            return Err(Counter::setivar_fallback_not_t_object);
+        }
+        assert!(profiled_type.shape().is_valid());
+        if profiled_type.shape().is_frozen() {
+            // Can't set ivars on frozen objects
+            return Err(Counter::setivar_fallback_frozen);
+        }
+        if profiled_type.shape().is_complex() {
+            // too-complex shapes can't use index access
+            return Err(Counter::setivar_fallback_complex);
+        }
+        if self.policy.no_side_exits {
+            // On the final version, skip GetIvar shape specialization.
+            // iseq_to_hir already generates polymorphic branches with a
+            // GetIvar C call fallback for getinstancevariable, so we don't
+            // need to wrap it again here.
+            return Err(Counter::setivar_fallback_no_side_exits);
+        }
+
+        let mut ivar_index: attr_index_t = 0;
+        let mut next_shape_id = profiled_type.shape();
+        if !unsafe { rb_shape_get_iv_index(profiled_type.shape().0, id, &mut ivar_index) } {
+            // Current shape does not contain this ivar; do a shape transition.
+            let current_shape_id = profiled_type.shape();
+            let class = profiled_type.class();
+            // We're only looking at T_OBJECT so ignore all of the imemo stuff.
+            assert!(profiled_type.flags().is_t_object());
+            next_shape_id = ShapeId(unsafe { rb_shape_transition_add_ivar_no_warnings(current_shape_id.0, id, class) });
+            // If the VM ran out of shapes, or this class generated too many leaf,
+            // it may be de-optimized into OBJ_COMPLEX_SHAPE (hash-table).
+            let new_shape_complex = unsafe { rb_jit_shape_complex_p(next_shape_id.0) };
+            // TODO(max): Is it OK to bail out here after making a shape transition?
+            if new_shape_complex {
+                return Err(Counter::setivar_fallback_new_shape_complex);
+            }
+            let ivar_result = unsafe { rb_shape_get_iv_index(next_shape_id.0, id, &mut ivar_index) };
+            assert!(ivar_result, "New shape must have the ivar index");
+            let current_capacity = unsafe { rb_jit_shape_capacity(current_shape_id.0) };
+            let next_capacity = unsafe { rb_jit_shape_capacity(next_shape_id.0) };
+            // If the new shape has a different capacity, or is COMPLEX, we'll have to
+            // reallocate it.
+            let needs_extension = next_capacity != current_capacity;
+            if needs_extension {
+                return Err(Counter::setivar_fallback_new_shape_needs_extension);
+            }
+            // Fall through to emitting the ivar write
+        }
+        let self_val = self.guard_heap(block, self_val, state);
+        let shape = self.load_shape(block, self_val);
+        self.guard_shape(block, shape, profiled_type.shape(), state, recompile);
+        // Current shape contains this ivar
+        let (ivar_storage, offset) = if profiled_type.flags().is_embedded() {
+            // See ROBJECT_FIELDS() from include/ruby/internal/core/robject.h
+            let offset = ROBJECT_OFFSET_AS_ARY + (SIZEOF_VALUE * ivar_index.to_usize()) as i32;
+            (self_val, offset)
+        } else {
+            let as_heap = self.push_insn(block, Insn::LoadField { recv: self_val, id: FieldName::as_heap, offset: ROBJECT_OFFSET_AS_HEAP_FIELDS, return_type: types::CPtr });
+            let offset = SIZEOF_VALUE_I32 * ivar_index as i32;
+            (as_heap, offset)
+        };
+        self.push_insn(block, Insn::StoreField { recv: ivar_storage, id: id.into(), offset, val });
+        self.push_insn(block, Insn::WriteBarrier { recv: self_val, val });
+        if next_shape_id != profiled_type.shape() {
+            // Write the new shape ID
+            let shape_id = self.push_insn(block, Insn::Const { val: Const::CShape(next_shape_id) });
+            let shape_id_offset = unsafe { rb_shape_id_offset() };
+            self.push_insn(block, Insn::StoreField { recv: self_val, id: FieldName::shape_id, offset: shape_id_offset, val: shape_id });
+        }
+        Ok(())
+    }
+
+    fn optimize_getivar(&mut self) {
+        // for block in self.reverse_post_order() {
+        //     let old_insns = std::mem::take(&mut self.blocks[block.0].insns);
+        //     assert!(self.blocks[block.0].insns.is_empty());
+        //     for insn_id in old_insns {
+        //         match self.find(insn_id) {
+        //             Insn::SetIvar { self_val, id, val, state, ic } => {
+        //             }
+        //             _ => { self.push_insn_id(block, insn_id); }
+        //         }
+        //     }
+        // }
+        // crate::stats::trace_compile_phase("infer_types", || self.infer_types());
     }
 
     fn gen_patch_points_for_optimized_ccall(&mut self, block: BlockId, recv_class: VALUE, method_id: ID, cme: *const rb_callable_method_entry_struct, state: InsnId) {
@@ -9113,7 +9113,7 @@ fn add_iseq_to_hir(
                 }
                 YARVINSN_setinstancevariable => {
                     let id = ID(get_arg(pc, 0).as_u64());
-                    let ic = get_arg(pc, 1).as_ptr();
+                    let ic: *const iseq_inline_iv_cache_entry = get_arg(pc, 1).as_ptr();
                     // Assume single-Ractor mode to omit gen_prepare_non_leaf_call on gen_setivar
                     // TODO: We only really need this if self_val is a class/module
                     if !fun.assume_single_ractor_mode(block, exit_id) {
@@ -9122,7 +9122,16 @@ fn add_iseq_to_hir(
                         break;  // End the block
                     }
                     let val = state.stack_pop()?;
-                    fun.push_insn(block, Insn::SetIvar { self_val: self_param, id, ic, val, state: exit_id });
+                    if let Some(profiled_type) = fun.monomorphic_summary(&profiles, self_param, exit_id) {
+                        // TODO(max): Assert ic is never null
+                        let recompile = if ic.is_null() { None } else { Some(Recompile::ProfileSelf) };
+                        fun.try_emit_optimized_setivar(block, self_param, id, val, profiled_type, exit_id, recompile).unwrap_or_else(|counter| {
+                            fun.count(block, counter);
+                            fun.push_insn(block, Insn::SetIvar { self_val: self_param, id, ic, val, state: exit_id });
+                        });
+                    } else {
+                        fun.push_insn(block, Insn::SetIvar { self_val: self_param, id, ic, val, state: exit_id });
+                    }
                     // SetIvar will raise if self is an immediate. If it raises, we will have
                     // exited JIT code. So upgrade the type within JIT code to a heap object.
                     self_param = fun.push_insn(block, Insn::RefineType { val: self_param, new_type: types::HeapBasicObject });

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -3942,14 +3942,25 @@ impl Function {
                             }
 
                             self.push_insn(block, Insn::PatchPoint { invariant: Invariant::MethodRedefined { klass, method: mid, cme }, state });
+
+                            let id = unsafe { get_cme_def_body_attr_id(cme) };
                             if let Some(profiled_type) = profiled_type {
                                 let argc = unsafe { vm_ci_argc(ci) } as i32;
                                 recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: Some(Recompile::ProfileSend{ argc }) });
-                            }
-                            let id = unsafe { get_cme_def_body_attr_id(cme) };
 
-                            let getivar = self.push_insn(block, Insn::GetIvar { self_val: recv, id, ic: std::ptr::null(), state });
-                            self.make_equal_to(insn_id, getivar);
+                                let replacement = self.try_emit_optimized_getivar(block, recv, id, profiled_type, state).unwrap_or_else(|counter| {
+                                    self.count(block, counter);
+                                    self.push_insn(block, Insn::GetIvar { self_val: recv, id, ic: std::ptr::null(), state })
+                                });
+                                self.make_equal_to(insn_id, replacement);
+                            } else {
+                                // No shape information, just static class information
+                                let resolution = self.resolve_receiver_type_from_profile(recv, state);
+                                let counter = Self::getivar_fallback_reason(resolution, std::ptr::null());
+                                self.count(block, counter);
+                                let getivar = self.push_insn(block, Insn::GetIvar { self_val: recv, id, ic: std::ptr::null(), state });
+                                self.make_equal_to(insn_id, getivar);
+                            }
                         } else if let (false, VM_METHOD_TYPE_ATTRSET, &[val]) = (has_block, def_type, args.as_slice()) {
                             // Check if we're accessing ivars of a Class or Module object as they require single-ractor mode.
                             // We omit gen_prepare_non_leaf_call on gen_getivar, so it's unsafe to raise for multi-ractor mode.
@@ -4952,43 +4963,35 @@ impl Function {
         }
     }
 
+    fn try_emit_optimized_getivar(&mut self, block: BlockId, self_val: InsnId, id: ID, profiled_type: ProfiledType, state: InsnId) -> Result<InsnId, Counter> {
+        if profiled_type.flags().is_immediate() {
+            // Instance variable lookups on immediate values are always nil
+            return Err(Counter::getivar_fallback_immediate);
+        }
+        assert!(profiled_type.shape().is_valid());
+        if profiled_type.shape().is_complex() {
+            // too-complex shapes can't use index access
+            return Err(Counter::getivar_fallback_complex);
+        }
+        if self.policy.no_side_exits {
+            // On the final version, skip GetIvar shape specialization.
+            // iseq_to_hir already generates polymorphic branches with a
+            // GetIvar C call fallback for getinstancevariable, so we don't
+            // need to wrap it again here.
+            return Err(Counter::getivar_fallback_no_side_exits);
+        }
+        let self_val = self.guard_heap(block, self_val, state);
+        let shape = self.load_shape(block, self_val);
+        self.guard_shape(block, shape, profiled_type.shape(), state, Some(Recompile::ProfileSelf));
+        Ok(self.load_ivar(block, self_val, profiled_type, id))
+    }
+
     fn optimize_getivar(&mut self) {
         for block in self.reverse_post_order() {
             let old_insns = std::mem::take(&mut self.blocks[block.0].insns);
             assert!(self.blocks[block.0].insns.is_empty());
             for insn_id in old_insns {
                 match self.find(insn_id) {
-                    Insn::GetIvar { self_val, id, ic, state } => {
-                        let Some(recv_type) = self.profiled_type_of_at(self_val, state) else {
-                            let resolution = self.resolve_receiver_type_from_profile(self_val, state);
-                            let counter = Self::getivar_fallback_reason(resolution, ic);
-                            self.count(block, counter);
-                            self.push_insn_id(block, insn_id); continue;
-                        };
-                        if recv_type.flags().is_immediate() {
-                            // Instance variable lookups on immediate values are always nil
-                            self.count(block, Counter::getivar_fallback_immediate);
-                            self.push_insn_id(block, insn_id); continue;
-                        }
-                        assert!(recv_type.shape().is_valid());
-                        if recv_type.shape().is_complex() {
-                            // too-complex shapes can't use index access
-                            self.count(block, Counter::getivar_fallback_complex);
-                            self.push_insn_id(block, insn_id); continue;
-                        }
-                        if self.policy.no_side_exits {
-                            // On the final version, skip GetIvar shape specialization.
-                            // iseq_to_hir already generates polymorphic branches with a
-                            // GetIvar C call fallback for getinstancevariable, so we don't
-                            // need to wrap it again here.
-                            self.push_insn_id(block, insn_id); continue;
-                        }
-                        let self_val = self.guard_heap(block, self_val, state);
-                        let shape = self.load_shape(block, self_val);
-                        self.guard_shape(block, shape, recv_type.shape(), state, Some(Recompile::ProfileSelf));
-                        let replacement = self.load_ivar(block, self_val, recv_type, id);
-                        self.make_equal_to(insn_id, replacement);
-                    }
                     Insn::SetIvar { self_val, id, val, state, ic } => {
                         let Some(recv_type) = self.profiled_type_of_at(self_val, state) else {
                             // No (monomorphic/skewed polymorphic) profile info
@@ -9093,9 +9096,19 @@ fn add_iseq_to_hir(
                         // make the right number of Params
                         block = join_block;
                     } else {
-                        // Possibly monomorphic case; handled in optimize_getivar
-                        let result = fun.push_insn(block, Insn::GetIvar { self_val: self_param, id, ic, state: exit_id });
-                        state.stack_push(result);
+                        if let Some(profiled_type) = fun.monomorphic_summary(&profiles, self_param, exit_id) {
+                            let result = fun.try_emit_optimized_getivar(block, self_param, id, profiled_type, exit_id).unwrap_or_else(|counter| {
+                                fun.count(block, counter);
+                                fun.push_insn(block, Insn::GetIvar { self_val: self_param, id, ic: std::ptr::null(), state: exit_id })
+                            });
+                            state.stack_push(result);
+                        } else {
+                            let resolution = fun.resolve_receiver_type_from_profile(self_param, exit_id);
+                            let counter = Function::getivar_fallback_reason(resolution, ic);
+                            fun.count(block, counter);
+                            let result = fun.push_insn(block, Insn::GetIvar { self_val: self_param, id, ic, state: exit_id });
+                            state.stack_push(result);
+                        }
                     }
                 }
                 YARVINSN_setinstancevariable => {

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5073,21 +5073,6 @@ impl Function {
         Ok(())
     }
 
-    fn optimize_getivar(&mut self) {
-        // for block in self.reverse_post_order() {
-        //     let old_insns = std::mem::take(&mut self.blocks[block.0].insns);
-        //     assert!(self.blocks[block.0].insns.is_empty());
-        //     for insn_id in old_insns {
-        //         match self.find(insn_id) {
-        //             Insn::SetIvar { self_val, id, val, state, ic } => {
-        //             }
-        //             _ => { self.push_insn_id(block, insn_id); }
-        //         }
-        //     }
-        // }
-        // crate::stats::trace_compile_phase("infer_types", || self.infer_types());
-    }
-
     fn gen_patch_points_for_optimized_ccall(&mut self, block: BlockId, recv_class: VALUE, method_id: ID, cme: *const rb_callable_method_entry_struct, state: InsnId) {
         self.push_insn(block, Insn::PatchPoint { invariant: Invariant::NoTracePoint, state });
         self.push_insn(block, Insn::PatchPoint { invariant: Invariant::MethodRedefined { klass: recv_class, method: method_id, cme }, state });
@@ -6248,7 +6233,6 @@ impl Function {
             // Bucket all strength reduction together
             (type_specialize) => { Counter::compile_hir_strength_reduce_time_ns };
             (inline_trivial) => { Counter::compile_hir_strength_reduce_time_ns };
-            (optimize_getivar) => { Counter::compile_hir_strength_reduce_time_ns };
             (optimize_c_calls) => { Counter::compile_hir_strength_reduce_time_ns };
             (convert_no_profile_sends) => { Counter::compile_hir_strength_reduce_time_ns };
             // End strength reduction bucket
@@ -6298,7 +6282,6 @@ impl Function {
             // inliner then handles more complex methods that require full inlining.
             run_pass!(inline_trivial);
             let did_inline = run_pass!(inline_methods);
-            run_pass!(optimize_getivar);
             run_pass!(optimize_c_calls);
             run_pass!(convert_no_profile_sends);
             run_pass!(optimize_load_store);

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -6299,11 +6299,11 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           v10:Fixnum[5] = Const Value(5)
           PatchPoint SingleRactorMode
-          v21:HeapBasicObject = GuardType v6, HeapBasicObject
-          v22:CShape = LoadField v21, :shape_id@0x1000
-          v23:CShape[0x1001] = GuardBitEquals v22, CShape(0x1001) recompile
-          StoreField v21, :@foo@0x1002, v10
-          WriteBarrier v21, v10
+          v14:HeapBasicObject = GuardType v6, HeapBasicObject
+          v15:CShape = LoadField v14, :shape_id@0x1000
+          v16:CShape[0x1001] = GuardBitEquals v15, CShape(0x1001) recompile
+          StoreField v14, :@foo@0x1002, v10
+          WriteBarrier v14, v10
           CheckInterrupts
           Return v10
         ");
@@ -6328,13 +6328,13 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           v10:Fixnum[5] = Const Value(5)
           PatchPoint SingleRactorMode
-          v21:HeapBasicObject = GuardType v6, HeapBasicObject
-          v22:CShape = LoadField v21, :shape_id@0x1000
-          v23:CShape[0x1001] = GuardBitEquals v22, CShape(0x1001) recompile
-          StoreField v21, :@foo@0x1002, v10
-          WriteBarrier v21, v10
-          v26:CShape[0x1003] = Const CShape(0x1003)
-          StoreField v21, :shape_id@0x1000, v26
+          v14:HeapBasicObject = GuardType v6, HeapBasicObject
+          v15:CShape = LoadField v14, :shape_id@0x1000
+          v16:CShape[0x1001] = GuardBitEquals v15, CShape(0x1001) recompile
+          StoreField v14, :@foo@0x1002, v10
+          WriteBarrier v14, v10
+          v19:CShape[0x1003] = Const CShape(0x1003)
+          StoreField v14, :shape_id@0x1000, v19
           CheckInterrupts
           Return v10
         ");
@@ -6373,21 +6373,21 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           v10:Fixnum[1] = Const Value(1)
           PatchPoint SingleRactorMode
-          v28:HeapBasicObject = GuardType v6, HeapBasicObject
-          v29:CShape = LoadField v28, :shape_id@0x1000
-          v30:CShape[0x1001] = GuardBitEquals v29, CShape(0x1001) recompile
-          StoreField v28, :@foo@0x1002, v10
-          WriteBarrier v28, v10
-          v33:CShape[0x1003] = Const CShape(0x1003)
-          StoreField v28, :shape_id@0x1000, v33
-          v17:Fixnum[2] = Const Value(2)
+          v13:HeapBasicObject = GuardType v6, HeapBasicObject
+          v14:CShape = LoadField v13, :shape_id@0x1000
+          v15:CShape[0x1001] = GuardBitEquals v14, CShape(0x1001) recompile
+          StoreField v13, :@foo@0x1002, v10
+          WriteBarrier v13, v10
+          v18:CShape[0x1003] = Const CShape(0x1003)
+          StoreField v13, :shape_id@0x1000, v18
+          v23:Fixnum[2] = Const Value(2)
           PatchPoint SingleRactorMode
-          StoreField v28, :@bar@0x1004, v17
-          WriteBarrier v28, v17
-          v40:CShape[0x1005] = Const CShape(0x1005)
-          StoreField v28, :shape_id@0x1000, v40
+          StoreField v13, :@bar@0x1004, v23
+          WriteBarrier v13, v23
+          v32:CShape[0x1005] = Const CShape(0x1005)
+          StoreField v13, :shape_id@0x1000, v32
           CheckInterrupts
-          Return v17
+          Return v23
         ");
     }
 
@@ -8703,8 +8703,8 @@ mod hir_opt_tests {
           v17:Fixnum[5] = Const Value(5)
           PatchPoint MethodRedefined(C@0x1008, foo=@0x1010, cme:0x1018)
           v28:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C] recompile
-          v31:CShape = LoadField v28, :shape_id@0x1040
-          v32:CShape[0x1041] = GuardBitEquals v31, CShape(0x1041)
+          v30:CShape = LoadField v28, :shape_id@0x1040
+          v31:CShape[0x1041] = GuardBitEquals v30, CShape(0x1041)
           StoreField v28, :@foo@0x1042, v17
           WriteBarrier v28, v17
           CheckInterrupts
@@ -9820,12 +9820,12 @@ mod hir_opt_tests {
           v17:Fixnum[5] = Const Value(5)
           PatchPoint MethodRedefined(C@0x1008, foo=@0x1010, cme:0x1018)
           v28:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C] recompile
-          v31:CShape = LoadField v28, :shape_id@0x1040
-          v32:CShape[0x1041] = GuardBitEquals v31, CShape(0x1041)
+          v30:CShape = LoadField v28, :shape_id@0x1040
+          v31:CShape[0x1041] = GuardBitEquals v30, CShape(0x1041)
           StoreField v28, :@foo@0x1042, v17
           WriteBarrier v28, v17
-          v35:CShape[0x1043] = Const CShape(0x1043)
-          StoreField v28, :shape_id@0x1040, v35
+          v34:CShape[0x1043] = Const CShape(0x1043)
+          StoreField v28, :shape_id@0x1040, v34
           CheckInterrupts
           Return v17
         ");
@@ -9859,12 +9859,12 @@ mod hir_opt_tests {
           v17:Fixnum[5] = Const Value(5)
           PatchPoint MethodRedefined(C@0x1008, foo=@0x1010, cme:0x1018)
           v28:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C] recompile
-          v31:CShape = LoadField v28, :shape_id@0x1040
-          v32:CShape[0x1041] = GuardBitEquals v31, CShape(0x1041)
+          v30:CShape = LoadField v28, :shape_id@0x1040
+          v31:CShape[0x1041] = GuardBitEquals v30, CShape(0x1041)
           StoreField v28, :@foo@0x1042, v17
           WriteBarrier v28, v17
-          v35:CShape[0x1043] = Const CShape(0x1043)
-          StoreField v28, :shape_id@0x1040, v35
+          v34:CShape[0x1043] = Const CShape(0x1043)
+          StoreField v28, :shape_id@0x1040, v34
           CheckInterrupts
           Return v17
         ");
@@ -16632,16 +16632,16 @@ mod hir_opt_tests {
         bb3(v8:BasicObject, v9:NilClass):
           v13:Fixnum[1] = Const Value(1)
           PatchPoint SingleRactorMode
-          v35:HeapBasicObject = GuardType v8, HeapBasicObject
-          v36:CShape = LoadField v35, :shape_id@0x1000
-          v37:CShape[0x1001] = GuardBitEquals v36, CShape(0x1001) recompile
-          StoreField v35, :@a@0x1002, v13
-          WriteBarrier v35, v13
-          v40:CShape[0x1003] = Const CShape(0x1003)
-          StoreField v35, :shape_id@0x1000, v40
+          v19:HeapBasicObject = GuardType v8, HeapBasicObject
+          v20:CShape = LoadField v19, :shape_id@0x1000
+          v21:CShape[0x1001] = GuardBitEquals v20, CShape(0x1001) recompile
+          StoreField v19, :@a@0x1002, v13
+          WriteBarrier v19, v13
+          v24:CShape[0x1003] = Const CShape(0x1003)
+          StoreField v19, :shape_id@0x1000, v24
           PatchPoint NoEPEscape(initialize)
           PatchPoint SingleRactorMode
-          WriteBarrier v35, v13
+          WriteBarrier v19, v13
           CheckInterrupts
           Return v13
         ");
@@ -16679,19 +16679,19 @@ mod hir_opt_tests {
         bb3(v10:BasicObject, v11:NilClass, v12:NilClass):
           v16:Fixnum[1] = Const Value(1)
           PatchPoint SingleRactorMode
-          v49:HeapBasicObject = GuardType v10, HeapBasicObject
-          v50:CShape = LoadField v49, :shape_id@0x1000
-          v51:CShape[0x1001] = GuardBitEquals v50, CShape(0x1001) recompile
-          StoreField v49, :@a@0x1002, v16
-          WriteBarrier v49, v16
-          v54:CShape[0x1003] = Const CShape(0x1003)
-          StoreField v49, :shape_id@0x1000, v54
-          v26:Fixnum[5] = Const Value(5)
+          v22:HeapBasicObject = GuardType v10, HeapBasicObject
+          v23:CShape = LoadField v22, :shape_id@0x1000
+          v24:CShape[0x1001] = GuardBitEquals v23, CShape(0x1001) recompile
+          StoreField v22, :@a@0x1002, v16
+          WriteBarrier v22, v16
+          v27:CShape[0x1003] = Const CShape(0x1003)
+          StoreField v22, :shape_id@0x1000, v27
+          v32:Fixnum[5] = Const Value(5)
           PatchPoint NoEPEscape(initialize)
           PatchPoint MethodRedefined(Integer@0x1008, +@0x1010, cme:0x1018)
-          v65:Fixnum[6] = Const Value(6)
+          v63:Fixnum[6] = Const Value(6)
           PatchPoint SingleRactorMode
-          WriteBarrier v49, v16
+          WriteBarrier v22, v16
           CheckInterrupts
           Return v16
         ");
@@ -16726,17 +16726,17 @@ mod hir_opt_tests {
         bb3(v8:BasicObject, v9:NilClass):
           v13:Fixnum[1] = Const Value(1)
           PatchPoint SingleRactorMode
-          v43:HeapBasicObject = GuardType v8, HeapBasicObject
-          v44:CShape = LoadField v43, :shape_id@0x1000
-          v45:CShape[0x1001] = GuardBitEquals v44, CShape(0x1001) recompile
-          StoreField v43, :@a@0x1002, v13
-          WriteBarrier v43, v13
-          v48:CShape[0x1003] = Const CShape(0x1003)
-          StoreField v43, :shape_id@0x1000, v48
+          v19:HeapBasicObject = GuardType v8, HeapBasicObject
+          v20:CShape = LoadField v19, :shape_id@0x1000
+          v21:CShape[0x1001] = GuardBitEquals v20, CShape(0x1001) recompile
+          StoreField v19, :@a@0x1002, v13
+          WriteBarrier v19, v13
+          v24:CShape[0x1003] = Const CShape(0x1003)
+          StoreField v19, :shape_id@0x1000, v24
           PatchPoint NoEPEscape(initialize)
           PatchPoint SingleRactorMode
-          WriteBarrier v43, v13
-          WriteBarrier v43, v13
+          WriteBarrier v19, v13
+          WriteBarrier v19, v13
           CheckInterrupts
           Return v13
         ");
@@ -17101,9 +17101,9 @@ mod hir_opt_tests {
         bb6(v19:HeapBasicObject, v20:Fixnum):
           v24:Fixnum[10] = Const Value(10)
           PatchPoint MethodRedefined(Integer@0x1000, <@0x1008, cme:0x1010)
-          v101:BoolExact = FixnumLt v20, v24
+          v100:BoolExact = FixnumLt v20, v24
           CheckInterrupts
-          v30:CBool = Test v101
+          v30:CBool = Test v100
           CondBranch v30, bb4(v19, v20), bb7()
         bb4(v40:HeapBasicObject, v41:Fixnum):
           PatchPoint SingleRactorMode
@@ -17132,19 +17132,19 @@ mod hir_opt_tests {
         bb13():
           PatchPoint NoEPEscape(set_value_loop)
           PatchPoint SingleRactorMode
-          v92:CShape = LoadField v40, :shape_id@0x1038
-          v93:CShape[0x103b] = GuardBitEquals v92, CShape(0x103b) recompile
+          v74:CShape = LoadField v40, :shape_id@0x1038
+          v75:CShape[0x103b] = GuardBitEquals v74, CShape(0x103b) recompile
           StoreField v40, :@levar@0x103a, v41
           WriteBarrier v40, v41
-          v96:CShape[0x1039] = Const CShape(0x1039)
-          StoreField v40, :shape_id@0x1038, v96
+          v78:CShape[0x1039] = Const CShape(0x1039)
+          StoreField v40, :shape_id@0x1038, v78
           Jump bb5(v40, v41)
-        bb5(v76:HeapBasicObject, v77:Fixnum):
+        bb5(v82:HeapBasicObject, v83:Fixnum):
           PatchPoint NoEPEscape(set_value_loop)
-          v84:Fixnum[1] = Const Value(1)
+          v90:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Integer@0x1000, +@0x103c, cme:0x1040)
-          v105:Fixnum = FixnumAdd v77, v84
-          Jump bb6(v76, v105)
+          v104:Fixnum = FixnumAdd v83, v90
+          Jump bb6(v82, v104)
         bb7():
           v35:NilClass = Const Value(nil)
           CheckInterrupts
@@ -19047,18 +19047,18 @@ mod hir_opt_tests {
           PatchPoint NoSingletonClass(Point@0x1008)
           PatchPoint MethodRedefined(Point@0x1008, initialize@0x1038, cme:0x1040)
           PushInlineFrame v91 (0x1068), v17, v19
-          v215:CShape = LoadField v91, :shape_id@0x1070
-          v216:CShape[0x1071] = GuardBitEquals v215, CShape(0x1071) recompile
+          v116:CShape = LoadField v91, :shape_id@0x1070
+          v117:CShape[0x1071] = GuardBitEquals v116, CShape(0x1071) recompile
           StoreField v91, :@x@0x1072, v17
           WriteBarrier v91, v17
-          v219:CShape[0x1073] = Const CShape(0x1073)
-          StoreField v91, :shape_id@0x1070, v219
+          v120:CShape[0x1073] = Const CShape(0x1073)
+          StoreField v91, :shape_id@0x1070, v120
           PatchPoint NoEPEscape(initialize)
           PatchPoint SingleRactorMode
           StoreField v91, :@y@0x1074, v19
           WriteBarrier v91, v19
-          v226:CShape[0x1075] = Const CShape(0x1075)
-          StoreField v91, :shape_id@0x1070, v226
+          v135:CShape[0x1075] = Const CShape(0x1075)
+          StoreField v91, :shape_id@0x1070, v135
           CheckInterrupts
           PopInlineFrame
           PatchPoint SingleRactorMode
@@ -19072,55 +19072,55 @@ mod hir_opt_tests {
           PatchPoint NoSingletonClass(Point@0x1008)
           PatchPoint MethodRedefined(Point@0x1008, initialize@0x1038, cme:0x1040)
           PushInlineFrame v98 (0x1068), v52, v54
-          v229:CShape = LoadField v98, :shape_id@0x1070
-          v230:CShape[0x1071] = GuardBitEquals v229, CShape(0x1071) recompile
+          v155:CShape = LoadField v98, :shape_id@0x1070
+          v156:CShape[0x1071] = GuardBitEquals v155, CShape(0x1071) recompile
           StoreField v98, :@x@0x1072, v52
           WriteBarrier v98, v52
-          v233:CShape[0x1073] = Const CShape(0x1073)
-          StoreField v98, :shape_id@0x1070, v233
+          v159:CShape[0x1073] = Const CShape(0x1073)
+          StoreField v98, :shape_id@0x1070, v159
           PatchPoint NoEPEscape(initialize)
           PatchPoint SingleRactorMode
           StoreField v98, :@y@0x1074, v54
           WriteBarrier v98, v54
-          v240:CShape[0x1075] = Const CShape(0x1075)
-          StoreField v98, :shape_id@0x1070, v240
+          v174:CShape[0x1075] = Const CShape(0x1075)
+          StoreField v98, :shape_id@0x1070, v174
           CheckInterrupts
           PopInlineFrame
           PatchPoint NoSingletonClass(Point@0x1008)
           PatchPoint MethodRedefined(Point@0x1008, ==@0x1080, cme:0x1088)
           PushInlineFrame v91 (0x1068), v98
           PatchPoint SingleRactorMode
-          v168:CShape = LoadField v91, :shape_id@0x1070
-          v169:CShape[0x1075] = GuardBitEquals v168, CShape(0x1075) recompile
-          v170:BasicObject = LoadField v91, :@x@0x1072
+          v192:CShape = LoadField v91, :shape_id@0x1070
+          v193:CShape[0x1075] = GuardBitEquals v192, CShape(0x1075) recompile
+          v194:BasicObject = LoadField v91, :@x@0x1072
           PatchPoint NoEPEscape(==)
           PatchPoint MethodRedefined(Point@0x1008, x@0x10b0, cme:0x10b8)
           PatchPoint MethodRedefined(Integer@0x10e0, ==@0x1080, cme:0x10e8)
-          v244:Fixnum = GuardType v170, Fixnum recompile
-          v246:BoolExact = FixnumEq v244, v52
-          v182:CBool = Test v246
-          v183:FalseClass = RefineType v246, Falsy
-          CondBranch v182, bb17(), bb16(v91, v98, v183)
+          v240:Fixnum = GuardType v194, Fixnum recompile
+          v242:BoolExact = FixnumEq v240, v52
+          v206:CBool = Test v242
+          v207:FalseClass = RefineType v242, Falsy
+          CondBranch v206, bb17(), bb16(v91, v98, v207)
         bb17():
           PatchPoint SingleRactorMode
-          v190:CShape = LoadField v91, :shape_id@0x1070
-          v191:CShape[0x1075] = GuardBitEquals v190, CShape(0x1075) recompile
-          v192:BasicObject = LoadField v91, :@y@0x1074
+          v214:CShape = LoadField v91, :shape_id@0x1070
+          v215:CShape[0x1075] = GuardBitEquals v214, CShape(0x1075) recompile
+          v216:BasicObject = LoadField v91, :@y@0x1074
           PatchPoint NoEPEscape(==)
           PatchPoint NoSingletonClass(Point@0x1008)
           PatchPoint MethodRedefined(Point@0x1008, y@0x1110, cme:0x1118)
-          v265:CShape = LoadField v98, :shape_id@0x1070
-          v266:CShape[0x1075] = GuardBitEquals v265, CShape(0x1075) recompile
-          v267:BasicObject = LoadField v98, :@y@0x1074
+          v261:CShape = LoadField v98, :shape_id@0x1070
+          v262:CShape[0x1075] = GuardBitEquals v261, CShape(0x1075) recompile
+          v263:BasicObject = LoadField v98, :@y@0x1074
           PatchPoint MethodRedefined(Integer@0x10e0, ==@0x1080, cme:0x10e8)
-          v249:Fixnum = GuardType v192, Fixnum recompile
-          v250:Fixnum = GuardType v267, Fixnum
-          v251:BoolExact = FixnumEq v249, v250
-          Jump bb16(v91, v98, v251)
-        bb16(v202:ObjectSubclass[class_exact:Point], v203:ObjectSubclass[class_exact:Point], v204:BoolExact):
+          v245:Fixnum = GuardType v216, Fixnum recompile
+          v246:Fixnum = GuardType v263, Fixnum
+          v247:BoolExact = FixnumEq v245, v246
+          Jump bb16(v91, v98, v247)
+        bb16(v226:ObjectSubclass[class_exact:Point], v227:ObjectSubclass[class_exact:Point], v228:BoolExact):
           CheckInterrupts
           PopInlineFrame
-          Return v204
+          Return v228
         ");
     }
 

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -8197,11 +8197,11 @@ mod hir_opt_tests {
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
           v23:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C] recompile
-          v26:CShape = LoadField v23, :shape_id@0x1040
-          v27:CShape[0x1041] = GuardBitEquals v26, CShape(0x1041) recompile
-          v28:BasicObject = LoadField v23, :@foo@0x1042
+          v25:CShape = LoadField v23, :shape_id@0x1040
+          v26:CShape[0x1041] = GuardBitEquals v25, CShape(0x1041) recompile
+          v27:BasicObject = LoadField v23, :@foo@0x1042
           CheckInterrupts
-          Return v28
+          Return v27
         ");
     }
 
@@ -8495,12 +8495,12 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
-          v17:HeapBasicObject = GuardType v6, HeapBasicObject
-          v18:CShape = LoadField v17, :shape_id@0x1000
-          v19:CShape[0x1001] = GuardBitEquals v18, CShape(0x1001) recompile
-          v20:NilClass = Const Value(nil)
+          v11:HeapBasicObject = GuardType v6, HeapBasicObject
+          v12:CShape = LoadField v11, :shape_id@0x1000
+          v13:CShape[0x1001] = GuardBitEquals v12, CShape(0x1001) recompile
+          v14:NilClass = Const Value(nil)
           CheckInterrupts
-          Return v20
+          Return v14
         ");
     }
 
@@ -8527,12 +8527,12 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
-          v17:HeapBasicObject = GuardType v6, HeapBasicObject
-          v18:CShape = LoadField v17, :shape_id@0x1000
-          v19:CShape[0x1001] = GuardBitEquals v18, CShape(0x1001) recompile
-          v20:NilClass = Const Value(nil)
+          v11:HeapBasicObject = GuardType v6, HeapBasicObject
+          v12:CShape = LoadField v11, :shape_id@0x1000
+          v13:CShape[0x1001] = GuardBitEquals v12, CShape(0x1001) recompile
+          v14:NilClass = Const Value(nil)
           CheckInterrupts
-          Return v20
+          Return v14
         ");
     }
 
@@ -8733,13 +8733,13 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
-          v17:HeapBasicObject = GuardType v6, HeapBasicObject
-          v18:CShape = LoadField v17, :shape_id@0x1000
-          v19:CShape[0x1001] = GuardBitEquals v18, CShape(0x1001) recompile
-          v20:RubyValue = LoadField v17, :fields_obj@0x1002
-          v21:BasicObject = LoadField v20, :@foo@0x1003
+          v11:HeapBasicObject = GuardType v6, HeapBasicObject
+          v12:CShape = LoadField v11, :shape_id@0x1000
+          v13:CShape[0x1001] = GuardBitEquals v12, CShape(0x1001) recompile
+          v14:RubyValue = LoadField v11, :fields_obj@0x1002
+          v15:BasicObject = LoadField v14, :@foo@0x1003
           CheckInterrupts
-          Return v21
+          Return v15
         ");
     }
 
@@ -8804,13 +8804,13 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
-          v17:HeapBasicObject = GuardType v6, HeapBasicObject
-          v18:CShape = LoadField v17, :shape_id@0x1000
-          v19:CShape[0x1001] = GuardBitEquals v18, CShape(0x1001) recompile
-          v20:RubyValue = LoadField v17, :fields_obj@0x1002
-          v21:BasicObject = LoadField v20, :@foo@0x1003
+          v11:HeapBasicObject = GuardType v6, HeapBasicObject
+          v12:CShape = LoadField v11, :shape_id@0x1000
+          v13:CShape[0x1001] = GuardBitEquals v12, CShape(0x1001) recompile
+          v14:RubyValue = LoadField v11, :fields_obj@0x1002
+          v15:BasicObject = LoadField v14, :@foo@0x1003
           CheckInterrupts
-          Return v21
+          Return v15
         ");
     }
 
@@ -8868,13 +8868,13 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
-          v17:HeapBasicObject = GuardType v6, HeapBasicObject
-          v18:CShape = LoadField v17, :shape_id@0x1000
-          v19:CShape[0x1001] = GuardBitEquals v18, CShape(0x1001) recompile
-          v20:CAttrIndex[0] = Const CAttrIndex(0)
-          v21:BasicObject = CCall v17, :rb_ivar_get_at_no_ractor_check@0x1008, v20
+          v11:HeapBasicObject = GuardType v6, HeapBasicObject
+          v12:CShape = LoadField v11, :shape_id@0x1000
+          v13:CShape[0x1001] = GuardBitEquals v12, CShape(0x1001) recompile
+          v14:CAttrIndex[0] = Const CAttrIndex(0)
+          v15:BasicObject = CCall v11, :rb_ivar_get_at_no_ractor_check@0x1008, v14
           CheckInterrupts
-          Return v21
+          Return v15
         ");
     }
 
@@ -8903,13 +8903,13 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
-          v17:HeapBasicObject = GuardType v6, HeapBasicObject
-          v18:CShape = LoadField v17, :shape_id@0x1000
-          v19:CShape[0x1001] = GuardBitEquals v18, CShape(0x1001) recompile
-          v20:RubyValue = LoadField v17, :fields_obj@0x1002
-          v21:BasicObject = LoadField v20, :@a@0x1002
+          v11:HeapBasicObject = GuardType v6, HeapBasicObject
+          v12:CShape = LoadField v11, :shape_id@0x1000
+          v13:CShape[0x1001] = GuardBitEquals v12, CShape(0x1001) recompile
+          v14:RubyValue = LoadField v11, :fields_obj@0x1002
+          v15:BasicObject = LoadField v14, :@a@0x1002
           CheckInterrupts
-          Return v21
+          Return v15
         ");
     }
 
@@ -9131,18 +9131,15 @@ mod hir_opt_tests {
           v24:BasicObject = LoadField v11, :@foo@0x1005
           Jump bb4(v24)
         bb8():
-          v39:CShape = LoadField v11, :shape_id@0x1000
-          v40:CShape[0x1001] = GuardBitEquals v39, CShape(0x1001) recompile
-          v41:CPtr = LoadField v11, :as_heap@0x1002
-          v42:BasicObject = LoadField v41, :@foo@0x1003
-          Jump bb4(v42)
+          v26:BasicObject = GetIvar v11, :@foo
+          Jump bb4(v26)
         bb4(v12:BasicObject):
           v29:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Integer@0x1008, +@0x1010, cme:0x1018)
-          v45:Fixnum = GuardType v12, Fixnum recompile
-          v46:Fixnum = FixnumAdd v45, v29
+          v40:Fixnum = GuardType v12, Fixnum recompile
+          v41:Fixnum = FixnumAdd v40, v29
           CheckInterrupts
-          Return v46
+          Return v41
         ");
     }
 
@@ -9679,11 +9676,11 @@ mod hir_opt_tests {
           v12:ObjectSubclass[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           PatchPoint NoSingletonClass(C@0x1010)
           PatchPoint MethodRedefined(C@0x1010, foo@0x1018, cme:0x1020)
-          v25:CShape = LoadField v12, :shape_id@0x1048
-          v26:CShape[0x1049] = GuardBitEquals v25, CShape(0x1049) recompile
-          v27:NilClass = Const Value(nil)
+          v24:CShape = LoadField v12, :shape_id@0x1048
+          v25:CShape[0x1049] = GuardBitEquals v24, CShape(0x1049) recompile
+          v26:NilClass = Const Value(nil)
           CheckInterrupts
-          Return v27
+          Return v26
         ");
     }
 
@@ -9715,11 +9712,11 @@ mod hir_opt_tests {
           v12:ObjectSubclass[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           PatchPoint NoSingletonClass(C@0x1010)
           PatchPoint MethodRedefined(C@0x1010, foo@0x1018, cme:0x1020)
-          v25:CShape = LoadField v12, :shape_id@0x1048
-          v26:CShape[0x1049] = GuardBitEquals v25, CShape(0x1049) recompile
-          v27:NilClass = Const Value(nil)
+          v24:CShape = LoadField v12, :shape_id@0x1048
+          v25:CShape[0x1049] = GuardBitEquals v24, CShape(0x1049) recompile
+          v26:NilClass = Const Value(nil)
           CheckInterrupts
-          Return v27
+          Return v26
         ");
     }
 
@@ -9751,11 +9748,11 @@ mod hir_opt_tests {
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
           v23:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C] recompile
-          v26:CShape = LoadField v23, :shape_id@0x1040
-          v27:CShape[0x1041] = GuardBitEquals v26, CShape(0x1041) recompile
-          v28:NilClass = Const Value(nil)
+          v25:CShape = LoadField v23, :shape_id@0x1040
+          v26:CShape[0x1041] = GuardBitEquals v25, CShape(0x1041) recompile
+          v27:NilClass = Const Value(nil)
           CheckInterrupts
-          Return v28
+          Return v27
         ");
     }
 
@@ -9787,11 +9784,11 @@ mod hir_opt_tests {
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
           v23:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C] recompile
-          v26:CShape = LoadField v23, :shape_id@0x1040
-          v27:CShape[0x1041] = GuardBitEquals v26, CShape(0x1041) recompile
-          v28:NilClass = Const Value(nil)
+          v25:CShape = LoadField v23, :shape_id@0x1040
+          v26:CShape[0x1041] = GuardBitEquals v25, CShape(0x1041) recompile
+          v27:NilClass = Const Value(nil)
           CheckInterrupts
-          Return v28
+          Return v27
         ");
     }
 
@@ -14689,9 +14686,9 @@ mod hir_opt_tests {
           v12:ObjectSubclass[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           PatchPoint NoSingletonClass(TestFrozen@0x1010)
           PatchPoint MethodRedefined(TestFrozen@0x1010, a@0x1018, cme:0x1020)
-          v29:Fixnum[1] = Const Value(1)
+          v28:Fixnum[1] = Const Value(1)
           CheckInterrupts
-          Return v29
+          Return v28
         ");
     }
 
@@ -14730,9 +14727,9 @@ mod hir_opt_tests {
           v12:ObjectSubclass[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           PatchPoint NoSingletonClass(TestMultiIvars@0x1010)
           PatchPoint MethodRedefined(TestMultiIvars@0x1010, b@0x1018, cme:0x1020)
-          v29:Fixnum[20] = Const Value(20)
+          v28:Fixnum[20] = Const Value(20)
           CheckInterrupts
-          Return v29
+          Return v28
         ");
     }
 
@@ -14769,9 +14766,9 @@ mod hir_opt_tests {
           v12:ObjectSubclass[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           PatchPoint NoSingletonClass(TestFrozenStr@0x1010)
           PatchPoint MethodRedefined(TestFrozenStr@0x1010, name@0x1018, cme:0x1020)
-          v29:StringExact[VALUE(0x1048)] = Const Value(VALUE(0x1048))
+          v28:StringExact[VALUE(0x1048)] = Const Value(VALUE(0x1048))
           CheckInterrupts
-          Return v29
+          Return v28
         ");
     }
 
@@ -14808,9 +14805,9 @@ mod hir_opt_tests {
           v12:ObjectSubclass[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           PatchPoint NoSingletonClass(TestFrozenNil@0x1010)
           PatchPoint MethodRedefined(TestFrozenNil@0x1010, value@0x1018, cme:0x1020)
-          v29:NilClass = Const Value(nil)
+          v28:NilClass = Const Value(nil)
           CheckInterrupts
-          Return v29
+          Return v28
         ");
     }
 
@@ -14847,11 +14844,11 @@ mod hir_opt_tests {
           v12:ObjectSubclass[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           PatchPoint NoSingletonClass(TestUnfrozen@0x1010)
           PatchPoint MethodRedefined(TestUnfrozen@0x1010, a@0x1018, cme:0x1020)
-          v25:CShape = LoadField v12, :shape_id@0x1048
-          v26:CShape[0x1049] = GuardBitEquals v25, CShape(0x1049) recompile
-          v27:BasicObject = LoadField v12, :@a@0x104a
+          v24:CShape = LoadField v12, :shape_id@0x1048
+          v25:CShape[0x1049] = GuardBitEquals v24, CShape(0x1049) recompile
+          v26:BasicObject = LoadField v12, :@a@0x104a
           CheckInterrupts
-          Return v27
+          Return v26
         ");
     }
 
@@ -14888,9 +14885,9 @@ mod hir_opt_tests {
           v12:ObjectSubclass[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           PatchPoint NoSingletonClass(TestAttrReader@0x1010)
           PatchPoint MethodRedefined(TestAttrReader@0x1010, value@0x1018, cme:0x1020)
-          v29:Fixnum[42] = Const Value(42)
+          v28:Fixnum[42] = Const Value(42)
           CheckInterrupts
-          Return v29
+          Return v28
         ");
     }
 
@@ -14927,9 +14924,9 @@ mod hir_opt_tests {
           v12:ObjectSubclass[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           PatchPoint NoSingletonClass(TestFrozenSym@0x1010)
           PatchPoint MethodRedefined(TestFrozenSym@0x1010, sym@0x1018, cme:0x1020)
-          v29:StaticSymbol[:hello] = Const Value(VALUE(0x1048))
+          v28:StaticSymbol[:hello] = Const Value(VALUE(0x1048))
           CheckInterrupts
-          Return v29
+          Return v28
         ");
     }
 
@@ -14966,9 +14963,9 @@ mod hir_opt_tests {
           v12:ObjectSubclass[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           PatchPoint NoSingletonClass(TestFrozenBool@0x1010)
           PatchPoint MethodRedefined(TestFrozenBool@0x1010, flag@0x1018, cme:0x1020)
-          v29:TrueClass = Const Value(true)
+          v28:TrueClass = Const Value(true)
           CheckInterrupts
-          Return v29
+          Return v28
         ");
     }
 
@@ -15005,11 +15002,11 @@ mod hir_opt_tests {
           PatchPoint NoSingletonClass(TestDynamic@0x1008)
           PatchPoint MethodRedefined(TestDynamic@0x1008, val@0x1010, cme:0x1018)
           v23:ObjectSubclass[class_exact:TestDynamic] = GuardType v10, ObjectSubclass[class_exact:TestDynamic] recompile
-          v26:CShape = LoadField v23, :shape_id@0x1040
-          v27:CShape[0x1041] = GuardBitEquals v26, CShape(0x1041) recompile
-          v28:BasicObject = LoadField v23, :@val@0x1042
+          v25:CShape = LoadField v23, :shape_id@0x1040
+          v26:CShape[0x1041] = GuardBitEquals v25, CShape(0x1041) recompile
+          v27:BasicObject = LoadField v23, :@val@0x1042
           CheckInterrupts
-          Return v28
+          Return v27
         ");
     }
 
@@ -15047,15 +15044,15 @@ mod hir_opt_tests {
           v12:ObjectSubclass[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           PatchPoint NoSingletonClass(TestNestedAccess@0x1010)
           PatchPoint MethodRedefined(TestNestedAccess@0x1010, x@0x1018, cme:0x1020)
-          v51:Fixnum[100] = Const Value(100)
+          v49:Fixnum[100] = Const Value(100)
           PatchPoint StableConstantNames(0x1048, NESTED_FROZEN)
           v18:ObjectSubclass[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           PatchPoint MethodRedefined(TestNestedAccess@0x1010, y@0x1050, cme:0x1058)
-          v53:Fixnum[200] = Const Value(200)
+          v51:Fixnum[200] = Const Value(200)
           PatchPoint MethodRedefined(Integer@0x1080, +@0x1088, cme:0x1090)
-          v54:Fixnum[300] = Const Value(300)
+          v52:Fixnum[300] = Const Value(300)
           CheckInterrupts
-          Return v54
+          Return v52
         ");
     }
 
@@ -17104,9 +17101,9 @@ mod hir_opt_tests {
         bb6(v19:HeapBasicObject, v20:Fixnum):
           v24:Fixnum[10] = Const Value(10)
           PatchPoint MethodRedefined(Integer@0x1000, <@0x1008, cme:0x1010)
-          v105:BoolExact = FixnumLt v20, v24
+          v101:BoolExact = FixnumLt v20, v24
           CheckInterrupts
-          v30:CBool = Test v105
+          v30:CBool = Test v101
           CondBranch v30, bb4(v19, v20), bb7()
         bb4(v40:HeapBasicObject, v41:Fixnum):
           PatchPoint SingleRactorMode
@@ -17126,10 +17123,8 @@ mod hir_opt_tests {
           v58:NilClass = Const Value(nil)
           Jump bb8(v58)
         bb12():
-          v92:CShape = LoadField v40, :shape_id@0x1038
-          v93:CShape[0x1039] = GuardBitEquals v92, CShape(0x1039) recompile
-          v94:BasicObject = LoadField v40, :@levar@0x103a
-          Jump bb8(v94)
+          v60:BasicObject = GetIvar v40, :@levar
+          Jump bb8(v60)
         bb8(v47:BasicObject):
           CheckInterrupts
           v64:CBool = Test v47
@@ -17137,19 +17132,19 @@ mod hir_opt_tests {
         bb13():
           PatchPoint NoEPEscape(set_value_loop)
           PatchPoint SingleRactorMode
-          v96:CShape = LoadField v40, :shape_id@0x1038
-          v97:CShape[0x103b] = GuardBitEquals v96, CShape(0x103b) recompile
+          v92:CShape = LoadField v40, :shape_id@0x1038
+          v93:CShape[0x103b] = GuardBitEquals v92, CShape(0x103b) recompile
           StoreField v40, :@levar@0x103a, v41
           WriteBarrier v40, v41
-          v100:CShape[0x1039] = Const CShape(0x1039)
-          StoreField v40, :shape_id@0x1038, v100
+          v96:CShape[0x1039] = Const CShape(0x1039)
+          StoreField v40, :shape_id@0x1038, v96
           Jump bb5(v40, v41)
         bb5(v76:HeapBasicObject, v77:Fixnum):
           PatchPoint NoEPEscape(set_value_loop)
           v84:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Integer@0x1000, +@0x103c, cme:0x1040)
-          v109:Fixnum = FixnumAdd v77, v84
-          Jump bb6(v76, v109)
+          v105:Fixnum = FixnumAdd v77, v84
+          Jump bb6(v76, v105)
         bb7():
           v35:NilClass = Const Value(nil)
           CheckInterrupts
@@ -19052,18 +19047,18 @@ mod hir_opt_tests {
           PatchPoint NoSingletonClass(Point@0x1008)
           PatchPoint MethodRedefined(Point@0x1008, initialize@0x1038, cme:0x1040)
           PushInlineFrame v91 (0x1068), v17, v19
-          v209:CShape = LoadField v91, :shape_id@0x1070
-          v210:CShape[0x1071] = GuardBitEquals v209, CShape(0x1071) recompile
+          v215:CShape = LoadField v91, :shape_id@0x1070
+          v216:CShape[0x1071] = GuardBitEquals v215, CShape(0x1071) recompile
           StoreField v91, :@x@0x1072, v17
           WriteBarrier v91, v17
-          v213:CShape[0x1073] = Const CShape(0x1073)
-          StoreField v91, :shape_id@0x1070, v213
+          v219:CShape[0x1073] = Const CShape(0x1073)
+          StoreField v91, :shape_id@0x1070, v219
           PatchPoint NoEPEscape(initialize)
           PatchPoint SingleRactorMode
           StoreField v91, :@y@0x1074, v19
           WriteBarrier v91, v19
-          v220:CShape[0x1075] = Const CShape(0x1075)
-          StoreField v91, :shape_id@0x1070, v220
+          v226:CShape[0x1075] = Const CShape(0x1075)
+          StoreField v91, :shape_id@0x1070, v226
           CheckInterrupts
           PopInlineFrame
           PatchPoint SingleRactorMode
@@ -19077,55 +19072,55 @@ mod hir_opt_tests {
           PatchPoint NoSingletonClass(Point@0x1008)
           PatchPoint MethodRedefined(Point@0x1008, initialize@0x1038, cme:0x1040)
           PushInlineFrame v98 (0x1068), v52, v54
-          v223:CShape = LoadField v98, :shape_id@0x1070
-          v224:CShape[0x1071] = GuardBitEquals v223, CShape(0x1071) recompile
+          v229:CShape = LoadField v98, :shape_id@0x1070
+          v230:CShape[0x1071] = GuardBitEquals v229, CShape(0x1071) recompile
           StoreField v98, :@x@0x1072, v52
           WriteBarrier v98, v52
-          v227:CShape[0x1073] = Const CShape(0x1073)
-          StoreField v98, :shape_id@0x1070, v227
+          v233:CShape[0x1073] = Const CShape(0x1073)
+          StoreField v98, :shape_id@0x1070, v233
           PatchPoint NoEPEscape(initialize)
           PatchPoint SingleRactorMode
           StoreField v98, :@y@0x1074, v54
           WriteBarrier v98, v54
-          v234:CShape[0x1075] = Const CShape(0x1075)
-          StoreField v98, :shape_id@0x1070, v234
+          v240:CShape[0x1075] = Const CShape(0x1075)
+          StoreField v98, :shape_id@0x1070, v240
           CheckInterrupts
           PopInlineFrame
           PatchPoint NoSingletonClass(Point@0x1008)
           PatchPoint MethodRedefined(Point@0x1008, ==@0x1080, cme:0x1088)
           PushInlineFrame v91 (0x1068), v98
           PatchPoint SingleRactorMode
-          v237:CShape = LoadField v91, :shape_id@0x1070
-          v238:CShape[0x1075] = GuardBitEquals v237, CShape(0x1075) recompile
-          v239:BasicObject = LoadField v91, :@x@0x1072
+          v168:CShape = LoadField v91, :shape_id@0x1070
+          v169:CShape[0x1075] = GuardBitEquals v168, CShape(0x1075) recompile
+          v170:BasicObject = LoadField v91, :@x@0x1072
           PatchPoint NoEPEscape(==)
           PatchPoint MethodRedefined(Point@0x1008, x@0x10b0, cme:0x10b8)
           PatchPoint MethodRedefined(Integer@0x10e0, ==@0x1080, cme:0x10e8)
-          v246:Fixnum = GuardType v239, Fixnum recompile
-          v248:BoolExact = FixnumEq v246, v52
-          v179:CBool = Test v248
-          v180:FalseClass = RefineType v248, Falsy
-          CondBranch v179, bb17(), bb16(v91, v98, v180)
+          v244:Fixnum = GuardType v170, Fixnum recompile
+          v246:BoolExact = FixnumEq v244, v52
+          v182:CBool = Test v246
+          v183:FalseClass = RefineType v246, Falsy
+          CondBranch v182, bb17(), bb16(v91, v98, v183)
         bb17():
           PatchPoint SingleRactorMode
-          v241:CShape = LoadField v91, :shape_id@0x1070
-          v242:CShape[0x1075] = GuardBitEquals v241, CShape(0x1075) recompile
-          v243:BasicObject = LoadField v91, :@y@0x1074
+          v190:CShape = LoadField v91, :shape_id@0x1070
+          v191:CShape[0x1075] = GuardBitEquals v190, CShape(0x1075) recompile
+          v192:BasicObject = LoadField v91, :@y@0x1074
           PatchPoint NoEPEscape(==)
           PatchPoint NoSingletonClass(Point@0x1008)
           PatchPoint MethodRedefined(Point@0x1008, y@0x1110, cme:0x1118)
-          v269:CShape = LoadField v98, :shape_id@0x1070
-          v270:CShape[0x1075] = GuardBitEquals v269, CShape(0x1075) recompile
-          v271:BasicObject = LoadField v98, :@y@0x1074
+          v265:CShape = LoadField v98, :shape_id@0x1070
+          v266:CShape[0x1075] = GuardBitEquals v265, CShape(0x1075) recompile
+          v267:BasicObject = LoadField v98, :@y@0x1074
           PatchPoint MethodRedefined(Integer@0x10e0, ==@0x1080, cme:0x10e8)
-          v251:Fixnum = GuardType v243, Fixnum recompile
-          v252:Fixnum = GuardType v271, Fixnum
-          v253:BoolExact = FixnumEq v251, v252
-          Jump bb16(v91, v98, v253)
-        bb16(v196:ObjectSubclass[class_exact:Point], v197:ObjectSubclass[class_exact:Point], v198:BoolExact):
+          v249:Fixnum = GuardType v192, Fixnum recompile
+          v250:Fixnum = GuardType v267, Fixnum
+          v251:BoolExact = FixnumEq v249, v250
+          Jump bb16(v91, v98, v251)
+        bb16(v202:ObjectSubclass[class_exact:Point], v203:ObjectSubclass[class_exact:Point], v204:BoolExact):
           CheckInterrupts
           PopInlineFrame
-          Return v198
+          Return v204
         ");
     }
 

--- a/zjit/src/hir/tests.rs
+++ b/zjit/src/hir/tests.rs
@@ -3232,9 +3232,12 @@ pub(crate) mod hir_build_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
-          v11:BasicObject = GetIvar v6, :@foo
+          v11:HeapBasicObject = GuardType v6, HeapBasicObject
+          v12:CShape = LoadField v11, :shape_id@0x1000
+          v13:CShape[0x1001] = GuardBitEquals v12, CShape(0x1001) recompile
+          v14:NilClass = Const Value(nil)
           CheckInterrupts
-          Return v11
+          Return v14
         ");
     }
 

--- a/zjit/src/hir/tests.rs
+++ b/zjit/src/hir/tests.rs
@@ -3261,8 +3261,14 @@ pub(crate) mod hir_build_tests {
         bb3(v6:BasicObject):
           v10:Fixnum[1] = Const Value(1)
           PatchPoint SingleRactorMode
-          SetIvar v6, :@foo, v10
-          v15:HeapBasicObject = RefineType v6, HeapBasicObject
+          v14:HeapBasicObject = GuardType v6, HeapBasicObject
+          v15:CShape = LoadField v14, :shape_id@0x1000
+          v16:CShape[0x1001] = GuardBitEquals v15, CShape(0x1001) recompile
+          StoreField v14, :@foo@0x1002, v10
+          WriteBarrier v14, v10
+          v19:CShape[0x1003] = Const CShape(0x1003)
+          StoreField v14, :shape_id@0x1000, v19
+          v21:HeapBasicObject = RefineType v6, HeapBasicObject
           CheckInterrupts
           Return v10
         ");

--- a/zjit/src/stats.rs
+++ b/zjit/src/stats.rs
@@ -318,6 +318,7 @@ make_counters! {
         setivar_fallback_shape_transition,
         setivar_fallback_new_shape_complex,
         setivar_fallback_new_shape_needs_extension,
+        setivar_fallback_no_side_exits,
     }
 
     // Ivar fallback counters that are summed as dynamic_getivar_count

--- a/zjit/src/stats.rs
+++ b/zjit/src/stats.rs
@@ -332,6 +332,7 @@ make_counters! {
         getivar_fallback_immediate,
         getivar_fallback_not_t_object,
         getivar_fallback_complex,
+        getivar_fallback_no_side_exits,
     }
 
     // Ivar fallback counters that are summed as dynamic_definedivar_count


### PR DESCRIPTION
Push all optimization of ivars into either HIR build or method specialization. While this cleans up the code and speeds up the compiler, the ultimate goal (which will probably come in the next PR) is to better specialize (polymorphic method lookup x polymorphic IV) combinations.