### PR TITLE
Don't depend on slot size for object shapes

### DIFF
--- a/debug.c
+++ b/debug.c
@@ -52,7 +52,6 @@ const union {
     enum ruby_econv_flag_type   econv_flag_types;
     rb_econv_result_t           econv_result;
     enum ruby_preserved_encindex encoding_index;
-    enum ruby_robject_flags     robject_flags;
     enum ruby_rmodule_flags     rmodule_flags;
     enum ruby_rstring_flags     rstring_flags;
     enum ruby_rarray_flags      rarray_flags;

--- a/ext/objspace/objspace_dump.c
+++ b/ext/objspace/objspace_dump.c
@@ -592,7 +592,7 @@ dump_object(VALUE obj, struct dump_config *dc)
         break;
 
       case T_OBJECT:
-        if (!FL_TEST_RAW(obj, ROBJECT_HEAP)) {
+        if (!rb_obj_shape_heap_p(obj)) {
             dump_append(dc, ", \"embedded\":true");
         }
 

--- a/gc.c
+++ b/gc.c
@@ -1356,7 +1356,7 @@ rb_gc_imemo_needs_cleanup_p(VALUE obj)
         return ((rb_imemo_tmpbuf_t *)obj)->ptr != NULL;
 
       case imemo_fields:
-        return FL_TEST_RAW(obj, OBJ_FIELD_HEAP) || (id2ref_tbl && rb_obj_shape_has_id(obj));
+        return rb_obj_shape_heap_p(obj) || (id2ref_tbl && rb_obj_shape_has_id(obj));
     }
     UNREACHABLE_RETURN(true);
 }
@@ -1412,7 +1412,7 @@ rb_gc_obj_needs_cleanup_p(VALUE obj)
 
     switch (flags & RUBY_T_MASK) {
       case T_OBJECT:
-        if (flags & ROBJECT_HEAP) return true;
+        if (rb_obj_shape_heap_p(obj)) return true;
         return false;
 
       case T_DATA:
@@ -1557,7 +1557,7 @@ rb_gc_obj_free(void *objspace, VALUE obj)
 
     switch (BUILTIN_TYPE(obj)) {
       case T_OBJECT:
-        if (FL_TEST_RAW(obj, ROBJECT_HEAP)) {
+        if (rb_obj_shape_heap_p(obj)) {
             if (rb_obj_shape_complex_p(obj)) {
                 RB_DEBUG_COUNTER_INC(obj_obj_complex);
                 st_free_table(ROBJECT_FIELDS_HASH(obj));
@@ -2198,7 +2198,7 @@ object_id0(VALUE obj)
     id = generate_next_object_id();
     rb_obj_field_set(obj, object_id_shape_id, 0, id);
 
-    RUBY_ASSERT(RBASIC_SHAPE_ID(obj) == object_id_shape_id);
+    RUBY_ASSERT(RBASIC_SHAPE_ID(obj) == object_id_shape_id || RBASIC_SHAPE_ID(obj) == rb_shape_transition_heap(object_id_shape_id));
     RUBY_ASSERT(rb_obj_shape_has_id(obj));
 
     if (RB_UNLIKELY(id2ref_tbl)) {
@@ -2604,7 +2604,7 @@ rb_obj_memsize_of(VALUE obj)
 
     switch (BUILTIN_TYPE(obj)) {
       case T_OBJECT:
-        if (FL_TEST_RAW(obj, ROBJECT_HEAP)) {
+        if (rb_obj_shape_heap_p(obj)) {
             if (rb_obj_shape_complex_p(obj)) {
                 size += rb_st_memsize(ROBJECT_FIELDS_HASH(obj));
             }
@@ -3882,7 +3882,7 @@ gc_ref_update_object(void *objspace, VALUE v)
 {
     VALUE *ptr = ROBJECT_FIELDS(v);
 
-    if (FL_TEST_RAW(v, ROBJECT_HEAP)) {
+    if (rb_obj_shape_heap_p(v)) {
         if (rb_obj_shape_complex_p(v)) {
             gc_ref_update_table_values_only(ROBJECT_FIELDS_HASH(v));
             return;
@@ -3894,7 +3894,7 @@ gc_ref_update_object(void *objspace, VALUE v)
             // Object can be re-embedded
             memcpy(ROBJECT(v)->as.ary, ptr, sizeof(VALUE) * ROBJECT_FIELDS_COUNT(v));
             SIZED_FREE_N(ptr, ROBJECT_FIELDS_CAPACITY(v));
-            FL_UNSET_RAW(v, ROBJECT_HEAP);
+            RBASIC_SET_SHAPE_ID(v, rb_obj_shape_transition_embedded(v));
             ptr = ROBJECT(v)->as.ary;
         }
     }
@@ -5087,7 +5087,7 @@ rb_raw_obj_info_buitin_type(char *const buff, const size_t buff_size, const VALU
             }
           case T_OBJECT:
             {
-                if (FL_TEST_RAW(obj, ROBJECT_HEAP)) {
+                if (rb_obj_shape_heap_p(obj)) {
                     if (rb_obj_shape_complex_p(obj)) {
                         size_t hash_len = rb_st_table_size(ROBJECT_FIELDS_HASH(obj));
                         APPEND_F("(complex) len:%zu", hash_len);

--- a/gc.c
+++ b/gc.c
@@ -871,7 +871,6 @@ ruby_modular_gc_init(void)
 # define rb_gc_impl_ractor_cache_alloc rb_gc_functions.ractor_cache_alloc
 # define rb_gc_impl_set_params rb_gc_functions.set_params
 # define rb_gc_impl_init rb_gc_functions.init
-# define rb_gc_impl_heap_sizes rb_gc_functions.heap_sizes
 // Shutdown
 # define rb_gc_impl_shutdown_free_objects rb_gc_functions.shutdown_free_objects
 # define rb_gc_impl_objspace_free rb_gc_functions.objspace_free
@@ -4714,12 +4713,6 @@ void
 rb_gc_initial_stress_set(VALUE flag)
 {
     initial_stress = flag;
-}
-
-size_t *
-rb_gc_heap_sizes(void)
-{
-    return rb_gc_impl_heap_sizes(rb_gc_get_objspace());
 }
 
 VALUE

--- a/gc.c
+++ b/gc.c
@@ -379,7 +379,9 @@ rb_gc_obj_changed_pool(VALUE obj, size_t heap_id)
 {
     RUBY_ASSERT(RB_TYPE_P(obj, T_OBJECT));
 
-    RBASIC_SET_SHAPE_ID(obj, rb_obj_shape_transition_heap(obj, heap_id));
+    size_t capacity = (rb_gc_obj_slot_size(obj) - offsetof(struct RObject, as.heap.fields)) / sizeof(VALUE);
+
+    RBASIC_SET_SHAPE_ID(obj, rb_obj_shape_transition_root(obj, capacity));
 }
 
 void rb_vm_update_references(void *ptr);
@@ -604,7 +606,6 @@ typedef struct gc_function_map {
     void *(*ractor_cache_alloc)(void *objspace_ptr, void *ractor);
     void (*set_params)(void *objspace_ptr);
     void (*init)(void);
-    size_t *(*heap_sizes)(void *objspace_ptr);
     // Shutdown
     void (*shutdown_free_objects)(void *objspace_ptr);
     void (*objspace_free)(void *objspace_ptr);
@@ -783,7 +784,6 @@ ruby_modular_gc_init(void)
     load_modular_gc_func(ractor_cache_alloc);
     load_modular_gc_func(set_params);
     load_modular_gc_func(init);
-    load_modular_gc_func(heap_sizes);
     // Shutdown
     load_modular_gc_func(shutdown_free_objects);
     load_modular_gc_func(objspace_free);
@@ -1028,14 +1028,10 @@ gc_newobj_hook(VALUE obj)
     RB_GC_VM_UNLOCK_NO_BARRIER(lev);
 }
 
-VALUE
-rb_newobj(rb_execution_context_t *ec, VALUE klass, VALUE flags, shape_id_t shape_id, bool wb_protected, size_t size)
+static void
+rb_newobj_post_alloc(VALUE obj, shape_id_t shape_id)
 {
-    GC_ASSERT((flags & FL_WB_PROTECTED) == 0);
-    rb_ractor_t *cr = rb_ec_ractor_ptr(ec);
-    VALUE obj = rb_gc_impl_new_obj(rb_gc_get_objspace(), cr->newobj_cache, klass, flags, wb_protected, size);
-
-#if RACTOR_CHECK_MODE
+    #if RACTOR_CHECK_MODE
     void rb_ractor_setup_belonging(VALUE obj);
     rb_ractor_setup_belonging(obj);
 #endif
@@ -1059,6 +1055,16 @@ rb_newobj(rb_execution_context_t *ec, VALUE klass, VALUE flags, shape_id_t shape
         rb_gc_obj_slot_size(obj) - sizeof(struct RBasic)
     );
 #endif
+}
+
+VALUE
+rb_newobj(rb_execution_context_t *ec, VALUE klass, VALUE flags, shape_id_t shape_id, bool wb_protected, size_t size)
+{
+    GC_ASSERT((flags & FL_WB_PROTECTED) == 0);
+    rb_ractor_t *cr = rb_ec_ractor_ptr(ec);
+    VALUE obj = rb_gc_impl_new_obj(rb_gc_get_objspace(), cr->newobj_cache, klass, flags, wb_protected, size);
+
+    rb_newobj_post_alloc(obj, shape_id);
 
     return obj;
 }
@@ -1077,23 +1083,30 @@ rb_ec_newobj_of(rb_execution_context_t *ec, VALUE klass, VALUE flags, size_t siz
     return rb_newobj(ec, klass, flags, ROOT_SHAPE_ID | SHAPE_ID_LAYOUT_OTHER, true, size);
 }
 
-static VALUE
-rb_newobj_of_with_shape(VALUE klass, VALUE flags, shape_id_t shape_id, size_t size)
-{
-    return rb_newobj(GET_EC(), klass, flags, shape_id, true, size);
-}
-
 VALUE
 rb_newobj_of(VALUE klass, VALUE flags, size_t size)
 {
     return rb_newobj(GET_EC(), klass, flags, ROOT_SHAPE_ID | SHAPE_ID_LAYOUT_OTHER, true, size);
 }
 
+static VALUE
+t_object_newobj(VALUE klass, size_t size)
+{
+    rb_ractor_t *cr = rb_ec_ractor_ptr(GET_EC());
+    VALUE obj = rb_gc_impl_new_obj(rb_gc_get_objspace(), cr->newobj_cache, klass, T_OBJECT, true, size);
+
+    size_t capacity = (rb_gc_obj_slot_size(obj) - offsetof(struct RObject, as.heap.fields)) / sizeof(VALUE);
+    shape_id_t shape_id = rb_shape_id_with_robject_layout(rb_shape_root_from_capacity(capacity));
+
+    rb_newobj_post_alloc(obj, shape_id);
+
+    return obj;
+}
+
 static
 VALUE class_allocate_complex_instance(VALUE klass, uint32_t capacity)
 {
-    shape_id_t initial_shape_id = rb_shape_id_with_robject_layout(rb_shape_root(rb_gc_heap_id_for_size(sizeof(struct RObject))));
-    VALUE obj = rb_newobj_of_with_shape(klass, T_OBJECT, initial_shape_id, sizeof(struct RObject));
+    VALUE obj = t_object_newobj(klass, sizeof(struct RObject));
     rb_obj_init_complex(obj, rb_st_init_numtable_with_size(capacity));
     return obj;
 }
@@ -1105,8 +1118,7 @@ rb_class_allocate_instance(VALUE klass)
     VALUE obj;
 
     // Directly start as COMPLEX if we know we're over the limit.
-    RUBY_ASSERT(rb_shape_tree.max_capacity > 0);
-    if (RB_UNLIKELY(index_tbl_num_entries > rb_shape_tree.max_capacity)) {
+    if (RB_UNLIKELY(index_tbl_num_entries > SHAPE_MAX_CAPACITY)) {
         obj = class_allocate_complex_instance(klass, index_tbl_num_entries);
     }
     else {
@@ -1117,7 +1129,7 @@ rb_class_allocate_instance(VALUE klass)
 
         // There might be a NEWOBJ tracepoint callback, and it may set fields.
         // So the shape must be passed to `NEWOBJ_OF`.
-        obj = rb_newobj_of_with_shape(klass, T_OBJECT, rb_shape_id_with_robject_layout(rb_shape_root(rb_gc_heap_id_for_size(size))), size);
+        obj = t_object_newobj(klass, size);
 
         #if RUBY_DEBUG
             VALUE *ptr = ROBJECT_FIELDS(obj);

--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -2611,21 +2611,6 @@ rb_gc_impl_heap_id_for_size(void *objspace_ptr, size_t size)
     return heap_idx_for_size(size);
 }
 
-
-static size_t heap_sizes[HEAP_COUNT + 1] = { 0 };
-
-size_t *
-rb_gc_impl_heap_sizes(void *objspace_ptr)
-{
-    if (heap_sizes[0] == 0) {
-        for (unsigned char i = 0; i < HEAP_COUNT; i++) {
-            heap_sizes[i] = heap_slot_size(i);
-        }
-    }
-
-    return heap_sizes;
-}
-
 NOINLINE(static VALUE newobj_cache_miss(rb_objspace_t *objspace, rb_ractor_newobj_cache_t *cache, size_t heap_idx, bool vm_locked));
 
 static VALUE

--- a/gc/gc_impl.h
+++ b/gc/gc_impl.h
@@ -38,7 +38,6 @@ GC_IMPL_FN void rb_gc_impl_objspace_init(void *objspace_ptr);
 GC_IMPL_FN void *rb_gc_impl_ractor_cache_alloc(void *objspace_ptr, void *ractor);
 GC_IMPL_FN void rb_gc_impl_set_params(void *objspace_ptr);
 GC_IMPL_FN void rb_gc_impl_init(void);
-GC_IMPL_FN size_t *rb_gc_impl_heap_sizes(void *objspace_ptr);
 // Shutdown
 GC_IMPL_FN void rb_gc_impl_shutdown_free_objects(void *objspace_ptr);
 GC_IMPL_FN void rb_gc_impl_objspace_free(void *objspace_ptr);

--- a/gc/mmtk/mmtk.c
+++ b/gc/mmtk/mmtk.c
@@ -687,12 +687,6 @@ rb_gc_impl_init(void)
     rb_define_singleton_method(rb_mGC, "verify_compaction_references", rb_f_notimplement, -1);
 }
 
-size_t *
-rb_gc_impl_heap_sizes(void *objspace_ptr)
-{
-    return heap_sizes;
-}
-
 int
 rb_mmtk_obj_free_iter_wrapper(VALUE obj, void *data)
 {

--- a/gc/wbcheck/wbcheck.c
+++ b/gc/wbcheck/wbcheck.c
@@ -536,12 +536,6 @@ rb_gc_impl_init(void)
     // Stub implementation
 }
 
-size_t *
-rb_gc_impl_heap_sizes(void *objspace_ptr)
-{
-    return heap_sizes;
-}
-
 // Shutdown
 void
 rb_gc_impl_shutdown_free_objects(void *objspace_ptr)

--- a/imemo.c
+++ b/imemo.c
@@ -141,7 +141,7 @@ rb_imemo_fields_new(VALUE owner, shape_id_t shape_id, bool shareable)
     // layout in the shape describes the layout of the thing on which it is set.
     // Imemo fields have the same layout as robject, therefore the layout
     // should reflect that fact.
-    RBASIC_SET_SHAPE_ID(fields, rb_shape_id_with_robject_layout(shape_id));
+    RBASIC_SET_SHAPE_ID(fields, rb_shape_id_with_robject_layout(rb_shape_transition_embedded(shape_id)));
     RUBY_ASSERT(IMEMO_TYPE_P(fields, imemo_fields));
     return fields;
 }
@@ -151,12 +151,11 @@ rb_imemo_fields_new_complex(VALUE owner, shape_id_t shape_id, size_t capa, bool 
 {
     VALUE fields = rb_imemo_new(imemo_fields, owner, sizeof(struct rb_fields), shareable);
     IMEMO_OBJ_FIELDS(fields)->as.complex.table = st_init_numtable_with_size(capa);
-    FL_SET_RAW(fields, OBJ_FIELD_HEAP);
     // imemo fields objects should always have "RObject" layout.  The
     // layout in the shape describes the layout of the thing on which it is set.
     // Imemo fields have the same layout as robject, therefore the layout
     // should reflect that fact.
-    RBASIC_SET_SHAPE_ID(fields, rb_shape_id_with_robject_layout(shape_id));
+    RBASIC_SET_SHAPE_ID(fields, rb_shape_id_with_robject_layout(rb_shape_transition_heap(shape_id)));
     return fields;
 }
 
@@ -180,12 +179,11 @@ rb_imemo_fields_new_complex_tbl(VALUE owner, shape_id_t shape_id, st_table *tbl,
 {
     VALUE fields = rb_imemo_new(imemo_fields, owner, sizeof(struct rb_fields), shareable);
     IMEMO_OBJ_FIELDS(fields)->as.complex.table = tbl;
-    FL_SET_RAW(fields, OBJ_FIELD_HEAP);
     // imemo fields objects should always have "RObject" layout.  The
     // layout in the shape describes the layout of the thing on which it is set.
     // Imemo fields have the same layout as robject, therefore the layout
     // should reflect that fact.
-    RBASIC_SET_SHAPE_ID(fields, rb_shape_id_with_robject_layout(shape_id));
+    RBASIC_SET_SHAPE_ID(fields, rb_shape_id_with_robject_layout(rb_shape_transition_heap(shape_id)));
     st_foreach(tbl, imemo_fields_trigger_wb_i, (st_data_t)fields);
     return fields;
 }
@@ -628,7 +626,7 @@ rb_free_const_table(struct rb_id_table *tbl)
 static inline void
 imemo_fields_free(struct rb_fields *fields)
 {
-    if (FL_TEST_RAW((VALUE)fields, OBJ_FIELD_HEAP)) {
+    if (rb_obj_shape_heap_p((VALUE)fields)) {
         RUBY_ASSERT(rb_shape_complex_p(RBASIC_SHAPE_ID((VALUE)fields)));
         st_free_table(fields->as.complex.table);
     }

--- a/include/ruby/internal/core/robject.h
+++ b/include/ruby/internal/core/robject.h
@@ -48,34 +48,6 @@
 #define ROBJECT_FIELDS              ROBJECT_FIELDS
 /** @endcond */
 
-/**
- * @private
- *
- * Bits that you can set to ::RBasic::flags.
- */
-enum ruby_robject_flags {
-    /**
-     * This flag marks that the object's instance variables are stored in an
-     * external heap buffer.
-     * Normally, instance variable references are stored inside the object slot,
-     * but if it overflow, Ruby may have to allocate a separate buffer and spills
-     * the instance variables there.
-     * This flag denotes that situation.
-     *
-     * @warning  This  bit has  to be  considered read-only.   Setting/clearing
-     *           this  bit without  corresponding fix  up must  cause immediate
-     *           SEGV.   Also,   internal  structures   of  an   object  change
-     *           dynamically  and  transparently  throughout of  its  lifetime.
-     *           Don't assume it being persistent.
-     *
-     * @internal
-     *
-     * 3rd parties must  not be aware that  there even is more than  one way to
-     * store instance variables.  Might better be hidden.
-     */
-    ROBJECT_HEAP = RUBY_FL_USER4
-};
-
 struct st_table;
 
 /**

--- a/internal/gc.h
+++ b/internal/gc.h
@@ -205,7 +205,6 @@ void *rb_gc_ractor_cache_alloc(rb_ractor_t *ractor);
 void rb_gc_ractor_cache_free(void *cache);
 
 bool rb_gc_size_allocatable_p(size_t size);
-size_t *rb_gc_heap_sizes(void);
 size_t rb_gc_heap_id_for_size(size_t size);
 
 void rb_gc_mark_and_move(VALUE *ptr);

--- a/internal/imemo.h
+++ b/internal/imemo.h
@@ -10,6 +10,7 @@
  */
 #include "ruby/internal/config.h"
 #include <stddef.h>             /* for size_t */
+#include "shape.h"
 #include "id_table.h"
 #include "internal/array.h"     /* for rb_ary_hidden_new_fill */
 #include "ruby/internal/stdbool.h"     /* for bool */
@@ -171,7 +172,7 @@ imemo_type(VALUE imemo)
 static inline int
 imemo_type_p(VALUE imemo, enum imemo_type imemo_type)
 {
-    if (LIKELY(!RB_SPECIAL_CONST_P(imemo))) {
+    if (RB_LIKELY(!RB_SPECIAL_CONST_P(imemo))) {
         /* fixed at compile time if imemo_type is given. */
         const VALUE mask = (IMEMO_MASK << FL_USHIFT) | RUBY_T_MASK;
         const VALUE expected_type = (imemo_type << FL_USHIFT) | T_IMEMO;
@@ -258,7 +259,6 @@ struct rb_fields {
 // IMEMO/fields and T_OBJECT have exactly the same layout.
 // This is useful for JIT and common codepaths.
 #define OBJ_FIELD_HEAP ROBJECT_HEAP
-STATIC_ASSERT(imemo_fields_flags, OBJ_FIELD_HEAP == IMEMO_FL_USER0);
 STATIC_ASSERT(imemo_fields_embed_offset, offsetof(struct RObject, as.ary) == offsetof(struct rb_fields, as.embed.fields));
 STATIC_ASSERT(imemo_fields_external_offset, offsetof(struct RObject, as.heap.fields) == offsetof(struct rb_fields, as.external.ptr));
 STATIC_ASSERT(imemo_fields_complex_offset, offsetof(struct RObject, as.heap.fields) == offsetof(struct rb_fields, as.complex.table));
@@ -308,7 +308,7 @@ rb_imemo_fields_ptr(VALUE fields_obj)
 
     RUBY_ASSERT(IMEMO_TYPE_P(fields_obj, imemo_fields) || RB_TYPE_P(fields_obj, T_OBJECT));
 
-    if (UNLIKELY(FL_TEST_RAW(fields_obj, OBJ_FIELD_HEAP))) {
+    if (RB_UNLIKELY(rb_obj_shape_heap_p(fields_obj))) {
         return IMEMO_OBJ_FIELDS(fields_obj)->as.external.ptr;
     }
     else {
@@ -324,7 +324,7 @@ rb_imemo_fields_complex_tbl(VALUE fields_obj)
     }
 
     RUBY_ASSERT(IMEMO_TYPE_P(fields_obj, imemo_fields) || RB_TYPE_P(fields_obj, T_OBJECT));
-    RUBY_ASSERT(FL_TEST_RAW(fields_obj, OBJ_FIELD_HEAP));
+    RUBY_ASSERT(rb_obj_shape_heap_p(fields_obj));
 
     // Some codepaths unconditionally access the fields_ptr, and assume it can be used as st_table if the
     // shape is complex.

--- a/internal/object.h
+++ b/internal/object.h
@@ -9,6 +9,7 @@
  * @brief      Internal header for Object.
  */
 #include "ruby/ruby.h"          /* for VALUE */
+#include "shape.h"
 
 /* object.c */
 
@@ -68,7 +69,7 @@ ROBJECT_FIELDS(VALUE obj)
 
     struct RObject *const ptr = ROBJECT(obj);
 
-    if (RB_UNLIKELY(RB_FL_ANY_RAW(obj, ROBJECT_HEAP))) {
+    if (RB_UNLIKELY(rb_obj_shape_heap_p(obj))) {
         return ptr->as.heap.fields;
     }
     else {

--- a/internal/variable.h
+++ b/internal/variable.h
@@ -14,6 +14,8 @@
 #include "ruby/internal/stdbool.h"     /* for bool */
 #include "ruby/ruby.h"          /* for VALUE */
 #include "shape.h"              /* for shape_id_t */
+#include "box.h"
+#include "internal/gc.h"
 
 /* variable.c */
 void rb_gc_mark_global_tbl(void);

--- a/object.c
+++ b/object.c
@@ -364,6 +364,7 @@ rb_obj_copy_ivar(VALUE dest, VALUE obj)
     RUBY_ASSERT(src_num_ivs <= dest_capa);
     if (initial_capa < dest_capa) {
         rb_ensure_iv_list_size(dest, 0, dest_capa);
+        dest_shape_id = rb_shape_transition_heap(dest_shape_id);
         dest_buf = ROBJECT_FIELDS(dest);
     }
 

--- a/repro_yjit_shape_capacity.rb
+++ b/repro_yjit_shape_capacity.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+# Reproducer/probe for dynamic T_OBJECT slot capacity being narrowed before
+# shape code clamps it. Run from build/ with:
+#
+#   ./ruby --yjit --yjit-call-threshold=1 ../repro_yjit_shape_capacity.rb
+#
+# A crashing YJIT run depends on the allocator returning a slot whose capacity
+# gets truncated to a smaller attr_index_t value. This script first checks the
+# underlying invariant directly so it is useful even when it does not crash.
+
+require "objspace"
+
+POINTER_SIZE = [0].pack("J").bytesize
+RBASIC_SIZE = GC::INTERNAL_CONSTANTS.fetch(:RBASIC_SIZE)
+
+def dump_hash(obj)
+  ObjectSpace.dump(obj).then do |dump|
+    require "json"
+    JSON.parse(dump)
+  end
+end
+
+def object_slot_capacity(obj)
+  dump = dump_hash(obj)
+  (dump.fetch("slot_size") - RBASIC_SIZE) / POINTER_SIZE
+end
+
+def shape_capacity(obj)
+  return RubyVM::Shape.of(obj).capacity if defined?(RubyVM::Shape)
+
+  # Without SHAPE_DEBUG, infer only from behavior below.
+  nil
+end
+
+def embedded?(obj)
+  dump_hash(obj).key?("embedded")
+end
+
+shape_max_fields = if defined?(RubyVM::Shape::SHAPE_MAX_FIELDS)
+  RubyVM::Shape::SHAPE_MAX_FIELDS
+else
+  126
+end
+
+class ShapeCapacityProbe
+  def read_last
+    @v_last
+  end
+end
+
+# Force future ShapeCapacityProbe instances to request the largest normal
+# T_OBJECT slot that shapes are supposed to support.
+seed = ShapeCapacityProbe.new
+shape_max_fields.times do |i|
+  seed.instance_variable_set(:"@seed_#{i}", i)
+end
+
+probe = ShapeCapacityProbe.new
+slot_capacity = object_slot_capacity(probe)
+root_capacity = shape_capacity(probe)
+expected_capacity = [slot_capacity, shape_max_fields].min
+
+puts "slot_capacity=#{slot_capacity} expected_shape_capacity=#{expected_capacity} shape_capacity=#{root_capacity.inspect}"
+puts "initial=#{ObjectSpace.dump(probe).strip}"
+
+if root_capacity && root_capacity < expected_capacity
+  abort "BUG: root shape capacity #{root_capacity} is smaller than actual supported capacity #{expected_capacity}"
+end
+
+# Behavior-only check for non-SHAPE_DEBUG builds: fill up to the capacity that
+# should be embeddable in this slot. A bad truncated root capacity externalizes
+# this object before the slot is full.
+expected_capacity.times do |i|
+  name = i == expected_capacity - 1 ? :@v_last : :"@v_#{i}"
+  probe.instance_variable_set(name, i)
+end
+
+puts "filled=#{ObjectSpace.dump(probe).strip}"
+
+unless embedded?(probe)
+  abort "BUG: object externalized after #{expected_capacity} ivars even though its slot can embed them"
+end
+
+if RubyVM.const_defined?(:YJIT) && RubyVM::YJIT.enabled?
+  expected = expected_capacity - 1
+  20_000.times do
+    value = probe.read_last
+    abort "BUG: YJIT read wrong value #{value.inspect}, expected #{expected.inspect}" unless value == expected
+  end
+  puts "YJIT read stress passed"
+else
+  warn "YJIT is not enabled; rerun with --yjit --yjit-call-threshold=1 for the JIT stress path."
+end
+
+puts "No capacity mismatch reproduced on this build."

--- a/shape.c
+++ b/shape.c
@@ -317,6 +317,8 @@ rb_shape_tree_t rb_shape_tree = { 0 };
 // Should be on its own cache line
 static RUBY_ALIGNAS(128) rb_atomic_t shape_next_id;
 
+static rb_atomic_t root_shape_ids[ATTR_INDEX_NOT_SET];
+
 rb_shape_t *
 rb_shape_get_root_shape(void)
 {
@@ -387,6 +389,18 @@ SHAPE_ID(rb_shape_t *shape, shape_id_t previous_shape_id)
     shape_id_t offset = (shape_id_t)(shape - rb_shape_tree.shape_list);
     return offset | RSHAPE_FLAGS(previous_shape_id);
 }
+
+#if RUBY_DEBUG
+static rb_shape_t *
+shape_get_root(rb_shape_t *shape)
+{
+    while (shape->parent_offset != INVALID_SHAPE_ID) {
+        shape = RSHAPE(shape->parent_offset);
+    }
+
+    return shape;
+}
+#endif
 
 void
 rb_shape_each_shape_id(each_shape_callback callback, void *data)
@@ -477,6 +491,38 @@ rb_shape_alloc(ID edge_name, rb_shape_t *parent, enum shape_type type)
     return shape;
 }
 
+shape_id_t
+rb_shape_root_from_capacity(attr_index_t capacity)
+{
+    if (capacity == 0) {
+        return ROOT_SHAPE_ID;
+    }
+    if (capacity > SHAPE_MAX_CAPACITY) {
+        capacity = SHAPE_MAX_CAPACITY;
+    }
+
+    shape_id_t root_shape_id = (shape_id_t)RUBY_ATOMIC_LOAD(root_shape_ids[capacity]);
+    if (root_shape_id) {
+        return root_shape_id;
+    }
+
+    rb_shape_t *root = rb_shape_alloc_with_parent_offset(0, INVALID_SHAPE_ID);
+    if (!root) {
+        return ROOT_SHAPE_ID;
+    }
+
+    root->capacity = capacity;
+    root->type = SHAPE_ROOT;
+
+    root_shape_id = SHAPE_OFFSET(root);
+    shape_id_t existing_root_shape_id = (shape_id_t)RUBY_ATOMIC_CAS(root_shape_ids[capacity], 0, root_shape_id);
+    if (existing_root_shape_id) {
+        return existing_root_shape_id;
+    }
+
+    return root_shape_id;
+}
+
 #ifdef HAVE_MMAP
 static redblack_node_t *
 redblack_cache_ancestors(rb_shape_t *shape)
@@ -513,17 +559,15 @@ redblack_cache_ancestors(rb_shape_t *shape)
 static attr_index_t
 shape_grow_capa(attr_index_t current_capa)
 {
-    const attr_index_t *capacities = rb_shape_tree.capacities;
-    size_t heaps_count = rb_shape_tree.heaps_count;
+    RUBY_ASSERT(current_capa < SHAPE_MAX_CAPACITY);
 
-    // First try to use the next size that will be embeddable in a larger object slot.
-    for (size_t i = 0; i < heaps_count; i++) {
-        attr_index_t capa = capacities[i];
-        if (capa > current_capa) {
-            return capa;
-        }
+    size_t next_capa = rb_malloc_grow_capa(current_capa, sizeof(VALUE));
+    if (next_capa > SHAPE_MAX_CAPACITY) {
+        next_capa = SHAPE_MAX_CAPACITY;
     }
-    return capacities[rb_shape_tree.heaps_count - 1];
+
+    RUBY_ASSERT(next_capa > current_capa);
+    return (attr_index_t)next_capa;
 }
 
 static rb_shape_t *
@@ -694,6 +738,21 @@ get_next_shape_internal(rb_shape_t *shape, ID id, enum shape_type shape_type, bo
 }
 
 shape_id_t
+rb_shape_transition_root(shape_id_t original_shape_id, attr_index_t capacity)
+{
+    if (rb_shape_complex_p(original_shape_id)) {
+        return original_shape_id;
+    }
+
+    rb_shape_t *original_shape = RSHAPE(original_shape_id);
+    if (original_shape->type != SHAPE_ROOT) {
+        return original_shape_id;
+    }
+
+    return RSHAPE_FLAGS(original_shape_id) | rb_shape_root_from_capacity(capacity);
+}
+
+shape_id_t
 rb_shape_transition_object_id(shape_id_t original_shape_id)
 {
     RUBY_ASSERT(!rb_shape_has_object_id(original_shape_id));
@@ -702,7 +761,7 @@ rb_shape_transition_object_id(shape_id_t original_shape_id)
 
     bool dont_care;
     rb_shape_t *shape = NULL;
-    if (LIKELY(original_shape->next_field_index < rb_shape_tree.max_capacity)) {
+    if (LIKELY(original_shape->next_field_index < SHAPE_MAX_CAPACITY)) {
         shape = get_next_shape_internal(original_shape, id_object_id, SHAPE_OBJ_ID, &dont_care, true);
     }
     if (!shape) {
@@ -790,8 +849,7 @@ shape_get_next(rb_shape_t *shape, enum shape_type shape_type, VALUE klass, ID id
     }
 #endif
 
-    RUBY_ASSERT(rb_shape_tree.max_capacity > 0);
-    if (UNLIKELY(shape->next_field_index >= rb_shape_tree.max_capacity)) {
+    if (UNLIKELY(shape->next_field_index >= SHAPE_MAX_CAPACITY)) {
         return NULL;
     }
 
@@ -1305,10 +1363,7 @@ rb_shape_verify_consistency(VALUE obj, shape_id_t shape_id)
         }
     }
 
-    // Make sure SHAPE_ID_HAS_IVAR_MASK is valid.
     if (rb_shape_complex_p(shape_id)) {
-        RUBY_ASSERT(shape_id & SHAPE_ID_HAS_IVAR_MASK);
-
         // Ensure complex object don't appear as embedded
         if (RB_TYPE_P(obj, T_OBJECT) || IMEMO_TYPE_P(obj, imemo_fields)) {
             RUBY_ASSERT(FL_TEST_RAW(obj, ROBJECT_HEAP));
@@ -1320,26 +1375,25 @@ rb_shape_verify_consistency(VALUE obj, shape_id_t shape_id)
             ivar_count--;
         }
         if (ivar_count) {
-            RUBY_ASSERT(shape_id & SHAPE_ID_HAS_IVAR_MASK);
+            RUBY_ASSERT(rb_shape_has_ivars(shape_id));
         }
         else {
-            RUBY_ASSERT(!(shape_id & SHAPE_ID_HAS_IVAR_MASK));
+            RUBY_ASSERT(!rb_shape_has_ivars(shape_id));
         }
     }
 
     uint8_t flags_heap_index = rb_shape_heap_index(shape_id);
-    if (RB_TYPE_P(obj, T_OBJECT)) {
-        RUBY_ASSERT(flags_heap_index > 0);
-        size_t shape_id_slot_size = rb_shape_tree.capacities[flags_heap_index - 1] * sizeof(VALUE) + sizeof(struct RBasic);
+    if (flags_heap_index) {
+        rb_bug("shape_id uses obsolete heap index flags: shape_id=%u obj=%s", shape_id, rb_obj_info(obj));
+    }
+
+    if (RB_TYPE_P(obj, T_OBJECT) && !rb_shape_complex_p(shape_id)) {
+        rb_shape_t *root = shape_get_root(RSHAPE(shape_id));
+        size_t shape_id_slot_size = root->capacity * sizeof(VALUE) + sizeof(struct RBasic);
         size_t actual_slot_size = rb_gc_obj_slot_size(obj);
 
-        if (shape_id_slot_size != actual_slot_size) {
-            rb_bug("shape_id heap_index flags mismatch: shape_id_slot_size=%zu, gc_slot_size=%zu\n", shape_id_slot_size, actual_slot_size);
-        }
-    }
-    else {
-        if (flags_heap_index) {
-            rb_bug("shape_id indicate heap_index > 0 but object is not T_OBJECT: %s", rb_obj_info(obj));
+        if (shape_id_slot_size > actual_slot_size) {
+            rb_bug("shape root capacity exceeds object slot size: shape_id_slot_size=%zu, gc_slot_size=%zu\n", shape_id_slot_size, actual_slot_size);
         }
     }
 
@@ -1586,30 +1640,6 @@ rb_shape_find_by_id(VALUE mod, VALUE id)
 void
 Init_default_shapes(void)
 {
-    size_t *heap_sizes = rb_gc_heap_sizes();
-    size_t heaps_count = 0;
-    while (heap_sizes[heaps_count]) {
-        heaps_count++;
-    }
-
-    if (heaps_count > SHAPE_ID_HEAP_INDEX_MAX) {
-        rb_bug("Init_default_shapes initialized with %zu heaps, only up to %u are supported", heaps_count, SHAPE_ID_HEAP_INDEX_MAX);
-    }
-
-    size_t index;
-    for (index = 0; index < heaps_count; index++) {
-        if (heap_sizes[index] > sizeof(struct RBasic)) {
-            size_t capa = (heap_sizes[index] - sizeof(struct RBasic)) / sizeof(VALUE);
-            RUBY_ASSERT(capa < ATTR_INDEX_NOT_SET);
-            rb_shape_tree.capacities[index] = (attr_index_t)capa;
-        }
-        else {
-            rb_shape_tree.capacities[index] = 0;
-        }
-    }
-    rb_shape_tree.heaps_count = heaps_count;
-    rb_shape_tree.max_capacity = rb_shape_tree.capacities[heaps_count - 1];
-
 #ifdef HAVE_MMAP
     size_t shape_list_mmap_size = rb_size_mul_or_raise(SHAPE_BUFFER_SIZE, sizeof(rb_shape_t), rb_eRuntimeError);
     rb_shape_tree.shape_list = (rb_shape_t *)mmap(NULL, shape_list_mmap_size,
@@ -1660,7 +1690,6 @@ Init_default_shapes(void)
     root->capacity = 0;
     root->type = SHAPE_ROOT;
     RUBY_ASSERT(SHAPE_OFFSET(root) == ROOT_SHAPE_ID);
-    RUBY_ASSERT(!(SHAPE_OFFSET(root) & SHAPE_ID_HAS_IVAR_MASK));
 
     bool dontcare;
     rb_shape_t *root_with_obj_id = get_next_shape_internal(root, id_object_id, SHAPE_OBJ_ID, &dontcare, true);
@@ -1669,7 +1698,6 @@ Init_default_shapes(void)
     RUBY_ASSERT(root_with_obj_id->type == SHAPE_OBJ_ID);
     RUBY_ASSERT(root_with_obj_id->edge_name == id_object_id);
     RUBY_ASSERT(root_with_obj_id->next_field_index == 1);
-    RUBY_ASSERT(!(SHAPE_OFFSET(root_with_obj_id) & SHAPE_ID_HAS_IVAR_MASK));
     (void)root_with_obj_id;
 }
 
@@ -1703,7 +1731,7 @@ Init_shape(void)
     rb_define_const(rb_cShape, "SHAPE_ID_NUM_BITS", INT2NUM(SHAPE_ID_NUM_BITS));
     rb_define_const(rb_cShape, "SHAPE_FLAG_SHIFT", INT2NUM(SHAPE_FLAG_SHIFT));
     rb_define_const(rb_cShape, "SHAPE_MAX_VARIATIONS", INT2NUM(SHAPE_MAX_VARIATIONS));
-    rb_define_const(rb_cShape, "SHAPE_MAX_FIELDS", INT2NUM(rb_shape_tree.max_capacity));
+    rb_define_const(rb_cShape, "SHAPE_MAX_FIELDS", INT2NUM(SHAPE_MAX_CAPACITY));
     rb_define_const(rb_cShape, "SIZEOF_RB_SHAPE_T", INT2NUM(sizeof(rb_shape_t)));
     rb_define_const(rb_cShape, "SIZEOF_REDBLACK_NODE_T", INT2NUM(sizeof(redblack_node_t)));
     rb_define_const(rb_cShape, "SHAPE_BUFFER_SIZE", INT2NUM(sizeof(rb_shape_t) * SHAPE_BUFFER_SIZE));

--- a/shape.c
+++ b/shape.c
@@ -492,7 +492,7 @@ rb_shape_alloc(ID edge_name, rb_shape_t *parent, enum shape_type type)
 }
 
 shape_id_t
-rb_shape_root_from_capacity(attr_index_t capacity)
+rb_shape_root_from_capacity(size_t capacity)
 {
     if (capacity == 0) {
         return ROOT_SHAPE_ID;
@@ -500,8 +500,9 @@ rb_shape_root_from_capacity(attr_index_t capacity)
     if (capacity > SHAPE_MAX_CAPACITY) {
         capacity = SHAPE_MAX_CAPACITY;
     }
+    attr_index_t root_capacity = (attr_index_t)capacity;
 
-    shape_id_t root_shape_id = (shape_id_t)RUBY_ATOMIC_LOAD(root_shape_ids[capacity]);
+    shape_id_t root_shape_id = (shape_id_t)RUBY_ATOMIC_LOAD(root_shape_ids[root_capacity]);
     if (root_shape_id) {
         return root_shape_id;
     }
@@ -511,11 +512,11 @@ rb_shape_root_from_capacity(attr_index_t capacity)
         return ROOT_SHAPE_ID;
     }
 
-    root->capacity = capacity;
+    root->capacity = root_capacity;
     root->type = SHAPE_ROOT;
 
     root_shape_id = SHAPE_OFFSET(root);
-    shape_id_t existing_root_shape_id = (shape_id_t)RUBY_ATOMIC_CAS(root_shape_ids[capacity], 0, root_shape_id);
+    shape_id_t existing_root_shape_id = (shape_id_t)RUBY_ATOMIC_CAS(root_shape_ids[root_capacity], 0, root_shape_id);
     if (existing_root_shape_id) {
         return existing_root_shape_id;
     }
@@ -738,7 +739,7 @@ get_next_shape_internal(rb_shape_t *shape, ID id, enum shape_type shape_type, bo
 }
 
 shape_id_t
-rb_shape_transition_root(shape_id_t original_shape_id, attr_index_t capacity)
+rb_shape_transition_root(shape_id_t original_shape_id, size_t capacity)
 {
     if (rb_shape_complex_p(original_shape_id)) {
         return original_shape_id;
@@ -1037,13 +1038,13 @@ rb_shape_get_iv_index_with_hint(shape_id_t shape_id, ID id, attr_index_t *value,
         if (shape_hint == shape) {
             // We've found a common ancestor so use the index hint
             *value = index_hint;
-            *shape_id_hint = SHAPE_OFFSET(shape);
+            *shape_id_hint = SHAPE_ID(shape, shape_id);
             return true;
         }
         if (shape->edge_name == id) {
             // We found the matching id before a common ancestor
             *value = shape->next_field_index - 1;
-            *shape_id_hint = SHAPE_OFFSET(shape);
+            *shape_id_hint = SHAPE_ID(shape, shape_id);
             return true;
         }
 
@@ -1366,7 +1367,7 @@ rb_shape_verify_consistency(VALUE obj, shape_id_t shape_id)
     if (rb_shape_complex_p(shape_id)) {
         // Ensure complex object don't appear as embedded
         if (RB_TYPE_P(obj, T_OBJECT) || IMEMO_TYPE_P(obj, imemo_fields)) {
-            RUBY_ASSERT(FL_TEST_RAW(obj, ROBJECT_HEAP));
+            RUBY_ASSERT(rb_obj_shape_heap_p(obj));
         }
     }
     else {
@@ -1380,11 +1381,6 @@ rb_shape_verify_consistency(VALUE obj, shape_id_t shape_id)
         else {
             RUBY_ASSERT(!rb_shape_has_ivars(shape_id));
         }
-    }
-
-    uint8_t flags_heap_index = rb_shape_heap_index(shape_id);
-    if (flags_heap_index) {
-        rb_bug("shape_id uses obsolete heap index flags: shape_id=%u obj=%s", shape_id, rb_obj_info(obj));
     }
 
     if (RB_TYPE_P(obj, T_OBJECT) && !rb_shape_complex_p(shape_id)) {
@@ -1470,7 +1466,6 @@ shape_id_t_to_rb_cShape(shape_id_t shape_id)
             INT2NUM(shape->parent_offset),
             rb_shape_edge_name(shape),
             INT2NUM(shape->next_field_index),
-            INT2NUM(rb_shape_heap_index(shape_id)),
             INT2NUM(shape->type),
             INT2NUM(RSHAPE_CAPACITY(shape_id)));
     rb_obj_freeze(obj);
@@ -1713,7 +1708,6 @@ Init_shape(void)
             "parent_offset",
             "edge_name",
             "next_field_index",
-            "heap_index",
             "type",
             "capacity",
             NULL);

--- a/shape.h
+++ b/shape.h
@@ -1,7 +1,7 @@
 #ifndef RUBY_SHAPE_H
 #define RUBY_SHAPE_H
 
-#include "internal/gc.h"
+#include "internal/static_assert.h"
 #include "internal/struct.h"
 
 typedef uint8_t attr_index_t;
@@ -14,23 +14,21 @@ STATIC_ASSERT(shape_id_num_bits, SHAPE_ID_NUM_BITS == sizeof(shape_id_t) * CHAR_
 #define SHAPE_BUFFER_SIZE (1 << SHAPE_ID_OFFSET_NUM_BITS)
 #define SHAPE_ID_OFFSET_MASK (SHAPE_BUFFER_SIZE - 1)
 
-#define SHAPE_ID_HEAP_INDEX_BITS 4
-#define SHAPE_ID_HEAP_INDEX_MAX (((attr_index_t)1 << SHAPE_ID_HEAP_INDEX_BITS) - 1)
-
 #define SHAPE_ID_HEAP_INDEX_OFFSET SHAPE_ID_OFFSET_NUM_BITS
-#define SHAPE_ID_FL_USHIFT (SHAPE_ID_OFFSET_NUM_BITS + SHAPE_ID_HEAP_INDEX_BITS)
+#define SHAPE_ID_FL_USHIFT (SHAPE_ID_OFFSET_NUM_BITS)
 
 // shape_id_t bits:
 //      0-18 SHAPE_ID_OFFSET_MASK
 //              index in rb_shape_tree.shape_list. Allow to access `rb_shape_t *`.
 //              This is the part that describe how fields are laid out in memory.
-//      19-22 SHAPE_ID_HEAP_INDEX_MASK
-//              Unused. Formerly encoded an index into a table of GC heap sizes.
-//      23 SHAPE_ID_FL_COMPLEX
+//      19 ROBJECT_HEAP
+//              Only used for T_OBJECT. Signals that the object is on the heap rather
+//              than embedded.
+//      20 SHAPE_ID_FL_COMPLEX
 //              The object is backed by a `st_table`.
-//      24 SHAPE_ID_FL_FROZEN
+//      21 SHAPE_ID_FL_FROZEN
 //              Whether the object is frozen or not.
-//      25 SHAPE_ID_FL_HAS_OBJECT_ID
+//      22 SHAPE_ID_FL_HAS_OBJECT_ID
 //              Whether the object has an `SHAPE_OBJ_ID` transition.
 //      26-27 SHAPE_ID_LAYOUT_MASK
 //              The object's physical field layout.
@@ -38,11 +36,10 @@ STATIC_ASSERT(shape_id_num_bits, SHAPE_ID_NUM_BITS == sizeof(shape_id_t) * CHAR_
 enum shape_id_fl_type {
 #define RBIMPL_SHAPE_ID_FL(n) (1<<(SHAPE_ID_FL_USHIFT+n))
 
-    SHAPE_ID_HEAP_INDEX_MASK = ((1 << SHAPE_ID_HEAP_INDEX_BITS) - 1) << SHAPE_ID_HEAP_INDEX_OFFSET,
-
-    SHAPE_ID_FL_COMPLEX = RBIMPL_SHAPE_ID_FL(0),
-    SHAPE_ID_FL_FROZEN = RBIMPL_SHAPE_ID_FL(1),
-    SHAPE_ID_FL_HAS_OBJECT_ID = RBIMPL_SHAPE_ID_FL(2),
+    ROBJECT_HEAP = RBIMPL_SHAPE_ID_FL(0),
+    SHAPE_ID_FL_COMPLEX = RBIMPL_SHAPE_ID_FL(1),
+    SHAPE_ID_FL_FROZEN = RBIMPL_SHAPE_ID_FL(2),
+    SHAPE_ID_FL_HAS_OBJECT_ID = RBIMPL_SHAPE_ID_FL(3),
 
     // Means IVs are found at an offset from the object's addr, or in a
     // malloc allocated side table
@@ -50,11 +47,11 @@ enum shape_id_fl_type {
 
     // Means this object is a class/module that is NOT RCLASS_BOXABLE, and IV's
     // are found in the fields_obj found on the rclass struct
-    SHAPE_ID_LAYOUT_RCLASS = RBIMPL_SHAPE_ID_FL(3),
+    SHAPE_ID_LAYOUT_RCLASS = RBIMPL_SHAPE_ID_FL(4),
 
     // Means this object is an RData or RTypedData and IVs are found in the
     // fields_obj found on the RData/RTypedData struct
-    SHAPE_ID_LAYOUT_RDATA = RBIMPL_SHAPE_ID_FL(4),
+    SHAPE_ID_LAYOUT_RDATA = RBIMPL_SHAPE_ID_FL(5),
 
     // Means this is a complicated object: boxable classes, structs, objects
     // that store IVs on the geniv table
@@ -63,7 +60,7 @@ enum shape_id_fl_type {
     SHAPE_ID_LAYOUT_MASK = SHAPE_ID_LAYOUT_OTHER,
 
     SHAPE_ID_FL_NON_CANONICAL_MASK = SHAPE_ID_FL_FROZEN | SHAPE_ID_FL_HAS_OBJECT_ID,
-    SHAPE_ID_FLAGS_MASK = SHAPE_ID_HEAP_INDEX_MASK | SHAPE_ID_FL_NON_CANONICAL_MASK | SHAPE_ID_FL_COMPLEX | SHAPE_ID_LAYOUT_MASK,
+    SHAPE_ID_FLAGS_MASK = ROBJECT_HEAP | SHAPE_ID_FL_NON_CANONICAL_MASK | SHAPE_ID_FL_COMPLEX | SHAPE_ID_LAYOUT_MASK,
 
 #undef RBIMPL_SHAPE_ID_FL
 };
@@ -77,9 +74,10 @@ enum shape_id_mask {
 // has its own checks for physical field layout when reading ivars.
 // So we normalize shape_id by clearing these bits to improve cache hits.
 // JITs however might care about some of it.
-#define SHAPE_ID_READ_ONLY_MASK (~(SHAPE_ID_FL_FROZEN | SHAPE_ID_HEAP_INDEX_MASK | SHAPE_ID_FL_HAS_OBJECT_ID | SHAPE_ID_LAYOUT_MASK))
+#define SHAPE_ID_READ_ONLY_MASK (~(SHAPE_ID_FL_FROZEN | SHAPE_ID_FL_HAS_OBJECT_ID | SHAPE_ID_LAYOUT_MASK))
 // For write it's the same idea, but here we do care about frozen status.
-#define SHAPE_ID_WRITE_MASK (~(SHAPE_ID_HEAP_INDEX_MASK | SHAPE_ID_FL_HAS_OBJECT_ID | SHAPE_ID_LAYOUT_MASK))
+#define SHAPE_ID_WRITE_MASK (~(SHAPE_ID_FL_HAS_OBJECT_ID | SHAPE_ID_LAYOUT_MASK))
+#define SHAPE_ID_READ_ONLY_CACHE_MASK (SHAPE_ID_OFFSET_MASK | ROBJECT_HEAP | SHAPE_ID_FL_COMPLEX)
 
 typedef uint32_t redblack_id_t;
 
@@ -139,7 +137,6 @@ static inline shape_id_t
 RBASIC_SHAPE_ID(VALUE obj)
 {
     RUBY_ASSERT(!RB_SPECIAL_CONST_P(obj));
-    RUBY_ASSERT(!RB_TYPE_P(obj, T_IMEMO) || IMEMO_TYPE_P(obj, imemo_fields));
 #if RBASIC_SHAPE_ID_FIELD
     return (shape_id_t)((RBASIC(obj)->shape_id));
 #else
@@ -181,8 +178,6 @@ static inline void
 RBASIC_SET_SHAPE_ID(VALUE obj, shape_id_t shape_id)
 {
     RUBY_ASSERT(!RB_SPECIAL_CONST_P(obj));
-    RUBY_ASSERT(!RB_TYPE_P(obj, T_IMEMO) || IMEMO_TYPE_P(obj, imemo_fields));
-    RUBY_ASSERT(!IMEMO_TYPE_P(obj, imemo_fields) || rb_shape_layout(shape_id) == SHAPE_ID_LAYOUT_ROBJECT);
 
     RBASIC_SET_SHAPE_ID_NO_CHECKS(obj, shape_id);
 
@@ -221,8 +216,8 @@ typedef int rb_shape_foreach_transition_callback(shape_id_t shape_id, void *data
 bool rb_shape_foreach_field(shape_id_t shape_id, rb_shape_foreach_transition_callback func, void *data);
 
 shape_id_t rb_shape_transition_add_ivar_no_warnings(shape_id_t shape_id, ID id, VALUE klass);
-shape_id_t rb_shape_root_from_capacity(attr_index_t capacity);
-shape_id_t rb_shape_transition_root(shape_id_t shape_id, attr_index_t capacity);
+shape_id_t rb_shape_root_from_capacity(size_t capacity);
+shape_id_t rb_shape_transition_root(shape_id_t shape_id, size_t capacity);
 
 shape_id_t rb_shape_object_id(shape_id_t original_shape_id);
 shape_id_t rb_shape_rebuild(shape_id_t initial_shape_id, shape_id_t dest_shape_id);
@@ -254,6 +249,18 @@ rb_shape_has_object_id(shape_id_t shape_id)
 }
 
 static inline bool
+rb_shape_heap_p(shape_id_t shape_id)
+{
+    return shape_id & ROBJECT_HEAP;
+}
+
+static inline bool
+rb_obj_shape_heap_p(VALUE obj)
+{
+    return !RB_SPECIAL_CONST_P(obj) && rb_shape_heap_p(RBASIC_SHAPE_ID(obj));
+}
+
+static inline bool
 rb_shape_canonical_p(shape_id_t shape_id)
 {
     return !(shape_id & SHAPE_ID_FL_NON_CANONICAL_MASK);
@@ -263,12 +270,6 @@ static inline shape_id_t
 rb_shape_id_with_robject_layout(shape_id_t shape_id)
 {
     return (shape_id & ~SHAPE_ID_LAYOUT_MASK) | SHAPE_ID_LAYOUT_ROBJECT;
-}
-
-static inline uint8_t
-rb_shape_heap_index(shape_id_t shape_id)
-{
-    return (uint8_t)((shape_id & SHAPE_ID_HEAP_INDEX_MASK) >> SHAPE_ID_HEAP_INDEX_OFFSET);
 }
 
 static inline shape_id_t
@@ -335,7 +336,7 @@ ROBJECT_FIELDS_HASH(VALUE obj)
 {
     RBIMPL_ASSERT_TYPE(obj, RUBY_T_OBJECT);
     RUBY_ASSERT(rb_obj_shape_complex_p(obj));
-    RUBY_ASSERT(FL_TEST_RAW(obj, ROBJECT_HEAP));
+    RUBY_ASSERT(rb_obj_shape_heap_p(obj));
 
     return ROBJECT(obj)->as.hash;
 }
@@ -345,7 +346,7 @@ ROBJECT_SET_FIELDS_HASH(VALUE obj, st_table *tbl)
 {
     RBIMPL_ASSERT_TYPE(obj, RUBY_T_OBJECT);
     RUBY_ASSERT(rb_obj_shape_complex_p(obj));
-    RUBY_ASSERT(FL_TEST_RAW(obj, ROBJECT_HEAP));
+    RUBY_ASSERT(rb_obj_shape_heap_p(obj));
 
     ROBJECT(obj)->as.hash = tbl;
 }
@@ -464,12 +465,28 @@ rb_shape_transition_frozen(shape_id_t shape_id)
 }
 
 static inline shape_id_t
+rb_shape_transition_heap(shape_id_t shape_id)
+{
+    return shape_id | ROBJECT_HEAP;
+}
+
+static inline shape_id_t
+rb_shape_transition_embedded(shape_id_t shape_id)
+{
+    return shape_id & ~ROBJECT_HEAP;
+}
+
+static inline shape_id_t
 rb_shape_transition_complex(shape_id_t shape_id)
 {
     shape_id_t next_shape_id = rb_shape_layout(shape_id) | ROOT_COMPLEX_SHAPE_ID;
 
     if (rb_shape_has_object_id(shape_id)) {
         next_shape_id = rb_shape_layout(shape_id) | ROOT_COMPLEX_WITH_OBJ_ID;
+    }
+
+    if (rb_shape_heap_p(shape_id)) {
+        next_shape_id |= ROBJECT_HEAP;
     }
 
     RUBY_ASSERT(rb_shape_has_object_id(shape_id) == rb_shape_has_object_id(next_shape_id));
@@ -495,13 +512,29 @@ rb_obj_shape_transition_frozen(VALUE obj)
 }
 
 static inline shape_id_t
-rb_obj_shape_transition_complex(VALUE obj)
+rb_obj_shape_transition_heap(VALUE obj)
 {
-    return rb_shape_transition_complex(RBASIC_SHAPE_ID(obj));
+    return rb_shape_transition_heap(RBASIC_SHAPE_ID(obj));
 }
 
 static inline shape_id_t
-rb_obj_shape_transition_root(VALUE obj, attr_index_t capacity)
+rb_obj_shape_transition_embedded(VALUE obj)
+{
+    return rb_shape_transition_embedded(RBASIC_SHAPE_ID(obj));
+}
+
+static inline shape_id_t
+rb_obj_shape_transition_complex(VALUE obj)
+{
+    shape_id_t shape_id = rb_shape_transition_complex(RBASIC_SHAPE_ID(obj));
+    if (RB_TYPE_P(obj, T_OBJECT)) {
+        shape_id = rb_shape_transition_heap(shape_id);
+    }
+    return shape_id;
+}
+
+static inline shape_id_t
+rb_obj_shape_transition_root(VALUE obj, size_t capacity)
 {
     return rb_shape_transition_root(RBASIC_SHAPE_ID(obj), capacity);
 }
@@ -549,19 +582,24 @@ rb_getivar_cache_unpack(uint64_t packed)
 
     // Because caches may initialized with all bits set (IVAR_CACHE_INIT), and `shape_offset` if 32bits,
     // we need to remove any potential extra bits set in the "padding".
-    cache.unpack.shape_offset &= SHAPE_ID_OFFSET_MASK;
+    if (RSHAPE_OFFSET(cache.unpack.shape_offset) == INVALID_SHAPE_ID) {
+        cache.unpack.shape_offset = INVALID_SHAPE_ID;
+    }
+    else {
+        cache.unpack.shape_offset &= SHAPE_ID_READ_ONLY_CACHE_MASK;
+    }
     return cache.unpack;
 }
 
 static inline uint64_t
-rb_getivar_cache_pack(shape_id_t shape_offset, attr_index_t index)
+rb_getivar_cache_pack(shape_id_t shape_id, attr_index_t index)
 {
-    RUBY_ASSERT(shape_offset == RSHAPE_OFFSET(shape_offset));
-    RUBY_ASSERT(shape_offset != INVALID_SHAPE_ID);
+    RUBY_ASSERT(shape_id == (shape_id & SHAPE_ID_READ_ONLY_CACHE_MASK));
+    RUBY_ASSERT(RSHAPE_OFFSET(shape_id) != INVALID_SHAPE_ID);
 
     union rb_getivar_cache cache = {
         .unpack = {
-            .shape_offset = shape_offset,
+            .shape_offset = shape_id,
             .index = index,
         },
     };
@@ -607,11 +645,11 @@ rb_setivar_cache_revalidate(shape_id_t shape_id, rb_setivar_cache cache)
     RUBY_ASSERT(cache.dest_shape_offset == INVALID_SHAPE_ID || cache.dest_shape_offset == RSHAPE_OFFSET(cache.dest_shape_offset));
 
     shape_id_t normalized_shape_id = shape_id & SHAPE_ID_WRITE_MASK;
-    if (UNLIKELY(normalized_shape_id != cache.source_shape_offset)) {
+    if (RB_UNLIKELY(normalized_shape_id != cache.source_shape_offset)) {
         return INVALID_SHAPE_ID;
     }
 
-    if (UNLIKELY(cache.index >= RSHAPE_CAPACITY(shape_id))) {
+    if (RB_UNLIKELY(cache.index >= RSHAPE_CAPACITY(shape_id))) {
         // That's still a hit in term of layout, but the object will need to be resized,
         // so unfortunately we'll have to go through the slow path regardless...
         return INVALID_SHAPE_ID;

--- a/shape.h
+++ b/shape.h
@@ -25,8 +25,7 @@ STATIC_ASSERT(shape_id_num_bits, SHAPE_ID_NUM_BITS == sizeof(shape_id_t) * CHAR_
 //              index in rb_shape_tree.shape_list. Allow to access `rb_shape_t *`.
 //              This is the part that describe how fields are laid out in memory.
 //      19-22 SHAPE_ID_HEAP_INDEX_MASK
-//              index in rb_shape_tree.capacities. Allow to access slot size.
-//              Currently always 0 except for T_OBJECT.
+//              Unused. Formerly encoded an index into a table of GC heap sizes.
 //      23 SHAPE_ID_FL_COMPLEX
 //              The object is backed by a `st_table`.
 //      24 SHAPE_ID_FL_FROZEN
@@ -69,13 +68,12 @@ enum shape_id_fl_type {
 #undef RBIMPL_SHAPE_ID_FL
 };
 
-// This mask allows to check if a shape_id contains any ivar.
-// It relies on ROOT_SHAPE_WITH_OBJ_ID==1.
+// Retained for generated bindings. Use rb_shape_has_ivars instead.
 enum shape_id_mask {
     SHAPE_ID_HAS_IVAR_MASK = SHAPE_ID_FL_COMPLEX | (SHAPE_ID_OFFSET_MASK - 1),
 };
 
-// The interpreter doesn't care about frozen status, slot size, or object id, and
+// The interpreter doesn't care about frozen status, obsolete heap-index bits, or object id, and
 // has its own checks for physical field layout when reading ivars.
 // So we normalize shape_id by clearing these bits to improve cache hits.
 // JITs however might care about some of it.
@@ -97,6 +95,8 @@ typedef uint32_t redblack_id_t;
 #define ROOT_SHAPE_WITH_OBJ_ID          0x1
 #define ROOT_COMPLEX_SHAPE_ID       (ROOT_SHAPE_ID | SHAPE_ID_FL_COMPLEX)
 #define ROOT_COMPLEX_WITH_OBJ_ID    (ROOT_SHAPE_WITH_OBJ_ID | SHAPE_ID_FL_COMPLEX | SHAPE_ID_FL_HAS_OBJECT_ID)
+
+#define SHAPE_MAX_CAPACITY 126
 
 enum shape_type {
     SHAPE_ROOT,
@@ -126,9 +126,6 @@ enum shape_flags {
 
 typedef struct {
     rb_shape_t *shape_list;
-    attr_index_t max_capacity;
-    attr_index_t heaps_count;
-    attr_index_t capacities[SHAPE_ID_HEAP_INDEX_MAX];
 } rb_shape_tree_t;
 
 RUBY_SYMBOL_EXPORT_BEGIN
@@ -224,6 +221,8 @@ typedef int rb_shape_foreach_transition_callback(shape_id_t shape_id, void *data
 bool rb_shape_foreach_field(shape_id_t shape_id, rb_shape_foreach_transition_callback func, void *data);
 
 shape_id_t rb_shape_transition_add_ivar_no_warnings(shape_id_t shape_id, ID id, VALUE klass);
+shape_id_t rb_shape_root_from_capacity(attr_index_t capacity);
+shape_id_t rb_shape_transition_root(shape_id_t shape_id, attr_index_t capacity);
 
 shape_id_t rb_shape_object_id(shape_id_t original_shape_id);
 shape_id_t rb_shape_rebuild(shape_id_t initial_shape_id, shape_id_t dest_shape_id);
@@ -273,18 +272,6 @@ rb_shape_heap_index(shape_id_t shape_id)
 }
 
 static inline shape_id_t
-rb_shape_root(size_t heap_id)
-{
-    shape_id_t heap_index = (shape_id_t)(heap_id + 1);
-    shape_id_t heap_flags = heap_index << SHAPE_ID_HEAP_INDEX_OFFSET;
-
-    RUBY_ASSERT((heap_flags & SHAPE_ID_HEAP_INDEX_MASK) == heap_flags);
-    RUBY_ASSERT(rb_shape_heap_index(heap_flags) == heap_index);
-
-    return ROOT_SHAPE_ID | heap_flags;
-}
-
-static inline shape_id_t
 RSHAPE_PARENT_OFFSET(shape_id_t shape_id)
 {
     return RSHAPE(shape_id)->parent_offset;
@@ -309,26 +296,9 @@ RSHAPE_TYPE_P(shape_id_t shape_id, enum shape_type type)
 }
 
 static inline attr_index_t
-RSHAPE_EMBEDDED_CAPACITY(shape_id_t shape_id)
-{
-    uint8_t heap_index = rb_shape_heap_index(shape_id);
-    if (heap_index) {
-        return rb_shape_tree.capacities[heap_index - 1];
-    }
-    return 0;
-}
-
-static inline attr_index_t
 RSHAPE_CAPACITY(shape_id_t shape_id)
 {
-    attr_index_t embedded_capacity = RSHAPE_EMBEDDED_CAPACITY(shape_id);
-
-    if (embedded_capacity > RSHAPE(shape_id)->capacity) {
-        return embedded_capacity;
-    }
-    else {
-        return RSHAPE(shape_id)->capacity;
-    }
+    return RSHAPE(shape_id)->capacity;
 }
 
 static inline attr_index_t
@@ -420,7 +390,19 @@ rb_obj_shape_has_id(VALUE obj)
 static inline bool
 rb_shape_has_ivars(shape_id_t shape_id)
 {
-    return shape_id & SHAPE_ID_HAS_IVAR_MASK;
+    if (rb_shape_complex_p(shape_id)) {
+        return true;
+    }
+
+    rb_shape_t *shape = RSHAPE(shape_id);
+    while (shape->parent_offset != INVALID_SHAPE_ID) {
+        if (shape->type == SHAPE_IVAR) {
+            return true;
+        }
+        shape = RSHAPE(shape->parent_offset);
+    }
+
+    return false;
 }
 
 static inline bool
@@ -432,7 +414,7 @@ rb_obj_shape_has_ivars(VALUE obj)
 static inline bool
 rb_shape_has_fields(shape_id_t shape_id)
 {
-    return shape_id & (SHAPE_ID_OFFSET_MASK | SHAPE_ID_FL_COMPLEX);
+    return rb_shape_complex_p(shape_id) || RSHAPE_LEN(shape_id) > 0;
 }
 
 static inline bool
@@ -490,11 +472,6 @@ rb_shape_transition_complex(shape_id_t shape_id)
         next_shape_id = rb_shape_layout(shape_id) | ROOT_COMPLEX_WITH_OBJ_ID;
     }
 
-    uint8_t heap_index = rb_shape_heap_index(shape_id);
-    if (heap_index) {
-        next_shape_id |= rb_shape_root(heap_index - 1);
-    }
-
     RUBY_ASSERT(rb_shape_has_object_id(shape_id) == rb_shape_has_object_id(next_shape_id));
 
     return next_shape_id;
@@ -506,12 +483,6 @@ rb_shape_transition_offset(shape_id_t shape_id, shape_id_t offset)
     offset = RSHAPE_OFFSET(offset);
     RUBY_ASSERT(RSHAPE_OFFSET(shape_id) == offset || RSHAPE_DIRECT_CHILD_P(shape_id, offset));
     return RSHAPE_FLAGS(shape_id) | offset;
-}
-
-static inline shape_id_t
-rb_shape_transition_heap(shape_id_t shape_id, size_t heap_index)
-{
-    return (shape_id & (~SHAPE_ID_HEAP_INDEX_MASK)) | rb_shape_root(heap_index);
 }
 
 shape_id_t rb_shape_transition_object_id(shape_id_t shape_id);
@@ -530,9 +501,9 @@ rb_obj_shape_transition_complex(VALUE obj)
 }
 
 static inline shape_id_t
-rb_obj_shape_transition_heap(VALUE obj, size_t heap_index)
+rb_obj_shape_transition_root(VALUE obj, attr_index_t capacity)
 {
-    return rb_shape_transition_heap(RBASIC_SHAPE_ID(obj), heap_index);
+    return rb_shape_transition_root(RBASIC_SHAPE_ID(obj), capacity);
 }
 
 static inline shape_id_t

--- a/variable.c
+++ b/variable.c
@@ -1578,16 +1578,14 @@ obj_transition_complex(VALUE obj, st_table *table)
     switch (BUILTIN_TYPE(obj)) {
       case T_OBJECT:
         {
+            shape_id = rb_shape_transition_heap(shape_id);
             VALUE *old_fields = NULL;
             uint32_t old_fields_len = 0;
-            if (FL_TEST_RAW(obj, ROBJECT_HEAP)) {
+            if (rb_obj_shape_heap_p(obj)) {
                 old_fields = ROBJECT_FIELDS(obj);
                 old_fields_len = ROBJECT_FIELDS_CAPACITY(obj);
             }
-            else {
-                FL_SET_RAW(obj, ROBJECT_HEAP);
-            }
-            RBASIC_SET_SHAPE_ID(obj, shape_id);
+            RBASIC_SET_SHAPE_ID(obj, rb_shape_transition_heap(shape_id));
             ROBJECT_SET_FIELDS_HASH(obj, table);
             if (old_fields) {
                 SIZED_FREE_N(old_fields, old_fields_len);
@@ -1682,7 +1680,7 @@ rb_ivar_delete(VALUE obj, ID id, VALUE undef)
     if (UNLIKELY(rb_shape_complex_p(next_shape_id))) {
         if (UNLIKELY(!rb_shape_complex_p(old_shape_id))) {
             if (type == T_OBJECT) {
-                rb_evict_fields_to_hash(obj);
+                next_shape_id = rb_evict_fields_to_hash(obj);
             }
             else {
                 fields_obj = imemo_fields_complex_from_obj(obj, fields_obj, next_shape_id);
@@ -1713,12 +1711,13 @@ rb_ivar_delete(VALUE obj, ID id, VALUE undef)
             RUBY_ASSERT(rb_shape_layout(next_shape_id) == SHAPE_ID_LAYOUT_ROBJECT);
             RBASIC_SET_SHAPE_ID(fields_obj, next_shape_id);
 
-            if (FL_TEST_RAW(fields_obj, OBJ_FIELD_HEAP)) {
+            if (rb_shape_heap_p(old_shape_id)) {
                 if (rb_obj_embedded_size(new_fields_count) <= rb_gc_obj_slot_size(fields_obj)) {
                     // Re-embed objects when instances become small enough
                     // This is necessary because YJIT assumes that objects with the same shape
                     // have the same embeddedness for efficiency (avoid extra checks)
-                    FL_UNSET_RAW(fields_obj, ROBJECT_HEAP);
+                    next_shape_id = rb_shape_transition_embedded(next_shape_id);
+                    RBASIC_SET_SHAPE_ID(fields_obj, next_shape_id);
                     MEMCPY(rb_imemo_fields_ptr(fields_obj), fields, VALUE, new_fields_count);
                     SIZED_FREE_N(fields, RSHAPE_CAPACITY(old_shape_id));
                 }
@@ -1826,6 +1825,8 @@ imemo_fields_set(VALUE owner, VALUE fields_obj, shape_id_t target_shape_id, ID f
     shape_id_t current_shape_id = fields_obj ? RBASIC_SHAPE_ID(fields_obj) : ROOT_SHAPE_ID;
 
     if (UNLIKELY(rb_shape_complex_p(target_shape_id))) {
+        shape_id_t heap_target_shape_id = rb_shape_transition_heap(target_shape_id);
+
         if (rb_shape_complex_p(current_shape_id)) {
             if (concurrent) {
                 // In multi-ractor case, we must always work on a copy because
@@ -1835,8 +1836,8 @@ imemo_fields_set(VALUE owner, VALUE fields_obj, shape_id_t target_shape_id, ID f
             }
         }
         else {
-            fields_obj = imemo_fields_complex_from_obj(owner, original_fields_obj, target_shape_id);
-            current_shape_id = target_shape_id;
+            fields_obj = imemo_fields_complex_from_obj(owner, original_fields_obj, heap_target_shape_id);
+            current_shape_id = heap_target_shape_id;
         }
 
         st_table *table = rb_imemo_fields_complex_tbl(fields_obj);
@@ -1844,7 +1845,7 @@ imemo_fields_set(VALUE owner, VALUE fields_obj, shape_id_t target_shape_id, ID f
         RUBY_ASSERT(field_name);
         st_insert(table, (st_data_t)field_name, (st_data_t)val);
         RB_OBJ_WRITTEN(fields_obj, Qundef, val);
-        RBASIC_SET_SHAPE_ID(fields_obj, rb_shape_id_with_robject_layout(target_shape_id));
+        RBASIC_SET_SHAPE_ID(fields_obj, rb_shape_id_with_robject_layout(heap_target_shape_id));
     }
     else {
         attr_index_t index = RSHAPE_INDEX(target_shape_id);
@@ -1909,15 +1910,15 @@ rb_ensure_iv_list_size(VALUE obj, uint32_t current_len, uint32_t new_capacity)
 {
     RUBY_ASSERT(!rb_obj_shape_complex_p(obj));
 
-    if (FL_TEST_RAW(obj, ROBJECT_HEAP)) {
+    if (rb_obj_shape_heap_p(obj)) {
         SIZED_REALLOC_N(ROBJECT(obj)->as.heap.fields, VALUE, new_capacity, current_len);
     }
     else {
         VALUE *ptr = ROBJECT_FIELDS(obj);
         VALUE *newptr = ALLOC_N(VALUE, new_capacity);
         MEMCPY(newptr, ptr, VALUE, current_len);
-        FL_SET_RAW(obj, ROBJECT_HEAP);
         ROBJECT(obj)->as.heap.fields = newptr;
+        RBASIC_SET_SHAPE_ID(obj, rb_obj_shape_transition_heap(obj));
     }
 }
 
@@ -1948,11 +1949,14 @@ obj_field_set(VALUE obj, shape_id_t target_shape_id, ID field_name, VALUE val)
     shape_id_t current_shape_id = RBASIC_SHAPE_ID(obj);
 
     if (UNLIKELY(rb_shape_complex_p(target_shape_id))) {
+        target_shape_id = rb_shape_transition_heap(target_shape_id);
+
         if (UNLIKELY(!rb_shape_complex_p(current_shape_id))) {
             current_shape_id = rb_evict_fields_to_hash(obj);
         }
 
         if (RSHAPE_LEN(target_shape_id) > RSHAPE_LEN(current_shape_id)) {
+            target_shape_id = rb_shape_transition_heap(target_shape_id);
             RBASIC_SET_SHAPE_ID(obj, target_shape_id);
         }
 
@@ -1972,6 +1976,10 @@ obj_field_set(VALUE obj, shape_id_t target_shape_id, ID field_name, VALUE val)
         if (index >= RSHAPE_LEN(current_shape_id)) {
             if (UNLIKELY(index >= RSHAPE_CAPACITY(current_shape_id))) {
                 rb_ensure_iv_list_size(obj, RSHAPE_CAPACITY(current_shape_id), RSHAPE_CAPACITY(target_shape_id));
+                target_shape_id = rb_shape_transition_heap(target_shape_id);
+            }
+            else if (rb_shape_heap_p(current_shape_id)) {
+                target_shape_id = rb_shape_transition_heap(target_shape_id);
             }
             RBASIC_SET_SHAPE_ID(obj, target_shape_id);
         }
@@ -4649,6 +4657,8 @@ class_fields_ivar_set(VALUE klass, VALUE fields_obj, ID id, VALUE val, bool conc
 
 complex:
     {
+        next_shape_id = rb_shape_transition_heap(next_shape_id);
+
         if (concurrent && fields_obj == original_fields_obj) {
             // In multi-ractor case, we must always work on a copy because
             // even if the field already exist, inserting in a st_table may

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -91,6 +91,7 @@ fn main() {
         .allowlist_function("rb_yjit_shape_capacity")
         .allowlist_function("rb_yjit_shape_index")
         .allowlist_var("SHAPE_ID_NUM_BITS")
+        .allowlist_type("shape_id_fl_type")
         .allowlist_type("shape_id_mask")
         .allowlist_function("rb_funcall")
         .allowlist_function("rb_obj_is_kind_of")

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -3187,7 +3187,7 @@ fn gen_set_ivar(
         let current_shape_id = comptime_receiver.shape_id_of();
         // We don't need to check about imemo_fields here because we're definitely looking at a T_OBJECT.
         let klass = unsafe { rb_obj_class(comptime_receiver) };
-        let next_shape_id = unsafe { rb_shape_transition_add_ivar_no_warnings(current_shape_id, ivar_name, klass) };
+        let mut next_shape_id = unsafe { rb_shape_transition_add_ivar_no_warnings(current_shape_id, ivar_name, klass) };
 
         // If the VM ran out of shapes, or this class generated too many leaf,
         // it may be de-optimized into OBJ_COMPLEX_SHAPE (hash-table).
@@ -3201,6 +3201,9 @@ fn gen_set_ivar(
             // If the new shape has a different capacity, or is COMPLEX, we'll have to
             // reallocate it.
             let needs_extension = next_capacity != current_capacity;
+            if needs_extension {
+                next_shape_id |= ROBJECT_HEAP as u32;
+            }
 
             // We can write to the object, but we need to transition the shape
             let ivar_index = unsafe { rb_yjit_shape_index(next_shape_id) } as usize;

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -453,9 +453,7 @@ impl VALUE {
     }
 
     pub fn embedded_p(self) -> bool {
-        unsafe {
-            FL_TEST_RAW(self, VALUE(ROBJECT_HEAP as usize)) == VALUE(0)
-        }
+        (self.shape_id_of() & ROBJECT_HEAP as u32) == 0
     }
 
     pub fn as_isize(self) -> isize {

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -271,8 +271,6 @@ pub const RARRAY_EMBED_LEN_SHIFT: ruby_rarray_consts = 15;
 pub type ruby_rarray_consts = u32;
 pub const RMODULE_IS_REFINEMENT: ruby_rmodule_flags = 8192;
 pub type ruby_rmodule_flags = u32;
-pub const ROBJECT_HEAP: ruby_robject_flags = 65536;
-pub type ruby_robject_flags = u32;
 pub type rb_block_call_func = ::std::option::Option<
     unsafe extern "C" fn(
         yielded_arg: VALUE,
@@ -302,6 +300,22 @@ pub const RUBY_ENCINDEX_EUC_JP: ruby_preserved_encindex = 10;
 pub const RUBY_ENCINDEX_Windows_31J: ruby_preserved_encindex = 11;
 pub const RUBY_ENCINDEX_BUILTIN_MAX: ruby_preserved_encindex = 12;
 pub type ruby_preserved_encindex = u32;
+pub type attr_index_t = u8;
+pub type shape_id_t = u32;
+pub const ROBJECT_HEAP: shape_id_fl_type = 524288;
+pub const SHAPE_ID_FL_COMPLEX: shape_id_fl_type = 1048576;
+pub const SHAPE_ID_FL_FROZEN: shape_id_fl_type = 2097152;
+pub const SHAPE_ID_FL_HAS_OBJECT_ID: shape_id_fl_type = 4194304;
+pub const SHAPE_ID_LAYOUT_ROBJECT: shape_id_fl_type = 0;
+pub const SHAPE_ID_LAYOUT_RCLASS: shape_id_fl_type = 8388608;
+pub const SHAPE_ID_LAYOUT_RDATA: shape_id_fl_type = 16777216;
+pub const SHAPE_ID_LAYOUT_OTHER: shape_id_fl_type = 25165824;
+pub const SHAPE_ID_LAYOUT_MASK: shape_id_fl_type = 25165824;
+pub const SHAPE_ID_FL_NON_CANONICAL_MASK: shape_id_fl_type = 6291456;
+pub const SHAPE_ID_FLAGS_MASK: shape_id_fl_type = 33030144;
+pub type shape_id_fl_type = u32;
+pub const SHAPE_ID_HAS_IVAR_MASK: shape_id_mask = 1572862;
+pub type shape_id_mask = u32;
 pub const BOP_PLUS: ruby_basic_operators = 0;
 pub const BOP_MINUS: ruby_basic_operators = 1;
 pub const BOP_MULT: ruby_basic_operators = 2;
@@ -630,10 +644,6 @@ pub const VM_ENV_FLAG_ESCAPED: vm_frame_env_flags = 4;
 pub const VM_ENV_FLAG_WB_REQUIRED: vm_frame_env_flags = 8;
 pub const VM_ENV_FLAG_ISOLATED: vm_frame_env_flags = 16;
 pub type vm_frame_env_flags = u32;
-pub type attr_index_t = u8;
-pub type shape_id_t = u32;
-pub const SHAPE_ID_HAS_IVAR_MASK: shape_id_mask = 8912894;
-pub type shape_id_mask = u32;
 #[repr(C)]
 pub struct rb_cvar_class_tbl_entry {
     pub imemo_flags: VALUE,
@@ -1074,6 +1084,14 @@ extern "C" {
     pub fn rb_attr_get(obj: VALUE, name: ID) -> VALUE;
     pub fn rb_const_get(space: VALUE, name: ID) -> VALUE;
     pub fn rb_obj_info_dump(obj: VALUE);
+    pub fn rb_shape_id_offset() -> i32;
+    pub fn rb_obj_shape_id(obj: VALUE) -> shape_id_t;
+    pub fn rb_shape_get_iv_index(shape_id: shape_id_t, id: ID, value: *mut attr_index_t) -> bool;
+    pub fn rb_shape_transition_add_ivar_no_warnings(
+        shape_id: shape_id_t,
+        id: ID,
+        klass: VALUE,
+    ) -> shape_id_t;
     pub fn rb_class_allocate_instance(klass: VALUE) -> VALUE;
     pub fn rb_obj_equal(obj1: VALUE, obj2: VALUE) -> VALUE;
     pub fn rb_reg_new_from_values(
@@ -1111,14 +1129,6 @@ extern "C" {
     ) -> *const rb_callable_method_entry_t;
     pub fn rb_obj_info(obj: VALUE) -> *const ::std::os::raw::c_char;
     pub fn rb_ec_stack_check(ec: *mut rb_execution_context_struct) -> ::std::os::raw::c_int;
-    pub fn rb_shape_id_offset() -> i32;
-    pub fn rb_obj_shape_id(obj: VALUE) -> shape_id_t;
-    pub fn rb_shape_get_iv_index(shape_id: shape_id_t, id: ID, value: *mut attr_index_t) -> bool;
-    pub fn rb_shape_transition_add_ivar_no_warnings(
-        shape_id: shape_id_t,
-        id: ID,
-        klass: VALUE,
-    ) -> shape_id_t;
     pub fn rb_ivar_get_at(obj: VALUE, index: attr_index_t, id: ID) -> VALUE;
     pub fn rb_ivar_get_at_no_ractor_check(obj: VALUE, index: attr_index_t) -> VALUE;
     pub fn rb_gvar_get(arg1: ID) -> VALUE;

--- a/zjit/bindgen/src/main.rs
+++ b/zjit/bindgen/src/main.rs
@@ -104,6 +104,7 @@ fn main() {
         .allowlist_function("rb_bug")
 
         .allowlist_function("rb_obj_shape_id")
+        .allowlist_function("rb_obj_shape_heap_p")
         .allowlist_function("rb_shape_id_offset")
         .allowlist_function("rb_shape_get_iv_index")
         .allowlist_function("rb_shape_transition_add_ivar_no_warnings")

--- a/zjit/src/cruby.rs
+++ b/zjit/src/cruby.rs
@@ -626,9 +626,7 @@ impl VALUE {
     }
 
     pub fn embedded_p(self) -> bool {
-        unsafe {
-            FL_TEST_RAW(self, VALUE(ROBJECT_HEAP as usize)) == VALUE(0)
-        }
+        (self.shape_id_of().0 & ROBJECT_HEAP as u32) == 0
     }
 
     pub fn struct_embedded_p(self) -> bool {

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -213,6 +213,7 @@ impl<T> ::std::cmp::Eq for __BindgenUnionField<T> {}
 pub const ONIG_OPTION_IGNORECASE: u32 = 1;
 pub const ONIG_OPTION_EXTEND: u32 = 2;
 pub const ONIG_OPTION_MULTILINE: u32 = 4;
+pub const SHAPE_ID_NUM_BITS: u32 = 32;
 pub const ARG_ENCODING_FIXED: u32 = 16;
 pub const ARG_ENCODING_NONE: u32 = 32;
 pub const INTEGER_REDEFINED_OP_FLAG: u32 = 1;
@@ -233,7 +234,6 @@ pub const VM_ENV_DATA_INDEX_ME_CREF: i32 = -2;
 pub const VM_ENV_DATA_INDEX_SPECVAL: i32 = -1;
 pub const VM_ENV_DATA_INDEX_FLAGS: u32 = 0;
 pub const VM_BLOCK_HANDLER_NONE: u32 = 0;
-pub const SHAPE_ID_NUM_BITS: u32 = 32;
 pub const ZJIT_STACK_MAP_VREG_TAG: u32 = 8;
 pub const ZJIT_STACK_MAP_SHIFT: u32 = 8;
 pub const ZJIT_JIT_RETURN_C_FRAME: u32 = 1;
@@ -342,8 +342,6 @@ pub const RARRAY_EMBED_LEN_SHIFT: ruby_rarray_consts = 15;
 pub type ruby_rarray_consts = u32;
 pub const RMODULE_IS_REFINEMENT: ruby_rmodule_flags = 8192;
 pub type ruby_rmodule_flags = u32;
-pub const ROBJECT_HEAP: ruby_robject_flags = 65536;
-pub type ruby_robject_flags = u32;
 pub type rb_event_flag_t = u32;
 pub type rb_block_call_func = ::std::option::Option<
     unsafe extern "C" fn(
@@ -380,6 +378,20 @@ pub const RUBY_ENCINDEX_EUC_JP: ruby_preserved_encindex = 10;
 pub const RUBY_ENCINDEX_Windows_31J: ruby_preserved_encindex = 11;
 pub const RUBY_ENCINDEX_BUILTIN_MAX: ruby_preserved_encindex = 12;
 pub type ruby_preserved_encindex = u32;
+pub type attr_index_t = u8;
+pub type shape_id_t = u32;
+pub const ROBJECT_HEAP: shape_id_fl_type = 524288;
+pub const SHAPE_ID_FL_COMPLEX: shape_id_fl_type = 1048576;
+pub const SHAPE_ID_FL_FROZEN: shape_id_fl_type = 2097152;
+pub const SHAPE_ID_FL_HAS_OBJECT_ID: shape_id_fl_type = 4194304;
+pub const SHAPE_ID_LAYOUT_ROBJECT: shape_id_fl_type = 0;
+pub const SHAPE_ID_LAYOUT_RCLASS: shape_id_fl_type = 8388608;
+pub const SHAPE_ID_LAYOUT_RDATA: shape_id_fl_type = 16777216;
+pub const SHAPE_ID_LAYOUT_OTHER: shape_id_fl_type = 25165824;
+pub const SHAPE_ID_LAYOUT_MASK: shape_id_fl_type = 25165824;
+pub const SHAPE_ID_FL_NON_CANONICAL_MASK: shape_id_fl_type = 6291456;
+pub const SHAPE_ID_FLAGS_MASK: shape_id_fl_type = 33030144;
+pub type shape_id_fl_type = u32;
 pub const BOP_PLUS: ruby_basic_operators = 0;
 pub const BOP_MINUS: ruby_basic_operators = 1;
 pub const BOP_MULT: ruby_basic_operators = 2;
@@ -1486,20 +1498,6 @@ pub const VM_ENV_FLAG_ESCAPED: vm_frame_env_flags = 4;
 pub const VM_ENV_FLAG_WB_REQUIRED: vm_frame_env_flags = 8;
 pub const VM_ENV_FLAG_ISOLATED: vm_frame_env_flags = 16;
 pub type vm_frame_env_flags = u32;
-pub type attr_index_t = u8;
-pub type shape_id_t = u32;
-pub const SHAPE_ID_HEAP_INDEX_MASK: shape_id_fl_type = 7864320;
-pub const SHAPE_ID_FL_COMPLEX: shape_id_fl_type = 8388608;
-pub const SHAPE_ID_FL_FROZEN: shape_id_fl_type = 16777216;
-pub const SHAPE_ID_FL_HAS_OBJECT_ID: shape_id_fl_type = 33554432;
-pub const SHAPE_ID_LAYOUT_ROBJECT: shape_id_fl_type = 0;
-pub const SHAPE_ID_LAYOUT_RCLASS: shape_id_fl_type = 67108864;
-pub const SHAPE_ID_LAYOUT_RDATA: shape_id_fl_type = 134217728;
-pub const SHAPE_ID_LAYOUT_OTHER: shape_id_fl_type = 201326592;
-pub const SHAPE_ID_LAYOUT_MASK: shape_id_fl_type = 201326592;
-pub const SHAPE_ID_FL_NON_CANONICAL_MASK: shape_id_fl_type = 50331648;
-pub const SHAPE_ID_FLAGS_MASK: shape_id_fl_type = 267911168;
-pub type shape_id_fl_type = u32;
 pub const CONST_DEPRECATED: rb_const_flag_t = 256;
 pub const CONST_VISIBILITY_MASK: rb_const_flag_t = 255;
 pub const CONST_PUBLIC: rb_const_flag_t = 0;
@@ -2063,6 +2061,14 @@ unsafe extern "C" {
     pub fn rb_ivar_defined(obj: VALUE, name: ID) -> VALUE;
     pub fn rb_attr_get(obj: VALUE, name: ID) -> VALUE;
     pub fn rb_const_get(space: VALUE, name: ID) -> VALUE;
+    pub fn rb_shape_id_offset() -> i32;
+    pub fn rb_obj_shape_id(obj: VALUE) -> shape_id_t;
+    pub fn rb_shape_get_iv_index(shape_id: shape_id_t, id: ID, value: *mut attr_index_t) -> bool;
+    pub fn rb_shape_transition_add_ivar_no_warnings(
+        shape_id: shape_id_t,
+        id: ID,
+        klass: VALUE,
+    ) -> shape_id_t;
     pub fn rb_class_allocate_instance(klass: VALUE) -> VALUE;
     pub fn rb_obj_equal(obj1: VALUE, obj2: VALUE) -> VALUE;
     pub fn rb_reg_new_from_values(
@@ -2107,14 +2113,6 @@ unsafe extern "C" {
     ) -> *const ::std::os::raw::c_char;
     pub fn rb_ec_stack_check(ec: *mut rb_execution_context_struct) -> ::std::os::raw::c_int;
     pub fn rb_gc_writebarrier_remember(obj: VALUE);
-    pub fn rb_shape_id_offset() -> i32;
-    pub fn rb_obj_shape_id(obj: VALUE) -> shape_id_t;
-    pub fn rb_shape_get_iv_index(shape_id: shape_id_t, id: ID, value: *mut attr_index_t) -> bool;
-    pub fn rb_shape_transition_add_ivar_no_warnings(
-        shape_id: shape_id_t,
-        id: ID,
-        klass: VALUE,
-    ) -> shape_id_t;
     pub fn rb_const_lookup(klass: VALUE, id: ID) -> *mut rb_const_entry_t;
     pub fn rb_ivar_get_at_no_ractor_check(obj: VALUE, index: attr_index_t) -> VALUE;
     pub fn rb_gvar_get(arg1: ID) -> VALUE;


### PR DESCRIPTION
Currently, root object shapes are created based on slot sizes available from the GC. This is limiting for GCs that don't have slot sizes, like MMTk, and also when the default GC supports larger object sizes.

This commit changes object shapes to not depend on slot sizes and can adapt to GCs that support dynamic slot sizes. This implementation should currently make no difference for the default GC as it will end up creating the same root shapes. We can see that there is basically no change in benchmarks:

```
--------------  ------------  ------------  ------------  ------------  --------------  -------------  -----------------
bench            master (ms)     RSS (MiB)   branch (ms)     RSS (MiB)  branch 1st itr  master/branch  RSS master/branch
activerecord    103.7 ± 3.3%   75.1 ± 0.3%  102.5 ± 2.9%   74.0 ± 0.6%           1.013          1.011              1.015
chunky-png      332.6 ± 0.2%   84.6 ± 2.4%  335.0 ± 0.6%   88.0 ± 1.8%           1.006          0.993              0.962
erubi-rails     432.3 ± 1.9%  136.5 ± 0.5%  453.7 ± 0.8%  141.9 ± 1.5%           1.006          0.953              0.962
hexapdf         859.6 ± 0.7%  626.2 ± 1.2%  890.0 ± 1.8%  608.2 ± 1.1%           0.989          0.966              1.030
liquid-c         21.9 ± 7.7%  68.7 ± 14.1%   22.7 ± 9.0%  70.1 ± 14.5%           1.017          0.964              0.981
liquid-compile   20.0 ± 7.8%   46.5 ± 6.0%   20.2 ± 7.1%   47.1 ± 5.3%           0.998          0.993              0.987
liquid-render    54.8 ± 3.4%   55.8 ± 9.1%   55.5 ± 3.1%   55.4 ± 8.9%           0.970          0.988              1.007
lobsters        356.9 ± 0.7%  327.9 ± 0.0%  363.4 ± 1.1%  338.5 ± 0.1%           1.035          0.982              0.969
mail             47.8 ± 1.2%   73.0 ± 0.8%   48.0 ± 1.9%   72.3 ± 0.6%           1.110          0.996              1.010
psych-load      839.8 ± 0.4%   55.2 ± 0.5%  863.9 ± 0.2%   55.0 ± 0.3%           0.968          0.972              1.003
railsbench      741.7 ± 3.5%  135.8 ± 1.0%  717.0 ± 0.2%  128.8 ± 0.4%           1.004          1.034              1.055
rubocop          74.4 ± 7.6%  106.1 ± 1.9%   74.2 ± 6.4%  107.1 ± 1.9%           1.105          1.003              0.990
ruby-lsp         69.6 ± 1.0%   78.0 ± 0.3%   69.2 ± 0.9%   75.8 ± 0.3%           1.073          1.006              1.029
sequel           21.3 ± 4.2%   55.8 ± 1.2%   20.9 ± 1.2%   48.4 ± 0.0%           0.881          1.019              1.151
shipit          620.7 ± 1.1%  160.0 ± 0.5%  633.7 ± 1.1%  157.2 ± 0.4%           0.994          0.979              1.018
--------------  ------------  ------------  ------------  ------------  --------------  -------------  -----------------
```