### PR TITLE
[DOC] Update documentation of refinement super

### DIFF
--- a/doc/syntax/refinements.rdoc
+++ b/doc/syntax/refinements.rdoc
@@ -246,7 +246,10 @@ invokes that method since +foo+ does not exist on Integer.
 
 When +super+ is invoked, method lookup starts:
 
-* If the method is in a refinement, at the refined class or module
+* If the method is in a refinement:
+  * At the next active refinement in scope at the +super+ call site,
+    excluding the current refinement, if such a refinement exists
+  * Otherwise, at the refined class or module
 * Otherwise, at the next ancestor
 
 Method lookup then proceeds as described in the Method Lookup section


### PR DESCRIPTION
Method lookup for refinement super starts with the next active refinement at the super call site, excluding the current refinment, if such a refinement exists. This has been the behavior since Ruby 2.7, and it is now confirmed to be the desired behavior.