### PR TITLE
ZJIT: Add HIR perf symbols for terminators

### DIFF
--- a/zjit/src/backend/arm64/mod.rs
+++ b/zjit/src/backend/arm64/mod.rs
@@ -1120,6 +1120,9 @@ impl Assembler {
                 Insn::PosMarker(..) => {
                     pos_markers.push((insn_idx, cb.get_write_ptr()))
                 }
+                Insn::PosMarkerAtBlockEnd(..) => {
+                    unreachable!("PosMarkerAtBlockEnd should have been lowered by linearize_instructions");
+                },
                 Insn::BakeString(text) => {
                     for byte in text.as_bytes() {
                         cb.write_byte(*byte);

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -3812,7 +3812,7 @@ impl Assembler {
             "pos_marker_at_block_end requires the current block to end with a terminator"
         );
 
-        let insert_pos = if len >= 2 && block.insns[len - 2].is_terminator() {
+        let insert_pos = if block.insns.get(len - 2).is_some_and(Insn::is_terminator) {
             len - 2
         } else {
             len - 1

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -3812,6 +3812,11 @@ impl Assembler {
             "pos_marker_at_block_end requires the current block to end with a terminator"
         );
 
+        // A block may end with two terminators, such as a conditional jump
+        // followed by an unconditional jump. Keep the pseudo-instruction before
+        // the whole terminator suffix so the LIR block itself still ends with
+        // terminators; linearize_instructions emits the real PosMarker after the
+        // block's instructions.
         let insert_pos = if block.insns.get(len - 2).is_some_and(Insn::is_terminator) {
             len - 2
         } else {

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -894,6 +894,10 @@ pub enum Insn {
     // Mark a position in the generated code
     PosMarker(PosMarkerFn),
 
+    /// Mark a position at the end of the current LIR block.
+    /// This is lowered to PosMarker during linearize_instructions().
+    PosMarkerAtBlockEnd(PosMarkerFn),
+
     /// Shift a value right by a certain amount (signed).
     RShift { opnd: Opnd, shift: Opnd, out: Opnd },
 
@@ -970,7 +974,8 @@ macro_rules! for_each_operand_impl {
             Insn::Comment(_) |
             Insn::CPop { .. } |
             Insn::PadPatchPoint |
-            Insn::PosMarker(_) => {},
+            Insn::PosMarker(_) |
+            Insn::PosMarkerAtBlockEnd(_) => {},
 
             Insn::CPopInto(opnd) |
             Insn::CPush(opnd) |
@@ -1149,6 +1154,7 @@ impl Insn {
             Insn::PatchPoint(..) => "PatchPoint",
             Insn::PadPatchPoint => "PadPatchPoint",
             Insn::PosMarker(_) => "PosMarker",
+            Insn::PosMarkerAtBlockEnd(_) => "PosMarkerAtBlockEnd",
             Insn::RShift { .. } => "RShift",
             Insn::Store { .. } => "Store",
             Insn::Sub { .. } => "Sub",
@@ -1827,8 +1833,14 @@ impl Assembler
             }
 
             // Process each instruction, expanding branch params if needed
+            let mut block_end_pos_marker = None;
             for insn in &block.insns {
-                self.expand_branch_insn(insn, &mut insns);
+                if let Insn::PosMarkerAtBlockEnd(marker) = insn {
+                    assert!(block_end_pos_marker.is_none(), "only one PosMarkerAtBlockEnd is supported per block");
+                    block_end_pos_marker = Some(marker.clone());
+                } else {
+                    self.expand_branch_insn(insn, &mut insns);
+                }
             }
 
             // Eliminate redundant jumps: if the last instruction is an
@@ -1841,6 +1853,10 @@ impl Assembler
                         insns.pop();
                     }
                 }
+            }
+
+            if let Some(marker) = block_end_pos_marker {
+                insns.push(Insn::PosMarker(marker));
             }
 
             // Make sure we don't stomp on the next function
@@ -3783,6 +3799,29 @@ impl Assembler {
 
     pub fn pos_marker(&mut self, marker_fn: impl Fn(CodePtr, &CodeBlock) + 'static) {
         self.push_insn(Insn::PosMarker(Rc::new(marker_fn)));
+    }
+
+    /// Insert a marker that linearize_instructions lowers to a PosMarker at the
+    /// end of the current block, after its terminator instructions.
+    pub fn pos_marker_at_block_end(&mut self, marker_fn: impl Fn(CodePtr, &CodeBlock) + 'static) {
+        let block_id = self.current_block_id;
+        let block = &self.basic_blocks[block_id.0];
+        let len = block.insns.len();
+        assert!(
+            len > 0 && block.insns[len - 1].is_terminator(),
+            "pos_marker_at_block_end requires the current block to end with a terminator"
+        );
+
+        let insert_pos = if len >= 2 && block.insns[len - 2].is_terminator() {
+            len - 2
+        } else {
+            len - 1
+        };
+
+        self.idx += 1;
+        let block = &mut self.basic_blocks[block_id.0];
+        block.insns.insert(insert_pos, Insn::PosMarkerAtBlockEnd(Rc::new(marker_fn)));
+        block.insn_ids.insert(insert_pos, None);
     }
 
     #[must_use]

--- a/zjit/src/backend/x86_64/mod.rs
+++ b/zjit/src/backend/x86_64/mod.rs
@@ -773,6 +773,9 @@ impl Assembler {
                 Insn::PosMarker(..) => {
                     pos_markers.push((insn_idx, cb.get_write_ptr()));
                 },
+                Insn::PosMarkerAtBlockEnd(..) => {
+                    unreachable!("PosMarkerAtBlockEnd should have been lowered by linearize_instructions");
+                },
 
                 Insn::BakeString(text) => {
                     for byte in text.as_bytes() {

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -3866,6 +3866,9 @@ pub fn perf_symbol_range_end_at_block_end(asm: &mut Assembler, perf_symbol: &Per
         if let Some((start, name)) = current.borrow_mut().take() {
             let start_addr = start.raw_addr(cb);
             let end_addr = end.raw_addr(cb);
+            // A terminator's jump can be removed when it targets the next
+            // linear block, leaving no code between the range start and the
+            // block-end marker. Skip zero-sized perf map entries.
             if start_addr < end_addr {
                 register_with_perf(name, start_addr, end_addr - start_addr);
             }

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -468,10 +468,11 @@ fn gen_function(cb: &mut CodeBlock, iseq: IseqPtr, version: IseqVersionRef, func
             // Compile all instructions
             for (insn_idx, &insn_id) in block.insns().enumerate() {
                 let insn = function.find(insn_id);
+                let perf_symbol = hir_perf_symbol_range_start(&mut asm, &insn);
 
-                match insn {
+                let result = match &insn {
                     Insn::CondBranch { val, if_true, if_false } => {
-                        let val_opnd = jit.get_opnd(val);
+                        let val_opnd = jit.get_opnd(*val);
                         let true_target = hir_to_lir[if_true.target.0].unwrap();
                         let false_target = hir_to_lir[if_false.target.0].unwrap();
 
@@ -490,6 +491,7 @@ fn gen_function(cb: &mut CodeBlock, iseq: IseqPtr, version: IseqVersionRef, func
                         asm.jmp(Target::Block(Box::new(false_branch)));
 
                         assert!(asm.current_block().insns.last().unwrap().is_terminator());
+                        Ok(())
                     }
                     Insn::Jump(target) => {
                         let lir_target = hir_to_lir[target.target.0].unwrap();
@@ -502,40 +504,38 @@ fn gen_function(cb: &mut CodeBlock, iseq: IseqPtr, version: IseqVersionRef, func
 
                         // Jump should always be the last instruction in an HIR block
                         assert!(insn_idx == block.insns().len() - 1, "Jump must be the last instruction in HIR block");
+                        Ok(())
                     },
                     _ => {
-                        // Start a new perf range for the HIR instruction. For now, we do this only for
-                        // non-terminator instructions because LIR blocks must end with a terminator instruction.
-                        let perf_symbol = if get_option!(perf) == Some(PerfMap::HIR) && !insn.is_terminator() {
-                            let insn_name = format!("{insn}").split_whitespace().next().unwrap().to_string();
-                            Some(perf_symbol_range_start(&mut asm, &insn_name))
-                        } else {
-                            None
-                        };
+                        gen_insn(cb, &mut jit, &mut asm, function, insn_id, &insn)
+                    }
+                };
 
-                        let result = gen_insn(cb, &mut jit, &mut asm, function, insn_id, &insn);
-
-                        // Close the current perf range for the HIR instruction.
-                        if let Some(perf_symbol) = &perf_symbol {
-                            perf_symbol_range_end(&mut asm, perf_symbol);
-                        }
-
-                        if let Err(last_snapshot) = result {
-                            debug!("ZJIT: gen_function: Failed to compile insn: {insn_id} {insn}. Generating side-exit.");
-                            gen_incr_counter(&mut asm, exit_counter_for_unhandled_hir_insn(&insn));
-                            let reason = match insn {
-                                Insn::Throw { .. }         => SideExitReason::UnhandledHIRThrow,
-                                Insn::InvokeBuiltin { .. } => SideExitReason::UnhandledHIRInvokeBuiltin,
-                                _                          => SideExitReason::UnhandledHIRUnknown(insn_id),
-                            };
-                            gen_side_exit(&mut jit, &mut asm, &reason, None, &function.frame_state(last_snapshot));
-                            // Don't bother generating code after a side-exit. We won't run it.
-                            // TODO(max): Generate ud2 or equivalent.
-                            break;
-                        };
-                        // It's fine; we generated the instruction
+                // Close the current perf range for the HIR instruction.
+                if let Some(perf_symbol) = &perf_symbol {
+                    let current_block_ends_with_terminator =
+                        asm.current_block().insns.last().is_some_and(|insn| insn.is_terminator());
+                    if result.is_ok() && insn.is_terminator() && current_block_ends_with_terminator {
+                        perf_symbol_range_end_at_block_end(&mut asm, perf_symbol);
+                    } else {
+                        perf_symbol_range_end(&mut asm, perf_symbol);
                     }
                 }
+
+                if let Err(last_snapshot) = result {
+                    debug!("ZJIT: gen_function: Failed to compile insn: {insn_id} {insn}. Generating side-exit.");
+                    gen_incr_counter(&mut asm, exit_counter_for_unhandled_hir_insn(&insn));
+                    let reason = match insn {
+                        Insn::Throw { .. }         => SideExitReason::UnhandledHIRThrow,
+                        Insn::InvokeBuiltin { .. } => SideExitReason::UnhandledHIRInvokeBuiltin,
+                        _                          => SideExitReason::UnhandledHIRUnknown(insn_id),
+                    };
+                    gen_side_exit(&mut jit, &mut asm, &reason, None, &function.frame_state(last_snapshot));
+                    // Don't bother generating code after a side-exit. We won't run it.
+                    // TODO(max): Generate ud2 or equivalent.
+                    break;
+                };
+                // It's fine; we generated the instruction
             }
             // Blocks should always end with control flow
             assert!(asm.current_block().insns.last().unwrap().is_terminator());
@@ -3824,6 +3824,16 @@ impl IseqCall {
 
 type PerfSymbol = Rc<RefCell<Option<(CodePtr, String)>>>;
 
+/// Start a HIR perf symbol range when --zjit-perf=hir is enabled.
+fn hir_perf_symbol_range_start(asm: &mut Assembler, insn: &Insn) -> Option<PerfSymbol> {
+    if get_option!(perf) == Some(PerfMap::HIR) {
+        let insn_name = format!("{insn}").split_whitespace().next().unwrap().to_string();
+        Some(perf_symbol_range_start(asm, &insn_name))
+    } else {
+        None
+    }
+}
+
 /// Mark the start of a perf symbol range via pos_marker.
 /// Returns a handle to pass to perf_symbol_range_end.
 pub fn perf_symbol_range_start(asm: &mut Assembler, symbol_name: &str) -> PerfSymbol {
@@ -3846,6 +3856,20 @@ pub fn perf_symbol_range_end(asm: &mut Assembler, perf_symbol: &PerfSymbol) {
             let start_addr = start.raw_addr(cb);
             let code_size = end.raw_addr(cb) - start_addr;
             register_with_perf(name, start_addr, code_size);
+        }
+    });
+}
+
+/// Mark the end of a perf symbol range at the end of the current LIR block.
+pub fn perf_symbol_range_end_at_block_end(asm: &mut Assembler, perf_symbol: &PerfSymbol) {
+    let current = perf_symbol.clone();
+    asm.pos_marker_at_block_end(move |end, cb| {
+        if let Some((start, name)) = current.borrow_mut().take() {
+            let start_addr = start.raw_addr(cb);
+            let end_addr = end.raw_addr(cb);
+            if start_addr < end_addr {
+                register_with_perf(name, start_addr, end_addr - start_addr);
+            }
         }
     });
 }

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -513,9 +513,8 @@ fn gen_function(cb: &mut CodeBlock, iseq: IseqPtr, version: IseqVersionRef, func
 
                 // Close the current perf range for the HIR instruction.
                 if let Some(perf_symbol) = &perf_symbol {
-                    let current_block_ends_with_terminator =
-                        asm.current_block().insns.last().is_some_and(|insn| insn.is_terminator());
-                    if result.is_ok() && insn.is_terminator() && current_block_ends_with_terminator {
+                    if result.is_ok() && insn.is_terminator() {
+                        assert!(asm.current_block().insns.last().is_some_and(|insn| insn.is_terminator()));
                         perf_symbol_range_end_at_block_end(&mut asm, perf_symbol);
                     } else {
                         perf_symbol_range_end(&mut asm, perf_symbol);


### PR DESCRIPTION
This PR fixes missing `--zjit-perf=hir` symbols for HIR terminators like `Jump` and `CondBranch`.

Instead of allowing `PosMarker` after a block terminator, this adds `PosMarkerAtBlockEnd`, which is inserted before the terminator in LIR and lowered to a regular `PosMarker` during `linearize_instructions`. That keeps the current LIR invariant that blocks end with terminators.