### PR TITLE
ZJIT: Translate only the reachable callee entry when inlining

### DIFF
--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -4810,6 +4810,27 @@ impl Function {
                 let pre_insn_types_len = self.insn_types.len();
                 let pre_blocks_len = self.blocks.len();
 
+                // Pick the callee body entry matching how many optional parameters
+                // the caller actually filled. Entry index `k` is where execution
+                // begins when `lead_num + k + post_num + kw_num` arguments are
+                // passed: it runs the default-init code for the remaining
+                // `opt_num - k` optionals (if any) before falling through into the
+                // post-default body. SendDirect emission already guarantees
+                // args.len() lies in `lead_num + post_num + kw_num..=lead_num +
+                // opt_num + post_num + kw_num`, with `kw_num` being the callee's
+                // full keyword count (zero when the callee has no keywords). After
+                // `prepare_direct_send_args` runs, the caller's arg list has a slot
+                // for every callee keyword (filled in callee table order, padded
+                // with defaults for omitted optional keywords), so the keyword tail
+                // is a fixed-size addition we subtract off before recovering the
+                // optional-positional count.
+                let callee_params = unsafe { iseq.params() };
+                let lead_num = callee_params.lead_num as usize;
+                let opt_num = callee_params.opt_num as usize;
+                let post_num = callee_params.post_num as usize;
+                let kw_num = callee_kw_num(iseq);
+                let passed_opt_num = args.len() - lead_num - post_num - kw_num;
+
                 // Create the continuation block before translating the callee so it
                 // can serve as the return_block argument; the callee's leaves become
                 // Jumps to this block directly during translation. The continuation
@@ -4825,7 +4846,12 @@ impl Function {
                 // callee sits one level deeper (caller_depth + 1).
                 let caller_depth = self.frame_depth(state);
 
-                let mode = AddIseqMode::Inlined { return_block: continuation, caller: state, depth: caller_depth + 1 };
+                let mode = AddIseqMode::Inlined {
+                    return_block: continuation,
+                    caller: state,
+                    depth: caller_depth + 1,
+                    jit_entry_idx: passed_opt_num,
+                };
                 let add_result = match add_iseq_to_hir(self, iseq, mode) {
                     Ok(r) => r,
                     Err(_) => {
@@ -4854,31 +4880,11 @@ impl Function {
                 let tail = self.blocks[block.0].insns.split_off(send_pos);
                 debug_assert!(matches!(self.find(tail[0]), Insn::SendDirect { .. }));
 
-                // Pick the callee body entry block matching how many optional
-                // parameters the caller actually filled. add_iseq_to_hir returns one
-                // body entry block per `jit_entry_idx`; entry index `k` is where
-                // execution begins when `lead_num + k + post_num + kw_num` arguments
-                // are passed: it runs the default-init code for the remaining
-                // `opt_num - k` optionals (if any) before falling through into the
-                // post-default body. SendDirect emission already guarantees
-                // args.len() lies in `lead_num + post_num + kw_num..=lead_num +
-                // opt_num + post_num + kw_num`, with `kw_num` being the callee's
-                // full keyword count (zero when the callee has no keywords). After
-                // `prepare_direct_send_args` runs, the caller's arg list has a slot
-                // for every callee keyword (filled in callee table order, padded
-                // with defaults for omitted optional keywords), so the keyword tail
-                // is a fixed-size addition we subtract off before recovering the
-                // optional-positional count.
-                let callee_params = unsafe { iseq.params() };
-                let lead_num = callee_params.lead_num as usize;
-                let opt_num = callee_params.opt_num as usize;
-                let post_num = callee_params.post_num as usize;
-                let kw_num = callee_kw_num(iseq);
-                let passed_opt_num = args.len() - lead_num - post_num - kw_num;
                 let omitted_opt_num = opt_num - passed_opt_num;
                 let positional_kw_end = lead_num + opt_num + post_num + kw_num;
                 let kw_bits_local_idx = callee_kw_bits_local_idx(iseq);
-                let callee_entry_body_block = add_result.body_entry_blocks[passed_opt_num];
+                let callee_entry_body_block = add_result.body_entry_block
+                    .expect("inlined compilation always produces a body entry block");
 
                 // Map callee body entry params to caller values:
                 //
@@ -4891,9 +4897,7 @@ impl Function {
                 //   * lead locals (indices 0..lead_num) and filled optional locals
                 //     (lead_num..lead_num + passed_opt_num) take args in order.
                 //   * unfilled optional locals (lead_num + passed_opt_num..lead_num + opt_num)
-                //     are nil-initialized; the body's default-init code (entered via
-                //     the chosen body_entry_blocks[passed_opt_num] target) overwrites
-                //     them.
+                //     are nil-initialized; the body's default-init code overwrites them.
                 //   * post-required and keyword locals
                 //     (lead_num + opt_num..lead_num + opt_num + post_num + kw_num) take the
                 //     trailing args, but their position in the local table leaves a gap
@@ -7222,17 +7226,21 @@ enum AddIseqMode {
         caller: InsnId,
         /// Inlining depth of every frame emitted for the callee.
         depth: InlineDepth,
+        /// The JIT entry index selected by the call site's argument count.
+        jit_entry_idx: usize,
     },
 }
 
 /// Result of populating a Function with HIR for an ISEQ.
 struct AddIseqResult {
-    /// Body entry block per `jit_entry_idx`. Indexed by the same `passed_opt_num`
-    /// the JIT entry scaffolding uses, this is the body block the scaffolding
-    /// (when generated) targets after running default-init code for missing
-    /// optionals. Callers that pass `make_entry_blocks=false` (e.g. the inliner)
-    /// use this to pick the right entry point without needing the scaffolding.
-    body_entry_blocks: Vec<BlockId>,
+    /// The callee body entry block where the inlined callee body begins
+    /// executing, populated only in inlined mode.
+    ///
+    /// `add_iseq_to_hir` slices the opt table to begin at the entry the call
+    /// site's argument count selects. This is that entry's block.
+    /// The value is `None` in standalone mode, as standalone has no single body entry
+    /// block and wires its JIT entry blocks through `fun.jit_entry_blocks` instead.
+    body_entry_block: Option<BlockId>,
     /// Profile oracle populated during compilation. The caller decides whether
     /// to assign it to `fun.profiles` (top-level) or append it to an existing
     /// oracle (inliner).
@@ -7296,8 +7304,23 @@ fn add_iseq_to_hir(
         }
     }
 
-    // Compute a map of PC->Block by finding jump targets
-    let jit_entry_insns = unsafe { iseq.params() }.opt_table_slice().iter().copied().map(VALUE::as_u32).collect::<Vec<_>>();
+    // Compute a map of PC->Block by finding jump targets.
+    //
+    // Standalone compilation translates every opt-table entry because each is a
+    // reachable JIT-to-JIT entrypoint. The inliner, by contrast, enters at a
+    // single entry fixed by the call site's argument count. So, the entries before
+    // it would run default-init code for optionals the caller already supplied.
+    // Those entries are known to be unreachable so slicing them off here avoids
+    // translating prologue blocks that would only be discarded later, rather
+    // than emitting them and relying on a downstream pass to prune the dead CFG.
+    let jit_entry_start = match mode {
+        AddIseqMode::Standalone => 0,
+        AddIseqMode::Inlined { jit_entry_idx, .. } => jit_entry_idx,
+    };
+    let jit_entry_insns = unsafe { iseq.params() }.opt_table_slice()
+        .get(jit_entry_start..)
+        .expect("JIT entry index must be within the callee opt table")
+        .iter().copied().map(VALUE::as_u32).collect::<Vec<_>>();
     let BytecodeInfo { jump_targets } = compute_bytecode_info(iseq, &jit_entry_insns);
 
     let compile_jit_entries = matches!(mode, AddIseqMode::Standalone) && iseq_supports_jit_entry(iseq);
@@ -7305,15 +7328,18 @@ fn add_iseq_to_hir(
     // Make all empty basic blocks. The ordering of the BBs matters for getting fallthrough jumps
     // in good places, but it's not necessary for correctness. TODO: Higher quality scheduling during lowering.
     let mut insn_idx_to_block = HashMap::new();
-    let mut body_entry_blocks = Vec::with_capacity(jit_entry_insns.len());
-    // Make blocks for optionals first, and put them right next to their JIT entrypoint
+    // Materialize a block at each opt-table entry PC, placing each right after
+    // its JIT-to-JIT entry block so fallthrough jumps land in good places.
+    // Standalone mode emits a real JIT entry block per entry. Inlined mode emits
+    // none here; only `body_entry_block` (the first sliced entry) is the inlined
+    // body's entry, and the rest are default-init body blocks reached by
+    // fallthrough.
     for insn_idx in jit_entry_insns.iter().copied() {
         if compile_jit_entries {
             let jit_entry_block = fun.new_block(insn_idx);
             fun.jit_entry_blocks.push(jit_entry_block);
         }
-        let body_entry = *insn_idx_to_block.entry(insn_idx).or_insert_with(|| fun.new_block(insn_idx));
-        body_entry_blocks.push(body_entry);
+        insn_idx_to_block.entry(insn_idx).or_insert_with(|| fun.new_block(insn_idx));
     }
     // Make blocks for the rest of the jump targets
     for insn_idx in jump_targets {
@@ -7321,6 +7347,17 @@ fn add_iseq_to_hir(
     }
     // Done, drop `mut`.
     let insn_idx_to_block = insn_idx_to_block;
+
+    // The callee body entry block where the inlined callee body begins
+    // executing. `jit_entry_insns` starts at the entry the call site selected
+    // (since `opt_table_slice` was sliced above), so its first element is that entry.
+    // Any later entries are the default-init blocks for the remaining unfilled
+    // optionals, reached from this one by fallthrough rather than targeted directly.
+    // Standalone compilation has no single body entry block, so it produces none.
+    let body_entry_block = match mode {
+        AddIseqMode::Standalone => None,
+        AddIseqMode::Inlined { .. } => Some(insn_idx_to_block[&jit_entry_insns[0]]),
+    };
 
     if matches!(mode, AddIseqMode::Standalone) {
         // Compile an entry_block for the interpreter
@@ -9156,7 +9193,7 @@ fn add_iseq_to_hir(
         }
     }
 
-    Ok(AddIseqResult { body_entry_blocks, profiles })
+    Ok(AddIseqResult { body_entry_block, profiles })
 }
 
 /// Compile an entry_block for the interpreter

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -7237,10 +7237,6 @@ struct AddIseqResult {
     /// to assign it to `fun.profiles` (top-level) or append it to an existing
     /// oracle (inliner).
     profiles: ProfileOracle,
-    /// Number of return paths emitted. Counts `YARVINSN_leave` translations,
-    /// whether they became `Insn::Return` or `Insn::Jump(return_block, ...)`.
-    /// Lets callers tell whether the ISEQ has any reachable return paths.
-    num_returns: usize,
 }
 
 /// Compile ISEQ into High-level IR
@@ -7287,7 +7283,6 @@ fn add_iseq_to_hir(
 ) -> Result<AddIseqResult, ParseError> {
     let payload = get_or_create_iseq_payload(iseq);
     let mut profiles = ProfileOracle::new();
-    let mut num_returns: usize = 0;
 
     // Build the initial FrameState for a block being translated. In inlined
     // mode it carries the caller's call-site Snapshot and this frame's depth;
@@ -8502,7 +8497,6 @@ fn add_iseq_to_hir(
                 YARVINSN_leave => {
                     fun.push_insn(block, Insn::CheckInterrupts { state: exit_id });
                     let val = state.stack_pop()?;
-                    num_returns += 1;
                     match mode {
                         AddIseqMode::Standalone => fun.push_insn(block, Insn::Return { val }),
                         AddIseqMode::Inlined { return_block, .. } => { fun.push_insn(block, Insn::Jump(BranchEdge { target: return_block, args: vec![val] })) }
@@ -9162,7 +9156,7 @@ fn add_iseq_to_hir(
         }
     }
 
-    Ok(AddIseqResult { body_entry_blocks, profiles, num_returns })
+    Ok(AddIseqResult { body_entry_blocks, profiles })
 }
 
 /// Compile an entry_block for the interpreter

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -1800,12 +1800,12 @@ mod hir_opt_tests {
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
           v20:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           PushInlineFrame v20 (0x1038), v11
-          v35:Fixnum[2] = Const Value(2)
+          v27:Fixnum[2] = Const Value(2)
           PatchPoint MethodRedefined(Integer@0x1040, +@0x1048, cme:0x1050)
-          v61:Fixnum[5] = Const Value(5)
+          v53:Fixnum[5] = Const Value(5)
           CheckInterrupts
           PopInlineFrame
-          Return v61
+          Return v53
         ");
     }
 
@@ -1833,10 +1833,10 @@ mod hir_opt_tests {
           v22:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           PushInlineFrame v22 (0x1038), v11, v13
           PatchPoint MethodRedefined(Integer@0x1040, +@0x1048, cme:0x1050)
-          v62:Fixnum[7] = Const Value(7)
+          v46:Fixnum[7] = Const Value(7)
           CheckInterrupts
           PopInlineFrame
-          Return v62
+          Return v46
         ");
     }
 
@@ -1873,8 +1873,8 @@ mod hir_opt_tests {
           v16:Fixnum[20] = Const Value(20)
           v18:Fixnum[30] = Const Value(30)
           PushInlineFrame v44 (0x1038), v14, v16, v18
-          v151:Fixnum[4] = Const Value(4)
-          v166:ArrayExact = NewArray v14, v16, v18, v151
+          v121:Fixnum[4] = Const Value(4)
+          v136:ArrayExact = NewArray v14, v16, v18, v121
           PopInlineFrame
           v24:Fixnum[10] = Const Value(10)
           v26:Fixnum[20] = Const Value(20)
@@ -1882,7 +1882,7 @@ mod hir_opt_tests {
           v30:Fixnum[40] = Const Value(40)
           v32:Fixnum[50] = Const Value(50)
           v34:BasicObject = Send v44, :target, v24, v26, v28, v30, v32 # SendFallbackReason: Argument count does not match parameter count
-          v37:ArrayExact = NewArray v101, v166, v34
+          v37:ArrayExact = NewArray v101, v136, v34
           CheckInterrupts
           Return v37
         ");
@@ -4191,11 +4191,11 @@ mod hir_opt_tests {
           v22:Fixnum[2] = Const Value(2)
           v24:Fixnum[4] = Const Value(4)
           v26:Fixnum[3] = Const Value(3)
-          v103:Fixnum[0] = Const Value(0)
+          v92:Fixnum[0] = Const Value(0)
           PushInlineFrame v37 (0x1038), v20, v22, v26, v24
-          v98:ArrayExact = NewArray v22, v26
+          v87:ArrayExact = NewArray v22, v26
           PopInlineFrame
-          v30:ArrayExact = NewArray v65, v98
+          v30:ArrayExact = NewArray v65, v87
           Return v30
         ");
     }
@@ -4234,11 +4234,11 @@ mod hir_opt_tests {
           v20:Fixnum[2] = Const Value(2)
           v22:Fixnum[40] = Const Value(40)
           v24:Fixnum[30] = Const Value(30)
-          v107:Fixnum[0] = Const Value(0)
+          v96:Fixnum[0] = Const Value(0)
           PushInlineFrame v37 (0x1038), v18, v20, v24, v22
-          v102:ArrayExact = NewArray v18, v20, v24, v22
+          v91:ArrayExact = NewArray v18, v20, v24, v22
           PopInlineFrame
-          v28:ArrayExact = NewArray v67, v102
+          v28:ArrayExact = NewArray v67, v91
           Return v28
         ");
     }
@@ -18363,14 +18363,14 @@ mod hir_opt_tests {
           PatchPoint MethodRedefined(Object@0x1008, add_opts@0x1010, cme:0x1018)
           v25:ObjectSubclass[class_exact*:Object@VALUE(0x1008)] = GuardType v9, ObjectSubclass[class_exact*:Object@VALUE(0x1008)] recompile
           PushInlineFrame v25 (0x1040), v10, v16
-          v42:Fixnum[100] = Const Value(100)
+          v33:Fixnum[100] = Const Value(100)
           PatchPoint MethodRedefined(Integer@0x1048, +@0x1050, cme:0x1058)
-          v71:Fixnum = GuardType v10, Fixnum recompile
-          v72:Fixnum = FixnumAdd v71, v16
-          v76:Fixnum = FixnumAdd v72, v42
+          v62:Fixnum = GuardType v10, Fixnum recompile
+          v63:Fixnum = FixnumAdd v62, v16
+          v67:Fixnum = FixnumAdd v63, v33
           CheckInterrupts
           PopInlineFrame
-          Return v76
+          Return v67
         ");
     }
 
@@ -18585,12 +18585,12 @@ mod hir_opt_tests {
           v27:ObjectSubclass[class_exact*:Object@VALUE(0x1008)] = GuardType v9, ObjectSubclass[class_exact*:Object@VALUE(0x1008)] recompile
           PushInlineFrame v27 (0x1040), v10, v16, v18
           PatchPoint MethodRedefined(Integer@0x1048, +@0x1050, cme:0x1058)
-          v72:Fixnum = GuardType v10, Fixnum recompile
-          v73:Fixnum = FixnumAdd v72, v16
-          v77:Fixnum = FixnumAdd v73, v18
+          v54:Fixnum = GuardType v10, Fixnum recompile
+          v55:Fixnum = FixnumAdd v54, v16
+          v59:Fixnum = FixnumAdd v55, v18
           CheckInterrupts
           PopInlineFrame
-          Return v77
+          Return v59
         ");
     }
 
@@ -19033,12 +19033,12 @@ mod hir_opt_tests {
           v27:ObjectSubclass[class_exact*:Object@VALUE(0x1008)] = GuardType v9, ObjectSubclass[class_exact*:Object@VALUE(0x1008)] recompile
           PushInlineFrame v27 (0x1040), v10, v16, v18
           PatchPoint MethodRedefined(Integer@0x1048, +@0x1050, cme:0x1058)
-          v63:Fixnum = GuardType v10, Fixnum recompile
-          v64:Fixnum = FixnumAdd v63, v16
-          v68:Fixnum = FixnumAdd v64, v18
+          v54:Fixnum = GuardType v10, Fixnum recompile
+          v55:Fixnum = FixnumAdd v54, v16
+          v59:Fixnum = FixnumAdd v55, v18
           CheckInterrupts
           PopInlineFrame
-          Return v68
+          Return v59
         ");
     }
 


### PR DESCRIPTION
Ruby methods can have optional parameters with default values, like `def foo(a, b = 1, c = 2)`. Those defaults are computed at runtime, but only for the arguments the caller actually leaves out: `foo(x)` has to initialize both `b` and `c`, `foo(x, y)` only `c`, and `foo(x, y, z)` neither.

To handle this, ZJIT gives a compiled method several entry points: one for each number of optional arguments a caller might supply. A call enters at the point matching its argument count and runs just the default-initialization it needs before falling into the body.

A standalone compilation can be called from anywhere, with any number of arguments, so it has to provide all of those entry points. When inlining, though, we make a local copy of the callee for one specific call site, and we already know exactly how many arguments that site passes. That lets us begin at the single entry point that applies and skip the others, which would only initialize arguments the caller already supplied and so can never be reached.