### PR TITLE
ZJIT: Split the getivar not_monomorphic fallback counter by cause

### DIFF
--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -4907,16 +4907,28 @@ impl Function {
         }
     }
 
+    fn getivar_fallback_reason(resolution: ReceiverTypeResolution, ic: *const iseq_inline_iv_cache_entry) -> Counter {
+        match resolution {
+            ReceiverTypeResolution::Megamorphic => Counter::getivar_fallback_megamorphic,
+            ReceiverTypeResolution::SkewedMegamorphic { .. } => Counter::getivar_fallback_skewed_megamorphic,
+            ReceiverTypeResolution::Polymorphic => Counter::getivar_fallback_polymorphic,
+            ReceiverTypeResolution::NoProfile if ic.is_null() => Counter::getivar_fallback_no_profile_missing_ic,
+            ReceiverTypeResolution::NoProfile => Counter::getivar_fallback_no_profile,
+            _ => Counter::getivar_fallback_not_monomorphic,
+        }
+    }
+
     fn optimize_getivar(&mut self) {
         for block in self.reverse_post_order() {
             let old_insns = std::mem::take(&mut self.blocks[block.0].insns);
             assert!(self.blocks[block.0].insns.is_empty());
             for insn_id in old_insns {
                 match self.find(insn_id) {
-                    Insn::GetIvar { self_val, id, ic: _, state } => {
+                    Insn::GetIvar { self_val, id, ic, state } => {
                         let Some(recv_type) = self.profiled_type_of_at(self_val, state) else {
-                            // No (monomorphic/skewed polymorphic) profile info
-                            self.count(block, Counter::getivar_fallback_not_monomorphic);
+                            let resolution = self.resolve_receiver_type_from_profile(self_val, state);
+                            let counter = Self::getivar_fallback_reason(resolution, ic);
+                            self.count(block, counter);
                             self.push_insn_id(block, insn_id); continue;
                         };
                         if recv_type.flags().is_immediate() {

--- a/zjit/src/stats.rs
+++ b/zjit/src/stats.rs
@@ -324,6 +324,11 @@ make_counters! {
     dynamic_getivar {
         // getivar_fallback_: Fallback reasons for dynamic getivar instructions
         getivar_fallback_not_monomorphic,
+        getivar_fallback_megamorphic,
+        getivar_fallback_skewed_megamorphic,
+        getivar_fallback_polymorphic,
+        getivar_fallback_no_profile_missing_ic,
+        getivar_fallback_no_profile,
         getivar_fallback_immediate,
         getivar_fallback_not_t_object,
         getivar_fallback_complex,


### PR DESCRIPTION
Before this commit we were lumping all getivar fallback reasons in to one counter. This made it very hard to find the most popular reasons for why we're doing slowpath IV reads.  This commit just adds more counters and splits up the fallback reason based on the type resolution.