### PR TITLE
Add Signal.[] to inspect signal handlers

### DIFF
--- a/signal.c
+++ b/signal.c
@@ -1287,6 +1287,27 @@ trap_signm(VALUE vsig)
 }
 
 static VALUE
+trap_handler_command(VALUE command, sighandler_t handler)
+{
+    switch (command) {
+      case 0:
+      case Qtrue:
+        if (handler == SIG_IGN) command = rb_str_new2("IGNORE");
+        else if (handler == SIG_DFL) command = rb_str_new2("SYSTEM_DEFAULT");
+        else if (handler == sighandler) command = rb_str_new2("DEFAULT");
+        else command = Qnil;
+        break;
+      case Qnil:
+        break;
+      case Qundef:
+        command = rb_str_new2("EXIT");
+        break;
+    }
+
+    return command;
+}
+
+static VALUE
 trap(int sig, sighandler_t func, VALUE command)
 {
     sighandler_t oldfunc;
@@ -1306,20 +1327,7 @@ trap(int sig, sighandler_t func, VALUE command)
         if (oldfunc == SIG_ERR) rb_sys_fail_str(rb_signo2signm(sig));
     }
     oldcmd = vm->trap_list.cmd[sig];
-    switch (oldcmd) {
-      case 0:
-      case Qtrue:
-        if (oldfunc == SIG_IGN) oldcmd = rb_str_new2("IGNORE");
-        else if (oldfunc == SIG_DFL) oldcmd = rb_str_new2("SYSTEM_DEFAULT");
-        else if (oldfunc == sighandler) oldcmd = rb_str_new2("DEFAULT");
-        else oldcmd = Qnil;
-        break;
-      case Qnil:
-        break;
-      case Qundef:
-        oldcmd = rb_str_new2("EXIT");
-        break;
-    }
+    oldcmd = trap_handler_command(oldcmd, oldfunc);
 
     ACCESS_ONCE(VALUE, vm->trap_list.cmd[sig]) = command;
 
@@ -1354,6 +1362,48 @@ reserved_signal_p(int signo)
 #endif
 
     return 0;
+}
+
+/*
+ * call-seq:
+ *   Signal[signal] -> obj
+ *
+ * Returns the current handler for the given signal without changing it.
+ *
+ * Argument +signal+ is a signal name (a string or symbol such
+ * as +SIGALRM+ or +SIGUSR1+) or an integer signal number. When +signal+
+ * is a string or symbol, the leading characters +SIG+ may be omitted.
+ *
+ * The returned object is represented the same way as the previous handler
+ * returned by Signal.trap.
+ *
+ *     Signal.trap("HUP", "IGNORE")
+ *     Signal["HUP"] # => "IGNORE"
+ */
+static VALUE
+sig_aref(VALUE recv, VALUE signo)
+{
+    int sig = trap_signm(signo);
+    sighandler_t func;
+    VALUE command = GET_VM()->trap_list.cmd[sig];
+
+    if (reserved_signal_p(sig)) {
+        const char *name = signo2signm(sig);
+        if (name)
+            rb_raise(rb_eArgError, "can't get reserved signal: SIG%s", name);
+        else
+            rb_raise(rb_eArgError, "can't get reserved signal: %d", sig);
+    }
+
+    if (sig == 0 || (command != 0 && command != Qtrue)) {
+        return trap_handler_command(command, SIG_ERR);
+    }
+
+    func = ruby_signal(sig, SIG_DFL);
+    if (func == SIG_ERR) rb_sys_fail_str(rb_signo2signm(sig));
+    if (ruby_signal(sig, func) == SIG_ERR) rb_sys_fail_str(rb_signo2signm(sig));
+
+    return trap_handler_command(command, func);
 }
 
 /*
@@ -1535,6 +1585,7 @@ Init_signal(void)
     VALUE mSignal = rb_define_module("Signal");
 
     rb_define_global_function("trap", sig_trap, -1);
+    rb_define_module_function(mSignal, "[]", sig_aref, 1);
     rb_define_module_function(mSignal, "trap", sig_trap, -1);
     rb_define_module_function(mSignal, "list", sig_list, 0);
     rb_define_module_function(mSignal, "signame", sig_signame, 1);

--- a/spec/ruby/core/signal/element_reference_spec.rb
+++ b/spec/ruby/core/signal/element_reference_spec.rb
@@ -1,0 +1,74 @@
+require_relative '../../spec_helper'
+
+ruby_version_is "4.1" do
+  describe "Signal.[]" do
+    before :each do
+      @signal = Signal.list.key?("HUP") ? :HUP : :INT
+      @signal_name = @signal.to_s
+      @signal_number = Signal.list[@signal_name]
+      @proc = -> {}
+      @saved_trap = Signal.trap(@signal, @proc)
+    end
+
+    after :each do
+      Signal.trap(@signal, @saved_trap)
+    end
+
+    it "returns the current handler" do
+      Signal[@signal].should.equal?(@proc)
+    end
+
+    it "accepts signal names and numbers" do
+      Signal[@signal_name].should.equal?(@proc)
+      Signal[:"SIG#{@signal_name}"].should.equal?(@proc)
+      Signal[@signal_number].should.equal?(@proc)
+    end
+
+    platform_is_not :windows do
+      it "does not change the current handler" do
+        done = false
+
+        Signal.trap(@signal) do
+          done = true
+        end
+
+        Signal[@signal].should.is_a?(Proc)
+
+        Process.kill @signal, Process.pid
+        Thread.pass until done
+      end
+    end
+
+    it "returns nil for nil handlers" do
+      Signal.trap(@signal, nil)
+      Signal[@signal].should == nil
+    end
+
+    it "returns IGNORE for ignored signals" do
+      Signal.trap(@signal, :IGNORE)
+      Signal[@signal].should == "IGNORE"
+    end
+
+    it "returns DEFAULT for Ruby default handlers" do
+      Signal.trap(@signal, :DEFAULT)
+      Signal[@signal].should == "DEFAULT"
+    end
+
+    it "returns SYSTEM_DEFAULT for system default handlers" do
+      Signal.trap(@signal, :SYSTEM_DEFAULT)
+      Signal[@signal].should == "SYSTEM_DEFAULT"
+    end
+
+    it "returns the current EXIT handler" do
+      handler = -> {}
+      saved_trap = Signal.trap(:EXIT, handler)
+
+      begin
+        Signal[0].should.equal?(handler)
+        Signal[:EXIT].should.equal?(handler)
+      ensure
+        Signal.trap(:EXIT, saved_trap || "DEFAULT")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds `Signal[]` for inspecting the current handler for a signal without changing it. The return value mirrors the previous-handler representation already returned by `Signal.trap`.

This is useful for code that needs to check whether a signal still has the default, ignored, system default, `EXIT`, `nil`, or custom Ruby handler state before deciding whether to install its own handler.

The implementation reuses the existing `Signal.trap` handler representation logic and only probes the native signal disposition when the Ruby VM stored command is default-like and needs that distinction.

Specs are added under ruby/spec for the new API. The Ruby-level handler inspection specs are cross-platform; only actual signal delivery is skipped on Windows.