### PR TITLE
Sync RubyGems and Bundler with the flattened upstream layout

### DIFF
--- a/lib/bundler/bundler.gemspec
+++ b/lib/bundler/bundler.gemspec
@@ -24,9 +24,9 @@ Gem::Specification.new do |s|
 
   s.metadata = {
     "bug_tracker_uri" => "https://github.com/ruby/rubygems/issues?q=is%3Aopen+is%3Aissue+label%3ABundler",
-    "changelog_uri" => "https://github.com/ruby/rubygems/blob/master/bundler/CHANGELOG.md",
+    "changelog_uri" => "https://github.com/ruby/rubygems/blob/master/CHANGELOG-bundler.md",
     "homepage_uri" => "https://bundler.io/",
-    "source_code_uri" => "https://github.com/ruby/rubygems/tree/master/bundler",
+    "source_code_uri" => "https://github.com/ruby/rubygems",
   }
 
   s.required_ruby_version     = ">= 3.2.0"
@@ -39,6 +39,9 @@ Gem::Specification.new do |s|
   # include the gemspec itself because warbler breaks w/o it
   s.files += %w[lib/bundler/bundler.gemspec]
 
+  # These live next to the gemspec when Bundler ships as a gem, but not when
+  # it is synced into Ruby core, where the gemspec moves under lib/bundler.
+  s.files += %w[CHANGELOG-bundler.md LICENSE-bundler.md README-bundler.md].select {|f| File.file?(f) }
   s.bindir        = "exe"
   s.executables   = %w[bundle bundler]
   s.require_paths = ["lib"]

--- a/lib/bundler/ci_detector.rb
+++ b/lib/bundler/ci_detector.rb
@@ -3,7 +3,7 @@
 module Bundler
   module CIDetector
     # NOTE: Any changes made here will need to be made to both lib/rubygems/ci_detector.rb and
-    # bundler/lib/bundler/ci_detector.rb (which are enforced duplicates).
+    # lib/bundler/ci_detector.rb (which are enforced duplicates).
     # TODO: Drop that duplication once bundler drops support for RubyGems 3.4
     #
     # ## Recognized CI providers, their signifiers, and the relevant docs ##

--- a/lib/rubygems/ci_detector.rb
+++ b/lib/rubygems/ci_detector.rb
@@ -3,7 +3,7 @@
 module Gem
   module CIDetector
     # NOTE: Any changes made here will need to be made to both lib/rubygems/ci_detector.rb and
-    # bundler/lib/bundler/ci_detector.rb (which are enforced duplicates).
+    # lib/bundler/ci_detector.rb (which are enforced duplicates).
     # TODO: Drop that duplication once bundler drops support for RubyGems 3.4
     #
     # ## Recognized CI providers, their signifiers, and the relevant docs ##

--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -292,7 +292,6 @@ By default, this RubyGems will install gem as:
 
   def install_lib(lib_dir)
     libs = { "RubyGems" => "lib" }
-    libs["Bundler"] = "bundler/lib"
     libs.each do |tool, path|
       say "Installing #{tool}" if @verbose
 
@@ -366,7 +365,7 @@ By default, this RubyGems will install gem as:
       target_specs_dir
     end
 
-    new_bundler_spec = Dir.chdir("bundler") { Gem::Specification.load("bundler.gemspec") }
+    new_bundler_spec = Gem::Specification.load("bundler.gemspec")
     full_name = new_bundler_spec.full_name
     gemspec_path = "#{full_name}.gemspec"
 
@@ -390,26 +389,24 @@ By default, this RubyGems will install gem as:
 
     require_relative "../installer"
 
-    Dir.chdir("bundler") do
-      built_gem = Gem::Package.build(new_bundler_spec)
-      begin
-        installer = Gem::Installer.at(
-          built_gem,
-          env_shebang: options[:env_shebang],
-          format_executable: options[:format_executable],
-          force: options[:force],
-          bin_dir: bin_dir,
-          install_dir: default_dir,
-          wrappers: true
-        )
-        # We need to install only executable and default spec files.
-        # lib/bundler.rb and lib/bundler/* are available under the site_ruby directory.
-        installer.extract_bin
-        installer.generate_bin
-        installer.write_default_spec
-      ensure
-        FileUtils.rm_f built_gem
-      end
+    built_gem = Gem::Package.build(new_bundler_spec)
+    begin
+      installer = Gem::Installer.at(
+        built_gem,
+        env_shebang: options[:env_shebang],
+        format_executable: options[:format_executable],
+        force: options[:force],
+        bin_dir: bin_dir,
+        install_dir: default_dir,
+        wrappers: true
+      )
+      # We need to install only executable and default spec files.
+      # lib/bundler.rb and lib/bundler/* are available under the site_ruby directory.
+      installer.extract_bin
+      installer.generate_bin
+      installer.write_default_spec
+    ensure
+      FileUtils.rm_f built_gem
     end
 
     new_bundler_spec.executables.each {|executable| bin_file_names << target_bin_path(bin_dir, executable) }
@@ -499,7 +496,7 @@ abort "#{deprecation_message}"
 
   def remove_old_lib_files(lib_dir)
     lib_dirs = { File.join(lib_dir, "rubygems") => "lib/rubygems" }
-    lib_dirs[File.join(lib_dir, "bundler")] = "bundler/lib/bundler"
+    lib_dirs[File.join(lib_dir, "bundler")] = "lib/bundler"
     lib_dirs.each do |old_lib_dir, new_lib_dir|
       lib_files = files_in(new_lib_dir)
 

--- a/lib/rubygems/platform.rb
+++ b/lib/rubygems/platform.rb
@@ -196,7 +196,7 @@ class Gem::Platform
   # the runtime platform.
   #
   #--
-  # NOTE: Until it can be removed, changes to this method must also be reflected in `bundler/lib/bundler/rubygems_ext.rb`
+  # NOTE: Until it can be removed, changes to this method must also be reflected in `lib/bundler/rubygems_ext.rb`
 
   def ===(other)
     return nil unless Gem::Platform === other
@@ -221,7 +221,7 @@ class Gem::Platform
   end
 
   #--
-  # NOTE: Until it can be removed, changes to this method must also be reflected in `bundler/lib/bundler/rubygems_ext.rb`
+  # NOTE: Until it can be removed, changes to this method must also be reflected in `lib/bundler/rubygems_ext.rb`
 
   def normalized_linux_version
     return nil unless @version

--- a/spec/bin/bundle
+++ b/spec/bin/bundle
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+require_relative "../bundler/support/switch_rubygems"
 require_relative "../bundler/support/activate"
 
 load File.expand_path("bundle", Spec::Path.exedir)

--- a/spec/bundler/commands/update_spec.rb
+++ b/spec/bundler/commands/update_spec.rb
@@ -1582,8 +1582,11 @@ RSpec.describe "bundle update --bundler" do
         999.0.0
     L
 
-    expect(the_bundle).to include_gems "bundler 999.0.0"
-    expect(the_bundle).to include_gems "myrack 1.0"
+    bundle "--version"
+    expect(out).to include("999.0.0")
+
+    bundle "list"
+    expect(out).to include("myrack (1.0)")
   end
 
   it "does not claim to update to Bundler version to a wrong version when cached gems are present" do
@@ -1665,8 +1668,11 @@ RSpec.describe "bundle update --bundler" do
         9.9.9
     L
 
-    expect(the_bundle).to include_gems "bundler 9.9.9"
-    expect(the_bundle).to include_gems "myrack 1.0"
+    bundle "--version"
+    expect(out).to include("9.9.9")
+
+    bundle "list"
+    expect(out).to include("myrack (1.0)")
   end
 
   it "errors if the explicit target version does not exist" do

--- a/spec/bundler/install/gemfile_spec.rb
+++ b/spec/bundler/install/gemfile_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe "bundle install" do
     it "shows culprit file and line" do
       skip "ruby-core test setup has always \"lib\" in $LOAD_PATH so `require \"bundler\"` always activates the local version rather than using RubyGems gem activation stuff, causing conflicts" if ruby_core?
 
-      install_gemfile "source 'https://gem.repo1'", requires: [bundler_bug], artifice: nil, raise_on_error: false
+      install_gemfile "source 'https://gem.repo1'", requires: [bundler_bug], artifice: nil, raise_on_error: false, bundle_bin: dev_binstub
       expect(err).to include("bundler_bug.rb:6")
     end
   end

--- a/spec/bundler/runtime/setup_spec.rb
+++ b/spec/bundler/runtime/setup_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe "Bundler.setup" do
 
       ruby <<-RUBY
         require 'bundler'
-        gem "bundler", "#{Bundler::VERSION}" if #{ruby_core?}
+        gem "bundler", "#{Bundler::VERSION}"
         Bundler.setup
         puts $LOAD_PATH
       RUBY
@@ -987,7 +987,8 @@ end
       puts Bundler.rubygems.installed_specs.map(&:name)
     R
 
-    expect(out).to eq("activesupport\nbundler\nactivesupport\nbundler")
+    expect(out).to include("activesupport")
+    expect(out).not_to include("myrack")
   end
 
   describe "when a vendored gem specification uses the :path option" do
@@ -1309,12 +1310,16 @@ end
     end
 
     context "is not present" do
-      # Skipped on ruby-core because `ruby "require 'bundler/setup'"` does not
-      # activate bundler as a gem there, so Source::Metadata falls back to a
-      # synthetic spec whose cache_file does not exist on disk and
-      # LockfileGenerator#bundler_checksum drops the bundler checksum, while
-      # the on-disk lockfile still has it.
+      # Skipped on ruby-core, and on the release-version CI variant, because
+      # `ruby "require 'bundler/setup'"` does not activate bundler as a gem
+      # there, so Source::Metadata falls back to a synthetic spec whose
+      # cache_file does not exist on disk and LockfileGenerator#bundler_checksum
+      # drops the bundler checksum, while the on-disk lockfile still has it.
+      # In-development (.dev) versions never write a bundler checksum, so the
+      # regular suite stays unaffected.
       it "does not change the lock", :ruby_repo do
+        skip "bundler is loaded from the source tree, not installed as a gem" unless Bundler::VERSION.end_with?(".dev")
+
         expect { ruby "require 'bundler/setup'" }.not_to change { lockfile }
       end
     end

--- a/spec/bundler/support/build_metadata.rb
+++ b/spec/bundler/support/build_metadata.rb
@@ -44,7 +44,7 @@ module Spec
     end
 
     def release_date_for(version, dir:)
-      changelog = File.expand_path("CHANGELOG.md", dir)
+      changelog = File.expand_path("CHANGELOG-bundler.md", dir)
       File.readlines(changelog)[2].scan(/^## #{Regexp.escape(version)} \((.*)\)/).first&.first if File.exist?(changelog)
     end
 

--- a/spec/bundler/support/path.rb
+++ b/spec/bundler/support/path.rb
@@ -10,7 +10,7 @@ module Spec
     include Spec::Env
 
     def source_root
-      @source_root ||= Pathname.new(ruby_core? ? "../../.." : "../../bundler").expand_path(__dir__)
+      @source_root ||= Pathname.new(ruby_core? ? "../../.." : "../..").expand_path(__dir__)
     end
 
     def root
@@ -50,7 +50,7 @@ module Spec
     end
 
     def bindir
-      @bindir ||= source_root.join(ruby_core? ? "spec/bin" : "../bin")
+      @bindir ||= source_root.join(ruby_core? ? "spec/bin" : "bin")
     end
 
     def exedir
@@ -76,7 +76,7 @@ module Spec
     end
 
     def spec_dir
-      @spec_dir ||= source_root.join(ruby_core? ? "spec/bundler" : "../spec")
+      @spec_dir ||= source_root.join(ruby_core? ? "spec/bundler" : "spec")
     end
 
     def man_dir
@@ -123,7 +123,7 @@ module Spec
         end
         Pathname(real)
       else
-        (ruby_core? ? source_root : source_root.parent).join("tmp")
+        source_root.join("tmp")
       end
     end
 
@@ -298,7 +298,7 @@ module Spec
     end
 
     def git_root
-      ruby_core? ? source_root : source_root.parent
+      source_root
     end
 
     def rake_path
@@ -345,11 +345,11 @@ module Spec
     end
 
     def tracked_files_glob
-      ruby_core? ? "libexec/bundle* lib/bundler lib/bundler.rb spec/bundler man/bundle*" : "lib exe CHANGELOG.md LICENSE.md README.md bundler.gemspec"
+      ruby_core? ? "libexec/bundle* lib/bundler lib/bundler.rb spec/bundler man/bundle*" : "exe/bundle exe/bundler lib/bundler lib/bundler.rb bundler.gemspec bundler/CHANGELOG.md bundler/LICENSE.md bundler/README.md"
     end
 
     def lib_tracked_files_glob
-      ruby_core? ? "lib/bundler lib/bundler.rb" : "lib"
+      "lib/bundler lib/bundler.rb"
     end
 
     def man_tracked_files_glob
@@ -371,7 +371,7 @@ module Spec
     end
 
     def tool_dir
-      ruby_core? ? source_root.join("tool/bundler") : source_root.join("../tool/bundler")
+      source_root.join("tool/bundler")
     end
 
     def templates_dir

--- a/spec/bundler/support/path.rb
+++ b/spec/bundler/support/path.rb
@@ -291,7 +291,7 @@ module Spec
     end
 
     def replace_changelog(version, dir:)
-      changelog = File.expand_path("CHANGELOG.md", dir)
+      changelog = File.expand_path("CHANGELOG-bundler.md", dir)
       contents = File.readlines(changelog)
       contents = [contents[0], contents[1], "## #{version} (2100-01-01)\n", *contents[3..-1]].join
       File.open(changelog, "w") {|f| f << contents }
@@ -345,7 +345,7 @@ module Spec
     end
 
     def tracked_files_glob
-      ruby_core? ? "libexec/bundle* lib/bundler lib/bundler.rb spec/bundler man/bundle*" : "exe/bundle exe/bundler lib/bundler lib/bundler.rb bundler.gemspec bundler/CHANGELOG.md bundler/LICENSE.md bundler/README.md"
+      ruby_core? ? "libexec/bundle* lib/bundler lib/bundler.rb spec/bundler man/bundle*" : "exe/bundle exe/bundler lib/bundler lib/bundler.rb bundler.gemspec CHANGELOG-bundler.md LICENSE-bundler.md README-bundler.md"
     end
 
     def lib_tracked_files_glob

--- a/test/rubygems/bundler_test_gem.rb
+++ b/test/rubygems/bundler_test_gem.rb
@@ -408,7 +408,7 @@ You may need to `bundle install` to install missing gems
     require "bundler"
 
     # If bundler gemspec exists, pretend it's installed
-    bundler_gemspec = File.expand_path("../../bundler/bundler.gemspec", __dir__)
+    bundler_gemspec = File.expand_path("../../bundler.gemspec", __dir__)
     if File.exist?(bundler_gemspec)
       target_gemspec_location = "#{path}/specifications/bundler-#{Bundler::VERSION}.gemspec"
 

--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -15,15 +15,15 @@ class TestGemCommandsSetupCommand < Gem::TestCase
       lib/rubygems.rb
       lib/rubygems/requirement.rb
       lib/rubygems/ssl_certs/rubygems.org/foo.pem
-      bundler/exe/bundle
-      bundler/exe/bundler
-      bundler/lib/bundler.rb
-      bundler/lib/bundler/b.rb
-      bundler/bin/bundler/man/bundle-b.1
-      bundler/lib/bundler/man/bundle-b.1.ronn
-      bundler/lib/bundler/man/gemfile.5
-      bundler/lib/bundler/man/gemfile.5.ronn
-      bundler/lib/bundler/templates/.circleci/config.yml
+      exe/bundle
+      exe/bundler
+      lib/bundler.rb
+      lib/bundler/b.rb
+      lib/bundler/man/bundle-b.1
+      lib/bundler/man/bundle-b.1.ronn
+      lib/bundler/man/gemfile.5
+      lib/bundler/man/gemfile.5.ronn
+      lib/bundler/templates/.circleci/config.yml
     ]
 
     create_dummy_files(filelist)
@@ -34,7 +34,7 @@ class TestGemCommandsSetupCommand < Gem::TestCase
       s.files = ["lib/bundler.rb"]
     end
 
-    File.open "bundler/bundler.gemspec", "w" do |io|
+    File.open "bundler.gemspec", "w" do |io|
       io.puts gemspec.to_ruby
     end
 
@@ -171,8 +171,18 @@ class TestGemCommandsSetupCommand < Gem::TestCase
   end
 
   def test_files_in
-    assert_equal %w[rubygems.rb rubygems/requirement.rb rubygems/ssl_certs/rubygems.org/foo.pem],
-                 @cmd.files_in("lib").sort
+    assert_equal %w[
+      bundler.rb
+      bundler/b.rb
+      bundler/man/bundle-b.1
+      bundler/man/bundle-b.1.ronn
+      bundler/man/gemfile.5
+      bundler/man/gemfile.5.ronn
+      bundler/templates/.circleci/config.yml
+      rubygems.rb
+      rubygems/requirement.rb
+      rubygems/ssl_certs/rubygems.org/foo.pem
+    ], @cmd.files_in("lib").sort
   end
 
   def test_install_lib
@@ -475,7 +485,7 @@ class TestGemCommandsSetupCommand < Gem::TestCase
   end
 
   def bundler_spec
-    Gem::Specification.load("bundler/bundler.gemspec")
+    Gem::Specification.load("bundler.gemspec")
   end
 
   def bundler_version

--- a/tool/sync_default_gems.rb
+++ b/tool/sync_default_gems.rb
@@ -241,11 +241,11 @@ module SyncDefaultGems
       ["lib/rubygems.rb", "lib/rubygems.rb"],
       ["lib/rubygems", "lib/rubygems"],
       ["test/rubygems", "test/rubygems"],
-      ["bundler/lib/bundler.rb", "lib/bundler.rb"],
-      ["bundler/lib/bundler", "lib/bundler"],
-      ["bundler/exe/bundle", "libexec/bundle"],
-      ["bundler/exe/bundler", "libexec/bundler"],
-      ["bundler/bundler.gemspec", "lib/bundler/bundler.gemspec"],
+      ["lib/bundler.rb", "lib/bundler.rb"],
+      ["lib/bundler", "lib/bundler"],
+      ["exe/bundle", "libexec/bundle"],
+      ["exe/bundler", "libexec/bundler"],
+      ["bundler.gemspec", "lib/bundler/bundler.gemspec"],
       ["spec", "spec/bundler"],
       *["bundle", "parallel_rspec", "rspec"].map {|binstub|
         ["bin/#{binstub}", "spec/bin/#{binstub}"]
@@ -369,12 +369,15 @@ module SyncDefaultGems
   end
 
   def rubygems_do_fixup
-    gemspec_content = File.readlines("lib/bundler/bundler.gemspec").map do |line|
-      next if line =~ /LICENSE\.md/
+    gemspec = "lib/bundler/bundler.gemspec"
+    if File.exist?(gemspec)
+      gemspec_content = File.readlines(gemspec).map do |line|
+        next if line =~ /LICENSE\.md/
 
-      line.gsub("bundler.gemspec", "lib/bundler/bundler.gemspec")
-    end.compact.join
-    File.write("lib/bundler/bundler.gemspec", gemspec_content)
+        line.gsub("bundler.gemspec", "lib/bundler/bundler.gemspec")
+      end.compact.join
+      File.write(gemspec, gemspec_content)
+    end
 
     ["bundle", "parallel_rspec", "rspec"].each do |binstub|
       path = "spec/bin/#{binstub}"


### PR DESCRIPTION
RubyGems upstream moved the Bundler runtime tree, executables, gemspec, and docs from bundler/ up to the repository root. This syncs that flattening into Ruby core together with the latest RubyGems commits.

tool/sync_default_gems.rb is updated to follow the new layout. The rubygems mappings now point at the top-level lib/bundler, exe, and bundler.gemspec, and the gemspec fixup is guarded so a sync across the flattening boundary no longer fails.

https://github.com/ruby/rubygems/pull/9634
