### PR TITLE
Fix flaky TestGc#test_stat_single by disabling GC

### DIFF
--- a/test/ruby/test_gc.rb
+++ b/test/ruby/test_gc.rb
@@ -194,8 +194,14 @@ class TestGc < Test::Unit::TestCase
   def test_stat_single
     omit 'stress' if GC.stress
 
-    stat = GC.stat
-    assert_equal stat[:count], GC.stat(:count)
+    # GC.stat and GC.stat(:count) are two separate reads of :count. If a GC
+    # runs between them (e.g. triggered by an allocation on another thread),
+    # :count changes and the two reads disagree. Disable GC so both reads
+    # observe the same :count.
+    EnvUtil.without_gc do
+      stat = GC.stat
+      assert_equal stat[:count], GC.stat(:count)
+    end
     assert_raise(ArgumentError){ GC.stat(:invalid) }
   end
 


### PR DESCRIPTION
test_stat_single fails intermittently:

  1) Failure:
  TestGc#test_stat_single [test/ruby/test_gc.rb:198]:
  <12> expected but was
  <13>.

The test reads the full GC.stat hash and then GC.stat(:count) separately and asserts they are equal:

    stat = GC.stat
    assert_equal stat[:count], GC.stat(:count)

GC.stat's :count is only equal across the two calls if no GC happens between them. Under the parallel test runner a thread leaked by an earlier test can still be allocating, and its allocation can trigger a GC between the two reads, bumping :count by one (or more) so that stat[:count] < GC.stat(:count). Reproduced deterministically by running the two reads in a loop with a background allocating thread (54/2,000,000 mismatches; 0 after the fix).

Wrap the two reads in EnvUtil.without_gc (matching test_stat_heap etc.) so :count cannot change between them.

CI: https://ci.rvm.jp/results/trunk@ruby-sp3/6395611
log: https://ci.rvm.jp/logfiles/brlog.trunk.20260629-050802


Claude-Session: https://claude.ai/code/session_013iJcxCVF6ehCdK2sdQaGjV