### PR TITLE
Emit `String#dump` hex escapes directly instead of via `snprintf`

### DIFF
--- a/string.c
+++ b/string.c
@@ -7398,6 +7398,19 @@ rb_str_inspect(VALUE str)
 
 #define IS_EVSTR(p,e) ((p) < (e) && (*(p) == '$' || *(p) == '@' || *(p) == '{'))
 
+#define DUMP_HEX4_MAX ((1u << 16) - 1)
+#define DUMP_HEX5_MAX ((1u << 20) - 1)
+#define upper_hexdigits (ruby_hexdigits+16)
+
+static char *
+dump_append_hex(char *q, unsigned int v, int len)
+{
+    for (int shift = (len - 1) * 4; shift >= 0; shift -= 4) {
+        *q++ = upper_hexdigits[(v >> shift) & 0xF];
+    }
+    return q;
+}
+
 /*
  *  call-seq:
  *    dump -> new_string
@@ -7450,9 +7463,9 @@ rb_str_dump(VALUE str)
                     int n = rb_enc_precise_mbclen(p-1, pend, enc);
                     if (MBCLEN_CHARFOUND_P(n)) {
                         unsigned int cc = rb_enc_mbc_to_codepoint(p-1, pend, enc);
-                        if (cc <= 0xFFFF)
+                        if (cc <= DUMP_HEX4_MAX)
                             clen = 6;  /* \uXXXX */
-                        else if (cc <= 0xFFFFF)
+                        else if (cc <= DUMP_HEX5_MAX)
                             clen = 9;  /* \u{XXXXX} */
                         else
                             clen = 10; /* \u{XXXXXX} */
@@ -7527,18 +7540,22 @@ rb_str_dump(VALUE str)
             if (u8) {
                 int n = rb_enc_precise_mbclen(p-1, pend, enc) - 1;
                 if (MBCLEN_CHARFOUND_P(n)) {
-                    int cc = rb_enc_mbc_to_codepoint(p-1, pend, enc);
+                    unsigned int cc = rb_enc_mbc_to_codepoint(p-1, pend, enc);
                     p += n;
-                    if (cc <= 0xFFFF)
-                        snprintf(q, qend-q, "u%04X", cc);    /* \uXXXX */
-                    else
-                        snprintf(q, qend-q, "u{%X}", cc);  /* \u{XXXXX} or \u{XXXXXX} */
-                    q += strlen(q);
+                    *q++ = 'u';
+                    if (cc <= DUMP_HEX4_MAX) {               /* \uXXXX */
+                        q = dump_append_hex(q, cc, 4);
+                    }
+                    else {                                   /* \u{XXXXX} or \u{XXXXXX} */
+                        *q++ = '{';
+                        q = dump_append_hex(q, cc, cc <= DUMP_HEX5_MAX ? 5 : 6);
+                        *q++ = '}';
+                    }
                     continue;
                 }
             }
-            snprintf(q, qend-q, "x%02X", c);
-            q += 3;
+            *q++ = 'x';                                      /* \xNN */
+            q = dump_append_hex(q, c, 2);
         }
     }
     *q++ = '"';


### PR DESCRIPTION
In `rb_str_dump` the escapes are all hex, so get rid of snprintf's format parsing.

I think something akin to this could be also done for `String#inspect` as a follow-up. (a hotter path!)

I started looking at this when I was reading @FletcherDares' https://github.com/ruby/ruby/pull/17287 and why dump_utf8 was slow. 

### Performance

[`benchmark/string_dump.yml`](https://github.com/FletcherDares/ruby/blob/32c383bce7696f88732b48469102199147c2c80b/benchmark/string_dump.yml) from https://github.com/ruby/ruby/pull/17287, GC disabled, Apple M1 Pro / macOS 26.5.1 (avg of 3 runs):

| Benchmark | master | this PR | Speedup |
|---|--:|--:|--:|
| `dump_binary_nonascii` (all `\xNN`) | 132,354 i/s | 1,161,424 i/s | **8.78x** |
| `dump_binary_ascii` | 130,283 i/s | 343,397 i/s | **2.64x** |
| `dump_utf8` (all `\uXXXX`) | 8,003 i/s | 17,074 i/s | **2.13x** |
| `dump_mixed` | 48,605 i/s | 89,270 i/s | **1.84x** |
| `dump_ascii` (no escapes) | 62,083 i/s | 64,153 i/s | 1.03x |
| `dump_evstr` | 138,965 i/s | 139,156 i/s | 1.00x |
| `dump_escaped_chars` | 355,667 i/s | 344,482 i/s | 0.97x |

Linux aarch64 / gcc 14.2 (apple/container):
| Benchmark | master | this PR | Speedup |
|---|--:|--:|--:|
| `dump_binary_nonascii` (all `\xNN`) | 96,536 i/s | 647,817 i/s | **6.71x** |
| `dump_binary_ascii` | 91,065 i/s | 255,033 i/s | **2.80x** |
| `dump_utf8` (all `\uXXXX`) | 6,153 i/s | 12,251 i/s | **1.99x** |
| `dump_mixed` | 38,812 i/s | 70,001 i/s | **1.80x** |
| `dump_ascii` | 59,385 i/s | 72,805 i/s | 1.23x |
| `dump_evstr` | 106,783 i/s | 115,334 i/s | 1.08x |
| `dump_escaped_chars` | 217,191 i/s | 178,033 i/s | 0.82x |

`dump_escaped_chars` is 3% slower on clang and around 20% on gcc: its bytes are all short escapes handled by the switch and never reach the changed hex path, so the difference seems to be the method's changed code layout. `dump_ascii`  and `dump_evstr` seems to gain though even though this shouldn't affect their code path. 