### PR TITLE
ZJIT: Add coverage test for polymorphic ISEQ dispatch at one call site

### DIFF
--- a/zjit/src/codegen_tests.rs
+++ b/zjit/src/codegen_tests.rs
@@ -3736,6 +3736,17 @@ fn test_method_call() {
 }
 
 #[test]
+fn test_polymorphic_iseq_dispatch_same_site() {
+    assert_snapshot!(inspect("
+        class A; def foo = 1; end
+        class B; def foo = 2; end
+        def test(obj) = obj.foo
+        test(A.new); test(A.new)   # warm up and specialize the call site for A
+        [test(A.new), test(B.new)]
+    "), @"[1, 2]");
+}
+
+#[test]
 fn test_recursive_fact() {
     assert_snapshot!(inspect("
         def fact(n)


### PR DESCRIPTION
A monomorphic-specialized call site (warmed up with class A) must still return correct results when a second class B with its own ISEQ method of the same name flows through it. The receiver type guard should send the B receiver to the side exit rather than dispatching to A#foo.

This side-exit-on-unexpected-class behavior was not covered by an existing test. Distinct return values (1 vs 2) make a broken guard observable.