### PR TITLE
ZJIT: Use interpreter IC in getivar fallback

### DIFF
--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -8967,7 +8967,7 @@ fn add_iseq_to_hir(
                         if let Some(profiled_type) = fun.monomorphic_summary(&profiles, self_param, exit_id) {
                             let result = fun.try_emit_optimized_getivar(block, self_param, id, profiled_type, exit_id).unwrap_or_else(|counter| {
                                 fun.count(block, counter);
-                                fun.push_insn(block, Insn::GetIvar { self_val: self_param, id, ic: std::ptr::null(), state: exit_id })
+                                fun.push_insn(block, Insn::GetIvar { self_val: self_param, id, ic, state: exit_id })
                             });
                             state.stack_push(result);
                         } else {


### PR DESCRIPTION
This was an accidental copy/paste error that caused optcarrot to have
uncached getivar fallbacks in optcarrot, completely regressing it.

Before this PR:

```
plum% WARMUP_ITRS=0 MIN_BENCH_ITRS=3 MIN_BENCH_TIME=0 ruby --zjit benchmarks/optcarrot/benchmark.rb
ruby 4.1.0dev (2026-06-24T20:22:42Z master a0c02a4d42) +ZJIT stats +PRISM [arm64-darwin25]
itr:   time
 #1: 2583ms
 #2: 2537ms
 #3: 2532ms
```

After this PR:

```
plum% WARMUP_ITRS=0 MIN_BENCH_ITRS=3 MIN_BENCH_TIME=0 ruby --zjit benchmarks/optcarrot/benchmark.rb
ruby 4.1.0dev (2026-06-24T20:22:42Z master a0c02a4d42) +ZJIT stats +PRISM [arm64-darwin25]
itr:   time
 #1: 1748ms
 #2: 1674ms
 #3: 1692ms
```
