### PR TITLE
ZJIT: Fold always failing `GuardType`

### DIFF
--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5541,6 +5541,19 @@ impl Function {
             let mut new_insns = vec![];
             for insn_id in old_insns {
                 let replacement_id = match self.find(insn_id) {
+                    // TODO (nirvdrum 2026-06-26): Folding the guard to a SideExit is a workaround,
+                    // not a proper fix. It relies on constant folding to keep an Empty-typed value
+                    // (see below) from reaching codegen; disabling this pass would let that value
+                    // through and the program would fail to compile on x86-64. Compilation correctness
+                    // should not depend on an optimization pass, so this should be replaced by a
+                    // comprehensive fix.
+                    Insn::GuardType { val, guard_type, state, recompile } if !self.type_of(val).could_be(guard_type) => {
+                        // The value's type is disjoint from the guard type, so the guard can never
+                        // pass. Every execution would side-exit here, so we replace the guard with an
+                        // unconditional exit. The terminator handling below then drops the rest of
+                        // the block, which is now unreachable.
+                        self.new_insn(Insn::SideExit { state, reason: SideExitReason::GuardType(guard_type), recompile })
+                    }
                     Insn::GuardType { val, guard_type, .. } if self.is_a(val, guard_type) => {
                         self.make_equal_to(insn_id, val);
                         // Don't bother re-inferring the type of val; we already know it.

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -2512,6 +2512,41 @@ mod hir_opt_tests {
         assert!(!insns.contains(&dead_const));
     }
 
+    // A GuardType whose value type is disjoint from the guard type can never pass, so every
+    // execution side-exits there. fold_constants should replace the guard with an unconditional
+    // SideExit and drop the now-unreachable instructions that follow.
+    #[test]
+    fn test_fold_guard_type_that_can_never_pass_into_side_exit() {
+        let mut function = Function::new(std::ptr::null());
+        let entry = function.entry_block;
+
+        let state = function.push_insn(entry, Insn::Snapshot { state: FrameState::new(std::ptr::null()) });
+        // A nil constant is a NilClass, which is disjoint from Fixnum, so the guard below can
+        // never pass and the optimizer infers its result as Empty.
+        let nil = function.push_insn(entry, Insn::Const { val: Const::Value(Qnil) });
+        let guard = function.push_insn(entry, Insn::GuardType { val: nil, guard_type: types::Fixnum, state, recompile: None });
+        function.push_insn(entry, Insn::StoreField { recv: nil, id: FieldName::len, offset: 0, val: guard });
+        function.push_insn(entry, Insn::Return { val: guard });
+        function.seal_entries();
+
+        function.infer_types();
+        function.fold_constants();
+
+        let insns: Vec<Insn> = function.blocks[entry.0].insns.iter().map(|&id| function.find(id)).collect();
+        assert!(
+            insns.iter().any(|insn| matches!(insn, Insn::SideExit { .. })),
+            "expected the always-failing guard to be folded into a SideExit, got {insns:?}",
+        );
+        assert!(
+            !insns.iter().any(|insn| matches!(insn, Insn::GuardType { .. })),
+            "the always-failing GuardType should have been removed, got {insns:?}",
+        );
+        assert!(
+            !insns.iter().any(|insn| matches!(insn, Insn::StoreField { .. } | Insn::Return { .. })),
+            "instructions after the unconditional SideExit are unreachable and should have been dropped, got {insns:?}",
+        );
+    }
+
     #[test]
     fn test_eliminate_new_array() {
         eval("

--- a/zjit/src/hir_type/mod.rs
+++ b/zjit/src/hir_type/mod.rs
@@ -593,6 +593,9 @@ impl Type {
     }
 
     pub fn num_bytes(&self) -> u8 {
+        assert!(!self.bit_equal(types::Empty),
+                "a value of type Empty is unreachable and should have been eliminated before codegen");
+
         if self.is_subtype(types::CUInt8) || self.is_subtype(types::CInt8) { return 1; }
         if self.is_subtype(types::CUInt16) || self.is_subtype(types::CInt16) { return 2; }
         if self.is_subtype(types::CUInt32) || self.is_subtype(types::CInt32) { return 4; }


### PR DESCRIPTION
I ran into an issue running the _erubi-rails_ benchmark on x86-64 Linux with inlining enabled and the call threshold set to `2`, mimicking what we do in CI. That panics due to a size mismatch between the value and register in a `StoreField`. The problem is that when we have a provably failing guard, its result type is reduced to `Empty`. The `StoreField` that consumes the guard's result inherits `Empty` as well, and even though that `StoreField` is unreachable, we still generate code for it. Since the size of an `Empty` value [is reported](https://github.com/ruby/ruby/blob/0a40bb7d0f51569054bc698dab1ac9abbd09e370/zjit/src/hir_type/mod.rs#L596) as `1`, we end up with the size mismatch panic we see below.
  
The fix is to rewrite type guards we know will fail with an unconditional `SideExit`. That allows the unreachable code to be cleaned up so it never hits codegen. I've added an assertion that would have more readily highlighted the problem, which I think will be useful should any `Empty` values sneak through to `num_bytes`. 
  
```
❯ RUST_BACKTRACE=1 ./build/ruby --zjit-call-threshold=2 --zjit-inline-threshold=30 --zjit-inline-max-iterations=1 ~/dev/worktrees/ruby-bench/main/benchmarks/erubi-rails/benchmark.rb
ruby 4.1.0dev (2026-06-25T17:47:15Z master 5d1a0239de) +ZJIT dev +PRISM [x86_64-linux]
Command: bundle check 2> /dev/null || bundle install
The Gemfile's dependencies are satisfied
ruby: ZJIT has panicked. More info to follow...

thread '<unnamed>' (399782) panicked at zjit/src/asm/x86_64/mod.rs:524:30:
assertion `left == right` failed
  left: 64
 right: 8
stack backtrace:
   0: __rustc::rust_begin_unwind
   1: core::panicking::panic_fmt
   2: core::panicking::assert_failed_inner
   3: core::panicking::assert_failed
             at /rustc/59807616e1fa2540724bfbac14d7976d7e4a3860/library/core/src/panicking.rs:394:5
   4: zjit::asm::x86_64::write_rm_multi
   5: zjit::asm::x86_64::mov
             at /home/nirvdrum/dev/worktrees/ruby/master/zjit/src/asm/x86_64/mod.rs:1007:13
   6: zjit::backend::x86_64::<impl zjit::backend::lir::Assembler>::x86_emit
             at /home/nirvdrum/dev/worktrees/ruby/master/zjit/src/backend/x86_64/mod.rs:873:21
   7: zjit::backend::x86_64::<impl zjit::backend::lir::Assembler>::compile_with_regs::{{closure}}
             at /home/nirvdrum/dev/worktrees/ruby/master/zjit/src/backend/x86_64/mod.rs:1236:34
   8: zjit::stats::trace_compile_phase
             at /home/nirvdrum/dev/worktrees/ruby/master/zjit/src/stats.rs:1030:16
   9: zjit::backend::x86_64::<impl zjit::backend::lir::Assembler>::compile_with_regs
             at /home/nirvdrum/dev/worktrees/ruby/master/zjit/src/backend/x86_64/mod.rs:1228:9
  10: zjit::backend::lir::Assembler::compile
             at /home/nirvdrum/dev/worktrees/ruby/master/zjit/src/backend/lir.rs:2516:24
  11: zjit::codegen::gen_function
             at /home/nirvdrum/dev/worktrees/ruby/master/zjit/src/codegen.rs:548:22
  12: zjit::codegen::gen_iseq_body::{{closure}}::{{closure}}
             at /home/nirvdrum/dev/worktrees/ruby/master/zjit/src/codegen.rs:375:79
  13: zjit::stats::with_time_stat
             at /home/nirvdrum/dev/worktrees/ruby/master/zjit/src/stats.rs:1015:15
  14: zjit::codegen::gen_iseq_body::{{closure}}
             at /home/nirvdrum/dev/worktrees/ruby/master/zjit/src/codegen.rs:375:17
  15: zjit::stats::trace_compile_phase
             at /home/nirvdrum/dev/worktrees/ruby/master/zjit/src/stats.rs:1030:16
  16: zjit::codegen::gen_iseq_body
             at /home/nirvdrum/dev/worktrees/ruby/master/zjit/src/codegen.rs:373:9
  17: zjit::codegen::gen_iseq
             at /home/nirvdrum/dev/worktrees/ruby/master/zjit/src/codegen.rs:342:9
  18: zjit::codegen::gen_iseq_entry_point::{{closure}}
             at /home/nirvdrum/dev/worktrees/ruby/master/zjit/src/codegen.rs:227:46
  19: zjit::stats::trace_compile_phase
             at /home/nirvdrum/dev/worktrees/ruby/master/zjit/src/stats.rs:1030:16
  20: zjit::codegen::gen_iseq_entry_point
             at /home/nirvdrum/dev/worktrees/ruby/master/zjit/src/codegen.rs:220:5
  21: zjit::codegen::rb_zjit_iseq_gen_entry_point::{{closure}}::{{closure}}
             at /home/nirvdrum/dev/worktrees/ruby/master/zjit/src/codegen.rs:188:63
  22: zjit::stats::with_time_stat
             at /home/nirvdrum/dev/worktrees/ruby/master/zjit/src/stats.rs:1015:15
  23: zjit::codegen::rb_zjit_iseq_gen_entry_point::{{closure}}
```