### PR TITLE
ZJIT: SHRINK IT ALL

### DIFF
--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -829,7 +829,12 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
             gen_opt_newarray_hash(jit, asm, opnds!(elements), &function.frame_state(*state))
         },
         &Insn::IsA { val, class } => gen_is_a(jit, asm, opnd!(val), opnd!(class)),
-        &Insn::ArrayMax { ref elements, state } => gen_array_max(jit, asm, opnds!(elements), &function.frame_state(state)),
+        Insn::ArrayMax { elements, state } => {
+            // Resolve to an owned Vec so the pool borrow is released before
+            // frame_state(), which calls find() and re-borrows the pool.
+            let elements = function.operands(*elements).to_vec();
+            gen_array_max(jit, asm, opnds!(elements), &function.frame_state(*state))
+        },
         &Insn::ArrayMin { ref elements, state } => gen_array_min(jit, asm, opnds!(elements), &function.frame_state(state)),
         &Insn::Throw { state, .. } => return Err(state),
         &Insn::CondBranch { .. }

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -723,7 +723,10 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
         &Insn::GuardLess { left, right, ref reason, state } => gen_guard_less(jit, asm, opnd!(left), opnd!(right), **reason, &function.frame_state(state)),
         &Insn::GuardGreaterEq { left, right, state, .. } => gen_guard_greater_eq(jit, asm, opnd!(left), opnd!(right), &function.frame_state(state)),
         Insn::PatchPoint { invariant, state } => no_output!(gen_patch_point(jit, asm, invariant, &function.frame_state(*state))),
-        Insn::CCall { cfunc, recv, args, name, owner: _, return_type: _, elidable: _ } => gen_ccall(asm, *cfunc, *name, opnd!(recv), opnds!(args)),
+        Insn::CCall { cfunc, recv, args, name, owner: _, return_type: _, elidable: _ } => {
+            let args = function.operands(*args);
+            gen_ccall(asm, *cfunc, *name, opnd!(recv), opnds!(args))
+        }
         Insn::CCallWithFrame(insn) => {
             let CCallWithFrameData { cfunc, recv, name, args, cme, state, block, .. } = &**insn;
             gen_ccall_with_frame(jit, asm, *cfunc, *name, opnd!(recv), opnds!(args), *cme, *block, &function.frame_state(*state))

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -814,7 +814,12 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
         &Insn::StoreField { recv, id, offset, val } => no_output!(gen_store_field(asm, opnd!(recv), id, offset, opnd!(val), function.type_of(val))),
         &Insn::WriteBarrier { recv, val } => no_output!(gen_write_barrier(jit, asm, opnd!(recv), opnd!(val), function.type_of(val))),
         &Insn::IsBlockGiven { lep } => gen_is_block_given(asm, opnd!(lep)),
-        Insn::ArrayInclude { elements, target, state } => gen_array_include(jit, asm, opnds!(elements), opnd!(target), &function.frame_state(*state)),
+        Insn::ArrayInclude { elements, target, state } => {
+            // Resolve to an owned Vec so the pool borrow is released before
+            // frame_state(), which calls find() and re-borrows the pool.
+            let elements = function.operands(*elements).to_vec();
+            gen_array_include(jit, asm, opnds!(elements), opnd!(target), &function.frame_state(*state))
+        },
         Insn::ArrayPackBuffer { elements, fmt, buffer, state } => {
             // Resolve to an owned Vec so the pool borrow is released before
             // frame_state(), which calls find() and re-borrows the pool.

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -2862,28 +2862,16 @@ fn gen_guard_bit_equals(jit: &mut JITState, asm: &mut Assembler, val: lir::Opnd,
     val
 }
 
-fn mask_to_opnd(mask: crate::hir::Const) -> Option<Opnd> {
-    match mask {
-        crate::hir::Const::CUInt8(v) => Some(Opnd::UImm(v as u64)),
-        crate::hir::Const::CUInt16(v) => Some(Opnd::UImm(v as u64)),
-        crate::hir::Const::CUInt32(v) => Some(Opnd::UImm(v as u64)),
-        crate::hir::Const::CUInt64(v) => Some(Opnd::UImm(v)),
-        _ => None
-    }
-}
-
 /// Compile a bitmask check with a side exit if none of the masked bits are not set
-fn gen_guard_any_bit_set(jit: &mut JITState, asm: &mut Assembler, val: lir::Opnd, mask: crate::hir::Const, reason: SideExitReason, recompile: Option<Recompile>, state: &FrameState) -> lir::Opnd {
-    let mask_opnd = mask_to_opnd(mask).unwrap_or_else(|| panic!("gen_guard_any_bit_set: unexpected hir::Const {mask:?}"));
-    asm.test(val, mask_opnd);
+fn gen_guard_any_bit_set(jit: &mut JITState, asm: &mut Assembler, val: lir::Opnd, mask: u64, reason: SideExitReason, recompile: Option<Recompile>, state: &FrameState) -> lir::Opnd {
+    asm.test(val, Opnd::UImm(mask));
     asm.jz(jit, side_exit_with_recompile(jit, state, reason, recompile));
     val
 }
 
 /// Compile a bitmask check with a side exit if any of the masked bits are set
-fn gen_guard_no_bits_set(jit: &mut JITState, asm: &mut Assembler, val: lir::Opnd, mask: crate::hir::Const, reason: SideExitReason, state: &FrameState) -> lir::Opnd {
-    let mask_opnd = mask_to_opnd(mask).unwrap_or_else(|| panic!("gen_guard_no_bits_set: unexpected hir::Const {mask:?}"));
-    asm.test(val, mask_opnd);
+fn gen_guard_no_bits_set(jit: &mut JITState, asm: &mut Assembler, val: lir::Opnd, mask: u64, reason: SideExitReason, state: &FrameState) -> lir::Opnd {
+    asm.test(val, Opnd::UImm(mask));
     asm.jnz(jit, side_exit(jit, state, reason));
     val
 }

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -785,7 +785,12 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
         &Insn::WriteBarrier { recv, val } => no_output!(gen_write_barrier(jit, asm, opnd!(recv), opnd!(val), function.type_of(val))),
         &Insn::IsBlockGiven { lep } => gen_is_block_given(asm, opnd!(lep)),
         Insn::ArrayInclude { elements, target, state } => gen_array_include(jit, asm, opnds!(elements), opnd!(target), &function.frame_state(*state)),
-        Insn::ArrayPackBuffer { elements, fmt, buffer, state } => gen_array_pack_buffer(jit, asm, opnds!(elements), opnd!(fmt), (*buffer).map(|buffer| opnd!(buffer)), &function.frame_state(*state)),
+        Insn::ArrayPackBuffer { elements, fmt, buffer, state } => {
+            // Resolve to an owned Vec so the pool borrow is released before
+            // frame_state(), which calls find() and re-borrows the pool.
+            let elements = function.operands(*elements).to_vec();
+            gen_array_pack_buffer(jit, asm, opnds!(elements), opnd!(fmt), (*buffer).map(|buffer| opnd!(buffer)), &function.frame_state(*state))
+        },
         &Insn::DupArrayInclude { ary, target, state } => gen_dup_array_include(jit, asm, ary, opnd!(target), &function.frame_state(state)),
         Insn::ArrayHash { elements, state } => gen_opt_newarray_hash(jit, asm, opnds!(elements), &function.frame_state(*state)),
         &Insn::IsA { val, class } => gen_is_a(jit, asm, opnd!(val), opnd!(class)),

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -822,7 +822,12 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
             gen_array_pack_buffer(jit, asm, opnds!(elements), opnd!(fmt), (*buffer).map(|buffer| opnd!(buffer)), &function.frame_state(*state))
         },
         &Insn::DupArrayInclude { ary, target, state } => gen_dup_array_include(jit, asm, ary, opnd!(target), &function.frame_state(state)),
-        Insn::ArrayHash { elements, state } => gen_opt_newarray_hash(jit, asm, opnds!(elements), &function.frame_state(*state)),
+        Insn::ArrayHash { elements, state } => {
+            // Resolve to an owned Vec so the pool borrow is released before
+            // frame_state(), which calls find() and re-borrows the pool.
+            let elements = function.operands(*elements).to_vec();
+            gen_opt_newarray_hash(jit, asm, opnds!(elements), &function.frame_state(*state))
+        },
         &Insn::IsA { val, class } => gen_is_a(jit, asm, opnd!(val), opnd!(class)),
         &Insn::ArrayMax { ref elements, state } => gen_array_max(jit, asm, opnds!(elements), &function.frame_state(state)),
         &Insn::ArrayMin { ref elements, state } => gen_array_min(jit, asm, opnds!(elements), &function.frame_state(state)),

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -717,10 +717,10 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
             let val_type = function.type_of(val);
             gen_guard_type(jit, asm, opnd!(val), val_type, guard_type, recompile, &function.frame_state(state))
         }
-        &Insn::GuardBitEquals { val, expected, reason, state, recompile } => gen_guard_bit_equals(jit, asm, opnd!(val), expected, reason, recompile, &function.frame_state(state)),
-        &Insn::GuardAnyBitSet { val, mask, reason, state, recompile, .. } => gen_guard_any_bit_set(jit, asm, opnd!(val), mask, reason, recompile, &function.frame_state(state)),
-        &Insn::GuardNoBitsSet { val, mask, reason, state, .. } => gen_guard_no_bits_set(jit, asm, opnd!(val), mask, reason, &function.frame_state(state)),
-        &Insn::GuardLess { left, right, reason, state } => gen_guard_less(jit, asm, opnd!(left), opnd!(right), reason, &function.frame_state(state)),
+        &Insn::GuardBitEquals { val, expected, ref reason, state, recompile } => gen_guard_bit_equals(jit, asm, opnd!(val), expected, **reason, recompile, &function.frame_state(state)),
+        &Insn::GuardAnyBitSet { val, mask, ref reason, state, recompile, .. } => gen_guard_any_bit_set(jit, asm, opnd!(val), mask, **reason, recompile, &function.frame_state(state)),
+        &Insn::GuardNoBitsSet { val, mask, ref reason, state, .. } => gen_guard_no_bits_set(jit, asm, opnd!(val), mask, **reason, &function.frame_state(state)),
+        &Insn::GuardLess { left, right, ref reason, state } => gen_guard_less(jit, asm, opnd!(left), opnd!(right), **reason, &function.frame_state(state)),
         &Insn::GuardGreaterEq { left, right, state, .. } => gen_guard_greater_eq(jit, asm, opnd!(left), opnd!(right), &function.frame_state(state)),
         Insn::PatchPoint { invariant, state } => no_output!(gen_patch_point(jit, asm, invariant, &function.frame_state(*state))),
         Insn::CCall { cfunc, recv, args, name, owner: _, return_type: _, elidable: _ } => gen_ccall(asm, *cfunc, *name, opnd!(recv), opnds!(args)),

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -676,7 +676,12 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
             let args = function.operands(*args).to_vec();
             gen_invokeblock_ifunc(jit, asm, *cd, opnd!(block_handler), opnds!(args), &function.frame_state(*state))
         },
-        Insn::InvokeProc { recv, args, state, kw_splat } => gen_invokeproc(jit, asm, opnd!(recv), opnds!(args), *kw_splat, &function.frame_state(*state)),
+        Insn::InvokeProc { recv, args, state, kw_splat } => {
+            // Resolve to an owned Vec so the pool borrow is released before
+            // frame_state(), which calls find() and re-borrows the pool.
+            let args = function.operands(*args).to_vec();
+            gen_invokeproc(jit, asm, opnd!(recv), opnds!(args), *kw_splat, &function.frame_state(*state))
+        },
         Insn::InvokeBuiltin { bf, leaf, args, state, .. } => {
             // Resolve to an owned Vec so the pool borrow is released before
             // frame_state(), which calls find() and re-borrows the pool.

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -667,7 +667,12 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
         &Insn::InvokeBlock { cd, state, reason, .. } => gen_invokeblock(jit, asm, cd, &function.frame_state(state), reason),
         Insn::InvokeBlockIfunc { cd, block_handler, args, state, .. } => gen_invokeblock_ifunc(jit, asm, *cd, opnd!(block_handler), opnds!(args), &function.frame_state(*state)),
         Insn::InvokeProc { recv, args, state, kw_splat } => gen_invokeproc(jit, asm, opnd!(recv), opnds!(args), *kw_splat, &function.frame_state(*state)),
-        Insn::InvokeBuiltin { bf, leaf, args, state, .. } => gen_invokebuiltin(jit, asm, &function.frame_state(*state), unsafe { &**bf }, *leaf, opnds!(args)),
+        Insn::InvokeBuiltin { bf, leaf, args, state, .. } => {
+            // Resolve to an owned Vec so the pool borrow is released before
+            // frame_state(), which calls find() and re-borrows the pool.
+            let args = function.operands(*args).to_vec();
+            gen_invokebuiltin(jit, asm, &function.frame_state(*state), unsafe { &**bf }, *leaf, opnds!(args))
+        },
         &Insn::EntryPoint { jit_entry_idx } => no_output!(gen_entry_point(jit, asm, jit_entry_idx)),
         Insn::Return { val } => no_output!(gen_return(asm, opnd!(val))),
         Insn::FixnumAdd { left, right, state } => gen_fixnum_add(jit, asm, opnd!(left), opnd!(right), &function.frame_state(*state)),

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -665,7 +665,12 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
         &Insn::InvokeSuper { cd, blockiseq, state, reason, .. } => gen_invokesuper(jit, asm, cd, blockiseq, &function.frame_state(state), reason),
         &Insn::InvokeSuperForward { cd, blockiseq, state, reason, .. } => gen_invokesuperforward(jit, asm, cd, blockiseq, &function.frame_state(state), reason),
         &Insn::InvokeBlock { cd, state, reason, .. } => gen_invokeblock(jit, asm, cd, &function.frame_state(state), reason),
-        Insn::InvokeBlockIfunc { cd, block_handler, args, state, .. } => gen_invokeblock_ifunc(jit, asm, *cd, opnd!(block_handler), opnds!(args), &function.frame_state(*state)),
+        Insn::InvokeBlockIfunc { cd, block_handler, args, state, .. } => {
+            // Resolve to an owned Vec so the pool borrow is released before
+            // frame_state(), which calls find() and re-borrows the pool.
+            let args = function.operands(*args).to_vec();
+            gen_invokeblock_ifunc(jit, asm, *cd, opnd!(block_handler), opnds!(args), &function.frame_state(*state))
+        },
         Insn::InvokeProc { recv, args, state, kw_splat } => gen_invokeproc(jit, asm, opnd!(recv), opnds!(args), *kw_splat, &function.frame_state(*state)),
         Insn::InvokeBuiltin { bf, leaf, args, state, .. } => {
             // Resolve to an owned Vec so the pool borrow is released before

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -631,7 +631,12 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
         Insn::ObjectAlloc { val, state } => gen_object_alloc(jit, asm, opnd!(val), &function.frame_state(*state)),
         &Insn::ObjectAllocClass { class, state } => gen_object_alloc_class(asm, class, &function.frame_state(state)),
         Insn::StringCopy { val, chilled, state } => gen_string_copy(asm, opnd!(val), *chilled, &function.frame_state(*state)),
-        Insn::StringConcat { strings, state } => gen_string_concat(jit, asm, opnds!(strings), &function.frame_state(*state)),
+        Insn::StringConcat { strings, state } => {
+            // Resolve to an owned Vec so the pool borrow is released before
+            // frame_state(), which calls find() and re-borrows the pool.
+            let strings = function.operands(*strings).to_vec();
+            gen_string_concat(jit, asm, opnds!(strings), &function.frame_state(*state))
+        },
         &Insn::StringGetbyte { string, index } => gen_string_getbyte(asm, opnd!(string), opnd!(index)),
         Insn::StringSetbyteFixnum { string, index, value } => gen_string_setbyte_fixnum(asm, opnd!(string), opnd!(index), opnd!(value)),
         Insn::StringAppend { recv, other, state } => gen_string_append(jit, asm, opnd!(recv), opnd!(other), &function.frame_state(*state)),

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -21,7 +21,7 @@ use crate::stats::{counter_ptr, with_time_stat, trace_compile_phase, Counter, Co
 use crate::{asm::CodeBlock, cruby::*, options::debug, virtualmem::CodePtr};
 use crate::backend::lir::{self, Assembler, C_ARG_OPNDS, C_RET_OPND, CFP, EC, NATIVE_BASE_PTR, Opnd, SP, SideExit, SideExitRecompile, Target, asm_ccall, asm_comment};
 use crate::hir::{iseq_to_hir, BlockId, Invariant, RangeType, SideExitReason::{self, *}, SpecialBackrefSymbol, SpecialObjectType};
-use crate::hir::{BlockHandler, CCallVariadicData, CCallWithFrameData, Const, FieldName, FrameState, Function, Insn, InsnId, Recompile, SendFallbackReason};
+use crate::hir::{BlockHandler, CCallVariadicData, CCallWithFrameData, Const, FieldName, FrameState, Function, Insn, InsnId, Recompile, SendDirectData, SendFallbackReason};
 use crate::hir_type::{types, Type};
 use crate::options::{get_option, InlineDepth, PerfMap};
 use crate::cast::IntoUsize;
@@ -646,10 +646,13 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
         &Insn::Send { cd, block: Some(BlockHandler::BlockIseq(blockiseq)), state, reason, .. } => gen_send(jit, asm, cd, blockiseq, &function.frame_state(state), reason),
         &Insn::Send { cd, block: Some(BlockHandler::BlockArg), state, reason, .. } => gen_send(jit, asm, cd, std::ptr::null(), &function.frame_state(state), reason),
         &Insn::SendForward { cd, blockiseq, state, reason, .. } => gen_send_forward(jit, asm, cd, blockiseq, &function.frame_state(state), reason),
-        &Insn::SendDirect { cme, iseq, recv, ref args, kw_bits, block, state, .. } => gen_send_iseq_direct(
-                cb, jit, asm, cme, iseq, opnd!(recv), opnds!(args),
-                kw_bits, &function.frame_state(state), block,
-            ),
+        Insn::SendDirect(insn) => {
+            let SendDirectData { cme, iseq, recv, args, kw_bits, block, state, .. } = &**insn;
+            gen_send_iseq_direct(
+                cb, jit, asm, *cme, *iseq, opnd!(recv), opnds!(args),
+                *kw_bits, &function.frame_state(*state), *block,
+            )
+        }
         Insn::PushInlineFrame { cme, iseq, recv, args, blockiseq, state, .. } => {
             no_output!(gen_push_inline_frame(jit, asm, *cme, *iseq, opnd!(recv), opnds!(args), &function.frame_state(*state), *blockiseq))
         },

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -638,7 +638,12 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
         Insn::StringAppendCodepoint { recv, other, state } => gen_string_append_codepoint(jit, asm, opnd!(recv), opnd!(other), &function.frame_state(*state)),
         Insn::StringEqual { left, right } => gen_string_equal(asm, opnd!(left), opnd!(right)),
         Insn::StringIntern { val, state } => gen_intern(asm, opnd!(val), &function.frame_state(*state)),
-        Insn::ToRegexp { opt, values, state } => gen_toregexp(jit, asm, *opt, opnds!(values), &function.frame_state(*state)),
+        Insn::ToRegexp { opt, values, state } => {
+            // Resolve to an owned Vec so the pool borrow is released before
+            // frame_state(), which calls find() and re-borrows the pool.
+            let values = function.operands(*values).to_vec();
+            gen_toregexp(jit, asm, *opt, opnds!(values), &function.frame_state(*state))
+        },
         Insn::Param => unreachable!("block.insns should not have Insn::Param"),
         Insn::LoadArg { .. } => return Ok(()), // compiled in the LoadArg pre-pass above
         Insn::Snapshot { .. } => return Ok(()), // we don't need to do anything for this instruction at the moment

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -21,7 +21,7 @@ use crate::stats::{counter_ptr, with_time_stat, trace_compile_phase, Counter, Co
 use crate::{asm::CodeBlock, cruby::*, options::debug, virtualmem::CodePtr};
 use crate::backend::lir::{self, Assembler, C_ARG_OPNDS, C_RET_OPND, CFP, EC, NATIVE_BASE_PTR, Opnd, SP, SideExit, SideExitRecompile, Target, asm_ccall, asm_comment};
 use crate::hir::{iseq_to_hir, BlockId, Invariant, RangeType, SideExitReason::{self, *}, SpecialBackrefSymbol, SpecialObjectType};
-use crate::hir::{BlockHandler, CCallData, CCallVariadicData, CCallWithFrameData, Const, FieldName, FrameState, Function, Insn, InsnId, Recompile, SendData, SendDirectData, SendFallbackReason};
+use crate::hir::{BlockHandler, CCallData, CCallVariadicData, CCallWithFrameData, Const, FieldName, FrameState, Function, Insn, InsnId, PushInlineFrameData, Recompile, SendData, SendDirectData, SendFallbackReason};
 use crate::hir_type::{types, Type};
 use crate::options::{get_option, InlineDepth, PerfMap};
 use crate::cast::IntoUsize;
@@ -679,7 +679,8 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
                 *kw_bits, &function.frame_state(*state), *block,
             )
         }
-        Insn::PushInlineFrame { cme, iseq, recv, args, blockiseq, state, .. } => {
+        Insn::PushInlineFrame { recv, args, state, data } => {
+            let PushInlineFrameData { iseq, cme, blockiseq } = &**data;
             // Resolve to an owned Vec so the pool borrow is released before
             // frame_state(), which calls find() and re-borrows the pool.
             let args = function.operands(*args).to_vec();

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -21,7 +21,7 @@ use crate::stats::{counter_ptr, with_time_stat, trace_compile_phase, Counter, Co
 use crate::{asm::CodeBlock, cruby::*, options::debug, virtualmem::CodePtr};
 use crate::backend::lir::{self, Assembler, C_ARG_OPNDS, C_RET_OPND, CFP, EC, NATIVE_BASE_PTR, Opnd, SP, SideExit, SideExitRecompile, Target, asm_ccall, asm_comment};
 use crate::hir::{iseq_to_hir, BlockId, Invariant, RangeType, SideExitReason::{self, *}, SpecialBackrefSymbol, SpecialObjectType};
-use crate::hir::{BlockHandler, CCallData, CCallVariadicData, CCallWithFrameData, Const, FieldName, FrameState, Function, Insn, InsnId, Recompile, SendDirectData, SendFallbackReason};
+use crate::hir::{BlockHandler, CCallData, CCallVariadicData, CCallWithFrameData, Const, FieldName, FrameState, Function, Insn, InsnId, Recompile, SendData, SendDirectData, SendFallbackReason};
 use crate::hir_type::{types, Type};
 use crate::options::{get_option, InlineDepth, PerfMap};
 use crate::cast::IntoUsize;
@@ -662,9 +662,15 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
         Insn::Param => unreachable!("block.insns should not have Insn::Param"),
         Insn::LoadArg { .. } => return Ok(()), // compiled in the LoadArg pre-pass above
         Insn::Snapshot { .. } => return Ok(()), // we don't need to do anything for this instruction at the moment
-        &Insn::Send { cd, block: None, state, reason, .. } => gen_send_without_block(jit, asm, cd, &function.frame_state(state), reason),
-        &Insn::Send { cd, block: Some(BlockHandler::BlockIseq(blockiseq)), state, reason, .. } => gen_send(jit, asm, cd, blockiseq, &function.frame_state(state), reason),
-        &Insn::Send { cd, block: Some(BlockHandler::BlockArg), state, reason, .. } => gen_send(jit, asm, cd, std::ptr::null(), &function.frame_state(state), reason),
+        Insn::Send { state, data, .. } => {
+            let SendData { cd, block, reason } = &**data;
+            let frame_state = function.frame_state(*state);
+            match block {
+                None => gen_send_without_block(jit, asm, *cd, &frame_state, *reason),
+                Some(BlockHandler::BlockIseq(blockiseq)) => gen_send(jit, asm, *cd, *blockiseq, &frame_state, *reason),
+                Some(BlockHandler::BlockArg) => gen_send(jit, asm, *cd, std::ptr::null(), &frame_state, *reason),
+            }
+        }
         &Insn::SendForward { cd, blockiseq, state, reason, .. } => gen_send_forward(jit, asm, cd, blockiseq, &function.frame_state(state), reason),
         Insn::SendDirect(insn) => {
             let SendDirectData { cme, iseq, recv, args, kw_bits, block, state, .. } = &**insn;

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -622,7 +622,12 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
             let elements = function.operands(*elements).to_vec();
             gen_new_array(jit, asm, opnds!(elements), &function.frame_state(*state))
         },
-        Insn::NewHash { elements, state } => gen_new_hash(jit, asm, opnds!(elements), &function.frame_state(*state)),
+        Insn::NewHash { elements, state } => {
+            // Resolve to an owned Vec so the pool borrow is released before
+            // frame_state(), which calls find() and re-borrows the pool.
+            let elements = function.operands(*elements).to_vec();
+            gen_new_hash(jit, asm, opnds!(elements), &function.frame_state(*state))
+        },
         Insn::NewRange { low, high, flag, state } => gen_new_range(jit, asm, opnd!(low), opnd!(high), *flag, &function.frame_state(*state)),
         Insn::NewRangeFixnum { low, high, flag, state } => gen_new_range_fixnum(asm, opnd!(low), opnd!(high), *flag, &function.frame_state(*state)),
         Insn::ArrayDup { val, state } => gen_array_dup(asm, opnd!(val), &function.frame_state(*state)),

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -616,7 +616,12 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
             gen_const_uint32(val.0)
         }
         Insn::Const { .. } => panic!("Unexpected Const in gen_insn: {insn}"),
-        Insn::NewArray { elements, state } => gen_new_array(jit, asm, opnds!(elements), &function.frame_state(*state)),
+        Insn::NewArray { elements, state } => {
+            // Resolve to an owned Vec so the pool borrow is released before
+            // frame_state(), which calls find() and re-borrows the pool.
+            let elements = function.operands(*elements).to_vec();
+            gen_new_array(jit, asm, opnds!(elements), &function.frame_state(*state))
+        },
         Insn::NewHash { elements, state } => gen_new_hash(jit, asm, opnds!(elements), &function.frame_state(*state)),
         Insn::NewRange { low, high, flag, state } => gen_new_range(jit, asm, opnd!(low), opnd!(high), *flag, &function.frame_state(*state)),
         Insn::NewRangeFixnum { low, high, flag, state } => gen_new_range_fixnum(asm, opnd!(low), opnd!(high), *flag, &function.frame_state(*state)),

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -654,6 +654,9 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
             )
         }
         Insn::PushInlineFrame { cme, iseq, recv, args, blockiseq, state, .. } => {
+            // Resolve to an owned Vec so the pool borrow is released before
+            // frame_state(), which calls find() and re-borrows the pool.
+            let args = function.operands(*args).to_vec();
             no_output!(gen_push_inline_frame(jit, asm, *cme, *iseq, opnd!(recv), opnds!(args), &function.frame_state(*state), *blockiseq))
         },
         Insn::PopInlineFrame { iseq, argc, state } => {

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -21,7 +21,7 @@ use crate::stats::{counter_ptr, with_time_stat, trace_compile_phase, Counter, Co
 use crate::{asm::CodeBlock, cruby::*, options::debug, virtualmem::CodePtr};
 use crate::backend::lir::{self, Assembler, C_ARG_OPNDS, C_RET_OPND, CFP, EC, NATIVE_BASE_PTR, Opnd, SP, SideExit, SideExitRecompile, Target, asm_ccall, asm_comment};
 use crate::hir::{iseq_to_hir, BlockId, Invariant, RangeType, SideExitReason::{self, *}, SpecialBackrefSymbol, SpecialObjectType};
-use crate::hir::{BlockHandler, CCallVariadicData, CCallWithFrameData, Const, FieldName, FrameState, Function, Insn, InsnId, Recompile, SendDirectData, SendFallbackReason};
+use crate::hir::{BlockHandler, CCallData, CCallVariadicData, CCallWithFrameData, Const, FieldName, FrameState, Function, Insn, InsnId, Recompile, SendDirectData, SendFallbackReason};
 use crate::hir_type::{types, Type};
 use crate::options::{get_option, InlineDepth, PerfMap};
 use crate::cast::IntoUsize;
@@ -761,7 +761,8 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
         &Insn::GuardLess { left, right, ref reason, state } => gen_guard_less(jit, asm, opnd!(left), opnd!(right), **reason, &function.frame_state(state)),
         &Insn::GuardGreaterEq { left, right, state, .. } => gen_guard_greater_eq(jit, asm, opnd!(left), opnd!(right), &function.frame_state(state)),
         Insn::PatchPoint { invariant, state } => no_output!(gen_patch_point(jit, asm, invariant, &function.frame_state(*state))),
-        Insn::CCall { cfunc, recv, args, name, owner: _, return_type: _, elidable: _ } => {
+        Insn::CCall { recv, args, data } => {
+            let CCallData { cfunc, name, .. } = &**data;
             let args = function.operands(*args);
             gen_ccall(asm, *cfunc, *name, opnd!(recv), opnds!(args))
         }

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -835,7 +835,12 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
             let elements = function.operands(*elements).to_vec();
             gen_array_max(jit, asm, opnds!(elements), &function.frame_state(*state))
         },
-        &Insn::ArrayMin { ref elements, state } => gen_array_min(jit, asm, opnds!(elements), &function.frame_state(state)),
+        Insn::ArrayMin { elements, state } => {
+            // Resolve to an owned Vec so the pool borrow is released before
+            // frame_state(), which calls find() and re-borrows the pool.
+            let elements = function.operands(*elements).to_vec();
+            gen_array_min(jit, asm, opnds!(elements), &function.frame_state(*state))
+        },
         &Insn::Throw { state, .. } => return Err(state),
         &Insn::CondBranch { .. }
         | &Insn::Jump { .. } | Insn::Entries { .. } => unreachable!(),

--- a/zjit/src/cruby.rs
+++ b/zjit/src/cruby.rs
@@ -848,6 +848,14 @@ impl From<VALUE> for u16 {
 }
 
 impl ID {
+    /// Sentinel meaning "no ID". CRuby reserves `0` as a non-ID.
+    pub const NONE: ID = ID(0);
+
+    /// Whether this is the [`ID::NONE`] sentinel rather than a real interned ID.
+    pub fn is_none(self) -> bool {
+        self == Self::NONE
+    }
+
     // Get a debug representation of the contents of the ID. Since `str` is UTF-8
     // and IDs have encodings that are not, this is a lossy representation.
     pub fn contents_lossy(&self) -> std::borrow::Cow<'_, str> {

--- a/zjit/src/cruby_methods.rs
+++ b/zjit/src/cruby_methods.rs
@@ -71,6 +71,10 @@ impl Annotations {
         let func_ptr = unsafe { (*bf).func_ptr as *mut c_void };
         self.builtin_funcs.get(&func_ptr).copied()
     }
+
+    pub fn get_builtin_return_type(&self, bf: *const rb_builtin_function) -> Type {
+        self.get_builtin_properties(bf).map(|p| p.return_type).unwrap_or(types::BasicObject)
+    }
 }
 
 fn annotate_c_method(props_map: &mut HashMap<*mut c_void, FnProperties>, class: VALUE, method_name: &'static str, props: FnProperties) {

--- a/zjit/src/cruby_methods.rs
+++ b/zjit/src/cruby_methods.rs
@@ -376,11 +376,11 @@ fn inline_array_aref(fun: &mut hir::Function, block: hir::BlockId, recv: hir::In
             let index = fun.coerce_to(block, index, types::Fixnum, state);
             let index = fun.push_insn(block, hir::Insn::UnboxFixnum { val: index });
             let length = fun.push_insn(block, hir::Insn::ArrayLength { array: recv });
-            let index = fun.push_insn(block, hir::Insn::GuardLess { left: index, right: length, reason: SideExitReason::GuardLess, state });
+            let index = fun.push_insn(block, hir::Insn::GuardLess { left: index, right: length, reason: Box::new(SideExitReason::GuardLess), state });
             let index = fun.push_insn(block, hir::Insn::AdjustBounds { index, length });
             let zero = fun.push_insn(block, hir::Insn::Const { val: hir::Const::CInt64(0) });
             use crate::hir::SideExitReason;
-            let index = fun.push_insn(block, hir::Insn::GuardGreaterEq { left: index, right: zero, reason: SideExitReason::GuardGreaterEq, state });
+            let index = fun.push_insn(block, hir::Insn::GuardGreaterEq { left: index, right: zero, reason: Box::new(SideExitReason::GuardGreaterEq), state });
             let result = fun.push_insn(block, hir::Insn::ArrayAref { array: recv, index });
             return Some(result);
         }
@@ -401,11 +401,11 @@ fn inline_array_aset(fun: &mut hir::Function, block: hir::BlockId, recv: hir::In
             // Bounds check: unbox Fixnum index and guard 0 <= idx < length.
             let index = fun.push_insn(block, hir::Insn::UnboxFixnum { val: index });
             let length = fun.push_insn(block, hir::Insn::ArrayLength { array: recv });
-            let index = fun.push_insn(block, hir::Insn::GuardLess { left: index, right: length, reason: SideExitReason::GuardLess, state });
+            let index = fun.push_insn(block, hir::Insn::GuardLess { left: index, right: length, reason: Box::new(SideExitReason::GuardLess), state });
             let index = fun.push_insn(block, hir::Insn::AdjustBounds { index, length });
             let zero = fun.push_insn(block, hir::Insn::Const { val: hir::Const::CInt64(0) });
             use crate::hir::SideExitReason;
-            let index = fun.push_insn(block, hir::Insn::GuardGreaterEq { left: index, right: zero, reason: SideExitReason::GuardGreaterEq, state });
+            let index = fun.push_insn(block, hir::Insn::GuardGreaterEq { left: index, right: zero, reason: Box::new(SideExitReason::GuardGreaterEq), state });
 
             let _ = fun.push_insn(block, hir::Insn::ArrayAset { array: recv, index, val });
             fun.push_insn(block, hir::Insn::WriteBarrier { recv, val });
@@ -501,11 +501,11 @@ fn inline_string_getbyte(fun: &mut hir::Function, block: hir::BlockId, recv: hir
         // the data dependency is gone (say, the StringGetbyte is elided), they can also be elided.
         //
         // This is unlike most other guards.
-        let unboxed_index = fun.push_insn(block, hir::Insn::GuardLess { left: unboxed_index, right: len, reason: SideExitReason::GuardLess, state });
+        let unboxed_index = fun.push_insn(block, hir::Insn::GuardLess { left: unboxed_index, right: len, reason: Box::new(SideExitReason::GuardLess), state });
         let unboxed_index = fun.push_insn(block, hir::Insn::AdjustBounds { index: unboxed_index, length: len });
         let zero = fun.push_insn(block, hir::Insn::Const { val: hir::Const::CInt64(0) });
         use crate::hir::SideExitReason;
-        let _ = fun.push_insn(block, hir::Insn::GuardGreaterEq { left: unboxed_index, right: zero, reason: SideExitReason::GuardGreaterEq, state });
+        let _ = fun.push_insn(block, hir::Insn::GuardGreaterEq { left: unboxed_index, right: zero, reason: Box::new(SideExitReason::GuardGreaterEq), state });
         let result = fun.push_insn(block, hir::Insn::StringGetbyte { string: recv, index: unboxed_index });
         return Some(result);
     }
@@ -525,11 +525,11 @@ fn inline_string_setbyte(fun: &mut hir::Function, block: hir::BlockId, recv: hir
             offset: RUBY_OFFSET_RSTRING_LEN,
             return_type: types::CInt64,
         });
-        let unboxed_index = fun.push_insn(block, hir::Insn::GuardLess { left: unboxed_index, right: len, reason: SideExitReason::GuardLess, state });
+        let unboxed_index = fun.push_insn(block, hir::Insn::GuardLess { left: unboxed_index, right: len, reason: Box::new(SideExitReason::GuardLess), state });
         let unboxed_index = fun.push_insn(block, hir::Insn::AdjustBounds { index: unboxed_index, length: len });
         let zero = fun.push_insn(block, hir::Insn::Const { val: hir::Const::CInt64(0) });
         use crate::hir::SideExitReason;
-        let _ = fun.push_insn(block, hir::Insn::GuardGreaterEq { left: unboxed_index, right: zero, reason: SideExitReason::GuardGreaterEq, state });
+        let _ = fun.push_insn(block, hir::Insn::GuardGreaterEq { left: unboxed_index, right: zero, reason: Box::new(SideExitReason::GuardGreaterEq), state });
         // We know that all String are HeapObject, so no need to insert a GuardType(HeapObject).
         fun.guard_not_frozen(block, recv, state);
         let _ = fun.push_insn(block, hir::Insn::StringSetbyteFixnum { string: recv, index, value });
@@ -565,7 +565,7 @@ fn guard_string_coderange(fun: &mut hir::Function, block: hir::BlockId, args: &[
     let mask = fun.push_insn(block, hir::Insn::Const { val: hir::Const::CUInt64(RUBY_ENC_CODERANGE_MASK.into()) });
     let cr = fun.push_insn(block, hir::Insn::IntAnd { left: flags, right: mask });
     let min_known = fun.push_insn(block, hir::Insn::Const { val: hir::Const::CInt64(RUBY_ENC_CODERANGE_7BIT.into()) });
-    Some(fun.push_insn(block, hir::Insn::GuardGreaterEq { left: cr, right: min_known, reason: SideExitReason::GuardGreaterEq, state }))
+    Some(fun.push_insn(block, hir::Insn::GuardGreaterEq { left: cr, right: min_known, reason: Box::new(SideExitReason::GuardGreaterEq), state }))
 }
 
 // Inlines String#ascii_only? (rb_str_is_ascii_only_p): coderange == 7BIT.

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -1202,7 +1202,7 @@ pub enum Insn {
     InvokeBuiltin {
         bf: *const rb_builtin_function,
         recv: InsnId,
-        args: Vec<InsnId>,
+        args: InsnIdList,
         state: InsnId,
         leaf: bool,
         return_type: Type,  // BasicObject for unannotated builtins
@@ -1515,13 +1515,13 @@ macro_rules! for_each_operand_impl {
             | Insn::PushInlineFrame { recv, args, state, .. }
             | Insn::SendForward { recv, args, state, .. }
             | Insn::InvokeSuper { recv, args, state, .. }
-            | Insn::InvokeSuperForward { recv, args, state, .. } => {
+            | Insn::InvokeSuperForward { recv, args, state, .. }
+            | Insn::InvokeBuiltin { recv, args, state, .. } => {
                 $visit_one!(*recv);
                 $visit_list!(*args);
                 $visit_one!(*state);
             }
-            Insn::InvokeBuiltin { recv, args, state, .. }
-            | Insn::InvokeProc { recv, args, state, .. } => {
+            Insn::InvokeProc { recv, args, state, .. } => {
                 $visit_one!(*recv);
                 $visit_many!(args);
                 $visit_one!(*state);
@@ -2196,6 +2196,7 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
                 Ok(())
             }
             Insn::InvokeBuiltin { bf, args, leaf, .. } => {
+                let args = self.pool.map_or(&[][..], |pool| pool.get(*args));
                 let bf_name = unsafe { CStr::from_ptr((**bf).name) }.to_str().unwrap();
                 write!(f, "InvokeBuiltin{} {}",
                            if *leaf { " leaf" } else { "" },
@@ -3045,7 +3046,7 @@ impl Function {
         // Operands stored in the operand pool (e.g. CCall/Send/PushInlineFrame/
         // SendForward/InvokeSuper/InvokeSuperForward args) are shared by handle with
         // the original insn. Duplicate the list so remapping below doesn't mutate the canonical entry.
-        if let Insn::CCall { args, .. } | Insn::Send { args, .. } | Insn::PushInlineFrame { args, .. } | Insn::SendForward { args, .. } | Insn::InvokeSuper { args, .. } | Insn::InvokeSuperForward { args, .. } = &mut result {
+        if let Insn::CCall { args, .. } | Insn::Send { args, .. } | Insn::PushInlineFrame { args, .. } | Insn::SendForward { args, .. } | Insn::InvokeSuper { args, .. } | Insn::InvokeSuperForward { args, .. } | Insn::InvokeBuiltin { args, .. } = &mut result {
             let dup = self.operand_pool.borrow().get(*args).to_vec();
             *args = self.operand_pool.borrow_mut().push(&dup);
         }
@@ -3849,7 +3850,7 @@ impl Function {
                 self.push_insn(block, Insn::InvokeBuiltin {
                     bf,
                     recv,
-                    args: vec![recv],
+                    args: self.push_operands(&[recv]),
                     state,
                     leaf: true,
                     return_type,
@@ -5395,6 +5396,7 @@ impl Function {
                         }
                     }
                     Insn::InvokeBuiltin { bf, recv, args, state, .. } => {
+                        let args = self.operands(args).to_vec();
                         let props = ZJITState::get_method_annotations().get_builtin_properties(bf).unwrap_or_default();
                         // Try inlining the cfunc into HIR
                         let tmp_block = self.new_block(u32::MAX);
@@ -6594,7 +6596,8 @@ impl Function {
             | Insn::PushInlineFrame { recv, args, .. }
             | Insn::SendForward { recv, args, .. }
             | Insn::InvokeSuper { recv, args, .. }
-            | Insn::InvokeSuperForward { recv, args, .. } => {
+            | Insn::InvokeSuperForward { recv, args, .. }
+            | Insn::InvokeBuiltin { recv, args, .. } => {
                 self.assert_subtype(insn_id, recv, types::BasicObject)?;
                 for &arg in self.operands(args).to_vec().iter() {
                     self.assert_subtype(insn_id, arg, types::BasicObject)?;
@@ -6602,8 +6605,7 @@ impl Function {
                 Ok(())
             }
             // Instructions with recv and a Vec of Ruby objects
-            Insn::InvokeBuiltin { recv, ref args, .. }
-            | Insn::InvokeProc { recv, ref args, .. }
+            Insn::InvokeProc { recv, ref args, .. }
             | Insn::ArrayInclude { target: recv, elements: ref args, .. } => {
                 self.assert_subtype(insn_id, recv, types::BasicObject)?;
                 for &arg in args {
@@ -9229,7 +9231,7 @@ fn add_iseq_to_hir(
                     let insn_id = fun.push_insn(block, Insn::InvokeBuiltin {
                         bf,
                         recv: self_param,
-                        args,
+                        args: fun.push_operands(&args),
                         state: exit_id,
                         leaf,
                         return_type,
@@ -9264,7 +9266,7 @@ fn add_iseq_to_hir(
                     let insn_id = fun.push_insn(block, Insn::InvokeBuiltin {
                         bf,
                         recv: self_param,
-                        args,
+                        args: fun.push_operands(&args),
                         state: exit_id,
                         leaf,
                         return_type,

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -954,6 +954,15 @@ pub struct CCallData {
     pub elidable: bool,
 }
 
+/// Cold metadata of [`Insn::Send`]. Boxed in the enum to keep `Insn` small;
+/// the operands (`recv`, `args`) and `state` stay inline for fast traversal.
+#[derive(Debug, Clone)]
+pub struct SendData {
+    pub cd: *const rb_call_data,
+    pub block: Option<BlockHandler>,
+    pub reason: SendFallbackReason,
+}
+
 /// An instruction in the SSA IR. The output of an instruction is referred to by the index of
 /// the instruction ([`InsnId`]). SSA form enables this, and [`UnionFind`] ([`Function::find`])
 /// helps with editing.
@@ -1137,11 +1146,9 @@ pub enum Insn {
     /// Ignoring keyword arguments etc for now
     Send {
         recv: InsnId,
-        cd: *const rb_call_data,
-        block: Option<BlockHandler>,
         args: InsnIdList,
         state: InsnId,
-        reason: SendFallbackReason,
+        data: Box<SendData>,
     },
     SendForward {
         recv: InsnId,
@@ -2170,7 +2177,8 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
             Insn::PopInlineFrame { .. } => {
                 write!(f, "PopInlineFrame")
             }
-            Insn::Send { recv, cd, args, block, reason, .. } => {
+            Insn::Send { recv, args, data, .. } => {
+                let SendData { cd, block, reason } = &**data;
                 // For tests, we want to check HIR snippets textually. Addresses change
                 // between runs, making tests fail. Instead, pick an arbitrary hex value to
                 // use as a "pointer" so we can check the rest of the HIR.
@@ -3099,8 +3107,8 @@ impl Function {
         // Always set the reason: convert_no_profile_sends depends on it to identify
         // sends that should be converted to side exits for exit-based recompilation.
         match self.insns.get_mut(insn_id.0).unwrap() {
-            Send { reason, .. }
-            | SendForward { reason, .. }
+            Send { data, .. } => data.reason = dynamic_send_reason,
+            SendForward { reason, .. }
             | InvokeSuper { reason, .. }
             | InvokeSuperForward { reason, .. }
             | InvokeBlock { reason, .. }
@@ -3906,11 +3914,12 @@ impl Function {
             assert!(self.blocks[block.0].insns.is_empty());
             for insn_id in old_insns {
                 match self.find(insn_id) {
-                    Insn::Send { recv, block: None, args, state, cd, .. } if ruby_call_method_id(cd) == ID!(freeze) && args.is_empty() =>
+                    Insn::Send { recv, args, state, data } if data.block.is_none() && ruby_call_method_id(data.cd) == ID!(freeze) && args.is_empty() =>
                         self.try_rewrite_freeze(block, insn_id, recv, state),
-                    Insn::Send { recv, block: None, args, state, cd, .. } if ruby_call_method_id(cd) == ID!(minusat) && args.is_empty() =>
+                    Insn::Send { recv, args, state, data } if data.block.is_none() && ruby_call_method_id(data.cd) == ID!(minusat) && args.is_empty() =>
                         self.try_rewrite_uminus(block, insn_id, recv, state),
-                    Insn::Send { mut recv, cd, state, block: send_block, args, .. } => {
+                    Insn::Send { mut recv, args, state, data } => {
+                        let SendData { cd, block: send_block, reason: _ } = *data;
                         let args = self.operands(args).to_vec();
                         let has_block = send_block.is_some();
                         let (klass, profiled_type) = match self.resolve_receiver_type(recv, self.type_of(recv), state) {
@@ -5185,9 +5194,10 @@ impl Function {
             send: Insn,
             send_insn_id: InsnId,
         ) -> Result<(), ()> {
-            let Insn::Send { mut recv, cd, block: send_block, args, state, .. } = send else {
+            let Insn::Send { mut recv, args, state, data } = send else {
                 return Err(());
             };
+            let SendData { cd, block: send_block, reason: _ } = *data;
             let args = fun.operands(args).to_vec();
 
             let call_info = unsafe { (*cd).ci };
@@ -5479,7 +5489,7 @@ impl Function {
             assert!(self.blocks[block.0].insns.is_empty());
             for insn_id in old_insns {
                 match self.find(insn_id) {
-                    Insn::Send { state, reason: SendFallbackReason::SendWithoutBlockNoProfiles | SendFallbackReason::SendNoProfiles, .. } => {
+                    Insn::Send { state, data, .. } if matches!(data.reason, SendFallbackReason::SendWithoutBlockNoProfiles | SendFallbackReason::SendNoProfiles) => {
                         self.push_insn(block, Insn::SideExit { state, reason: Box::new(SideExitReason::NoProfileSend), recompile: Some(Recompile) });
                         // SideExit is a terminator; don't add remaining instructions
                         break;
@@ -8687,7 +8697,7 @@ fn add_iseq_to_hir(
                     }
                     let args = state.stack_pop_n(argc as usize)?;
                     let recv = state.stack_pop()?;
-                    let send = fun.push_insn(block, Insn::Send { recv, cd, block: None, args: fun.push_operands(&args), state: exit_id, reason: Uncategorized(opcode) });
+                    let send = fun.push_insn(block, Insn::Send { recv, args: fun.push_operands(&args), state: exit_id, data: Box::new(SendData { cd, block: None, reason: Uncategorized(opcode) }) });
                     state.stack_push(send);
                 }
                 YARVINSN_opt_hash_freeze => {
@@ -8844,19 +8854,19 @@ fn add_iseq_to_hir(
                             // keyed at exit_id.
                             let snapshot = fun.push_insn(iftrue_block, Insn::Snapshot { state: Box::new(exit_state.clone()) });
                             let refined_recv = fun.push_insn(iftrue_block, Insn::RefineType { val: recv, new_type: expected });
-                            let send = fun.push_insn(iftrue_block, Insn::Send { recv: refined_recv, cd, block: None, args: fun.push_operands(&args), state: snapshot, reason: Uncategorized(opcode) });
+                            let send = fun.push_insn(iftrue_block, Insn::Send { recv: refined_recv, args: fun.push_operands(&args), state: snapshot, data: Box::new(SendData { cd, block: None, reason: Uncategorized(opcode) }) });
                             fun.push_insn(iftrue_block, Insn::Jump(Box::new(BranchEdge { target: join_block, args: vec![send] })));
                         }
                         // In the fallthrough case, do a generic interpreter send and then join.
                         let reason = SendWithoutBlockPolymorphicFallback;
-                        let send = fun.push_insn(block, Insn::Send { recv, cd, block: None, args: fun.push_operands(&args), state: exit_id, reason });
+                        let send = fun.push_insn(block, Insn::Send { recv, args: fun.push_operands(&args), state: exit_id, data: Box::new(SendData { cd, block: None, reason }) });
                         fun.push_insn(block, Insn::Jump(Box::new(BranchEdge { target: join_block, args: vec![send] })));
                         state.stack_push(join_param);
                         // Continue compilation from the join block at the next instruction.
                         block = join_block;
                     } else {
                         // Maybe monomorphic; handled in type_specialize
-                        let send = fun.push_insn(block, Insn::Send { recv, cd, block: None, args: fun.push_operands(&args), state: exit_id, reason: Uncategorized(opcode) });
+                        let send = fun.push_insn(block, Insn::Send { recv, args: fun.push_operands(&args), state: exit_id, data: Box::new(SendData { cd, block: None, reason: Uncategorized(opcode) }) });
                         state.stack_push(send);
                     }
                 }
@@ -8886,7 +8896,7 @@ fn add_iseq_to_hir(
                     } else {
                         None
                     };
-                    let send = fun.push_insn(block, Insn::Send { recv, cd, block: block_handler, args: fun.push_operands(&args), state: exit_id, reason: Uncategorized(opcode) });
+                    let send = fun.push_insn(block, Insn::Send { recv, args: fun.push_operands(&args), state: exit_id, data: Box::new(SendData { cd, block: block_handler, reason: Uncategorized(opcode) }) });
                     state.stack_push(send);
 
                     if let Some(BlockHandler::BlockIseq(_)) = block_handler {
@@ -9350,7 +9360,7 @@ fn add_iseq_to_hir(
                             fun.push_insn(block, Insn::GuardType { val: recv, guard_type: types::String, state: exit_id, recompile: None })
                         } else {
                             let recv = fun.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state: exit_id, recompile: None });
-                            fun.push_insn(block, Insn::Send { recv, cd, block: None, args: InsnIdList::EMPTY, state: exit_id, reason: ObjToStringNotString })
+                            fun.push_insn(block, Insn::Send { recv, args: InsnIdList::EMPTY, state: exit_id, data: Box::new(SendData { cd, block: None, reason: ObjToStringNotString }) })
                         }
                     } else {
                         let has_type = fun.push_insn(block, Insn::HasType { val: recv, expected: types::String });
@@ -9367,7 +9377,7 @@ fn add_iseq_to_hir(
                         fun.push_insn(iftrue_block, Insn::Jump(Box::new(BranchEdge { target: join_block, args: vec![refined] })));
                         // false block
                         let refined = fun.push_insn(iffalse_block, Insn::RefineType { val: recv, new_type: types::NotString });
-                        let send = fun.push_insn(iffalse_block, Insn::Send { recv: refined, cd, block: None, args: InsnIdList::EMPTY, state: exit_id, reason: ObjToStringNotString });
+                        let send = fun.push_insn(iffalse_block, Insn::Send { recv: refined, args: InsnIdList::EMPTY, state: exit_id, data: Box::new(SendData { cd, block: None, reason: ObjToStringNotString }) });
                         fun.push_insn(iffalse_block, Insn::Jump(Box::new(BranchEdge { target: join_block, args: vec![send] })));
                         // join block
                         block = join_block;

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -1186,7 +1186,7 @@ pub enum Insn {
         iseq: IseqPtr,
         cme: *const rb_callable_method_entry_t,
         recv: InsnId,
-        args: Vec<InsnId>,
+        args: InsnIdList,
         blockiseq: Option<IseqPtr>,
         state: InsnId,
     },
@@ -1511,13 +1511,13 @@ macro_rules! for_each_operand_impl {
                 $visit_one!(*val);
                 $visit_one!(*state);
             }
-            Insn::Send { recv, args, state, .. } => {
+            Insn::Send { recv, args, state, .. }
+            | Insn::PushInlineFrame { recv, args, state, .. } => {
                 $visit_one!(*recv);
                 $visit_list!(*args);
                 $visit_one!(*state);
             }
             Insn::SendForward { recv, args, state, .. }
-            | Insn::PushInlineFrame { recv, args, state, .. }
             | Insn::InvokeBuiltin { recv, args, state, .. }
             | Insn::InvokeSuper { recv, args, state, .. }
             | Insn::InvokeSuperForward { recv, args, state, .. }
@@ -2131,6 +2131,7 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
             }
             Insn::PushInlineFrame { recv, iseq, args, .. } => {
                 write!(f, "PushInlineFrame {recv} ({:?})", self.ptr_map.map_ptr(iseq))?;
+                let args = self.pool.map_or(&[][..], |pool| pool.get(*args));
                 write_separated!(f, ", ", ", ", args);
                 Ok(())
             }
@@ -3038,10 +3039,10 @@ impl Function {
         }
         let insn_id = find!(insn_id);
         let mut result = self.insns[insn_id.0].clone();
-        // Operands stored in the operand pool (e.g. CCall/Send args) are shared
-        // by handle with the original insn. Duplicate the list so remapping below
-        // doesn't mutate the canonical entry.
-        if let Insn::CCall { args, .. } | Insn::Send { args, .. } = &mut result {
+        // Operands stored in the operand pool (e.g. CCall/Send/PushInlineFrame
+        // args) are shared by handle with the original insn. Duplicate the list
+        // so remapping below doesn't mutate the canonical entry.
+        if let Insn::CCall { args, .. } | Insn::Send { args, .. } | Insn::PushInlineFrame { args, .. } = &mut result {
             let dup = self.operand_pool.borrow().get(*args).to_vec();
             *args = self.operand_pool.borrow_mut().push(&dup);
         }
@@ -4825,7 +4826,7 @@ impl Function {
 
                 // Insert PushLightweightFrame and jump to callee body entry.
                 self.push_insn(block, Insn::PushInlineFrame {
-                    iseq, cme, recv, args: args.clone(), blockiseq, state,
+                    iseq, cme, recv, args: self.push_operands(&args), blockiseq, state,
                 });
                 self.count(block, Counter::inline_iseq_optimized_send_count);
                 self.push_insn(block, Insn::Jump(Box::new(BranchEdge {
@@ -6584,8 +6585,9 @@ impl Function {
                 self.assert_subtype(insn_id, klass, types::BasicObject)?;
                 self.assert_subtype(insn_id, allow_nil, types::BoolExact)
             }
-            // Send keeps its operands in the pool; resolve before checking.
-            Insn::Send { recv, args, .. } => {
+            // Send and PushInlineFrame keep their operands in the pool; resolve before checking.
+            Insn::Send { recv, args, .. }
+            | Insn::PushInlineFrame { recv, args, .. } => {
                 self.assert_subtype(insn_id, recv, types::BasicObject)?;
                 for &arg in self.operands(args).to_vec().iter() {
                     self.assert_subtype(insn_id, arg, types::BasicObject)?;
@@ -6593,8 +6595,7 @@ impl Function {
                 Ok(())
             }
             // Instructions with recv and a Vec of Ruby objects
-            Insn::PushInlineFrame { recv, ref args, .. }
-            | Insn::SendForward { recv, ref args, .. }
+            Insn::SendForward { recv, ref args, .. }
             | Insn::InvokeSuper { recv, ref args, .. }
             | Insn::InvokeSuperForward { recv, ref args, .. }
             | Insn::InvokeBuiltin { recv, ref args, .. }

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -973,7 +973,7 @@ pub enum Insn {
     StringEqual { left: InsnId, right: InsnId },
 
     /// Combine count stack values into a regexp
-    ToRegexp { opt: usize, values: Vec<InsnId>, state: InsnId },
+    ToRegexp { opt: usize, values: InsnIdList, state: InsnId },
 
     /// Put special object (VMCORE, CBASE, etc.) based on value_type
     PutSpecialObject { value_type: SpecialObjectType, state: InsnId },
@@ -1389,7 +1389,7 @@ macro_rules! for_each_operand_impl {
                 $visit_one!(*right);
             }
             Insn::ToRegexp { values, state, .. } => {
-                $visit_many!(values);
+                $visit_list!(*values);
                 $visit_one!(*state);
             }
             Insn::RefineType { val, .. }
@@ -2095,6 +2095,7 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
                 write!(f, "StringEqual {left}, {right}")
             }
             Insn::ToRegexp { values, opt, .. } => {
+                let values = self.pool.map_or(&[][..], |pool| pool.get(*values));
                 write!(f, "ToRegexp")?;
                 write_separated!(f, " ", ", ", values);
 
@@ -6667,8 +6668,13 @@ impl Function {
                 }
                 Ok(())
             }
-            Insn::StringConcat { ref strings, .. }
-            | Insn::ToRegexp { values: ref strings, .. } => {
+            Insn::ToRegexp { values, .. } => {
+                for &string in self.operands(values).to_vec().iter() {
+                    self.assert_subtype(insn_id, string, types::String)?;
+                }
+                Ok(())
+            }
+            Insn::StringConcat { ref strings, .. } => {
                 for &string in strings {
                     self.assert_subtype(insn_id, string, types::String)?;
                 }
@@ -7694,7 +7700,7 @@ fn add_iseq_to_hir(
                     let opt = get_arg(pc, 0).as_usize();
                     let count = get_arg(pc, 1).as_usize();
                     let values = state.stack_pop_n(count)?;
-                    let insn_id = fun.push_insn(block, Insn::ToRegexp { opt, values, state: exit_id });
+                    let insn_id = fun.push_insn(block, Insn::ToRegexp { opt, values: fun.push_operands(&values), state: exit_id });
                     state.stack_push(insn_id);
                 }
                 YARVINSN_newarray => {

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -1256,9 +1256,9 @@ pub enum Insn {
     /// Side-exit if val is not the expected Const.
     GuardBitEquals { val: InsnId, expected: Const, reason: Box<SideExitReason>, state: InsnId, recompile: Option<Recompile> },
     /// Side-exit if (val & mask) == 0
-    GuardAnyBitSet { val: InsnId, mask: Const, mask_name: Option<ID>, reason: Box<SideExitReason>, state: InsnId, recompile: Option<Recompile> },
+    GuardAnyBitSet { val: InsnId, mask: Const, mask_name: ID, reason: Box<SideExitReason>, state: InsnId, recompile: Option<Recompile> },
     /// Side-exit if (val & mask) != 0
-    GuardNoBitsSet { val: InsnId, mask: Const, mask_name: Option<ID>, reason: Box<SideExitReason>, state: InsnId },
+    GuardNoBitsSet { val: InsnId, mask: Const, mask_name: ID, reason: Box<SideExitReason>, state: InsnId },
     /// Side-exit if left is not greater than or equal to right (both operands are C long).
     GuardGreaterEq { left: InsnId, right: InsnId, reason: Box<SideExitReason>, state: InsnId },
     /// Side-exit if left is not less than right (both operands are C long).
@@ -2251,13 +2251,13 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
             Insn::GuardAnyBitSet { val, mask, mask_name, recompile, .. } => {
                 let mask = mask.print(self.ptr_map);
                 let recompile = if recompile.is_some() { " recompile" } else { "" };
-                if let Some(name) = mask_name {
-                    write!(f, "GuardAnyBitSet {val}, {name}={mask}{recompile}")
+                if !mask_name.is_none() {
+                    write!(f, "GuardAnyBitSet {val}, {mask_name}={mask}{recompile}")
                 } else {
                     write!(f, "GuardAnyBitSet {val}, {mask}{recompile}")
                 }
             },
-            Insn::GuardNoBitsSet { val, mask, mask_name: Some(name), .. } => { write!(f, "GuardNoBitsSet {val}, {name}={}", mask.print(self.ptr_map)) },
+            Insn::GuardNoBitsSet { val, mask, mask_name, .. } if !mask_name.is_none() => { write!(f, "GuardNoBitsSet {val}, {mask_name}={}", mask.print(self.ptr_map)) },
             Insn::GuardNoBitsSet { val, mask, .. } => { write!(f, "GuardNoBitsSet {val}, {}", mask.print(self.ptr_map)) },
             Insn::GuardLess { left, right, .. } => write!(f, "GuardLess {left}, {right}"),
             Insn::GuardGreaterEq { left, right, .. } => write!(f, "GuardGreaterEq {left}, {right}"),
@@ -3750,12 +3750,12 @@ impl Function {
 
     pub fn guard_not_frozen(&mut self, block: BlockId, recv: InsnId, state: InsnId) {
         let flags = self.load_rbasic_flags(block, recv);
-        self.push_insn(block, Insn::GuardNoBitsSet { val: flags, mask: Const::CUInt64(RUBY_FL_FREEZE as u64), mask_name: Some(ID!(RUBY_FL_FREEZE)), reason: Box::new(SideExitReason::GuardNotFrozen), state });
+        self.push_insn(block, Insn::GuardNoBitsSet { val: flags, mask: Const::CUInt64(RUBY_FL_FREEZE as u64), mask_name: ID!(RUBY_FL_FREEZE), reason: Box::new(SideExitReason::GuardNotFrozen), state });
     }
 
     pub fn guard_not_shared(&mut self, block: BlockId, recv: InsnId, state: InsnId) {
         let flags = self.load_rbasic_flags(block, recv);
-        self.push_insn(block, Insn::GuardNoBitsSet { val: flags, mask: Const::CUInt64(RUBY_ELTS_SHARED as u64), mask_name: Some(ID!(RUBY_ELTS_SHARED)), reason: Box::new(SideExitReason::GuardNotShared), state });
+        self.push_insn(block, Insn::GuardNoBitsSet { val: flags, mask: Const::CUInt64(RUBY_ELTS_SHARED as u64), mask_name: ID!(RUBY_ELTS_SHARED), reason: Box::new(SideExitReason::GuardNotShared), state });
     }
 
     /// `iseq` is the ISEQ that `ep_offset` is relative to, which is the ISEQ that
@@ -8364,7 +8364,7 @@ fn add_iseq_to_hir(
                             // So to check for either of those cases we can use: val & 0x1 == 0x1
 
                             // Bail out if the block handler is neither ISEQ nor ifunc
-                            fun.push_insn(unmodified_block, Insn::GuardAnyBitSet { val: block_handler, mask: Const::CUInt64(0x1), mask_name: None, reason: Box::new(SideExitReason::BlockParamProxyFallbackMiss), state: exit_id, recompile: Some(Recompile) });
+                            fun.push_insn(unmodified_block, Insn::GuardAnyBitSet { val: block_handler, mask: Const::CUInt64(0x1), mask_name: ID::NONE, reason: Box::new(SideExitReason::BlockParamProxyFallbackMiss), state: exit_id, recompile: Some(Recompile) });
                             // TODO(Shopify/ruby#753): GC root, so we should be able to avoid unnecessary GC tracing
                             let proxy_val = fun.push_insn(unmodified_block, Insn::Const { val: Const::Value(unsafe { rb_block_param_proxy }) });
                             let mut args = vec![proxy_val];
@@ -8394,7 +8394,7 @@ fn add_iseq_to_hir(
                                 // So to check for either of those cases we can use: val & 0x1 == 0x1
 
                                 // Bail out if the block handler is neither ISEQ nor ifunc
-                                fun.push_insn(unmodified_block, Insn::GuardAnyBitSet { val: block_handler, mask: Const::CUInt64(0x1), mask_name: None, reason: Box::new(SideExitReason::BlockParamProxyNotIseqOrIfunc), state: exit_id, recompile: Some(Recompile) });
+                                fun.push_insn(unmodified_block, Insn::GuardAnyBitSet { val: block_handler, mask: Const::CUInt64(0x1), mask_name: ID::NONE, reason: Box::new(SideExitReason::BlockParamProxyNotIseqOrIfunc), state: exit_id, recompile: Some(Recompile) });
                                 // TODO(Shopify/ruby#753): GC root, so we should be able to avoid unnecessary GC tracing
                                 let proxy_val = fun.push_insn(unmodified_block, Insn::Const { val: Const::Value(unsafe { rb_block_param_proxy }) });
                                 let mut args = vec![proxy_val];

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -132,6 +132,11 @@ pub struct InsnIdList(u32);
 impl InsnIdList {
     /// Handle to the canonical empty list (pool slot 0 always holds length 0).
     pub const EMPTY: InsnIdList = InsnIdList(0);
+
+    /// Whether this handle refers to the empty list. `OperandPool::push` returns
+    /// [`InsnIdList::EMPTY`] (handle 0) for empty slices and a non-zero offset
+    /// otherwise, so this needs no pool lookup.
+    pub fn is_empty(self) -> bool { self.0 == 0 }
 }
 
 /// Dense arena of operand lists referenced by [`InsnIdList`] handles. Operand
@@ -1123,7 +1128,7 @@ pub enum Insn {
         recv: InsnId,
         cd: *const rb_call_data,
         block: Option<BlockHandler>,
-        args: Vec<InsnId>,
+        args: InsnIdList,
         state: InsnId,
         reason: SendFallbackReason,
     },
@@ -1506,8 +1511,12 @@ macro_rules! for_each_operand_impl {
                 $visit_one!(*val);
                 $visit_one!(*state);
             }
-            Insn::Send { recv, args, state, .. }
-            | Insn::SendForward { recv, args, state, .. }
+            Insn::Send { recv, args, state, .. } => {
+                $visit_one!(*recv);
+                $visit_list!(*args);
+                $visit_one!(*state);
+            }
+            Insn::SendForward { recv, args, state, .. }
             | Insn::PushInlineFrame { recv, args, state, .. }
             | Insn::InvokeBuiltin { recv, args, state, .. }
             | Insn::InvokeSuper { recv, args, state, .. }
@@ -2140,6 +2149,7 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
                     None =>
                         write!(f, "Send {recv}, :{}", ruby_call_method_name(*cd))?,
                 }
+                let args = self.pool.map_or(&[][..], |pool| pool.get(*args));
                 write_separated!(f, ", ", ", ", args);
                 write!(f, " # SendFallbackReason: {reason}")?;
                 Ok(())
@@ -3028,10 +3038,10 @@ impl Function {
         }
         let insn_id = find!(insn_id);
         let mut result = self.insns[insn_id.0].clone();
-        // Operands stored in the operand pool (e.g. CCall args) are shared by
-        // handle with the original insn. Duplicate the list so remapping below
+        // Operands stored in the operand pool (e.g. CCall/Send args) are shared
+        // by handle with the original insn. Duplicate the list so remapping below
         // doesn't mutate the canonical entry.
-        if let Insn::CCall { args, .. } = &mut result {
+        if let Insn::CCall { args, .. } | Insn::Send { args, .. } = &mut result {
             let dup = self.operand_pool.borrow().get(*args).to_vec();
             *args = self.operand_pool.borrow_mut().push(&dup);
         }
@@ -3860,6 +3870,7 @@ impl Function {
                     Insn::Send { recv, block: None, args, state, cd, .. } if ruby_call_method_id(cd) == ID!(minusat) && args.is_empty() =>
                         self.try_rewrite_uminus(block, insn_id, recv, state),
                     Insn::Send { mut recv, cd, state, block: send_block, args, .. } => {
+                        let args = self.operands(args).to_vec();
                         let has_block = send_block.is_some();
                         let (klass, profiled_type) = match self.resolve_receiver_type(recv, self.type_of(recv), state) {
                             ReceiverTypeResolution::StaticallyKnown { class } => (class, None),
@@ -5133,6 +5144,7 @@ impl Function {
             let Insn::Send { mut recv, cd, block: send_block, args, state, .. } = send else {
                 return Err(());
             };
+            let args = fun.operands(args).to_vec();
 
             let call_info = unsafe { (*cd).ci };
             let argc = unsafe { vm_ci_argc(call_info) };
@@ -6572,9 +6584,16 @@ impl Function {
                 self.assert_subtype(insn_id, klass, types::BasicObject)?;
                 self.assert_subtype(insn_id, allow_nil, types::BoolExact)
             }
+            // Send keeps its operands in the pool; resolve before checking.
+            Insn::Send { recv, args, .. } => {
+                self.assert_subtype(insn_id, recv, types::BasicObject)?;
+                for &arg in self.operands(args).to_vec().iter() {
+                    self.assert_subtype(insn_id, arg, types::BasicObject)?;
+                }
+                Ok(())
+            }
             // Instructions with recv and a Vec of Ruby objects
             Insn::PushInlineFrame { recv, ref args, .. }
-            | Insn::Send { recv, ref args, .. }
             | Insn::SendForward { recv, ref args, .. }
             | Insn::InvokeSuper { recv, ref args, .. }
             | Insn::InvokeSuperForward { recv, ref args, .. }
@@ -8597,7 +8616,7 @@ fn add_iseq_to_hir(
                     }
                     let args = state.stack_pop_n(argc as usize)?;
                     let recv = state.stack_pop()?;
-                    let send = fun.push_insn(block, Insn::Send { recv, cd, block: None, args, state: exit_id, reason: Uncategorized(opcode) });
+                    let send = fun.push_insn(block, Insn::Send { recv, cd, block: None, args: fun.push_operands(&args), state: exit_id, reason: Uncategorized(opcode) });
                     state.stack_push(send);
                 }
                 YARVINSN_opt_hash_freeze => {
@@ -8754,19 +8773,19 @@ fn add_iseq_to_hir(
                             // keyed at exit_id.
                             let snapshot = fun.push_insn(iftrue_block, Insn::Snapshot { state: Box::new(exit_state.clone()) });
                             let refined_recv = fun.push_insn(iftrue_block, Insn::RefineType { val: recv, new_type: expected });
-                            let send = fun.push_insn(iftrue_block, Insn::Send { recv: refined_recv, cd, block: None, args: args.clone(), state: snapshot, reason: Uncategorized(opcode) });
+                            let send = fun.push_insn(iftrue_block, Insn::Send { recv: refined_recv, cd, block: None, args: fun.push_operands(&args), state: snapshot, reason: Uncategorized(opcode) });
                             fun.push_insn(iftrue_block, Insn::Jump(Box::new(BranchEdge { target: join_block, args: vec![send] })));
                         }
                         // In the fallthrough case, do a generic interpreter send and then join.
                         let reason = SendWithoutBlockPolymorphicFallback;
-                        let send = fun.push_insn(block, Insn::Send { recv, cd, block: None, args, state: exit_id, reason });
+                        let send = fun.push_insn(block, Insn::Send { recv, cd, block: None, args: fun.push_operands(&args), state: exit_id, reason });
                         fun.push_insn(block, Insn::Jump(Box::new(BranchEdge { target: join_block, args: vec![send] })));
                         state.stack_push(join_param);
                         // Continue compilation from the join block at the next instruction.
                         block = join_block;
                     } else {
                         // Maybe monomorphic; handled in type_specialize
-                        let send = fun.push_insn(block, Insn::Send { recv, cd, block: None, args, state: exit_id, reason: Uncategorized(opcode) });
+                        let send = fun.push_insn(block, Insn::Send { recv, cd, block: None, args: fun.push_operands(&args), state: exit_id, reason: Uncategorized(opcode) });
                         state.stack_push(send);
                     }
                 }
@@ -8796,7 +8815,7 @@ fn add_iseq_to_hir(
                     } else {
                         None
                     };
-                    let send = fun.push_insn(block, Insn::Send { recv, cd, block: block_handler, args, state: exit_id, reason: Uncategorized(opcode) });
+                    let send = fun.push_insn(block, Insn::Send { recv, cd, block: block_handler, args: fun.push_operands(&args), state: exit_id, reason: Uncategorized(opcode) });
                     state.stack_push(send);
 
                     if let Some(BlockHandler::BlockIseq(_)) = block_handler {
@@ -9260,7 +9279,7 @@ fn add_iseq_to_hir(
                             fun.push_insn(block, Insn::GuardType { val: recv, guard_type: types::String, state: exit_id, recompile: None })
                         } else {
                             let recv = fun.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state: exit_id, recompile: None });
-                            fun.push_insn(block, Insn::Send { recv, cd, block: None, args: vec![], state: exit_id, reason: ObjToStringNotString })
+                            fun.push_insn(block, Insn::Send { recv, cd, block: None, args: InsnIdList::EMPTY, state: exit_id, reason: ObjToStringNotString })
                         }
                     } else {
                         let has_type = fun.push_insn(block, Insn::HasType { val: recv, expected: types::String });
@@ -9277,7 +9296,7 @@ fn add_iseq_to_hir(
                         fun.push_insn(iftrue_block, Insn::Jump(Box::new(BranchEdge { target: join_block, args: vec![refined] })));
                         // false block
                         let refined = fun.push_insn(iffalse_block, Insn::RefineType { val: recv, new_type: types::NotString });
-                        let send = fun.push_insn(iffalse_block, Insn::Send { recv: refined, cd, block: None, args: vec![], state: exit_id, reason: ObjToStringNotString });
+                        let send = fun.push_insn(iffalse_block, Insn::Send { recv: refined, cd, block: None, args: InsnIdList::EMPTY, state: exit_id, reason: ObjToStringNotString });
                         fun.push_insn(iffalse_block, Insn::Jump(Box::new(BranchEdge { target: join_block, args: vec![send] })));
                         // join block
                         block = join_block;

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -1158,7 +1158,7 @@ pub enum Insn {
     },
     InvokeBlock {
         cd: *const rb_call_data,
-        args: Vec<InsnId>,
+        args: InsnIdList,
         state: InsnId,
         reason: SendFallbackReason,
     },
@@ -1545,7 +1545,7 @@ macro_rules! for_each_operand_impl {
                 $visit_one!(insn.state);
             }
             Insn::InvokeBlock { args, state, .. } => {
-                $visit_many!(args);
+                $visit_list!(*args);
                 $visit_one!(*state);
             }
             Insn::InvokeBlockIfunc { block_handler, args, state, .. } => {
@@ -2178,6 +2178,7 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
                 Ok(())
             }
             Insn::InvokeBlock { args, reason, .. } => {
+                let args = self.pool.map_or(&[][..], |pool| pool.get(*args));
                 write!(f, "InvokeBlock")?;
                 write_separated!(f, " ", ", ", args);
                 write!(f, " # SendFallbackReason: {reason}")?;
@@ -6638,9 +6639,15 @@ impl Function {
                 }
                 Ok(())
             }
+            // Instructions whose operands live in the pool.
+            Insn::InvokeBlock { args, .. } => {
+                for &arg in self.operands(args).to_vec().iter() {
+                    self.assert_subtype(insn_id, arg, types::BasicObject)?;
+                }
+                Ok(())
+            }
             // Instructions with a Vec of Ruby objects
-            Insn::InvokeBlock { ref args, .. }
-            | Insn::InvokeBlockIfunc { ref args, .. }
+            Insn::InvokeBlockIfunc { ref args, .. }
             | Insn::NewArray { elements: ref args, .. }
             | Insn::ArrayHash { elements: ref args, .. }
             | Insn::ArrayMin { elements: ref args, .. }
@@ -9049,7 +9056,7 @@ fn add_iseq_to_hir(
 
                         // In the fallthrough case, use generic rb_vm_invokeblock and join
                         let fallback_result = fun.push_insn(block, Insn::InvokeBlock {
-                            cd, args, state: exit_id, reason: InvokeBlockNotSpecialized,
+                            cd, args: fun.push_operands(&args), state: exit_id, reason: InvokeBlockNotSpecialized,
                         });
                         fun.push_insn(block, Insn::Jump(Box::new(BranchEdge { target: join_block, args: vec![fallback_result] })));
 
@@ -9057,7 +9064,7 @@ fn add_iseq_to_hir(
                         block = join_block;
                         join_param
                     } else {
-                        fun.push_insn(block, Insn::InvokeBlock { cd, args, state: exit_id, reason: InvokeBlockNotSpecialized })
+                        fun.push_insn(block, Insn::InvokeBlock { cd, args: fun.push_operands(&args), state: exit_id, reason: InvokeBlockNotSpecialized })
                     };
                     state.stack_push(result);
                 }

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -1167,7 +1167,7 @@ pub enum Insn {
     InvokeBlockIfunc {
         cd: *const rb_call_data,
         block_handler: InsnId,
-        args: Vec<InsnId>,
+        args: InsnIdList,
         state: InsnId,
     },
     /// Call Proc#call optimized method type.
@@ -1550,7 +1550,7 @@ macro_rules! for_each_operand_impl {
             }
             Insn::InvokeBlockIfunc { block_handler, args, state, .. } => {
                 $visit_one!(*block_handler);
-                $visit_many!(args);
+                $visit_list!(*args);
                 $visit_one!(*state);
             }
             Insn::CCall { recv, args, .. } => {
@@ -2185,6 +2185,7 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
                 Ok(())
             }
             Insn::InvokeBlockIfunc { block_handler, args, .. } => {
+                let args = self.pool.map_or(&[][..], |pool| pool.get(*args));
                 write!(f, "InvokeBlockIfunc {block_handler}")?;
                 write_separated!(f, ", ", ", ", args);
                 Ok(())
@@ -6640,15 +6641,15 @@ impl Function {
                 Ok(())
             }
             // Instructions whose operands live in the pool.
-            Insn::InvokeBlock { args, .. } => {
+            Insn::InvokeBlock { args, .. }
+            | Insn::InvokeBlockIfunc { args, .. } => {
                 for &arg in self.operands(args).to_vec().iter() {
                     self.assert_subtype(insn_id, arg, types::BasicObject)?;
                 }
                 Ok(())
             }
             // Instructions with a Vec of Ruby objects
-            Insn::InvokeBlockIfunc { ref args, .. }
-            | Insn::NewArray { elements: ref args, .. }
+            Insn::NewArray { elements: ref args, .. }
             | Insn::ArrayHash { elements: ref args, .. }
             | Insn::ArrayMin { elements: ref args, .. }
             | Insn::ArrayMax { elements: ref args, .. } => {
@@ -9049,7 +9050,7 @@ fn add_iseq_to_hir(
                         let ifunc_result = fun.push_insn(ifunc_block, Insn::InvokeBlockIfunc {
                             cd,
                             block_handler,
-                            args: args.clone(),
+                            args: fun.push_operands(&args),
                             state: exit_id,
                         });
                         fun.push_insn(ifunc_block, Insn::Jump(Box::new(BranchEdge { target: join_block, args: vec![ifunc_result] })));

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -943,6 +943,17 @@ pub struct CCallVariadicData {
     pub block: Option<BlockHandler>,
 }
 
+/// Cold metadata of [`Insn::CCall`]. Boxed in the enum to keep `Insn` small;
+/// the operands (`recv`, `args`) stay inline for fast traversal.
+#[derive(Debug, Clone)]
+pub struct CCallData {
+    pub cfunc: *const u8,
+    pub name: ID,
+    pub owner: VALUE,
+    pub return_type: Type,
+    pub elidable: bool,
+}
+
 /// An instruction in the SSA IR. The output of an instruction is referred to by the index of
 /// the instruction ([`InsnId`]). SSA form enables this, and [`UnionFind`] ([`Function::find`])
 /// helps with editing.
@@ -1113,7 +1124,7 @@ pub enum Insn {
 
     /// Call a C function without pushing a frame
     /// `name` and `owner` are for printing purposes only
-    CCall { cfunc: *const u8, recv: InsnId, args: InsnIdList, name: ID, owner: VALUE, return_type: Type, elidable: bool },
+    CCall { recv: InsnId, args: InsnIdList, data: Box<CCallData> },
 
     /// Call a C function that pushes a frame
     CCallWithFrame(Box<CCallWithFrameData>),
@@ -1792,8 +1803,8 @@ impl Insn {
             Insn::Snapshot { .. } => effects::Empty,
             Insn::Jump(_) => effects::Any,
             Insn::CondBranch { .. } => effects::Any,
-            Insn::CCall { elidable, .. } => {
-                if *elidable {
+            Insn::CCall { data, .. } => {
+                if data.elidable {
                     Effect::write(abstract_heaps::Allocator)
                 }
                 else {
@@ -2303,7 +2314,8 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
             Insn::GetConstantPath { ic, .. } => { write!(f, "GetConstantPath {:p}", self.ptr_map.map_ptr(ic)) },
             Insn::IsBlockGiven { lep } => { write!(f, "IsBlockGiven {lep}") },
             Insn::FixnumBitCheck {val, index} => { write!(f, "FixnumBitCheck {val}, {index}") },
-            Insn::CCall { cfunc, recv, args, name, owner, return_type: _, elidable: _ } => {
+            Insn::CCall { recv, args, data } => {
+                let CCallData { cfunc, name, owner, .. } = &**data;
                 let display_name = if *owner == Qnil { name.contents_lossy().to_string() } else { qualified_method_name(*owner, *name) };
                 write!(f, "CCall {recv}, :{}@{:p}", display_name, self.ptr_map.map_ptr(cfunc))?;
                 let args = self.pool.map_or(&[][..], |pool| pool.get(*args));
@@ -3182,7 +3194,7 @@ impl Function {
             Insn::ObjectAlloc { .. } => types::HeapBasicObject,
             Insn::ObjectAllocClass { class, .. } => Type::from_class(*class),
             Insn::CCallWithFrame(insn) => insn.return_type,
-            Insn::CCall { return_type, .. } => *return_type,
+            Insn::CCall { data, .. } => data.return_type,
             Insn::CCallVariadic(insn) => insn.return_type,
             Insn::CheckMatch { .. } => types::BasicObject,
             Insn::GuardType { val, guard_type, .. } => self.type_of(*val).intersection(*guard_type),
@@ -4438,7 +4450,7 @@ impl Function {
                                     // Filter for a leaf and GC free function
                                     let ccall = if props.leaf && props.no_gc {
                                         self.count(block, Counter::inline_cfunc_optimized_send_count);
-                                        self.push_insn(block, Insn::CCall { cfunc: cfunc_ptr, recv, args: self.push_operands(&args), name, owner, return_type, elidable })
+                                        self.push_insn(block, Insn::CCall { recv, args: self.push_operands(&args), data: Box::new(CCallData { cfunc: cfunc_ptr, name, owner, return_type, elidable }) })
                                     } else {
                                         if get_option!(stats) {
                                             self.count_not_inlined_cfunc(block, super_cme);
@@ -4488,7 +4500,7 @@ impl Function {
                                     // Filter for a leaf and GC free function
                                     let ccall = if props.leaf && props.no_gc {
                                         self.count(block, Counter::inline_cfunc_optimized_send_count);
-                                        self.push_insn(block, Insn::CCall { cfunc: cfunc_ptr, recv, args: self.push_operands(&args), name, owner, return_type, elidable })
+                                        self.push_insn(block, Insn::CCall { recv, args: self.push_operands(&args), data: Box::new(CCallData { cfunc: cfunc_ptr, name, owner, return_type, elidable }) })
                                     } else {
                                         if get_option!(stats) {
                                             self.count_not_inlined_cfunc(block, super_cme);
@@ -4913,13 +4925,15 @@ impl Function {
         // getinstancevariable does assume_single_ractor_mode()
         let ivar_index_insn = self.push_insn(block, Insn::Const { val: Const::CAttrIndex(ivar_index) });
         self.push_insn(block, Insn::CCall {
-            cfunc: rb_ivar_get_at_no_ractor_check as *const u8,
             recv,
             args: self.push_operands(&[ivar_index_insn]),
-            name: ID!(rb_ivar_get_at_no_ractor_check),
-            owner: Qnil,
-            return_type: types::BasicObject,
-            elidable: true })
+            data: Box::new(CCallData {
+                cfunc: rb_ivar_get_at_no_ractor_check as *const u8,
+                name: ID!(rb_ivar_get_at_no_ractor_check),
+                owner: Qnil,
+                return_type: types::BasicObject,
+                elidable: true,
+            }) })
     }
 
     fn load_ivar_heap(&mut self, block: BlockId,  recv: InsnId, id: ID, ivar_index: attr_index_t) -> InsnId {
@@ -5306,7 +5320,7 @@ impl Function {
                         if props.leaf && props.no_gc {
                             fun.count(block, Counter::inline_cfunc_optimized_send_count);
                             let owner = unsafe { (*cme).owner };
-                            let ccall = fun.push_insn(block, Insn::CCall { cfunc: cfunc_ptr, recv, args: fun.push_operands(&args), name, owner, return_type, elidable });
+                            let ccall = fun.push_insn(block, Insn::CCall { recv, args: fun.push_operands(&args), data: Box::new(CCallData { cfunc: cfunc_ptr, name, owner, return_type, elidable }) });
                             fun.make_equal_to(send_insn_id, ccall);
                             return Ok(());
                         }
@@ -5372,7 +5386,7 @@ impl Function {
                         if props.leaf && props.no_gc {
                             fun.count(block, Counter::inline_cfunc_optimized_send_count);
                             let owner = unsafe { (*cme).owner };
-                            let ccall = fun.push_insn(block, Insn::CCall { cfunc: cfunc_ptr, recv, args: fun.push_operands(&args), name, owner, return_type, elidable });
+                            let ccall = fun.push_insn(block, Insn::CCall { recv, args: fun.push_operands(&args), data: Box::new(CCallData { cfunc: cfunc_ptr, name, owner, return_type, elidable }) });
                             fun.make_equal_to(send_insn_id, ccall);
                             return Ok(());
                         }
@@ -8451,13 +8465,15 @@ fn add_iseq_to_hir(
                             ProfiledBlockHandlerFamily::Proc => {
                                 let proc_val = fun.load_ep_env_field(unmodified_block, ep, FieldName::VM_ENV_DATA_INDEX_SPECVAL, VM_ENV_DATA_INDEX_SPECVAL, types::BasicObject);
                                 let is_proc = fun.push_insn(unmodified_block, Insn::CCall {
-                                    cfunc: rb_obj_is_proc as *const u8,
                                     recv: proc_val,
                                     args: InsnIdList::EMPTY,
-                                    name: ID!(rb_obj_is_proc),
-                                    owner: Qnil,
-                                    return_type: types::BasicObject,
-                                    elidable: true,
+                                    data: Box::new(CCallData {
+                                        cfunc: rb_obj_is_proc as *const u8,
+                                        name: ID!(rb_obj_is_proc),
+                                        owner: Qnil,
+                                        return_type: types::BasicObject,
+                                        elidable: true,
+                                    }),
                                 });
                                 fun.push_insn(unmodified_block, Insn::GuardBitEquals { val: is_proc, expected: Const::Value(Qtrue), reason: Box::new(SideExitReason::BlockParamProxyNotProc), state: exit_id, recompile: Some(Recompile) });
                                 let mut args = vec![proc_val];
@@ -8539,13 +8555,15 @@ fn add_iseq_to_hir(
 
                                         let proc_val = fun.load_ep_env_field(proc_check_block, ep, FieldName::VM_ENV_DATA_INDEX_SPECVAL, VM_ENV_DATA_INDEX_SPECVAL, types::BasicObject);
                                         let proc_result = fun.push_insn(proc_check_block, Insn::CCall {
-                                            cfunc: rb_obj_is_proc as *const u8,
                                             recv: proc_val,
                                             args: InsnIdList::EMPTY,
-                                            name: ID!(rb_obj_is_proc),
-                                            owner: Qnil,
-                                            return_type: types::BasicObject,
-                                            elidable: true,
+                                            data: Box::new(CCallData {
+                                                cfunc: rb_obj_is_proc as *const u8,
+                                                name: ID!(rb_obj_is_proc),
+                                                owner: Qnil,
+                                                return_type: types::BasicObject,
+                                                elidable: true,
+                                            }),
                                         });
                                         let true_val = fun.push_insn(proc_check_block, Insn::Const { val: Const::Value(Qtrue) });
                                         let is_proc = fun.push_insn(proc_check_block, Insn::IsBitEqual { left: proc_result, right: true_val });

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -993,7 +993,7 @@ pub enum Insn {
     ArrayMax { elements: Vec<InsnId>, state: InsnId },
     ArrayMin { elements: Vec<InsnId>, state: InsnId },
     ArrayInclude { elements: Vec<InsnId>, target: InsnId, state: InsnId },
-    ArrayPackBuffer { elements: Vec<InsnId>, fmt: InsnId, buffer: Option<InsnId>, state: InsnId },
+    ArrayPackBuffer { elements: InsnIdList, fmt: InsnId, buffer: Option<InsnId>, state: InsnId },
     DupArrayInclude { ary: VALUE, target: InsnId, state: InsnId },
     /// Extend `left` with the elements from `right`. `left` and `right` must both be `Array`.
     ArrayExtend { left: InsnId, right: InsnId, state: InsnId },
@@ -1348,7 +1348,7 @@ macro_rules! for_each_operand_impl {
                 $visit_one!(*state);
             }
             Insn::ArrayPackBuffer { elements, fmt, buffer, state, .. } => {
-                $visit_many!(elements);
+                $visit_list!(*elements);
                 $visit_one!(*fmt);
                 if let Some(buffer) = buffer {
                     $visit_one!(*buffer);
@@ -2050,6 +2050,7 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
                 write!(f, " | {target}")
             }
             Insn::ArrayPackBuffer { elements, fmt, buffer, .. } => {
+                let elements = self.pool.map_or(&[][..], |pool| pool.get(*elements));
                 write!(f, "ArrayPackBuffer ")?;
                 for element in elements {
                     write!(f, "{element}, ")?;
@@ -3046,7 +3047,7 @@ impl Function {
         // Operands stored in the operand pool (e.g. CCall/Send/PushInlineFrame/
         // SendForward/InvokeSuper/InvokeSuperForward args) are shared by handle with
         // the original insn. Duplicate the list so remapping below doesn't mutate the canonical entry.
-        if let Insn::CCall { args, .. } | Insn::Send { args, .. } | Insn::PushInlineFrame { args, .. } | Insn::SendForward { args, .. } | Insn::InvokeSuper { args, .. } | Insn::InvokeSuperForward { args, .. } | Insn::InvokeBuiltin { args, .. } = &mut result {
+        if let Insn::CCall { args, .. } | Insn::Send { args, .. } | Insn::PushInlineFrame { args, .. } | Insn::SendForward { args, .. } | Insn::InvokeSuper { args, .. } | Insn::InvokeSuperForward { args, .. } | Insn::InvokeBuiltin { args, .. } | Insn::ArrayPackBuffer { elements: args, .. } = &mut result {
             let dup = self.operand_pool.borrow().get(*args).to_vec();
             *args = self.operand_pool.borrow_mut().push(&dup);
         }
@@ -6634,12 +6635,12 @@ impl Function {
                 }
                 Ok(())
             }
-            Insn::ArrayPackBuffer { ref elements, fmt, buffer, .. } => {
+            Insn::ArrayPackBuffer { elements, fmt, buffer, .. } => {
                 self.assert_subtype(insn_id, fmt, types::BasicObject)?;
                 if let Some(buffer) = buffer {
                     self.assert_subtype(insn_id, buffer, types::BasicObject)?;
                 }
-                for &element in elements {
+                for &element in self.operands(elements).to_vec().iter() {
                     self.assert_subtype(insn_id, element, types::BasicObject)?;
                 }
                 Ok(())
@@ -7724,13 +7725,13 @@ fn add_iseq_to_hir(
                         VM_OPT_NEWARRAY_SEND_PACK => {
                             let fmt = state.stack_pop()?;
                             let elements = state.stack_pop_n(count - 1)?;
-                            (BOP_PACK, Insn::ArrayPackBuffer { elements, fmt, buffer: None, state: exit_id })
+                            (BOP_PACK, Insn::ArrayPackBuffer { elements: fun.push_operands(&elements), fmt, buffer: None, state: exit_id })
                         }
                         VM_OPT_NEWARRAY_SEND_PACK_BUFFER => {
                             let buffer = state.stack_pop()?;
                             let fmt = state.stack_pop()?;
                             let elements = state.stack_pop_n(count - 2)?;
-                            (BOP_PACK, Insn::ArrayPackBuffer { elements, fmt, buffer: Some(buffer), state: exit_id })
+                            (BOP_PACK, Insn::ArrayPackBuffer { elements: fun.push_operands(&elements), fmt, buffer: Some(buffer), state: exit_id })
                         }
                         _ => {
                             // Unknown opcode; side-exit into the interpreter

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -1136,7 +1136,7 @@ pub enum Insn {
         recv: InsnId,
         cd: *const rb_call_data,
         blockiseq: IseqPtr,
-        args: Vec<InsnId>,
+        args: InsnIdList,
         state: InsnId,
         reason: SendFallbackReason,
     },
@@ -1512,13 +1512,13 @@ macro_rules! for_each_operand_impl {
                 $visit_one!(*state);
             }
             Insn::Send { recv, args, state, .. }
-            | Insn::PushInlineFrame { recv, args, state, .. } => {
+            | Insn::PushInlineFrame { recv, args, state, .. }
+            | Insn::SendForward { recv, args, state, .. } => {
                 $visit_one!(*recv);
                 $visit_list!(*args);
                 $visit_one!(*state);
             }
-            Insn::SendForward { recv, args, state, .. }
-            | Insn::InvokeBuiltin { recv, args, state, .. }
+            Insn::InvokeBuiltin { recv, args, state, .. }
             | Insn::InvokeSuper { recv, args, state, .. }
             | Insn::InvokeSuperForward { recv, args, state, .. }
             | Insn::InvokeProc { recv, args, state, .. } => {
@@ -2157,6 +2157,7 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
             }
             Insn::SendForward { recv, cd, args, blockiseq, reason, .. } => {
                 write!(f, "SendForward {recv}, {:p}, :{}", self.ptr_map.map_ptr(blockiseq), ruby_call_method_name(*cd))?;
+                let args = self.pool.map_or(&[][..], |pool| pool.get(*args));
                 write_separated!(f, ", ", ", ", args);
                 write!(f, " # SendFallbackReason: {reason}")?;
                 Ok(())
@@ -3039,10 +3040,10 @@ impl Function {
         }
         let insn_id = find!(insn_id);
         let mut result = self.insns[insn_id.0].clone();
-        // Operands stored in the operand pool (e.g. CCall/Send/PushInlineFrame
-        // args) are shared by handle with the original insn. Duplicate the list
-        // so remapping below doesn't mutate the canonical entry.
-        if let Insn::CCall { args, .. } | Insn::Send { args, .. } | Insn::PushInlineFrame { args, .. } = &mut result {
+        // Operands stored in the operand pool (e.g. CCall/Send/PushInlineFrame/
+        // SendForward args) are shared by handle with the original insn. Duplicate
+        // the list so remapping below doesn't mutate the canonical entry.
+        if let Insn::CCall { args, .. } | Insn::Send { args, .. } | Insn::PushInlineFrame { args, .. } | Insn::SendForward { args, .. } = &mut result {
             let dup = self.operand_pool.borrow().get(*args).to_vec();
             *args = self.operand_pool.borrow_mut().push(&dup);
         }
@@ -6585,9 +6586,10 @@ impl Function {
                 self.assert_subtype(insn_id, klass, types::BasicObject)?;
                 self.assert_subtype(insn_id, allow_nil, types::BoolExact)
             }
-            // Send and PushInlineFrame keep their operands in the pool; resolve before checking.
+            // Send/PushInlineFrame/SendForward keep their operands in the pool; resolve before checking.
             Insn::Send { recv, args, .. }
-            | Insn::PushInlineFrame { recv, args, .. } => {
+            | Insn::PushInlineFrame { recv, args, .. }
+            | Insn::SendForward { recv, args, .. } => {
                 self.assert_subtype(insn_id, recv, types::BasicObject)?;
                 for &arg in self.operands(args).to_vec().iter() {
                     self.assert_subtype(insn_id, arg, types::BasicObject)?;
@@ -6595,8 +6597,7 @@ impl Function {
                 Ok(())
             }
             // Instructions with recv and a Vec of Ruby objects
-            Insn::SendForward { recv, ref args, .. }
-            | Insn::InvokeSuper { recv, ref args, .. }
+            Insn::InvokeSuper { recv, ref args, .. }
             | Insn::InvokeSuperForward { recv, ref args, .. }
             | Insn::InvokeBuiltin { recv, ref args, .. }
             | Insn::InvokeProc { recv, ref args, .. }
@@ -8864,7 +8865,7 @@ fn add_iseq_to_hir(
 
                     let args = state.stack_pop_n(argc as usize + usize::from(forwarding))?;
                     let recv = state.stack_pop()?;
-                    let send_forward = fun.push_insn(block, Insn::SendForward { recv, cd, blockiseq, args, state: exit_id, reason: SendForwardNotSpecialized });
+                    let send_forward = fun.push_insn(block, Insn::SendForward { recv, cd, blockiseq, args: fun.push_operands(&args), state: exit_id, reason: SendForwardNotSpecialized });
                     state.stack_push(send_forward);
 
                     if !blockiseq.is_null() {

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -983,7 +983,7 @@ pub enum Insn {
     /// Call `to_a` on `val` if the method is defined, or make a new array `[val]` otherwise. If we
     /// called `to_a`, duplicate the returned array.
     ToNewArray { val: InsnId, state: InsnId },
-    NewArray { elements: Vec<InsnId>, state: InsnId },
+    NewArray { elements: InsnIdList, state: InsnId },
     /// NewHash contains a vec of (key, value) pairs
     NewHash { elements: Vec<InsnId>, state: InsnId },
     NewRange { low: InsnId, high: InsnId, flag: RangeType, state: InsnId },
@@ -1337,9 +1337,12 @@ macro_rules! for_each_operand_impl {
             Insn::ArrayMax { elements, state, .. }
             | Insn::ArrayMin { elements, state, .. }
             | Insn::ArrayHash { elements, state, .. }
-            | Insn::NewHash { elements, state, .. }
-            | Insn::NewArray { elements, state, .. } => {
+            | Insn::NewHash { elements, state, .. } => {
                 $visit_many!(elements);
+                $visit_one!(*state);
+            }
+            Insn::NewArray { elements, state, .. } => {
+                $visit_list!(*elements);
                 $visit_one!(*state);
             }
             Insn::ArrayInclude { elements, target, state, .. } => {
@@ -1993,6 +1996,7 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
                 Ok(())
             }
             Insn::NewArray { elements, .. } => {
+                let elements = self.pool.map_or(&[][..], |pool| pool.get(*elements));
                 write!(f, "NewArray")?;
                 write_separated!(f, " ", ", ", elements);
                 Ok(())
@@ -6657,9 +6661,14 @@ impl Function {
                 }
                 Ok(())
             }
+            Insn::NewArray { elements, .. } => {
+                for &arg in self.operands(elements).to_vec().iter() {
+                    self.assert_subtype(insn_id, arg, types::BasicObject)?;
+                }
+                Ok(())
+            }
             // Instructions with a Vec of Ruby objects
-            Insn::NewArray { elements: ref args, .. }
-            | Insn::ArrayHash { elements: ref args, .. }
+            Insn::ArrayHash { elements: ref args, .. }
             | Insn::ArrayMin { elements: ref args, .. }
             | Insn::ArrayMax { elements: ref args, .. } => {
                 for &arg in args {
@@ -7709,7 +7718,7 @@ fn add_iseq_to_hir(
                 YARVINSN_newarray => {
                     let count = get_arg(pc, 0).as_usize();
                     let elements = state.stack_pop_n(count)?;
-                    state.stack_push(fun.push_insn(block, Insn::NewArray { elements, state: exit_id }));
+                    state.stack_push(fun.push_insn(block, Insn::NewArray { elements: fun.push_operands(&elements), state: exit_id }));
                 }
                 YARVINSN_opt_newarray_send => {
                     let count = get_arg(pc, 0).as_usize();
@@ -10303,7 +10312,7 @@ mod infer_tests {
     fn newarray() {
         let mut function = Function::new(std::ptr::null());
         // Fake FrameState index of 0usize
-        let val = function.push_insn(function.entry_block, Insn::NewArray { elements: vec![], state: InsnId(0usize) });
+        let val = function.push_insn(function.entry_block, Insn::NewArray { elements: InsnIdList::EMPTY, state: InsnId(0usize) });
         assert_bit_equal(function.infer_type(val), types::ArrayExact);
     }
 
@@ -10311,7 +10320,7 @@ mod infer_tests {
     fn arraydup() {
         let mut function = Function::new(std::ptr::null());
         // Fake FrameState index of 0usize
-        let arr = function.push_insn(function.entry_block, Insn::NewArray { elements: vec![], state: InsnId(0usize) });
+        let arr = function.push_insn(function.entry_block, Insn::NewArray { elements: InsnIdList::EMPTY, state: InsnId(0usize) });
         let val = function.push_insn(function.entry_block, Insn::ArrayDup { val: arr, state: InsnId(0usize) });
         assert_bit_equal(function.infer_type(val), types::ArrayExact);
     }

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -1194,15 +1194,15 @@ pub enum Insn {
     /// Side-exit if val doesn't have the expected type.
     GuardType { val: InsnId, guard_type: Type, state: InsnId, recompile: Option<Recompile> },
     /// Side-exit if val is not the expected Const.
-    GuardBitEquals { val: InsnId, expected: Const, reason: SideExitReason, state: InsnId, recompile: Option<Recompile> },
+    GuardBitEquals { val: InsnId, expected: Const, reason: Box<SideExitReason>, state: InsnId, recompile: Option<Recompile> },
     /// Side-exit if (val & mask) == 0
-    GuardAnyBitSet { val: InsnId, mask: Const, mask_name: Option<ID>, reason: SideExitReason, state: InsnId, recompile: Option<Recompile> },
+    GuardAnyBitSet { val: InsnId, mask: Const, mask_name: Option<ID>, reason: Box<SideExitReason>, state: InsnId, recompile: Option<Recompile> },
     /// Side-exit if (val & mask) != 0
-    GuardNoBitsSet { val: InsnId, mask: Const, mask_name: Option<ID>, reason: SideExitReason, state: InsnId },
+    GuardNoBitsSet { val: InsnId, mask: Const, mask_name: Option<ID>, reason: Box<SideExitReason>, state: InsnId },
     /// Side-exit if left is not greater than or equal to right (both operands are C long).
-    GuardGreaterEq { left: InsnId, right: InsnId, reason: SideExitReason, state: InsnId },
+    GuardGreaterEq { left: InsnId, right: InsnId, reason: Box<SideExitReason>, state: InsnId },
     /// Side-exit if left is not less than right (both operands are C long).
-    GuardLess { left: InsnId, right: InsnId, reason: SideExitReason, state: InsnId },
+    GuardLess { left: InsnId, right: InsnId, reason: Box<SideExitReason>, state: InsnId },
 
     /// Generate no code (or padding if necessary) and insert a patch point
     /// that can be rewritten to a side exit when the Invariant is broken.
@@ -1211,7 +1211,7 @@ pub enum Insn {
     /// Side-exit into the interpreter.
     /// If recompile is not None, the side exit will profile and invalidate the ISEQ
     /// so that it gets recompiled with the new profile data.
-    SideExit { state: InsnId, reason: SideExitReason, recompile: Option<Recompile> },
+    SideExit { state: InsnId, reason: Box<SideExitReason>, recompile: Option<Recompile> },
 
     /// Increment a counter in ZJIT stats
     IncrCounter(Counter),
@@ -2912,7 +2912,7 @@ impl Function {
         if self.assume_bop_not_redefined(block, klass, bop, state) {
             return true;
         }
-        self.push_insn(block, Insn::SideExit { state, reason: SideExitReason::PatchPoint(Invariant::BOPRedefined { klass, bop }), recompile: None });
+        self.push_insn(block, Insn::SideExit { state, reason: Box::new(SideExitReason::PatchPoint(Invariant::BOPRedefined { klass, bop })), recompile: None });
         false
     }
 
@@ -3646,12 +3646,12 @@ impl Function {
 
     pub fn guard_not_frozen(&mut self, block: BlockId, recv: InsnId, state: InsnId) {
         let flags = self.load_rbasic_flags(block, recv);
-        self.push_insn(block, Insn::GuardNoBitsSet { val: flags, mask: Const::CUInt64(RUBY_FL_FREEZE as u64), mask_name: Some(ID!(RUBY_FL_FREEZE)), reason: SideExitReason::GuardNotFrozen, state });
+        self.push_insn(block, Insn::GuardNoBitsSet { val: flags, mask: Const::CUInt64(RUBY_FL_FREEZE as u64), mask_name: Some(ID!(RUBY_FL_FREEZE)), reason: Box::new(SideExitReason::GuardNotFrozen), state });
     }
 
     pub fn guard_not_shared(&mut self, block: BlockId, recv: InsnId, state: InsnId) {
         let flags = self.load_rbasic_flags(block, recv);
-        self.push_insn(block, Insn::GuardNoBitsSet { val: flags, mask: Const::CUInt64(RUBY_ELTS_SHARED as u64), mask_name: Some(ID!(RUBY_ELTS_SHARED)), reason: SideExitReason::GuardNotShared, state });
+        self.push_insn(block, Insn::GuardNoBitsSet { val: flags, mask: Const::CUInt64(RUBY_ELTS_SHARED as u64), mask_name: Some(ID!(RUBY_ELTS_SHARED)), reason: Box::new(SideExitReason::GuardNotShared), state });
     }
 
     /// `iseq` is the ISEQ that `ep_offset` is relative to, which is the ISEQ that
@@ -4135,13 +4135,13 @@ impl Function {
                             // Load ep[VM_ENV_DATA_INDEX_ME_CREF]
                             let method_entry = fun.push_insn(block, Insn::LoadField { recv: lep, id: FieldName::VM_ENV_DATA_INDEX_ME_CREF, offset: SIZEOF_VALUE_I32 * VM_ENV_DATA_INDEX_ME_CREF, return_type: types::RubyValue });
                             // Guard that it matches the expected CME
-                            fun.push_insn(block, Insn::GuardBitEquals { val: method_entry, expected: Const::Value(current_cme.into()), reason: SideExitReason::GuardSuperMethodEntry, state, recompile: None });
+                            fun.push_insn(block, Insn::GuardBitEquals { val: method_entry, expected: Const::Value(current_cme.into()), reason: Box::new(SideExitReason::GuardSuperMethodEntry), state, recompile: None });
 
                             let block_handler = fun.push_insn(block, Insn::LoadField { recv: lep, id: FieldName::VM_ENV_DATA_INDEX_SPECVAL, offset: SIZEOF_VALUE_I32 * VM_ENV_DATA_INDEX_SPECVAL, return_type: types::RubyValue });
                             fun.push_insn(block, Insn::GuardBitEquals {
                                 val: block_handler,
                                 expected: Const::Value(VALUE(VM_BLOCK_HANDLER_NONE as usize)),
-                                reason: SideExitReason::UnhandledBlockArg,
+                                reason: Box::new(SideExitReason::UnhandledBlockArg),
                                 state,
                                 recompile: None,
                             });
@@ -4773,7 +4773,7 @@ impl Function {
         self.push_insn(block, Insn::GuardBitEquals {
             val,
             expected: Const::CShape(expected),
-            reason: SideExitReason::GuardShape(expected),
+            reason: Box::new(SideExitReason::GuardShape(expected)),
             state,
             recompile,
         })
@@ -5335,7 +5335,7 @@ impl Function {
             for insn_id in old_insns {
                 match self.find(insn_id) {
                     Insn::Send { state, reason: SendFallbackReason::SendWithoutBlockNoProfiles | SendFallbackReason::SendNoProfiles, .. } => {
-                        self.push_insn(block, Insn::SideExit { state, reason: SideExitReason::NoProfileSend, recompile: Some(Recompile) });
+                        self.push_insn(block, Insn::SideExit { state, reason: Box::new(SideExitReason::NoProfileSend), recompile: Some(Recompile) });
                         // SideExit is a terminator; don't add remaining instructions
                         break;
                     }
@@ -5513,7 +5513,7 @@ impl Function {
                         // pass. Every execution would side-exit here, so we replace the guard with an
                         // unconditional exit. The terminator handling below then drops the rest of
                         // the block, which is now unreachable.
-                        self.new_insn(Insn::SideExit { state, reason: SideExitReason::GuardType(guard_type), recompile })
+                        self.new_insn(Insn::SideExit { state, reason: Box::new(SideExitReason::GuardType(guard_type)), recompile })
                     }
                     Insn::GuardType { val, guard_type, .. } if self.is_a(val, guard_type) => {
                         self.make_equal_to(insn_id, val);
@@ -7614,7 +7614,7 @@ fn add_iseq_to_hir(
                         }
                         _ => {
                             // Unknown opcode; side-exit into the interpreter
-                            fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledNewarraySend(method), recompile: None });
+                            fun.push_insn(block, Insn::SideExit { state: exit_id, reason: Box::new(SideExitReason::UnhandledNewarraySend(method)), recompile: None });
                             break;  // End the block
                         }
                     };
@@ -7640,7 +7640,7 @@ fn add_iseq_to_hir(
                     let bop = match method_id {
                         x if x == ID!(include_p).0 => BOP_INCLUDE_P,
                         _ => {
-                            fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledDuparraySend(method_id), recompile: None });
+                            fun.push_insn(block, Insn::SideExit { state: exit_id, reason: Box::new(SideExitReason::UnhandledDuparraySend(method_id)), recompile: None });
                             break;
                         },
                     };
@@ -7687,11 +7687,11 @@ fn add_iseq_to_hir(
                         .and_then(|types| types.first())
                         .map(|dist| TypeDistributionSummary::new(dist));
                     let Some(summary) = summary else {
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::SplatKwNotProfiled, recompile: None });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: Box::new(SideExitReason::SplatKwNotProfiled), recompile: None });
                         break;  // End the block
                     };
                     if !summary.is_monomorphic() {
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::SplatKwPolymorphic, recompile: None });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: Box::new(SideExitReason::SplatKwPolymorphic), recompile: None });
                         break;  // End the block
                     }
                     let ty = Type::from_profiled_type(summary.bucket(0));
@@ -7700,7 +7700,7 @@ fn add_iseq_to_hir(
                     } else if ty.is_subtype(types::HashExact) {
                         fun.push_insn(block, Insn::GuardType { val: hash, guard_type: types::HashExact, state: exit_id, recompile: None })
                     } else {
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::SplatKwNotNilOrHash, recompile: None });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: Box::new(SideExitReason::SplatKwNotNilOrHash), recompile: None });
                         break;  // End the block
                     };
                     state.stack_push(obj);
@@ -7846,7 +7846,7 @@ fn add_iseq_to_hir(
                     // This can only happen in iseqs taking more than 32 keywords.
                     // In this case, we side exit to the interpreter.
                     if unsafe {(*rb_get_iseq_body_param_keyword(iseq)).num >= VM_KW_SPECIFIED_BITS_MAX.try_into().unwrap()} {
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::TooManyKeywordParameters, recompile: None });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: Box::new(SideExitReason::TooManyKeywordParameters), recompile: None });
                         break;
                     }
                     let ep_offset = get_arg(pc, 0).as_u32();
@@ -8243,7 +8243,7 @@ fn add_iseq_to_hir(
                             // So to check for either of those cases we can use: val & 0x1 == 0x1
 
                             // Bail out if the block handler is neither ISEQ nor ifunc
-                            fun.push_insn(unmodified_block, Insn::GuardAnyBitSet { val: block_handler, mask: Const::CUInt64(0x1), mask_name: None, reason: SideExitReason::BlockParamProxyFallbackMiss, state: exit_id, recompile: Some(Recompile) });
+                            fun.push_insn(unmodified_block, Insn::GuardAnyBitSet { val: block_handler, mask: Const::CUInt64(0x1), mask_name: None, reason: Box::new(SideExitReason::BlockParamProxyFallbackMiss), state: exit_id, recompile: Some(Recompile) });
                             // TODO(Shopify/ruby#753): GC root, so we should be able to avoid unnecessary GC tracing
                             let proxy_val = fun.push_insn(unmodified_block, Insn::Const { val: Const::Value(unsafe { rb_block_param_proxy }) });
                             let mut args = vec![proxy_val];
@@ -8256,7 +8256,7 @@ fn add_iseq_to_hir(
                         [profiled_handler] => match profiled_handler {
                             ProfiledBlockHandlerFamily::Nil => {
                                 let block_handler = fun.load_ep_env_field(unmodified_block, ep, FieldName::VM_ENV_DATA_INDEX_SPECVAL, VM_ENV_DATA_INDEX_SPECVAL, types::CInt64);
-                                fun.push_insn(unmodified_block, Insn::GuardBitEquals { val: block_handler, expected: Const::CInt64(VM_BLOCK_HANDLER_NONE.into()), reason: SideExitReason::BlockParamProxyNotNil, state: exit_id, recompile: Some(Recompile) });
+                                fun.push_insn(unmodified_block, Insn::GuardBitEquals { val: block_handler, expected: Const::CInt64(VM_BLOCK_HANDLER_NONE.into()), reason: Box::new(SideExitReason::BlockParamProxyNotNil), state: exit_id, recompile: Some(Recompile) });
                                 let nil_val = fun.push_insn(unmodified_block, Insn::Const { val: Const::Value(Qnil) });
                                 let mut args = vec![nil_val];
                                 if let Some(local) = original_local {
@@ -8273,7 +8273,7 @@ fn add_iseq_to_hir(
                                 // So to check for either of those cases we can use: val & 0x1 == 0x1
 
                                 // Bail out if the block handler is neither ISEQ nor ifunc
-                                fun.push_insn(unmodified_block, Insn::GuardAnyBitSet { val: block_handler, mask: Const::CUInt64(0x1), mask_name: None, reason: SideExitReason::BlockParamProxyNotIseqOrIfunc, state: exit_id, recompile: Some(Recompile) });
+                                fun.push_insn(unmodified_block, Insn::GuardAnyBitSet { val: block_handler, mask: Const::CUInt64(0x1), mask_name: None, reason: Box::new(SideExitReason::BlockParamProxyNotIseqOrIfunc), state: exit_id, recompile: Some(Recompile) });
                                 // TODO(Shopify/ruby#753): GC root, so we should be able to avoid unnecessary GC tracing
                                 let proxy_val = fun.push_insn(unmodified_block, Insn::Const { val: Const::Value(unsafe { rb_block_param_proxy }) });
                                 let mut args = vec![proxy_val];
@@ -8293,7 +8293,7 @@ fn add_iseq_to_hir(
                                     return_type: types::BasicObject,
                                     elidable: true,
                                 });
-                                fun.push_insn(unmodified_block, Insn::GuardBitEquals { val: is_proc, expected: Const::Value(Qtrue), reason: SideExitReason::BlockParamProxyNotProc, state: exit_id, recompile: Some(Recompile) });
+                                fun.push_insn(unmodified_block, Insn::GuardBitEquals { val: is_proc, expected: Const::Value(Qtrue), reason: Box::new(SideExitReason::BlockParamProxyNotProc), state: exit_id, recompile: Some(Recompile) });
                                 let mut args = vec![proc_val];
                                 if let Some(local) = original_local {
                                     args.push(local);
@@ -8397,7 +8397,7 @@ fn add_iseq_to_hir(
                                 }
                             }
 
-                            fun.push_insn(current_block, Insn::SideExit { state: exit_id, reason: SideExitReason::BlockParamProxyProfileNotCovered, recompile: None });
+                            fun.push_insn(current_block, Insn::SideExit { state: exit_id, reason: Box::new(SideExitReason::BlockParamProxyProfileNotCovered), recompile: None });
                         }
                     }
 
@@ -8490,7 +8490,7 @@ fn add_iseq_to_hir(
                     let flags = unsafe { rb_vm_ci_flag(call_info) };
                     if let Err(call_type) = unhandled_call_type(flags) {
                         // Can't handle the call type; side-exit into the interpreter
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledCallType(call_type), recompile: None });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: Box::new(SideExitReason::UnhandledCallType(call_type)), recompile: None });
                         break;  // End the block
                     }
                     let argc = crate::profile::num_arguments_on_stack(cd);
@@ -8498,7 +8498,7 @@ fn add_iseq_to_hir(
 
                     // Side-exit send fallbacks while tracing to avoid FLAG_FINISH breaking throw TAG_RETURN semantics
                     if unsafe { rb_zjit_iseq_tracing_currently_enabled() } {
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::SendWhileTracing, recompile: None });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: Box::new(SideExitReason::SendWhileTracing), recompile: None });
                         break;
                     }
                     let args = state.stack_pop_n(argc as usize)?;
@@ -8589,7 +8589,7 @@ fn add_iseq_to_hir(
                     let flags = unsafe { rb_vm_ci_flag(call_info) };
                     if let Err(call_type) = unhandled_call_type(flags) {
                         // Can't handle tailcall; side-exit into the interpreter
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledCallType(call_type), recompile: None });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: Box::new(SideExitReason::UnhandledCallType(call_type)), recompile: None });
                         break;  // End the block
                     }
                     let argc = crate::profile::num_arguments_on_stack(cd);
@@ -8606,7 +8606,7 @@ fn add_iseq_to_hir(
                         if mid == ID!(induce_side_exit_bang)
                             && state::zjit_module_method_match_serial(ID!(induce_side_exit_bang), &state::INDUCE_SIDE_EXIT_SERIAL)
                         {
-                            fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::DirectiveInduced, recompile: None });
+                            fun.push_insn(block, Insn::SideExit { state: exit_id, reason: Box::new(SideExitReason::DirectiveInduced), recompile: None });
                             break;  // End the block
                         }
                         if mid == ID!(induce_compile_failure_bang)
@@ -8625,7 +8625,7 @@ fn add_iseq_to_hir(
 
                     // Side-exit send fallbacks while tracing to avoid FLAG_FINISH breaking throw TAG_RETURN semantics
                     if unsafe { rb_zjit_iseq_tracing_currently_enabled() } {
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::SendWhileTracing, recompile: None });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: Box::new(SideExitReason::SendWhileTracing), recompile: None });
                         break;
                     }
 
@@ -8683,12 +8683,12 @@ fn add_iseq_to_hir(
                     let flags = unsafe { rb_vm_ci_flag(call_info) };
                     if let Err(call_type) = unhandled_call_type(flags) {
                         // Can't handle tailcall; side-exit into the interpreter
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledCallType(call_type), recompile: None });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: Box::new(SideExitReason::UnhandledCallType(call_type)), recompile: None });
                         break;  // End the block
                     }
                     // Side-exit send fallbacks while tracing to avoid FLAG_FINISH breaking throw TAG_RETURN semantics
                     if unsafe { rb_zjit_iseq_tracing_currently_enabled() } {
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::SendWhileTracing, recompile: None });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: Box::new(SideExitReason::SendWhileTracing), recompile: None });
                         break;
                     }
                     let block_arg = (flags & VM_CALL_ARGS_BLOCKARG) != 0;
@@ -8738,12 +8738,12 @@ fn add_iseq_to_hir(
                     let forwarding = (flags & VM_CALL_FORWARDING) != 0;
                     if let Err(call_type) = unhandled_call_type(flags) {
                         // Can't handle the call type; side-exit into the interpreter
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledCallType(call_type), recompile: None });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: Box::new(SideExitReason::UnhandledCallType(call_type)), recompile: None });
                         break;  // End the block
                     }
                     // Side-exit send fallbacks while tracing to avoid FLAG_FINISH breaking throw TAG_RETURN semantics
                     if unsafe { rb_zjit_iseq_tracing_currently_enabled() } {
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::SendWhileTracing, recompile: None });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: Box::new(SideExitReason::SendWhileTracing), recompile: None });
                         break;
                     }
                     let argc = unsafe { vm_ci_argc((*cd).ci) };
@@ -8782,12 +8782,12 @@ fn add_iseq_to_hir(
                     let flags = unsafe { rb_vm_ci_flag(call_info) };
                     if let Err(call_type) = unhandled_call_type(flags) {
                         // Can't handle tailcall; side-exit into the interpreter
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledCallType(call_type), recompile: None });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: Box::new(SideExitReason::UnhandledCallType(call_type)), recompile: None });
                         break;  // End the block
                     }
                     // Side-exit send fallbacks while tracing to avoid FLAG_FINISH breaking throw TAG_RETURN semantics
                     if unsafe { rb_zjit_iseq_tracing_currently_enabled() } {
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::SendWhileTracing, recompile: None });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: Box::new(SideExitReason::SendWhileTracing), recompile: None });
                         break;
                     }
                     let args = state.stack_pop_n(crate::profile::num_arguments_on_stack(cd))?;
@@ -8829,12 +8829,12 @@ fn add_iseq_to_hir(
                     let forwarding = (flags & VM_CALL_FORWARDING) != 0;
                     if let Err(call_type) = unhandled_call_type(flags) {
                         // Can't handle tailcall; side-exit into the interpreter
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledCallType(call_type), recompile: None });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: Box::new(SideExitReason::UnhandledCallType(call_type)), recompile: None });
                         break;  // End the block
                     }
                     // Side-exit send fallbacks while tracing to avoid FLAG_FINISH breaking throw TAG_RETURN semantics
                     if unsafe { rb_zjit_iseq_tracing_currently_enabled() } {
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::SendWhileTracing, recompile: None });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: Box::new(SideExitReason::SendWhileTracing), recompile: None });
                         break;
                     }
                     let argc = unsafe { vm_ci_argc((*cd).ci) };
@@ -8874,12 +8874,12 @@ fn add_iseq_to_hir(
                     let flags = unsafe { rb_vm_ci_flag(call_info) };
                     if let Err(call_type) = unhandled_call_type(flags) {
                         // Can't handle tailcall; side-exit into the interpreter
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledCallType(call_type), recompile: None });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: Box::new(SideExitReason::UnhandledCallType(call_type)), recompile: None });
                         break;  // End the block
                     }
                     // Side-exit send fallbacks while tracing to avoid FLAG_FINISH breaking throw TAG_RETURN semantics
                     if unsafe { rb_zjit_iseq_tracing_currently_enabled() } {
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::SendWhileTracing, recompile: None });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: Box::new(SideExitReason::SendWhileTracing), recompile: None });
                         break;
                     }
                     let args = state.stack_pop_n(crate::profile::num_arguments_on_stack(cd))?;
@@ -8965,7 +8965,7 @@ fn add_iseq_to_hir(
                     // TODO: We only really need this if self_val is a class/module
                     if !fun.assume_single_ractor_mode(block, exit_id) {
                         // gen_getivar assumes single Ractor; side-exit into the interpreter
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledYARVInsn(opcode), recompile: None });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: Box::new(SideExitReason::UnhandledYARVInsn(opcode)), recompile: None });
                         break;  // End the block
                     }
                     if let Some(summary) = fun.polymorphic_summary(&profiles, self_param, exit_id) {
@@ -9038,7 +9038,7 @@ fn add_iseq_to_hir(
                     // TODO: We only really need this if self_val is a class/module
                     if !fun.assume_single_ractor_mode(block, exit_id) {
                         // gen_setivar assumes single Ractor; side-exit into the interpreter
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledYARVInsn(opcode), recompile: None });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: Box::new(SideExitReason::UnhandledYARVInsn(opcode)), recompile: None });
                         break;  // End the block
                     }
                     let val = state.stack_pop()?;
@@ -9090,7 +9090,7 @@ fn add_iseq_to_hir(
                     // TODO: Support passing arguments on the stack in C calls
                     // +2 for ec, self
                     if (unsafe { (*bf).argc } + 2) as usize > C_ARG_OPNDS.len() {
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::TooManyArgsForLir, recompile: None });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: Box::new(SideExitReason::TooManyArgsForLir), recompile: None });
                         break; // End the block
                     }
 
@@ -9125,7 +9125,7 @@ fn add_iseq_to_hir(
                     // +2 for ec, self
                     let argc = unsafe { (*bf).argc } as usize;
                     if argc + 2 > C_ARG_OPNDS.len() {
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::TooManyArgsForLir, recompile: None });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: Box::new(SideExitReason::TooManyArgsForLir), recompile: None });
                         break; // End the block
                     }
 
@@ -9204,7 +9204,7 @@ fn add_iseq_to_hir(
 
                     if svar == 0 {
                         // TODO: Handle non-backref
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnknownSpecialVariable(key), recompile: None });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: Box::new(SideExitReason::UnknownSpecialVariable(key)), recompile: None });
                         // End the block
                         break;
                     } else if svar & 0x01 != 0 {
@@ -9227,14 +9227,14 @@ fn add_iseq_to_hir(
                         // (reverse?)
                         //
                         // Unhandled opcode; side-exit into the interpreter
-                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledYARVInsn(opcode), recompile: None });
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: Box::new(SideExitReason::UnhandledYARVInsn(opcode)), recompile: None });
                         break;  // End the block
                     }
                     let val = state.stack_pop()?;
                     let array = fun.push_insn(block, Insn::GuardType { val, guard_type: types::ArrayExact, state: exit_id, recompile: None });
                     let length = fun.push_insn(block, Insn::ArrayLength { array });
                     let expected = fun.push_insn(block, Insn::Const { val: Const::CInt64(num as i64) });
-                    fun.push_insn(block, Insn::GuardGreaterEq { left: length, right: expected, reason: SideExitReason::ExpandArray, state: exit_id });
+                    fun.push_insn(block, Insn::GuardGreaterEq { left: length, right: expected, reason: Box::new(SideExitReason::ExpandArray), state: exit_id });
                     for i in (0..num).rev() {
                         // We do not emit a length guard here because in-bounds is already
                         // ensured by the expandarray length check above.
@@ -9245,7 +9245,7 @@ fn add_iseq_to_hir(
                 }
                 _ => {
                     // Unhandled opcode; side-exit into the interpreter
-                    fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledYARVInsn(opcode), recompile: None });
+                    fun.push_insn(block, Insn::SideExit { state: exit_id, reason: Box::new(SideExitReason::UnhandledYARVInsn(opcode)), recompile: None });
                     break;  // End the block
                 }
             }

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -1046,10 +1046,10 @@ pub enum Insn {
     Snapshot { state: Box<FrameState> },
 
     /// Unconditional jump
-    Jump(BranchEdge),
+    Jump(Box<BranchEdge>),
 
     /// Conditional branch
-    CondBranch { val: InsnId, if_true: BranchEdge, if_false: BranchEdge },
+    CondBranch { val: InsnId, if_true: Box<BranchEdge>, if_false: Box<BranchEdge> },
 
     /// Call a C function without pushing a frame
     /// `name` and `owner` are for printing purposes only
@@ -1405,13 +1405,13 @@ macro_rules! for_each_operand_impl {
                 $visit_one!(*left);
                 $visit_one!(*right);
             }
-            Insn::Jump(BranchEdge { args, .. }) => {
-                $visit_many!(args);
+            Insn::Jump(edge) => {
+                $visit_many!(edge.args);
             }
-            Insn::CondBranch { val, if_true: BranchEdge { args: true_args, .. }, if_false: BranchEdge { args: false_args, .. } } => {
+            Insn::CondBranch { val, if_true, if_false } => {
                 $visit_one!(*val);
-                $visit_many!(true_args);
-                $visit_many!(false_args);
+                $visit_many!(if_true.args);
+                $visit_many!(if_false.args);
             }
             Insn::ArrayDup { val, state }
             | Insn::Throw { val, state, .. }
@@ -3236,9 +3236,10 @@ impl Function {
                             }
                             continue;
                         }
-                        &Insn::Jump(BranchEdge { target, ref args }) => {
+                        Insn::Jump(edge) => {
+                            let target = edge.target;
                             reachable.insert(target);
-                            let arg_types: Vec<Type> = args.iter().map(|a| self.type_of(*a)).collect();
+                            let arg_types: Vec<Type> = edge.args.iter().map(|a| self.type_of(*a)).collect();
                             for (idx, arg_type) in arg_types.into_iter().enumerate() {
                                 let param = self.blocks[target.0].params[idx];
                                 changed |= set_type!(param, self.type_of(param).union(arg_type));
@@ -4729,10 +4730,10 @@ impl Function {
                     iseq, cme, recv, args: args.clone(), blockiseq, state,
                 });
                 self.count(block, Counter::inline_iseq_optimized_send_count);
-                self.push_insn(block, Insn::Jump(BranchEdge {
+                self.push_insn(block, Insn::Jump(Box::new(BranchEdge {
                     target: callee_entry_body_block,
                     args: vec![],
-                }));
+                })));
 
                 // Append the callee's profile entries. The callee body was emitted directly into
                 // this Function, so its Snapshot and operand InsnIds already live in caller space.
@@ -5852,8 +5853,9 @@ impl Function {
     fn absorb_dst_block(&mut self, num_in_edges: &[u32], block: BlockId) -> bool {
         let Some(terminator_id) = self.blocks[block.0].insns.last()
             else { return false };
-        let Insn::Jump(BranchEdge { target, args }) = self.find(*terminator_id)
+        let Insn::Jump(edge) = self.find(*terminator_id)
             else { return false };
+        let BranchEdge { target, args } = *edge;
         if target == block {
             // Can't absorb self
             return false;
@@ -7797,12 +7799,12 @@ fn add_iseq_to_hir(
                             let expected_shape = fun.push_insn(block, Insn::Const { val: Const::CShape(profiled_shape) });
                             let has_shape = fun.push_insn(block, Insn::IsBitEqual { left: actual_shape, right: expected_shape });
                             let iftrue_block = fun.new_block(insn_idx);
-                            let target = BranchEdge { target: iftrue_block, args: vec![] };
+                            let target = Box::new(BranchEdge { target: iftrue_block, args: vec![] });
                             let fall_through = fun.new_block(insn_idx);
 
                             fun.push_insn(block, Insn::CondBranch { val: has_shape,
                                 if_true: target,
-                                if_false: BranchEdge { target: fall_through, args: vec![] }
+                                if_false: Box::new(BranchEdge { target: fall_through, args: vec![] })
                             });
 
                             block = fall_through;
@@ -7812,11 +7814,11 @@ fn add_iseq_to_hir(
                             } else {
                                 fun.push_insn(iftrue_block, Insn::Const { val: Const::Value(Qnil) })
                             };
-                            fun.push_insn(iftrue_block, Insn::Jump(BranchEdge { target: join_block, args: vec![result] }));
+                            fun.push_insn(iftrue_block, Insn::Jump(Box::new(BranchEdge { target: join_block, args: vec![result] })));
                         }
                         // In the fallthrough case, do a generic interpreter definedivar and then join.
                         let result = fun.push_insn(block, Insn::DefinedIvar { self_val: self_param, id, pushval, state: exit_id });
-                        fun.push_insn(block, Insn::Jump(BranchEdge { target: join_block, args: vec![result] }));
+                        fun.push_insn(block, Insn::Jump(Box::new(BranchEdge { target: join_block, args: vec![result] })));
                         state.stack_push(join_param);
                         block = join_block;
                     } else {
@@ -7935,8 +7937,8 @@ fn add_iseq_to_hir(
 
                     fun.push_insn(block, Insn::CondBranch {
                         val: test_id,
-                        if_true: BranchEdge { target: fall_through, args: vec![] },
-                        if_false: BranchEdge { target, args: iffalse_state.as_args(self_param) }
+                        if_true: Box::new(BranchEdge { target: fall_through, args: vec![] }),
+                        if_false: Box::new(BranchEdge { target, args: iffalse_state.as_args(self_param) })
                     });
 
                     block = fall_through;
@@ -7964,8 +7966,8 @@ fn add_iseq_to_hir(
 
                     fun.push_insn(block, Insn::CondBranch {
                         val: test_id,
-                        if_true: BranchEdge { target, args: iftrue_state.as_args(self_param) },
-                        if_false: BranchEdge { target: fall_through, args: vec![] }
+                        if_true: Box::new(BranchEdge { target, args: iftrue_state.as_args(self_param) }),
+                        if_false: Box::new(BranchEdge { target: fall_through, args: vec![] })
                     });
 
                     block = fall_through;
@@ -7992,8 +7994,8 @@ fn add_iseq_to_hir(
 
                     fun.push_insn(block, Insn::CondBranch {
                         val: test_id,
-                        if_true: BranchEdge { target, args: iftrue_state.as_args(self_param) },
-                        if_false: BranchEdge { target: fall_through, args: vec![] }
+                        if_true: Box::new(BranchEdge { target, args: iftrue_state.as_args(self_param) }),
+                        if_false: Box::new(BranchEdge { target: fall_through, args: vec![] })
                     });
 
                     block = fall_through;
@@ -8028,8 +8030,8 @@ fn add_iseq_to_hir(
                     let fall_through = fun.new_block(insn_idx);
                     fun.push_insn(block, Insn::CondBranch {
                         val: test_id,
-                        if_true: BranchEdge { target: fall_through, args: vec![] },
-                        if_false: BranchEdge { target, args: state.as_args(self_param) }
+                        if_true: Box::new(BranchEdge { target: fall_through, args: vec![] }),
+                        if_false: Box::new(BranchEdge { target, args: state.as_args(self_param) })
                     });
                     block = fall_through;
                     queue.push_back((state.clone(), target, target_idx, local_inval));
@@ -8047,7 +8049,7 @@ fn add_iseq_to_hir(
                     let target_idx = insn_idx_at_offset(insn_idx, offset);
                     let target = insn_idx_to_block[&target_idx];
                     let _branch_id = fun.push_insn(block, Insn::Jump(
-                        BranchEdge { target, args: state.as_args(self_param) }
+                        Box::new(BranchEdge { target, args: state.as_args(self_param) })
                     ));
                     queue.push_back((state.clone(), target, target_idx, local_inval));
                     break;  // Don't enqueue the next block as a successor
@@ -8194,15 +8196,15 @@ fn add_iseq_to_hir(
 
                     fun.push_insn(block, Insn::CondBranch {
                         val: is_modified,
-                        if_true: BranchEdge { target: modified_block, args: vec![] },
-                        if_false: BranchEdge { target: unmodified_block, args: vec![] }
+                        if_true: Box::new(BranchEdge { target: modified_block, args: vec![] }),
+                        if_false: Box::new(BranchEdge { target: unmodified_block, args: vec![] })
                     });
 
                     // Push modified block: load the block local via EP.
                     let modified_val = fun.get_local_from_ep(modified_block, iseq, ep, ep_offset, level, types::BasicObject);
                     let mut modified_args = vec![modified_val];
                     if level == 0 { modified_args.push(modified_val); }
-                    fun.push_insn(modified_block, Insn::Jump(BranchEdge { target: join_block, args: modified_args }));
+                    fun.push_insn(modified_block, Insn::Jump(Box::new(BranchEdge { target: join_block, args: modified_args })));
 
                     let original_local = if level == 0 { Some(state.getlocal(ep_offset)) } else { None };
                     // `block_handler & 1 == 1` accepts both ISEQ (0b01) and ifunc
@@ -8250,7 +8252,7 @@ fn add_iseq_to_hir(
                             if let Some(local) = original_local {
                                 args.push(local);
                             }
-                            fun.push_insn(unmodified_block, Insn::Jump(BranchEdge { target: join_block, args }));
+                            fun.push_insn(unmodified_block, Insn::Jump(Box::new(BranchEdge { target: join_block, args })));
                         }
                         // A single supported profiled family. Emit a monomorphic fast path
                         [profiled_handler] => match profiled_handler {
@@ -8262,7 +8264,7 @@ fn add_iseq_to_hir(
                                 if let Some(local) = original_local {
                                     args.push(local);
                                 }
-                                fun.push_insn(unmodified_block, Insn::Jump(BranchEdge { target: join_block, args }));
+                                fun.push_insn(unmodified_block, Insn::Jump(Box::new(BranchEdge { target: join_block, args })));
                             }
                             ProfiledBlockHandlerFamily::IseqOrIfunc => {
                                 let block_handler = fun.load_ep_env_field(unmodified_block, ep, FieldName::VM_ENV_DATA_INDEX_SPECVAL, VM_ENV_DATA_INDEX_SPECVAL, types::CInt64);
@@ -8280,7 +8282,7 @@ fn add_iseq_to_hir(
                                 if let Some(local) = original_local {
                                     args.push(local);
                                 }
-                                fun.push_insn(unmodified_block, Insn::Jump(BranchEdge { target: join_block, args }));
+                                fun.push_insn(unmodified_block, Insn::Jump(Box::new(BranchEdge { target: join_block, args })));
                             }
                             ProfiledBlockHandlerFamily::Proc => {
                                 let proc_val = fun.load_ep_env_field(unmodified_block, ep, FieldName::VM_ENV_DATA_INDEX_SPECVAL, VM_ENV_DATA_INDEX_SPECVAL, types::BasicObject);
@@ -8298,7 +8300,7 @@ fn add_iseq_to_hir(
                                 if let Some(local) = original_local {
                                     args.push(local);
                                 }
-                                fun.push_insn(unmodified_block, Insn::Jump(BranchEdge { target: join_block, args }));
+                                fun.push_insn(unmodified_block, Insn::Jump(Box::new(BranchEdge { target: join_block, args })));
                             }
                         },
                         // Multiple supported profiled families. Emit a polymorphic dispatch
@@ -8325,8 +8327,8 @@ fn add_iseq_to_hir(
 
                                         fun.push_insn(current_block, Insn::CondBranch {
                                             val: is_none,
-                                            if_true: BranchEdge { target: profiled_block, args: vec![] },
-                                            if_false: BranchEdge { target: next_block, args: vec![] },
+                                            if_true: Box::new(BranchEdge { target: profiled_block, args: vec![] }),
+                                            if_false: Box::new(BranchEdge { target: next_block, args: vec![] }),
                                         });
 
                                         current_block = next_block;
@@ -8334,7 +8336,7 @@ fn add_iseq_to_hir(
                                         let val = fun.push_insn(profiled_block, Insn::Const { val: Const::Value(Qnil) });
                                         let mut args = vec![val];
                                         if let Some(local) = original_local { args.push(local); }
-                                        fun.push_insn(profiled_block, Insn::Jump(BranchEdge { target: join_block, args }));
+                                        fun.push_insn(profiled_block, Insn::Jump(Box::new(BranchEdge { target: join_block, args })));
 
                                     }
                                     ProfiledBlockHandlerFamily::IseqOrIfunc => {
@@ -8355,8 +8357,8 @@ fn add_iseq_to_hir(
                                         let next_block = fun.new_block(branch_insn_idx);
                                         fun.push_insn(current_block, Insn::CondBranch {
                                             val: is_iseq_or_ifunc,
-                                            if_true: BranchEdge { target: profiled_block, args: vec![] },
-                                            if_false: BranchEdge { target: next_block, args: vec![] },
+                                            if_true: Box::new(BranchEdge { target: profiled_block, args: vec![] }),
+                                            if_false: Box::new(BranchEdge { target: next_block, args: vec![] }),
                                         });
                                         current_block = next_block;
 
@@ -8364,12 +8366,12 @@ fn add_iseq_to_hir(
                                         let val = fun.push_insn(profiled_block, Insn::Const { val: Const::Value(unsafe { rb_block_param_proxy }) });
                                         let mut args = vec![val];
                                         if let Some(local) = original_local { args.push(local); }
-                                        fun.push_insn(profiled_block, Insn::Jump(BranchEdge { target: join_block, args }));
+                                        fun.push_insn(profiled_block, Insn::Jump(Box::new(BranchEdge { target: join_block, args })));
                                     },
                                     ProfiledBlockHandlerFamily::Proc => {
                                         let proc_check_block = fun.new_block(branch_insn_idx);
                                         let next_block = fun.new_block(branch_insn_idx);
-                                        fun.push_insn(current_block, Insn::Jump(BranchEdge { target: proc_check_block, args: vec![] }));
+                                        fun.push_insn(current_block, Insn::Jump(Box::new(BranchEdge { target: proc_check_block, args: vec![] })));
 
                                         let proc_val = fun.load_ep_env_field(proc_check_block, ep, FieldName::VM_ENV_DATA_INDEX_SPECVAL, VM_ENV_DATA_INDEX_SPECVAL, types::BasicObject);
                                         let proc_result = fun.push_insn(proc_check_block, Insn::CCall {
@@ -8385,14 +8387,14 @@ fn add_iseq_to_hir(
                                         let is_proc = fun.push_insn(proc_check_block, Insn::IsBitEqual { left: proc_result, right: true_val });
                                         fun.push_insn(proc_check_block, Insn::CondBranch {
                                             val: is_proc,
-                                            if_true: BranchEdge { target: profiled_block, args: vec![] },
-                                            if_false: BranchEdge { target: next_block, args: vec![] },
+                                            if_true: Box::new(BranchEdge { target: profiled_block, args: vec![] }),
+                                            if_false: Box::new(BranchEdge { target: next_block, args: vec![] }),
                                         });
                                         current_block = next_block;
 
                                         let mut args = vec![proc_val];
                                         if let Some(local) = original_local { args.push(local); }
-                                        fun.push_insn(profiled_block, Insn::Jump(BranchEdge { target: join_block, args }));
+                                        fun.push_insn(profiled_block, Insn::Jump(Box::new(BranchEdge { target: join_block, args })));
                                     }
                                 }
                             }
@@ -8427,13 +8429,13 @@ fn add_iseq_to_hir(
 
                     fun.push_insn(block, Insn::CondBranch {
                         val: is_modified,
-                        if_true: BranchEdge { target: modified_block, args: vec![] },
-                        if_false: BranchEdge { target: unmodified_block, args: vec![] }
+                        if_true: Box::new(BranchEdge { target: modified_block, args: vec![] }),
+                        if_false: Box::new(BranchEdge { target: unmodified_block, args: vec![] })
                     });
 
                     // Push modified block: read Proc from EP.
                     let modified_val = fun.get_local_from_ep(modified_block, iseq, ep, ep_offset, level, types::BasicObject);
-                    fun.push_insn(modified_block, Insn::Jump(BranchEdge { target: join_block, args: vec![modified_val] }));
+                    fun.push_insn(modified_block, Insn::Jump(Box::new(BranchEdge { target: join_block, args: vec![modified_val] })));
 
                     // Push unmodified block: convert block handler to Proc.
                     let unmodified_val = fun.push_insn(unmodified_block, Insn::GetBlockParam {
@@ -8441,7 +8443,7 @@ fn add_iseq_to_hir(
                         level,
                         state: exit_id,
                     });
-                    fun.push_insn(unmodified_block, Insn::Jump(BranchEdge { target: join_block, args: vec![unmodified_val] }));
+                    fun.push_insn(unmodified_block, Insn::Jump(Box::new(BranchEdge { target: join_block, args: vec![unmodified_val] })));
 
                     // Continue compilation from the join block at the next instruction.
                     if level == 0 {
@@ -8548,7 +8550,7 @@ fn add_iseq_to_hir(
                     num_returns += 1;
                     match mode {
                         AddIseqMode::Standalone => fun.push_insn(block, Insn::Return { val }),
-                        AddIseqMode::Inlined { return_block, .. } => { fun.push_insn(block, Insn::Jump(BranchEdge { target: return_block, args: vec![val] })) }
+                        AddIseqMode::Inlined { return_block, .. } => { fun.push_insn(block, Insn::Jump(Box::new(BranchEdge { target: return_block, args: vec![val] }))) }
                     };
                     break;  // Don't enqueue the next block as a successor
                 }
@@ -8650,8 +8652,8 @@ fn add_iseq_to_hir(
                             let fall_through = fun.new_block(insn_idx);
                             fun.push_insn(block, Insn::CondBranch {
                                 val: has_type,
-                                if_true: BranchEdge { target: iftrue_block, args: vec![] },
-                                if_false: BranchEdge { target: fall_through, args: vec![] }
+                                if_true: Box::new(BranchEdge { target: iftrue_block, args: vec![] }),
+                                if_false: Box::new(BranchEdge { target: fall_through, args: vec![] })
                             });
                             block = fall_through;
                             // Take a fresh Snapshot rather than
@@ -8661,12 +8663,12 @@ fn add_iseq_to_hir(
                             let snapshot = fun.push_insn(iftrue_block, Insn::Snapshot { state: Box::new(exit_state.clone()) });
                             let refined_recv = fun.push_insn(iftrue_block, Insn::RefineType { val: recv, new_type: expected });
                             let send = fun.push_insn(iftrue_block, Insn::Send { recv: refined_recv, cd, block: None, args: args.clone(), state: snapshot, reason: Uncategorized(opcode) });
-                            fun.push_insn(iftrue_block, Insn::Jump(BranchEdge { target: join_block, args: vec![send] }));
+                            fun.push_insn(iftrue_block, Insn::Jump(Box::new(BranchEdge { target: join_block, args: vec![send] })));
                         }
                         // In the fallthrough case, do a generic interpreter send and then join.
                         let reason = SendWithoutBlockPolymorphicFallback;
                         let send = fun.push_insn(block, Insn::Send { recv, cd, block: None, args, state: exit_id, reason });
-                        fun.push_insn(block, Insn::Jump(BranchEdge { target: join_block, args: vec![send] }));
+                        fun.push_insn(block, Insn::Jump(Box::new(BranchEdge { target: join_block, args: vec![send] })));
                         state.stack_push(join_param);
                         // Continue compilation from the join block at the next instruction.
                         block = join_block;
@@ -8919,8 +8921,8 @@ fn add_iseq_to_hir(
 
                         fun.push_insn(block, Insn::CondBranch {
                             val: is_ifunc_match,
-                            if_true: BranchEdge { target: ifunc_block, args: vec![] },
-                            if_false: BranchEdge { target: fall_through, args: vec![] },
+                            if_true: Box::new(BranchEdge { target: ifunc_block, args: vec![] }),
+                            if_false: Box::new(BranchEdge { target: fall_through, args: vec![] }),
                         });
 
                         block = fall_through;
@@ -8931,13 +8933,13 @@ fn add_iseq_to_hir(
                             args: args.clone(),
                             state: exit_id,
                         });
-                        fun.push_insn(ifunc_block, Insn::Jump(BranchEdge { target: join_block, args: vec![ifunc_result] }));
+                        fun.push_insn(ifunc_block, Insn::Jump(Box::new(BranchEdge { target: join_block, args: vec![ifunc_result] })));
 
                         // In the fallthrough case, use generic rb_vm_invokeblock and join
                         let fallback_result = fun.push_insn(block, Insn::InvokeBlock {
                             cd, args, state: exit_id, reason: InvokeBlockNotSpecialized,
                         });
-                        fun.push_insn(block, Insn::Jump(BranchEdge { target: join_block, args: vec![fallback_result] }));
+                        fun.push_insn(block, Insn::Jump(Box::new(BranchEdge { target: join_block, args: vec![fallback_result] })));
 
                         // Continue compilation from the join block
                         block = join_block;
@@ -8994,21 +8996,21 @@ fn add_iseq_to_hir(
                             let expected_shape = fun.push_insn(block, Insn::Const { val: Const::CShape(profiled_shape) });
                             let has_shape = fun.push_insn(block, Insn::IsBitEqual { left: actual_shape, right: expected_shape });
                             let iftrue_block = fun.new_block(insn_idx);
-                            let target = BranchEdge { target: iftrue_block, args: vec![] };
+                            let target = Box::new(BranchEdge { target: iftrue_block, args: vec![] });
                             let fall_through = fun.new_block(insn_idx);
 
                             fun.push_insn(block, Insn::CondBranch { val: has_shape,
                                 if_true: target,
-                                if_false: BranchEdge { target: fall_through, args: vec![] }
+                                if_false: Box::new(BranchEdge { target: fall_through, args: vec![] })
                             });
 
                             block = fall_through;
                             let result = fun.load_ivar(iftrue_block, self_param, profiled_type, id);
-                            fun.push_insn(iftrue_block, Insn::Jump(BranchEdge { target: join_block, args: vec![result] }));
+                            fun.push_insn(iftrue_block, Insn::Jump(Box::new(BranchEdge { target: join_block, args: vec![result] })));
                         }
                         // In the fallthrough case, do a generic interpreter getivar and then join.
                         let result = fun.push_insn(block, Insn::GetIvar { self_val: self_param, id, ic, state: exit_id });
-                        fun.push_insn(block, Insn::Jump(BranchEdge { target: join_block, args: vec![result] }));
+                        fun.push_insn(block, Insn::Jump(Box::new(BranchEdge { target: join_block, args: vec![result] })));
                         state.stack_push(join_param);
                         // Continue compilation from the join block at the next instruction.
                         // Make a copy of the current state without the args (pop the receiver
@@ -9175,16 +9177,16 @@ fn add_iseq_to_hir(
                         let join_block = fun.new_block(insn_idx);
                         fun.push_insn(block, Insn::CondBranch {
                             val: has_type,
-                            if_true: BranchEdge { target: iftrue_block, args: vec![] },
-                            if_false: BranchEdge { target: iffalse_block, args: vec![] }
+                            if_true: Box::new(BranchEdge { target: iftrue_block, args: vec![] }),
+                            if_false: Box::new(BranchEdge { target: iffalse_block, args: vec![] })
                         });
                         // true block
                         let refined = fun.push_insn(iftrue_block, Insn::RefineType { val: recv, new_type: types::String });
-                        fun.push_insn(iftrue_block, Insn::Jump(BranchEdge { target: join_block, args: vec![refined] }));
+                        fun.push_insn(iftrue_block, Insn::Jump(Box::new(BranchEdge { target: join_block, args: vec![refined] })));
                         // false block
                         let refined = fun.push_insn(iffalse_block, Insn::RefineType { val: recv, new_type: types::NotString });
                         let send = fun.push_insn(iffalse_block, Insn::Send { recv: refined, cd, block: None, args: vec![], state: exit_id, reason: ObjToStringNotString });
-                        fun.push_insn(iffalse_block, Insn::Jump(BranchEdge { target: join_block, args: vec![send] }));
+                        fun.push_insn(iffalse_block, Insn::Jump(Box::new(BranchEdge { target: join_block, args: vec![send] })));
                         // join block
                         block = join_block;
                         fun.push_insn(join_block, Insn::Param)
@@ -9252,7 +9254,7 @@ fn add_iseq_to_hir(
 
             if insn_idx_to_block.contains_key(&insn_idx) {
                 let target = insn_idx_to_block[&insn_idx];
-                fun.push_insn(block, Insn::Jump(BranchEdge { target, args: state.as_args(self_param) }));
+                fun.push_insn(block, Insn::Jump(Box::new(BranchEdge { target, args: state.as_args(self_param) })));
                 queue.push_back((state, target, insn_idx, local_inval));
                 break;  // End the block
             }
@@ -9306,8 +9308,8 @@ fn compile_entry_block(fun: &mut Function, jit_entry_insns: &[u32], insn_idx_to_
 
         fun.push_insn(entry_block, Insn::CondBranch {
             val: test_id,
-            if_true: BranchEdge { target: target_block, args: entry_state.as_args(self_param) },
-            if_false: BranchEdge { target: fall_through, args: vec![] }
+            if_true: Box::new(BranchEdge { target: target_block, args: entry_state.as_args(self_param) }),
+            if_false: Box::new(BranchEdge { target: fall_through, args: vec![] })
         });
         entry_block = fall_through;
     }
@@ -9317,7 +9319,7 @@ fn compile_entry_block(fun: &mut Function, jit_entry_insns: &[u32], insn_idx_to_
         .copied()
         .expect("we make a block for each jump target and \
                  each entry in the ISEQ opt_table is a jump target");
-    fun.push_insn(entry_block, Insn::Jump(BranchEdge { target: target_block, args: entry_state.as_args(self_param) }));
+    fun.push_insn(entry_block, Insn::Jump(Box::new(BranchEdge { target: target_block, args: entry_state.as_args(self_param) })));
 }
 
 /// Compile initial locals for an entry_block for the interpreter
@@ -9376,7 +9378,7 @@ fn compile_jit_entry_block(fun: &mut Function, jit_entry_idx: usize, target_bloc
         fun.count_iseq_calls(jit_entry_block);
     }
     // Jump to target_block
-    fun.push_insn(jit_entry_block, Insn::Jump(BranchEdge { target: target_block, args: entry_state.as_args(self_param) }));
+    fun.push_insn(jit_entry_block, Insn::Jump(Box::new(BranchEdge { target: target_block, args: entry_state.as_args(self_param) })));
 }
 
 /// Compile params and initial locals for a jit_entry_block
@@ -9774,7 +9776,7 @@ mod rpo_tests {
         let entries = function.entries_block;
         let entry = function.entry_block;
         let exit = function.new_block(0);
-        function.push_insn(entry, Insn::Jump(BranchEdge { target: exit, args: vec![] }));
+        function.push_insn(entry, Insn::Jump(Box::new(BranchEdge { target: exit, args: vec![] })));
         let val = function.push_insn(exit, Insn::Const { val: Const::Value(Qnil) });
         function.push_insn(exit, Insn::Return { val });
         function.seal_entries();
@@ -9788,12 +9790,12 @@ mod rpo_tests {
         let entry = function.entry_block;
         let side = function.new_block(0);
         let exit = function.new_block(0);
-        function.push_insn(side, Insn::Jump(BranchEdge { target: exit, args: vec![] }));
+        function.push_insn(side, Insn::Jump(Box::new(BranchEdge { target: exit, args: vec![] })));
         let val = function.push_insn(entry, Insn::Const { val: Const::Value(Qnil) });
         function.push_insn(entry, Insn::CondBranch {
             val,
-            if_true: BranchEdge { target: side, args: vec![] },
-            if_false: BranchEdge { target: exit, args: vec![] }
+            if_true: Box::new(BranchEdge { target: side, args: vec![] }),
+            if_false: Box::new(BranchEdge { target: exit, args: vec![] })
         });
         let val = function.push_insn(exit, Insn::Const { val: Const::Value(Qnil) });
         function.push_insn(exit, Insn::Return { val });
@@ -9808,12 +9810,12 @@ mod rpo_tests {
         let entry = function.entry_block;
         let side = function.new_block(0);
         let exit = function.new_block(0);
-        function.push_insn(side, Insn::Jump(BranchEdge { target: exit, args: vec![] }));
+        function.push_insn(side, Insn::Jump(Box::new(BranchEdge { target: exit, args: vec![] })));
         let val = function.push_insn(entry, Insn::Const { val: Const::Value(Qnil) });
         function.push_insn(entry, Insn::CondBranch {
             val,
-            if_true: BranchEdge { target: exit, args: vec![] },
-            if_false: BranchEdge { target: side, args: vec![] },
+            if_true: Box::new(BranchEdge { target: exit, args: vec![] }),
+            if_false: Box::new(BranchEdge { target: side, args: vec![] }),
         });
         let val = function.push_insn(exit, Insn::Const { val: Const::Value(Qnil) });
         function.push_insn(exit, Insn::Return { val });
@@ -9826,7 +9828,7 @@ mod rpo_tests {
         let mut function = Function::new(std::ptr::null());
         let entries = function.entries_block;
         let entry = function.entry_block;
-        function.push_insn(entry, Insn::Jump(BranchEdge { target: entry, args: vec![] }));
+        function.push_insn(entry, Insn::Jump(Box::new(BranchEdge { target: entry, args: vec![] })));
         function.seal_entries();
         assert_eq!(function.reverse_post_order(), vec![entries, entry]);
     }
@@ -9878,8 +9880,8 @@ mod validation_tests {
         function.push_insn(side, Insn::Unreachable);
         function.push_insn(entry, Insn::CondBranch {
             val,
-            if_true: BranchEdge { target: side, args: vec![val, val, val] },
-            if_false: BranchEdge { target: fall_through, args: vec![] }
+            if_true: Box::new(BranchEdge { target: side, args: vec![val, val, val] }),
+            if_false: Box::new(BranchEdge { target: fall_through, args: vec![] })
         });
         function.seal_entries();
         assert_matches_err(function.validate(), ValidationError::MismatchedBlockArity(entry, 0, 3));
@@ -9896,8 +9898,8 @@ mod validation_tests {
         function.push_insn(side, Insn::Unreachable);
         function.push_insn(entry, Insn::CondBranch {
             val,
-            if_true: BranchEdge { target: fall_through, args: vec![] },
-            if_false: BranchEdge { target: side, args: vec![val, val, val] },
+            if_true: Box::new(BranchEdge { target: fall_through, args: vec![] }),
+            if_false: Box::new(BranchEdge { target: side, args: vec![val, val, val] }),
         });
         function.seal_entries();
         assert_matches_err(function.validate(), ValidationError::MismatchedBlockArity(entry, 0, 3));
@@ -9909,7 +9911,7 @@ mod validation_tests {
         let entry = function.entry_block;
         let side = function.new_block(0);
         let val = function.push_insn(entry, Insn::Const { val: Const::Value(Qnil) });
-        function.push_insn(entry, Insn::Jump ( BranchEdge { target: side, args: vec![val, val, val] } ));
+        function.push_insn(entry, Insn::Jump ( Box::new(BranchEdge { target: side, args: vec![val, val, val] }) ));
         function.push_insn(side, Insn::Unreachable);
         function.seal_entries();
         assert_matches_err(function.validate(), ValidationError::MismatchedBlockArity(entry, 0, 3));
@@ -9948,12 +9950,12 @@ mod validation_tests {
         let side = function.new_block(0);
         let exit = function.new_block(0);
         let v0 = function.push_insn(side, Insn::Const { val: Const::Value(VALUE::fixnum_from_usize(3)) });
-        function.push_insn(side, Insn::Jump(BranchEdge { target: exit, args: vec![] }));
+        function.push_insn(side, Insn::Jump(Box::new(BranchEdge { target: exit, args: vec![] })));
         let val1 = function.push_insn(entry, Insn::Const { val: Const::CBool(false) });
         function.push_insn(entry, Insn::CondBranch {
             val: val1,
-            if_true: BranchEdge { target: exit, args: vec![] },
-            if_false: BranchEdge { target: side, args: vec![] },
+            if_true: Box::new(BranchEdge { target: exit, args: vec![] }),
+            if_false: Box::new(BranchEdge { target: side, args: vec![] }),
         });
         let val2 = function.push_insn(exit, Insn::ArrayDup { val: v0, state: v0 });
         let const_ = function.push_insn(exit, Insn::Const{val: Const::CBool(true)});
@@ -9974,12 +9976,12 @@ mod validation_tests {
         let side = function.new_block(0);
         let exit = function.new_block(0);
         let v0 = function.push_insn(entry, Insn::Const { val: Const::Value(VALUE::fixnum_from_usize(3)) });
-        function.push_insn(side, Insn::Jump(BranchEdge { target: exit, args: vec![] }));
+        function.push_insn(side, Insn::Jump(Box::new(BranchEdge { target: exit, args: vec![] })));
         let val = function.push_insn(entry, Insn::Const { val: Const::CBool(false) });
         function.push_insn(entry, Insn::CondBranch {
             val,
-            if_true: BranchEdge { target: exit, args: vec![] },
-            if_false: BranchEdge { target: side, args: vec![] }
+            if_true: Box::new(BranchEdge { target: exit, args: vec![] }),
+            if_false: Box::new(BranchEdge { target: side, args: vec![] })
         });
         let _val = function.push_insn(exit, Insn::ArrayDup { val: v0, state: v0 });
         let const_ = function.push_insn(exit, Insn::Const{val: Const::CBool(true)});
@@ -9996,7 +9998,7 @@ mod validation_tests {
     fn instruction_appears_twice_in_same_block() {
         let mut function = Function::new(std::ptr::null());
         let block = function.new_block(0);
-        function.push_insn(function.entry_block, Insn::Jump(BranchEdge { target: block, args: vec![] }));
+        function.push_insn(function.entry_block, Insn::Jump(Box::new(BranchEdge { target: block, args: vec![] })));
         let val = function.push_insn(block, Insn::Const { val: Const::Value(Qnil) });
         function.push_insn_id(block, val);
         function.push_insn(block, Insn::Return { val });
@@ -10008,7 +10010,7 @@ mod validation_tests {
     fn instruction_appears_twice_with_different_ids() {
         let mut function = Function::new(std::ptr::null());
         let block = function.new_block(0);
-        function.push_insn(function.entry_block, Insn::Jump(BranchEdge { target: block, args: vec![] }));
+        function.push_insn(function.entry_block, Insn::Jump(Box::new(BranchEdge { target: block, args: vec![] })));
         let val0 = function.push_insn(block, Insn::Const { val: Const::Value(Qnil) });
         let val1 = function.push_insn(block, Insn::Const { val: Const::Value(Qnil) });
         function.make_equal_to(val1, val0);
@@ -10021,10 +10023,10 @@ mod validation_tests {
     fn instruction_appears_twice_in_different_blocks() {
         let mut function = Function::new(std::ptr::null());
         let block = function.new_block(0);
-        function.push_insn(function.entry_block, Insn::Jump(BranchEdge { target: block, args: vec![] }));
+        function.push_insn(function.entry_block, Insn::Jump(Box::new(BranchEdge { target: block, args: vec![] })));
         let val = function.push_insn(block, Insn::Const { val: Const::Value(Qnil) });
         let exit = function.new_block(0);
-        function.push_insn(block, Insn::Jump(BranchEdge { target: exit, args: vec![] }));
+        function.push_insn(block, Insn::Jump(Box::new(BranchEdge { target: exit, args: vec![] })));
         function.push_insn_id(exit, val);
         function.push_insn(exit, Insn::Return { val });
         function.seal_entries();
@@ -10192,13 +10194,13 @@ mod infer_tests {
         let side = function.new_block(0);
         let exit = function.new_block(0);
         let v0 = function.push_insn(side, Insn::Const { val: Const::Value(VALUE::fixnum_from_usize(3)) });
-        function.push_insn(side, Insn::Jump(BranchEdge { target: exit, args: vec![v0] }));
+        function.push_insn(side, Insn::Jump(Box::new(BranchEdge { target: exit, args: vec![v0] })));
         let val = function.push_insn(entry, Insn::Const { val: Const::CBool(false) });
         let v1 = function.push_insn(entry, Insn::Const { val: Const::Value(VALUE::fixnum_from_usize(4)) });
         function.push_insn(entry, Insn::CondBranch {
             val,
-            if_true: BranchEdge { target: exit, args: vec![v1] },
-            if_false: BranchEdge { target: side, args: vec![] },
+            if_true: Box::new(BranchEdge { target: exit, args: vec![v1] }),
+            if_false: Box::new(BranchEdge { target: side, args: vec![] }),
         });
         let param = function.push_insn(exit, Insn::Param);
         function.push_insn(exit, Insn::Unreachable);
@@ -10227,19 +10229,19 @@ mod infer_tests {
         let c2 = function.push_insn(entry, Insn::Const { val: Const::Value(Qfalse) });
         let c3 = function.push_insn(entry, Insn::Const { val: Const::Value(Qnil) });
         let c4 = function.push_insn(entry, Insn::Const { val: Const::Value(VALUE::fixnum_from_usize(7)) });
-        function.push_insn(entry, Insn::Jump(BranchEdge {
+        function.push_insn(entry, Insn::Jump(Box::new(BranchEdge {
             target: loop_block,
             args: vec![c1, c2, c3, c4],
-        }));
+        })));
 
         let p1 = function.push_insn(loop_block, Insn::Param);
         let p2 = function.push_insn(loop_block, Insn::Param);
         let p3 = function.push_insn(loop_block, Insn::Param);
         let p4 = function.push_insn(loop_block, Insn::Param);
-        function.push_insn(loop_block, Insn::Jump(BranchEdge {
+        function.push_insn(loop_block, Insn::Jump(Box::new(BranchEdge {
             target: loop_block,
             args: vec![p2, p3, p4, p1],
-        }));
+        })));
 
         function.seal_entries();
         crate::cruby::with_rubyvm(|| {
@@ -10263,13 +10265,13 @@ mod infer_tests {
         let side = function.new_block(0);
         let exit = function.new_block(0);
         let v0 = function.push_insn(side, Insn::Const { val: Const::Value(Qtrue) });
-        function.push_insn(side, Insn::Jump(BranchEdge { target: exit, args: vec![v0] }));
+        function.push_insn(side, Insn::Jump(Box::new(BranchEdge { target: exit, args: vec![v0] })));
         let val = function.push_insn(entry, Insn::Const { val: Const::CBool(false) });
         let v1 = function.push_insn(entry, Insn::Const { val: Const::Value(Qfalse) });
         function.push_insn(entry, Insn::CondBranch {
             val,
-            if_true: BranchEdge { target: exit, args: vec![v1] },
-            if_false: BranchEdge { target: side, args: vec![] },
+            if_true: Box::new(BranchEdge { target: exit, args: vec![v1] }),
+            if_false: Box::new(BranchEdge { target: side, args: vec![] }),
         });
         let param = function.push_insn(exit, Insn::Param);
         function.push_insn(exit, Insn::Unreachable);

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -856,6 +856,19 @@ pub struct CCallWithFrameData {
     pub block: Option<BlockHandler>,
 }
 
+/// Payload of [`Insn::SendDirect`]. Boxed in the enum to keep `Insn` small.
+#[derive(Debug, Clone)]
+pub struct SendDirectData {
+    pub recv: InsnId,
+    pub cd: *const rb_call_data,
+    pub cme: *const rb_callable_method_entry_t,
+    pub iseq: IseqPtr,
+    pub args: Vec<InsnId>,
+    pub kw_bits: u32,
+    pub block: Option<BlockHandler>,
+    pub state: InsnId,
+}
+
 /// Payload of [`Insn::CCallVariadic`]. Boxed in the enum to keep `Insn` small.
 #[derive(Debug, Clone)]
 pub struct CCallVariadicData {
@@ -1106,16 +1119,7 @@ pub enum Insn {
     },
 
     /// Optimized ISEQ call
-    SendDirect {
-        recv: InsnId,
-        cd: *const rb_call_data,
-        cme: *const rb_callable_method_entry_t,
-        iseq: IseqPtr,
-        args: Vec<InsnId>,
-        kw_bits: u32,
-        block: Option<BlockHandler>,
-        state: InsnId,
-    },
+    SendDirect(Box<SendDirectData>),
 
     /// Push a lighter weight frame used for inlined methods.
     PushInlineFrame {
@@ -1448,7 +1452,6 @@ macro_rules! for_each_operand_impl {
             }
             Insn::Send { recv, args, state, .. }
             | Insn::SendForward { recv, args, state, .. }
-            | Insn::SendDirect { recv, args, state, .. }
             | Insn::PushInlineFrame { recv, args, state, .. }
             | Insn::InvokeBuiltin { recv, args, state, .. }
             | Insn::InvokeSuper { recv, args, state, .. }
@@ -1458,9 +1461,14 @@ macro_rules! for_each_operand_impl {
                 $visit_many!(args);
                 $visit_one!(*state);
             }
-            // CCallWithFrame/CCallVariadic carry their operands behind a Box, which
-            // stable Rust can't destructure in a pattern. visit_one takes a place, so
+            // SendDirect/CCallWithFrame/CCallVariadic carry their operands behind a Box,
+            // which stable Rust can't destructure in a pattern. visit_one takes a place, so
             // a box field works the same as the deref'd bindings used by other arms.
+            Insn::SendDirect(insn) => {
+                $visit_one!(insn.recv);
+                $visit_many!(insn.args);
+                $visit_one!(insn.state);
+            }
             Insn::CCallWithFrame(insn) => {
                 $visit_one!(insn.recv);
                 $visit_many!(insn.args);
@@ -1727,7 +1735,7 @@ impl Insn {
             Insn::InvokeSuperForward { .. } => effects::Any,
             Insn::InvokeBlock { .. } => effects::Any,
             Insn::InvokeBlockIfunc { .. } => effects::Any,
-            Insn::SendDirect { .. } => effects::Any,
+            Insn::SendDirect(_) => effects::Any,
             // TODO (nirvdrum 2026-05-28): Revisit when PushInlineFrame is
             // actually lightweight. The frame writes here pay for the spill
             // ceremony in the current full frame-push codegen. A lightweight
@@ -2042,7 +2050,8 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
             Insn::FixnumAref { recv, index } => write!(f, "FixnumAref {recv}, {index}"),
             Insn::Jump(target) => { write!(f, "Jump {target}") }
             Insn::CondBranch { val, if_true, if_false } => { write!(f, "CondBranch {val}, {if_true}, {if_false}") },
-            Insn::SendDirect { recv, cme, iseq, args, block, .. } => {
+            Insn::SendDirect(insn) => {
+                let SendDirectData { recv, cme, iseq, args, block, .. } = &**insn;
                 let blockiseq = block.map(|bh| match bh { BlockHandler::BlockIseq(iseq) => iseq, BlockHandler::BlockArg => unreachable!() });
                 let method_name = unsafe { (**cme).called_id };
                 write!(f, "SendDirect {recv}, {:p}, :{} ({:?})", self.ptr_map.map_ptr(&blockiseq), method_name, self.ptr_map.map_ptr(iseq))?;
@@ -3087,7 +3096,7 @@ impl Function {
             Insn::FixnumLShift { .. } => types::Fixnum,
             Insn::FixnumRShift { .. } => types::Fixnum,
             Insn::PutSpecialObject { .. } => types::BasicObject,
-            Insn::SendDirect { .. } => types::BasicObject,
+            Insn::SendDirect(_) => types::BasicObject,
             Insn::Send { .. } => types::BasicObject,
             Insn::SendForward { .. } => types::BasicObject,
             Insn::InvokeSuper { .. } => types::BasicObject,
@@ -3701,9 +3710,14 @@ impl Function {
     /// Try trivially inlining the method. If we can't, emit a SendDirect instruction instead and
     /// leave it to the general-purpose inliner to handle.
     fn try_inline_send_direct(&mut self, block: BlockId, insn: Insn) -> InsnId {
-        let Insn::SendDirect { recv, iseq, cd, ref args, state, .. } = insn else {
+        let Insn::SendDirect(data) = &insn else {
             panic!("try_inline_send_direct called with non-SendDirect instruction");
         };
+        let recv = data.recv;
+        let iseq = data.iseq;
+        let cd = data.cd;
+        let state = data.state;
+        let args = &data.args;
         // The trivial inliner runs first to handle simple cases (constant returns,
         // parameter returns, etc.) without frame push/pop overhead. The general
         // inliner then handles more complex methods that require full inlining.
@@ -3857,7 +3871,7 @@ impl Function {
                                 recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: Some(Recompile) });
                             }
 
-                            let replacement = self.try_inline_send_direct(block, Insn::SendDirect { recv, cd, cme, iseq, args: processed_args, kw_bits, state: send_state, block: send_block });
+                            let replacement = self.try_inline_send_direct(block, Insn::SendDirect(Box::new(SendDirectData { recv, cd, cme, iseq, args: processed_args, kw_bits, state: send_state, block: send_block })));
                             self.make_equal_to(insn_id, replacement);
                         } else if !has_block && def_type == VM_METHOD_TYPE_BMETHOD {
                             let procv = unsafe { rb_get_def_bmethod_proc((*cme).def) };
@@ -3900,7 +3914,7 @@ impl Function {
                                 recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: Some(Recompile) });
                             }
 
-                            let replacement = self.try_inline_send_direct(block, Insn::SendDirect { recv, cd, cme, iseq, args: processed_args, kw_bits, state: send_state, block: None });
+                            let replacement = self.try_inline_send_direct(block, Insn::SendDirect(Box::new(SendDirectData { recv, cd, cme, iseq, args: processed_args, kw_bits, state: send_state, block: None })));
                             self.make_equal_to(insn_id, replacement);
                         } else if !has_block && def_type == VM_METHOD_TYPE_IVAR && args.is_empty() {
                             // Check if we're accessing ivars of a Class or Module object as they require single-ractor mode.
@@ -4229,7 +4243,7 @@ impl Function {
                             emit_super_call_guards(self, block, super_cme, current_cme, mid, state, frame_state.iseq);
 
                             // Use SendDirect with the super method's CME and ISEQ.
-                            let replacement = self.try_inline_send_direct(block, Insn::SendDirect {
+                            let replacement = self.try_inline_send_direct(block, Insn::SendDirect(Box::new(SendDirectData {
                                 recv,
                                 cd,
                                 cme: super_cme,
@@ -4238,7 +4252,7 @@ impl Function {
                                 kw_bits,
                                 state: send_state,
                                 block: None,
-                            });
+                            })));
                             self.make_equal_to(insn_id, replacement);
 
                         } else if def_type == VM_METHOD_TYPE_CFUNC {
@@ -4508,18 +4522,18 @@ impl Function {
             let mut search_start = 0;
             loop {
                 let Some(offset) = self.blocks[block.0].insns[search_start..].iter()
-                    .position(|&id| matches!(self.find(id), Insn::SendDirect { .. }))
+                    .position(|&id| matches!(self.find(id), Insn::SendDirect(..)))
                 else {
                     break;
                 };
                 let send_pos = search_start + offset;
 
                 let send_insn_id = self.blocks[block.0].insns[send_pos];
-                let Insn::SendDirect { recv, cd: _, cme, iseq, args, kw_bits, block: call_block, state }
-                    = self.find(send_insn_id)
+                let Insn::SendDirect(data) = self.find(send_insn_id)
                 else {
                     unreachable!("position {send_insn_id} is not a SendDirect");
                 };
+                let SendDirectData { recv, cme, iseq, args, kw_bits, block: call_block, state, .. } = *data;
                 // SendDirect invariant: block is either None or BlockIseq.
                 // BlockArg is rejected upstream during type specialization.
                 let blockiseq: Option<IseqPtr> = call_block.map(|bh| match bh {
@@ -4591,7 +4605,7 @@ impl Function {
                 // pre-Send body, before the PushLightweightFrame and Jump we add
                 // last).
                 let tail = self.blocks[block.0].insns.split_off(send_pos);
-                debug_assert!(matches!(self.find(tail[0]), Insn::SendDirect { .. }));
+                debug_assert!(matches!(self.find(tail[0]), Insn::SendDirect(..)));
 
                 // Pick the callee body entry block matching how many optional
                 // parameters the caller actually filled. add_iseq_to_hir returns one
@@ -6466,8 +6480,7 @@ impl Function {
                 self.assert_subtype(insn_id, allow_nil, types::BoolExact)
             }
             // Instructions with recv and a Vec of Ruby objects
-            Insn::SendDirect { recv, ref args, .. }
-            | Insn::PushInlineFrame { recv, ref args, .. }
+            Insn::PushInlineFrame { recv, ref args, .. }
             | Insn::Send { recv, ref args, .. }
             | Insn::SendForward { recv, ref args, .. }
             | Insn::InvokeSuper { recv, ref args, .. }
@@ -6477,6 +6490,13 @@ impl Function {
             | Insn::ArrayInclude { target: recv, elements: ref args, .. } => {
                 self.assert_subtype(insn_id, recv, types::BasicObject)?;
                 for &arg in args {
+                    self.assert_subtype(insn_id, arg, types::BasicObject)?;
+                }
+                Ok(())
+            }
+            Insn::SendDirect(insn) => {
+                self.assert_subtype(insn_id, insn.recv, types::BasicObject)?;
+                for &arg in &insn.args {
                     self.assert_subtype(insn_id, arg, types::BasicObject)?;
                 }
                 Ok(())

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -1256,9 +1256,9 @@ pub enum Insn {
     /// Side-exit if val is not the expected Const.
     GuardBitEquals { val: InsnId, expected: Const, reason: Box<SideExitReason>, state: InsnId, recompile: Option<Recompile> },
     /// Side-exit if (val & mask) == 0
-    GuardAnyBitSet { val: InsnId, mask: Const, mask_name: ID, reason: Box<SideExitReason>, state: InsnId, recompile: Option<Recompile> },
+    GuardAnyBitSet { val: InsnId, mask: u64, mask_name: ID, reason: Box<SideExitReason>, state: InsnId, recompile: Option<Recompile> },
     /// Side-exit if (val & mask) != 0
-    GuardNoBitsSet { val: InsnId, mask: Const, mask_name: ID, reason: Box<SideExitReason>, state: InsnId },
+    GuardNoBitsSet { val: InsnId, mask: u64, mask_name: ID, reason: Box<SideExitReason>, state: InsnId },
     /// Side-exit if left is not greater than or equal to right (both operands are C long).
     GuardGreaterEq { left: InsnId, right: InsnId, reason: Box<SideExitReason>, state: InsnId },
     /// Side-exit if left is not less than right (both operands are C long).
@@ -2272,7 +2272,8 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
                 return Ok(())
             },
             Insn::GuardAnyBitSet { val, mask, mask_name, recompile, .. } => {
-                let mask = mask.print(self.ptr_map);
+                let mask_const = Const::CUInt64(*mask);
+                let mask = mask_const.print(self.ptr_map);
                 let recompile = if recompile.is_some() { " recompile" } else { "" };
                 if !mask_name.is_none() {
                     write!(f, "GuardAnyBitSet {val}, {mask_name}={mask}{recompile}")
@@ -2280,8 +2281,14 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
                     write!(f, "GuardAnyBitSet {val}, {mask}{recompile}")
                 }
             },
-            Insn::GuardNoBitsSet { val, mask, mask_name, .. } if !mask_name.is_none() => { write!(f, "GuardNoBitsSet {val}, {mask_name}={}", mask.print(self.ptr_map)) },
-            Insn::GuardNoBitsSet { val, mask, .. } => { write!(f, "GuardNoBitsSet {val}, {}", mask.print(self.ptr_map)) },
+            Insn::GuardNoBitsSet { val, mask, mask_name, .. } if !mask_name.is_none() => {
+                let mask_const = Const::CUInt64(*mask);
+                write!(f, "GuardNoBitsSet {val}, {mask_name}={}", mask_const.print(self.ptr_map))
+            },
+            Insn::GuardNoBitsSet { val, mask, .. } => {
+                let mask_const = Const::CUInt64(*mask);
+                write!(f, "GuardNoBitsSet {val}, {}", mask_const.print(self.ptr_map))
+            },
             Insn::GuardLess { left, right, .. } => write!(f, "GuardLess {left}, {right}"),
             Insn::GuardGreaterEq { left, right, .. } => write!(f, "GuardGreaterEq {left}, {right}"),
             &Insn::GetBlockParam { level, ep_offset, .. } => {
@@ -3766,12 +3773,12 @@ impl Function {
 
     pub fn guard_not_frozen(&mut self, block: BlockId, recv: InsnId, state: InsnId) {
         let flags = self.load_rbasic_flags(block, recv);
-        self.push_insn(block, Insn::GuardNoBitsSet { val: flags, mask: Const::CUInt64(RUBY_FL_FREEZE as u64), mask_name: ID!(RUBY_FL_FREEZE), reason: Box::new(SideExitReason::GuardNotFrozen), state });
+        self.push_insn(block, Insn::GuardNoBitsSet { val: flags, mask: RUBY_FL_FREEZE as u64, mask_name: ID!(RUBY_FL_FREEZE), reason: Box::new(SideExitReason::GuardNotFrozen), state });
     }
 
     pub fn guard_not_shared(&mut self, block: BlockId, recv: InsnId, state: InsnId) {
         let flags = self.load_rbasic_flags(block, recv);
-        self.push_insn(block, Insn::GuardNoBitsSet { val: flags, mask: Const::CUInt64(RUBY_ELTS_SHARED as u64), mask_name: ID!(RUBY_ELTS_SHARED), reason: Box::new(SideExitReason::GuardNotShared), state });
+        self.push_insn(block, Insn::GuardNoBitsSet { val: flags, mask: RUBY_ELTS_SHARED as u64, mask_name: ID!(RUBY_ELTS_SHARED), reason: Box::new(SideExitReason::GuardNotShared), state });
     }
 
     /// `iseq` is the ISEQ that `ep_offset` is relative to, which is the ISEQ that
@@ -6868,16 +6875,12 @@ impl Function {
                     Const::CPtr(_) => self.assert_subtype(insn_id, val, types::CPtr),
                 }
             }
-            Insn::GuardAnyBitSet { val, mask, .. }
-            | Insn::GuardNoBitsSet { val, mask, .. } => {
-                match mask {
-                    Const::CUInt8(_) | Const::CUInt16(_) | Const::CUInt32(_) | Const::CUInt64(_)
-                        if self.is_a(val, types::CInt) || self.is_a(val, types::RubyValue) => {
-                        Ok(())
-                    }
-                    _ => {
-                        Err(ValidationError::MiscValidationError(insn_id, "GuardAnyBitSet/GuardNoBitsSet can only compare RubyValue/CUInt or CInt/CUInt".to_string()))
-                    }
+            Insn::GuardAnyBitSet { val, .. }
+            | Insn::GuardNoBitsSet { val, .. } => {
+                if self.is_a(val, types::CInt) || self.is_a(val, types::RubyValue) {
+                    Ok(())
+                } else {
+                    Err(ValidationError::MiscValidationError(insn_id, "GuardAnyBitSet/GuardNoBitsSet can only compare RubyValue or CInt".to_string()))
                 }
             }
             Insn::GuardLess { left, right, .. }
@@ -8406,7 +8409,7 @@ fn add_iseq_to_hir(
                             // So to check for either of those cases we can use: val & 0x1 == 0x1
 
                             // Bail out if the block handler is neither ISEQ nor ifunc
-                            fun.push_insn(unmodified_block, Insn::GuardAnyBitSet { val: block_handler, mask: Const::CUInt64(0x1), mask_name: ID::NONE, reason: Box::new(SideExitReason::BlockParamProxyFallbackMiss), state: exit_id, recompile: Some(Recompile) });
+                            fun.push_insn(unmodified_block, Insn::GuardAnyBitSet { val: block_handler, mask: 0x1, mask_name: ID::NONE, reason: Box::new(SideExitReason::BlockParamProxyFallbackMiss), state: exit_id, recompile: Some(Recompile) });
                             // TODO(Shopify/ruby#753): GC root, so we should be able to avoid unnecessary GC tracing
                             let proxy_val = fun.push_insn(unmodified_block, Insn::Const { val: Const::Value(unsafe { rb_block_param_proxy }) });
                             let mut args = vec![proxy_val];
@@ -8436,7 +8439,7 @@ fn add_iseq_to_hir(
                                 // So to check for either of those cases we can use: val & 0x1 == 0x1
 
                                 // Bail out if the block handler is neither ISEQ nor ifunc
-                                fun.push_insn(unmodified_block, Insn::GuardAnyBitSet { val: block_handler, mask: Const::CUInt64(0x1), mask_name: ID::NONE, reason: Box::new(SideExitReason::BlockParamProxyNotIseqOrIfunc), state: exit_id, recompile: Some(Recompile) });
+                                fun.push_insn(unmodified_block, Insn::GuardAnyBitSet { val: block_handler, mask: 0x1, mask_name: ID::NONE, reason: Box::new(SideExitReason::BlockParamProxyNotIseqOrIfunc), state: exit_id, recompile: Some(Recompile) });
                                 // TODO(Shopify/ruby#753): GC root, so we should be able to avoid unnecessary GC tracing
                                 let proxy_val = fun.push_insn(unmodified_block, Insn::Const { val: Const::Value(unsafe { rb_block_param_proxy }) });
                                 let mut args = vec![proxy_val];

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -990,7 +990,7 @@ pub enum Insn {
     NewRangeFixnum { low: InsnId, high: InsnId, flag: RangeType, state: InsnId },
     ArrayDup { val: InsnId, state: InsnId },
     ArrayHash { elements: InsnIdList, state: InsnId },
-    ArrayMax { elements: Vec<InsnId>, state: InsnId },
+    ArrayMax { elements: InsnIdList, state: InsnId },
     ArrayMin { elements: Vec<InsnId>, state: InsnId },
     ArrayInclude { elements: Vec<InsnId>, target: InsnId, state: InsnId },
     ArrayPackBuffer { elements: InsnIdList, fmt: InsnId, buffer: Option<InsnId>, state: InsnId },
@@ -1334,9 +1334,12 @@ macro_rules! for_each_operand_impl {
             Insn::FixnumBitCheck { val, .. } => {
                 $visit_one!(*val);
             }
-            Insn::ArrayMax { elements, state, .. }
-            | Insn::ArrayMin { elements, state, .. } => {
+            Insn::ArrayMin { elements, state, .. } => {
                 $visit_many!(elements);
+                $visit_one!(*state);
+            }
+            Insn::ArrayMax { elements, state, .. } => {
+                $visit_list!(*elements);
                 $visit_one!(*state);
             }
             Insn::ArrayHash { elements, state, .. } => {
@@ -2041,6 +2044,7 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
                 write!(f, "NewRangeFixnum {low} {flag} {high}")
             }
             Insn::ArrayMax { elements, .. } => {
+                let elements = self.pool.map_or(&[][..], |pool| pool.get(*elements));
                 write!(f, "ArrayMax")?;
                 write_separated!(f, " ", ", ", elements);
                 Ok(())
@@ -6681,9 +6685,14 @@ impl Function {
                 }
                 Ok(())
             }
+            Insn::ArrayMax { elements, .. } => {
+                for &arg in self.operands(elements).to_vec().iter() {
+                    self.assert_subtype(insn_id, arg, types::BasicObject)?;
+                }
+                Ok(())
+            }
             // Instructions with a Vec of Ruby objects
-            Insn::ArrayMin { elements: ref args, .. }
-            | Insn::ArrayMax { elements: ref args, .. } => {
+            Insn::ArrayMin { elements: ref args, .. } => {
                 for &arg in args {
                     self.assert_subtype(insn_id, arg, types::BasicObject)?;
                 }
@@ -7740,7 +7749,7 @@ fn add_iseq_to_hir(
                     let (bop, insn) = match method {
                         VM_OPT_NEWARRAY_SEND_MAX => {
                             let elements = state.stack_pop_n(count)?;
-                            (BOP_MAX, Insn::ArrayMax { elements, state: exit_id })
+                            (BOP_MAX, Insn::ArrayMax { elements: fun.push_operands(&elements), state: exit_id })
                         }
                         VM_OPT_NEWARRAY_SEND_MIN => {
                             let elements = state.stack_pop_n(count)?;

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -963,6 +963,16 @@ pub struct SendData {
     pub reason: SendFallbackReason,
 }
 
+/// Cold metadata of [`Insn::PushInlineFrame`]. Boxed in the enum to keep
+/// `Insn` small; the operands (`recv`, `args`) and `state` stay inline for
+/// fast traversal.
+#[derive(Debug, Clone)]
+pub struct PushInlineFrameData {
+    pub iseq: IseqPtr,
+    pub cme: *const rb_callable_method_entry_t,
+    pub blockiseq: Option<IseqPtr>,
+}
+
 /// An instruction in the SSA IR. The output of an instruction is referred to by the index of
 /// the instruction ([`InsnId`]). SSA form enables this, and [`UnionFind`] ([`Function::find`])
 /// helps with editing.
@@ -1201,12 +1211,10 @@ pub enum Insn {
 
     /// Push a lighter weight frame used for inlined methods.
     PushInlineFrame {
-        iseq: IseqPtr,
-        cme: *const rb_callable_method_entry_t,
         recv: InsnId,
         args: InsnIdList,
-        blockiseq: Option<IseqPtr>,
         state: InsnId,
+        data: Box<PushInlineFrameData>,
     },
 
     /// Pop a lighter weight frame used for inlined methods.
@@ -2168,8 +2176,8 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
                 write_separated!(f, ", ", ", ", args);
                 Ok(())
             }
-            Insn::PushInlineFrame { recv, iseq, args, .. } => {
-                write!(f, "PushInlineFrame {recv} ({:?})", self.ptr_map.map_ptr(iseq))?;
+            Insn::PushInlineFrame { recv, args, data, .. } => {
+                write!(f, "PushInlineFrame {recv} ({:?})", self.ptr_map.map_ptr(&data.iseq))?;
                 let args = self.pool.map_or(&[][..], |pool| pool.get(*args));
                 write_separated!(f, ", ", ", ", args);
                 Ok(())
@@ -4876,7 +4884,8 @@ impl Function {
 
                 // Insert PushLightweightFrame and jump to callee body entry.
                 self.push_insn(block, Insn::PushInlineFrame {
-                    iseq, cme, recv, args: self.push_operands(&args), blockiseq, state,
+                    recv, args: self.push_operands(&args), state,
+                    data: Box::new(PushInlineFrameData { iseq, cme, blockiseq }),
                 });
                 self.count(block, Counter::inline_iseq_optimized_send_count);
                 self.push_insn(block, Insn::Jump(Box::new(BranchEdge {

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -3044,13 +3044,6 @@ impl Function {
         }
         let insn_id = find!(insn_id);
         let mut result = self.insns[insn_id.0].clone();
-        // Operands stored in the operand pool (e.g. CCall/Send/PushInlineFrame/
-        // SendForward/InvokeSuper/InvokeSuperForward args) are shared by handle with
-        // the original insn. Duplicate the list so remapping below doesn't mutate the canonical entry.
-        if let Insn::CCall { args, .. } | Insn::Send { args, .. } | Insn::PushInlineFrame { args, .. } | Insn::SendForward { args, .. } | Insn::InvokeSuper { args, .. } | Insn::InvokeSuperForward { args, .. } | Insn::InvokeBuiltin { args, .. } | Insn::ArrayPackBuffer { elements: args, .. } = &mut result {
-            let dup = self.operand_pool.borrow().get(*args).to_vec();
-            *args = self.operand_pool.borrow_mut().push(&dup);
-        }
         let mut pool = self.operand_pool.borrow_mut();
         result.for_each_operand_mut(&mut pool, &mut |operand: &mut InsnId| {
             *operand = find!(*operand);

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -985,7 +985,7 @@ pub enum Insn {
     ToNewArray { val: InsnId, state: InsnId },
     NewArray { elements: InsnIdList, state: InsnId },
     /// NewHash contains a vec of (key, value) pairs
-    NewHash { elements: Vec<InsnId>, state: InsnId },
+    NewHash { elements: InsnIdList, state: InsnId },
     NewRange { low: InsnId, high: InsnId, flag: RangeType, state: InsnId },
     NewRangeFixnum { low: InsnId, high: InsnId, flag: RangeType, state: InsnId },
     ArrayDup { val: InsnId, state: InsnId },
@@ -1336,9 +1336,12 @@ macro_rules! for_each_operand_impl {
             }
             Insn::ArrayMax { elements, state, .. }
             | Insn::ArrayMin { elements, state, .. }
-            | Insn::ArrayHash { elements, state, .. }
-            | Insn::NewHash { elements, state, .. } => {
+            | Insn::ArrayHash { elements, state, .. } => {
                 $visit_many!(elements);
+                $visit_one!(*state);
+            }
+            Insn::NewHash { elements, state, .. } => {
+                $visit_list!(*elements);
                 $visit_one!(*state);
             }
             Insn::NewArray { elements, state, .. } => {
@@ -2017,6 +2020,7 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
                 write!(f, "AdjustBounds {index}, {length}")
             }
             Insn::NewHash { elements, .. } => {
+                let elements = self.pool.map_or(&[][..], |pool| pool.get(*elements));
                 write!(f, "NewHash")?;
                 let mut prefix = " ";
                 for chunk in elements.chunks(2) {
@@ -6676,11 +6680,12 @@ impl Function {
                 }
                 Ok(())
             }
-            Insn::NewHash { ref elements, .. } => {
+            Insn::NewHash { elements, .. } => {
+                let elements = self.operands(elements).to_vec();
                 if elements.len() % 2 != 0 {
                     return Err(ValidationError::MiscValidationError(insn_id, "NewHash elements length is not even".to_string()));
                 }
-                for &element in elements {
+                for &element in elements.iter() {
                     self.assert_subtype(insn_id, element, types::BasicObject)?;
                 }
                 Ok(())
@@ -7801,7 +7806,7 @@ fn add_iseq_to_hir(
                         elements.push(key);
                     }
                     elements.reverse();
-                    state.stack_push(fun.push_insn(block, Insn::NewHash { elements, state: exit_id }));
+                    state.stack_push(fun.push_insn(block, Insn::NewHash { elements: fun.push_operands(&elements), state: exit_id }));
                 }
                 YARVINSN_duphash => {
                     let val = fun.push_insn(block, Insn::Const { val: Const::Value(get_arg(pc, 0)) });

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -1173,7 +1173,7 @@ pub enum Insn {
     /// Call Proc#call optimized method type.
     InvokeProc {
         recv: InsnId,
-        args: Vec<InsnId>,
+        args: InsnIdList,
         state: InsnId,
         kw_splat: bool,
     },
@@ -1523,7 +1523,7 @@ macro_rules! for_each_operand_impl {
             }
             Insn::InvokeProc { recv, args, state, .. } => {
                 $visit_one!(*recv);
-                $visit_many!(args);
+                $visit_list!(*args);
                 $visit_one!(*state);
             }
             // SendDirect/CCallWithFrame/CCallVariadic carry their operands behind a Box,
@@ -2192,6 +2192,7 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
                 Ok(())
             }
             Insn::InvokeProc { recv, args, kw_splat, .. } => {
+                let args = self.pool.map_or(&[][..], |pool| pool.get(*args));
                 write!(f, "InvokeProc {recv}")?;
                 write_separated!(f, ", ", ", ", args);
                 if *kw_splat {
@@ -4092,7 +4093,7 @@ impl Function {
                                         recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: Some(Recompile) });
                                     }
                                     let kw_splat = flags & VM_CALL_KW_SPLAT != 0;
-                                    let invoke_proc = self.push_insn(block, Insn::InvokeProc { recv, args: args.clone(), state, kw_splat });
+                                    let invoke_proc = self.push_insn(block, Insn::InvokeProc { recv, args: self.push_operands(&args), state, kw_splat });
                                     self.make_equal_to(insn_id, invoke_proc);
                                 }
                                 (OptimizedMethodType::StructAref, &[]) | (OptimizedMethodType::StructAset, &[_]) => {
@@ -6601,9 +6602,15 @@ impl Function {
                 }
                 Ok(())
             }
+            Insn::InvokeProc { recv, args, .. } => {
+                self.assert_subtype(insn_id, recv, types::BasicObject)?;
+                for &arg in self.operands(args).to_vec().iter() {
+                    self.assert_subtype(insn_id, arg, types::BasicObject)?;
+                }
+                Ok(())
+            }
             // Instructions with recv and a Vec of Ruby objects
-            Insn::InvokeProc { recv, ref args, .. }
-            | Insn::ArrayInclude { target: recv, elements: ref args, .. } => {
+            Insn::ArrayInclude { target: recv, elements: ref args, .. } => {
                 self.assert_subtype(insn_id, recv, types::BasicObject)?;
                 for &arg in args {
                     self.assert_subtype(insn_id, arg, types::BasicObject)?;

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -1145,7 +1145,7 @@ pub enum Insn {
         args: Vec<InsnId>,
         state: InsnId,
         leaf: bool,
-        return_type: Option<Type>,  // None for unannotated builtins
+        return_type: Type,  // BasicObject for unannotated builtins
     },
 
     /// Set up frame. Remember the address as the JIT entry for the insn_idx in `jit_entry_insns()[jit_entry_idx]`.
@@ -2635,8 +2635,8 @@ enum IseqReturn {
     Value(VALUE),
     LocalVariable(u32),
     Receiver,
-    // Builtin descriptor and return type (if known)
-    InvokeLeafBuiltin(*const rb_builtin_function, Option<Type>),
+    // Builtin descriptor and return type
+    InvokeLeafBuiltin(*const rb_builtin_function, Type),
 }
 
 unsafe extern "C" {
@@ -2706,8 +2706,7 @@ fn iseq_get_return_value(iseq: IseqPtr, captured_opnd: Option<InsnId>, ci_flags:
             if !leaf { return None; }
             // Check if this builtin is annotated
             let return_type = ZJITState::get_method_annotations()
-                .get_builtin_properties(bf)
-                .map(|props| props.return_type);
+                .get_builtin_return_type(bf);
             Some(IseqReturn::InvokeLeafBuiltin(bf, return_type))
         }
         _ => None,
@@ -3104,7 +3103,7 @@ impl Function {
             Insn::InvokeBlock { .. } => types::BasicObject,
             Insn::InvokeBlockIfunc { .. } => types::BasicObject,
             Insn::InvokeProc { .. } => types::BasicObject,
-            Insn::InvokeBuiltin { return_type, .. } => return_type.unwrap_or(types::BasicObject),
+            Insn::InvokeBuiltin { return_type, .. } => *return_type,
             Insn::Defined { pushval, .. } => Type::from_value(*pushval).union(types::NilClass),
             Insn::DefinedIvar { pushval, .. } => Type::from_value(*pushval).union(types::NilClass),
             Insn::GetConstant { .. } => types::BasicObject,
@@ -9104,8 +9103,7 @@ fn add_iseq_to_hir(
 
                     // Check if this builtin is annotated
                     let return_type = ZJITState::get_method_annotations()
-                        .get_builtin_properties(bf)
-                        .map(|props| props.return_type);
+                        .get_builtin_return_type(bf);
 
                     let builtin_attrs = unsafe { rb_jit_iseq_builtin_attrs(iseq) };
                     let leaf = builtin_attrs & BUILTIN_ATTR_LEAF != 0;
@@ -9140,8 +9138,7 @@ fn add_iseq_to_hir(
 
                     // Check if this builtin is annotated
                     let return_type = ZJITState::get_method_annotations()
-                        .get_builtin_properties(bf)
-                        .map(|props| props.return_type);
+                        .get_builtin_return_type(bf);
 
                     let builtin_attrs = unsafe { rb_jit_iseq_builtin_attrs(iseq) };
                     let leaf = builtin_attrs & BUILTIN_ATTR_LEAF != 0;

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -122,6 +122,61 @@ impl<'a> std::fmt::Display for VALUEPrinter<'a> {
     }
 }
 
+/// Compact 4-byte handle to a slice of [`InsnId`]s stored in a [`Function`]'s
+/// operand pool, replacing an inline `Vec<InsnId>` (24 bytes) in large `Insn`
+/// variants. The list is length-prefixed in the pool: the slot at `start` holds
+/// the length N, followed by the N operands.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct InsnIdList(u32);
+
+impl InsnIdList {
+    /// Handle to the canonical empty list (pool slot 0 always holds length 0).
+    pub const EMPTY: InsnIdList = InsnIdList(0);
+}
+
+/// Dense arena of operand lists referenced by [`InsnIdList`] handles. Operand
+/// lists are appended contiguously, each length-prefixed, so a handle is a
+/// single `u32` offset into `data`.
+#[derive(Debug, Clone)]
+pub struct OperandPool {
+    data: Vec<InsnId>,
+}
+
+impl OperandPool {
+    /// Slot 0 is reserved for the canonical empty list ([`InsnIdList::EMPTY`]).
+    fn new() -> Self { OperandPool { data: vec![InsnId(0)] } }
+
+    /// Append `operands` to the pool and return a compact handle to them.
+    pub fn push(&mut self, operands: &[InsnId]) -> InsnIdList {
+        if operands.is_empty() {
+            return InsnIdList::EMPTY;
+        }
+        let start = self.data.len();
+        assert!(start <= u32::MAX as usize, "operand pool overflow");
+        self.data.push(InsnId(operands.len()));
+        self.data.extend_from_slice(operands);
+        InsnIdList(start as u32)
+    }
+
+    /// Resolve a handle to its operand slice. Returns an empty slice for handles
+    /// that point past the end (e.g. standalone `Insn` Display with no pool).
+    pub fn get(&self, list: InsnIdList) -> &[InsnId] {
+        let start = list.0 as usize;
+        if start >= self.data.len() {
+            return &[];
+        }
+        let len = self.data[start].0;
+        &self.data[start + 1 .. start + 1 + len]
+    }
+
+    /// Resolve a handle to a mutable operand slice (for in-place operand rewrites).
+    pub fn get_mut(&mut self, list: InsnIdList) -> &mut [InsnId] {
+        let start = list.0 as usize;
+        let len = self.data[start].0;
+        &mut self.data[start + 1 .. start + 1 + len]
+    }
+}
+
 #[derive(Debug, PartialEq, Clone)]
 pub struct BranchEdge {
     pub target: BlockId,
@@ -1053,7 +1108,7 @@ pub enum Insn {
 
     /// Call a C function without pushing a frame
     /// `name` and `owner` are for printing purposes only
-    CCall { cfunc: *const u8, recv: InsnId, args: Vec<InsnId>, name: ID, owner: VALUE, return_type: Type, elidable: bool },
+    CCall { cfunc: *const u8, recv: InsnId, args: InsnIdList, name: ID, owner: VALUE, return_type: Type, elidable: bool },
 
     /// Call a C function that pushes a frame
     CCallWithFrame(Box<CCallWithFrameData>),
@@ -1232,10 +1287,11 @@ pub enum Insn {
 }
 
 /// Macro that enumerates all operands of an Insn, dispatching to caller-provided
-/// `$visit_one` macro for a single InsnId field and `$visit_many` macro for a
-/// slice/Vec of InsnIds. Used by both `for_each_operand` and `for_each_operand_mut`.
+/// `$visit_one` macro for a single InsnId field, `$visit_many` macro for a
+/// `Vec<InsnId>`, and `$visit_list` macro for an [`InsnIdList`] handle (resolved
+/// through the operand pool). Used by `for_each_operand` and friends.
 macro_rules! for_each_operand_impl {
-    ($self:expr, $visit_one:ident, $visit_many:ident) => {
+    ($self:expr, $visit_one:ident, $visit_many:ident, $visit_list:ident) => {
         match $self {
             Insn::Comment { .. }
             | Insn::Const { .. }
@@ -1490,7 +1546,7 @@ macro_rules! for_each_operand_impl {
             }
             Insn::CCall { recv, args, .. } => {
                 $visit_one!(*recv);
-                $visit_many!(args);
+                $visit_list!(*args);
             }
             Insn::GetIvar { self_val, state, .. }
             | Insn::DefinedIvar { self_val, state, .. } => {
@@ -1591,29 +1647,32 @@ impl Insn {
     }
 
     /// Call `f` on each operand (InsnId) of this instruction.
-    pub fn for_each_operand(&self, mut f: impl FnMut(InsnId)) {
+    pub fn for_each_operand(&self, pool: &OperandPool, mut f: impl FnMut(InsnId)) {
         macro_rules! visit_one { ($p:expr) => { f($p) }; }
         macro_rules! visit_many { ($s:expr) => { for id in ($s).iter() { f(*id) } }; }
-        for_each_operand_impl!(self, visit_one, visit_many);
+        macro_rules! visit_list { ($s:expr) => { for id in pool.get($s) { f(*id) } }; }
+        for_each_operand_impl!(self, visit_one, visit_many, visit_list);
     }
 
     /// Call `f` on a mutable reference to each operand (InsnId) of this instruction.
-    pub fn for_each_operand_mut(&mut self, mut f: impl FnMut(&mut InsnId)) {
+    pub fn for_each_operand_mut(&mut self, pool: &mut OperandPool, mut f: impl FnMut(&mut InsnId)) {
         macro_rules! visit_one { ($p:expr) => { f(&mut $p) }; }
         macro_rules! visit_many { ($s:expr) => { for id in ($s).iter_mut() { f(id) } }; }
-        for_each_operand_impl!(self, visit_one, visit_many);
+        macro_rules! visit_list { ($s:expr) => { for id in pool.get_mut($s).iter_mut() { f(id) } }; }
+        for_each_operand_impl!(self, visit_one, visit_many, visit_list);
     }
 
     /// Call `f` on each operand, short-circuiting on the first error.
-    pub fn try_for_each_operand<E>(&self, mut f: impl FnMut(InsnId) -> Result<(), E>) -> Result<(), E> {
+    pub fn try_for_each_operand<E>(&self, pool: &OperandPool, mut f: impl FnMut(InsnId) -> Result<(), E>) -> Result<(), E> {
         macro_rules! visit_one { ($p:expr) => { f($p)? }; }
         macro_rules! visit_many { ($s:expr) => { for id in ($s).iter() { f(*id)? } }; }
-        for_each_operand_impl!(self, visit_one, visit_many);
+        macro_rules! visit_list { ($s:expr) => { for id in pool.get($s) { f(*id)? } }; }
+        for_each_operand_impl!(self, visit_one, visit_many, visit_list);
         Ok(())
     }
 
-    pub fn print<'a>(&self, ptr_map: &'a PtrPrintMap, iseq: Option<IseqPtr>) -> InsnPrinter<'a> {
-        InsnPrinter { inner: self.clone(), ptr_map, iseq }
+    pub fn print<'a>(&self, ptr_map: &'a PtrPrintMap, iseq: Option<IseqPtr>, pool: Option<&'a OperandPool>) -> InsnPrinter<'a> {
+        InsnPrinter { inner: self.clone(), ptr_map, iseq, pool }
     }
 
     // TODO(Jacob): Model SP. ie, all allocations modify stack size but using the effect for stack modification feels excessive
@@ -1842,6 +1901,9 @@ pub struct InsnPrinter<'a> {
     inner: Insn,
     ptr_map: &'a PtrPrintMap,
     iseq: Option<IseqPtr>,
+    /// Operand pool for resolving [`InsnIdList`] handles (e.g. `CCall` args).
+    /// `None` for standalone `Insn` Display, where pooled operands render empty.
+    pool: Option<&'a OperandPool>,
 }
 
 fn get_local_var_id(iseq: IseqPtr, level: u32, ep_offset: u32) -> ID {
@@ -2198,6 +2260,7 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
             Insn::CCall { cfunc, recv, args, name, owner, return_type: _, elidable: _ } => {
                 let display_name = if *owner == Qnil { name.contents_lossy().to_string() } else { qualified_method_name(*owner, *name) };
                 write!(f, "CCall {recv}, :{}@{:p}", display_name, self.ptr_map.map_ptr(cfunc))?;
+                let args = self.pool.map_or(&[][..], |pool| pool.get(*args));
                 write_separated!(f, ", ", ", ", args);
                 Ok(())
             },
@@ -2325,7 +2388,7 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
 
 impl std::fmt::Display for Insn {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        self.print(&PtrPrintMap::identity(), None).fmt(f)
+        self.print(&PtrPrintMap::identity(), None, None).fmt(f)
     }
 }
 
@@ -2618,6 +2681,10 @@ pub struct Function {
 
     insns: Vec<Insn>,
     union_find: std::cell::RefCell<UnionFind<InsnId>>,
+    /// Arena backing the compact [`InsnIdList`] operand handles stored in large
+    /// `Insn` variants (e.g. `CCall`). Wrapped in `RefCell` because `find` and
+    /// Display read/append lists through `&self`.
+    operand_pool: std::cell::RefCell<OperandPool>,
     insn_types: Vec<Type>,
     blocks: Vec<Block>,
     /// Superblock that targets all entry blocks. The sole root for RPO/dominator computation.
@@ -2723,6 +2790,7 @@ impl Function {
             insns: vec![],
             insn_types: vec![],
             union_find: UnionFind::new().into(),
+            operand_pool: std::cell::RefCell::new(OperandPool::new()),
             blocks: vec![Block::default(), Block::default()],
             entries_block: BlockId(0),
             entry_block: BlockId(1),
@@ -2773,6 +2841,17 @@ impl Function {
     /// Return the number of instructions
     pub fn num_insns(&self) -> usize {
         self.insns.len()
+    }
+
+    /// Intern a slice of operands into the operand pool, returning a compact
+    /// [`InsnIdList`] handle for storage inside a large `Insn` variant.
+    pub fn push_operands(&self, operands: &[InsnId]) -> InsnIdList {
+        self.operand_pool.borrow_mut().push(operands)
+    }
+
+    /// Resolve an [`InsnIdList`] handle to its operand slice.
+    pub fn operands(&self, list: InsnIdList) -> std::cell::Ref<'_, [InsnId]> {
+        std::cell::Ref::map(self.operand_pool.borrow(), |pool| pool.get(list))
     }
 
     /// Return the deepest inlining nesting present in this function's frames.
@@ -2949,7 +3028,15 @@ impl Function {
         }
         let insn_id = find!(insn_id);
         let mut result = self.insns[insn_id.0].clone();
-        result.for_each_operand_mut(&mut |operand: &mut InsnId| {
+        // Operands stored in the operand pool (e.g. CCall args) are shared by
+        // handle with the original insn. Duplicate the list so remapping below
+        // doesn't mutate the canonical entry.
+        if let Insn::CCall { args, .. } = &mut result {
+            let dup = self.operand_pool.borrow().get(*args).to_vec();
+            *args = self.operand_pool.borrow_mut().push(&dup);
+        }
+        let mut pool = self.operand_pool.borrow_mut();
+        result.for_each_operand_mut(&mut pool, &mut |operand: &mut InsnId| {
             *operand = find!(*operand);
         });
         result
@@ -4310,7 +4397,7 @@ impl Function {
                                     // Filter for a leaf and GC free function
                                     let ccall = if props.leaf && props.no_gc {
                                         self.count(block, Counter::inline_cfunc_optimized_send_count);
-                                        self.push_insn(block, Insn::CCall { cfunc: cfunc_ptr, recv, args, name, owner, return_type, elidable })
+                                        self.push_insn(block, Insn::CCall { cfunc: cfunc_ptr, recv, args: self.push_operands(&args), name, owner, return_type, elidable })
                                     } else {
                                         if get_option!(stats) {
                                             self.count_not_inlined_cfunc(block, super_cme);
@@ -4360,7 +4447,7 @@ impl Function {
                                     // Filter for a leaf and GC free function
                                     let ccall = if props.leaf && props.no_gc {
                                         self.count(block, Counter::inline_cfunc_optimized_send_count);
-                                        self.push_insn(block, Insn::CCall { cfunc: cfunc_ptr, recv, args, name, owner, return_type, elidable })
+                                        self.push_insn(block, Insn::CCall { cfunc: cfunc_ptr, recv, args: self.push_operands(&args), name, owner, return_type, elidable })
                                     } else {
                                         if get_option!(stats) {
                                             self.count_not_inlined_cfunc(block, super_cme);
@@ -4787,7 +4874,7 @@ impl Function {
         self.push_insn(block, Insn::CCall {
             cfunc: rb_ivar_get_at_no_ractor_check as *const u8,
             recv,
-            args: vec![ivar_index_insn],
+            args: self.push_operands(&[ivar_index_insn]),
             name: ID!(rb_ivar_get_at_no_ractor_check),
             owner: Qnil,
             return_type: types::BasicObject,
@@ -5177,7 +5264,7 @@ impl Function {
                         if props.leaf && props.no_gc {
                             fun.count(block, Counter::inline_cfunc_optimized_send_count);
                             let owner = unsafe { (*cme).owner };
-                            let ccall = fun.push_insn(block, Insn::CCall { cfunc: cfunc_ptr, recv, args, name, owner, return_type, elidable });
+                            let ccall = fun.push_insn(block, Insn::CCall { cfunc: cfunc_ptr, recv, args: fun.push_operands(&args), name, owner, return_type, elidable });
                             fun.make_equal_to(send_insn_id, ccall);
                             return Ok(());
                         }
@@ -5243,7 +5330,7 @@ impl Function {
                         if props.leaf && props.no_gc {
                             fun.count(block, Counter::inline_cfunc_optimized_send_count);
                             let owner = unsafe { (*cme).owner };
-                            let ccall = fun.push_insn(block, Insn::CCall { cfunc: cfunc_ptr, recv, args, name, owner, return_type, elidable });
+                            let ccall = fun.push_insn(block, Insn::CCall { cfunc: cfunc_ptr, recv, args: fun.push_operands(&args), name, owner, return_type, elidable });
                             fun.make_equal_to(send_insn_id, ccall);
                             return Ok(());
                         }
@@ -5464,10 +5551,12 @@ impl Function {
                 let canonical_id = self.union_find.borrow().find_const(insn_id);
 
                 let union_find = &self.union_find;
-                self.insns[canonical_id.0].for_each_operand_mut(|operand| {
+                let mut pool = self.operand_pool.borrow_mut();
+                self.insns[canonical_id.0].for_each_operand_mut(&mut pool, |operand| {
                     let canon = union_find.borrow().find_const(*operand);
                     *operand = rewrite_map.get(&canon).copied().unwrap_or(canon);
                 });
+                drop(pool);
 
                 // For the binary guards only `left` is registered because their infer_type is
                 // type_of(left).
@@ -5840,7 +5929,8 @@ impl Function {
             if necessary.get(insn_id) { continue; }
             necessary.insert(insn_id);
             let insn_id = self.union_find.borrow().find_const(insn_id);
-            self.insns[insn_id.0].for_each_operand(|operand| {
+            let pool = self.operand_pool.borrow();
+            self.insns[insn_id.0].for_each_operand(&pool, |operand| {
                 worklist.push_back(self.union_find.borrow().find_const(operand));
             });
         }
@@ -6104,11 +6194,12 @@ impl Function {
                 };
 
 
-                let opcode = insn.print(&ptr_map, Some(self.iseq)).to_string();
+                let pool = self.operand_pool.borrow();
+                let opcode = insn.print(&ptr_map, Some(self.iseq), Some(&*pool)).to_string();
 
                 // Collect inputs for a given instruction.
                 let mut inputs = Vec::new();
-                insn.for_each_operand(|id| inputs.push(id.0.into()));
+                insn.for_each_operand(&pool, |id| inputs.push(id.0.into()));
                 let inputs: Vec<Json> = inputs;
 
                 instructions.push(
@@ -6374,7 +6465,8 @@ impl Function {
             }
             for &insn_id in &self.blocks[block.0].insns {
                 let insn_id = self.union_find.borrow().find_const(insn_id);
-                self.insns[insn_id.0].try_for_each_operand(|operand| {
+                let pool = self.operand_pool.borrow();
+                self.insns[insn_id.0].try_for_each_operand(&pool, |operand| {
                     let operand = self.union_find.borrow().find_const(operand);
                     if !assigned.get(operand) {
                         return Err(ValidationError::OperandNotDefined(block, insn_id, operand));
@@ -6818,7 +6910,7 @@ impl<'a> std::fmt::Display for FunctionPrinter<'a> {
                         write!(f, "{insn_id}:{} = ", insn_type.print(&self.ptr_map))?;
                     }
                 }
-                writeln!(f, "{}", insn.print(&self.ptr_map, Some(fun.iseq)))?;
+                writeln!(f, "{}", insn.print(&self.ptr_map, Some(fun.iseq), Some(&*fun.operand_pool.borrow())))?;
             }
         }
         Ok(())
@@ -8289,7 +8381,7 @@ fn add_iseq_to_hir(
                                 let is_proc = fun.push_insn(unmodified_block, Insn::CCall {
                                     cfunc: rb_obj_is_proc as *const u8,
                                     recv: proc_val,
-                                    args: vec![],
+                                    args: InsnIdList::EMPTY,
                                     name: ID!(rb_obj_is_proc),
                                     owner: Qnil,
                                     return_type: types::BasicObject,
@@ -8377,7 +8469,7 @@ fn add_iseq_to_hir(
                                         let proc_result = fun.push_insn(proc_check_block, Insn::CCall {
                                             cfunc: rb_obj_is_proc as *const u8,
                                             recv: proc_val,
-                                            args: vec![],
+                                            args: InsnIdList::EMPTY,
                                             name: ID!(rb_obj_is_proc),
                                             owner: Qnil,
                                             return_type: types::BasicObject,

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -1152,7 +1152,7 @@ pub enum Insn {
         recv: InsnId,
         cd: *const rb_call_data,
         blockiseq: IseqPtr,
-        args: Vec<InsnId>,
+        args: InsnIdList,
         state: InsnId,
         reason: SendFallbackReason,
     },
@@ -1514,13 +1514,13 @@ macro_rules! for_each_operand_impl {
             Insn::Send { recv, args, state, .. }
             | Insn::PushInlineFrame { recv, args, state, .. }
             | Insn::SendForward { recv, args, state, .. }
-            | Insn::InvokeSuper { recv, args, state, .. } => {
+            | Insn::InvokeSuper { recv, args, state, .. }
+            | Insn::InvokeSuperForward { recv, args, state, .. } => {
                 $visit_one!(*recv);
                 $visit_list!(*args);
                 $visit_one!(*state);
             }
             Insn::InvokeBuiltin { recv, args, state, .. }
-            | Insn::InvokeSuperForward { recv, args, state, .. }
             | Insn::InvokeProc { recv, args, state, .. } => {
                 $visit_one!(*recv);
                 $visit_many!(args);
@@ -2171,6 +2171,7 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
             }
             Insn::InvokeSuperForward { recv, blockiseq, args, reason, .. } => {
                 write!(f, "InvokeSuperForward {recv}, {:p}", self.ptr_map.map_ptr(blockiseq))?;
+                let args = self.pool.map_or(&[][..], |pool| pool.get(*args));
                 write_separated!(f, ", ", ", ", args);
                 write!(f, " # SendFallbackReason: {reason}")?;
                 Ok(())
@@ -3042,9 +3043,9 @@ impl Function {
         let insn_id = find!(insn_id);
         let mut result = self.insns[insn_id.0].clone();
         // Operands stored in the operand pool (e.g. CCall/Send/PushInlineFrame/
-        // SendForward/InvokeSuper args) are shared by handle with the original
-        // insn. Duplicate the list so remapping below doesn't mutate the canonical entry.
-        if let Insn::CCall { args, .. } | Insn::Send { args, .. } | Insn::PushInlineFrame { args, .. } | Insn::SendForward { args, .. } | Insn::InvokeSuper { args, .. } = &mut result {
+        // SendForward/InvokeSuper/InvokeSuperForward args) are shared by handle with
+        // the original insn. Duplicate the list so remapping below doesn't mutate the canonical entry.
+        if let Insn::CCall { args, .. } | Insn::Send { args, .. } | Insn::PushInlineFrame { args, .. } | Insn::SendForward { args, .. } | Insn::InvokeSuper { args, .. } | Insn::InvokeSuperForward { args, .. } = &mut result {
             let dup = self.operand_pool.borrow().get(*args).to_vec();
             *args = self.operand_pool.borrow_mut().push(&dup);
         }
@@ -6588,11 +6589,12 @@ impl Function {
                 self.assert_subtype(insn_id, klass, types::BasicObject)?;
                 self.assert_subtype(insn_id, allow_nil, types::BoolExact)
             }
-            // Send/PushInlineFrame/SendForward/InvokeSuper keep their operands in the pool; resolve before checking.
+            // These keep their operands in the pool; resolve before checking.
             Insn::Send { recv, args, .. }
             | Insn::PushInlineFrame { recv, args, .. }
             | Insn::SendForward { recv, args, .. }
-            | Insn::InvokeSuper { recv, args, .. } => {
+            | Insn::InvokeSuper { recv, args, .. }
+            | Insn::InvokeSuperForward { recv, args, .. } => {
                 self.assert_subtype(insn_id, recv, types::BasicObject)?;
                 for &arg in self.operands(args).to_vec().iter() {
                     self.assert_subtype(insn_id, arg, types::BasicObject)?;
@@ -6600,8 +6602,7 @@ impl Function {
                 Ok(())
             }
             // Instructions with recv and a Vec of Ruby objects
-            Insn::InvokeSuperForward { recv, ref args, .. }
-            | Insn::InvokeBuiltin { recv, ref args, .. }
+            Insn::InvokeBuiltin { recv, ref args, .. }
             | Insn::InvokeProc { recv, ref args, .. }
             | Insn::ArrayInclude { target: recv, elements: ref args, .. } => {
                 self.assert_subtype(insn_id, recv, types::BasicObject)?;
@@ -8957,7 +8958,7 @@ fn add_iseq_to_hir(
                     let argc = unsafe { vm_ci_argc((*cd).ci) };
                     let args = state.stack_pop_n(argc as usize + usize::from(forwarding))?;
                     let recv = state.stack_pop()?;
-                    let result = fun.push_insn(block, Insn::InvokeSuperForward { recv, cd, blockiseq, args, state: exit_id, reason: InvokeSuperForwardNotSpecialized });
+                    let result = fun.push_insn(block, Insn::InvokeSuperForward { recv, cd, blockiseq, args: fun.push_operands(&args), state: exit_id, reason: InvokeSuperForwardNotSpecialized });
                     state.stack_push(result);
 
                     if !blockiseq.is_null() {

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -964,7 +964,7 @@ pub enum Insn {
 
     StringCopy { val: InsnId, chilled: bool, state: InsnId },
     StringIntern { val: InsnId, state: InsnId },
-    StringConcat { strings: Vec<InsnId>, state: InsnId },
+    StringConcat { strings: InsnIdList, state: InsnId },
     /// Call rb_str_getbyte with known-Fixnum index
     StringGetbyte { string: InsnId, index: InsnId },
     StringSetbyteFixnum { string: InsnId, index: InsnId, value: InsnId },
@@ -1366,7 +1366,7 @@ macro_rules! for_each_operand_impl {
                 $visit_one!(*state);
             }
             Insn::StringConcat { strings, state, .. } => {
-                $visit_many!(strings);
+                $visit_list!(*strings);
                 $visit_one!(*state);
             }
             Insn::StringGetbyte { string, index } => {
@@ -2075,6 +2075,7 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
             }
             Insn::StringCopy { val, .. } => { write!(f, "StringCopy {val}") }
             Insn::StringConcat { strings, .. } => {
+                let strings = self.pool.map_or(&[][..], |pool| pool.get(*strings));
                 write!(f, "StringConcat")?;
                 write_separated!(f, " ", ", ", strings);
                 Ok(())
@@ -6675,14 +6676,9 @@ impl Function {
                 }
                 Ok(())
             }
-            Insn::ToRegexp { values, .. } => {
-                for &string in self.operands(values).to_vec().iter() {
-                    self.assert_subtype(insn_id, string, types::String)?;
-                }
-                Ok(())
-            }
-            Insn::StringConcat { ref strings, .. } => {
-                for &string in strings {
+            Insn::ToRegexp { values: strings, .. }
+            | Insn::StringConcat { strings, .. } => {
+                for &string in self.operands(strings).to_vec().iter() {
                     self.assert_subtype(insn_id, string, types::String)?;
                 }
                 Ok(())
@@ -7699,7 +7695,7 @@ fn add_iseq_to_hir(
                     let count = get_arg(pc, 0).as_u32();
                     debug_assert!(count > 0, "concatstrings should have arguments");
                     let strings = state.stack_pop_n(count as usize)?;
-                    let insn_id = fun.push_insn(block, Insn::StringConcat { strings, state: exit_id });
+                    let insn_id = fun.push_insn(block, Insn::StringConcat { strings: fun.push_operands(&strings), state: exit_id });
                     state.stack_push(insn_id);
                 }
                 YARVINSN_toregexp => {

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -989,7 +989,7 @@ pub enum Insn {
     NewRange { low: InsnId, high: InsnId, flag: RangeType, state: InsnId },
     NewRangeFixnum { low: InsnId, high: InsnId, flag: RangeType, state: InsnId },
     ArrayDup { val: InsnId, state: InsnId },
-    ArrayHash { elements: Vec<InsnId>, state: InsnId },
+    ArrayHash { elements: InsnIdList, state: InsnId },
     ArrayMax { elements: Vec<InsnId>, state: InsnId },
     ArrayMin { elements: Vec<InsnId>, state: InsnId },
     ArrayInclude { elements: Vec<InsnId>, target: InsnId, state: InsnId },
@@ -1335,9 +1335,12 @@ macro_rules! for_each_operand_impl {
                 $visit_one!(*val);
             }
             Insn::ArrayMax { elements, state, .. }
-            | Insn::ArrayMin { elements, state, .. }
-            | Insn::ArrayHash { elements, state, .. } => {
+            | Insn::ArrayMin { elements, state, .. } => {
                 $visit_many!(elements);
+                $visit_one!(*state);
+            }
+            Insn::ArrayHash { elements, state, .. } => {
+                $visit_list!(*elements);
                 $visit_one!(*state);
             }
             Insn::NewHash { elements, state, .. } => {
@@ -2048,6 +2051,7 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
                 Ok(())
             }
             Insn::ArrayHash { elements, .. } => {
+                let elements = self.pool.map_or(&[][..], |pool| pool.get(*elements));
                 write!(f, "ArrayHash")?;
                 write_separated!(f, " ", ", ", elements);
                 Ok(())
@@ -6671,9 +6675,14 @@ impl Function {
                 }
                 Ok(())
             }
+            Insn::ArrayHash { elements, .. } => {
+                for &arg in self.operands(elements).to_vec().iter() {
+                    self.assert_subtype(insn_id, arg, types::BasicObject)?;
+                }
+                Ok(())
+            }
             // Instructions with a Vec of Ruby objects
-            Insn::ArrayHash { elements: ref args, .. }
-            | Insn::ArrayMin { elements: ref args, .. }
+            Insn::ArrayMin { elements: ref args, .. }
             | Insn::ArrayMax { elements: ref args, .. } => {
                 for &arg in args {
                     self.assert_subtype(insn_id, arg, types::BasicObject)?;
@@ -7739,7 +7748,7 @@ fn add_iseq_to_hir(
                         }
                         VM_OPT_NEWARRAY_SEND_HASH => {
                             let elements = state.stack_pop_n(count)?;
-                            (BOP_HASH, Insn::ArrayHash { elements, state: exit_id })
+                            (BOP_HASH, Insn::ArrayHash { elements: fun.push_operands(&elements), state: exit_id })
                         }
                         VM_OPT_NEWARRAY_SEND_INCLUDE_P => {
                             let target = state.stack_pop()?;

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -991,7 +991,7 @@ pub enum Insn {
     ArrayDup { val: InsnId, state: InsnId },
     ArrayHash { elements: InsnIdList, state: InsnId },
     ArrayMax { elements: InsnIdList, state: InsnId },
-    ArrayMin { elements: Vec<InsnId>, state: InsnId },
+    ArrayMin { elements: InsnIdList, state: InsnId },
     ArrayInclude { elements: Vec<InsnId>, target: InsnId, state: InsnId },
     ArrayPackBuffer { elements: InsnIdList, fmt: InsnId, buffer: Option<InsnId>, state: InsnId },
     DupArrayInclude { ary: VALUE, target: InsnId, state: InsnId },
@@ -1335,7 +1335,7 @@ macro_rules! for_each_operand_impl {
                 $visit_one!(*val);
             }
             Insn::ArrayMin { elements, state, .. } => {
-                $visit_many!(elements);
+                $visit_list!(*elements);
                 $visit_one!(*state);
             }
             Insn::ArrayMax { elements, state, .. } => {
@@ -2050,6 +2050,7 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
                 Ok(())
             }
             Insn::ArrayMin { elements, .. } => {
+                let elements = self.pool.map_or(&[][..], |pool| pool.get(*elements));
                 write!(f, "ArrayMin")?;
                 write_separated!(f, " ", ", ", elements);
                 Ok(())
@@ -6691,9 +6692,8 @@ impl Function {
                 }
                 Ok(())
             }
-            // Instructions with a Vec of Ruby objects
-            Insn::ArrayMin { elements: ref args, .. } => {
-                for &arg in args {
+            Insn::ArrayMin { elements, .. } => {
+                for &arg in self.operands(elements).to_vec().iter() {
                     self.assert_subtype(insn_id, arg, types::BasicObject)?;
                 }
                 Ok(())
@@ -7753,7 +7753,7 @@ fn add_iseq_to_hir(
                         }
                         VM_OPT_NEWARRAY_SEND_MIN => {
                             let elements = state.stack_pop_n(count)?;
-                            (BOP_MIN, Insn::ArrayMin { elements, state: exit_id })
+                            (BOP_MIN, Insn::ArrayMin { elements: fun.push_operands(&elements), state: exit_id })
                         }
                         VM_OPT_NEWARRAY_SEND_HASH => {
                             let elements = state.stack_pop_n(count)?;

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -1144,7 +1144,7 @@ pub enum Insn {
         recv: InsnId,
         cd: *const rb_call_data,
         blockiseq: IseqPtr,
-        args: Vec<InsnId>,
+        args: InsnIdList,
         state: InsnId,
         reason: SendFallbackReason,
     },
@@ -1513,13 +1513,13 @@ macro_rules! for_each_operand_impl {
             }
             Insn::Send { recv, args, state, .. }
             | Insn::PushInlineFrame { recv, args, state, .. }
-            | Insn::SendForward { recv, args, state, .. } => {
+            | Insn::SendForward { recv, args, state, .. }
+            | Insn::InvokeSuper { recv, args, state, .. } => {
                 $visit_one!(*recv);
                 $visit_list!(*args);
                 $visit_one!(*state);
             }
             Insn::InvokeBuiltin { recv, args, state, .. }
-            | Insn::InvokeSuper { recv, args, state, .. }
             | Insn::InvokeSuperForward { recv, args, state, .. }
             | Insn::InvokeProc { recv, args, state, .. } => {
                 $visit_one!(*recv);
@@ -2164,6 +2164,7 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
             }
             Insn::InvokeSuper { recv, blockiseq, args, reason, .. } => {
                 write!(f, "InvokeSuper {recv}, {:p}", self.ptr_map.map_ptr(blockiseq))?;
+                let args = self.pool.map_or(&[][..], |pool| pool.get(*args));
                 write_separated!(f, ", ", ", ", args);
                 write!(f, " # SendFallbackReason: {reason}")?;
                 Ok(())
@@ -3041,9 +3042,9 @@ impl Function {
         let insn_id = find!(insn_id);
         let mut result = self.insns[insn_id.0].clone();
         // Operands stored in the operand pool (e.g. CCall/Send/PushInlineFrame/
-        // SendForward args) are shared by handle with the original insn. Duplicate
-        // the list so remapping below doesn't mutate the canonical entry.
-        if let Insn::CCall { args, .. } | Insn::Send { args, .. } | Insn::PushInlineFrame { args, .. } | Insn::SendForward { args, .. } = &mut result {
+        // SendForward/InvokeSuper args) are shared by handle with the original
+        // insn. Duplicate the list so remapping below doesn't mutate the canonical entry.
+        if let Insn::CCall { args, .. } | Insn::Send { args, .. } | Insn::PushInlineFrame { args, .. } | Insn::SendForward { args, .. } | Insn::InvokeSuper { args, .. } = &mut result {
             let dup = self.operand_pool.borrow().get(*args).to_vec();
             *args = self.operand_pool.borrow_mut().push(&dup);
         }
@@ -4208,6 +4209,7 @@ impl Function {
                         };
                     }
                     Insn::InvokeSuper { recv, cd, blockiseq, args, state, .. } => {
+                        let args = self.operands(args).to_vec();
                         // Helper to emit common guards for super call optimization.
                         fn emit_super_call_guards(
                             fun: &mut Function,
@@ -6586,10 +6588,11 @@ impl Function {
                 self.assert_subtype(insn_id, klass, types::BasicObject)?;
                 self.assert_subtype(insn_id, allow_nil, types::BoolExact)
             }
-            // Send/PushInlineFrame/SendForward keep their operands in the pool; resolve before checking.
+            // Send/PushInlineFrame/SendForward/InvokeSuper keep their operands in the pool; resolve before checking.
             Insn::Send { recv, args, .. }
             | Insn::PushInlineFrame { recv, args, .. }
-            | Insn::SendForward { recv, args, .. } => {
+            | Insn::SendForward { recv, args, .. }
+            | Insn::InvokeSuper { recv, args, .. } => {
                 self.assert_subtype(insn_id, recv, types::BasicObject)?;
                 for &arg in self.operands(args).to_vec().iter() {
                     self.assert_subtype(insn_id, arg, types::BasicObject)?;
@@ -6597,8 +6600,7 @@ impl Function {
                 Ok(())
             }
             // Instructions with recv and a Vec of Ruby objects
-            Insn::InvokeSuper { recv, ref args, .. }
-            | Insn::InvokeSuperForward { recv, ref args, .. }
+            Insn::InvokeSuperForward { recv, ref args, .. }
             | Insn::InvokeBuiltin { recv, ref args, .. }
             | Insn::InvokeProc { recv, ref args, .. }
             | Insn::ArrayInclude { target: recv, elements: ref args, .. } => {
@@ -8908,7 +8910,7 @@ fn add_iseq_to_hir(
                     let args = state.stack_pop_n(crate::profile::num_arguments_on_stack(cd))?;
                     let recv = state.stack_pop()?;
                     let blockiseq: IseqPtr = get_arg(pc, 1).as_ptr();
-                    let result = fun.push_insn(block, Insn::InvokeSuper { recv, cd, blockiseq, args, state: exit_id, reason: Uncategorized(opcode) });
+                    let result = fun.push_insn(block, Insn::InvokeSuper { recv, cd, blockiseq, args: fun.push_operands(&args), state: exit_id, reason: Uncategorized(opcode) });
                     state.stack_push(result);
 
                     if !blockiseq.is_null() {

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -992,7 +992,7 @@ pub enum Insn {
     ArrayHash { elements: InsnIdList, state: InsnId },
     ArrayMax { elements: InsnIdList, state: InsnId },
     ArrayMin { elements: InsnIdList, state: InsnId },
-    ArrayInclude { elements: Vec<InsnId>, target: InsnId, state: InsnId },
+    ArrayInclude { elements: InsnIdList, target: InsnId, state: InsnId },
     ArrayPackBuffer { elements: InsnIdList, fmt: InsnId, buffer: Option<InsnId>, state: InsnId },
     DupArrayInclude { ary: VALUE, target: InsnId, state: InsnId },
     /// Extend `left` with the elements from `right`. `left` and `right` must both be `Array`.
@@ -1355,7 +1355,7 @@ macro_rules! for_each_operand_impl {
                 $visit_one!(*state);
             }
             Insn::ArrayInclude { elements, target, state, .. } => {
-                $visit_many!(elements);
+                $visit_list!(*elements);
                 $visit_one!(*target);
                 $visit_one!(*state);
             }
@@ -2062,6 +2062,7 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
                 Ok(())
             }
             Insn::ArrayInclude { elements, target, .. } => {
+                let elements = self.pool.map_or(&[][..], |pool| pool.get(*elements));
                 write!(f, "ArrayInclude")?;
                 write_separated!(f, " ", ", ", elements);
                 write!(f, " | {target}")
@@ -6627,10 +6628,9 @@ impl Function {
                 }
                 Ok(())
             }
-            // Instructions with recv and a Vec of Ruby objects
-            Insn::ArrayInclude { target: recv, elements: ref args, .. } => {
+            Insn::ArrayInclude { target: recv, elements, .. } => {
                 self.assert_subtype(insn_id, recv, types::BasicObject)?;
-                for &arg in args {
+                for &arg in self.operands(elements).to_vec().iter() {
                     self.assert_subtype(insn_id, arg, types::BasicObject)?;
                 }
                 Ok(())
@@ -7762,7 +7762,7 @@ fn add_iseq_to_hir(
                         VM_OPT_NEWARRAY_SEND_INCLUDE_P => {
                             let target = state.stack_pop()?;
                             let elements = state.stack_pop_n(count - 1)?;
-                            (BOP_INCLUDE_P, Insn::ArrayInclude { elements, target, state: exit_id })
+                            (BOP_INCLUDE_P, Insn::ArrayInclude { elements: fun.push_operands(&elements), target, state: exit_id })
                         }
                         VM_OPT_NEWARRAY_SEND_PACK => {
                             let fmt = state.stack_pop()?;

--- a/zjit/src/hir/tests.rs
+++ b/zjit/src/hir/tests.rs
@@ -7,7 +7,7 @@ mod size_tests {
 
     #[test]
     fn test_size_of_insn() {
-        assert_eq!(std::mem::size_of::<Insn>(), 56);
+        assert_eq!(std::mem::size_of::<Insn>(), 48);
     }
 
     #[test]

--- a/zjit/src/hir/tests.rs
+++ b/zjit/src/hir/tests.rs
@@ -5842,8 +5842,8 @@ pub(crate) mod hir_build_tests {
  mod control_flow_info_tests {
      use super::*;
 
-     fn edge(target: BlockId) -> BranchEdge {
-         BranchEdge { target, args: vec![] }
+     fn edge(target: BlockId) -> Box<BranchEdge> {
+         Box::new(BranchEdge { target, args: vec![] })
      }
 
      #[test]
@@ -5925,8 +5925,8 @@ pub(crate) mod hir_build_tests {
      use super::*;
      use insta::assert_snapshot;
 
-     fn edge(target: BlockId) -> BranchEdge {
-         BranchEdge { target, args: vec![] }
+     fn edge(target: BlockId) -> Box<BranchEdge> {
+         Box::new(BranchEdge { target, args: vec![] })
      }
 
      fn assert_dominators_contains_self(function: &Function, dominators: &Dominators) {
@@ -6191,8 +6191,8 @@ mod loop_info_tests {
     use super::*;
     use insta::assert_snapshot;
 
-    fn edge(target: BlockId) -> BranchEdge {
-        BranchEdge { target, args: vec![] }
+    fn edge(target: BlockId) -> Box<BranchEdge> {
+        Box::new(BranchEdge { target, args: vec![] })
     }
 
     #[test]
@@ -6570,8 +6570,8 @@ mod iongraph_tests {
     use super::*;
     use insta::assert_snapshot;
 
-    fn edge(target: BlockId) -> BranchEdge {
-        BranchEdge { target, args: vec![] }
+    fn edge(target: BlockId) -> Box<BranchEdge> {
+        Box::new(BranchEdge { target, args: vec![] })
     }
 
     #[test]

--- a/zjit/src/hir/tests.rs
+++ b/zjit/src/hir/tests.rs
@@ -7,7 +7,7 @@ mod size_tests {
 
     #[test]
     fn test_size_of_insn() {
-        assert_eq!(std::mem::size_of::<Insn>(), 64);
+        assert_eq!(std::mem::size_of::<Insn>(), 56);
     }
 
     #[test]

--- a/zjit/src/hir/tests.rs
+++ b/zjit/src/hir/tests.rs
@@ -7,7 +7,7 @@ mod size_tests {
 
     #[test]
     fn test_size_of_insn() {
-        assert_eq!(std::mem::size_of::<Insn>(), 72);
+        assert_eq!(std::mem::size_of::<Insn>(), 64);
     }
 
     #[test]

--- a/zjit/src/hir/tests.rs
+++ b/zjit/src/hir/tests.rs
@@ -7,7 +7,7 @@ mod size_tests {
 
     #[test]
     fn test_size_of_insn() {
-        assert_eq!(std::mem::size_of::<Insn>(), 80);
+        assert_eq!(std::mem::size_of::<Insn>(), 72);
     }
 
     #[test]

--- a/zjit/src/hir/tests.rs
+++ b/zjit/src/hir/tests.rs
@@ -7,7 +7,7 @@ mod size_tests {
 
     #[test]
     fn test_size_of_insn() {
-        assert_eq!(std::mem::size_of::<Insn>(), 88);
+        assert_eq!(std::mem::size_of::<Insn>(), 80);
     }
 
     #[test]


### PR DESCRIPTION
- **ZJIT: Box SendDirect data**
- **ZJIT: Remove Option<Type> from InvokeBuiltin**
- **ZJIT: Box SideExitReason**
- **ZJIT: Box BranchEdge**
- **ZJIT: Store CCall args in an operand pool**
- **ZJIT: Store Send args in an operand pool**
- **ZJIT: Store PushInlineFrame args in an operand pool**
- **ZJIT: Store SendForward args in an operand pool**
- **ZJIT: Store InvokeSuper args in an operand pool**
- **ZJIT: Store InvokeSuperForward args in an operand pool**
- **ZJIT: Store InvokeBuiltin args in an operand pool**
- **ZJIT: Store ArrayPackBuffer elements in an operand pool**
- **ZJIT: Use ID::NONE sentinel for Guard bitset mask_name**
- **.**
- **ZJIT: Store InvokeBlock args in an operand pool**
- **ZJIT: Store InvokeBlockIfunc args in an operand pool**
- **ZJIT: Store ToRegexp values in an operand pool**
- **ZJIT: Store InvokeProc args in an operand pool**
- **ZJIT: Store StringConcat strings in an operand pool**
- **ZJIT: Store NewArray elements in an operand pool**
- **ZJIT: Store NewHash elements in an operand pool**
- **ZJIT: Store ArrayHash elements in an operand pool**
- **ZJIT: Store ArrayMax elements in an operand pool**
- **ZJIT: Store ArrayMin elements in an operand pool**
- **ZJIT: Store ArrayInclude elements in an operand pool**
- **ZJIT: Store Guard bitset mask as a plain u64**
