### PR TITLE
[Bug #18995] Fix encoding lookup failure in io_encoding_set

### DIFF
--- a/io.c
+++ b/io.c
@@ -11776,15 +11776,27 @@ io_encoding_set(rb_io_t *fptr, VALUE v1, VALUE v2, VALUE opt)
 
     if (!NIL_P(v2)) {
         enc2 = find_encoding(v1);
+        if (!enc2) {
+            /* v1 is an invalid encoding name */
+            enc2 = rb_default_external_encoding();
+        }
         tmp = rb_check_string_type(v2);
         if (!NIL_P(tmp)) {
             if (RSTRING_LEN(tmp) == 1 && RSTRING_PTR(tmp)[0] == '-') {
                 /* Special case - "-" => no transcoding */
+                enc = NULL;
+            }
+            else {
+                enc = find_encoding(v2);
+                if (!enc) {
+                    /* v2 is an invalid encoding name */
+                    enc = rb_default_internal_encoding();
+                }
+            }
+            if (!enc) {
                 enc = enc2;
                 enc2 = NULL;
             }
-            else
-                enc = find_encoding(v2);
             if (enc == enc2) {
                 /* Special case - "-" => no transcoding */
                 enc2 = NULL;


### PR DESCRIPTION
If find_encoding(v1) or find_encoding(v2) fails, fallback to rb_default_external_encoding() and rb_default_internal_encoding() respectively in the 2 string argument case.  This matches the behavior of the 1 string argument with colon separated encoding names case.