### PR TITLE
Avoid array allocation in `Array#include?` on literal arrays

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -4357,7 +4357,8 @@ iseq_specialized_instruction(rb_iseq_t *iseq, INSN *iobj)
         INSN *niobj = (INSN *)iobj->link.next;
         if ((IS_INSN_ID(niobj, getlocal) ||
              IS_INSN_ID(niobj, getinstancevariable) ||
-             IS_INSN_ID(niobj, putself)) &&
+             IS_INSN_ID(niobj, putself) ||
+             IS_INSN_ID(niobj, putobject)) &&
             IS_NEXT_INSN_ID(&niobj->link, send)) {
 
             LINK_ELEMENT *sendobj = &(niobj->link); // Below we call ->next;

--- a/compile.c
+++ b/compile.c
@@ -4358,7 +4358,8 @@ iseq_specialized_instruction(rb_iseq_t *iseq, INSN *iobj)
         if ((IS_INSN_ID(niobj, getlocal) ||
              IS_INSN_ID(niobj, getinstancevariable) ||
              IS_INSN_ID(niobj, putself) ||
-             IS_INSN_ID(niobj, putobject)) &&
+             IS_INSN_ID(niobj, putobject) ||
+             IS_INSN_ID(niobj, putnil)) &&
             IS_NEXT_INSN_ID(&niobj->link, send)) {
 
             LINK_ELEMENT *sendobj = &(niobj->link); // Below we call ->next;

--- a/test/ruby/test_optimization.rb
+++ b/test/ruby/test_optimization.rb
@@ -1119,6 +1119,12 @@ class TestRubyOptimization < Test::Unit::TestCase
       '@c = :b; [:a, :b].include?(@c)',
       '@c = "b"; %i[a b].include?(@c.to_sym)',
       '[:a, :b].include?(self) == false',
+      "[:a, :b].include?(:a)",
+      "[true, false].include?(false)",
+      "# frozen_string_literal: true\n['a', 'b'].include?('a')",
+      "# frozen_string_literal: true\n['a', 'b'].include?('c') == false",
+      "# frozen_string_literal: true\n['a', 'b'].include?(2) == false",
+      "# frozen_string_literal: true\n['a', 'b'].include?(/a/) == false",
     ].each do |code|
       iseq = RubyVM::InstructionSequence.compile(code)
       insn = iseq.disasm

--- a/test/ruby/test_optimization.rb
+++ b/test/ruby/test_optimization.rb
@@ -1121,6 +1121,7 @@ class TestRubyOptimization < Test::Unit::TestCase
       '[:a, :b].include?(self) == false',
       "[:a, :b].include?(:a)",
       "[true, false].include?(false)",
+      "[1, nil].include?(nil)",
       "# frozen_string_literal: true\n['a', 'b'].include?('a')",
       "# frozen_string_literal: true\n['a', 'b'].include?('c') == false",
       "# frozen_string_literal: true\n['a', 'b'].include?(2) == false",


### PR DESCRIPTION
`Array#include?` on a literal array of frozen-shareable elements (Integers, Symbols, true/false/nil, frozen String literals) compiles the receiver to `duparray`, which allocates a fresh `Array` copy on every call — even though `#include?` only reads it.

Bug Tracker: https://bugs.ruby-lang.org/issues/22131

## Environment

- OS: macOS 26.5.1 (25F80)
- Compiler: Apple clang 21.0.0
- CPU: Apple M3 Max
- Memory: 64 GB

## TL;DR

| case | master | candidate | speedup |
|---|---|---|---:|
| `[1,2,3].include?(2)` | 17.83M i/s (56.09 ns) | 30.00M i/s (33.33 ns) | 1.68x |
| `ARR.include?(2)` (const) | 23.92M i/s (41.80 ns) | 23.92M i/s (41.81 ns) | ~1.00x |

Allocations — 1,000,000 calls of `[1,2,3].include?(2)`

| case                        | master     | candidate |
|-----------------------------|------------|-----------|
|[1,2,3].include?(2) (literal)|  1,000,004 | 2         |
| ARR.include?(2) (constant)  | 5          | 5         |

**Benefits**

- Eliminates per-call array allocation for `[literals].include?(x)` (1/call becomes 0).
- ~1.68x faster on the hot path (56 ns to 33 ns/call).

## Before

```ruby
# frozen_string_literal: true
[1, 2].include?(3)
```

```                        
== disasm: #<ISeq:<main>@-e:2 (2,0)-(2,18)>
0000 duparray                               [1, 2]                    (   2)[Li]
0002 putobject                              3
0004 opt_send_without_block                 <calldata!mid:include?, argc:1, ARGS_SIMPLE>
0006 leave
```

## After

```ruby
# frozen_string_literal: true
[1, 2].include?(3)
```

```
== disasm: #<ISeq:<main>@-e:2 (2,0)-(2,18)>
0000 putobject                              3                         (   2)[Li]
0002 opt_duparray_send                      [1, 2], :include?, 1
0006 leave
```

## Benchmark

`benchmark/array_include_literal.yml`

```yaml
benchmark:
  - name: int_literal_array_include_int_literal
    script: |
      [1, 2, 3].include?(2)
  - name: symbol_literal_array_include_symbol_literal
    script: |
      [:a, :b, :c].include?(:b)
  - name: int_literal_array_include_int_miss
    script: |
      [1, 2, 3].include?(9)
loop_count: 10000000
```

Run with:

```bash
benchmark-driver \
  --executables="master::/path/to/master/ruby" \
  --executables="candidate::./ruby" \
  --output=markdown --output-compare \
  benchmark/array_include_literal.yml --repeat-count=3 --run-duration=1
```

Another benchmark

```ruby
require 'benchmark/ips'

GC.disable

ARR = [1, 2, 3]

Benchmark.ips do |x|
  x.report "literal  [1,2,3].include?(2)" do |loop|
    loop.times { [1, 2, 3].include?(2) }
  end
  x.report "constant ARR.include?(2)" do |loop|
    loop.times { ARR.include?(2) }
  end
  x.compare!
end
```

| case | master | candidate | speedup |
|---|---|---|---:|
| `[1,2,3].include?(2)` | 17.83M i/s (56.09 ns) | 30.00M i/s (33.33 ns) | 1.68x |
| `ARR.include?(2)` (const) | 23.92M i/s (41.80 ns) | 23.92M i/s (41.81 ns) | ~1.00x |


