### PR TITLE
[Bug] win32: create directory symlinks for relative directory targets

### DIFF
--- a/test/ruby/test_file_exhaustive.rb
+++ b/test/ruby/test_file_exhaustive.rb
@@ -715,6 +715,28 @@ class TestFileExhaustive < Test::Unit::TestCase
     assert_raise(Errno::EEXIST) { File.symlink(utf8_file, utf8_file) }
   end
 
+  def test_symlink_to_relative_directory
+    # A relative target is interpreted relative to the link's directory, not the
+    # current directory.  A relative target pointing at a directory must produce
+    # a directory symlink even when the current directory differs from the link's
+    # directory; otherwise Dir operations on the link fail (Windows).
+    Dir.mktmpdir(__method__.to_s) do |tmpdir|
+      Dir.chdir(tmpdir) do
+        Dir.mkdir("subdir")
+        Dir.mkdir(File.join("subdir", "target"))
+        link = File.join("subdir", "link")
+        begin
+          File.symlink("target", link)
+        rescue NotImplementedError, Errno::EACCES, Errno::EPERM => e
+          omit e.message
+        end
+        assert_file.symlink?(link)
+        assert_file.directory?(link)
+        assert(Dir.exist?(link), "relative directory symlink should be a directory")
+      end
+    end
+  end
+
   def test_utime
     t = Time.local(2000)
     File.utime(t + 1, t + 2, zerofile)

--- a/win32/win32.c
+++ b/win32/win32.c
@@ -5293,11 +5293,11 @@ w32_symlink(UINT cp, const char *src, const char *link)
        from the link's directory. */
     {
         WCHAR *sep;
-        int absolute =
+        int independent =
             (((wsrc[0] >= L'A' && wsrc[0] <= L'Z') ||
               (wsrc[0] >= L'a' && wsrc[0] <= L'z')) && wsrc[1] == L':') ||
             wsrc[0] == L'\\';
-        if (!absolute && (sep = wcsrchr(wlink, L'\\')) != NULL) {
+        if (!independent && (sep = wcsrchr(wlink, L'\\')) != NULL) {
             VALUE buf2;
             size_t dirlen = sep - wlink + 1;
             size_t srclen = wcslen(wsrc) + 1;

--- a/win32/win32.c
+++ b/win32/win32.c
@@ -5284,8 +5284,33 @@ w32_symlink(UINT cp, const char *src, const char *link)
     MultiByteToWideChar(cp, 0, src, -1, wsrc, len1);
     MultiByteToWideChar(cp, 0, link, -1, wlink, len2);
     translate_wchar(wsrc, L'/', L'\\');
+    translate_wchar(wlink, L'/', L'\\');
 
-    atts = GetFileAttributesW(wsrc);
+    /* A relative target is interpreted relative to the directory of the link,
+       not the current directory.  Resolve it there to decide whether to create
+       a directory symlink; otherwise a relative target pointing at a directory
+       would wrongly become a file symlink when the current directory differs
+       from the link's directory. */
+    {
+        WCHAR *sep;
+        int absolute =
+            (((wsrc[0] >= L'A' && wsrc[0] <= L'Z') ||
+              (wsrc[0] >= L'a' && wsrc[0] <= L'z')) && wsrc[1] == L':') ||
+            (wsrc[0] == L'\\' && wsrc[1] == L'\\');
+        if (!absolute && (sep = wcsrchr(wlink, L'\\')) != NULL) {
+            VALUE buf2;
+            size_t dirlen = sep - wlink + 1;
+            size_t srclen = wcslen(wsrc) + 1;
+            WCHAR *fullsrc = ALLOCV_N(WCHAR, buf2, dirlen + srclen);
+            memcpy(fullsrc, wlink, dirlen * sizeof(WCHAR));
+            memcpy(fullsrc + dirlen, wsrc, srclen * sizeof(WCHAR));
+            atts = GetFileAttributesW(fullsrc);
+            ALLOCV_END(buf2);
+        }
+        else {
+            atts = GetFileAttributesW(wsrc);
+        }
+    }
     if (atts != -1 && atts & FILE_ATTRIBUTE_DIRECTORY)
         flag = SYMBOLIC_LINK_FLAG_DIRECTORY;
     ret = CreateSymbolicLinkW(wlink, wsrc, flag |= create_flag);

--- a/win32/win32.c
+++ b/win32/win32.c
@@ -5302,8 +5302,8 @@ w32_symlink(UINT cp, const char *src, const char *link)
             size_t dirlen = sep - wlink + 1;
             size_t srclen = wcslen(wsrc) + 1;
             WCHAR *fullsrc = ALLOCV_N(WCHAR, buf2, dirlen + srclen);
-            memcpy(fullsrc, wlink, dirlen * sizeof(WCHAR));
-            memcpy(fullsrc + dirlen, wsrc, srclen * sizeof(WCHAR));
+            MEMCPY(fullsrc, wlink, WCHAR, dirlen);
+            MEMCPY(fullsrc + dirlen, wsrc, WCHAR, srclen);
             atts = GetFileAttributesW(fullsrc);
             ALLOCV_END(buf2);
         }

--- a/win32/win32.c
+++ b/win32/win32.c
@@ -5296,7 +5296,7 @@ w32_symlink(UINT cp, const char *src, const char *link)
         int absolute =
             (((wsrc[0] >= L'A' && wsrc[0] <= L'Z') ||
               (wsrc[0] >= L'a' && wsrc[0] <= L'z')) && wsrc[1] == L':') ||
-            (wsrc[0] == L'\\' && wsrc[1] == L'\\');
+            wsrc[0] == L'\\';
         if (!absolute && (sep = wcsrchr(wlink, L'\\')) != NULL) {
             VALUE buf2;
             size_t dirlen = sep - wlink + 1;


### PR DESCRIPTION
On Windows, `File.symlink` decides whether to create a directory symlink (`SYMBOLIC_LINK_FLAG_DIRECTORY`) by calling `GetFileAttributesW` on the target. For a relative target this resolves against the process current directory, but a symlink's relative target is interpreted relative to the directory that contains the link. When the current directory differs from the link's directory, a relative target that points at a directory is created as a file symlink, so `Dir.exist?` and `File.directory?` on the link return false even though `File.exist?` on entries beneath it still succeeds.

This breaks `nmake test-bundled-gems` on mswin. Extension-backed bundled gems such as fiddle and rbs have their `lib` directory relatively symlinked into the build tree by `ext/extmk.rb` (via `tool/ln_sr.rb`), and the link is created while the current directory is not the link's parent. Those lib directories became file symlinks, so `Gem::Specification` could not walk them and `Gem.try_activate` silently failed. As a result `require` of reline (which loads fiddle), repl_type_completor, and rdoc (which load rbs) failed as if the files were missing.

The fix resolves a relative target against the link's directory before testing whether it is a directory, so a relative directory target now produces a directory symlink (`<SYMLINKD>`) regardless of the current directory. Absolute and UNC targets keep their previous behavior.

Verified on an mswin build (x64-mswin64_140): the new regression test and the existing File symlink, readlink, and realpath tests in test/ruby pass, the ruby/spec core/file symlink specs pass, and `nmake test-bundled-gems-run BUNDLED_GEMS=reline,repl_type_completor,rdoc` passes with the regenerated directory symlinks.