### PR TITLE
Expose pending interrupt C API

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -149,6 +149,8 @@ Ruby 4.0 bundled RubyGems and Bundler version 4. see the following links for det
 
 ## C API updates
 
+* `rb_thread_pending_interrupt_p()` has been added to check whether the current thread has pending interrupts.
+
 ### Embedded TypedData
 
 * The `RUBY_TYPED_EMBEDDABLE` flag is now public and documented and can be used by C extensions.

--- a/include/ruby/internal/intern/thread.h
+++ b/include/ruby/internal/intern/thread.h
@@ -375,6 +375,16 @@ void rb_thread_check_ints(void);
 int rb_thread_interrupted(VALUE thval);
 
 /**
+ * Checks whether the current thread has pending interrupts.
+ *
+ * This is equivalent to `Thread.pending_interrupt?`.
+ *
+ * @retval     0          The current thread has no pending interrupts.
+ * @retval     otherwise  The current thread has pending interrupts.
+ */
+int rb_thread_pending_interrupt_p(void);
+
+/**
  * A special  UBF for blocking IO  operations.  You need deep  understanding of
  * what this  actually do before using.   Basically you should not  use it from
  * extension libraries.  It is too easy to mess up.

--- a/spec/ruby/optional/capi/ext/thread_spec.c
+++ b/spec/ruby/optional/capi/ext/thread_spec.c
@@ -172,6 +172,12 @@ static VALUE thread_spec_ruby_thread_has_gvl_p(VALUE self) {
 }
 #endif
 
+#ifdef RUBY_VERSION_IS_4_1
+static VALUE thread_spec_rb_thread_pending_interrupt_p(VALUE self) {
+  return rb_thread_pending_interrupt_p() ? Qtrue : Qfalse;
+}
+#endif
+
 void Init_thread_spec(void) {
   VALUE cls = rb_define_class("CApiThreadSpecs", rb_cObject);
   rb_define_method(cls, "rb_thread_alone", thread_spec_rb_thread_alone, 0);
@@ -187,6 +193,9 @@ void Init_thread_spec(void) {
   rb_define_method(cls,  "ruby_native_thread_p_new_thread", thread_spec_ruby_native_thread_p_new_thread, 0);
 #ifdef RUBY_VERSION_IS_4_0
   rb_define_method(cls,  "ruby_thread_has_gvl_p", thread_spec_ruby_thread_has_gvl_p, 0);
+#endif
+#ifdef RUBY_VERSION_IS_4_1
+  rb_define_method(cls,  "rb_thread_pending_interrupt_p", thread_spec_rb_thread_pending_interrupt_p, 0);
 #endif
 }
 

--- a/spec/ruby/optional/capi/thread_spec.rb
+++ b/spec/ruby/optional/capi/thread_spec.rb
@@ -192,4 +192,20 @@ describe "C-API Thread function" do
       end
     end
   end
+
+  ruby_version_is "4.1" do
+    describe "rb_thread_pending_interrupt_p" do
+      it "returns whether the current thread has pending interrupts" do
+        @t.rb_thread_pending_interrupt_p.should == false
+
+        begin
+          Thread.handle_interrupt(RuntimeError => :never) do
+            Thread.current.raise(RuntimeError)
+            @t.rb_thread_pending_interrupt_p.should == true
+          end
+        rescue RuntimeError
+        end
+      end
+    end
+  end
 end

--- a/thread.c
+++ b/thread.c
@@ -2493,15 +2493,31 @@ rb_thread_s_handle_interrupt(VALUE self, VALUE mask_arg)
  *
  * See ::pending_interrupt? for more information.
  */
+static int
+thread_pending_interrupt_p(rb_thread_t *target_th)
+{
+    if (!target_th->pending_interrupt_queue) {
+        return FALSE;
+    }
+    if (rb_threadptr_pending_interrupt_empty_p(target_th)) {
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+int
+rb_thread_pending_interrupt_p(void)
+{
+    return thread_pending_interrupt_p(GET_THREAD());
+}
+
 static VALUE
-rb_thread_pending_interrupt_p(int argc, VALUE *argv, VALUE target_thread)
+thread_pending_interrupt_m(int argc, VALUE *argv, VALUE target_thread)
 {
     rb_thread_t *target_th = rb_thread_ptr(target_thread);
 
-    if (!target_th->pending_interrupt_queue) {
-        return Qfalse;
-    }
-    if (rb_threadptr_pending_interrupt_empty_p(target_th)) {
+    if (!thread_pending_interrupt_p(target_th)) {
         return Qfalse;
     }
     if (rb_check_arity(argc, 0, 1)) {
@@ -2576,7 +2592,7 @@ rb_thread_pending_interrupt_p(int argc, VALUE *argv, VALUE target_thread)
 static VALUE
 rb_thread_s_pending_interrupt_p(int argc, VALUE *argv, VALUE self)
 {
-    return rb_thread_pending_interrupt_p(argc, argv, GET_THREAD()->self);
+    return thread_pending_interrupt_m(argc, argv, GET_THREAD()->self);
 }
 
 NORETURN(static void rb_threadptr_to_kill(rb_thread_t *th));
@@ -5718,7 +5734,7 @@ Init_Thread(void)
     rb_define_singleton_method(rb_cThread, "ignore_deadlock=", rb_thread_s_ignore_deadlock_set, 1);
     rb_define_singleton_method(rb_cThread, "handle_interrupt", rb_thread_s_handle_interrupt, 1);
     rb_define_singleton_method(rb_cThread, "pending_interrupt?", rb_thread_s_pending_interrupt_p, -1);
-    rb_define_method(rb_cThread, "pending_interrupt?", rb_thread_pending_interrupt_p, -1);
+    rb_define_method(rb_cThread, "pending_interrupt?", thread_pending_interrupt_m, -1);
 
     rb_define_method(rb_cThread, "initialize", thread_initialize, -2);
     rb_define_method(rb_cThread, "raise", thread_raise_m, -1);
@@ -6322,4 +6338,3 @@ rb_ractor_interrupt_exec(struct rb_ractor_struct *target_r,
     rb_thread_t *main_th = target_r->threads.main;
     rb_threadptr_interrupt_exec(main_th, func, data, flags | rb_interrupt_exec_flag_new_thread);
 }
-


### PR DESCRIPTION
This adds `rb_thread_pending_interrupt_p()` as a public C API for checking whether the current thread has pending interrupts. It is equivalent to `Thread.pending_interrupt?` without arguments, but avoids requiring extensions to call back into Ruby to check before entering a blocking operation.

The existing Ruby method implementation is split so `Thread#pending_interrupt?` can continue to support arbitrary receiver threads and the optional exception-class filter, while the public C API exposes the narrower current-thread predicate needed by extensions.

Tests:

* `make test-spec MSPECOPT=../spec/ruby/optional/capi/thread_spec.rb`
* `make test-all TESTS='../test/ruby/test_thread.rb -n /test_pending_interrupt/'`