### PR TITLE
Annotate Symbol#empty? as leaf

### DIFF
--- a/benchmark/symbol_empty.yml
+++ b/benchmark/symbol_empty.yml
@@ -1,0 +1,8 @@
+prelude: |
+  sym0  = :""
+  sym8  = :abcdefgh
+  GC.disable
+benchmark:
+  symbol_empty-0:  sym0.empty?
+  symbol_empty-8:  sym8.empty?
+loop_count: 20000000

--- a/string.c
+++ b/string.c
@@ -12624,20 +12624,6 @@ sym_length(VALUE sym)
 
 /*
  *  call-seq:
- *    empty? -> true or false
- *
- *  Returns +true+ if +self+ is <tt>:''</tt>, +false+ otherwise.
- *
- */
-
-static VALUE
-sym_empty(VALUE sym)
-{
-    return rb_str_empty(rb_sym2str(sym));
-}
-
-/*
- *  call-seq:
  *    upcase(mapping) -> symbol
  *
  *  Equivalent to <tt>sym.to_s.upcase.to_sym</tt>.
@@ -13072,7 +13058,6 @@ Init_String(void)
     rb_define_method(rb_cSymbol, "slice", sym_aref, -1);
     rb_define_method(rb_cSymbol, "length", sym_length, 0);
     rb_define_method(rb_cSymbol, "size", sym_length, 0);
-    rb_define_method(rb_cSymbol, "empty?", sym_empty, 0);
     rb_define_method(rb_cSymbol, "match", sym_match_m, -1);
     rb_define_method(rb_cSymbol, "match?", sym_match_m_p, -1);
 

--- a/symbol.rb
+++ b/symbol.rb
@@ -29,6 +29,15 @@ class Symbol
   end
 
   # call-seq:
+  #   empty? -> true or false
+  #
+  # Returns +true+ if +self+ is <tt>:''</tt>, +false+ otherwise.
+  def empty?
+    Primitive.attr! :leaf
+    Primitive.cexpr! 'RBOOL(RSTRING_LEN(rb_sym2str(self)) == 0)'
+  end
+
+  # call-seq:
   #   to_sym -> self
   #
   # Returns +self+.

--- a/zjit/src/cruby_methods.rs
+++ b/zjit/src/cruby_methods.rs
@@ -290,6 +290,7 @@ pub fn init() -> Annotations {
     annotate_builtin!(rb_cSymbol, "to_s", types::StringExact);
     annotate_builtin!(rb_cString, "ascii_only?", inline_string_ascii_only_p, types::BoolExact, no_gc, leaf);
     annotate_builtin!(rb_cString, "valid_encoding?", inline_string_valid_encoding_p, types::BoolExact, no_gc, leaf);
+    annotate_builtin!(rb_cSymbol, "empty?", types::BoolExact);
 
     // Array iteration builtins (used in with_jit Array#each, map, select, find)
     builtin_funcs.insert(rb_jit_fixnum_inc as *mut c_void, FnProperties { inline: inline_fixnum_inc, return_type: types::Fixnum, ..Default::default() });


### PR DESCRIPTION
Move `Symbol#empty?` from the C `sym_empty` into `symbol.rb`, implemented as `RBOOL(RSTRING_LEN(rb_sym2str(self)) == 0)`, mirroring the existing Symbol#to_s and #name leaf builtins.

Also added an `annotate_builtin! ` in `zjit/src/cruby_methods.rs` to tell ZJIT that the method does not need GC now. 

`Symbol#empty?` as a leaf builtin, via `benchmark-driver` (`GC.disable`, `loop_count: 20_000_000`, Apple M1). Speedup vs master (CFUNC `sym_empty`):

| benchmark | interpreter | `--yjit` | `--zjit` |
|---|---:|---:|---:|
| `:"".empty?`       | **1.24x** | **1.30x** | **1.19x** |
| `:abcdefgh.empty?` | **1.19x** | **1.19x** | **1.17x** |

Windows native and WSL2 also get faster:

| benchmark | interpreter |
|---|---:|
| `:"".empty?`       | **1.47x** |
| `:abcdefgh.empty?` | **1.36x** |

### WSL2 (Ubuntu) `x86_64-linux`

| benchmark | interpreter | `--yjit` | `--zjit` |
|---|---:|---:|---:|
| `:"".empty?`       | **1.39x** | **1.33x** | **1.32x** |
| `:abcdefgh.empty?` | **1.37x** | **1.39x** | **1.33x** |
