### PR TITLE
ZJIT: Add perf symbol for block padding

### DIFF
--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -1705,6 +1705,9 @@ impl Assembler
             symbol_name: &str,
             push_insns: impl FnOnce(&mut Vec<Insn>),
         ) {
+            // ISEQ perf symbols cover the whole compiled ISEQ, including this
+            // padding. HIR perf needs a separate symbol because the padding
+            // doesn't belong to any HIR instruction.
             if get_option!(perf) != Some(PerfMap::HIR) {
                 push_insns(insns);
                 return;

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -1,9 +1,10 @@
+use std::cell::RefCell;
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::fmt;
 use std::mem::take;
 use std::rc::Rc;
 use crate::bitset::BitSet;
-use crate::codegen::{local_size_and_idx_to_ep_offset, perf_symbol_range_start, perf_symbol_range_end};
+use crate::codegen::{local_size_and_idx_to_ep_offset, perf_symbol_range_start, perf_symbol_range_end, register_with_perf};
 use crate::cruby::{IseqPtr, RUBY_OFFSET_CFP_ISEQ, RUBY_OFFSET_CFP_JIT_RETURN, RUBY_OFFSET_CFP_PC, RUBY_OFFSET_CFP_SP, SIZEOF_VALUE_I32, VALUE, ZJIT_STACK_MAP_SHIFT, ZJIT_STACK_MAP_VREG_TAG, vm_stack_canary, YarvInsnIdx, zjit_jit_frame};
 use crate::hir::{Invariant, SideExitReason};
 use crate::hir;
@@ -1697,6 +1698,40 @@ impl Assembler
     }
 
     pub fn linearize_instructions(&self) -> Vec<Insn> {
+        // Wrap instructions emitted by `push_insns` with PosMarkers and record
+        // the emitted byte range under `symbol_name` in the perf map.
+        fn push_insns_with_perf_symbol(
+            insns: &mut Vec<Insn>,
+            symbol_name: &str,
+            push_insns: impl FnOnce(&mut Vec<Insn>),
+        ) {
+            if get_option!(perf) != Some(PerfMap::HIR) {
+                push_insns(insns);
+                return;
+            }
+
+            let symbol_name = symbol_name.to_string();
+            let start = Rc::new(RefCell::new(None));
+            let current = start.clone();
+            insns.push(Insn::PosMarker(Rc::new(move |code_ptr, _| {
+                let mut current = current.borrow_mut();
+                assert!(current.is_none(), "perf symbol range already open");
+                *current = Some(code_ptr);
+            })));
+
+            push_insns(insns);
+
+            insns.push(Insn::PosMarker(Rc::new(move |end, cb| {
+                if let Some(start) = start.borrow_mut().take() {
+                    let start_addr = start.raw_addr(cb);
+                    let end_addr = end.raw_addr(cb);
+                    if start_addr < end_addr {
+                        register_with_perf(symbol_name.clone(), start_addr, end_addr - start_addr);
+                    }
+                }
+            })));
+        }
+
         // Emit instructions with labels, expanding branch parameters
         let mut insns = Vec::with_capacity(ASSEMBLER_INSNS_CAPACITY);
 
@@ -1708,7 +1743,9 @@ impl Assembler
             // Entry blocks shouldn't ever be preceded by something that can
             // stomp on this block.
             if !block.is_entry {
-                insns.push(Insn::PadPatchPoint);
+                push_insns_with_perf_symbol(&mut insns, "PadPatchPoint", |insns| {
+                    insns.push(Insn::PadPatchPoint);
+                });
             }
 
             // Process each instruction, expanding branch params if needed
@@ -1730,7 +1767,9 @@ impl Assembler
 
             // Make sure we don't stomp on the next function
             if block_id.0 == num_blocks - 1 {
-                insns.push(Insn::PadPatchPoint);
+                push_insns_with_perf_symbol(&mut insns, "PadPatchPoint", |insns| {
+                    insns.push(Insn::PadPatchPoint);
+                });
             }
         }
         insns

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -276,7 +276,7 @@ pub fn gen_iseq_call(cb: &mut CodeBlock, iseq_call: &IseqCallRef) -> Result<(), 
 }
 
 /// Write an entry to the perf map in /tmp
-fn register_with_perf(symbol_name: String, start_ptr: usize, code_size: usize) {
+pub(crate) fn register_with_perf(symbol_name: String, start_ptr: usize, code_size: usize) {
     use std::io::Write;
     let perf_map = format!("/tmp/perf-{}.map", std::process::id());
     let Ok(file) = std::fs::OpenOptions::new().create(true).append(true).open(&perf_map) else {


### PR DESCRIPTION
This PR adds a perf symbol for `Insn::PadPatchPoint` inserted by the `linearize_instructions` pass. The instruction is not generated by codegen, so nobody marks it in perf map right now.