### PR TITLE
ZJIT: Reuse instruction profiling for recompile exits

### DIFF
--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -549,22 +549,18 @@ pub struct SideExit {
     pub stack: Vec<Opnd>,
     pub locals: Vec<Opnd>,
     pub iseq: IseqPtr,
-    /// If set, the side exit will call the recompile function with these arguments
-    /// to profile the send and invalidate the ISEQ for recompilation.
+    /// If set, the side exit will profile the current instruction and invalidate
+    /// the compiled ISEQ for recompilation.
     pub recompile: Option<SideExitRecompile>,
 }
 
-/// Arguments for the recompile callback on side exit.
+/// Metadata for the recompile callback on side exit.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct SideExitRecompile {
-    /// The frame's own iseq, where the runtime profile is recorded at `insn_idx`.
-    /// For an exit out of inlined code this is the inlined callee.
-    pub frame_iseq: Opnd,
     /// The compiled unit whose version must be invalidated to force a recompile. For inlined
     /// methods, this will be the outer function it was inlined into.
     pub compiled_iseq: Opnd,
     pub insn_idx: u32,
-    pub strategy: hir::Recompile,
 }
 
 /// Branch target (something that we can jump to)
@@ -2588,15 +2584,10 @@ impl Assembler
                 let payload = get_or_create_iseq_payload(exit.iseq);
                 payload.reset_profiles_remaining(recompile.insn_idx as YarvInsnIdx);
                 use crate::codegen::exit_recompile;
-                let (profile_kind, profile_payload) = recompile.strategy.to_c_args();
                 asm_comment!(asm, "profile and maybe recompile");
                 asm_ccall!(asm, exit_recompile,
                     EC,
-                    recompile.frame_iseq,
-                    recompile.compiled_iseq,
-                    recompile.insn_idx.into(),
-                    profile_kind.into(),
-                    profile_payload.into()
+                    recompile.compiled_iseq
                 );
             }
         }

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -21,7 +21,7 @@ use crate::stats::{counter_ptr, with_time_stat, trace_compile_phase, Counter, Co
 use crate::{asm::CodeBlock, cruby::*, options::debug, virtualmem::CodePtr};
 use crate::backend::lir::{self, Assembler, C_ARG_OPNDS, C_RET_OPND, CFP, EC, NATIVE_BASE_PTR, Opnd, SP, SideExit, SideExitRecompile, Target, asm_ccall, asm_comment};
 use crate::hir::{iseq_to_hir, BlockId, Invariant, RangeType, SideExitReason::{self, *}, SpecialBackrefSymbol, SpecialObjectType};
-use crate::hir::{BlockHandler, Const, FieldName, FrameState, Function, Insn, InsnId, Recompile, SendFallbackReason};
+use crate::hir::{BlockHandler, Const, FieldName, FrameState, Function, Insn, InsnId, SendFallbackReason};
 use crate::hir_type::{types, Type};
 use crate::options::{get_option, InlineDepth, PerfMap};
 use crate::cast::IntoUsize;
@@ -523,7 +523,7 @@ fn gen_function(cb: &mut CodeBlock, iseq: IseqPtr, version: IseqVersionRef, func
                                 Insn::InvokeBuiltin { .. } => SideExitReason::UnhandledHIRInvokeBuiltin,
                                 _                          => SideExitReason::UnhandledHIRUnknown(insn_id),
                             };
-                            gen_side_exit(&mut jit, &mut asm, &reason, None, &function.frame_state(last_snapshot));
+                            gen_side_exit(&mut jit, &mut asm, &reason, false, &function.frame_state(last_snapshot));
                             // Don't bother generating code after a side-exit. We won't run it.
                             // TODO(max): Generate ud2 or equivalent.
                             break;
@@ -1240,7 +1240,7 @@ fn gen_setglobal(jit: &mut JITState, asm: &mut Assembler, id: ID, val: Opnd, sta
 }
 
 /// Side-exit into the interpreter
-fn gen_side_exit(jit: &mut JITState, asm: &mut Assembler, reason: &SideExitReason, recompile: Option<Recompile>, state: &FrameState) {
+fn gen_side_exit(jit: &mut JITState, asm: &mut Assembler, reason: &SideExitReason, recompile: bool, state: &FrameState) {
     asm.jmp(side_exit_with_recompile(jit, state, *reason, recompile));
 }
 
@@ -2661,7 +2661,7 @@ fn gen_has_type(jit: &mut JITState, asm: &mut Assembler, val: lir::Opnd, val_typ
 }
 
 /// Compile a type check with a side exit
-fn gen_guard_type(jit: &mut JITState, asm: &mut Assembler, val: lir::Opnd, val_type: Type, guard_type: Type, recompile: Option<Recompile>, state: &FrameState) -> lir::Opnd {
+fn gen_guard_type(jit: &mut JITState, asm: &mut Assembler, val: lir::Opnd, val_type: Type, guard_type: Type, recompile: bool, state: &FrameState) -> lir::Opnd {
     let is_known_heap_basic_object = val_type.is_subtype(types::HeapBasicObject);
     gen_incr_counter(asm, Counter::guard_type_count);
     if guard_type.is_subtype(types::Fixnum) {
@@ -2746,7 +2746,7 @@ fn gen_guard_type(jit: &mut JITState, asm: &mut Assembler, val: lir::Opnd, val_t
 }
 
 /// Compile an identity check with a side exit
-fn gen_guard_bit_equals(jit: &mut JITState, asm: &mut Assembler, val: lir::Opnd, expected: crate::hir::Const, reason: SideExitReason, recompile: Option<Recompile>, state: &FrameState) -> lir::Opnd {
+fn gen_guard_bit_equals(jit: &mut JITState, asm: &mut Assembler, val: lir::Opnd, expected: crate::hir::Const, reason: SideExitReason, recompile: bool, state: &FrameState) -> lir::Opnd {
     if matches!(reason, SideExitReason::GuardShape(_) ) {
         gen_incr_counter(asm, Counter::guard_shape_count);
     }
@@ -2772,7 +2772,7 @@ fn mask_to_opnd(mask: crate::hir::Const) -> Option<Opnd> {
 }
 
 /// Compile a bitmask check with a side exit if none of the masked bits are not set
-fn gen_guard_any_bit_set(jit: &mut JITState, asm: &mut Assembler, val: lir::Opnd, mask: crate::hir::Const, reason: SideExitReason, recompile: Option<Recompile>, state: &FrameState) -> lir::Opnd {
+fn gen_guard_any_bit_set(jit: &mut JITState, asm: &mut Assembler, val: lir::Opnd, mask: crate::hir::Const, reason: SideExitReason, recompile: bool, state: &FrameState) -> lir::Opnd {
     let mask_opnd = mask_to_opnd(mask).unwrap_or_else(|| panic!("gen_guard_any_bit_set: unexpected hir::Const {mask:?}"));
     asm.test(val, mask_opnd);
     asm.jz(jit, side_exit_with_recompile(jit, state, reason, recompile));
@@ -3151,14 +3151,14 @@ fn side_exit(jit: &JITState, state: &FrameState, reason: SideExitReason) -> Targ
 }
 
 /// Build a Target::SideExit that optionally triggers exit_recompile on the exit path.
-fn side_exit_with_recompile(jit: &JITState, state: &FrameState, reason: SideExitReason, recompile: Option<Recompile>) -> Target {
+fn side_exit_with_recompile(jit: &JITState, state: &FrameState, reason: SideExitReason, recompile: bool) -> Target {
     let mut exit = build_side_exit(jit, state);
-    exit.recompile = recompile.map(|strategy| SideExitRecompile {
-        frame_iseq: Opnd::Value(VALUE::from(state.iseq)),
-        compiled_iseq: Opnd::Value(VALUE::from(jit.iseq())),
-        insn_idx: state.insn_idx() as u32,
-        strategy,
-    });
+    if recompile {
+        exit.recompile = Some(SideExitRecompile {
+            compiled_iseq: Opnd::Value(VALUE::from(jit.iseq())),
+            insn_idx: state.insn_idx() as u32,
+        });
+    }
     Target::SideExit { exit, reason }
 }
 
@@ -3204,19 +3204,13 @@ pub(crate) use c_callable;
 
 c_callable! {
     /// Called from JIT side-exit code to profile operands and trigger recompilation.
-    /// `profile_kind` selects what to profile; `profile_payload` carries kind-specific data.
     /// Once enough profiles are gathered, invalidates the compiled unit for recompilation.
     ///
-    /// Two iseqs are passed because they diverge for inlined code. `frame_iseq_raw` is
-    /// the frame's own iseq, where the runtime profile is recorded; for an exit out of
-    /// an inlined callee this is the callee, which typically has no compiled version of
-    /// its own. `compiled_iseq_raw` is the function that was actually compiled (the
-    /// inliner folds the callee's body into it), so its version is the one holding the
-    /// failing guard and the one we must invalidate to force a recompile. For
-    /// non-inlined code the two are identical.
-    pub(crate) fn exit_recompile(ec: EcPtr, frame_iseq_raw: VALUE, compiled_iseq_raw: VALUE, insn_idx: u32, profile_kind: i32, profile_payload: i32) {
-        let recompile = Recompile::from_c_args(profile_kind, profile_payload);
-
+    /// `compiled_iseq_raw` is the ISEQ that was actually compiled. For an exit out
+    /// of inlined code, the inliner folds the callee's body into the outer ISEQ, so
+    /// the outer ISEQ's version holds the failing guard and must be invalidated to
+    /// force a recompile. For non-inlined code, it is the same as the frame ISEQ.
+    pub(crate) fn exit_recompile(ec: EcPtr, compiled_iseq_raw: VALUE) {
         // Fast check before taking the VM lock: skip if the compiled unit is already
         // invalidated or at the version limit. This avoids expensive lock acquisition
         // on every shape guard exit after the recompile has already been triggered.
@@ -3233,37 +3227,10 @@ c_callable! {
         }
 
         with_vm_lock(src_loc!(), || {
-            let frame_iseq: IseqPtr = frame_iseq_raw.as_iseq();
             let compiled_iseq: IseqPtr = compiled_iseq_raw.as_iseq();
 
-            // For no-profile sends, skip if already profiled at this insn_idx.
-            // For shape guard exits, always re-profile because the
-            // original YARV profiles were monomorphic but runtime showed new shapes.
-            if matches!(recompile, Recompile::ProfileSend { .. }) &&
-                get_or_create_iseq_payload(frame_iseq).profile.done_profiling_at(insn_idx as usize) {
-                return;
-            }
-
             let should_recompile = with_time_stat(Counter::profile_time_ns, || {
-                let cfp = unsafe { get_ec_cfp(ec) };
-                let payload = get_or_create_iseq_payload(frame_iseq);
-
-                match recompile {
-                    Recompile::ProfileSend { argc } => {
-                        let sp = unsafe { get_cfp_sp(cfp) };
-                        // Profile the receiver and arguments for this send instruction
-                        payload.profile.profile_send_at(frame_iseq, insn_idx as usize, sp, argc as usize)
-                    }
-                    Recompile::ProfileSelf => {
-                        // Profile self for shape guard exits
-                        let self_val = unsafe { get_cfp_self(cfp) };
-                        payload.profile.profile_self_at(frame_iseq, insn_idx as usize, self_val)
-                    }
-                    Recompile::ProfileBlockHandler => {
-                        // Profile the block handler for this getblockparamproxy instruction
-                        payload.profile.profile_getblockparamproxy_at(frame_iseq, insn_idx as usize, cfp)
-                    }
-                }
+                crate::profile::profile_recompile_insn(ec)
             });
 
             // Once we have enough profiles, invalidate the compiled unit so it

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -21,7 +21,7 @@ use crate::stats::{counter_ptr, with_time_stat, trace_compile_phase, Counter, Co
 use crate::{asm::CodeBlock, cruby::*, options::debug, virtualmem::CodePtr};
 use crate::backend::lir::{self, Assembler, C_ARG_OPNDS, C_RET_OPND, CFP, EC, NATIVE_BASE_PTR, Opnd, SP, SideExit, SideExitRecompile, Target, asm_ccall, asm_comment};
 use crate::hir::{iseq_to_hir, BlockId, Invariant, RangeType, SideExitReason::{self, *}, SpecialBackrefSymbol, SpecialObjectType};
-use crate::hir::{BlockHandler, Const, FieldName, FrameState, Function, Insn, InsnId, SendFallbackReason};
+use crate::hir::{BlockHandler, Const, FieldName, FrameState, Function, Insn, InsnId, Recompile, SendFallbackReason};
 use crate::hir_type::{types, Type};
 use crate::options::{get_option, InlineDepth, PerfMap};
 use crate::cast::IntoUsize;
@@ -523,7 +523,7 @@ fn gen_function(cb: &mut CodeBlock, iseq: IseqPtr, version: IseqVersionRef, func
                                 Insn::InvokeBuiltin { .. } => SideExitReason::UnhandledHIRInvokeBuiltin,
                                 _                          => SideExitReason::UnhandledHIRUnknown(insn_id),
                             };
-                            gen_side_exit(&mut jit, &mut asm, &reason, false, &function.frame_state(last_snapshot));
+                            gen_side_exit(&mut jit, &mut asm, &reason, None, &function.frame_state(last_snapshot));
                             // Don't bother generating code after a side-exit. We won't run it.
                             // TODO(max): Generate ud2 or equivalent.
                             break;
@@ -1240,7 +1240,7 @@ fn gen_setglobal(jit: &mut JITState, asm: &mut Assembler, id: ID, val: Opnd, sta
 }
 
 /// Side-exit into the interpreter
-fn gen_side_exit(jit: &mut JITState, asm: &mut Assembler, reason: &SideExitReason, recompile: bool, state: &FrameState) {
+fn gen_side_exit(jit: &mut JITState, asm: &mut Assembler, reason: &SideExitReason, recompile: Option<Recompile>, state: &FrameState) {
     asm.jmp(side_exit_with_recompile(jit, state, *reason, recompile));
 }
 
@@ -2661,7 +2661,7 @@ fn gen_has_type(jit: &mut JITState, asm: &mut Assembler, val: lir::Opnd, val_typ
 }
 
 /// Compile a type check with a side exit
-fn gen_guard_type(jit: &mut JITState, asm: &mut Assembler, val: lir::Opnd, val_type: Type, guard_type: Type, recompile: bool, state: &FrameState) -> lir::Opnd {
+fn gen_guard_type(jit: &mut JITState, asm: &mut Assembler, val: lir::Opnd, val_type: Type, guard_type: Type, recompile: Option<Recompile>, state: &FrameState) -> lir::Opnd {
     let is_known_heap_basic_object = val_type.is_subtype(types::HeapBasicObject);
     gen_incr_counter(asm, Counter::guard_type_count);
     if guard_type.is_subtype(types::Fixnum) {
@@ -2746,7 +2746,7 @@ fn gen_guard_type(jit: &mut JITState, asm: &mut Assembler, val: lir::Opnd, val_t
 }
 
 /// Compile an identity check with a side exit
-fn gen_guard_bit_equals(jit: &mut JITState, asm: &mut Assembler, val: lir::Opnd, expected: crate::hir::Const, reason: SideExitReason, recompile: bool, state: &FrameState) -> lir::Opnd {
+fn gen_guard_bit_equals(jit: &mut JITState, asm: &mut Assembler, val: lir::Opnd, expected: crate::hir::Const, reason: SideExitReason, recompile: Option<Recompile>, state: &FrameState) -> lir::Opnd {
     if matches!(reason, SideExitReason::GuardShape(_) ) {
         gen_incr_counter(asm, Counter::guard_shape_count);
     }
@@ -2772,7 +2772,7 @@ fn mask_to_opnd(mask: crate::hir::Const) -> Option<Opnd> {
 }
 
 /// Compile a bitmask check with a side exit if none of the masked bits are not set
-fn gen_guard_any_bit_set(jit: &mut JITState, asm: &mut Assembler, val: lir::Opnd, mask: crate::hir::Const, reason: SideExitReason, recompile: bool, state: &FrameState) -> lir::Opnd {
+fn gen_guard_any_bit_set(jit: &mut JITState, asm: &mut Assembler, val: lir::Opnd, mask: crate::hir::Const, reason: SideExitReason, recompile: Option<Recompile>, state: &FrameState) -> lir::Opnd {
     let mask_opnd = mask_to_opnd(mask).unwrap_or_else(|| panic!("gen_guard_any_bit_set: unexpected hir::Const {mask:?}"));
     asm.test(val, mask_opnd);
     asm.jz(jit, side_exit_with_recompile(jit, state, reason, recompile));
@@ -3151,14 +3151,12 @@ fn side_exit(jit: &JITState, state: &FrameState, reason: SideExitReason) -> Targ
 }
 
 /// Build a Target::SideExit that optionally triggers exit_recompile on the exit path.
-fn side_exit_with_recompile(jit: &JITState, state: &FrameState, reason: SideExitReason, recompile: bool) -> Target {
+fn side_exit_with_recompile(jit: &JITState, state: &FrameState, reason: SideExitReason, recompile: Option<Recompile>) -> Target {
     let mut exit = build_side_exit(jit, state);
-    if recompile {
-        exit.recompile = Some(SideExitRecompile {
-            compiled_iseq: Opnd::Value(VALUE::from(jit.iseq())),
-            insn_idx: state.insn_idx() as u32,
-        });
-    }
+    exit.recompile = recompile.map(|_| SideExitRecompile {
+        compiled_iseq: Opnd::Value(VALUE::from(jit.iseq())),
+        insn_idx: state.insn_idx() as u32,
+    });
     Target::SideExit { exit, reason }
 }
 

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -568,6 +568,10 @@ pub enum SideExitReason {
     InvokeBlockNotIfunc,
 }
 
+/// Marks a side exit as triggering profiling and recompilation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Recompile;
+
 #[derive(Debug, Clone, Copy)]
 pub enum MethodType {
     Iseq,
@@ -1179,11 +1183,11 @@ pub enum Insn {
     HasType { val: InsnId, expected: Type },
 
     /// Side-exit if val doesn't have the expected type.
-    GuardType { val: InsnId, guard_type: Type, state: InsnId, recompile: bool },
+    GuardType { val: InsnId, guard_type: Type, state: InsnId, recompile: Option<Recompile> },
     /// Side-exit if val is not the expected Const.
-    GuardBitEquals { val: InsnId, expected: Const, reason: SideExitReason, state: InsnId, recompile: bool },
+    GuardBitEquals { val: InsnId, expected: Const, reason: SideExitReason, state: InsnId, recompile: Option<Recompile> },
     /// Side-exit if (val & mask) == 0
-    GuardAnyBitSet { val: InsnId, mask: Const, mask_name: Option<ID>, reason: SideExitReason, state: InsnId, recompile: bool },
+    GuardAnyBitSet { val: InsnId, mask: Const, mask_name: Option<ID>, reason: SideExitReason, state: InsnId, recompile: Option<Recompile> },
     /// Side-exit if (val & mask) != 0
     GuardNoBitsSet { val: InsnId, mask: Const, mask_name: Option<ID>, reason: SideExitReason, state: InsnId },
     /// Side-exit if left is not greater than or equal to right (both operands are C long).
@@ -1196,9 +1200,9 @@ pub enum Insn {
     PatchPoint { invariant: Invariant, state: InsnId },
 
     /// Side-exit into the interpreter.
-    /// If recompile is true, the side exit will profile and invalidate the ISEQ
+    /// If recompile is not None, the side exit will profile and invalidate the ISEQ
     /// so that it gets recompiled with the new profile data.
-    SideExit { state: InsnId, reason: SideExitReason, recompile: bool },
+    SideExit { state: InsnId, reason: SideExitReason, recompile: Option<Recompile> },
 
     /// Increment a counter in ZJIT stats
     IncrCounter(Counter),
@@ -2132,7 +2136,7 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
             Insn::FixnumRShift { left, right, .. } => { write!(f, "FixnumRShift {left}, {right}") },
             Insn::GuardType { val, guard_type, recompile, .. } => {
                 write!(f, "GuardType {val}, {}", guard_type.print(self.ptr_map))?;
-                if *recompile {
+                if recompile.is_some() {
                     write!(f, " recompile")?;
                 }
                 return Ok(())
@@ -2141,14 +2145,14 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
             Insn::HasType { val, expected, .. } => { write!(f, "HasType {val}, {}", expected.print(self.ptr_map)) },
             Insn::GuardBitEquals { val, expected, recompile, .. } => {
                 write!(f, "GuardBitEquals {val}, {}", expected.print(self.ptr_map))?;
-                if *recompile {
+                if recompile.is_some() {
                     write!(f, " recompile")?;
                 }
                 return Ok(())
             },
             Insn::GuardAnyBitSet { val, mask, mask_name, recompile, .. } => {
                 let mask = mask.print(self.ptr_map);
-                let recompile = if *recompile { " recompile" } else { "" };
+                let recompile = if recompile.is_some() { " recompile" } else { "" };
                 if let Some(name) = mask_name {
                     write!(f, "GuardAnyBitSet {val}, {name}={mask}{recompile}")
                 } else {
@@ -2263,7 +2267,7 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
             Insn::StringIntern { val, .. } => { write!(f, "StringIntern {val}") },
             Insn::AnyToString { val, str, .. } => { write!(f, "AnyToString {val}, str: {str}") },
             Insn::SideExit { reason, recompile, .. } => {
-                if *recompile {
+                if recompile.is_some() {
                     write!(f, "SideExit {reason} recompile")
                 } else {
                     write!(f, "SideExit {reason}")
@@ -2888,7 +2892,7 @@ impl Function {
         if self.assume_bop_not_redefined(block, klass, bop, state) {
             return true;
         }
-        self.push_insn(block, Insn::SideExit { state, reason: SideExitReason::PatchPoint(Invariant::BOPRedefined { klass, bop }), recompile: false });
+        self.push_insn(block, Insn::SideExit { state, reason: SideExitReason::PatchPoint(Invariant::BOPRedefined { klass, bop }), recompile: None });
         false
     }
 
@@ -3537,7 +3541,7 @@ impl Function {
 
     pub fn coerce_to(&mut self, block: BlockId, val: InsnId, guard_type: Type, state: InsnId) -> InsnId {
         if self.is_a(val, guard_type) { return val; }
-        self.push_insn(block, Insn::GuardType { val, guard_type, state, recompile: false })
+        self.push_insn(block, Insn::GuardType { val, guard_type, state, recompile: None })
     }
 
     fn count_complex_call_features(&mut self, block: BlockId, ci_flags: c_uint) {
@@ -3794,7 +3798,7 @@ impl Function {
 
                             // Add GuardType for profiled receiver
                             if let Some(profiled_type) = profiled_type {
-                                recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: true });
+                                recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: Some(Recompile) });
                             }
 
                             let send_direct = self.push_insn(block, Insn::SendDirect { recv, cd, cme, iseq, args: processed_args, kw_bits, state: send_state, block: send_block });
@@ -3837,7 +3841,7 @@ impl Function {
                             self.push_insn(block, Insn::PatchPoint { invariant: Invariant::MethodRedefined { klass, method: mid, cme }, state });
 
                             if let Some(profiled_type) = profiled_type {
-                                recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: true });
+                                recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: Some(Recompile) });
                             }
 
                             let send_direct = self.push_insn(block, Insn::SendDirect { recv, cd, cme, iseq, args: processed_args, kw_bits, state: send_state, block: None });
@@ -3859,7 +3863,7 @@ impl Function {
 
                             let id = unsafe { get_cme_def_body_attr_id(cme) };
                             if let Some(profiled_type) = profiled_type {
-                                recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: true });
+                                recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: Some(Recompile) });
 
                                 let replacement = self.try_emit_optimized_getivar(block, recv, id, profiled_type, state).unwrap_or_else(|counter| {
                                     self.count(block, counter);
@@ -3888,8 +3892,8 @@ impl Function {
                                 // TODO: attr_writer SetIvar has a null inline cache and may target a receiver
                                 // operand other than CFP self. Support it with a reprofile strategy that
                                 // profiles the receiver operand even after the send insn has finished profiling.
-                                let recompile = false;
-                                recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: true });
+                                let recompile = None;
+                                recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: Some(Recompile) });
                                 self.try_emit_optimized_setivar(block, recv, id, val, profiled_type, state, recompile).unwrap_or_else(|counter| {
                                     self.count(block, counter);
                                     self.push_insn(block, Insn::SetIvar { self_val: recv, id, ic: std::ptr::null(), val, state });
@@ -3915,7 +3919,7 @@ impl Function {
                                     }
                                     self.push_insn(block, Insn::PatchPoint { invariant: Invariant::MethodRedefined { klass, method: mid, cme }, state });
                                     if let Some(profiled_type) = profiled_type {
-                                        recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: true });
+                                        recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: Some(Recompile) });
                                     }
                                     let kw_splat = flags & VM_CALL_KW_SPLAT != 0;
                                     let invoke_proc = self.push_insn(block, Insn::InvokeProc { recv, args: args.clone(), state, kw_splat });
@@ -3953,7 +3957,7 @@ impl Function {
                                     }
                                     self.push_insn(block, Insn::PatchPoint { invariant: Invariant::MethodRedefined { klass, method: mid, cme }, state });
                                     if let Some(profiled_type) = profiled_type {
-                                        recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: true });
+                                        recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: Some(Recompile) });
                                     }
                                     // All structs from the same Struct class should have the same
                                     // length. So if our recv is embedded all runtime
@@ -4006,12 +4010,12 @@ impl Function {
 
                         if recv_type.is_string() {
                             self.push_insn(block, Insn::PatchPoint { invariant: Invariant::NoSingletonClass { klass: recv_type.class() }, state });
-                            let guard = self.push_insn(block, Insn::GuardType { val, guard_type: types::String, state, recompile: false });
+                            let guard = self.push_insn(block, Insn::GuardType { val, guard_type: types::String, state, recompile: None });
                             // Infer type so AnyToString can fold off this
                             self.insn_types[guard.0] = self.infer_type(guard);
                             self.make_equal_to(insn_id, guard);
                         } else {
-                            let recv = self.push_insn(block, Insn::GuardType { val, guard_type: Type::from_profiled_type(recv_type), state, recompile: false });
+                            let recv = self.push_insn(block, Insn::GuardType { val, guard_type: Type::from_profiled_type(recv_type), state, recompile: None });
                             let send_to_s = self.push_insn(block, Insn::Send { recv, cd, block: None, args: vec![], state, reason: ObjToStringNotString });
                             self.make_equal_to(insn_id, send_to_s);
                         }
@@ -4084,7 +4088,7 @@ impl Function {
                             // Load ep[VM_ENV_DATA_INDEX_ME_CREF]
                             let method_entry = fun.push_insn(block, Insn::LoadField { recv: lep, id: FieldName::VM_ENV_DATA_INDEX_ME_CREF, offset: SIZEOF_VALUE_I32 * VM_ENV_DATA_INDEX_ME_CREF, return_type: types::RubyValue });
                             // Guard that it matches the expected CME
-                            fun.push_insn(block, Insn::GuardBitEquals { val: method_entry, expected: Const::Value(current_cme.into()), reason: SideExitReason::GuardSuperMethodEntry, state, recompile: false });
+                            fun.push_insn(block, Insn::GuardBitEquals { val: method_entry, expected: Const::Value(current_cme.into()), reason: SideExitReason::GuardSuperMethodEntry, state, recompile: None });
 
                             let block_handler = fun.push_insn(block, Insn::LoadField { recv: lep, id: FieldName::VM_ENV_DATA_INDEX_SPECVAL, offset: SIZEOF_VALUE_I32 * VM_ENV_DATA_INDEX_SPECVAL, return_type: types::RubyValue });
                             fun.push_insn(block, Insn::GuardBitEquals {
@@ -4092,7 +4096,7 @@ impl Function {
                                 expected: Const::Value(VALUE(VM_BLOCK_HANDLER_NONE as usize)),
                                 reason: SideExitReason::UnhandledBlockArg,
                                 state,
-                                recompile: false,
+                                recompile: None,
                             });
                         }
 
@@ -4772,7 +4776,7 @@ impl Function {
         })
     }
 
-    fn guard_shape(&mut self, block: BlockId, val: InsnId, expected: ShapeId, state: InsnId, recompile: bool) -> InsnId {
+    fn guard_shape(&mut self, block: BlockId, val: InsnId, expected: ShapeId, state: InsnId, recompile: Option<Recompile>) -> InsnId {
         self.push_insn(block, Insn::GuardBitEquals {
             val,
             expected: Const::CShape(expected),
@@ -4822,7 +4826,7 @@ impl Function {
 
     /// Guard that `recv` is a heap allocated object
     fn guard_heap(&mut self, block: BlockId, recv: InsnId, state: InsnId) -> InsnId {
-        self.push_insn(block, Insn::GuardType { val: recv, guard_type: types::HeapBasicObject, state, recompile: false })
+        self.push_insn(block, Insn::GuardType { val: recv, guard_type: types::HeapBasicObject, state, recompile: None })
     }
 
     fn load_ivar(&mut self, block: BlockId, self_val: InsnId, recv_type: ProfiledType, id: ID) -> InsnId {
@@ -4901,11 +4905,11 @@ impl Function {
         }
         let self_val = self.guard_heap(block, self_val, state);
         let shape = self.load_shape(block, self_val);
-        self.guard_shape(block, shape, profiled_type.shape(), state, true);
+        self.guard_shape(block, shape, profiled_type.shape(), state, Some(Recompile));
         Ok(self.load_ivar(block, self_val, profiled_type, id))
     }
 
-    fn try_emit_optimized_setivar(&mut self, block: BlockId, self_val: InsnId, id: ID, val: InsnId, profiled_type: ProfiledType, state: InsnId, recompile: bool) -> Result<(), Counter> {
+    fn try_emit_optimized_setivar(&mut self, block: BlockId, self_val: InsnId, id: ID, val: InsnId, profiled_type: ProfiledType, state: InsnId, recompile: Option<Recompile>) -> Result<(), Counter> {
         if profiled_type.flags().is_immediate() {
             // Instance variable lookups on immediate values are always nil
             return Err(Counter::setivar_fallback_immediate);
@@ -5153,7 +5157,7 @@ impl Function {
 
                     if let Some(profiled_type) = profiled_type {
                         // Guard receiver class
-                        recv = fun.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: true });
+                        recv = fun.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: Some(Recompile) });
                         fun.insn_types[recv.0] = fun.infer_type(recv);
                     }
 
@@ -5219,7 +5223,7 @@ impl Function {
 
                     if let Some(profiled_type) = profiled_type {
                         // Guard receiver class
-                        recv = fun.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: true });
+                        recv = fun.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: Some(Recompile) });
                         fun.insn_types[recv.0] = fun.infer_type(recv);
                     }
 
@@ -5338,7 +5342,7 @@ impl Function {
             for insn_id in old_insns {
                 match self.find(insn_id) {
                     Insn::Send { state, reason: SendFallbackReason::SendWithoutBlockNoProfiles | SendFallbackReason::SendNoProfiles, .. } => {
-                        self.push_insn(block, Insn::SideExit { state, reason: SideExitReason::NoProfileSend, recompile: true });
+                        self.push_insn(block, Insn::SideExit { state, reason: SideExitReason::NoProfileSend, recompile: Some(Recompile) });
                         // SideExit is a terminator; don't add remaining instructions
                         break;
                     }
@@ -5565,7 +5569,7 @@ impl Function {
                                 self.make_equal_to(insn_id, left);
                                 continue
                             },
-                            (Some(_), Some(_)) => self.new_insn(Insn::SideExit { state, reason, recompile: false }),
+                            (Some(_), Some(_)) => self.new_insn(Insn::SideExit { state, reason, recompile: None }),
                             _ => insn_id,
                         }
                     },
@@ -5577,7 +5581,7 @@ impl Function {
                                 self.make_equal_to(insn_id, left);
                                 continue
                             },
-                            (Some(_), Some(_)) => self.new_insn(Insn::SideExit { state, reason, recompile: false }),
+                            (Some(_), Some(_)) => self.new_insn(Insn::SideExit { state, reason, recompile: None }),
                             _ => insn_id,
                         }
                     },
@@ -7584,7 +7588,7 @@ fn add_iseq_to_hir(
                         }
                         _ => {
                             // Unknown opcode; side-exit into the interpreter
-                            fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledNewarraySend(method), recompile: false });
+                            fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledNewarraySend(method), recompile: None });
                             break;  // End the block
                         }
                     };
@@ -7610,7 +7614,7 @@ fn add_iseq_to_hir(
                     let bop = match method_id {
                         x if x == ID!(include_p).0 => BOP_INCLUDE_P,
                         _ => {
-                            fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledDuparraySend(method_id), recompile: false });
+                            fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledDuparraySend(method_id), recompile: None });
                             break;
                         },
                     };
@@ -7657,20 +7661,20 @@ fn add_iseq_to_hir(
                         .and_then(|types| types.first())
                         .map(|dist| TypeDistributionSummary::new(dist));
                     let Some(summary) = summary else {
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::SplatKwNotProfiled, recompile: false });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::SplatKwNotProfiled, recompile: None });
                         break;  // End the block
                     };
                     if !summary.is_monomorphic() {
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::SplatKwPolymorphic, recompile: false });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::SplatKwPolymorphic, recompile: None });
                         break;  // End the block
                     }
                     let ty = Type::from_profiled_type(summary.bucket(0));
                     let obj = if ty.is_subtype(types::NilClass) {
-                        fun.push_insn(block, Insn::GuardType { val: hash, guard_type: types::NilClass, state: exit_id, recompile: false })
+                        fun.push_insn(block, Insn::GuardType { val: hash, guard_type: types::NilClass, state: exit_id, recompile: None })
                     } else if ty.is_subtype(types::HashExact) {
-                        fun.push_insn(block, Insn::GuardType { val: hash, guard_type: types::HashExact, state: exit_id, recompile: false })
+                        fun.push_insn(block, Insn::GuardType { val: hash, guard_type: types::HashExact, state: exit_id, recompile: None })
                     } else {
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::SplatKwNotNilOrHash, recompile: false });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::SplatKwNotNilOrHash, recompile: None });
                         break;  // End the block
                     };
                     state.stack_push(obj);
@@ -7749,7 +7753,7 @@ fn add_iseq_to_hir(
                         Some(profiled_shape)
                     }
                     if let Some(summary) = fun.polymorphic_summary(&profiles, self_param, exit_id) {
-                        self_param = fun.push_insn(block, Insn::GuardType { val: self_param, guard_type: types::HeapBasicObject, state: exit_id, recompile: false });
+                        self_param = fun.push_insn(block, Insn::GuardType { val: self_param, guard_type: types::HeapBasicObject, state: exit_id, recompile: None });
                         let join_block = fun.new_block(insn_idx);
                         let join_param = fun.push_insn(join_block, Insn::Param);
                         // Dedup by expected shape so objects with different classes but the
@@ -7795,7 +7799,7 @@ fn add_iseq_to_hir(
                             .and_then(can_optimize) {
                             self_param = fun.guard_heap(block, self_param, exit_id);
                             let shape = fun.load_shape(block, self_param);
-                            fun.guard_shape(block, shape, profiled_shape, exit_id, true);
+                            fun.guard_shape(block, shape, profiled_shape, exit_id, Some(Recompile));
                             let mut ivar_index: attr_index_t = 0;
                             let result = if unsafe { rb_shape_get_iv_index(profiled_shape.0, id, &mut ivar_index) } {
                                 fun.push_insn(block, Insn::Const { val: Const::Value(pushval) })
@@ -7816,7 +7820,7 @@ fn add_iseq_to_hir(
                     // This can only happen in iseqs taking more than 32 keywords.
                     // In this case, we side exit to the interpreter.
                     if unsafe {(*rb_get_iseq_body_param_keyword(iseq)).num >= VM_KW_SPECIFIED_BITS_MAX.try_into().unwrap()} {
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::TooManyKeywordParameters, recompile: false });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::TooManyKeywordParameters, recompile: None });
                         break;
                     }
                     let ep_offset = get_arg(pc, 0).as_u32();
@@ -8213,7 +8217,7 @@ fn add_iseq_to_hir(
                             // So to check for either of those cases we can use: val & 0x1 == 0x1
 
                             // Bail out if the block handler is neither ISEQ nor ifunc
-                            fun.push_insn(unmodified_block, Insn::GuardAnyBitSet { val: block_handler, mask: Const::CUInt64(0x1), mask_name: None, reason: SideExitReason::BlockParamProxyFallbackMiss, state: exit_id, recompile: true });
+                            fun.push_insn(unmodified_block, Insn::GuardAnyBitSet { val: block_handler, mask: Const::CUInt64(0x1), mask_name: None, reason: SideExitReason::BlockParamProxyFallbackMiss, state: exit_id, recompile: Some(Recompile) });
                             // TODO(Shopify/ruby#753): GC root, so we should be able to avoid unnecessary GC tracing
                             let proxy_val = fun.push_insn(unmodified_block, Insn::Const { val: Const::Value(unsafe { rb_block_param_proxy }) });
                             let mut args = vec![proxy_val];
@@ -8226,7 +8230,7 @@ fn add_iseq_to_hir(
                         [profiled_handler] => match profiled_handler {
                             ProfiledBlockHandlerFamily::Nil => {
                                 let block_handler = fun.load_ep_env_field(unmodified_block, ep, FieldName::VM_ENV_DATA_INDEX_SPECVAL, VM_ENV_DATA_INDEX_SPECVAL, types::CInt64);
-                                fun.push_insn(unmodified_block, Insn::GuardBitEquals { val: block_handler, expected: Const::CInt64(VM_BLOCK_HANDLER_NONE.into()), reason: SideExitReason::BlockParamProxyNotNil, state: exit_id, recompile: true });
+                                fun.push_insn(unmodified_block, Insn::GuardBitEquals { val: block_handler, expected: Const::CInt64(VM_BLOCK_HANDLER_NONE.into()), reason: SideExitReason::BlockParamProxyNotNil, state: exit_id, recompile: Some(Recompile) });
                                 let nil_val = fun.push_insn(unmodified_block, Insn::Const { val: Const::Value(Qnil) });
                                 let mut args = vec![nil_val];
                                 if let Some(local) = original_local {
@@ -8243,7 +8247,7 @@ fn add_iseq_to_hir(
                                 // So to check for either of those cases we can use: val & 0x1 == 0x1
 
                                 // Bail out if the block handler is neither ISEQ nor ifunc
-                                fun.push_insn(unmodified_block, Insn::GuardAnyBitSet { val: block_handler, mask: Const::CUInt64(0x1), mask_name: None, reason: SideExitReason::BlockParamProxyNotIseqOrIfunc, state: exit_id, recompile: true });
+                                fun.push_insn(unmodified_block, Insn::GuardAnyBitSet { val: block_handler, mask: Const::CUInt64(0x1), mask_name: None, reason: SideExitReason::BlockParamProxyNotIseqOrIfunc, state: exit_id, recompile: Some(Recompile) });
                                 // TODO(Shopify/ruby#753): GC root, so we should be able to avoid unnecessary GC tracing
                                 let proxy_val = fun.push_insn(unmodified_block, Insn::Const { val: Const::Value(unsafe { rb_block_param_proxy }) });
                                 let mut args = vec![proxy_val];
@@ -8263,7 +8267,7 @@ fn add_iseq_to_hir(
                                     return_type: types::BasicObject,
                                     elidable: true,
                                 });
-                                fun.push_insn(unmodified_block, Insn::GuardBitEquals { val: is_proc, expected: Const::Value(Qtrue), reason: SideExitReason::BlockParamProxyNotProc, state: exit_id, recompile: true });
+                                fun.push_insn(unmodified_block, Insn::GuardBitEquals { val: is_proc, expected: Const::Value(Qtrue), reason: SideExitReason::BlockParamProxyNotProc, state: exit_id, recompile: Some(Recompile) });
                                 let mut args = vec![proc_val];
                                 if let Some(local) = original_local {
                                     args.push(local);
@@ -8367,7 +8371,7 @@ fn add_iseq_to_hir(
                                 }
                             }
 
-                            fun.push_insn(current_block, Insn::SideExit { state: exit_id, reason: SideExitReason::BlockParamProxyProfileNotCovered, recompile: false });
+                            fun.push_insn(current_block, Insn::SideExit { state: exit_id, reason: SideExitReason::BlockParamProxyProfileNotCovered, recompile: None });
                         }
                     }
 
@@ -8460,7 +8464,7 @@ fn add_iseq_to_hir(
                     let flags = unsafe { rb_vm_ci_flag(call_info) };
                     if let Err(call_type) = unhandled_call_type(flags) {
                         // Can't handle the call type; side-exit into the interpreter
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledCallType(call_type), recompile: false });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledCallType(call_type), recompile: None });
                         break;  // End the block
                     }
                     let argc = crate::profile::num_arguments_on_stack(cd);
@@ -8468,7 +8472,7 @@ fn add_iseq_to_hir(
 
                     // Side-exit send fallbacks while tracing to avoid FLAG_FINISH breaking throw TAG_RETURN semantics
                     if unsafe { rb_zjit_iseq_tracing_currently_enabled() } {
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::SendWhileTracing, recompile: false });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::SendWhileTracing, recompile: None });
                         break;
                     }
                     let args = state.stack_pop_n(argc as usize)?;
@@ -8559,7 +8563,7 @@ fn add_iseq_to_hir(
                     let flags = unsafe { rb_vm_ci_flag(call_info) };
                     if let Err(call_type) = unhandled_call_type(flags) {
                         // Can't handle tailcall; side-exit into the interpreter
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledCallType(call_type), recompile: false });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledCallType(call_type), recompile: None });
                         break;  // End the block
                     }
                     let argc = crate::profile::num_arguments_on_stack(cd);
@@ -8576,7 +8580,7 @@ fn add_iseq_to_hir(
                         if mid == ID!(induce_side_exit_bang)
                             && state::zjit_module_method_match_serial(ID!(induce_side_exit_bang), &state::INDUCE_SIDE_EXIT_SERIAL)
                         {
-                            fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::DirectiveInduced, recompile: false });
+                            fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::DirectiveInduced, recompile: None });
                             break;  // End the block
                         }
                         if mid == ID!(induce_compile_failure_bang)
@@ -8595,7 +8599,7 @@ fn add_iseq_to_hir(
 
                     // Side-exit send fallbacks while tracing to avoid FLAG_FINISH breaking throw TAG_RETURN semantics
                     if unsafe { rb_zjit_iseq_tracing_currently_enabled() } {
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::SendWhileTracing, recompile: false });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::SendWhileTracing, recompile: None });
                         break;
                     }
 
@@ -8653,12 +8657,12 @@ fn add_iseq_to_hir(
                     let flags = unsafe { rb_vm_ci_flag(call_info) };
                     if let Err(call_type) = unhandled_call_type(flags) {
                         // Can't handle tailcall; side-exit into the interpreter
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledCallType(call_type), recompile: false });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledCallType(call_type), recompile: None });
                         break;  // End the block
                     }
                     // Side-exit send fallbacks while tracing to avoid FLAG_FINISH breaking throw TAG_RETURN semantics
                     if unsafe { rb_zjit_iseq_tracing_currently_enabled() } {
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::SendWhileTracing, recompile: false });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::SendWhileTracing, recompile: None });
                         break;
                     }
                     let block_arg = (flags & VM_CALL_ARGS_BLOCKARG) != 0;
@@ -8708,12 +8712,12 @@ fn add_iseq_to_hir(
                     let forwarding = (flags & VM_CALL_FORWARDING) != 0;
                     if let Err(call_type) = unhandled_call_type(flags) {
                         // Can't handle the call type; side-exit into the interpreter
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledCallType(call_type), recompile: false });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledCallType(call_type), recompile: None });
                         break;  // End the block
                     }
                     // Side-exit send fallbacks while tracing to avoid FLAG_FINISH breaking throw TAG_RETURN semantics
                     if unsafe { rb_zjit_iseq_tracing_currently_enabled() } {
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::SendWhileTracing, recompile: false });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::SendWhileTracing, recompile: None });
                         break;
                     }
                     let argc = unsafe { vm_ci_argc((*cd).ci) };
@@ -8752,12 +8756,12 @@ fn add_iseq_to_hir(
                     let flags = unsafe { rb_vm_ci_flag(call_info) };
                     if let Err(call_type) = unhandled_call_type(flags) {
                         // Can't handle tailcall; side-exit into the interpreter
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledCallType(call_type), recompile: false });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledCallType(call_type), recompile: None });
                         break;  // End the block
                     }
                     // Side-exit send fallbacks while tracing to avoid FLAG_FINISH breaking throw TAG_RETURN semantics
                     if unsafe { rb_zjit_iseq_tracing_currently_enabled() } {
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::SendWhileTracing, recompile: false });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::SendWhileTracing, recompile: None });
                         break;
                     }
                     let args = state.stack_pop_n(crate::profile::num_arguments_on_stack(cd))?;
@@ -8799,12 +8803,12 @@ fn add_iseq_to_hir(
                     let forwarding = (flags & VM_CALL_FORWARDING) != 0;
                     if let Err(call_type) = unhandled_call_type(flags) {
                         // Can't handle tailcall; side-exit into the interpreter
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledCallType(call_type), recompile: false });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledCallType(call_type), recompile: None });
                         break;  // End the block
                     }
                     // Side-exit send fallbacks while tracing to avoid FLAG_FINISH breaking throw TAG_RETURN semantics
                     if unsafe { rb_zjit_iseq_tracing_currently_enabled() } {
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::SendWhileTracing, recompile: false });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::SendWhileTracing, recompile: None });
                         break;
                     }
                     let argc = unsafe { vm_ci_argc((*cd).ci) };
@@ -8844,12 +8848,12 @@ fn add_iseq_to_hir(
                     let flags = unsafe { rb_vm_ci_flag(call_info) };
                     if let Err(call_type) = unhandled_call_type(flags) {
                         // Can't handle tailcall; side-exit into the interpreter
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledCallType(call_type), recompile: false });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledCallType(call_type), recompile: None });
                         break;  // End the block
                     }
                     // Side-exit send fallbacks while tracing to avoid FLAG_FINISH breaking throw TAG_RETURN semantics
                     if unsafe { rb_zjit_iseq_tracing_currently_enabled() } {
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::SendWhileTracing, recompile: false });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::SendWhileTracing, recompile: None });
                         break;
                     }
                     let args = state.stack_pop_n(crate::profile::num_arguments_on_stack(cd))?;
@@ -8935,11 +8939,11 @@ fn add_iseq_to_hir(
                     // TODO: We only really need this if self_val is a class/module
                     if !fun.assume_single_ractor_mode(block, exit_id) {
                         // gen_getivar assumes single Ractor; side-exit into the interpreter
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledYARVInsn(opcode), recompile: false });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledYARVInsn(opcode), recompile: None });
                         break;  // End the block
                     }
                     if let Some(summary) = fun.polymorphic_summary(&profiles, self_param, exit_id) {
-                        self_param = fun.push_insn(block, Insn::GuardType { val: self_param, guard_type: types::HeapBasicObject, state: exit_id, recompile: false });
+                        self_param = fun.push_insn(block, Insn::GuardType { val: self_param, guard_type: types::HeapBasicObject, state: exit_id, recompile: None });
                         let join_block = fun.new_block(insn_idx);
                         let join_param = fun.push_insn(join_block, Insn::Param);
                         // Dedup by expected shape so objects with different classes but the same shape can share code
@@ -9008,13 +9012,13 @@ fn add_iseq_to_hir(
                     // TODO: We only really need this if self_val is a class/module
                     if !fun.assume_single_ractor_mode(block, exit_id) {
                         // gen_setivar assumes single Ractor; side-exit into the interpreter
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledYARVInsn(opcode), recompile: false });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledYARVInsn(opcode), recompile: None });
                         break;  // End the block
                     }
                     let val = state.stack_pop()?;
                     if let Some(profiled_type) = fun.monomorphic_summary(&profiles, self_param, exit_id) {
                         // TODO(max): Assert ic is never null
-                        let recompile = !ic.is_null();
+                        let recompile = (!ic.is_null()).then_some(Recompile);
                         fun.try_emit_optimized_setivar(block, self_param, id, val, profiled_type, exit_id, recompile).unwrap_or_else(|counter| {
                             fun.count(block, counter);
                             fun.push_insn(block, Insn::SetIvar { self_val: self_param, id, ic, val, state: exit_id });
@@ -9060,7 +9064,7 @@ fn add_iseq_to_hir(
                     // TODO: Support passing arguments on the stack in C calls
                     // +2 for ec, self
                     if (bf.argc + 2) as usize > C_ARG_OPNDS.len() {
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::TooManyArgsForLir, recompile: false });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::TooManyArgsForLir, recompile: None });
                         break; // End the block
                     }
 
@@ -9095,7 +9099,7 @@ fn add_iseq_to_hir(
                     // TODO: Support passing arguments on the stack in C calls
                     // +2 for ec, self
                     if (bf.argc + 2) as usize > C_ARG_OPNDS.len() {
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::TooManyArgsForLir, recompile: false });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::TooManyArgsForLir, recompile: None });
                         break; // End the block
                     }
 
@@ -9147,7 +9151,7 @@ fn add_iseq_to_hir(
 
                     if svar == 0 {
                         // TODO: Handle non-backref
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnknownSpecialVariable(key), recompile: false });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnknownSpecialVariable(key), recompile: None });
                         // End the block
                         break;
                     } else if svar & 0x01 != 0 {
@@ -9170,11 +9174,11 @@ fn add_iseq_to_hir(
                         // (reverse?)
                         //
                         // Unhandled opcode; side-exit into the interpreter
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledYARVInsn(opcode), recompile: false });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledYARVInsn(opcode), recompile: None });
                         break;  // End the block
                     }
                     let val = state.stack_pop()?;
-                    let array = fun.push_insn(block, Insn::GuardType { val, guard_type: types::ArrayExact, state: exit_id, recompile: false });
+                    let array = fun.push_insn(block, Insn::GuardType { val, guard_type: types::ArrayExact, state: exit_id, recompile: None });
                     let length = fun.push_insn(block, Insn::ArrayLength { array });
                     let expected = fun.push_insn(block, Insn::Const { val: Const::CInt64(num as i64) });
                     fun.push_insn(block, Insn::GuardGreaterEq { left: length, right: expected, reason: SideExitReason::ExpandArray, state: exit_id });
@@ -9188,7 +9192,7 @@ fn add_iseq_to_hir(
                 }
                 _ => {
                     // Unhandled opcode; side-exit into the interpreter
-                    fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledYARVInsn(opcode), recompile: false });
+                    fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledYARVInsn(opcode), recompile: None });
                     break;  // End the block
                 }
             }

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -568,42 +568,6 @@ pub enum SideExitReason {
     InvokeBlockNotIfunc,
 }
 
-/// Controls how a side exit triggers recompilation.
-pub const RECOMPILE_PROFILE_SEND: i32 = 0;
-pub const RECOMPILE_PROFILE_SELF: i32 = 1;
-pub const RECOMPILE_PROFILE_BLOCK_HANDLER: i32 = 2;
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum Recompile {
-    /// Profile receiver + arguments from the stack (for sends without profile data).
-    ProfileSend { argc: i32 },
-    /// Profile self from the CFP (for shape guard failures).
-    ProfileSelf,
-    /// Profile the block handler from the CFP (for getblockparamproxy guard failures).
-    ProfileBlockHandler,
-}
-
-impl Recompile {
-    /// Convert to primitive arguments for passing across the C ABI.
-    pub fn to_c_args(self) -> (i32, i32) {
-        match self {
-            Recompile::ProfileSend { argc } => (RECOMPILE_PROFILE_SEND, argc),
-            Recompile::ProfileSelf => (RECOMPILE_PROFILE_SELF, 0),
-            Recompile::ProfileBlockHandler => (RECOMPILE_PROFILE_BLOCK_HANDLER, 0),
-        }
-    }
-
-    /// Reconstruct from primitive arguments received across the C ABI.
-    pub fn from_c_args(kind: i32, payload: i32) -> Self {
-        match kind {
-            RECOMPILE_PROFILE_SEND => Recompile::ProfileSend { argc: payload },
-            RECOMPILE_PROFILE_SELF => Recompile::ProfileSelf,
-            RECOMPILE_PROFILE_BLOCK_HANDLER => Recompile::ProfileBlockHandler,
-            _ => unreachable!("unknown recompile profile kind: {kind}"),
-        }
-    }
-}
-
 #[derive(Debug, Clone, Copy)]
 pub enum MethodType {
     Iseq,
@@ -1215,11 +1179,11 @@ pub enum Insn {
     HasType { val: InsnId, expected: Type },
 
     /// Side-exit if val doesn't have the expected type.
-    GuardType { val: InsnId, guard_type: Type, state: InsnId, recompile: Option<Recompile> },
+    GuardType { val: InsnId, guard_type: Type, state: InsnId, recompile: bool },
     /// Side-exit if val is not the expected Const.
-    GuardBitEquals { val: InsnId, expected: Const, reason: SideExitReason, state: InsnId, recompile: Option<Recompile> },
+    GuardBitEquals { val: InsnId, expected: Const, reason: SideExitReason, state: InsnId, recompile: bool },
     /// Side-exit if (val & mask) == 0
-    GuardAnyBitSet { val: InsnId, mask: Const, mask_name: Option<ID>, reason: SideExitReason, state: InsnId, recompile: Option<Recompile> },
+    GuardAnyBitSet { val: InsnId, mask: Const, mask_name: Option<ID>, reason: SideExitReason, state: InsnId, recompile: bool },
     /// Side-exit if (val & mask) != 0
     GuardNoBitsSet { val: InsnId, mask: Const, mask_name: Option<ID>, reason: SideExitReason, state: InsnId },
     /// Side-exit if left is not greater than or equal to right (both operands are C long).
@@ -1232,9 +1196,9 @@ pub enum Insn {
     PatchPoint { invariant: Invariant, state: InsnId },
 
     /// Side-exit into the interpreter.
-    /// If recompile is not None, the side exit will profile and invalidate the ISEQ
+    /// If recompile is true, the side exit will profile and invalidate the ISEQ
     /// so that it gets recompiled with the new profile data.
-    SideExit { state: InsnId, reason: SideExitReason, recompile: Option<Recompile> },
+    SideExit { state: InsnId, reason: SideExitReason, recompile: bool },
 
     /// Increment a counter in ZJIT stats
     IncrCounter(Counter),
@@ -2168,7 +2132,7 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
             Insn::FixnumRShift { left, right, .. } => { write!(f, "FixnumRShift {left}, {right}") },
             Insn::GuardType { val, guard_type, recompile, .. } => {
                 write!(f, "GuardType {val}, {}", guard_type.print(self.ptr_map))?;
-                if recompile.is_some() {
+                if *recompile {
                     write!(f, " recompile")?;
                 }
                 return Ok(())
@@ -2177,14 +2141,14 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
             Insn::HasType { val, expected, .. } => { write!(f, "HasType {val}, {}", expected.print(self.ptr_map)) },
             Insn::GuardBitEquals { val, expected, recompile, .. } => {
                 write!(f, "GuardBitEquals {val}, {}", expected.print(self.ptr_map))?;
-                if recompile.is_some() {
+                if *recompile {
                     write!(f, " recompile")?;
                 }
                 return Ok(())
             },
             Insn::GuardAnyBitSet { val, mask, mask_name, recompile, .. } => {
                 let mask = mask.print(self.ptr_map);
-                let recompile = if recompile.is_some() { " recompile" } else { "" };
+                let recompile = if *recompile { " recompile" } else { "" };
                 if let Some(name) = mask_name {
                     write!(f, "GuardAnyBitSet {val}, {name}={mask}{recompile}")
                 } else {
@@ -2299,7 +2263,7 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
             Insn::StringIntern { val, .. } => { write!(f, "StringIntern {val}") },
             Insn::AnyToString { val, str, .. } => { write!(f, "AnyToString {val}, str: {str}") },
             Insn::SideExit { reason, recompile, .. } => {
-                if recompile.is_some() {
+                if *recompile {
                     write!(f, "SideExit {reason} recompile")
                 } else {
                     write!(f, "SideExit {reason}")
@@ -2924,7 +2888,7 @@ impl Function {
         if self.assume_bop_not_redefined(block, klass, bop, state) {
             return true;
         }
-        self.push_insn(block, Insn::SideExit { state, reason: SideExitReason::PatchPoint(Invariant::BOPRedefined { klass, bop }), recompile: None });
+        self.push_insn(block, Insn::SideExit { state, reason: SideExitReason::PatchPoint(Invariant::BOPRedefined { klass, bop }), recompile: false });
         false
     }
 
@@ -3573,7 +3537,7 @@ impl Function {
 
     pub fn coerce_to(&mut self, block: BlockId, val: InsnId, guard_type: Type, state: InsnId) -> InsnId {
         if self.is_a(val, guard_type) { return val; }
-        self.push_insn(block, Insn::GuardType { val, guard_type, state, recompile: None })
+        self.push_insn(block, Insn::GuardType { val, guard_type, state, recompile: false })
     }
 
     fn count_complex_call_features(&mut self, block: BlockId, ci_flags: c_uint) {
@@ -3830,8 +3794,7 @@ impl Function {
 
                             // Add GuardType for profiled receiver
                             if let Some(profiled_type) = profiled_type {
-                                let argc = unsafe { vm_ci_argc(ci) } as i32;
-                                recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: Some(Recompile::ProfileSend { argc }) });
+                                recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: true });
                             }
 
                             let send_direct = self.push_insn(block, Insn::SendDirect { recv, cd, cme, iseq, args: processed_args, kw_bits, state: send_state, block: send_block });
@@ -3874,8 +3837,7 @@ impl Function {
                             self.push_insn(block, Insn::PatchPoint { invariant: Invariant::MethodRedefined { klass, method: mid, cme }, state });
 
                             if let Some(profiled_type) = profiled_type {
-                                let argc = unsafe { vm_ci_argc(ci) } as i32;
-                                recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: Some(Recompile::ProfileSend{ argc }) });
+                                recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: true });
                             }
 
                             let send_direct = self.push_insn(block, Insn::SendDirect { recv, cd, cme, iseq, args: processed_args, kw_bits, state: send_state, block: None });
@@ -3897,8 +3859,7 @@ impl Function {
 
                             let id = unsafe { get_cme_def_body_attr_id(cme) };
                             if let Some(profiled_type) = profiled_type {
-                                let argc = unsafe { vm_ci_argc(ci) } as i32;
-                                recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: Some(Recompile::ProfileSend{ argc }) });
+                                recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: true });
 
                                 let replacement = self.try_emit_optimized_getivar(block, recv, id, profiled_type, state).unwrap_or_else(|counter| {
                                     self.count(block, counter);
@@ -3924,12 +3885,11 @@ impl Function {
                             self.push_insn(block, Insn::PatchPoint { invariant: Invariant::MethodRedefined { klass, method: mid, cme }, state });
                             let id = unsafe { get_cme_def_body_attr_id(cme) };
                             if let Some(profiled_type) = profiled_type {
-                                let argc = unsafe { vm_ci_argc(ci) } as i32;
                                 // TODO: attr_writer SetIvar has a null inline cache and may target a receiver
                                 // operand other than CFP self. Support it with a reprofile strategy that
                                 // profiles the receiver operand even after the send insn has finished profiling.
-                                let recompile = None;
-                                recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: Some(Recompile::ProfileSend{ argc }) });
+                                let recompile = false;
+                                recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: true });
                                 self.try_emit_optimized_setivar(block, recv, id, val, profiled_type, state, recompile).unwrap_or_else(|counter| {
                                     self.count(block, counter);
                                     self.push_insn(block, Insn::SetIvar { self_val: recv, id, ic: std::ptr::null(), val, state });
@@ -3955,8 +3915,7 @@ impl Function {
                                     }
                                     self.push_insn(block, Insn::PatchPoint { invariant: Invariant::MethodRedefined { klass, method: mid, cme }, state });
                                     if let Some(profiled_type) = profiled_type {
-                                        let argc = unsafe { vm_ci_argc(ci) } as i32;
-                                        recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: Some(Recompile::ProfileSend{ argc }) });
+                                        recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: true });
                                     }
                                     let kw_splat = flags & VM_CALL_KW_SPLAT != 0;
                                     let invoke_proc = self.push_insn(block, Insn::InvokeProc { recv, args: args.clone(), state, kw_splat });
@@ -3994,8 +3953,7 @@ impl Function {
                                     }
                                     self.push_insn(block, Insn::PatchPoint { invariant: Invariant::MethodRedefined { klass, method: mid, cme }, state });
                                     if let Some(profiled_type) = profiled_type {
-                                        let argc = unsafe { vm_ci_argc(ci) } as i32;
-                                        recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: Some(Recompile::ProfileSend{ argc }) });
+                                        recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: true });
                                     }
                                     // All structs from the same Struct class should have the same
                                     // length. So if our recv is embedded all runtime
@@ -4048,12 +4006,12 @@ impl Function {
 
                         if recv_type.is_string() {
                             self.push_insn(block, Insn::PatchPoint { invariant: Invariant::NoSingletonClass { klass: recv_type.class() }, state });
-                            let guard = self.push_insn(block, Insn::GuardType { val, guard_type: types::String, state, recompile: None });
+                            let guard = self.push_insn(block, Insn::GuardType { val, guard_type: types::String, state, recompile: false });
                             // Infer type so AnyToString can fold off this
                             self.insn_types[guard.0] = self.infer_type(guard);
                             self.make_equal_to(insn_id, guard);
                         } else {
-                            let recv = self.push_insn(block, Insn::GuardType { val, guard_type: Type::from_profiled_type(recv_type), state, recompile: None });
+                            let recv = self.push_insn(block, Insn::GuardType { val, guard_type: Type::from_profiled_type(recv_type), state, recompile: false });
                             let send_to_s = self.push_insn(block, Insn::Send { recv, cd, block: None, args: vec![], state, reason: ObjToStringNotString });
                             self.make_equal_to(insn_id, send_to_s);
                         }
@@ -4126,7 +4084,7 @@ impl Function {
                             // Load ep[VM_ENV_DATA_INDEX_ME_CREF]
                             let method_entry = fun.push_insn(block, Insn::LoadField { recv: lep, id: FieldName::VM_ENV_DATA_INDEX_ME_CREF, offset: SIZEOF_VALUE_I32 * VM_ENV_DATA_INDEX_ME_CREF, return_type: types::RubyValue });
                             // Guard that it matches the expected CME
-                            fun.push_insn(block, Insn::GuardBitEquals { val: method_entry, expected: Const::Value(current_cme.into()), reason: SideExitReason::GuardSuperMethodEntry, state, recompile: None });
+                            fun.push_insn(block, Insn::GuardBitEquals { val: method_entry, expected: Const::Value(current_cme.into()), reason: SideExitReason::GuardSuperMethodEntry, state, recompile: false });
 
                             let block_handler = fun.push_insn(block, Insn::LoadField { recv: lep, id: FieldName::VM_ENV_DATA_INDEX_SPECVAL, offset: SIZEOF_VALUE_I32 * VM_ENV_DATA_INDEX_SPECVAL, return_type: types::RubyValue });
                             fun.push_insn(block, Insn::GuardBitEquals {
@@ -4134,7 +4092,7 @@ impl Function {
                                 expected: Const::Value(VALUE(VM_BLOCK_HANDLER_NONE as usize)),
                                 reason: SideExitReason::UnhandledBlockArg,
                                 state,
-                                recompile: None,
+                                recompile: false,
                             });
                         }
 
@@ -4814,7 +4772,7 @@ impl Function {
         })
     }
 
-    fn guard_shape(&mut self, block: BlockId, val: InsnId, expected: ShapeId, state: InsnId, recompile: Option<Recompile>) -> InsnId {
+    fn guard_shape(&mut self, block: BlockId, val: InsnId, expected: ShapeId, state: InsnId, recompile: bool) -> InsnId {
         self.push_insn(block, Insn::GuardBitEquals {
             val,
             expected: Const::CShape(expected),
@@ -4864,7 +4822,7 @@ impl Function {
 
     /// Guard that `recv` is a heap allocated object
     fn guard_heap(&mut self, block: BlockId, recv: InsnId, state: InsnId) -> InsnId {
-        self.push_insn(block, Insn::GuardType { val: recv, guard_type: types::HeapBasicObject, state, recompile: None })
+        self.push_insn(block, Insn::GuardType { val: recv, guard_type: types::HeapBasicObject, state, recompile: false })
     }
 
     fn load_ivar(&mut self, block: BlockId, self_val: InsnId, recv_type: ProfiledType, id: ID) -> InsnId {
@@ -4943,11 +4901,11 @@ impl Function {
         }
         let self_val = self.guard_heap(block, self_val, state);
         let shape = self.load_shape(block, self_val);
-        self.guard_shape(block, shape, profiled_type.shape(), state, Some(Recompile::ProfileSelf));
+        self.guard_shape(block, shape, profiled_type.shape(), state, true);
         Ok(self.load_ivar(block, self_val, profiled_type, id))
     }
 
-    fn try_emit_optimized_setivar(&mut self, block: BlockId, self_val: InsnId, id: ID, val: InsnId, profiled_type: ProfiledType, state: InsnId, recompile: Option<Recompile>) -> Result<(), Counter> {
+    fn try_emit_optimized_setivar(&mut self, block: BlockId, self_val: InsnId, id: ID, val: InsnId, profiled_type: ProfiledType, state: InsnId, recompile: bool) -> Result<(), Counter> {
         if profiled_type.flags().is_immediate() {
             // Instance variable lookups on immediate values are always nil
             return Err(Counter::setivar_fallback_immediate);
@@ -5195,8 +5153,7 @@ impl Function {
 
                     if let Some(profiled_type) = profiled_type {
                         // Guard receiver class
-                        let argc = unsafe { vm_ci_argc(call_info) } as i32;
-                        recv = fun.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: Some(Recompile::ProfileSend { argc }) });
+                        recv = fun.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: true });
                         fun.insn_types[recv.0] = fun.infer_type(recv);
                     }
 
@@ -5262,8 +5219,7 @@ impl Function {
 
                     if let Some(profiled_type) = profiled_type {
                         // Guard receiver class
-                        let argc = unsafe { vm_ci_argc(call_info) } as i32;
-                        recv = fun.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: Some(Recompile::ProfileSend { argc }) });
+                        recv = fun.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: true });
                         fun.insn_types[recv.0] = fun.infer_type(recv);
                     }
 
@@ -5381,9 +5337,8 @@ impl Function {
             assert!(self.blocks[block.0].insns.is_empty());
             for insn_id in old_insns {
                 match self.find(insn_id) {
-                    Insn::Send { cd, state, reason: SendFallbackReason::SendWithoutBlockNoProfiles | SendFallbackReason::SendNoProfiles, .. } => {
-                        let argc = unsafe { vm_ci_argc((*cd).ci) } as i32;
-                        self.push_insn(block, Insn::SideExit { state, reason: SideExitReason::NoProfileSend, recompile: Some(Recompile::ProfileSend { argc }) });
+                    Insn::Send { state, reason: SendFallbackReason::SendWithoutBlockNoProfiles | SendFallbackReason::SendNoProfiles, .. } => {
+                        self.push_insn(block, Insn::SideExit { state, reason: SideExitReason::NoProfileSend, recompile: true });
                         // SideExit is a terminator; don't add remaining instructions
                         break;
                     }
@@ -5610,7 +5565,7 @@ impl Function {
                                 self.make_equal_to(insn_id, left);
                                 continue
                             },
-                            (Some(_), Some(_)) => self.new_insn(Insn::SideExit { state, reason, recompile: None }),
+                            (Some(_), Some(_)) => self.new_insn(Insn::SideExit { state, reason, recompile: false }),
                             _ => insn_id,
                         }
                     },
@@ -5622,7 +5577,7 @@ impl Function {
                                 self.make_equal_to(insn_id, left);
                                 continue
                             },
-                            (Some(_), Some(_)) => self.new_insn(Insn::SideExit { state, reason, recompile: None }),
+                            (Some(_), Some(_)) => self.new_insn(Insn::SideExit { state, reason, recompile: false }),
                             _ => insn_id,
                         }
                     },
@@ -7629,7 +7584,7 @@ fn add_iseq_to_hir(
                         }
                         _ => {
                             // Unknown opcode; side-exit into the interpreter
-                            fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledNewarraySend(method), recompile: None });
+                            fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledNewarraySend(method), recompile: false });
                             break;  // End the block
                         }
                     };
@@ -7655,7 +7610,7 @@ fn add_iseq_to_hir(
                     let bop = match method_id {
                         x if x == ID!(include_p).0 => BOP_INCLUDE_P,
                         _ => {
-                            fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledDuparraySend(method_id), recompile: None });
+                            fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledDuparraySend(method_id), recompile: false });
                             break;
                         },
                     };
@@ -7702,20 +7657,20 @@ fn add_iseq_to_hir(
                         .and_then(|types| types.first())
                         .map(|dist| TypeDistributionSummary::new(dist));
                     let Some(summary) = summary else {
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::SplatKwNotProfiled, recompile: None });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::SplatKwNotProfiled, recompile: false });
                         break;  // End the block
                     };
                     if !summary.is_monomorphic() {
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::SplatKwPolymorphic, recompile: None });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::SplatKwPolymorphic, recompile: false });
                         break;  // End the block
                     }
                     let ty = Type::from_profiled_type(summary.bucket(0));
                     let obj = if ty.is_subtype(types::NilClass) {
-                        fun.push_insn(block, Insn::GuardType { val: hash, guard_type: types::NilClass, state: exit_id, recompile: None })
+                        fun.push_insn(block, Insn::GuardType { val: hash, guard_type: types::NilClass, state: exit_id, recompile: false })
                     } else if ty.is_subtype(types::HashExact) {
-                        fun.push_insn(block, Insn::GuardType { val: hash, guard_type: types::HashExact, state: exit_id, recompile: None })
+                        fun.push_insn(block, Insn::GuardType { val: hash, guard_type: types::HashExact, state: exit_id, recompile: false })
                     } else {
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::SplatKwNotNilOrHash, recompile: None });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::SplatKwNotNilOrHash, recompile: false });
                         break;  // End the block
                     };
                     state.stack_push(obj);
@@ -7794,7 +7749,7 @@ fn add_iseq_to_hir(
                         Some(profiled_shape)
                     }
                     if let Some(summary) = fun.polymorphic_summary(&profiles, self_param, exit_id) {
-                        self_param = fun.push_insn(block, Insn::GuardType { val: self_param, guard_type: types::HeapBasicObject, state: exit_id, recompile: None });
+                        self_param = fun.push_insn(block, Insn::GuardType { val: self_param, guard_type: types::HeapBasicObject, state: exit_id, recompile: false });
                         let join_block = fun.new_block(insn_idx);
                         let join_param = fun.push_insn(join_block, Insn::Param);
                         // Dedup by expected shape so objects with different classes but the
@@ -7840,7 +7795,7 @@ fn add_iseq_to_hir(
                             .and_then(can_optimize) {
                             self_param = fun.guard_heap(block, self_param, exit_id);
                             let shape = fun.load_shape(block, self_param);
-                            fun.guard_shape(block, shape, profiled_shape, exit_id, Some(Recompile::ProfileSelf));
+                            fun.guard_shape(block, shape, profiled_shape, exit_id, true);
                             let mut ivar_index: attr_index_t = 0;
                             let result = if unsafe { rb_shape_get_iv_index(profiled_shape.0, id, &mut ivar_index) } {
                                 fun.push_insn(block, Insn::Const { val: Const::Value(pushval) })
@@ -7861,7 +7816,7 @@ fn add_iseq_to_hir(
                     // This can only happen in iseqs taking more than 32 keywords.
                     // In this case, we side exit to the interpreter.
                     if unsafe {(*rb_get_iseq_body_param_keyword(iseq)).num >= VM_KW_SPECIFIED_BITS_MAX.try_into().unwrap()} {
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::TooManyKeywordParameters, recompile: None });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::TooManyKeywordParameters, recompile: false });
                         break;
                     }
                     let ep_offset = get_arg(pc, 0).as_u32();
@@ -8258,7 +8213,7 @@ fn add_iseq_to_hir(
                             // So to check for either of those cases we can use: val & 0x1 == 0x1
 
                             // Bail out if the block handler is neither ISEQ nor ifunc
-                            fun.push_insn(unmodified_block, Insn::GuardAnyBitSet { val: block_handler, mask: Const::CUInt64(0x1), mask_name: None, reason: SideExitReason::BlockParamProxyFallbackMiss, state: exit_id, recompile: Some(Recompile::ProfileBlockHandler) });
+                            fun.push_insn(unmodified_block, Insn::GuardAnyBitSet { val: block_handler, mask: Const::CUInt64(0x1), mask_name: None, reason: SideExitReason::BlockParamProxyFallbackMiss, state: exit_id, recompile: true });
                             // TODO(Shopify/ruby#753): GC root, so we should be able to avoid unnecessary GC tracing
                             let proxy_val = fun.push_insn(unmodified_block, Insn::Const { val: Const::Value(unsafe { rb_block_param_proxy }) });
                             let mut args = vec![proxy_val];
@@ -8271,7 +8226,7 @@ fn add_iseq_to_hir(
                         [profiled_handler] => match profiled_handler {
                             ProfiledBlockHandlerFamily::Nil => {
                                 let block_handler = fun.load_ep_env_field(unmodified_block, ep, FieldName::VM_ENV_DATA_INDEX_SPECVAL, VM_ENV_DATA_INDEX_SPECVAL, types::CInt64);
-                                fun.push_insn(unmodified_block, Insn::GuardBitEquals { val: block_handler, expected: Const::CInt64(VM_BLOCK_HANDLER_NONE.into()), reason: SideExitReason::BlockParamProxyNotNil, state: exit_id, recompile: Some(Recompile::ProfileBlockHandler) });
+                                fun.push_insn(unmodified_block, Insn::GuardBitEquals { val: block_handler, expected: Const::CInt64(VM_BLOCK_HANDLER_NONE.into()), reason: SideExitReason::BlockParamProxyNotNil, state: exit_id, recompile: true });
                                 let nil_val = fun.push_insn(unmodified_block, Insn::Const { val: Const::Value(Qnil) });
                                 let mut args = vec![nil_val];
                                 if let Some(local) = original_local {
@@ -8288,7 +8243,7 @@ fn add_iseq_to_hir(
                                 // So to check for either of those cases we can use: val & 0x1 == 0x1
 
                                 // Bail out if the block handler is neither ISEQ nor ifunc
-                                fun.push_insn(unmodified_block, Insn::GuardAnyBitSet { val: block_handler, mask: Const::CUInt64(0x1), mask_name: None, reason: SideExitReason::BlockParamProxyNotIseqOrIfunc, state: exit_id, recompile: Some(Recompile::ProfileBlockHandler) });
+                                fun.push_insn(unmodified_block, Insn::GuardAnyBitSet { val: block_handler, mask: Const::CUInt64(0x1), mask_name: None, reason: SideExitReason::BlockParamProxyNotIseqOrIfunc, state: exit_id, recompile: true });
                                 // TODO(Shopify/ruby#753): GC root, so we should be able to avoid unnecessary GC tracing
                                 let proxy_val = fun.push_insn(unmodified_block, Insn::Const { val: Const::Value(unsafe { rb_block_param_proxy }) });
                                 let mut args = vec![proxy_val];
@@ -8308,7 +8263,7 @@ fn add_iseq_to_hir(
                                     return_type: types::BasicObject,
                                     elidable: true,
                                 });
-                                fun.push_insn(unmodified_block, Insn::GuardBitEquals { val: is_proc, expected: Const::Value(Qtrue), reason: SideExitReason::BlockParamProxyNotProc, state: exit_id, recompile: Some(Recompile::ProfileBlockHandler) });
+                                fun.push_insn(unmodified_block, Insn::GuardBitEquals { val: is_proc, expected: Const::Value(Qtrue), reason: SideExitReason::BlockParamProxyNotProc, state: exit_id, recompile: true });
                                 let mut args = vec![proc_val];
                                 if let Some(local) = original_local {
                                     args.push(local);
@@ -8412,7 +8367,7 @@ fn add_iseq_to_hir(
                                 }
                             }
 
-                            fun.push_insn(current_block, Insn::SideExit { state: exit_id, reason: SideExitReason::BlockParamProxyProfileNotCovered, recompile: None });
+                            fun.push_insn(current_block, Insn::SideExit { state: exit_id, reason: SideExitReason::BlockParamProxyProfileNotCovered, recompile: false });
                         }
                     }
 
@@ -8505,7 +8460,7 @@ fn add_iseq_to_hir(
                     let flags = unsafe { rb_vm_ci_flag(call_info) };
                     if let Err(call_type) = unhandled_call_type(flags) {
                         // Can't handle the call type; side-exit into the interpreter
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledCallType(call_type), recompile: None });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledCallType(call_type), recompile: false });
                         break;  // End the block
                     }
                     let argc = crate::profile::num_arguments_on_stack(cd);
@@ -8513,7 +8468,7 @@ fn add_iseq_to_hir(
 
                     // Side-exit send fallbacks while tracing to avoid FLAG_FINISH breaking throw TAG_RETURN semantics
                     if unsafe { rb_zjit_iseq_tracing_currently_enabled() } {
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::SendWhileTracing, recompile: None });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::SendWhileTracing, recompile: false });
                         break;
                     }
                     let args = state.stack_pop_n(argc as usize)?;
@@ -8604,7 +8559,7 @@ fn add_iseq_to_hir(
                     let flags = unsafe { rb_vm_ci_flag(call_info) };
                     if let Err(call_type) = unhandled_call_type(flags) {
                         // Can't handle tailcall; side-exit into the interpreter
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledCallType(call_type), recompile: None });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledCallType(call_type), recompile: false });
                         break;  // End the block
                     }
                     let argc = crate::profile::num_arguments_on_stack(cd);
@@ -8621,7 +8576,7 @@ fn add_iseq_to_hir(
                         if mid == ID!(induce_side_exit_bang)
                             && state::zjit_module_method_match_serial(ID!(induce_side_exit_bang), &state::INDUCE_SIDE_EXIT_SERIAL)
                         {
-                            fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::DirectiveInduced, recompile: None });
+                            fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::DirectiveInduced, recompile: false });
                             break;  // End the block
                         }
                         if mid == ID!(induce_compile_failure_bang)
@@ -8640,7 +8595,7 @@ fn add_iseq_to_hir(
 
                     // Side-exit send fallbacks while tracing to avoid FLAG_FINISH breaking throw TAG_RETURN semantics
                     if unsafe { rb_zjit_iseq_tracing_currently_enabled() } {
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::SendWhileTracing, recompile: None });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::SendWhileTracing, recompile: false });
                         break;
                     }
 
@@ -8698,12 +8653,12 @@ fn add_iseq_to_hir(
                     let flags = unsafe { rb_vm_ci_flag(call_info) };
                     if let Err(call_type) = unhandled_call_type(flags) {
                         // Can't handle tailcall; side-exit into the interpreter
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledCallType(call_type), recompile: None });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledCallType(call_type), recompile: false });
                         break;  // End the block
                     }
                     // Side-exit send fallbacks while tracing to avoid FLAG_FINISH breaking throw TAG_RETURN semantics
                     if unsafe { rb_zjit_iseq_tracing_currently_enabled() } {
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::SendWhileTracing, recompile: None });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::SendWhileTracing, recompile: false });
                         break;
                     }
                     let block_arg = (flags & VM_CALL_ARGS_BLOCKARG) != 0;
@@ -8753,12 +8708,12 @@ fn add_iseq_to_hir(
                     let forwarding = (flags & VM_CALL_FORWARDING) != 0;
                     if let Err(call_type) = unhandled_call_type(flags) {
                         // Can't handle the call type; side-exit into the interpreter
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledCallType(call_type), recompile: None });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledCallType(call_type), recompile: false });
                         break;  // End the block
                     }
                     // Side-exit send fallbacks while tracing to avoid FLAG_FINISH breaking throw TAG_RETURN semantics
                     if unsafe { rb_zjit_iseq_tracing_currently_enabled() } {
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::SendWhileTracing, recompile: None });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::SendWhileTracing, recompile: false });
                         break;
                     }
                     let argc = unsafe { vm_ci_argc((*cd).ci) };
@@ -8797,12 +8752,12 @@ fn add_iseq_to_hir(
                     let flags = unsafe { rb_vm_ci_flag(call_info) };
                     if let Err(call_type) = unhandled_call_type(flags) {
                         // Can't handle tailcall; side-exit into the interpreter
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledCallType(call_type), recompile: None });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledCallType(call_type), recompile: false });
                         break;  // End the block
                     }
                     // Side-exit send fallbacks while tracing to avoid FLAG_FINISH breaking throw TAG_RETURN semantics
                     if unsafe { rb_zjit_iseq_tracing_currently_enabled() } {
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::SendWhileTracing, recompile: None });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::SendWhileTracing, recompile: false });
                         break;
                     }
                     let args = state.stack_pop_n(crate::profile::num_arguments_on_stack(cd))?;
@@ -8844,12 +8799,12 @@ fn add_iseq_to_hir(
                     let forwarding = (flags & VM_CALL_FORWARDING) != 0;
                     if let Err(call_type) = unhandled_call_type(flags) {
                         // Can't handle tailcall; side-exit into the interpreter
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledCallType(call_type), recompile: None });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledCallType(call_type), recompile: false });
                         break;  // End the block
                     }
                     // Side-exit send fallbacks while tracing to avoid FLAG_FINISH breaking throw TAG_RETURN semantics
                     if unsafe { rb_zjit_iseq_tracing_currently_enabled() } {
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::SendWhileTracing, recompile: None });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::SendWhileTracing, recompile: false });
                         break;
                     }
                     let argc = unsafe { vm_ci_argc((*cd).ci) };
@@ -8889,12 +8844,12 @@ fn add_iseq_to_hir(
                     let flags = unsafe { rb_vm_ci_flag(call_info) };
                     if let Err(call_type) = unhandled_call_type(flags) {
                         // Can't handle tailcall; side-exit into the interpreter
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledCallType(call_type), recompile: None });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledCallType(call_type), recompile: false });
                         break;  // End the block
                     }
                     // Side-exit send fallbacks while tracing to avoid FLAG_FINISH breaking throw TAG_RETURN semantics
                     if unsafe { rb_zjit_iseq_tracing_currently_enabled() } {
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::SendWhileTracing, recompile: None });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::SendWhileTracing, recompile: false });
                         break;
                     }
                     let args = state.stack_pop_n(crate::profile::num_arguments_on_stack(cd))?;
@@ -8980,11 +8935,11 @@ fn add_iseq_to_hir(
                     // TODO: We only really need this if self_val is a class/module
                     if !fun.assume_single_ractor_mode(block, exit_id) {
                         // gen_getivar assumes single Ractor; side-exit into the interpreter
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledYARVInsn(opcode), recompile: None });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledYARVInsn(opcode), recompile: false });
                         break;  // End the block
                     }
                     if let Some(summary) = fun.polymorphic_summary(&profiles, self_param, exit_id) {
-                        self_param = fun.push_insn(block, Insn::GuardType { val: self_param, guard_type: types::HeapBasicObject, state: exit_id, recompile: None });
+                        self_param = fun.push_insn(block, Insn::GuardType { val: self_param, guard_type: types::HeapBasicObject, state: exit_id, recompile: false });
                         let join_block = fun.new_block(insn_idx);
                         let join_param = fun.push_insn(join_block, Insn::Param);
                         // Dedup by expected shape so objects with different classes but the same shape can share code
@@ -9053,13 +9008,13 @@ fn add_iseq_to_hir(
                     // TODO: We only really need this if self_val is a class/module
                     if !fun.assume_single_ractor_mode(block, exit_id) {
                         // gen_setivar assumes single Ractor; side-exit into the interpreter
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledYARVInsn(opcode), recompile: None });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledYARVInsn(opcode), recompile: false });
                         break;  // End the block
                     }
                     let val = state.stack_pop()?;
                     if let Some(profiled_type) = fun.monomorphic_summary(&profiles, self_param, exit_id) {
                         // TODO(max): Assert ic is never null
-                        let recompile = if ic.is_null() { None } else { Some(Recompile::ProfileSelf) };
+                        let recompile = !ic.is_null();
                         fun.try_emit_optimized_setivar(block, self_param, id, val, profiled_type, exit_id, recompile).unwrap_or_else(|counter| {
                             fun.count(block, counter);
                             fun.push_insn(block, Insn::SetIvar { self_val: self_param, id, ic, val, state: exit_id });
@@ -9105,7 +9060,7 @@ fn add_iseq_to_hir(
                     // TODO: Support passing arguments on the stack in C calls
                     // +2 for ec, self
                     if (bf.argc + 2) as usize > C_ARG_OPNDS.len() {
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::TooManyArgsForLir, recompile: None });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::TooManyArgsForLir, recompile: false });
                         break; // End the block
                     }
 
@@ -9140,7 +9095,7 @@ fn add_iseq_to_hir(
                     // TODO: Support passing arguments on the stack in C calls
                     // +2 for ec, self
                     if (bf.argc + 2) as usize > C_ARG_OPNDS.len() {
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::TooManyArgsForLir, recompile: None });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::TooManyArgsForLir, recompile: false });
                         break; // End the block
                     }
 
@@ -9192,7 +9147,7 @@ fn add_iseq_to_hir(
 
                     if svar == 0 {
                         // TODO: Handle non-backref
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnknownSpecialVariable(key), recompile: None });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnknownSpecialVariable(key), recompile: false });
                         // End the block
                         break;
                     } else if svar & 0x01 != 0 {
@@ -9215,11 +9170,11 @@ fn add_iseq_to_hir(
                         // (reverse?)
                         //
                         // Unhandled opcode; side-exit into the interpreter
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledYARVInsn(opcode), recompile: None });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledYARVInsn(opcode), recompile: false });
                         break;  // End the block
                     }
                     let val = state.stack_pop()?;
-                    let array = fun.push_insn(block, Insn::GuardType { val, guard_type: types::ArrayExact, state: exit_id, recompile: None });
+                    let array = fun.push_insn(block, Insn::GuardType { val, guard_type: types::ArrayExact, state: exit_id, recompile: false });
                     let length = fun.push_insn(block, Insn::ArrayLength { array });
                     let expected = fun.push_insn(block, Insn::Const { val: Const::CInt64(num as i64) });
                     fun.push_insn(block, Insn::GuardGreaterEq { left: length, right: expected, reason: SideExitReason::ExpandArray, state: exit_id });
@@ -9233,7 +9188,7 @@ fn add_iseq_to_hir(
                 }
                 _ => {
                     // Unhandled opcode; side-exit into the interpreter
-                    fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledYARVInsn(opcode), recompile: None });
+                    fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledYARVInsn(opcode), recompile: false });
                     break;  // End the block
                 }
             }

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -16856,6 +16856,74 @@ mod hir_opt_tests {
     }
 
     #[test]
+    fn test_recompile_no_profile_send_with_blockarg() {
+        // Test that no-profile send recompilation profiles explicit blockargs.
+        // The call remains a Send fallback because &block is still complex, but
+        // it should no longer be a NoProfileSend side exit after recompilation.
+        eval("
+            def passthrough_recompile_blockarg(x, &block)
+              block.call(x)
+            end
+
+            def test(flag, block)
+              if flag
+                passthrough_recompile_blockarg(42, &block)
+              else
+                'hello'
+              end
+            end
+        ");
+
+        // With call_threshold=2, num_profiles=1, the send is not profiled
+        // during initial profiling because flag=false skips that branch.
+        eval("
+            block = proc { |x| x }
+            test(false, block)
+            test(false, block)
+        ");
+
+        // This hits the NoProfileSend side exit, profiles the send including
+        // its explicit blockarg, and invalidates the ISEQ for recompilation.
+        eval("
+            block = proc { |x| x }
+            test(true, block)
+        ");
+
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:7:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          v2:CPtr = LoadSP
+          v3:BasicObject = LoadField v2, :flag@0x1000
+          v4:BasicObject = LoadField v2, :block@0x1001
+          Jump bb3(v1, v3, v4)
+        bb2():
+          EntryPoint JIT(0)
+          v7:BasicObject = LoadArg :self@0
+          v8:BasicObject = LoadArg :flag@1
+          v9:BasicObject = LoadArg :block@2
+          Jump bb3(v7, v8, v9)
+        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          CheckInterrupts
+          v19:CBool = Test v12
+          v20:Falsy = RefineType v12, Falsy
+          CondBranch v19, bb5(), bb4(v11, v20, v13)
+        bb5():
+          v22:Truthy = RefineType v12, Truthy
+          v26:Fixnum[42] = Const Value(42)
+          v29:BasicObject = Send v11, &block, :passthrough_recompile_blockarg, v26, v13 # SendFallbackReason: Complex argument passing
+          CheckInterrupts
+          Return v29
+        bb4(v34:BasicObject, v35:Falsy, v36:BasicObject):
+          v40:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          v41:StringExact = StringCopy v40
+          CheckInterrupts
+          Return v41
+        ");
+    }
+
+    #[test]
     fn test_no_profile_send_on_final_version() {
         // On the final ISEQ version (MAX_ISEQ_VERSIONS reached), no-profile sends should
         // remain as Send fallbacks instead of being converted to SideExits, since recompilation

--- a/zjit/src/profile.rs
+++ b/zjit/src/profile.rs
@@ -59,9 +59,11 @@ pub extern "C" fn rb_zjit_profile_insn(bare_opcode: u32, ec: EcPtr) {
 }
 
 /// Profile a YARV instruction
-fn profile_insn(bare_opcode: ruby_vminsn_type, ec: EcPtr) {
-    let profiler = &mut Profiler::new(ec);
-    let profile = &mut get_or_create_iseq_payload(profiler.iseq).profile;
+fn profile_insn_sample(
+    bare_opcode: ruby_vminsn_type,
+    profiler: &mut Profiler,
+    profile: &mut IseqProfile,
+) -> bool {
     match bare_opcode {
         YARVINSN_opt_nil_p => profile_operands(profiler, profile, 1),
         YARVINSN_opt_plus  => profile_operands(profiler, profile, 2),
@@ -100,8 +102,17 @@ fn profile_insn(bare_opcode: ruby_vminsn_type, ec: EcPtr) {
             profile_operands(profiler, profile, argc + 1);
         }
         YARVINSN_splatkw => profile_operands(profiler, profile, 2),
-        _ => {}
+        _ => return false,
     }
+
+    true
+}
+
+/// Profile a YARV instruction
+fn profile_insn(bare_opcode: ruby_vminsn_type, ec: EcPtr) {
+    let profiler = &mut Profiler::new(ec);
+    let profile = &mut get_or_create_iseq_payload(profiler.iseq).profile;
+    let _ = profile_insn_sample(bare_opcode, profiler, profile);
 
     // Once we profile the instruction enough times, we stop profiling it.
     let entry = profile.entry_mut(profiler.insn_idx);
@@ -109,6 +120,38 @@ fn profile_insn(bare_opcode: ruby_vminsn_type, ec: EcPtr) {
     if entry.profiles_remaining == 0 {
         unsafe { rb_zjit_iseq_insn_set(profiler.iseq, profiler.insn_idx as u32, bare_opcode); }
     }
+}
+
+/// Profile the instruction at the current CFP for a recompile side exit.
+pub fn profile_recompile_insn(ec: EcPtr) -> bool {
+    let profiler = &mut Profiler::new(ec);
+    let pc = unsafe { get_cfp_pc(profiler.cfp) };
+    let bare_opcode = unsafe {
+        rb_zjit_insn_to_bare_insn(rb_iseq_opcode_at_pc(profiler.iseq, pc))
+    } as ruby_vminsn_type;
+    let profile = &mut get_or_create_iseq_payload(profiler.iseq).profile;
+
+    let is_send = matches!(bare_opcode, YARVINSN_send | YARVINSN_opt_send_without_block);
+    // For now, send recompile exits only fill in missing profiles. Once the send site
+    // has finished profiling, don't recompile it on later exits.
+    if is_send && profile.done_profiling_at(profiler.insn_idx) {
+        return false;
+    }
+    // For now, non-send recompile exits reset the profiling counter before requesting recompilation
+    // so that we can collect enough samples.
+    if !is_send && profile.done_profiling_at(profiler.insn_idx) {
+        profile.entry_mut(profiler.insn_idx)
+            .set_profiles_remaining(get_option!(num_profiles));
+    }
+
+    // If this opcode can't be sampled here, this exit has no profile data to collect.
+    if !profile_insn_sample(bare_opcode, profiler, profile) {
+        return false;
+    }
+
+    let entry = profile.entry_mut(profiler.insn_idx);
+    entry.profiles_remaining = entry.profiles_remaining.saturating_sub(1);
+    entry.profiles_remaining == 0
 }
 
 /// Return the argc as stated in the calldata plus:
@@ -424,70 +467,6 @@ impl IseqProfile {
     /// Check if enough profiles have been gathered for this instruction.
     pub fn done_profiling_at(&self, insn_idx: YarvInsnIdx) -> bool {
         self.entry(insn_idx).map_or(false, |e| e.profiles_remaining == 0)
-    }
-
-    /// Profile send operands from the stack at runtime.
-    /// `sp` is the current stack pointer (after the args and receiver).
-    /// `argc` is the number of arguments (not counting receiver).
-    /// Returns true if enough profiles have been gathered and the ISEQ should be recompiled.
-    pub fn profile_send_at(&mut self, iseq: IseqPtr, insn_idx: YarvInsnIdx, sp: *const VALUE, argc: usize) -> bool {
-        let n = argc + 1; // args + receiver
-        let entry = self.entry_mut(insn_idx);
-        if entry.opnd_types.is_empty() {
-            entry.opnd_types.resize(n, TypeDistribution::new());
-        }
-        for i in 0..n {
-            let obj = unsafe { *sp.offset(i as isize - n as isize) };
-            let ty = ProfiledType::new(obj);
-            VALUE::from(iseq).write_barrier(ty.class());
-            entry.opnd_types[i].observe(ty);
-        }
-        entry.profiles_remaining = entry.profiles_remaining.saturating_sub(1);
-        entry.profiles_remaining == 0
-    }
-
-    /// Profile self for a shape guard exit at runtime.
-    /// This may be called on an instruction that was already profiled by YARV,
-    /// so we reset the counter to re-profile with the new shapes seen at runtime.
-    /// Returns true if enough profiles have been gathered and the ISEQ should be recompiled.
-    pub fn profile_self_at(&mut self, iseq: IseqPtr, insn_idx: YarvInsnIdx, self_val: VALUE) -> bool {
-        let entry = self.entry_mut(insn_idx);
-        // Reset profiling if the previous round already finished (stale YARV profiles).
-        // This ensures we collect num_profiles samples of the new shapes before recompiling.
-        if entry.profiles_remaining == 0 {
-            entry.profiles_remaining = get_option!(num_profiles);
-        }
-        if entry.opnd_types.is_empty() {
-            entry.opnd_types.resize(1, TypeDistribution::new());
-        }
-        let ty = ProfiledType::new(self_val);
-        VALUE::from(iseq).write_barrier(ty.class());
-        entry.opnd_types[0].observe(ty);
-        entry.profiles_remaining = entry.profiles_remaining.saturating_sub(1);
-        entry.profiles_remaining == 0
-    }
-
-    /// Profile the block handler for a getblockparamproxy guard exit at runtime.
-    pub fn profile_getblockparamproxy_at(&mut self, iseq: IseqPtr, insn_idx: YarvInsnIdx, cfp: CfpPtr) -> bool {
-        let pc = unsafe { rb_iseq_pc_at_idx(iseq, insn_idx as u32) };
-        let level = unsafe { pc.add(2).read() }.as_u32();
-
-        let entry = self.entry_mut(insn_idx);
-        if entry.profiles_remaining == 0 {
-            entry.profiles_remaining = get_option!(num_profiles);
-        }
-        if entry.opnd_types.is_empty() {
-            entry.opnd_types.resize(1, TypeDistribution::new());
-        }
-        let ep = unsafe { get_cfp_ep_level(cfp, level) };
-        let block_handler = unsafe { *ep.offset(VM_ENV_DATA_INDEX_SPECVAL as isize) };
-        let untagged = unsafe { rb_vm_untag_block_handler(block_handler) };
-
-        let ty = ProfiledType::object(untagged);
-        VALUE::from(iseq).write_barrier(ty.class());
-        entry.opnd_types[0].observe(ty);
-        entry.profiles_remaining = entry.profiles_remaining.saturating_sub(1);
-        entry.profiles_remaining == 0
     }
 
     /// Get profiled operand types for a given instruction index


### PR DESCRIPTION
Closes: https://github.com/Shopify/ruby/issues/994

Deduplicate recompile-exit profiling by sharing the per-instruction profiling logic used by `zjit_*` instructions.

Recompile exits now use the materialized CFP state to recover the current instruction and collect profiles through profile.rs, instead of passing kind-specific profiling payloads across the C ABI.

I didn't see any regressions in the benchmark metrics. Full stats details are below on lobsters:

<details>

<summary>before patch</summary>

```
Top-2 not optimized method types for send (100.0% of total 133,037):
       null: 110,374 (83.0%)
  optimized:  22,663 (17.0%)
Top-3 not optimized method types for send_without_block (100.0% of total 711,322):
        optimized_send: 706,549 (99.3%)
  optimized_block_call:   4,299 ( 0.6%)
                zsuper:     474 ( 0.1%)
Top-1 not optimized method types for super (100.0% of total 3,342):
  attrset: 3,342 (100.0%)
Top-1 instructions with uncategorized fallback reason (100.0% of total 66,802):
  opt_send_without_block: 66,802 (100.0%)
Top-20 send fallback reasons (99.7% of total 28,971,805):
                          send_without_block_polymorphic: 6,008,501 (20.7%)
                             invokeblock_not_specialized: 5,938,295 (20.5%)
                            one_or_more_complex_arg_pass: 4,785,856 (16.5%)
                          send_without_block_no_profiles: 3,619,894 (12.5%)
                          send_without_block_megamorphic: 3,407,023 (11.8%)
                                        send_polymorphic: 1,494,690 ( 5.2%)
                             sendforward_not_specialized:   981,523 ( 3.4%)
  send_without_block_not_optimized_method_type_optimized:   710,848 ( 2.5%)
                                       super_polymorphic:   355,115 ( 1.2%)
                                   too_many_args_for_lir:   341,929 ( 1.2%)
                      send_not_optimized_need_permission:   238,842 ( 0.8%)
        send_without_block_not_optimized_need_permission:   198,230 ( 0.7%)
                                        send_no_profiles:   184,340 ( 0.6%)
                          send_not_optimized_method_type:   133,037 ( 0.5%)
                                     argc_param_mismatch:   131,357 ( 0.5%)
                                 super_complex_args_pass:    91,594 ( 0.3%)
                      invokesuperforward_not_specialized:    80,700 ( 0.3%)
                                           uncategorized:    66,802 ( 0.2%)
                                        send_megamorphic:    59,999 ( 0.2%)
                                obj_to_string_not_string:    44,725 ( 0.2%)
Top-4 setivar fallback reasons (100.0% of total 1,688,384):
              no_side_exits: 1,463,049 (86.7%)
               not_t_object:   119,505 ( 7.1%)
                    complex:   105,573 ( 6.3%)
  new_shape_needs_extension:       257 ( 0.0%)
Top-4 getivar fallback reasons (100.0% of total 16,863,879):
          no_side_exits: 8,790,443 (52.1%)
  no_profile_missing_ic: 5,552,770 (32.9%)
             no_profile: 2,204,338 (13.1%)
                complex:   316,328 ( 1.9%)
Top-5 invokeblock handler (100.0% of total 6,959,587):
  monomorphic_ifunc: 4,140,876 (59.5%)
  monomorphic_other: 1,446,869 (20.8%)
   monomorphic_iseq:   850,331 (12.2%)
        polymorphic:   515,557 ( 7.4%)
        megamorphic:     5,954 ( 0.1%)
Top-6 getblockparamproxy handler (100.0% of total 3,514,143):
  polymorphic: 2,602,532 (74.1%)
          nil:   422,687 (12.0%)
         iseq:   231,829 ( 6.6%)
  no_profiles:   170,055 ( 4.8%)
         proc:    76,419 ( 2.2%)
  megamorphic:    10,621 ( 0.3%)
Top-7 popular complex argument-parameter features not optimized (100.0% of total 5,131,638):
    caller_blockarg: 3,408,229 (66.4%)
  param_forwardable:   741,597 (14.5%)
         param_rest:   453,358 ( 8.8%)
       caller_kwarg:   227,629 ( 4.4%)
       param_kwrest:   153,285 ( 3.0%)
    caller_kw_splat:    87,174 ( 1.7%)
       caller_splat:    60,366 ( 1.2%)
Top-2 compile error reasons (100.0% of total 185,862):
       exception_handler: 184,871 (99.5%)
  native_stack_too_large:     991 ( 0.5%)
Top-1 unhandled YARV insns (100.0% of total 350):
  expandarray: 350 (100.0%)
Top-1 unhandled HIR insns (100.0% of total 188,952):
  throw: 188,952 (100.0%)
Top-20 side exit reasons (100.0% of total 2,987,260):
                   guard_type_failure: 2,172,962 (72.7%)
                   unhandled_hir_insn:   188,952 ( 6.3%)
                        compile_error:   185,862 ( 6.2%)
          patchpoint_method_redefined:   114,752 ( 3.8%)
                      no_profile_send:   107,271 ( 3.6%)
      block_param_proxy_fallback_miss:    72,424 ( 2.4%)
     patchpoint_stable_constant_names:    49,680 ( 1.7%)
                too_many_args_for_lir:    35,418 ( 1.2%)
        patchpoint_no_singleton_class:    21,427 ( 0.7%)
                  unhandled_block_arg:    14,476 ( 0.5%)
               fixnum_lshift_overflow:    10,165 ( 0.3%)
             guard_greater_eq_failure:     8,631 ( 0.3%)
                   guard_less_failure:     3,201 ( 0.1%)
                  guard_shape_failure:     1,129 ( 0.0%)
             guard_super_method_entry:       407 ( 0.0%)
                  unhandled_yarv_insn:       350 ( 0.0%)
  block_param_proxy_not_iseq_or_ifunc:        62 ( 0.0%)
               obj_to_string_fallback:        37 ( 0.0%)
            block_param_proxy_not_nil:        31 ( 0.0%)
                            interrupt:        23 ( 0.0%)
                             send_count: 197,297,382
                     dynamic_send_count:  28,971,805 (14.7%)
                   optimized_send_count: 168,325,577 (85.3%)
              iseq_optimized_send_count:  57,610,725 (29.2%)
      inline_cfunc_optimized_send_count:  77,869,956 (39.5%)
       inline_iseq_optimized_send_count:   6,757,456 ( 3.4%)
                    inline_method_count:           0 ( 0.0%)
non_variadic_cfunc_optimized_send_count:  14,749,376 ( 7.5%)
    variadic_cfunc_optimized_send_count:  11,338,064 ( 5.7%)
dynamic_setivar_count:                            1,688,384
dynamic_getivar_count:                           16,863,879
dynamic_definedivar_count:                                0
compiled_iseq_count:                                  6,637
compiled_side_exit_count:                            98,276
failed_iseq_count:                                        1
compile_time:                                       3,233ms
compile_side_exit_time:                               159ms
compile_side_exit_time_ratio:                          4.9%
compile_hir_time:                                     956ms
compile_hir_build_time:                               330ms
compile_hir_strength_reduce_time:                     302ms
compile_hir_inline_methods_time:                        0ms
compile_hir_canonicalize_time:                         82ms
compile_hir_fold_constants_time:                       48ms
compile_hir_clean_cfg_time:                            31ms
compile_hir_eliminate_dead_code_time:                  36ms
compile_lir_time:                                   2,081ms
profile_time:                                          20ms
gc_time:                                               42ms
invalidation_time:                                     16ms
vm_write_jit_frame_count:                       151,486,065
vm_write_sp_count:                              151,486,065
vm_write_locals_count:                          144,704,814
vm_write_stack_count:                            57,411,507
vm_write_to_parent_iseq_local_count:                741,734
guard_type_count:                               115,949,618
guard_type_exit_ratio:                                 1.9%
guard_shape_count:                               33,384,942
guard_shape_exit_ratio:                                0.0%
load_field_count:                               217,173,074
store_field_count:                               15,517,594
side_exit_size:                                  17,402,692
code_region_bytes:                               39,157,760
side_exit_size_ratio:                                 44.4%
zjit_alloc_bytes:                                24,422,541
total_mem_bytes:                                 63,580,301
side_exit_count:                                  2,987,260
total_insn_count:                               985,383,057
vm_insn_count:                                   57,334,881
zjit_insn_count:                                928,048,176
ratio_in_zjit:                                        94.2%
```

</details>

<details>

<summary>after patch</summary>

```
Top-2 not optimized method types for send (100.0% of total 133,256):
       null: 110,593 (83.0%)
  optimized:  22,663 (17.0%)
Top-3 not optimized method types for send_without_block (100.0% of total 711,322):
        optimized_send: 706,549 (99.3%)
  optimized_block_call:   4,299 ( 0.6%)
                zsuper:     474 ( 0.1%)
Top-1 not optimized method types for super (100.0% of total 3,342):
  attrset: 3,342 (100.0%)
Top-1 instructions with uncategorized fallback reason (100.0% of total 66,803):
  opt_send_without_block: 66,803 (100.0%)
Top-20 send fallback reasons (99.6% of total 28,979,060):
                          send_without_block_polymorphic: 6,009,014 (20.7%)
                             invokeblock_not_specialized: 5,939,738 (20.5%)
                            one_or_more_complex_arg_pass: 4,789,231 (16.5%)
                          send_without_block_no_profiles: 3,620,145 (12.5%)
                          send_without_block_megamorphic: 3,407,024 (11.8%)
                                        send_polymorphic: 1,494,690 ( 5.2%)
                             sendforward_not_specialized:   981,522 ( 3.4%)
  send_without_block_not_optimized_method_type_optimized:   710,848 ( 2.5%)
                                       super_polymorphic:   355,115 ( 1.2%)
                                   too_many_args_for_lir:   341,929 ( 1.2%)
                      send_not_optimized_need_permission:   238,842 ( 0.8%)
        send_without_block_not_optimized_need_permission:   198,230 ( 0.7%)
                                        send_no_profiles:   181,185 ( 0.6%)
                          send_not_optimized_method_type:   133,256 ( 0.5%)
                                     argc_param_mismatch:   131,357 ( 0.5%)
                                 super_complex_args_pass:    91,595 ( 0.3%)
                      invokesuperforward_not_specialized:    80,700 ( 0.3%)
                                           uncategorized:    66,803 ( 0.2%)
                                        send_megamorphic:    60,000 ( 0.2%)
                                obj_to_string_not_string:    44,725 ( 0.2%)
Top-4 setivar fallback reasons (100.0% of total 1,688,384):
              no_side_exits: 1,463,049 (86.7%)
               not_t_object:   119,505 ( 7.1%)
                    complex:   105,573 ( 6.3%)
  new_shape_needs_extension:       257 ( 0.0%)
Top-4 getivar fallback reasons (100.0% of total 16,876,216):
          no_side_exits: 8,802,277 (52.2%)
  no_profile_missing_ic: 5,553,273 (32.9%)
             no_profile: 2,204,338 (13.1%)
                complex:   316,328 ( 1.9%)
Top-5 invokeblock handler (100.0% of total 6,961,031):
  monomorphic_ifunc: 4,140,877 (59.5%)
  monomorphic_other: 1,446,869 (20.8%)
   monomorphic_iseq:   851,775 (12.2%)
        polymorphic:   515,556 ( 7.4%)
        megamorphic:     5,954 ( 0.1%)
Top-6 getblockparamproxy handler (100.0% of total 3,514,144):
  polymorphic: 2,602,533 (74.1%)
          nil:   422,687 (12.0%)
         iseq:   231,829 ( 6.6%)
  no_profiles:   170,055 ( 4.8%)
         proc:    76,419 ( 2.2%)
  megamorphic:    10,621 ( 0.3%)
Top-7 popular complex argument-parameter features not optimized (100.0% of total 5,135,232):
    caller_blockarg: 3,411,384 (66.4%)
  param_forwardable:   742,035 (14.4%)
         param_rest:   453,359 ( 8.8%)
       caller_kwarg:   227,629 ( 4.4%)
       param_kwrest:   153,285 ( 3.0%)
    caller_kw_splat:    87,174 ( 1.7%)
       caller_splat:    60,366 ( 1.2%)
Top-2 compile error reasons (100.0% of total 185,862):
       exception_handler: 184,871 (99.5%)
  native_stack_too_large:     991 ( 0.5%)
Top-1 unhandled YARV insns (100.0% of total 350):
  expandarray: 350 (100.0%)
Top-1 unhandled HIR insns (100.0% of total 188,952):
  throw: 188,952 (100.0%)
Top-20 side exit reasons (100.0% of total 2,973,961):
                   guard_type_failure: 2,172,957 (73.1%)
                   unhandled_hir_insn:   188,952 ( 6.4%)
                        compile_error:   185,862 ( 6.2%)
          patchpoint_method_redefined:   114,752 ( 3.9%)
                      no_profile_send:    93,973 ( 3.2%)
      block_param_proxy_fallback_miss:    72,424 ( 2.4%)
     patchpoint_stable_constant_names:    49,680 ( 1.7%)
                too_many_args_for_lir:    35,418 ( 1.2%)
        patchpoint_no_singleton_class:    21,427 ( 0.7%)
                  unhandled_block_arg:    14,476 ( 0.5%)
               fixnum_lshift_overflow:    10,165 ( 0.3%)
             guard_greater_eq_failure:     8,631 ( 0.3%)
                   guard_less_failure:     3,201 ( 0.1%)
                  guard_shape_failure:     1,129 ( 0.0%)
             guard_super_method_entry:       407 ( 0.0%)
                  unhandled_yarv_insn:       350 ( 0.0%)
  block_param_proxy_not_iseq_or_ifunc:        62 ( 0.0%)
               obj_to_string_fallback:        37 ( 0.0%)
            block_param_proxy_not_nil:        31 ( 0.0%)
                            interrupt:        27 ( 0.0%)
                             send_count: 197,376,758
                     dynamic_send_count:  28,979,060 (14.7%)
                   optimized_send_count: 168,397,698 (85.3%)
              iseq_optimized_send_count:  57,642,840 (29.2%)
      inline_cfunc_optimized_send_count:  77,906,859 (39.5%)
       inline_iseq_optimized_send_count:   6,760,207 ( 3.4%)
                    inline_method_count:           0 ( 0.0%)
non_variadic_cfunc_optimized_send_count:  14,749,356 ( 7.5%)
    variadic_cfunc_optimized_send_count:  11,338,436 ( 5.7%)
dynamic_setivar_count:                            1,688,384
dynamic_getivar_count:                           16,876,216
dynamic_definedivar_count:                                0
compiled_iseq_count:                                  6,640
compiled_side_exit_count:                            97,354
failed_iseq_count:                                        1
compile_time:                                       2,718ms
compile_side_exit_time:                               132ms
compile_side_exit_time_ratio:                          4.9%
compile_hir_time:                                     831ms
compile_hir_build_time:                               279ms
compile_hir_strength_reduce_time:                     281ms
compile_hir_inline_methods_time:                        0ms
compile_hir_canonicalize_time:                         53ms
compile_hir_fold_constants_time:                       44ms
compile_hir_clean_cfg_time:                            29ms
compile_hir_eliminate_dead_code_time:                  34ms
compile_lir_time:                                   1,721ms
profile_time:                                          24ms
gc_time:                                               34ms
invalidation_time:                                     15ms
vm_write_jit_frame_count:                       151,530,402
vm_write_sp_count:                              151,530,402
vm_write_locals_count:                          144,749,148
vm_write_stack_count:                            57,419,115
vm_write_to_parent_iseq_local_count:                741,734
guard_type_count:                               116,016,802
guard_type_exit_ratio:                                 1.9%
guard_shape_count:                               33,385,130
guard_shape_exit_ratio:                                0.0%
load_field_count:                               217,232,100
store_field_count:                               15,524,719
side_exit_size:                                  16,725,256
code_region_bytes:                               38,486,016
side_exit_size_ratio:                                 43.5%
zjit_alloc_bytes:                                24,386,305
total_mem_bytes:                                 62,872,321
side_exit_count:                                  2,973,961
total_insn_count:                               985,367,650
vm_insn_count:                                   56,946,089
zjit_insn_count:                                928,421,561
ratio_in_zjit:                                        94.2%
```

</details>

