### PR TITLE
[DOC] Fix the return value of Ractor#monitor

### DIFF
--- a/ractor.rb
+++ b/ractor.rb
@@ -615,13 +615,17 @@ class Ractor
 
   #
   # call-seq:
-  #    ractor.monitor(port) -> self
+  #    ractor.monitor(port) -> true or false
   #
   # Registers the port as a monitoring port for this ractor. When the ractor terminates,
   # the port receives a Symbol object.
   #
   # * +:exited+ is sent if the ractor terminates without an unhandled exception.
   # * +:aborted+ is sent if the ractor terminates by an unhandled exception.
+  #
+  # Returns +true+ if the monitor was registered (the ractor is still running).
+  # Returns +false+ if the ractor had already terminated; in that case the
+  # termination message (+:exited+ or +:aborted+) is sent to the port immediately.
   #
   #     r = Ractor.new{ some_task() }
   #     r.monitor(port = Ractor::Port.new)


### PR DESCRIPTION
The RDoc `call-seq` for `Ractor#monitor` says it returns `self`, but the method actually returns `true`/`false`.

It is implemented by `ractor_monitor()` in `ractor_sync.c`, which returns only `Qtrue` or `Qfalse` — there is no code path that returns `self`:

- `true`  — the monitor was registered (the ractor is still running)
- `false` — the ractor had already terminated, so it was not registered; the termination message (`:exited` / `:aborted`) is sent to the port immediately

(For comparison, `Ractor#unmonitor` does `return self`, so its existing `-> self` call-seq is correct and is left unchanged.)

This patch corrects the `call-seq` to `-> true or false` and documents the meaning of the two return values.