### PR TITLE
ZJIT: Enable the inliner by default

### DIFF
--- a/.github/workflows/zjit-macos.yml
+++ b/.github/workflows/zjit-macos.yml
@@ -181,8 +181,15 @@ jobs:
     strategy:
       matrix:
         include:
+          # Run with the inliner enabled (on by default)
           # Test --call-threshold=2 with 2 iterations in total
           - ruby_opts: '--zjit-call-threshold=2'
+            bench_opts: '--warmup=1 --bench=1 --excludes=shipit'
+            configure: '--enable-zjit=dev_nodebug' # --enable-zjit=dev is too slow
+
+          # Run with inliner disabled #
+          # Test --call-threshold=2 with 2 iterations in total
+          - ruby_opts: '--zjit-inline-threshold=0 --zjit-call-threshold=2'
             bench_opts: '--warmup=1 --bench=1 --excludes=shipit'
             configure: '--enable-zjit=dev_nodebug' # --enable-zjit=dev is too slow
 

--- a/.github/workflows/zjit-ubuntu.yml
+++ b/.github/workflows/zjit-ubuntu.yml
@@ -59,19 +59,14 @@ jobs:
       matrix:
         include:
           - test_task: 'check'
-            run_opts: '--zjit-call-threshold=1'
-            specopts: '-T --zjit-call-threshold=1'
-            configure: '--enable-zjit=dev'
-
-          - test_task: 'check'
-            run_opts: '--zjit-call-threshold=1 --zjit-inline-threshold=30'
-            specopts: '-T --zjit-call-threshold=1 -T --zjit-inline-threshold=30'
-            configure: '--enable-zjit=dev'
-            continue-on-test_task: true
-
-          - test_task: 'check'
             run_opts: '--zjit-disable-hir-opt --zjit-call-threshold=1'
             specopts: '-T --zjit-disable-hir-opt -T --zjit-call-threshold=1'
+            configure: '--enable-zjit=dev'
+
+          ## Run with default options (inliner enabled) ##
+          - test_task: 'check'
+            run_opts: '--zjit-call-threshold=1'
+            specopts: '-T --zjit-call-threshold=1'
             configure: '--enable-zjit=dev'
 
             # The optimizer benefits from at least 1 iteration of profiling. Also, many
@@ -79,6 +74,26 @@ jobs:
           - test_task: 'btest'
             run_opts: '--zjit-call-threshold=2'
             configure: '--enable-zjit=dev'
+
+          - test_task: 'test-bundled-gems'
+            configure: '--enable-zjit=dev'
+            run_opts: '--zjit-call-threshold=1'
+
+          ## Run with inliner disabled ##
+          - test_task: 'check'
+            run_opts: '--zjit-inline-threshold=0 --zjit-call-threshold=1'
+            specopts: '-T --zjit-inline-threshold=0 -T --zjit-call-threshold=1'
+            configure: '--enable-zjit=dev'
+
+            # The optimizer benefits from at least 1 iteration of profiling. Also, many
+            # regression tests in bootstraptest/test_yjit.rb assume call-threshold=2.
+          - test_task: 'btest'
+            run_opts: '--zjit-inline-threshold=0 --zjit-call-threshold=2'
+            configure: '--enable-zjit=dev'
+
+          - test_task: 'test-bundled-gems'
+            configure: '--enable-zjit=dev'
+            run_opts: '--zjit-inline-threshold=0 --zjit-call-threshold=1'
 
           - test_task: 'zjit-check' # zjit-test + quick feedback of test_zjit.rb
             configure: '--enable-yjit --enable-zjit=dev'
@@ -90,10 +105,6 @@ jobs:
             configure: '--enable-zjit=dev --enable-yjit --with-gcc=clang-16'
             clang_path: '/usr/bin/clang-16'
             runs-on: 'ubuntu-24.04' # for clang-16
-
-          - test_task: 'test-bundled-gems'
-            configure: '--enable-zjit=dev'
-            run_opts: '--zjit-call-threshold=1'
 
     env:
       GITPULLOPTIONS: --no-tags origin ${{ github.ref }}
@@ -246,11 +257,14 @@ jobs:
     strategy:
       matrix:
         include:
-          # Test --call-threshold=2 with 2 iterations in total
+          # Test --call-threshold=2 with 2 iterations in total (inlining enabled)
           - ruby_opts: '--zjit-call-threshold=2'
             bench_opts: '--warmup=1 --bench=1 --excludes=shipit'
             configure: '--enable-zjit=dev_nodebug' # --enable-zjit=dev is too slow
-
+          # Test --call-threshold=2 with 2 iterations in total (inlining disabled)
+          - ruby_opts: '--zjit-inline-threshold=0 --zjit-call-threshold=2'
+            bench_opts: '--warmup=1 --bench=1 --excludes=shipit'
+            configure: '--enable-zjit=dev_nodebug' # --enable-zjit=dev is too slow
     runs-on: ubuntu-24.04
 
     if: >-

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -734,7 +734,7 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
         Insn::GetGlobal { id, state } => gen_getglobal(jit, asm, *id, &function.frame_state(*state)),
         &Insn::IsBlockParamModified { flags } => gen_is_block_param_modified(asm, opnd!(flags)),
         &Insn::GetBlockParam { ep_offset, level, state } => gen_getblockparam(jit, asm, ep_offset, level, &function.frame_state(state)),
-        &Insn::SetLocal { val, ep_offset, level } => no_output!(gen_setlocal(asm, opnd!(val), function.type_of(val), ep_offset, level)),
+        &Insn::SetLocal { val, ep_offset, level, .. } => no_output!(gen_setlocal(asm, opnd!(val), function.type_of(val), ep_offset, level)),
         Insn::GetConstant { klass, id, allow_nil, state } => gen_getconstant(jit, asm, opnd!(klass), *id, opnd!(allow_nil), &function.frame_state(*state)),
         Insn::GetConstantPath { ic, state } => gen_get_constant_path(jit, asm, *ic, &function.frame_state(*state)),
         Insn::GetClassVar { id, ic, state } => gen_getclassvar(jit, asm, *id, *ic, &function.frame_state(*state)),

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -1015,7 +1015,7 @@ pub enum Insn {
     /// Get the block parameter as a Proc.
     GetBlockParam { level: u32, ep_offset: u32, state: InsnId },
     /// Set a local variable in a higher scope or the heap
-    SetLocal { level: u32, ep_offset: u32, val: InsnId },
+    SetLocal { level: u32, ep_offset: u32, val: InsnId, state: InsnId },
     GetSpecialSymbol { symbol_type: SpecialBackrefSymbol, state: InsnId },
     GetSpecialNumber { nth: u64, state: InsnId },
 
@@ -1604,8 +1604,8 @@ impl Insn {
         Ok(())
     }
 
-    pub fn print<'a>(&self, ptr_map: &'a PtrPrintMap, iseq: Option<IseqPtr>) -> InsnPrinter<'a> {
-        InsnPrinter { inner: self.clone(), ptr_map, iseq }
+    pub fn print<'a>(&self, ptr_map: &'a PtrPrintMap, fun: Option<&'a Function>) -> InsnPrinter<'a> {
+        InsnPrinter { inner: self.clone(), ptr_map, fun }
     }
 
     // TODO(Jacob): Model SP. ie, all allocations modify stack size but using the effect for stack modification feels excessive
@@ -1831,9 +1831,9 @@ impl Insn {
 
 /// Print adaptor for [`Insn`]. See [`PtrPrintMap`].
 pub struct InsnPrinter<'a> {
+    fun: Option<&'a Function>,
     inner: Insn,
     ptr_map: &'a PtrPrintMap,
-    iseq: Option<IseqPtr>,
 }
 
 fn get_local_var_id(iseq: IseqPtr, level: u32, ep_offset: u32) -> ID {
@@ -2174,8 +2174,9 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
             Insn::GuardNoBitsSet { val, mask, .. } => { write!(f, "GuardNoBitsSet {val}, {}", mask.print(self.ptr_map)) },
             Insn::GuardLess { left, right, .. } => write!(f, "GuardLess {left}, {right}"),
             Insn::GuardGreaterEq { left, right, .. } => write!(f, "GuardGreaterEq {left}, {right}"),
-            &Insn::GetBlockParam { level, ep_offset, .. } => {
-                let name = get_local_var_name_for_printer(self.iseq, level, ep_offset)
+            &Insn::GetBlockParam { level, ep_offset, state, .. } => {
+                let iseq = self.fun.map(|fun| fun.frame_state(state).iseq);
+                let name = get_local_var_name_for_printer(iseq, level, ep_offset)
                     .map_or(String::new(), |x| format!("{x}, "));
                 write!(f, "GetBlockParam {name}l{level}, EP@{ep_offset}")
             },
@@ -2264,8 +2265,9 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
             &Insn::IsBlockParamModified { flags } => {
                 write!(f, "IsBlockParamModified {flags}")
             },
-            &Insn::SetLocal { val, level, ep_offset } => {
-                let name = get_local_var_name_for_printer(self.iseq, level, ep_offset).map_or(String::new(), |x| format!("{x}, "));
+            &Insn::SetLocal { val, level, ep_offset, state } => {
+                let iseq = self.fun.map(|fun| fun.frame_state(state).iseq);
+                let name = get_local_var_name_for_printer(iseq, level, ep_offset).map_or(String::new(), |x| format!("{x}, "));
                 write!(f, "SetLocal {name}l{level}, EP@{ep_offset}, {val}")
             },
             Insn::GetSpecialSymbol { symbol_type, .. } => write!(f, "GetSpecialSymbol {symbol_type:?}"),
@@ -6089,7 +6091,7 @@ impl Function {
                 };
 
 
-                let opcode = insn.print(&ptr_map, Some(self.iseq)).to_string();
+                let opcode = insn.print(&ptr_map, Some(self)).to_string();
 
                 // Collect inputs for a given instruction.
                 let mut inputs = Vec::new();
@@ -6797,7 +6799,7 @@ impl<'a> std::fmt::Display for FunctionPrinter<'a> {
                         write!(f, "{insn_id}:{} = ", insn_type.print(&self.ptr_map))?;
                     }
                 }
-                writeln!(f, "{}", insn.print(&self.ptr_map, Some(fun.iseq)))?;
+                writeln!(f, "{}", insn.print(&self.ptr_map, Some(fun)))?;
             }
         }
         Ok(())
@@ -8064,7 +8066,7 @@ fn add_iseq_to_hir(
                     let val = state.stack_pop()?;
                     if ep_escaped {
                         // Write the local using EP
-                        fun.push_insn(block, Insn::SetLocal { val, ep_offset, level: 0 });
+                        fun.push_insn(block, Insn::SetLocal { val, ep_offset, level: 0, state: exit_id });
                     } else if local_inval {
                         // If there has been any non-leaf call since JIT entry or the last patch point,
                         // add a patch point to make sure locals have not been escaped.
@@ -8082,7 +8084,7 @@ fn add_iseq_to_hir(
                 }
                 YARVINSN_setlocal_WC_1 => {
                     let ep_offset = get_arg(pc, 0).as_u32();
-                    fun.push_insn(block, Insn::SetLocal { val: state.stack_pop()?, ep_offset, level: 1 });
+                    fun.push_insn(block, Insn::SetLocal { val: state.stack_pop()?, ep_offset, level: 1, state: exit_id });
                 }
                 YARVINSN_getlocal => {
                     let ep_offset = get_arg(pc, 0).as_u32();
@@ -8103,13 +8105,13 @@ fn add_iseq_to_hir(
                 YARVINSN_setlocal => {
                     let ep_offset = get_arg(pc, 0).as_u32();
                     let level = get_arg(pc, 1).as_u32();
-                    fun.push_insn(block, Insn::SetLocal { val: state.stack_pop()?, ep_offset, level });
+                    fun.push_insn(block, Insn::SetLocal { val: state.stack_pop()?, ep_offset, level, state: exit_id });
                 }
                 YARVINSN_setblockparam => {
                     let ep_offset = get_arg(pc, 0).as_u32();
                     let level = get_arg(pc, 1).as_u32();
                     let val = state.stack_pop()?;
-                    fun.push_insn(block, Insn::SetLocal { val, ep_offset, level });
+                    fun.push_insn(block, Insn::SetLocal { val, ep_offset, level, state: exit_id });
                     if level == 0 {
                         state.setlocal(ep_offset, val);
                     }

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -2,9 +2,9 @@
 mod hir_opt_tests {
     use crate::hir::*;
 
+    use crate::hir::tests::hir_build_tests::assert_contains_opcode;
     use crate::{hir_strings, options::*};
     use insta::assert_snapshot;
-    use crate::hir::tests::hir_build_tests::assert_contains_opcode;
 
     #[track_caller]
     fn hir_string_function(function: &Function) -> String {
@@ -1467,34 +1467,6 @@ mod hir_opt_tests {
     }
 
     #[test]
-    fn test_optimize_top_level_call_into_send_direct() {
-        eval("
-            def foo = []
-            def test
-              foo
-            end
-            test; test
-        ");
-        assert_snapshot!(hir_string("test"), @"
-        fn test@<compiled>:4:
-        bb1():
-          EntryPoint interpreter
-          v1:BasicObject = LoadSelf
-          Jump bb3(v1)
-        bb2():
-          EntryPoint JIT(0)
-          v4:BasicObject = LoadArg :self@0
-          Jump bb3(v4)
-        bb3(v6:BasicObject):
-          PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
-          v18:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
-          v19:BasicObject = SendDirect v18, 0x1038, :foo (0x1048)
-          CheckInterrupts
-          Return v19
-        ");
-    }
-
-    #[test]
     fn test_optimize_send_without_block_to_aliased_iseq() {
         eval("
             def foo = 1
@@ -1549,13 +1521,7 @@ mod hir_opt_tests {
     }
 
     #[test]
-    fn test_no_inline_nonparam_local_return() {
-        // Methods that return non-parameter local variables should NOT be inlined,
-        // because the local variable index will be out of bounds for args.
-        // The method must have a parameter so param_size > 0, and return a local
-        // that's not a parameter so local_idx >= param_size.
-        // Use dead code (if false) to create a local without initialization instructions,
-        // resulting in just getlocal + leave which enters the inlining code path.
+    fn test_inline_nonparam_local_return() {
         eval("
             def foo(a)
               if false
@@ -1580,9 +1546,11 @@ mod hir_opt_tests {
           v11:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
           v20:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
-          v21:BasicObject = SendDirect v20, 0x1038, :foo (0x1048), v11
+          v32:NilClass = Const Value(nil)
+          PushInlineFrame v20 (0x1038), v11
           CheckInterrupts
-          Return v21
+          PopInlineFrame
+          Return v32
         ");
     }
 
@@ -1722,7 +1690,7 @@ mod hir_opt_tests {
     }
 
     #[test]
-    fn test_optimize_private_top_level_call() {
+    fn test_optimize_private_call() {
         eval("
             def foo = []
             private :foo
@@ -1744,14 +1712,16 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
           v18:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
-          v19:BasicObject = SendDirect v18, 0x1038, :foo (0x1048)
+          PushInlineFrame v18 (0x1038)
+          v24:ArrayExact = NewArray
           CheckInterrupts
-          Return v19
+          PopInlineFrame
+          Return v24
         ");
     }
 
     #[test]
-    fn test_optimize_top_level_call_with_overloaded_cme() {
+    fn test_optimize_call_with_overloaded_cme() {
         eval("
             def test
               Integer(3)
@@ -1772,14 +1742,16 @@ mod hir_opt_tests {
           v11:Fixnum[3] = Const Value(3)
           PatchPoint MethodRedefined(Object@0x1000, Integer@0x1008, cme:0x1010)
           v20:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
-          v21:BasicObject = SendDirect v20, 0x1038, :Integer (0x1048), v11
+          PushInlineFrame v20 (0x1038), v11
+          v27:BasicObject = InvokeBuiltin rb_f_integer1, v20, v11
           CheckInterrupts
-          Return v21
+          PopInlineFrame
+          Return v27
         ");
     }
 
     #[test]
-    fn test_optimize_top_level_call_with_args_into_send_direct() {
+    fn test_optimize_call_with_args() {
         eval("
             def foo(a, b) = []
             def test
@@ -1802,46 +1774,16 @@ mod hir_opt_tests {
           v13:Fixnum[2] = Const Value(2)
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
           v22:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
-          v23:BasicObject = SendDirect v22, 0x1038, :foo (0x1048), v11, v13
+          PushInlineFrame v22 (0x1038), v11, v13
+          v30:ArrayExact = NewArray
           CheckInterrupts
-          Return v23
+          PopInlineFrame
+          Return v30
         ");
     }
 
     #[test]
-    fn test_optimize_top_level_sends_into_send_direct() {
-        eval("
-            def foo = []
-            def bar = []
-            def test
-              foo
-              bar
-            end
-            test; test
-        ");
-        assert_snapshot!(hir_string("test"), @"
-        fn test@<compiled>:5:
-        bb1():
-          EntryPoint interpreter
-          v1:BasicObject = LoadSelf
-          Jump bb3(v1)
-        bb2():
-          EntryPoint JIT(0)
-          v4:BasicObject = LoadArg :self@0
-          Jump bb3(v4)
-        bb3(v6:BasicObject):
-          PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
-          v23:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
-          v24:BasicObject = SendDirect v23, 0x1038, :foo (0x1048)
-          PatchPoint MethodRedefined(Object@0x1000, bar@0x1050, cme:0x1058)
-          v27:BasicObject = SendDirect v23, 0x1038, :bar (0x1048)
-          CheckInterrupts
-          Return v27
-        ");
-    }
-
-    #[test]
-    fn test_optimize_send_direct_no_optionals_passed() {
+    fn test_optimize_send_no_optionals_passed() {
         eval("
             def foo(a=1, b=2) = a + b
             def test = foo
@@ -1860,14 +1802,19 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
           v18:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
-          v19:BasicObject = SendDirect v18, 0x1038, :foo (0x1048)
+          PushInlineFrame v18 (0x1038)
+          v25:Fixnum[1] = Const Value(1)
+          v33:Fixnum[2] = Const Value(2)
+          PatchPoint MethodRedefined(Integer@0x1040, +@0x1048, cme:0x1050)
+          v60:Fixnum[3] = Const Value(3)
           CheckInterrupts
-          Return v19
+          PopInlineFrame
+          Return v60
         ");
     }
 
     #[test]
-    fn test_optimize_send_direct_one_optional_passed() {
+    fn test_optimize_send_one_optional_passed() {
         eval("
             def foo(a=1, b=2) = a + b
             def test = foo 3
@@ -1887,14 +1834,18 @@ mod hir_opt_tests {
           v11:Fixnum[3] = Const Value(3)
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
           v20:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
-          v21:BasicObject = SendDirect v20, 0x1038, :foo (0x1048), v11
+          PushInlineFrame v20 (0x1038), v11
+          v35:Fixnum[2] = Const Value(2)
+          PatchPoint MethodRedefined(Integer@0x1040, +@0x1048, cme:0x1050)
+          v61:Fixnum[5] = Const Value(5)
           CheckInterrupts
-          Return v21
+          PopInlineFrame
+          Return v61
         ");
     }
 
     #[test]
-    fn test_optimize_send_direct_all_optionals_passed() {
+    fn test_optimize_send_all_optionals_passed() {
         eval("
             def foo(a=1, b=2) = a + b
             def test = foo 3, 4
@@ -1915,9 +1866,12 @@ mod hir_opt_tests {
           v13:Fixnum[4] = Const Value(4)
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
           v22:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
-          v23:BasicObject = SendDirect v22, 0x1038, :foo (0x1048), v11, v13
+          PushInlineFrame v22 (0x1038), v11, v13
+          PatchPoint MethodRedefined(Integer@0x1040, +@0x1048, cme:0x1050)
+          v62:Fixnum[7] = Const Value(7)
           CheckInterrupts
-          Return v23
+          PopInlineFrame
+          Return v62
         ");
     }
 
@@ -1942,19 +1896,28 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint MethodRedefined(Object@0x1000, target@0x1008, cme:0x1010)
           v44:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
-          v45:BasicObject = SendDirect v44, 0x1038, :target (0x1048)
+          PushInlineFrame v44 (0x1038)
+          v56:Fixnum[1] = Const Value(1)
+          v66:Fixnum[2] = Const Value(2)
+          v76:Fixnum[3] = Const Value(3)
+          v86:Fixnum[4] = Const Value(4)
+          v101:ArrayExact = NewArray v56, v66, v76, v86
+          CheckInterrupts
+          PopInlineFrame
           v14:Fixnum[10] = Const Value(10)
           v16:Fixnum[20] = Const Value(20)
           v18:Fixnum[30] = Const Value(30)
-          PatchPoint MethodRedefined(Object@0x1000, target@0x1008, cme:0x1010)
-          v48:BasicObject = SendDirect v44, 0x1038, :target (0x1048), v14, v16, v18
+          PushInlineFrame v44 (0x1038), v14, v16, v18
+          v151:Fixnum[4] = Const Value(4)
+          v166:ArrayExact = NewArray v14, v16, v18, v151
+          PopInlineFrame
           v24:Fixnum[10] = Const Value(10)
           v26:Fixnum[20] = Const Value(20)
           v28:Fixnum[30] = Const Value(30)
           v30:Fixnum[40] = Const Value(40)
           v32:Fixnum[50] = Const Value(50)
           v34:BasicObject = Send v44, :target, v24, v26, v28, v30, v32 # SendFallbackReason: Argument count does not match parameter count
-          v37:ArrayExact = NewArray v45, v48, v34
+          v37:ArrayExact = NewArray v101, v166, v34
           CheckInterrupts
           Return v37
         ");
@@ -3839,7 +3802,7 @@ mod hir_opt_tests {
     }
 
     #[test]
-    fn test_send_direct_to_instance_method() {
+    fn test_send_to_instance_method() {
         eval("
             class C
               def foo = []
@@ -3868,14 +3831,16 @@ mod hir_opt_tests {
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
           v23:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C] recompile
-          v24:BasicObject = SendDirect v23, 0x1040, :foo (0x1050)
+          PushInlineFrame v23 (0x1040)
+          v29:ArrayExact = NewArray
           CheckInterrupts
-          Return v24
+          PopInlineFrame
+          Return v29
         ");
     }
 
     #[test]
-    fn test_send_direct_iseq_with_block() {
+    fn test_send_iseq_with_block() {
         let result = eval("
             def foo(a, b, &block) = block.call(a, b)
             def test = foo(1, 2) { |a, b| a + b }
@@ -3898,9 +3863,25 @@ mod hir_opt_tests {
           v13:Fixnum[2] = Const Value(2)
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
           v22:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
-          v23:BasicObject = SendDirect v22, 0x1038, :foo (0x1048), v11, v13
+          v51:NilClass = Const Value(nil)
+          PushInlineFrame v22 (0x1038), v11, v13
+          v33:CPtr = GetEP 0
+          v34:CUInt64 = LoadField v33, :VM_ENV_DATA_INDEX_FLAGS@0x1040
+          v35:CBool = IsBlockParamModified v34
+          CondBranch v35, bb6(), bb7()
+        bb6():
+          v37:BasicObject = LoadField v33, :block@0x1041
+          Jump bb8(v37, v37)
+        bb7():
+          v39:CInt64 = LoadField v33, :VM_ENV_DATA_INDEX_SPECVAL@0x1042
+          v40:CInt64 = GuardAnyBitSet v39, CUInt64(1) recompile
+          v41:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1048))
+          Jump bb8(v41, v51)
+        bb8(v31:BasicObject, v32:BasicObject):
+          v46:BasicObject = Send v31, :call, v11, v13 # SendFallbackReason: SendWithoutBlock: unsupported optimized method type BlockCall
           CheckInterrupts
-          Return v23
+          PopInlineFrame
+          Return v46
         ");
     }
 
@@ -4039,9 +4020,11 @@ mod hir_opt_tests {
           v11:Fixnum[10] = Const Value(10)
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
           v20:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
-          v21:BasicObject = SendDirect v20, 0x1038, :foo (0x1048), v11
+          PushInlineFrame v20 (0x1038), v11
+          v27:Fixnum[80] = Const Value(80)
           CheckInterrupts
-          Return v21
+          PopInlineFrame
+          Return v11
         ");
     }
 
@@ -4069,9 +4052,13 @@ mod hir_opt_tests {
           v13:Fixnum[20] = Const Value(20)
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
           v22:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
-          v23:BasicObject = SendDirect v22, 0x1038, :foo (0x1048), v11, v13
+          PushInlineFrame v22 (0x1038), v11, v13
+          v30:Fixnum[80] = Const Value(80)
+          PatchPoint MethodRedefined(Integer@0x1040, +@0x1048, cme:0x1050)
+          v66:Fixnum[110] = Const Value(110)
           CheckInterrupts
-          Return v23
+          PopInlineFrame
+          Return v66
         ");
     }
 
@@ -4098,9 +4085,12 @@ mod hir_opt_tests {
           v13:Fixnum[2] = Const Value(2)
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
           v22:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
-          v23:BasicObject = SendDirect v22, 0x1038, :foo (0x1048), v11, v13
+          v38:Fixnum[0] = Const Value(0)
+          PushInlineFrame v22 (0x1038), v11, v13
+          v33:ArrayExact = NewArray v11, v13
           CheckInterrupts
-          Return v23
+          PopInlineFrame
+          Return v33
         ");
     }
 
@@ -4128,9 +4118,12 @@ mod hir_opt_tests {
           v15:Fixnum[2] = Const Value(2)
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
           v25:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
-          v26:BasicObject = SendDirect v25, 0x1038, :foo (0x1048), v13, v15, v11
+          v43:Fixnum[0] = Const Value(0)
+          PushInlineFrame v25 (0x1038), v13, v15, v11
+          v38:ArrayExact = NewArray v13, v15, v11
           CheckInterrupts
-          Return v26
+          PopInlineFrame
+          Return v38
         ");
     }
 
@@ -4158,9 +4151,12 @@ mod hir_opt_tests {
           v15:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
           v25:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
-          v26:BasicObject = SendDirect v25, 0x1038, :foo (0x1048), v11, v15, v13
+          v43:Fixnum[0] = Const Value(0)
+          PushInlineFrame v25 (0x1038), v11, v15, v13
+          v38:ArrayExact = NewArray v11, v15, v13
           CheckInterrupts
-          Return v26
+          PopInlineFrame
+          Return v38
         ");
     }
 
@@ -4187,9 +4183,12 @@ mod hir_opt_tests {
           v13:Fixnum[2] = Const Value(2)
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
           v22:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
-          v23:BasicObject = SendDirect v22, 0x1038, :foo (0x1048), v11, v13
+          v38:Fixnum[0] = Const Value(0)
+          PushInlineFrame v22 (0x1038), v11, v13
+          v33:ArrayExact = NewArray v11, v13
           CheckInterrupts
-          Return v23
+          PopInlineFrame
+          Return v33
         ");
     }
 
@@ -4217,15 +4216,21 @@ mod hir_opt_tests {
           v15:Fixnum[4] = Const Value(4)
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
           v37:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
-          v38:BasicObject = SendDirect v37, 0x1038, :foo (0x1048), v11, v13, v15
+          v71:Fixnum[0] = Const Value(0)
+          PushInlineFrame v37 (0x1038), v11, v13, v15
+          v51:Fixnum[2] = Const Value(2)
+          v65:ArrayExact = NewArray v51, v13
+          CheckInterrupts
+          PopInlineFrame
           v20:Fixnum[1] = Const Value(1)
           v22:Fixnum[2] = Const Value(2)
           v24:Fixnum[4] = Const Value(4)
           v26:Fixnum[3] = Const Value(3)
-          PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
-          v42:BasicObject = SendDirect v37, 0x1038, :foo (0x1048), v20, v22, v26, v24
-          v30:ArrayExact = NewArray v38, v42
-          CheckInterrupts
+          v103:Fixnum[0] = Const Value(0)
+          PushInlineFrame v37 (0x1038), v20, v22, v26, v24
+          v98:ArrayExact = NewArray v22, v26
+          PopInlineFrame
+          v30:ArrayExact = NewArray v65, v98
           Return v30
         ");
     }
@@ -4254,15 +4259,21 @@ mod hir_opt_tests {
           v34:Fixnum[4] = Const Value(4)
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
           v37:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
-          v38:BasicObject = SendDirect v37, 0x1038, :foo (0x1048), v11, v13, v34
+          v73:Fixnum[0] = Const Value(0)
+          PushInlineFrame v37 (0x1038), v11, v13, v34
+          v51:Fixnum[2] = Const Value(2)
+          v67:ArrayExact = NewArray v11, v51, v13, v34
+          CheckInterrupts
+          PopInlineFrame
           v18:Fixnum[1] = Const Value(1)
           v20:Fixnum[2] = Const Value(2)
           v22:Fixnum[40] = Const Value(40)
           v24:Fixnum[30] = Const Value(30)
-          PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
-          v42:BasicObject = SendDirect v37, 0x1038, :foo (0x1048), v18, v20, v24, v22
-          v28:ArrayExact = NewArray v38, v42
-          CheckInterrupts
+          v107:Fixnum[0] = Const Value(0)
+          PushInlineFrame v37 (0x1038), v18, v20, v24, v22
+          v102:ArrayExact = NewArray v18, v20, v24, v22
+          PopInlineFrame
+          v28:ArrayExact = NewArray v67, v102
           Return v28
         ");
     }
@@ -4331,9 +4342,11 @@ mod hir_opt_tests {
           v11:Fixnum[2] = Const Value(2)
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
           v20:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
-          v21:BasicObject = SendDirect v20, 0x1038, :foo (0x1048), v11
+          v32:Fixnum[0] = Const Value(0)
+          PushInlineFrame v20 (0x1038), v11
           CheckInterrupts
-          Return v21
+          PopInlineFrame
+          Return v11
         ");
     }
 
@@ -4446,9 +4459,14 @@ mod hir_opt_tests {
           v17:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
           v20:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
-          v21:BasicObject = SendDirect v20, 0x1038, :foo (0x1048), v17
+          v37:Fixnum[0] = Const Value(0)
+          PushInlineFrame v20 (0x1038), v17
+          v29:Fixnum[1] = Const Value(1)
+          PatchPoint MethodRedefined(Integer@0x1040, +@0x1048, cme:0x1050)
+          v46:Fixnum[2] = Const Value(2)
           CheckInterrupts
-          Return v21
+          PopInlineFrame
+          Return v46
         ");
     }
 
@@ -4748,8 +4766,15 @@ mod hir_opt_tests {
           v48:ObjectSubclass[class_exact:C] = ObjectAllocClass C:VALUE(0x1008)
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, initialize@0x1038, cme:0x1040)
-          v52:BasicObject = SendDirect v48, 0x1068, :initialize (0x1078), v17
+          PushInlineFrame v48 (0x1068), v17
+          v62:CShape = LoadField v48, :shape_id@0x1070
+          v63:CShape[0x1071] = GuardBitEquals v62, CShape(0x1071) recompile
+          StoreField v48, :@x@0x1072, v17
+          WriteBarrier v48, v17
+          v66:CShape[0x1073] = Const CShape(0x1073)
+          StoreField v48, :shape_id@0x1070, v66
           CheckInterrupts
+          PopInlineFrame
           Return v48
         ");
     }
@@ -4842,8 +4867,24 @@ mod hir_opt_tests {
           v46:Fixnum[0] = Const Value(0)
           PatchPoint NoSingletonClass(Hash@0x1008)
           PatchPoint MethodRedefined(Hash@0x1008, initialize@0x1038, cme:0x1040)
-          v51:BasicObject = SendDirect v45, 0x1068, :initialize (0x1078), v46
+          v94:Fixnum[0] = Const Value(0)
+          v95:NilClass = Const Value(nil)
+          PushInlineFrame v45 (0x1068), v46
+          v61:TrueClass = Const Value(true)
+          v79:CPtr = GetEP 0
+          v80:CUInt64 = LoadField v79, :VM_ENV_DATA_INDEX_FLAGS@0x1070
+          v81:CBool = IsBlockParamModified v80
+          CondBranch v81, bb10(), bb11()
+        bb10():
+          v83:BasicObject = LoadField v79, :block@0x1071
+          Jump bb12(v83)
+        bb11():
+          v85:BasicObject = GetBlockParam :block, l0, EP@4
+          Jump bb12(v85)
+        bb12(v78:BasicObject):
+          v88:BasicObject = InvokeBuiltin rb_hash_init, v45, v46, v61, v61, v78
           CheckInterrupts
+          PopInlineFrame
           Return v45
         ");
         assert_snapshot!(inspect("test"), @"{}");
@@ -7330,9 +7371,11 @@ mod hir_opt_tests {
           v13:Fixnum[10] = Const Value(10)
           PatchPoint NoSingletonClass(Array@0x1008)
           PatchPoint MethodRedefined(Array@0x1008, []@0x1010, cme:0x1018)
-          v24:BasicObject = SendDirect v11, 0x1040, :[] (0x1050), v13
+          PushInlineFrame v11 (0x1040), v13
+          v30:ArrayExact = NewArray
           CheckInterrupts
-          Return v24
+          PopInlineFrame
+          Return v30
         ");
     }
 
@@ -7390,9 +7433,11 @@ mod hir_opt_tests {
           v11:ArrayExact = ArrayDup v10
           PatchPoint NoSingletonClass(Array@0x1008)
           PatchPoint MethodRedefined(Array@0x1008, max@0x1010, cme:0x1018)
-          v21:BasicObject = SendDirect v11, 0x1040, :max (0x1050)
+          PushInlineFrame v11 (0x1040)
+          v26:ArrayExact = NewArray
           CheckInterrupts
-          Return v21
+          PopInlineFrame
+          Return v26
         ");
     }
 
@@ -9593,7 +9638,7 @@ mod hir_opt_tests {
     }
 
     #[test]
-    fn test_send_direct_iseq_with_block_no_callee_block_param() {
+    fn test_send_iseq_with_block_no_callee_block_param() {
         let result = eval(r#"
             def foo
               yield 1
@@ -9616,9 +9661,12 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
           v18:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
-          v19:BasicObject = SendDirect v18, 0x1038, :foo (0x1048)
+          PushInlineFrame v18 (0x1038)
+          v24:Fixnum[1] = Const Value(1)
+          v26:BasicObject = InvokeBlock v24 # SendFallbackReason: InvokeBlock: not yet specialized
           CheckInterrupts
-          Return v19
+          PopInlineFrame
+          Return v26
         ");
     }
 
@@ -9646,9 +9694,49 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
           v18:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
-          v19:BasicObject = SendDirect v18, 0x1038, :foo (0x1048)
+          v71:NilClass = Const Value(nil)
+          PushInlineFrame v18 (0x1038)
+          v27:CPtr = GetEP 0
+          v28:CUInt64 = LoadField v27, :VM_ENV_DATA_INDEX_FLAGS@0x1040
+          v29:CBool = IsBlockParamModified v28
+          CondBranch v29, bb7(), bb8()
+        bb7():
+          v31:BasicObject = LoadField v27, :blk@0x1041
+          Jump bb9(v31, v31)
+        bb8():
+          v33:CInt64 = LoadField v27, :VM_ENV_DATA_INDEX_SPECVAL@0x1042
+          v34:CInt64[0] = GuardBitEquals v33, CInt64(0) recompile
+          v35:NilClass = Const Value(nil)
+          Jump bb9(v35, v71)
+        bb9(v25:BasicObject, v26:BasicObject):
           CheckInterrupts
-          Return v19
+          v39:CBool = Test v25
+          CondBranch v39, bb10(), bb6(v18, v26)
+        bb10():
+          v46:CPtr = GetEP 0
+          v47:CUInt64 = LoadField v46, :VM_ENV_DATA_INDEX_FLAGS@0x1040
+          v48:CBool = IsBlockParamModified v47
+          CondBranch v48, bb11(), bb12()
+        bb11():
+          v50:BasicObject = LoadField v46, :blk@0x1041
+          Jump bb13(v50, v50)
+        bb12():
+          v52:CInt64 = LoadField v46, :VM_ENV_DATA_INDEX_SPECVAL@0x1042
+          v53:CInt64 = GuardAnyBitSet v52, CUInt64(1) recompile
+          v54:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1048))
+          Jump bb13(v54, v26)
+        bb13(v44:BasicObject, v45:BasicObject):
+          v57:BasicObject = Send v44, :call # SendFallbackReason: SendWithoutBlock: no profile data available
+          CheckInterrupts
+          Jump bb4(v57)
+        bb6(v62:ObjectSubclass[class_exact*:Object@VALUE(0x1000)], v63:BasicObject):
+          v66:Fixnum[42] = Const Value(42)
+          CheckInterrupts
+          Jump bb4(v66)
+        bb4(v72:BasicObject):
+          PopInlineFrame
+          CheckInterrupts
+          Return v72
         ");
     }
 
@@ -9677,9 +9765,12 @@ mod hir_opt_tests {
           PatchPoint SingleRactorMode
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
           v19:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
-          v20:BasicObject = SendDirect v19, 0x1038, :foo (0x1048)
+          v48:NilClass = Const Value(nil)
+          PushInlineFrame v19 (0x1038)
           CheckInterrupts
-          Return v20
+          v43:Fixnum[42] = Const Value(42)
+          PopInlineFrame
+          Return v43
         ");
     }
 
@@ -15417,7 +15508,7 @@ mod hir_opt_tests {
     }
 
     #[test]
-    fn test_invokesuper_to_iseq_optimizes_to_direct() {
+    fn test_invokesuper_to_iseq_optimizes() {
         eval("
             class A
               def foo
@@ -15437,7 +15528,6 @@ mod hir_opt_tests {
         // A Ruby method as the target of `super` should optimize provided no block is given.
         let hir = hir_string_proc("B.new.method(:foo)");
         assert!(!hir.contains("InvokeSuper "), "InvokeSuper should optimize to SendDirect but got:\n{hir}");
-        assert!(hir.contains("SendDirect"), "Should optimize to SendDirect for call without args or block:\n{hir}");
 
         assert_snapshot!(hir, @"
         fn foo@<compiled>:10:
@@ -15456,9 +15546,12 @@ mod hir_opt_tests {
           v20:CallableMethodEntry[VALUE(0x1040)] = GuardBitEquals v19, Value(VALUE(0x1040))
           v21:RubyValue = LoadField v18, :VM_ENV_DATA_INDEX_SPECVAL@0x1048
           v22:FalseClass = GuardBitEquals v21, Value(false)
-          v23:BasicObject = SendDirect v6, 0x1050, :foo (0x1060)
+          PushInlineFrame v6 (0x1050)
+          v28:StringExact[VALUE(0x1058)] = Const Value(VALUE(0x1058))
+          v29:StringExact = StringCopy v28
           CheckInterrupts
-          Return v23
+          PopInlineFrame
+          Return v29
         ");
     }
 
@@ -15487,7 +15580,7 @@ mod hir_opt_tests {
     }
 
     #[test]
-    fn test_invokesuper_with_positional_args_optimizes_to_direct() {
+    fn test_invokesuper_with_positional_args_optimizes() {
         eval("
             class A
               def foo(x)
@@ -15506,7 +15599,6 @@ mod hir_opt_tests {
 
         let hir = hir_string_proc("B.new.method(:foo)");
         assert!(!hir.contains("InvokeSuper "), "InvokeSuper should optimize to SendDirect but got:\n{hir}");
-        assert!(hir.contains("SendDirect"), "Should optimize to SendDirect for call without args or block:\n{hir}");
 
         assert_snapshot!(hir, @"
         fn foo@<compiled>:10:
@@ -15528,13 +15620,17 @@ mod hir_opt_tests {
           v30:CallableMethodEntry[VALUE(0x1048)] = GuardBitEquals v29, Value(VALUE(0x1048))
           v31:RubyValue = LoadField v28, :VM_ENV_DATA_INDEX_SPECVAL@0x1050
           v32:FalseClass = GuardBitEquals v31, Value(false)
-          v33:BasicObject = SendDirect v9, 0x1058, :foo (0x1068), v10
-          v18:Fixnum[1] = Const Value(1)
-          PatchPoint MethodRedefined(Integer@0x1070, +@0x1078, cme:0x1080)
-          v36:Fixnum = GuardType v33, Fixnum recompile
-          v37:Fixnum = FixnumAdd v36, v18
+          PushInlineFrame v9 (0x1058), v10
+          v40:Fixnum[2] = Const Value(2)
+          PatchPoint MethodRedefined(Integer@0x1060, *@0x1068, cme:0x1070)
+          v54:Fixnum = GuardType v10, Fixnum recompile
+          v55:Fixnum = FixnumMult v54, v40
           CheckInterrupts
-          Return v37
+          PopInlineFrame
+          v18:Fixnum[1] = Const Value(1)
+          PatchPoint MethodRedefined(Integer@0x1060, +@0x1098, cme:0x10a0)
+          v59:Fixnum = FixnumAdd v55, v18
+          Return v59
         ");
     }
 
@@ -16856,7 +16952,7 @@ mod hir_opt_tests {
 
         // After profiling via the side exit, rebuilding HIR should now
         // have a SendDirect for greet_recompile instead of SideExit.
-        assert_snapshot!(hir_string("test_no_profile_recompile"), @r"
+        assert_snapshot!(hir_string("test_no_profile_recompile"), @"
         fn test_no_profile_recompile@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -16879,11 +16975,14 @@ mod hir_opt_tests {
           v23:Fixnum[42] = Const Value(42)
           PatchPoint MethodRedefined(Object@0x1008, greet_recompile@0x1010, cme:0x1018)
           v43:ObjectSubclass[class_exact*:Object@VALUE(0x1008)] = GuardType v9, ObjectSubclass[class_exact*:Object@VALUE(0x1008)] recompile
-          v44:BasicObject = SendDirect v43, 0x1040, :greet_recompile (0x1050), v23
+          PushInlineFrame v43 (0x1040), v23
+          PatchPoint MethodRedefined(Integer@0x1048, to_s@0x1050, cme:0x1058)
+          v63:StringExact = CCallVariadic v23, :Integer#to_s@0x1080
           CheckInterrupts
-          Return v44
+          PopInlineFrame
+          Return v63
         bb4(v30:BasicObject, v31:Falsy):
-          v35:StringExact[VALUE(0x1058)] = Const Value(VALUE(0x1058))
+          v35:StringExact[VALUE(0x1088)] = Const Value(VALUE(0x1088))
           v36:StringExact = StringCopy v35
           CheckInterrupts
           Return v36
@@ -16968,6 +17067,8 @@ mod hir_opt_tests {
         // the HIR. The auto-compile creates version 1, and hir_string() creates version 2
         // (= MAX_ISEQ_VERSIONS), so this is the final version.
         set_call_threshold(3);
+        set_inline_threshold(0);
+
         eval("
             def greet_final(x) = x.to_s
             def test_final_version(flag)
@@ -16983,7 +17084,7 @@ mod hir_opt_tests {
         eval("3.times { test_final_version(false) }");
 
         // On the final version, greet_final should be a Send fallback, not a SideExit.
-        assert_snapshot!(hir_string("test_final_version"), @r"
+        assert_snapshot!(hir_string("test_final_version"), @"
         fn test_final_version@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -17833,6 +17934,7 @@ mod hir_opt_tests {
 
     #[test]
     fn test_trigger_guard_type_recompilation() {
+        set_inline_threshold(0);
         eval("
             class C
               def f(x)
@@ -17864,7 +17966,6 @@ mod hir_opt_tests {
             # Do this enough times to cause a recompilation
             num_to_compile.times { c.f(1.5) }
         ");
-
         let final_hir = hir_string_proc("C.new.method(:f)");
 
         assert_snapshot!(format!("{intermediate_hir}\n{final_hir}"), @"

--- a/zjit/src/hir/tests.rs
+++ b/zjit/src/hir/tests.rs
@@ -107,7 +107,7 @@ mod snapshot_tests {
     }
 
     #[test]
-    fn test_send_direct_with_reordered_kwargs_has_snapshot() {
+    fn test_send_with_reordered_kwargs_has_snapshot() {
         eval("
             def foo(a:, b:, c:) = [a, b, c]
             def test = foo(c: 3, a: 1, b: 2)
@@ -136,16 +136,19 @@ mod snapshot_tests {
           v23:Any = Snapshot FrameState { pc: 0x1008, stack: [v6, v13, v15, v11], locals: [] }
           PatchPoint MethodRedefined(Object@0x1010, foo@0x1018, cme:0x1020)
           v25:ObjectSubclass[class_exact*:Object@VALUE(0x1010)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1010)] recompile
-          v26:BasicObject = SendDirect v25, 0x1048, :foo (0x1058), v13, v15, v11
-          v18:Any = Snapshot FrameState { pc: 0x1060, stack: [v26], locals: [] }
-          PatchPoint NoTracePoint
+          v43:Fixnum[0] = Const Value(0)
+          PushInlineFrame v25 (0x1048), v13, v15, v11
+          v37:Any = Snapshot FrameState { pc: 0x1050, stack: [v13, v15, v11], locals: [a=v13, b=v15, c=v11, ID(0)=v43], caller: v23 }
+          v38:ArrayExact = NewArray v13, v15, v11
+          v39:Any = Snapshot FrameState { pc: 0x1058, stack: [v38], locals: [a=v13, b=v15, c=v11, ID(0)=v43], caller: v23 }
           CheckInterrupts
-          Return v26
+          PopInlineFrame
+          Return v38
         ");
     }
 
     #[test]
-    fn test_send_direct_with_kwargs_in_order_has_snapshot() {
+    fn test_send_with_kwargs_in_order_has_snapshot() {
         eval("
             def foo(a:, b:) = [a, b]
             def test = foo(a: 1, b: 2)
@@ -172,11 +175,14 @@ mod snapshot_tests {
           v14:Any = Snapshot FrameState { pc: 0x1008, stack: [v6, v11, v13], locals: [] }
           PatchPoint MethodRedefined(Object@0x1010, foo@0x1018, cme:0x1020)
           v22:ObjectSubclass[class_exact*:Object@VALUE(0x1010)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1010)] recompile
-          v23:BasicObject = SendDirect v22, 0x1048, :foo (0x1058), v11, v13
-          v16:Any = Snapshot FrameState { pc: 0x1060, stack: [v23], locals: [] }
-          PatchPoint NoTracePoint
+          v38:Fixnum[0] = Const Value(0)
+          PushInlineFrame v22 (0x1048), v11, v13
+          v32:Any = Snapshot FrameState { pc: 0x1050, stack: [v11, v13], locals: [a=v11, b=v13, ID(0)=v38], caller: v14 }
+          v33:ArrayExact = NewArray v11, v13
+          v34:Any = Snapshot FrameState { pc: 0x1058, stack: [v33], locals: [a=v11, b=v13, ID(0)=v38], caller: v14 }
           CheckInterrupts
-          Return v23
+          PopInlineFrame
+          Return v33
         ");
     }
 

--- a/zjit/src/options.rs
+++ b/zjit/src/options.rs
@@ -25,11 +25,15 @@ pub const DEFAULT_CALL_THRESHOLD: CallThreshold = 30;
 pub type CallThreshold = u64;
 
 /// Default --zjit-inline-threshold
-pub const DEFAULT_INLINE_THRESHOLD: InlineThreshold = 0;
+/// TODO (nirvdrum 2026-06-25): 30 has proven to work well with ruby-bench, but we should finely
+/// tune across more workloads.
+pub const DEFAULT_INLINE_THRESHOLD: InlineThreshold = 30;
 pub type InlineThreshold = usize;
 
 /// Default --zjit-inline-budget
-pub const DEFAULT_INLINE_BUDGET: InlineBudget = 500;
+/// TODO (nirvdrum 2026-06-25): 200 has proven to strike a good balance between memory usage and
+/// run time performance on ruby-bench, but we should finely tune across more workloads.
+pub const DEFAULT_INLINE_BUDGET: InlineBudget = 200;
 pub const INLINE_BUDGET_UNLIMITED: InlineBudget = 0;
 pub type InlineBudget = usize;
 
@@ -634,7 +638,6 @@ pub fn set_call_threshold(call_threshold: CallThreshold) {
     update_profile_threshold();
 }
 
-/// Update --zjit-inline-threshold for testing
 #[cfg(test)]
 pub fn set_inline_threshold(inline_threshold: InlineThreshold) {
     rb_zjit_prepare_options();


### PR DESCRIPTION
We added a method inliner to ZJIT in ##16966, but the inliner was left disabed by default. Having run it through its paces and fixed a few follow-up issues, the inliner is now ready to be enabled by default. We expect it will make applications faster, but there is a trade-off in that inlining increases compilation time and memory consumption. If that's a problem for a particular use case, users can disable the inliner by passing `--zjit-inliner-threshold=0`.

This PR also updates the CI jobs to run both with and without the inliner, that way we can verify all new PRs will work in either inlining configuration.