### PR TITLE
re.c: Simplify rb_reg_equal

### DIFF
--- a/re.c
+++ b/re.c
@@ -3633,11 +3633,15 @@ rb_reg_equal(VALUE re1, VALUE re2)
     if (re1 == re2) return Qtrue;
     if (!RB_TYPE_P(re2, T_REGEXP)) return Qfalse;
     rb_reg_check(re1); rb_reg_check(re2);
+
+    // src is a fstring, so a pointer comparison is enough
+    RUBY_ASSERT(FL_TEST_RAW(RREGEXP_SRC(re1), RSTRING_FSTR));
+    RUBY_ASSERT(FL_TEST_RAW(RREGEXP_SRC(re2), RSTRING_FSTR));
+    if (RBOOL(RREGEXP_SRC(re1) != RREGEXP_SRC(re2))) return Qfalse;
+
     if (FL_TEST(re1, KCODE_FIXED) != FL_TEST(re2, KCODE_FIXED)) return Qfalse;
     if (RREGEXP_PTR(re1)->options != RREGEXP_PTR(re2)->options) return Qfalse;
-    if (RREGEXP_SRC_LEN(re1) != RREGEXP_SRC_LEN(re2)) return Qfalse;
-    if (ENCODING_GET(re1) != ENCODING_GET(re2)) return Qfalse;
-    return RBOOL(memcmp(RREGEXP_SRC_PTR(re1), RREGEXP_SRC_PTR(re2), RREGEXP_SRC_LEN(re1)) == 0);
+    return RBOOL(ENCODING_GET(re1) == ENCODING_GET(re2));
 }
 
 /*


### PR DESCRIPTION
Since `src` is always a `fstring` we don't need to compare length nor content, we can just compare the pointers.