### PR TITLE
Respect `handle_interrupt` for default `SIGINT`.

### DIFF
--- a/signal.c
+++ b/signal.c
@@ -1112,7 +1112,7 @@ rb_signal_exec(rb_thread_t *th, int sig)
     if (cmd == 0) {
         switch (sig) {
           case SIGINT:
-            rb_interrupt();
+            rb_threadptr_interrupt_raise(th);
             break;
 #ifdef SIGHUP
           case SIGHUP:

--- a/spec/ruby/core/thread/handle_interrupt_spec.rb
+++ b/spec/ruby/core/thread/handle_interrupt_spec.rb
@@ -122,4 +122,50 @@ describe "Thread.handle_interrupt" do
   it "supports multiple pairs in the Hash" do
     make_handle_interrupt_thread(ArgumentError => :never, RuntimeError => :never).should == [:deferred]
   end
+
+  ruby_version_is "4.1" do
+    platform_is_not :windows do
+      def signal_exception_deferred_by_handle_interrupt(signal)
+        ruby_exe(<<-RUBY)
+          waiting = Thread::Queue.new
+          release = Thread::Queue.new
+          inner = false
+
+          Thread.new do
+            waiting.pop
+            Process.kill(:#{signal}, Process.pid)
+            release.push(true)
+          end
+
+          begin
+            Thread.handle_interrupt(SignalException => :never) do
+              begin
+                waiting.push(true)
+                release.pop
+              rescue SignalException
+                inner = true
+                raise
+              end
+            end
+          rescue SignalException => exception
+            puts exception.class
+            puts exception.signo
+            puts inner
+          end
+        RUBY
+      end
+
+      it "defers the default SIGINT Interrupt until exiting the handle_interrupt block" do
+        out = signal_exception_deferred_by_handle_interrupt(:INT)
+
+        out.should == "Interrupt\n#{Signal.list.fetch("INT")}\nfalse\n"
+      end
+
+      it "defers the default SIGTERM SignalException until exiting the handle_interrupt block" do
+        out = signal_exception_deferred_by_handle_interrupt(:TERM)
+
+        out.should == "SignalException\n#{Signal.list.fetch("TERM")}\nfalse\n"
+      end
+    end
+  end
 end

--- a/test/ruby/test_thread.rb
+++ b/test/ruby/test_thread.rb
@@ -847,6 +847,40 @@ class TestThread < Test::Unit::TestCase
     assert_equal(:ok, r)
   end
 
+  def test_handle_interrupt_masks_sigint
+    if /mswin|mingw/ =~ RUBY_PLATFORM
+      omit "SIGINT handling differs on Windows"
+    end
+
+    assert_in_out_err([], <<-INPUT, %w(outer false), [])
+      waiting = Thread::Queue.new
+      release = Thread::Queue.new
+      inner = false
+
+      Thread.new do
+        waiting.pop
+        Process.kill(:INT, Process.pid)
+        release.push(true)
+      end
+
+      begin
+        Thread.handle_interrupt(SignalException => :never) do
+          begin
+            waiting.push(true)
+            release.pop
+          rescue Interrupt
+            inner = true
+            raise
+          end
+        end
+      rescue Interrupt
+        puts "outer"
+      end
+
+      puts inner
+    INPUT
+  end
+
   def test_handle_interrupt_and_io
     assert_in_out_err([], <<-INPUT, %w(ok), [])
       th_waiting = true

--- a/thread.c
+++ b/thread.c
@@ -2775,6 +2775,29 @@ rb_threadptr_signal_raise(rb_thread_t *th, int sig)
 }
 
 void
+rb_threadptr_interrupt_raise(rb_thread_t *th)
+{
+    rb_thread_t *target_th = th->vm->ractor.main_thread;
+
+    if (rb_threadptr_dead(target_th)) {
+        return;
+    }
+
+    /* Preserve the traditional no-message Interrupt from default SIGINT. */
+    VALUE exc = rb_exc_new(rb_eInterrupt, 0, 0);
+
+    /* making an exception object can switch thread,
+       so we need to check thread deadness again */
+    if (rb_threadptr_dead(target_th)) {
+        return;
+    }
+
+    rb_ec_setup_exception(GET_EC(), exc, Qundef);
+    rb_threadptr_pending_interrupt_enque(target_th, exc);
+    rb_threadptr_interrupt(target_th);
+}
+
+void
 rb_threadptr_signal_exit(rb_thread_t *th)
 {
     VALUE argv[2];

--- a/vm_core.h
+++ b/vm_core.h
@@ -2258,6 +2258,7 @@ int rb_signal_buff_size(void);
 int rb_signal_exec(rb_thread_t *th, int sig);
 void rb_threadptr_check_signal(rb_thread_t *mth);
 void rb_threadptr_signal_raise(rb_thread_t *th, int sig);
+void rb_threadptr_interrupt_raise(rb_thread_t *th);
 void rb_threadptr_signal_exit(rb_thread_t *th);
 int rb_threadptr_execute_interrupts(rb_thread_t *, int);
 void rb_threadptr_interrupt(rb_thread_t *th);


### PR DESCRIPTION
Default `SIGINT` delivery currently calls `rb_interrupt()` directly, so an `Interrupt` can be raised inside a `Thread.handle_interrupt(SignalException => :never)` block. This bypasses the pending interrupt queue used by `Thread#raise` and other default signal exceptions.

This PR adds a regression test using two `Thread::Queue` instances to coordinate `Process.kill(:INT, Process.pid)`, then changes the default SIGINT path to enqueue an `Interrupt` on the main thread. This preserves the default exception class while allowing `Thread.handle_interrupt` to defer it consistently.

Commits:

1. Add the failing regression test.
2. Route default SIGINT through the pending interrupt queue.

Tested with:

```
make test-all TESTS='ruby/test_thread.rb -n /test_handle_interrupt_masks_sigint/'
make test-all TESTS='ruby/test_thread.rb -n /handle_interrupt/'
make test-all TESTS='ruby/test_signal.rb'
```

https://bugs.ruby-lang.org/issues/22133