### PR TITLE
Fix mswin nmake check failures on a non-UTF-8 locale

### DIFF
--- a/doc/distribution/windows.md
+++ b/doc/distribution/windows.md
@@ -149,6 +149,11 @@ sh ../../ruby/configure -C --disable-install-doc --with-opt-dir=C:\Users\usernam
     of `cmd.exe`.  If you want to enable it explicitly, run `cmd.exe` with
     `/E:ON` option.
 
+7.  Some tests in `nmake check` create symbolic links.  Enable
+    [Developer Mode](https://learn.microsoft.com/windows/apps/get-started/developer-mode-features-and-debugging)
+    (Settings > System > For developers) so that they do not fail with
+    `Permission denied @ rb_file_s_symlink`.
+
 ### How to compile and install
 
 1.  Execute `win32\configure.bat` on your build directory.

--- a/lib/rubygems/util/atomic_file_writer.rb
+++ b/lib/rubygems/util/atomic_file_writer.rb
@@ -26,6 +26,16 @@ module Gem
       basename = File.basename(file_name)
       tmp_path = File.join(dirname, ".#{basename.byteslice(0, 254 - tmp_suffix.bytesize)}#{tmp_suffix}")
 
+      # The temporary name is longer than the final one, so on Windows a
+      # writable destination can still map to a path beyond the 260-character
+      # MAX_PATH limit. Only in that case, trim the random suffix just enough to
+      # fit, keeping at least 8 hex characters to avoid collisions.
+      if tmp_path.length >= 260 && Gem.win_platform?
+        keep = [tmp_suffix.bytesize - (tmp_path.length - 259), ".tmp.".bytesize + 8].max
+        tmp_suffix = tmp_suffix.byteslice(0, keep)
+        tmp_path = File.join(dirname, ".#{basename.byteslice(0, 254 - tmp_suffix.bytesize)}#{tmp_suffix}")
+      end
+
       flags = File::RDWR | File::CREAT | File::EXCL | File::BINARY
       flags |= File::SHARE_DELETE if defined?(File::SHARE_DELETE)
 

--- a/ruby.c
+++ b/ruby.c
@@ -2227,7 +2227,7 @@ prism_script(ruby_cmdline_options_t *opt, pm_parse_result_t *result)
     const bool read_stdin = (strcmp(opt->script, "-") == 0);
 
     if (read_stdin) {
-        pm_options_encoding_set(options, rb_enc_name(rb_locale_encoding()));
+        pm_options_encoding_set(options, rb_enc_name(IF_UTF8_PATH(rb_utf8_encoding(), rb_locale_encoding())));
     }
     if (opt->src.enc.name != 0) {
         pm_options_encoding_set(options, StringValueCStr(opt->src.enc.name));
@@ -2844,7 +2844,7 @@ load_file_internal(VALUE argp_v)
         enc = rb_enc_from_index(opt->src.enc.index);
     }
     else if (f == rb_stdin) {
-        enc = rb_locale_encoding();
+        enc = IF_UTF8_PATH(rb_utf8_encoding(), rb_locale_encoding());
     }
     else {
         enc = rb_utf8_encoding();

--- a/spec/ruby/core/kernel/require_spec.rb
+++ b/spec/ruby/core/kernel/require_spec.rb
@@ -34,7 +34,7 @@ describe "Kernel#require" do
       features -= %w[java.rb jruby/util.rb]
     when "ruby"
       so = RbConfig::CONFIG['DLEXT']
-      features -= ["windows_1252.#{so}", "windows_31.#{so}"]
+      features.reject! { |feature| feature.end_with?("windows_1252.#{so}", "windows_31j.#{so}") }
       features.reject! { |feature| feature.end_with? "encdb.#{so}" }
       features.reject! { |feature| feature.end_with? "transdb.#{so}" }
       features.reject! { |feature| feature.include?('-fake') }


### PR DESCRIPTION
On a Visual C++ (mswin) build running on a non-UTF-8 console such as Japanese CP932, `nmake check` fails in a few places that pass on the usual CI. This branch addresses them.

1. `Gem::AtomicFileWriter` builds a temporary file whose name is longer than the destination, so on Windows a writable file can still map to a path beyond the 260-character MAX_PATH and fail with ENOENT. The setup_command destdir tests hit this because the staged path embeds the temporary directory twice. The temporary suffix is now trimmed to fit only when the path would exceed MAX_PATH on Windows, leaving the normal case untouched.
1. A script read from stdin used the locale encoding for its source encoding, so on CP932 it became Windows-31J instead of the UTF-8 that a script read from a file already gets. ruby.c now defaults the stdin script encoding to UTF-8 on Windows in both the Prism and legacy paths, matching the expectation already encoded in magic_comment_spec.
1. The kernel/require spec excluded the locale encoding artifact from `$LOADED_FEATURES` with an array subtraction that never matched, since the feature list holds full paths, and `windows_31` was a typo for `windows_31j`. It now filters with `end_with?` like the adjacent encdb/transdb filters.
1. Finally, the Windows build document now notes that Developer Mode must be enabled so the symlink tests in `nmake check` do not fail with `Permission denied`.
