### PR TITLE
Ignore *.ilk incremental link artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ lcov*.info
 /*-fake.rb
 /*.dll
 /*.exe
+/*.ilk
 /*.res
 /*.pc
 /*.rc


### PR DESCRIPTION
MSVC builds leave `dump_ast.ilk` at the top of the source tree. It is the only build product not already covered by `.gitignore`, where `*.dll`, `*.exe`, `*.obj`, `*.pdb`, and the extensionless `dump_ast` are all ignored, so it shows up as the lone untracked file after an mswin build. Add `/*.ilk` to ignore it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)