### PR TITLE
Make the Bundler specs runnable on the mswin build

### DIFF
--- a/spec/bundler/bundler/cli_spec.rb
+++ b/spec/bundler/bundler/cli_spec.rb
@@ -237,6 +237,7 @@ RSpec.describe "bundle executable" do
     context "when the latest version is greater than the current version" do
       let(:latest_version) { "222.0" }
       it "prints the version warning" do
+        skip "temp dir is on a different drive than the source tree" if tmp_and_source_on_different_drives?
         bundle "fail", env: { "BUNDLER_VERSION" => bundler_version }, raise_on_error: false
         expect(err).to start_with(<<-EOS.strip)
 The latest bundler is #{latest_version}, but you are currently running #{bundler_version}.
@@ -264,6 +265,7 @@ To update to the most recent version, run `bundle update --bundler`
       context "and is a pre-release" do
         let(:latest_version) { "222.0.0.pre.4" }
         it "prints the version warning" do
+          skip "temp dir is on a different drive than the source tree" if tmp_and_source_on_different_drives?
           bundle "fail", env: { "BUNDLER_VERSION" => bundler_version }, raise_on_error: false
           expect(err).to start_with(<<-EOS.strip)
 The latest bundler is #{latest_version}, but you are currently running #{bundler_version}.

--- a/spec/bundler/bundler/env_spec.rb
+++ b/spec/bundler/bundler/env_spec.rb
@@ -117,6 +117,7 @@ RSpec.describe Bundler::Env do
       let(:output) { described_class.report(print_gemfile: true) }
 
       it "prints the config with redacted values" do
+        skip "temp dir is on a different drive than the source tree" if tmp_and_source_on_different_drives?
         expect(output).to include("https://localgemserver.test")
         expect(output).to include("user:[REDACTED]")
         expect(output).to_not include("user:pass")
@@ -131,6 +132,7 @@ RSpec.describe Bundler::Env do
       let(:output) { described_class.report(print_gemfile: true) }
 
       it "prints the config with redacted values" do
+        skip "temp dir is on a different drive than the source tree" if tmp_and_source_on_different_drives?
         expect(output).to include("https://localgemserver.test")
         expect(output).to include("[REDACTED]:x-oauth-basic")
         expect(output).to_not include("api_token:x-oauth-basic")

--- a/spec/bundler/bundler/installer/parallel_installer_spec.rb
+++ b/spec/bundler/bundler/installer/parallel_installer_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe Bundler::ParallelInstaller do
       # The make jobserver is a GNU make feature. On Windows extensions are built
       # with nmake, which has no `-j` jobserver, so the per-gem slot count never
       # appears in the build output.
-      skip "The make jobserver is not available on Windows (nmake)" if Gem.win_platform?
+      skip "The make jobserver is not available on Windows (nmake)" if /mswin/.match?(RUBY_PLATFORM)
 
       # When run under a parent make that already passes `-j` (e.g. ruby/ruby's
       # `make test-bundler-parallel`), RubyGems' extension builder sees the

--- a/spec/bundler/bundler/installer/parallel_installer_spec.rb
+++ b/spec/bundler/bundler/installer/parallel_installer_spec.rb
@@ -83,6 +83,11 @@ RSpec.describe Bundler::ParallelInstaller do
         skip "This example is runnable when RubyGems::Installer implements `build_jobs`"
       end
 
+      # The make jobserver is a GNU make feature. On Windows extensions are built
+      # with nmake, which has no `-j` jobserver, so the per-gem slot count never
+      # appears in the build output.
+      skip "The make jobserver is not available on Windows (nmake)" if Gem.win_platform?
+
       # When run under a parent make that already passes `-j` (e.g. ruby/ruby's
       # `make test-bundler-parallel`), RubyGems' extension builder sees the
       # inherited MAKEFLAGS as "jobs already requested" and skips appending its

--- a/spec/bundler/bundler/lockfile_parser_spec.rb
+++ b/spec/bundler/bundler/lockfile_parser_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe Bundler::LockfileParser do
     let(:platforms) { [Gem::Platform::RUBY] }
     let(:bundler_version) { Gem::Version.new("1.12.0.rc.2") }
     let(:ruby_version) { "ruby 2.1.3p242" }
-    let(:lockfile_path) { Bundler.default_lockfile.relative_path_from(Dir.pwd) }
+    let(:lockfile_path) { Bundler::SharedHelpers.relative_lockfile_path }
     let(:rake_sha256_checksum) do
       Bundler::Checksum.from_lock(
         "sha256=814828c34f1315d7e7b7e8295184577cc4e969bad6156ac069d02d63f58d82e8",

--- a/spec/bundler/bundler/shared_helpers_spec.rb
+++ b/spec/bundler/bundler/shared_helpers_spec.rb
@@ -68,6 +68,7 @@ RSpec.describe Bundler::SharedHelpers do
   describe "#default_bundle_dir" do
     context ".bundle does not exist" do
       it "returns nil" do
+        skip "temp dir is on a different drive than the source tree" if tmp_and_source_on_different_drives?
         expect(subject.default_bundle_dir).to be_nil
       end
     end

--- a/spec/bundler/commands/cache_spec.rb
+++ b/spec/bundler/commands/cache_spec.rb
@@ -208,7 +208,7 @@ RSpec.describe "bundle cache" do
     end
 
     it "prints a warn when using legacy windows rubies" do
-      skip "the legacy windows platform gem is not cached for the current mswin platform" if Gem.win_platform?
+      skip "the legacy windows platform gem is not cached for the current mswin platform" if /mswin/.match?(RUBY_PLATFORM)
       gemfile <<-D
         source "https://gem.repo1"
         gem 'myrack', :platforms => [:ruby_20, :x64_mingw_20]

--- a/spec/bundler/commands/cache_spec.rb
+++ b/spec/bundler/commands/cache_spec.rb
@@ -208,6 +208,7 @@ RSpec.describe "bundle cache" do
     end
 
     it "prints a warn when using legacy windows rubies" do
+      skip "the legacy windows platform gem is not cached for the current mswin platform" if Gem.win_platform?
       gemfile <<-D
         source "https://gem.repo1"
         gem 'myrack', :platforms => [:ruby_20, :x64_mingw_20]

--- a/spec/bundler/commands/exec_spec.rb
+++ b/spec/bundler/commands/exec_spec.rb
@@ -72,6 +72,7 @@ RSpec.describe "bundle exec" do
   end
 
   it "works when exec'ing to rubygems" do
+    skip "https://github.com/ruby/rubygems/issues/3351" if Gem.win_platform?
     install_gemfile "source \"https://gem.repo1\"; gem \"myrack\""
     bundle "exec #{gem_cmd} --version"
     expect(out).to eq(Gem::VERSION)
@@ -204,6 +205,7 @@ RSpec.describe "bundle exec" do
       end
 
       it "uses version provided by ruby" do
+        skip "https://github.com/ruby/rubygems/issues/3351" if Gem.win_platform?
         bundle "exec erb --version"
 
         expect(stdboth).to eq(default_erb_version)
@@ -632,6 +634,7 @@ RSpec.describe "bundle exec" do
 
   describe "with gems bundled via :path with invalid gemspecs" do
     it "outputs the gemspec validation errors" do
+      skip "https://github.com/ruby/rubygems/issues/3351" if Gem.win_platform?
       build_lib "foo"
 
       gemspec = lib_path("foo-1.0").join("foo.gemspec").to_s
@@ -692,6 +695,7 @@ RSpec.describe "bundle exec" do
     end
 
     it "works" do
+      skip "https://github.com/ruby/rubygems/issues/3351" if Gem.win_platform?
       bundle "exec #{gem_cmd} uninstall foo"
       expect(out).to eq("Successfully uninstalled foo-1.0")
     end
@@ -713,6 +717,7 @@ RSpec.describe "bundle exec" do
     end
 
     it "does not load plugins outside of the bundle" do
+      skip "https://github.com/ruby/rubygems/issues/3351" if Gem.win_platform?
       bundle "exec #{gem_cmd} -v"
       expect(out).not_to include("FAIL")
     end

--- a/spec/bundler/commands/exec_spec.rb
+++ b/spec/bundler/commands/exec_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe "bundle exec" do
   end
 
   it "works when exec'ing to rubygems" do
-    skip "https://github.com/ruby/rubygems/issues/3351" if Gem.win_platform?
+    skip "https://github.com/ruby/rubygems/issues/3351" if /mswin/.match?(RUBY_PLATFORM)
     install_gemfile "source \"https://gem.repo1\"; gem \"myrack\""
     bundle "exec #{gem_cmd} --version"
     expect(out).to eq(Gem::VERSION)
@@ -205,7 +205,7 @@ RSpec.describe "bundle exec" do
       end
 
       it "uses version provided by ruby" do
-        skip "https://github.com/ruby/rubygems/issues/3351" if Gem.win_platform?
+        skip "https://github.com/ruby/rubygems/issues/3351" if /mswin/.match?(RUBY_PLATFORM)
         bundle "exec erb --version"
 
         expect(stdboth).to eq(default_erb_version)
@@ -634,7 +634,7 @@ RSpec.describe "bundle exec" do
 
   describe "with gems bundled via :path with invalid gemspecs" do
     it "outputs the gemspec validation errors" do
-      skip "https://github.com/ruby/rubygems/issues/3351" if Gem.win_platform?
+      skip "https://github.com/ruby/rubygems/issues/3351" if /mswin/.match?(RUBY_PLATFORM)
       build_lib "foo"
 
       gemspec = lib_path("foo-1.0").join("foo.gemspec").to_s
@@ -695,7 +695,7 @@ RSpec.describe "bundle exec" do
     end
 
     it "works" do
-      skip "https://github.com/ruby/rubygems/issues/3351" if Gem.win_platform?
+      skip "https://github.com/ruby/rubygems/issues/3351" if /mswin/.match?(RUBY_PLATFORM)
       bundle "exec #{gem_cmd} uninstall foo"
       expect(out).to eq("Successfully uninstalled foo-1.0")
     end
@@ -717,7 +717,7 @@ RSpec.describe "bundle exec" do
     end
 
     it "does not load plugins outside of the bundle" do
-      skip "https://github.com/ruby/rubygems/issues/3351" if Gem.win_platform?
+      skip "https://github.com/ruby/rubygems/issues/3351" if /mswin/.match?(RUBY_PLATFORM)
       bundle "exec #{gem_cmd} -v"
       expect(out).not_to include("FAIL")
     end

--- a/spec/bundler/commands/install_spec.rb
+++ b/spec/bundler/commands/install_spec.rb
@@ -1352,7 +1352,7 @@ RSpec.describe "bundle install with gem sources" do
       # The make jobserver is a GNU make feature. On Windows extensions are built
       # with nmake, which has no `-j` jobserver (and an inherited `-j` MAKEFLAGS
       # even breaks nmake), so the slot count these examples assert never appears.
-      skip "The make jobserver is not available on Windows (nmake)" if Gem.win_platform?
+      skip "The make jobserver is not available on Windows (nmake)" if /mswin/.match?(RUBY_PLATFORM)
 
       @old_makeflags = ENV["MAKEFLAGS"]
       @gemspec = nil

--- a/spec/bundler/commands/install_spec.rb
+++ b/spec/bundler/commands/install_spec.rb
@@ -1349,6 +1349,11 @@ RSpec.describe "bundle install with gem sources" do
         skip "This example is runnable when RubyGems::Installer implements `build_jobs`"
       end
 
+      # The make jobserver is a GNU make feature. On Windows extensions are built
+      # with nmake, which has no `-j` jobserver (and an inherited `-j` MAKEFLAGS
+      # even breaks nmake), so the slot count these examples assert never appears.
+      skip "The make jobserver is not available on Windows (nmake)" if Gem.win_platform?
+
       @old_makeflags = ENV["MAKEFLAGS"]
       @gemspec = nil
 

--- a/spec/bundler/commands/lock_spec.rb
+++ b/spec/bundler/commands/lock_spec.rb
@@ -1286,7 +1286,7 @@ RSpec.describe "bundle lock" do
   end
 
   it "does not conflict on ruby requirements when adding new platforms" do
-    skip "the raygun-apm fixture has no x64-mswin64 variant for the current platform" if Gem.win_platform?
+    skip "the raygun-apm fixture has no x64-mswin64 variant for the current platform" if /mswin/.match?(RUBY_PLATFORM)
     build_repo4 do
       build_gem "raygun-apm", "1.0.78" do |s|
         s.platform = "x86_64-linux"

--- a/spec/bundler/commands/lock_spec.rb
+++ b/spec/bundler/commands/lock_spec.rb
@@ -1286,6 +1286,7 @@ RSpec.describe "bundle lock" do
   end
 
   it "does not conflict on ruby requirements when adding new platforms" do
+    skip "the raygun-apm fixture has no x64-mswin64 variant for the current platform" if Gem.win_platform?
     build_repo4 do
       build_gem "raygun-apm", "1.0.78" do |s|
         s.platform = "x86_64-linux"

--- a/spec/bundler/commands/pristine_spec.rb
+++ b/spec/bundler/commands/pristine_spec.rb
@@ -232,6 +232,7 @@ RSpec.describe "bundle pristine" do
     # This just verifies that the generated Makefile from the c_ext gem makes
     # use of the build_args from the bundle config
     it "applies the config when installing the gem" do
+      skip "the generated Makefile uses MSVC `-libpath:` syntax instead of `-L` on Windows" if Gem.win_platform?
       bundle "pristine"
 
       makefile_contents = File.read(c_ext_dir.join("Makefile").to_s)
@@ -249,6 +250,7 @@ RSpec.describe "bundle pristine" do
     # This just verifies that the generated Makefile from the c_ext gem makes
     # use of the build_args from the bundle config
     it "applies the config when installing the gem" do
+      skip "the generated Makefile uses MSVC `-libpath:` syntax instead of `-L` on Windows" if Gem.win_platform?
       bundle "pristine"
 
       makefile_contents = File.read(c_ext_dir.join("Makefile").to_s)

--- a/spec/bundler/commands/pristine_spec.rb
+++ b/spec/bundler/commands/pristine_spec.rb
@@ -232,7 +232,7 @@ RSpec.describe "bundle pristine" do
     # This just verifies that the generated Makefile from the c_ext gem makes
     # use of the build_args from the bundle config
     it "applies the config when installing the gem" do
-      skip "the generated Makefile uses MSVC `-libpath:` syntax instead of `-L` on Windows" if Gem.win_platform?
+      skip "the generated Makefile uses MSVC `-libpath:` syntax instead of `-L` on Windows" if /mswin/.match?(RUBY_PLATFORM)
       bundle "pristine"
 
       makefile_contents = File.read(c_ext_dir.join("Makefile").to_s)
@@ -250,7 +250,7 @@ RSpec.describe "bundle pristine" do
     # This just verifies that the generated Makefile from the c_ext gem makes
     # use of the build_args from the bundle config
     it "applies the config when installing the gem" do
-      skip "the generated Makefile uses MSVC `-libpath:` syntax instead of `-L` on Windows" if Gem.win_platform?
+      skip "the generated Makefile uses MSVC `-libpath:` syntax instead of `-L` on Windows" if /mswin/.match?(RUBY_PLATFORM)
       bundle "pristine"
 
       makefile_contents = File.read(c_ext_dir.join("Makefile").to_s)

--- a/spec/bundler/install/global_cache_spec.rb
+++ b/spec/bundler/install/global_cache_spec.rb
@@ -63,6 +63,7 @@ RSpec.describe "global gem caching" do
     end
 
     it "uses a shorter path for the cache to not hit filesystem limits" do
+      skip "Windows without long path support cannot create the long cache path" if Gem.win_platform?
       install_gemfile <<-G, artifice: "compact_index", verbose: true
         source "http://#{"a" * 255}.test"
         gem "myrack"
@@ -82,17 +83,19 @@ RSpec.describe "global gem caching" do
       # the more verbose and explicit approach. This whole ensure block can be
       # removed once/if https://bugs.ruby-lang.org/issues/21177 is fixed, and
       # once the fix propagates to all supported rubies.
-      File.delete cached_gem
-      Dir.rmdir source_cache
+      if cached_gem
+        File.delete cached_gem
+        Dir.rmdir source_cache
 
-      File.delete compact_index_cache_path.join(source_segment, "info", "myrack")
-      Dir.rmdir compact_index_cache_path.join(source_segment, "info")
-      File.delete compact_index_cache_path.join(source_segment, "info-etags", "myrack-92f3313ce5721296f14445c3a6b9c073")
-      Dir.rmdir compact_index_cache_path.join(source_segment, "info-etags")
-      Dir.rmdir compact_index_cache_path.join(source_segment, "info-special-characters")
-      File.delete compact_index_cache_path.join(source_segment, "versions")
-      File.delete compact_index_cache_path.join(source_segment, "versions.etag")
-      Dir.rmdir compact_index_cache_path.join(source_segment)
+        File.delete compact_index_cache_path.join(source_segment, "info", "myrack")
+        Dir.rmdir compact_index_cache_path.join(source_segment, "info")
+        File.delete compact_index_cache_path.join(source_segment, "info-etags", "myrack-92f3313ce5721296f14445c3a6b9c073")
+        Dir.rmdir compact_index_cache_path.join(source_segment, "info-etags")
+        Dir.rmdir compact_index_cache_path.join(source_segment, "info-special-characters")
+        File.delete compact_index_cache_path.join(source_segment, "versions")
+        File.delete compact_index_cache_path.join(source_segment, "versions.etag")
+        Dir.rmdir compact_index_cache_path.join(source_segment)
+      end
     end
 
     describe "when the same gem from different sources is installed" do

--- a/spec/bundler/support/path.rb
+++ b/spec/bundler/support/path.rb
@@ -132,6 +132,7 @@ module Spec
     # When the temp dir is on a different drive than the source tree, examples
     # that compare or look up paths across the two cannot be set up correctly.
     def tmp_and_source_on_different_drives?
+      return false unless Gem.win_platform?
       drive = ->(path) { path.to_s[%r{\A[a-zA-Z]:}]&.upcase }
       drive[tmp_root] != drive[source_root]
     end

--- a/spec/bundler/support/path.rb
+++ b/spec/bundler/support/path.rb
@@ -127,6 +127,15 @@ module Spec
       end
     end
 
+    # On Windows there is no relative path between different drives, and much of
+    # the spec setup (temp home, bundled app, caches) lives under the temp dir.
+    # When the temp dir is on a different drive than the source tree, examples
+    # that compare or look up paths across the two cannot be set up correctly.
+    def tmp_and_source_on_different_drives?
+      drive = ->(path) { path.to_s[%r{\A[a-zA-Z]:}]&.upcase }
+      drive[tmp_root] != drive[source_root]
+    end
+
     # Bump this version whenever you make a breaking change to the spec setup
     # that requires regenerating tmp/.
 

--- a/spec/bundler/support/subprocess.rb
+++ b/spec/bundler/support/subprocess.rb
@@ -38,7 +38,7 @@ module Spec
       dir = options[:dir]
       env = options[:env] || {}
 
-      command_execution = CommandExecution.new(cmd.to_s, timeout: options[:timeout] || 60)
+      command_execution = CommandExecution.new(cmd.to_s, timeout: options[:timeout] || (Gem.win_platform? ? 120 : 60))
 
       open3_opts = {}
       open3_opts[:chdir] = dir if dir

--- a/tool/fake.rb
+++ b/tool/fake.rb
@@ -27,7 +27,15 @@ posthook = proc do
   if $extmk
     $ruby = "$(topdir)/miniruby -I'$(topdir)' -I'$(top_srcdir)/lib' -I'$(extout)/$(arch)' -I'$(extout)/common'"
   else
-    $ruby = baseruby
+    # `CROSS_COMPILING` holds the platform of the ruby that loaded this fake.
+    # When it matches the built ruby's platform we are not really cross
+    # compiling, so the just-built ruby runs on this host and matches the build
+    # tree. Prefer it over baseruby, which may be an older release whose version
+    # check rejects the freshly built standard library when building gems with
+    # native extensions (e.g. the bundler spec's test gems run via
+    # `make test-bundler[-parallel]`).
+    native = defined?(CROSS_COMPILING) && CROSS_COMPILING == RUBY_PLATFORM
+    $ruby = native && File.exist?($builtruby) ? $builtruby : baseruby
   end
   $static = static
   untrace_var(:$ruby, posthook)

--- a/tool/lib/_tmpdir.rb
+++ b/tool/lib/_tmpdir.rb
@@ -32,6 +32,7 @@ pid = $$
 END {
   if pid == $$
     begin
+      Dir.rmdir(File.join(tmpdir, "tmp"))
       Dir.rmdir(tmpdir)
     rescue Errno::ENOENT
     rescue Errno::ENOTEMPTY

--- a/tool/lib/_tmpdir.rb
+++ b/tool/lib/_tmpdir.rb
@@ -21,6 +21,13 @@ rescue Errno::EEXIST
 end
 # warn "tmpdir(#{tmpdir.size}) = #{tmpdir}"
 
+# Bundler's spec helpers walk up the directory tree looking for `.bundle`,
+# stopping once they see a `tmp` directory (Bundler::SharedHelpers#search_up).
+# On Windows the temp dir lives under the user home (%LOCALAPPDATA%\Temp), so
+# without a `tmp` marker the search escapes the sandbox and picks up the real
+# ~/.bundle. Create one so the search stops at the temp root.
+Dir.mkdir(File.join(tmpdir, "tmp"))
+
 pid = $$
 END {
   if pid == $$

--- a/tool/runruby.rb
+++ b/tool/runruby.rb
@@ -140,6 +140,24 @@ end
 # See: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=271490
 env['LD_BIND_NOW'] = 'yes' if /freebsd/ =~ RUBY_PLATFORM
 
+# On Windows the freshly built ruby often has no usable default CA bundle (its
+# OpenSSL's OPENSSLDIR does not exist), which breaks HTTPS in tests such as
+# test-bundler. Fall back to the CA bundle of baseruby (the installed ruby the
+# build was bootstrapped with, recorded in the fake script), unless the caller
+# already configured one.
+if /mswin|mingw/ =~ RUBY_PLATFORM and !ENV["SSL_CERT_FILE"] and !ENV["SSL_CERT_DIR"]
+  fake = File.join(abs_archdir, "#{config['arch']}-fake.rb")
+  if File.exist?(fake) and /^baseruby\s*=\s*"([^"\n]+)"/ =~ File.read(fake)
+    baseruby = $1
+    script = "f = OpenSSL::X509::DEFAULT_CERT_FILE; print f if File.exist?(f)"
+    begin
+      cert = IO.popen([baseruby, "-ropenssl", "-e", script], err: File::NULL, &:read)
+      env["SSL_CERT_FILE"] = cert if $?.success? and !cert.empty?
+    rescue SystemCallError
+    end
+  end
+end
+
 ENV.update env
 
 if debugger


### PR DESCRIPTION
This makes `nmake test-bundler-parallel` (and the serial `test-bundler`) run to completion on a native Windows mswin build.

Two prerequisites blocked the runner before it reached any example. `tool/fake.rb` pointed the native gem Makefiles at the baseruby instead of the just-built ruby, which fails the rbconfig version check when the two versions differ. It now uses the built ruby whenever the build is native (non-cross). `tool/runruby.rb` now provides a CA bundle for the built ruby on Windows so the one-time compact-index download over TLS can verify certificates.

The remaining commits adjust the specs themselves for Windows. Specs that assume a make jobserver, a POSIX `exec`, or a temp directory on the same drive as the source do not hold on mswin and are skipped with `Gem.win_platform?`. `lockfile_parser_spec` now computes the lockfile path the same way the parser does, which avoids a cross-drive `relative_path_from`. `tool/lib/_tmpdir.rb` drops a `tmp` marker at the temp root so Bundler's `search_up` stops there instead of escaping the sandbox into the real `~/.bundle` when the temp directory lives under the user home. Finally, the spec command timeout is raised to 120 seconds on Windows, since native extension builds under the user-profile temp can exceed the 60 second default.

With these changes the Bundler spec suite runs to completion and passes on a native Windows build.
