### PR TITLE
ZJIT: Ensure we specialize the results of the last inlining operation

### DIFF
--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -6221,19 +6221,27 @@ impl Function {
         }
 
         // The optimization pipeline runs in a fixed-point loop so that inlining and
-        // type specialization can feed each other: the first iteration inlines direct
-        // calls and specializes the inlined code, and subsequent iterations can inline
-        // calls that only became monomorphic after the previous round of specialization.
-        // Termination is guaranteed because each iteration either inlines at least one
-        // call (growing the function toward the inlining budget) or reaches a fixed point.
-        for _ in 0..get_option!(inline_max_iterations) {
+        // type specialization can feed each other: an iteration inlines direct calls and
+        // the next one specializes the freshly inlined code, which in turn can expose
+        // calls that only became monomorphic after that specialization. Inlining naturally
+        // stops when it reaches a fixed point, while inline_max_iterations sets an upper bound
+        // on inlining passes. If we reach the max, we run the loop one more time with inlining
+        // disabled in order to optimize the results of the last inlining operation.
+        let inline_max_iterations = get_option!(inline_max_iterations);
+        for iteration in 0..=inline_max_iterations {
             // Function is assumed to have types inferred already
             run_pass!(type_specialize);
             // The trivial inliner runs first to handle simple cases (constant returns,
             // parameter returns, etc.) without frame push/pop overhead. The general
             // inliner then handles more complex methods that require full inlining.
             run_pass!(inline_trivial);
-            let did_inline = run_pass!(inline_methods);
+            // Cap inlining at inline_max_iterations passes; the trailing iteration (see above)
+            // runs the rest of the pipeline with inlining off.
+            let did_inline = if iteration < inline_max_iterations {
+                run_pass!(inline_methods)
+            } else {
+                false
+            };
             run_pass!(optimize_c_calls);
             run_pass!(convert_no_profile_sends);
             run_pass!(optimize_load_store);

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -17986,6 +17986,66 @@ mod hir_opt_tests {
     }
 
     #[test]
+    fn test_final_inline_iteration_specializes_inlined_iseq_send() {
+        eval("
+            def inner(x)
+              x + 1
+            end
+            def outer(x)
+              inner(x)
+            end
+            def test(n)
+              outer(n)
+            end
+            test(1)
+            test(1)
+        ");
+
+        let old_threshold = get_option!(inline_threshold);
+        let old_max_iterations = get_option!(inline_max_iterations);
+        unsafe {
+            OPTIONS.as_mut().unwrap().inline_threshold = 30;
+            OPTIONS.as_mut().unwrap().inline_max_iterations = 1;
+        }
+        let result = hir_string("test");
+        unsafe {
+            OPTIONS.as_mut().unwrap().inline_threshold = old_threshold;
+            OPTIONS.as_mut().unwrap().inline_max_iterations = old_max_iterations;
+        }
+
+        assert!(result.contains("PushInlineFrame"),
+            "Expected outer to be inlined with inline_max_iterations=1:\n{result}");
+        assert!(result.contains(" = SendDirect "),
+            "Expected the Send inside the final inlined body to be specialized to SendDirect:\n{result}");
+        assert!(!result.contains(" = Send "),
+            "Expected no unspecialized Send after the final specialization round:\n{result}");
+
+        assert_snapshot!(result, @"
+        fn test@<compiled>:9:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          v2:CPtr = LoadSP
+          v3:BasicObject = LoadField v2, :n@0x1000
+          Jump bb3(v1, v3)
+        bb2():
+          EntryPoint JIT(0)
+          v6:BasicObject = LoadArg :self@0
+          v7:BasicObject = LoadArg :n@1
+          Jump bb3(v6, v7)
+        bb3(v9:BasicObject, v10:BasicObject):
+          PatchPoint MethodRedefined(Object@0x1008, outer@0x1010, cme:0x1018)
+          v23:ObjectSubclass[class_exact*:Object@VALUE(0x1008)] = GuardType v9, ObjectSubclass[class_exact*:Object@VALUE(0x1008)] recompile
+          PushInlineFrame v23 (0x1040), v10
+          PatchPoint MethodRedefined(Object@0x1008, inner@0x1048, cme:0x1050)
+          v43:BasicObject = SendDirect v23, 0x1078, :inner (0x1088), v10
+          CheckInterrupts
+          PopInlineFrame
+          Return v43
+        ");
+    }
+
+    #[test]
     fn test_inline_budget_rejects_when_exceeded() {
         // The same workload as test_inline_arithmetic_method, which we know inlines
         // successfully under the default settings (budget=500, threshold=30). Setting

--- a/zjit/src/options.rs
+++ b/zjit/src/options.rs
@@ -178,9 +178,12 @@ pub struct Options {
     /// Upper bound on how many times the `optimize` fixed-point loop will iterate
     /// before giving up. Each iteration runs `type_specialize` → `inline` →
     /// `inline_methods` → the rest of the HIR pipeline; in steady state the loop
-    /// terminates as soon as an iteration fails to inline anything new. The cap
-    /// exists to bound compile time when something pathological prevents the loop
-    /// from reaching a fixed point.
+    /// terminates as soon as an iteration fails to inline anything new. If the
+    /// cap is hit while inlining is still ongoing, the optimizer runs one final
+    /// specialization/cleanup round without `inline_methods`, so the callee HIR
+    /// inserted by the last iteration does not keep unspecialized `Send`s. The
+    /// cap exists to bound compile time when something pathological prevents the
+    /// loop from reaching a fixed point.
     pub inline_max_iterations: InlineDepth,
 }
 


### PR DESCRIPTION
When we introduced the inliner we also added repeated passes of the optimization pipeline. The idea being that we want to optimize the results of inlining and, because we only inline one level deep, allow us to perform inlining on the result of the last inlining operation. The optimization loop would exit if we couldn't inline any more. If we could inline more, there's an upper bound that kicks us out of the loop so we don't try to inline the world. However, if we exited the loop by hitting that upper bound, we didn't end up specializing the results of the last inlining pass. This PR rectifies that.

This is immediately visible in the 30k_methods benchmark, where performance roughly doubles.

Before:

```
❯ WARMUP_ITRS=0 MIN_BENCH_ITRS=10 MIN_BENCH_TIME=0 ./run_benchmarks.rb --chruby 'ruby-master --zjit-inline-threshold=30' 30k_methods
Running benchmark "30k_methods" (1/1)
+ /Users/nirvdrum/.rubies/ruby-master/bin/ruby --zjit-inline-threshold\=30 -I harness /Users/nirvdrum/dev/worktrees/ruby-bench/main/benchmarks/30k_methods.rb
ruby 4.1.0dev (2026-06-23T13:29:36Z master 13fe77dd2b) +ZJIT dev +PRISM [arm64-darwin25]
itr:   time
 #1: 2689ms
 #2:   33ms
 #3:   32ms
 #4:   32ms
 #5:   32ms
 #6:   32ms
 #7:   32ms
 #8:   35ms
 #9:   33ms
#10:   33ms
```

After:

```
❯ WARMUP_ITRS=0 MIN_BENCH_ITRS=10 MIN_BENCH_TIME=0 ./run_benchmarks.rb --chruby 'ruby-zjit-opt-last-inline --zjit-inline-threshold=30' 30k_methods
Running benchmark "30k_methods" (1/1)
+ /Users/nirvdrum/.rubies/ruby-zjit-opt-last-inline/bin/ruby --zjit-inline-threshold\=30 -I harness /Users/nirvdrum/dev/worktrees/ruby-bench/main/benchmarks/30k_methods.rb
ruby 4.1.0dev (2026-06-25T13:56:41Z zjit-opt-last-inline 18ce64d9d1) +ZJIT dev +PRISM [arm64-darwin25]
itr:   time
 #1: 2700ms
 #2:   17ms
 #3:   16ms
 #4:   16ms
 #5:   17ms
 #6:   16ms
 #7:   16ms
 #8:   17ms
 #9:   16ms
#10:   16ms
```

Fixes https://github.com/Shopify/ruby/issues/998.