### PR TITLE
Extend rb_scan_args() for kwargs with ":^" (no duplication)

### DIFF
--- a/class.c
+++ b/class.c
@@ -2848,8 +2848,8 @@ rb_extract_keywords(VALUE *orighash)
     return parthash[0];
 }
 
-int
-rb_get_kwargs(VALUE keyword_hash, const ID *table, int required, int optional, VALUE *values)
+static int
+get_kwargs(VALUE keyword_hash, const ID *table, int required, int optional, VALUE *values, bool remove)
 {
     int i = 0, j;
     int rest = 0;
@@ -2858,10 +2858,14 @@ rb_get_kwargs(VALUE keyword_hash, const ID *table, int required, int optional, V
 
 #define extract_kwarg(keyword, val) \
     (key = (st_data_t)(keyword), values ? \
-     (rb_hash_stlike_delete(keyword_hash, &key, &(val)) || ((val) = Qundef, 0)) : \
+     (remove ? \
+      (rb_hash_stlike_delete(keyword_hash, &key, &(val)) || ((val) = Qundef, 0)) : \
+      (rb_hash_stlike_lookup(keyword_hash, key, &(val)) || ((val) = Qundef, 0))) : \
      rb_hash_stlike_lookup(keyword_hash, key, NULL))
 
     if (NIL_P(keyword_hash)) keyword_hash = 0;
+
+    RUBY_ASSERT(!(remove && values) || !keyword_hash || !RB_OBJ_FROZEN((VALUE)keyword_hash));
 
     if (optional < 0) {
         rest = 1;
@@ -2891,7 +2895,7 @@ rb_get_kwargs(VALUE keyword_hash, const ID *table, int required, int optional, V
         }
     }
     if (!rest && keyword_hash) {
-        if (RHASH_SIZE(keyword_hash) > (unsigned int)(values ? 0 : j)) {
+        if (RHASH_SIZE(keyword_hash) > (unsigned int)((values && remove) ? 0 : j)) {
             unknown_keyword_error(keyword_hash, table, required+optional);
         }
     }
@@ -2904,6 +2908,18 @@ rb_get_kwargs(VALUE keyword_hash, const ID *table, int required, int optional, V
 #undef extract_kwarg
 }
 
+int
+rb_get_kwargs(VALUE keyword_hash, const ID *table, int required, int optional, VALUE *values)
+{
+    return get_kwargs(keyword_hash, table, required, optional, values, true);
+}
+
+int
+rb_get_kwargs_const(VALUE keyword_hash, const ID *table, int required, int optional, VALUE *values)
+{
+    return get_kwargs(keyword_hash, table, required, optional, values, false);
+}
+
 struct rb_scan_args_t {
     int kw_flag;
     int n_lead;
@@ -2911,6 +2927,7 @@ struct rb_scan_args_t {
     int n_trail;
     bool f_var;
     bool f_hash;
+    bool f_hash_borrow;
     bool f_block;
 };
 
@@ -2941,6 +2958,10 @@ rb_scan_args_parse(int kw_flag, const char *fmt, struct rb_scan_args_t *arg)
     if (*p == ':') {
         arg->f_hash = 1;
         p++;
+        if (*p == '^') {
+            arg->f_hash_borrow = 1;
+            p++;
+        }
     }
     if (*p == '&') {
         arg->f_block = 1;
@@ -2964,13 +2985,14 @@ rb_scan_args_assign(const struct rb_scan_args_t *arg, int argc, const VALUE *con
     const int n_mand = n_lead + n_trail;
     const bool f_var = arg->f_var;
     const bool f_hash = arg->f_hash;
+    const bool f_hash_borrow = arg->f_hash_borrow;
     const bool f_block = arg->f_block;
 
     /* capture an option hash - phase 1: pop from the argv */
     if (f_hash && argc > 0) {
         VALUE last = argv[argc - 1];
         if (rb_scan_args_keyword_p(kw_flag, last)) {
-            hash = rb_hash_dup(last);
+            hash = rb_scan_args_borrow_hash(kw_flag, f_hash_borrow, last);
             argc--;
         }
     }

--- a/complex.c
+++ b/complex.c
@@ -555,7 +555,7 @@ nucomp_f_complex(int argc, VALUE *argv, VALUE klass)
     VALUE a1, a2, opts = Qnil;
     int raise = TRUE;
 
-    if (rb_scan_args(argc, argv, "11:", &a1, &a2, &opts) == 1) {
+    if (rb_scan_args(argc, argv, "11:^", &a1, &a2, &opts) == 1) {
         a2 = Qundef;
     }
     if (!NIL_P(opts)) {

--- a/enumerator.c
+++ b/enumerator.c
@@ -3565,7 +3565,7 @@ enum_product_initialize(int argc, VALUE *argv, VALUE obj)
     struct enum_product *ptr;
     VALUE enums = Qnil, options = Qnil;
 
-    rb_scan_args(argc, argv, "*:", &enums, &options);
+    rb_scan_args(argc, argv, "*:^", &enums, &options);
 
     if (!NIL_P(options) && !RHASH_EMPTY_P(options)) {
         rb_exc_raise(rb_keyword_error_new("unknown", rb_hash_keys(options)));
@@ -3808,7 +3808,7 @@ enumerator_s_product(int argc, VALUE *argv, VALUE klass)
 {
     VALUE enums = Qnil, options = Qnil, block = Qnil;
 
-    rb_scan_args(argc, argv, "*:&", &enums, &options, &block);
+    rb_scan_args(argc, argv, "*:^&", &enums, &options, &block);
 
     if (!NIL_P(options) && !RHASH_EMPTY_P(options)) {
         rb_exc_raise(rb_keyword_error_new("unknown", rb_hash_keys(options)));

--- a/error.c
+++ b/error.c
@@ -291,8 +291,8 @@ rb_warning_s_warn(int argc, VALUE *argv, VALUE mod)
     VALUE opt;
     VALUE category = Qnil;
 
-    rb_scan_args(argc, argv, "1:", &str, &opt);
-    if (!NIL_P(opt)) rb_get_kwargs(opt, &id_category, 0, 1, &category);
+    rb_scan_args(argc, argv, "1:^", &str, &opt);
+    if (!NIL_P(opt)) rb_get_kwargs_const(opt, &id_category, 0, 1, &category);
 
     Check_Type(str, T_STRING);
     rb_must_asciicompat(str);
@@ -1810,7 +1810,7 @@ exc_detailed_message(int argc, VALUE *argv, VALUE exc)
 {
     VALUE opt;
 
-    rb_scan_args(argc, argv, "0:", &opt);
+    rb_scan_args(argc, argv, "0:^", &opt);
 
     VALUE highlight = check_highlight_keyword(opt, 0);
 
@@ -2322,9 +2322,9 @@ frozen_err_initialize(int argc, VALUE *argv, VALUE self)
     ID keywords[1];
     VALUE values[numberof(keywords)], options;
 
-    argc = rb_scan_args(argc, argv, "*:", NULL, &options);
+    argc = rb_scan_args(argc, argv, "*:^", NULL, &options);
     keywords[0] = id_receiver;
-    rb_get_kwargs(options, keywords, 0, numberof(values), values);
+    rb_get_kwargs_const(options, keywords, 0, numberof(values), values);
     rb_call_super(argc, argv);
     err_init_recv(self, values[0]);
     return self;
@@ -2403,9 +2403,9 @@ name_err_initialize(int argc, VALUE *argv, VALUE self)
     ID keywords[1];
     VALUE values[numberof(keywords)], name, options;
 
-    argc = rb_scan_args(argc, argv, "*:", NULL, &options);
+    argc = rb_scan_args(argc, argv, "*:^", NULL, &options);
     keywords[0] = id_receiver;
-    rb_get_kwargs(options, keywords, 0, numberof(values), values);
+    rb_get_kwargs_const(options, keywords, 0, numberof(values), values);
     name = (argc > 1) ? argv[--argc] : Qnil;
     rb_call_super(argc, argv);
     name_err_init_attr(self, values[0], name);
@@ -2494,7 +2494,7 @@ nometh_err_initialize(int argc, VALUE *argv, VALUE self)
 {
     int priv;
     VALUE args, options;
-    argc = rb_scan_args(argc, argv, "*:", NULL, &options);
+    argc = rb_scan_args(argc, argv, "*:^", NULL, &options);
     priv = (argc > 3) && (--argc, RTEST(argv[argc]));
     args = (argc > 2) ? argv[--argc] : Qnil;
     if (!NIL_P(options)) argv[argc++] = options;
@@ -2898,7 +2898,7 @@ key_err_initialize(int argc, VALUE *argv, VALUE self)
 {
     VALUE options;
 
-    rb_call_super(rb_scan_args(argc, argv, "01:", NULL, &options), argv);
+    rb_call_super(rb_scan_args(argc, argv, "01:^", NULL, &options), argv);
 
     if (!NIL_P(options)) {
         ID keywords[2];
@@ -2906,7 +2906,7 @@ key_err_initialize(int argc, VALUE *argv, VALUE self)
         int i;
         keywords[0] = id_receiver;
         keywords[1] = id_key;
-        rb_get_kwargs(options, keywords, 0, numberof(values), values);
+        rb_get_kwargs_const(options, keywords, 0, numberof(values), values);
         for (i = 0; i < numberof(values); ++i) {
             if (!UNDEF_P(values[i])) {
                 rb_ivar_set(self, keywords[i], values[i]);
@@ -2964,7 +2964,7 @@ no_matching_pattern_key_err_initialize(int argc, VALUE *argv, VALUE self)
 {
     VALUE options;
 
-    rb_call_super(rb_scan_args(argc, argv, "01:", NULL, &options), argv);
+    rb_call_super(rb_scan_args(argc, argv, "01:^", NULL, &options), argv);
 
     if (!NIL_P(options)) {
         ID keywords[2];
@@ -2972,7 +2972,7 @@ no_matching_pattern_key_err_initialize(int argc, VALUE *argv, VALUE self)
         int i;
         keywords[0] = id_matchee;
         keywords[1] = id_key;
-        rb_get_kwargs(options, keywords, 0, numberof(values), values);
+        rb_get_kwargs_const(options, keywords, 0, numberof(values), values);
         for (i = 0; i < numberof(values); ++i) {
             if (!UNDEF_P(values[i])) {
                 rb_ivar_set(self, keywords[i], values[i]);

--- a/hash.c
+++ b/hash.c
@@ -6910,10 +6910,8 @@ static VALUE
 env_clone(int argc, VALUE *argv, VALUE obj)
 {
     if (argc) {
-        VALUE opt;
-        if (rb_scan_args(argc, argv, "0:", &opt) < argc) {
-            rb_get_freeze_opt(1, &opt);
-        }
+        /* Validate args (raises on bad positional/keyword) before the TypeError. */
+        rb_get_freeze_opt(argc, argv);
     }
 
     rb_raise(rb_eTypeError, "Cannot clone ENV, use ENV.to_h to get a copy of ENV as a hash");

--- a/include/ruby/internal/eval.h
+++ b/include/ruby/internal/eval.h
@@ -384,6 +384,28 @@ RBIMPL_ATTR_NONNULL((2))
  */
 int rb_get_kwargs(VALUE keyword_hash, const ID *table, int required, int optional, VALUE *values);
 
+RBIMPL_ATTR_NONNULL((2))
+/**
+ * Identical to ::rb_get_kwargs, except it never modifies `keyword_hash`.
+ *
+ * ::rb_get_kwargs deletes each retrieved entry from `keyword_hash` (and so the
+ * standard `rb_scan_args(..., ":", ...)` idiom must duplicate the keyword hash
+ * before handing it over).  This variant reads the values in place instead, so
+ * `keyword_hash` may be a hash the caller does not own -- for instance the
+ * keyword hash sitting in `argv` -- with no intermediate copy.  Unknown
+ * keywords are still detected.
+ *
+ * @param[in]   keyword_hash  Target hash to read (left unmodified).
+ * @param[in]   table         List of keywords that you are interested in.
+ * @param[in]   required      Number of mandatory keywords.
+ * @param[in]   optional      Number of optional keywords (can be negative).
+ * @param[out]  values        Buffer to be filled.
+ * @exception   rb_eArgError  Absence of a mandatory keyword.
+ * @exception   rb_eArgError  Found an unknown keyword.
+ * @return      Number of found values that are stored into `values`.
+ */
+int rb_get_kwargs_const(VALUE keyword_hash, const ID *table, int required, int optional, VALUE *values);
+
 RBIMPL_ATTR_NONNULL(())
 /**
  * Splits a hash into two.

--- a/include/ruby/internal/scan_args.h
+++ b/include/ruby/internal/scan_args.h
@@ -88,6 +88,22 @@
  */
 #define HAVE_RB_SCAN_ARGS_OPTIONAL_HASH 1
 
+/**
+ * This macro is defined when rb_scan_args() understands the `:^` "borrowed
+ * keyword hash" format flag (see the description of the format string below).
+ * An extension that wants to use it while still compiling against Ruby versions
+ * that predate the feature can guard its use behind this macro:
+ *
+ * ```CXX
+ * #ifdef HAVE_RB_SCAN_ARGS_BORROW_KEYWORDS
+ *     rb_scan_args(argc, argv, "01:^", &x, &opts);
+ * #else
+ *     rb_scan_args(argc, argv, "01:",  &x, &opts);
+ * #endif
+ * ```
+ */
+#define HAVE_RB_SCAN_ARGS_BORROW_KEYWORDS 1
+
 RBIMPL_SYMBOL_EXPORT_BEGIN()
 RBIMPL_ATTR_NONNULL((2, 3))
 /**
@@ -105,7 +121,7 @@ RBIMPL_ATTR_NONNULL((2, 3))
  *                          [num-of-trailing-mandatory-args]
  * pre-opt-post-arg-spec := num-of-leading-mandatory-args num-of-optional-args
  *                          num-of-trailing-mandatory-args
- * keyword-arg-spec      := sym-for-keyword-arg
+ * keyword-arg-spec      := sym-for-keyword-arg [sym-for-borrowed-keyword-arg]
  * block-arg-spec        := sym-for-block-arg
  *
  * num-of-leading-mandatory-args  := DIGIT ; The number of leading mandatory
@@ -120,6 +136,25 @@ RBIMPL_ATTR_NONNULL((2, 3))
  *                                         ; captured as a hash.
  *                                         ; If keyword arguments are not
  *                                         ; provided, returns nil.
+ * sym-for-borrowed-keyword-arg   := "^"   ; Only valid right after ":".  The
+ *                                         ; captured keyword hash is the
+ *                                         ; VM-owned hash built for this call,
+ *                                         ; borrowed without the usual
+ *                                         ; defensive copy.  Saves one hash
+ *                                         ; allocation per call, but only takes
+ *                                         ; effect in the default
+ *                                         ; (PASS_CALLED) keyword mode where
+ *                                         ; the hash is guaranteed private to
+ *                                         ; the callee; otherwise it falls back
+ *                                         ; to copying.  The callee may read it
+ *                                         ; freely but must not retain it after
+ *                                         ; mutating it (e.g. rb_get_kwargs
+ *                                         ; deletes matched keys -- use
+ *                                         ; rb_get_kwargs_const to read without
+ *                                         ; mutating).  Extensions can
+ *                                         ; feature-detect this flag with the
+ *                                         ; HAVE_RB_SCAN_ARGS_BORROW_KEYWORDS
+ *                                         ; macro.
  * sym-for-block-arg              := "&"   ; Indicates that an iterator block
  *                                         ; should be captured if given
  * ```
@@ -205,7 +240,9 @@ RBIMPL_SYMBOL_EXPORT_END()
 #define rb_scan_args_count_hash(fmt, ofs, vari) \
     ((fmt)[ofs]!=':' ? \
      rb_scan_args_count_block(fmt, ofs, vari) : \
-     rb_scan_args_count_block(fmt, (ofs)+1, (vari)+1))
+     (fmt)[(ofs)+1]!='^' ? \
+     rb_scan_args_count_block(fmt, (ofs)+1, (vari)+1) : \
+     rb_scan_args_count_block(fmt, (ofs)+2, (vari)+1))
 
 #define rb_scan_args_count_trail(fmt, ofs, vari) \
     (!rb_scan_args_isdigit((fmt)[ofs]) ? \
@@ -262,6 +299,15 @@ rb_scan_args_keyword_p(int kw_flag, VALUE last)
       default:
         return false;
     }
+}
+
+static inline VALUE
+rb_scan_args_borrow_hash(int kw_flag, bool f_hash_borrow, VALUE last)
+{
+    if (f_hash_borrow && kw_flag == RB_SCAN_ARGS_PASS_CALLED_KEYWORDS) {
+        return last;
+    }
+    return rb_hash_dup(last);
 }
 
 RBIMPL_ATTR_FORCEINLINE()
@@ -338,11 +384,20 @@ rb_scan_args_f_hash(const char *fmt)
 }
 
 RBIMPL_ATTR_FORCEINLINE()
+static bool
+rb_scan_args_f_hash_borrow(const char *fmt)
+{
+    const int idx = rb_scan_args_hash_idx(fmt);
+    return (fmt[idx]==':' && fmt[idx+1]=='^');
+}
+
+RBIMPL_ATTR_FORCEINLINE()
 static int
 rb_scan_args_block_idx(const char *fmt)
 {
     const int idx = rb_scan_args_hash_idx(fmt);
-    return idx+(fmt[idx]==':');
+    const int colon = (fmt[idx]==':');
+    return idx + colon + (colon && fmt[idx+1]=='^');
 }
 
 RBIMPL_ATTR_FORCEINLINE()
@@ -371,6 +426,7 @@ rb_scan_args_end_idx(const char *fmt)
                      rb_scan_args_n_trail(fmt), \
                      rb_scan_args_f_var(fmt), \
                      rb_scan_args_f_hash(fmt), \
+                     rb_scan_args_f_hash_borrow(fmt), \
                      rb_scan_args_f_block(fmt), \
                      (rb_scan_args_verify(fmt, varc), vars), (char *)fmt, varc)
 # define rb_scan_args_kw0(kw_flag, argc, argv, fmt, varc, vars) \
@@ -380,6 +436,7 @@ rb_scan_args_end_idx(const char *fmt)
                      rb_scan_args_n_trail(fmt), \
                      rb_scan_args_f_var(fmt), \
                      rb_scan_args_f_hash(fmt), \
+                     rb_scan_args_f_hash_borrow(fmt), \
                      rb_scan_args_f_block(fmt), \
                      (rb_scan_args_verify(fmt, varc), vars), (char *)fmt, varc)
 
@@ -387,7 +444,7 @@ RBIMPL_ATTR_FORCEINLINE()
 static int
 rb_scan_args_set(int kw_flag, int argc, const VALUE *argv,
                  int n_lead, int n_opt, int n_trail,
-                 bool f_var, bool f_hash, bool f_block,
+                 bool f_var, bool f_hash, bool f_hash_borrow, bool f_block,
                  VALUE *vars[], RB_UNUSED_VAR(const char *fmt), RB_UNUSED_VAR(int varc))
     RBIMPL_ATTR_DIAGNOSE_IF(rb_scan_args_count(fmt) <  0,    "bad scan arg format",                    "error")
     RBIMPL_ATTR_DIAGNOSE_IF(rb_scan_args_count(fmt) != varc, "variable argument length doesn't match", "error")
@@ -401,7 +458,7 @@ rb_scan_args_set(int kw_flag, int argc, const VALUE *argv,
     if (f_hash && argc > 0) {
         VALUE last = argv[argc - 1];
         if (rb_scan_args_keyword_p(kw_flag, last)) {
-            hash = rb_hash_dup(last);
+            hash = rb_scan_args_borrow_hash(kw_flag, f_hash_borrow, last);
             argc--;
         }
     }

--- a/io.c
+++ b/io.c
@@ -4117,7 +4117,7 @@ extract_getline_opts(VALUE opts, struct getline_arg *args)
         if (!kwds[0]) {
             kwds[0] = rb_intern_const("chomp");
         }
-        rb_get_kwargs(opts, kwds, 0, -2, &vchomp);
+        rb_get_kwargs_const(opts, kwds, 0, -2, &vchomp);
         chomp = (!UNDEF_P(vchomp)) && RTEST(vchomp);
     }
     args->chomp = chomp;
@@ -4180,7 +4180,7 @@ static void
 prepare_getline_args(int argc, VALUE *argv, struct getline_arg *args, VALUE io)
 {
     VALUE opts;
-    argc = rb_scan_args(argc, argv, "02:", NULL, NULL, &opts);
+    argc = rb_scan_args(argc, argv, "02:^", NULL, NULL, &opts);
     extract_getline_args(argc, argv, args);
     extract_getline_opts(opts, args);
     check_getline_args(&args->rs, &args->limit, io);
@@ -8495,7 +8495,7 @@ rb_io_reopen(int argc, VALUE *argv, VALUE file)
     int oflags;
     rb_io_t *fptr;
 
-    if (rb_scan_args(argc, argv, "11:", &fname, &nmode, &opt) == 1) {
+    if (rb_scan_args(argc, argv, "11:^", &fname, &nmode, &opt) == 1) {
         VALUE tmp = rb_io_check_io(fname);
         if (!NIL_P(tmp)) {
             return io_reopen(file, tmp);
@@ -9547,7 +9547,7 @@ rb_io_initialize(int argc, VALUE *argv, VALUE io)
     VALUE fnum, vmode;
     VALUE opt;
 
-    rb_scan_args(argc, argv, "11:", &fnum, &vmode, &opt);
+    rb_scan_args(argc, argv, "11:^", &fnum, &vmode, &opt);
     return io_initialize(io, fnum, vmode, opt);
 }
 
@@ -9717,7 +9717,7 @@ rb_file_initialize(int argc, VALUE *argv, VALUE io)
         rb_raise(rb_eRuntimeError, "reinitializing File");
     }
     VALUE fname, vmode, vperm, opt;
-    int posargc = rb_scan_args(argc, argv, "12:", &fname, &vmode, &vperm, &opt);
+    int posargc = rb_scan_args(argc, argv, "12:^", &fname, &vmode, &vperm, &opt);
     if (posargc < 3) {          /* perm is File only */
         VALUE fd = rb_check_to_int(fname);
 
@@ -11947,7 +11947,7 @@ rb_io_s_pipe(int argc, VALUE *argv, VALUE klass)
     enum rb_io_mode fmode = 0;
     VALUE ret;
 
-    argc = rb_scan_args(argc, argv, "02:", &v1, &v2, &opt);
+    argc = rb_scan_args(argc, argv, "02:^", &v1, &v2, &opt);
     if (rb_pipe(pipes) < 0)
         rb_sys_fail(0);
 
@@ -12153,7 +12153,7 @@ rb_io_s_foreach(int argc, VALUE *argv, VALUE self)
     struct foreach_arg arg;
     struct getline_arg garg;
 
-    argc = rb_scan_args(argc, argv, "12:", NULL, NULL, NULL, &opt);
+    argc = rb_scan_args(argc, argv, "12:^", NULL, NULL, NULL, &opt);
     RETURN_ENUMERATOR(self, orig_argc, argv);
     extract_getline_args(argc-1, argv+1, &garg);
     open_key_args(self, argc, argv, opt, &arg);
@@ -12226,7 +12226,7 @@ rb_io_s_readlines(int argc, VALUE *argv, VALUE io)
     struct foreach_arg arg;
     struct getline_arg garg;
 
-    argc = rb_scan_args(argc, argv, "12:", NULL, NULL, NULL, &opt);
+    argc = rb_scan_args(argc, argv, "12:^", NULL, NULL, NULL, &opt);
     extract_getline_args(argc-1, argv+1, &garg);
     open_key_args(io, argc, argv, opt, &arg);
     if (NIL_P(arg.io)) return Qnil;
@@ -12326,7 +12326,7 @@ rb_io_s_read(int argc, VALUE *argv, VALUE io)
     long off;
     struct foreach_arg arg;
 
-    argc = rb_scan_args(argc, argv, "13:", NULL, NULL, &offset, NULL, &opt);
+    argc = rb_scan_args(argc, argv, "13:^", NULL, NULL, &offset, NULL, &opt);
     if (!NIL_P(offset) && (off = NUM2LONG(offset)) < 0) {
         rb_raise(rb_eArgError, "negative offset %ld given", off);
     }
@@ -12407,7 +12407,7 @@ io_s_write(int argc, VALUE *argv, VALUE klass, int binary)
     struct foreach_arg arg;
     struct write_arg warg;
 
-    rb_scan_args(argc, argv, "21:", NULL, &string, &offset, &opt);
+    rb_scan_args(argc, argv, "21:^", NULL, &string, &offset, &opt);
 
     if (NIL_P(opt)) opt = rb_hash_new();
     else opt = rb_hash_dup(opt);
@@ -13605,7 +13605,7 @@ rb_io_set_encoding(int argc, VALUE *argv, VALUE io)
         return forward(io, id_set_encoding, argc, argv);
     }
 
-    argc = rb_scan_args(argc, argv, "11:", &v1, &v2, &opt);
+    argc = rb_scan_args(argc, argv, "11:^", &v1, &v2, &opt);
     GetOpenFile(io, fptr);
     io_encoding_set(fptr, v1, v2, opt);
     return io;
@@ -14049,7 +14049,7 @@ argf_read_nonblock(int argc, VALUE *argv, VALUE argf)
 {
     VALUE opts;
 
-    rb_scan_args(argc, argv, "11:", NULL, NULL, &opts);
+    rb_scan_args(argc, argv, "11:^", NULL, NULL, &opts);
 
     if (!NIL_P(opts))
         argc--;

--- a/iseq.c
+++ b/iseq.c
@@ -1650,7 +1650,7 @@ iseqw_s_compile_parser(int argc, VALUE *argv, VALUE self, bool prism)
     VALUE src, file = Qnil, path = Qnil, line = Qnil, opt = Qnil;
     int i;
 
-    i = rb_scan_args(argc, argv, "1*:", &src, NULL, &opt);
+    i = rb_scan_args(argc, argv, "1*:^", &src, NULL, &opt);
     if (i > 4+NIL_P(opt)) rb_error_arity(argc, 1, 5);
     switch (i) {
       case 5: opt = argv[--i];
@@ -1840,7 +1840,7 @@ iseqw_s_compile_file(int argc, VALUE *argv, VALUE self)
     rb_compile_option_t option;
     int i;
 
-    i = rb_scan_args(argc, argv, "1*:", &file, NULL, &opt);
+    i = rb_scan_args(argc, argv, "1*:^", &file, NULL, &opt);
     if (i > 1+NIL_P(opt)) rb_error_arity(argc, 1, 2);
     switch (i) {
       case 2: opt = argv[--i];
@@ -1909,7 +1909,7 @@ iseqw_s_compile_file_prism(int argc, VALUE *argv, VALUE self)
     rb_compile_option_t option;
     int i;
 
-    i = rb_scan_args(argc, argv, "1*:", &file, NULL, &opt);
+    i = rb_scan_args(argc, argv, "1*:^", &file, NULL, &opt);
     if (i > 1+NIL_P(opt)) rb_error_arity(argc, 1, 2);
     switch (i) {
       case 2: opt = argv[--i];

--- a/numeric.c
+++ b/numeric.c
@@ -223,7 +223,7 @@ rb_num_get_rounding_option(VALUE opts)
         if (!round_kwds[0]) {
             round_kwds[0] = rb_intern_const("half");
         }
-        if (!rb_get_kwargs(opts, round_kwds, 0, 1, &rounding)) goto noopt;
+        if (!rb_get_kwargs_const(opts, round_kwds, 0, 1, &rounding)) goto noopt;
         if (SYMBOL_P(rounding)) {
             str = rb_sym2str(rounding);
         }
@@ -2478,7 +2478,7 @@ flo_round(int argc, VALUE *argv, VALUE num)
     int ndigits = 0;
     enum ruby_num_rounding_mode mode;
 
-    if (rb_scan_args(argc, argv, "01:", &nd, &opt)) {
+    if (rb_scan_args(argc, argv, "01:^", &nd, &opt)) {
         ndigits = NUM2INT(nd);
     }
     mode = rb_num_get_rounding_option(opt);
@@ -2848,13 +2848,13 @@ num_step_extract_args(int argc, const VALUE *argv, VALUE *to, VALUE *step, VALUE
 {
     VALUE hash;
 
-    argc = rb_scan_args(argc, argv, "02:", to, step, &hash);
+    argc = rb_scan_args(argc, argv, "02:^", to, step, &hash);
     if (!NIL_P(hash)) {
         ID keys[2];
         VALUE values[2];
         keys[0] = id_to;
         keys[1] = id_by;
-        rb_get_kwargs(hash, keys, 0, 2, values);
+        rb_get_kwargs_const(hash, keys, 0, 2, values);
         if (!UNDEF_P(values[0])) {
             if (argc > 0) rb_raise(rb_eArgError, "to is given twice");
             *to = values[0];
@@ -6021,7 +6021,7 @@ int_round(int argc, VALUE* argv, VALUE num)
     int mode;
     VALUE nd, opt;
 
-    if (!rb_scan_args(argc, argv, "01:", &nd, &opt)) return num;
+    if (!rb_scan_args(argc, argv, "01:^", &nd, &opt)) return num;
     ndigits = NUM2INT(nd);
     mode = rb_num_get_rounding_option(opt);
     if (ndigits >= 0) {

--- a/object.c
+++ b/object.c
@@ -454,19 +454,14 @@ VALUE
 rb_get_freeze_opt(int argc, VALUE *argv)
 {
     static ID keyword_ids[1];
-    VALUE opt;
-    VALUE kwfreeze = Qnil;
+    VALUE opt, kwfreeze = Qnil;
 
     if (!keyword_ids[0]) {
         CONST_ID(keyword_ids[0], "freeze");
     }
-    rb_scan_args(argc, argv, "0:", &opt);
-    if (!NIL_P(opt)) {
-        rb_get_kwargs(opt, keyword_ids, 0, 1, &kwfreeze);
-        if (!UNDEF_P(kwfreeze))
-            kwfreeze = obj_freeze_opt(kwfreeze);
-    }
-    return kwfreeze;
+    rb_scan_args(argc, argv, "0:^", &opt);
+    rb_get_kwargs_const(opt, keyword_ids, 0, 1, &kwfreeze);
+    return UNDEF_P(kwfreeze) ? Qnil : obj_freeze_opt(kwfreeze);
 }
 
 static VALUE
@@ -687,7 +682,7 @@ static VALUE
 rb_obj_init_clone(int argc, VALUE *argv, VALUE obj)
 {
     VALUE orig, opts;
-    if (rb_scan_args(argc, argv, "1:", &orig, &opts) < argc) {
+    if (rb_scan_args(argc, argv, "1:^", &orig, &opts) < argc) {
         /* Ignore a freeze keyword */
         rb_get_freeze_opt(1, &opts);
     }
@@ -2152,7 +2147,7 @@ static VALUE
 rb_mod_initialize_clone(int argc, VALUE* argv, VALUE clone)
 {
     VALUE ret, orig, opts;
-    rb_scan_args(argc, argv, "1:", &orig, &opts);
+    rb_scan_args(argc, argv, "1:^", &orig, &opts);
     ret = rb_obj_init_clone(argc, argv, clone);
     if (OBJ_FROZEN(orig))
         rb_class_name(clone);
@@ -3518,7 +3513,7 @@ rb_opts_exception_p(VALUE opts, int default_value)
 {
     static const ID kwds[1] = {idException};
     VALUE exception;
-    if (rb_get_kwargs(opts, kwds, 0, 1, &exception))
+    if (rb_get_kwargs_const(opts, kwds, 0, 1, &exception))
         return rb_bool_expected(exception, "exception", TRUE);
     return default_value;
 }

--- a/proc.c
+++ b/proc.c
@@ -1614,9 +1614,9 @@ rb_proc_parameters(int argc, VALUE *argv, VALUE self)
         CONST_ID(keyword_ids[0], "lambda");
     }
 
-    rb_scan_args(argc, argv, "0:", &opt);
+    rb_scan_args(argc, argv, "0:^", &opt);
     if (!NIL_P(opt)) {
-        rb_get_kwargs(opt, keyword_ids, 0, 1, kwargs);
+        rb_get_kwargs_const(opt, keyword_ids, 0, 1, kwargs);
         lambda = kwargs[0];
         if (!NIL_P(lambda)) {
             is_proc = !RTEST(lambda);

--- a/rational.c
+++ b/rational.c
@@ -546,7 +546,7 @@ nurat_f_rational(int argc, VALUE *argv, VALUE klass)
     VALUE a1, a2, opts = Qnil;
     int raise = TRUE;
 
-    if (rb_scan_args(argc, argv, "11:", &a1, &a2, &opts) == 1) {
+    if (rb_scan_args(argc, argv, "11:^", &a1, &a2, &opts) == 1) {
         a2 = Qundef;
     }
     if (!NIL_P(opts)) {
@@ -1563,7 +1563,7 @@ nurat_round_n(int argc, VALUE *argv, VALUE self)
 {
     VALUE opt;
     enum ruby_num_rounding_mode mode = (
-        argc = rb_scan_args(argc, argv, "*:", NULL, &opt),
+        argc = rb_scan_args(argc, argv, "*:^", NULL, &opt),
         rb_num_get_rounding_option(opt));
     VALUE (*round_func)(VALUE) = ROUND_FUNC(mode, nurat_round);
     return f_round_common(argc, argv, self, round_func);

--- a/re.c
+++ b/re.c
@@ -2521,7 +2521,7 @@ match_named_captures(int argc, VALUE *argv, VALUE match)
     VALUE opt;
     int symbolize_names = 0;
 
-    rb_scan_args(argc, argv, "0:", &opt);
+    rb_scan_args(argc, argv, "0:^", &opt);
 
     if (!NIL_P(opt)) {
         static ID keyword_ids[1];
@@ -2531,7 +2531,7 @@ match_named_captures(int argc, VALUE *argv, VALUE match)
         if (!keyword_ids[0]) {
             keyword_ids[0] = rb_intern_const("symbolize_names");
         }
-        rb_get_kwargs(opt, keyword_ids, 0, 1, &symbolize_names_val);
+        rb_get_kwargs_const(opt, keyword_ids, 0, 1, &symbolize_names_val);
         if (!UNDEF_P(symbolize_names_val) && RTEST(symbolize_names_val)) {
             symbolize_names = 1;
         }
@@ -4194,7 +4194,7 @@ reg_extract_args(int argc, VALUE *argv, struct reg_init_args *args)
     VALUE str, src, opts = Qundef, kwargs;
     VALUE re = Qnil;
 
-    rb_scan_args(argc, argv, "11:", &src, &opts, &kwargs);
+    rb_scan_args(argc, argv, "11:^", &src, &opts, &kwargs);
 
     args->timeout = Qnil;
     if (!NIL_P(kwargs)) {
@@ -4202,7 +4202,7 @@ reg_extract_args(int argc, VALUE *argv, struct reg_init_args *args)
         if (!keywords[0]) {
             keywords[0] = rb_intern_const("timeout");
         }
-        rb_get_kwargs(kwargs, keywords, 0, 1, &args->timeout);
+        rb_get_kwargs_const(kwargs, keywords, 0, 1, &args->timeout);
     }
 
     if (RB_TYPE_P(src, T_REGEXP)) {

--- a/string.c
+++ b/string.c
@@ -2079,9 +2079,9 @@ rb_str_init(int argc, VALUE *argv, VALUE str)
         CONST_ID(keyword_ids[1], "capacity");
     }
 
-    n = rb_scan_args(argc, argv, "01:", &orig, &opt);
+    n = rb_scan_args(argc, argv, "01:^", &orig, &opt);
     if (!NIL_P(opt)) {
-        rb_get_kwargs(opt, keyword_ids, 0, 2, kwargs);
+        rb_get_kwargs_const(opt, keyword_ids, 0, 2, kwargs);
         venc = kwargs[0];
         vcapa = kwargs[1];
         if (!UNDEF_P(venc) && !NIL_P(venc)) {
@@ -2155,14 +2155,14 @@ rb_str_s_new(int argc, VALUE *argv, VALUE klass)
     VALUE kwargs[2];
     rb_encoding *enc = NULL;
 
-    int n = rb_scan_args(argc, argv, "01:", &orig, &opt);
+    int n = rb_scan_args(argc, argv, "01:^", &orig, &opt);
     if (NIL_P(opt)) {
         return rb_class_new_instance_pass_kw(argc, argv, klass);
     }
 
     keyword_ids[0] = rb_id_encoding();
     CONST_ID(keyword_ids[1], "capacity");
-    rb_get_kwargs(opt, keyword_ids, 0, 2, kwargs);
+    rb_get_kwargs_const(opt, keyword_ids, 0, 2, kwargs);
     encoding = kwargs[0];
     capacity = kwargs[1];
 
@@ -9498,14 +9498,14 @@ rb_str_enumerate_lines(int argc, VALUE *argv, VALUE str, VALUE ary)
     long pos, rslen;
     int rsnewline = 0;
 
-    if (rb_scan_args(argc, argv, "01:", &rs, &opts) == 0)
+    if (rb_scan_args(argc, argv, "01:^", &rs, &opts) == 0)
         rs = rb_rs;
     if (!NIL_P(opts)) {
         static ID keywords[1];
         if (!keywords[0]) {
             keywords[0] = rb_intern_const("chomp");
         }
-        rb_get_kwargs(opts, keywords, 0, 1, &chomp);
+        rb_get_kwargs_const(opts, keywords, 0, 1, &chomp);
         chomp = (!UNDEF_P(chomp) && RTEST(chomp));
     }
 

--- a/struct.c
+++ b/struct.c
@@ -647,7 +647,7 @@ rb_struct_s_def(int argc, VALUE *argv, VALUE klass)
     VALUE st;
     VALUE opt;
 
-    argc = rb_scan_args(argc, argv, "0*:", NULL, &opt);
+    argc = rb_scan_args(argc, argv, "0*:^", NULL, &opt);
     if (argc >= 1 && !SYMBOL_P(argv[0])) {
         name = argv[0];
         --argc;
@@ -660,7 +660,7 @@ rb_struct_s_def(int argc, VALUE *argv, VALUE klass)
         if (!keyword_ids[0]) {
             keyword_ids[0] = rb_intern("keyword_init");
         }
-        rb_get_kwargs(opt, keyword_ids, 0, 1, &keyword_init);
+        rb_get_kwargs_const(opt, keyword_ids, 0, 1, &keyword_init);
         if (UNDEF_P(keyword_init)) {
             keyword_init = Qnil;
         }
@@ -1921,7 +1921,7 @@ static VALUE
 rb_data_with(int argc, const VALUE *argv, VALUE self)
 {
     VALUE kwargs;
-    rb_scan_args(argc, argv, "0:", &kwargs);
+    rb_scan_args(argc, argv, "0:^", &kwargs);
     if (NIL_P(kwargs)) {
         return self;
     }

--- a/transcode.c
+++ b/transcode.c
@@ -2899,7 +2899,7 @@ str_transcode(int argc, VALUE *argv, VALUE *self)
     int ecflags = 0;
     VALUE ecopts = Qnil;
 
-    argc = rb_scan_args(argc, argv, "02:", NULL, NULL, &opt);
+    argc = rb_scan_args(argc, argv, "02:^", NULL, NULL, &opt);
     if (!NIL_P(opt)) {
         ecflags = rb_econv_prepare_opts(opt, &ecopts);
     }
@@ -3110,7 +3110,7 @@ econv_args(int argc, VALUE *argv,
     rb_encoding *senc, *denc;
     int ecflags;
 
-    argc = rb_scan_args(argc, argv, "21:", snamev_p, dnamev_p, &flags_v, &opt);
+    argc = rb_scan_args(argc, argv, "21:^", snamev_p, dnamev_p, &flags_v, &opt);
 
     if (!NIL_P(flags_v)) {
         if (!NIL_P(opt)) {
@@ -3822,7 +3822,7 @@ econv_primitive_convert(int argc, VALUE *argv, VALUE self)
     unsigned long output_byteend;
     int flags;
 
-    argc = rb_scan_args(argc, argv, "23:", &input, &output, &output_byteoffset_v, &output_bytesize_v, &flags_v, &opt);
+    argc = rb_scan_args(argc, argv, "23:^", &input, &output, &output_byteoffset_v, &output_bytesize_v, &flags_v, &opt);
 
     if (NIL_P(output_byteoffset_v))
         output_byteoffset = 0; /* dummy */

--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -1232,10 +1232,10 @@ ec_backtrace_range(const rb_execution_context_t *ec, int argc, const VALUE *argv
     VALUE level, vn, opts;
     long lev, n;
 
-    rb_scan_args(argc, argv, "02:", &level, &vn, &opts);
+    rb_scan_args(argc, argv, "02:^", &level, &vn, &opts);
 
     if (!NIL_P(opts)) {
-        rb_get_kwargs(opts, (ID []){0}, 0, 0, NULL);
+        rb_get_kwargs_const(opts, (ID []){0}, 0, 0, NULL);
     }
     if (argc == 2 && NIL_P(vn)) argc--;
 


### PR DESCRIPTION
Ex:

```
VALUE opt;
rb_scan_args(argc, argv, "1:^", &str, &opt);
if (!NIL_P(opt)) rb_get_kwargs_const(opt, &id_category, 0, 1, &category);
```

`opt` will be the keyword hash created for this call, available in `argv`. Without the "^", it will be a duplicate of that keyword hash.

Use `rb_get_kwargs_const` instead of `rb_get_kwargs` so that it doesn't mutate the keyword args hash itself, unless that's what you want.

C extensions can check for this feature if they wish: `HAVE_RB_SCAN_ARGS_BORROW_KEYWORDS`.