### PR TITLE
ZJIT: Optimize GetEP in optimize_load_store

### DIFF
--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5445,6 +5445,36 @@ impl Function {
                         }
                         insn_id
                     }
+                    Insn::GetEP { level } => {
+                        let key = (InsnId(999999+level as usize), RUBY_OFFSET_CFP_EP);
+                        match compile_time_heap.entry(key) {
+                            std::collections::hash_map::Entry::Occupied(entry) => {
+                                let cached_insn = *entry.get();
+
+                                // TODO (nirvdrum 2026-06-04): Remove the return type guard and supporting code when the type checker becomes more accurate.
+                                // If there's an an embedded<=>heap shape storage transition, it's possible for this `LoadField` to have a different return
+                                // type than the cached entry (`CPtr` vs `BasicObject`). While the loaded value would be the same in either case, the
+                                // difference in associated type causes type checking to fail. Consequently, we conservatively retain the duplicate `LoadField`.
+                                // The `optimize_load_store_does_not_alias_loads_with_incompatible_return_types` test checks the problematic case.
+                                let can_forward_cached_insn = match self.find(cached_insn) {
+                                    Insn::LoadField { return_type : cached_return_type,.. } => cached_return_type.is_subtype(types::CPtr),
+                                    _ => true
+                                };
+
+                                if can_forward_cached_insn {
+                                    // If the value is stored already, we should short circuit.
+                                    // However, we need to replace insn_id with its representative in the SSA union.
+                                    self.make_equal_to(insn_id, cached_insn);
+                                    continue
+                                }
+                            }
+                            std::collections::hash_map::Entry::Vacant(_) => {
+                                // If the value has not been accessed, cache a copy to optimize future loads or stores.
+                                compile_time_heap.insert(key, insn_id);
+                            }
+                        }
+                        insn_id
+                    }
                     Insn::WriteBarrier { .. } => {
                         // Currently, WriteBarrier write effects are Allocator and Memory when we'd really like them to be flags.
                         // We don't use LoadField for mark bits so we can ignore them for now.

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -8152,10 +8152,10 @@ fn add_iseq_to_hir(
                         recv: ep,
                         id: FieldName::VM_ENV_DATA_INDEX_FLAGS,
                         offset: SIZEOF_VALUE_I32 * (VM_ENV_DATA_INDEX_FLAGS as i32),
-                        return_type: types::CInt64,
+                        return_type: types::CUInt64,
                     });
                     let modified_flag = fun.push_insn(block, Insn::Const {
-                        val: Const::CInt64(VM_FRAME_FLAG_MODIFIED_BLOCK_PARAM.into()),
+                        val: Const::CUInt64(VM_FRAME_FLAG_MODIFIED_BLOCK_PARAM.into()),
                     });
                     let modified = fun.push_insn(block, Insn::IntOr { left: flags, right: modified_flag });
                     fun.push_insn(block, Insn::StoreField {

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -3942,10 +3942,8 @@ mod hir_opt_tests {
           v22:CPtr = GetEP 0
           v23:BasicObject = LoadField v22, :a@0x1000
           PatchPoint MethodRedefined(Object@0x1008, foo@0x1050, cme:0x1058)
-          v34:CPtr = GetEP 0
-          v35:BasicObject = LoadField v34, :a@0x1000
           CheckInterrupts
-          Return v35
+          Return v23
         ");
     }
 
@@ -16549,8 +16547,7 @@ mod hir_opt_tests {
           SetLocal :kwsplat, l0, EP@3, v108
           v113:CPtr = GetEP 0
           v114:BasicObject = LoadField v113, :list@0x1001
-          v116:CPtr = GetEP 0
-          v117:BasicObject = LoadField v116, :iter_method@0x1005
+          v117:BasicObject = LoadField v113, :iter_method@0x1005
           v119:BasicObject = Send v114, 0x1068, :__send__, v117 # SendFallbackReason: Send: unsupported method type Optimized
           v120:CPtr = GetEP 0
           v121:BasicObject = LoadField v120, :list@0x1001

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -5555,9 +5555,9 @@ mod hir_opt_tests {
           v14:NilClass = Const Value(nil)
           SetLocal :block, l0, EP@3, v14
           v18:CPtr = GetEP 0
-          v19:CInt64 = LoadField v18, :VM_ENV_DATA_INDEX_FLAGS@0x1001
-          v20:CInt64[512] = Const CInt64(512)
-          v21:CInt64 = IntOr v19, v20
+          v19:CUInt64 = LoadField v18, :VM_ENV_DATA_INDEX_FLAGS@0x1001
+          v20:CUInt64[512] = Const CUInt64(512)
+          v21:CUInt64 = IntOr v19, v20
           StoreField v18, :VM_ENV_DATA_INDEX_FLAGS@0x1001, v21
           CheckInterrupts
           Return v14
@@ -5587,9 +5587,9 @@ mod hir_opt_tests {
           v10:NilClass = Const Value(nil)
           SetLocal :block, l1, EP@3, v10
           v14:CPtr = GetEP 1
-          v15:CInt64 = LoadField v14, :VM_ENV_DATA_INDEX_FLAGS@0x1000
-          v16:CInt64[512] = Const CInt64(512)
-          v17:CInt64 = IntOr v15, v16
+          v15:CUInt64 = LoadField v14, :VM_ENV_DATA_INDEX_FLAGS@0x1000
+          v16:CUInt64[512] = Const CUInt64(512)
+          v17:CUInt64 = IntOr v15, v16
           StoreField v14, :VM_ENV_DATA_INDEX_FLAGS@0x1000, v17
           CheckInterrupts
           Return v10

--- a/zjit/src/hir/tests.rs
+++ b/zjit/src/hir/tests.rs
@@ -3821,9 +3821,9 @@ pub(crate) mod hir_build_tests {
           v14:NilClass = Const Value(nil)
           SetLocal :block, l0, EP@3, v14
           v18:CPtr = GetEP 0
-          v19:CInt64 = LoadField v18, :VM_ENV_DATA_INDEX_FLAGS@0x1001
-          v20:CInt64[512] = Const CInt64(512)
-          v21:CInt64 = IntOr v19, v20
+          v19:CUInt64 = LoadField v18, :VM_ENV_DATA_INDEX_FLAGS@0x1001
+          v20:CUInt64[512] = Const CUInt64(512)
+          v21:CUInt64 = IntOr v19, v20
           StoreField v18, :VM_ENV_DATA_INDEX_FLAGS@0x1001, v21
           CheckInterrupts
           Return v14
@@ -3853,9 +3853,9 @@ pub(crate) mod hir_build_tests {
           v10:NilClass = Const Value(nil)
           SetLocal :block, l1, EP@3, v10
           v14:CPtr = GetEP 1
-          v15:CInt64 = LoadField v14, :VM_ENV_DATA_INDEX_FLAGS@0x1000
-          v16:CInt64[512] = Const CInt64(512)
-          v17:CInt64 = IntOr v15, v16
+          v15:CUInt64 = LoadField v14, :VM_ENV_DATA_INDEX_FLAGS@0x1000
+          v16:CUInt64[512] = Const CUInt64(512)
+          v17:CUInt64 = IntOr v15, v16
           StoreField v14, :VM_ENV_DATA_INDEX_FLAGS@0x1000, v17
           CheckInterrupts
           Return v10


### PR DESCRIPTION
- **ZJIT: Use CUInt64 instead of CInt64 for loading env flags**
- **ZJIT: Optimize GetEP in optimize_load_store**
