### PR TITLE
Fix Windows-only test failures in test-spec and test-all

### DIFF
--- a/spec/ruby/core/file/atime_spec.rb
+++ b/spec/ruby/core/file/atime_spec.rb
@@ -19,7 +19,7 @@ describe "File.atime" do
     unless ENV.key?('TRAVIS') # https://bugs.ruby-lang.org/issues/17926
       ## NOTE also that some Linux systems disable atime (e.g. via mount params) for better filesystem speed.
       it "returns the last access time for the named file with microseconds" do
-        supports_subseconds = Integer(`stat -c%x '#{__FILE__}'`[/\.(\d{1,6})/, 1], 10)
+        supports_subseconds = Integer(`stat -c%x #{__FILE__}`[/\.(\d{1,6})/, 1], 10)
         if supports_subseconds != 0
           expected_time = Time.at(Time.now.to_i + 0.123456)
           File.utime expected_time, 0, @file

--- a/spec/ruby/core/file/ctime_spec.rb
+++ b/spec/ruby/core/file/ctime_spec.rb
@@ -16,7 +16,7 @@ describe "File.ctime" do
 
   platform_is :linux, :windows do
     it "returns the change time for the named file (the time at which directory information about the file was changed, not the file itself) with microseconds." do
-      supports_subseconds = Integer(`stat -c%z '#{__FILE__}'`[/\.(\d{1,6})/, 1], 10)
+      supports_subseconds = Integer(`stat -c%z #{__FILE__}`[/\.(\d{1,6})/, 1], 10)
       if supports_subseconds != 0
         File.ctime(__FILE__).usec.should > 0
       else

--- a/spec/ruby/core/file/mtime_spec.rb
+++ b/spec/ruby/core/file/mtime_spec.rb
@@ -18,7 +18,7 @@ describe "File.mtime" do
   platform_is :linux, :windows do
     unless ENV.key?('TRAVIS') # https://bugs.ruby-lang.org/issues/17926
       it "returns the modification Time of the file with microseconds" do
-        supports_subseconds = Integer(`stat -c%y '#{__FILE__}'`[/\.(\d{1,6})/, 1], 10)
+        supports_subseconds = Integer(`stat -c%y #{__FILE__}`[/\.(\d{1,6})/, 1], 10)
         if supports_subseconds != 0
           expected_time = Time.at(Time.now.to_i + 0.123456)
           File.utime 0, expected_time, @filename

--- a/test/ruby/test_file_exhaustive.rb
+++ b/test/ruby/test_file_exhaustive.rb
@@ -827,10 +827,11 @@ class TestFileExhaustive < Test::Unit::TestCase
     def test_realpath_mount_point
       vol = IO.popen(["mountvol", DRIVE, "/l"], &:read).strip
       Dir.mkdir(mnt = File.join(@dir, mntpnt = "mntpnt"))
-      system("mountvol", mntpnt, vol, chdir: @dir)
+      err = IO.popen(%W"mountvol #{mntpnt} #{vol}", chdir: @dir, err: %i[child out], &:read)
+      omit err unless $?.success?
       assert_equal(mnt, File.realpath(mnt))
     ensure
-      system("mountvol", mntpnt, "/d", chdir: @dir)
+      system("mountvol", mntpnt, "/d", chdir: @dir, out: IO::NULL, err: IO::NULL)
     end
   end
 

--- a/test/ruby/test_io_m17n.rb
+++ b/test/ruby/test_io_m17n.rb
@@ -404,8 +404,17 @@ EOT
   end
 
   def test_stdin
-    assert_equal(Encoding.default_external, STDIN.external_encoding)
-    assert_equal(nil, STDIN.internal_encoding)
+    encoding = Encoding.default_external
+    internal = nil
+    if /mswin|mingw/ =~ RUBY_PLATFORM and STDIN.tty?
+      # Interactive console input on Windows is read in the locale (console
+      # code page) encoding and transcoded to the default external encoding.
+      encoding = Encoding.find("locale")
+      internal = Encoding.default_internal || Encoding.default_external
+      internal = nil if internal == encoding
+    end
+    assert_equal(encoding, STDIN.external_encoding)
+    assert_equal(internal, STDIN.internal_encoding)
   end
 
   def test_stdout


### PR DESCRIPTION
These are Windows-only failures seen when running `nmake test-spec` and `nmake test-all` from an interactive console.

The `File.atime` / `File.ctime` / `File.mtime` subsecond specs shell out to `stat` with the path wrapped in POSIX single quotes. On Windows the backtick runs through cmd.exe, which keeps the quotes literally, so coreutils `stat` fails on the invalid filename and returns empty output. `Integer(nil, 10)` then raises `ArgumentError` instead of being skipped. Dropping the quotes passes the path through unchanged on both POSIX and Windows.

`TestFileExhaustive#test_realpath_mount_point` runs `mountvol` to create and delete a mount point, which needs elevation. Without it `mountvol` prints "Access is denied." to stdout. Under the parallel runner the worker stdout doubles as the IPC channel, so the message leaks through and the parent reports it as `unknown command: "Access is denied."`. Capture the output and `omit` when the command fails, matching the neighbouring `test_readlink_junction`.

`TestIO_M17N#test_stdin` assumes `STDIN.external_encoding` always equals `Encoding.default_external`. On Windows `default_external` is UTF-8, but an interactive console STDIN is read in the locale (console code page) encoding and transcoded to the default external encoding. The assertion only held when stdin was redirected, so it failed on a console with a non-UTF-8 code page. Expect the locale encoding when stdin is a tty.

The `spec/ruby/core/file/*` changes live in the ruby/spec mirror and should be reflected upstream as well.
