### PR TITLE
Make ROBJECT_FIELDS private

### DIFF
--- a/include/ruby/internal/core/robject.h
+++ b/include/ruby/internal/core/robject.h
@@ -116,32 +116,4 @@ struct RObject {
     } as;
 };
 
-RBIMPL_ATTR_PURE_UNLESS_DEBUG()
-RBIMPL_ATTR_ARTIFICIAL()
-/**
- * Queries the instance variables.
- *
- * @param[in]  obj  Object in question.
- * @return     Its instance variables, in C array.
- * @pre        `obj` must be an instance of ::RObject.
- *
- * @internal
- *
- * @shyouhei finds no reason for this to be visible from extension libraries.
- */
-static inline VALUE *
-ROBJECT_FIELDS(VALUE obj)
-{
-    RBIMPL_ASSERT_TYPE(obj, RUBY_T_OBJECT);
-
-    struct RObject *const ptr = ROBJECT(obj);
-
-    if (RB_UNLIKELY(RB_FL_ANY_RAW(obj, ROBJECT_HEAP))) {
-        return ptr->as.heap.fields;
-    }
-    else {
-        return ptr->as.ary;
-    }
-}
-
 #endif /* RBIMPL_ROBJECT_H */

--- a/internal/object.h
+++ b/internal/object.h
@@ -61,6 +61,21 @@ RBASIC_SET_CLASS(VALUE obj, VALUE klass)
     RB_OBJ_WRITTEN(obj, oldv, klass);
 }
 
+static inline VALUE *
+ROBJECT_FIELDS(VALUE obj)
+{
+    RBIMPL_ASSERT_TYPE(obj, RUBY_T_OBJECT);
+
+    struct RObject *const ptr = ROBJECT(obj);
+
+    if (RB_UNLIKELY(RB_FL_ANY_RAW(obj, ROBJECT_HEAP))) {
+        return ptr->as.heap.fields;
+    }
+    else {
+        return ptr->as.ary;
+    }
+}
+
 static inline size_t
 rb_obj_embedded_size(uint32_t fields_count)
 {


### PR DESCRIPTION
Commit 0ea210d renamed ROBJECT_IVPTR to ROBJECT_FIELDS, so it would have caused compatibility issues anyways. Since there has been no issues, it means that nobody is using it. We can make this dangerous API private since no C extension should be using it anyways.