### PR TITLE
[Backport #21882] IO::Buffer#locked leaves the buffer locked when the block raises

### DIFF
--- a/io_buffer.c
+++ b/io_buffer.c
@@ -1424,6 +1424,17 @@ rb_io_buffer_try_unlock(VALUE self)
     return 0;
 }
 
+static VALUE
+rb_io_buffer_locked_ensure(VALUE self)
+{
+    struct rb_io_buffer *buffer = NULL;
+    TypedData_Get_Struct(self, struct rb_io_buffer, &rb_io_buffer_type, buffer);
+
+    buffer->flags &= ~RB_IO_BUFFER_LOCKED;
+
+    return Qnil;
+}
+
 /*
  *  call-seq: locked { ... }
  *
@@ -1466,11 +1477,7 @@ rb_io_buffer_locked(VALUE self)
 
     buffer->flags |= RB_IO_BUFFER_LOCKED;
 
-    VALUE result = rb_yield(self);
-
-    buffer->flags &= ~RB_IO_BUFFER_LOCKED;
-
-    return result;
+    return rb_ensure(rb_yield, self, rb_io_buffer_locked_ensure, self);
 }
 
 /*


### PR DESCRIPTION
Backport of https://bugs.ruby-lang.org/issues/21882 to ruby_4_0.