### PR TITLE
Prefer rb_sym2str over rb_id2str(SYM2ID)

### DIFF
--- a/ext/socket/ipsocket.c
+++ b/ext/socket/ipsocket.c
@@ -1448,7 +1448,7 @@ rsock_revlookup_flag(VALUE revlookup, int *norevlookup)
         id = SYM2ID(revlookup);
         if (id == id_numeric) return_norevlookup(1);
         if (id == id_hostname) return_norevlookup(0);
-        rb_raise(rb_eArgError, "invalid reverse_lookup flag: :%s", rb_id2name(id));
+        rb_raise(rb_eArgError, "invalid reverse_lookup flag: :%"PRIsVALUE, rb_sym2str(revlookup));
     }
     return 0;
 #undef return_norevlookup

--- a/struct.c
+++ b/struct.c
@@ -1016,7 +1016,7 @@ inspect_struct(VALUE s, VALUE prefix, int recur)
         slot = RARRAY_AREF(members, i);
         id = SYM2ID(slot);
         if (rb_is_local_id(id) || rb_is_const_id(id)) {
-            rb_str_append(str, rb_id2str(id));
+            rb_str_append(str, rb_sym2str(slot));
         }
         else {
             rb_str_append(str, rb_inspect(slot));


### PR DESCRIPTION
Just a few cases where we can jump to `rb_sym2str` directly.