### PR TITLE
ZJIT: Print string name of constant in rb_zjit_constant_state_changed

### DIFF
--- a/zjit/src/invariants.rs
+++ b/zjit/src/invariants.rs
@@ -374,10 +374,10 @@ pub extern "C" fn rb_zjit_constant_state_changed(id: ID) {
         let invariants = ZJITState::get_invariants();
         if let Some(patch_points) = invariants.constant_state_patch_points.remove(&id) {
             let cb = ZJITState::get_code_block();
-            debug!("Constant state changed: {:?}", id);
+            debug!("Constant state changed: {id:?}: {}", id.contents_lossy());
 
             // Invalidate all patch points for this constant ID
-            compile_patch_points!(cb, patch_points, Const, "Constant state changed: {:?}", id);
+            compile_patch_points!(cb, patch_points, Const, "Constant state changed: {id:?}: {}", id.contents_lossy());
 
             cb.mark_all_executable();
         }


### PR DESCRIPTION
It's not so useful to see `ID(abc)` when debugging with `--zjit-debug`
or in Perfetto traces. Also provide the string representation of the ID,
for example: `ID(abc): String`.
