### PR TITLE
ZJIT: Shrink lir::Insn from 184 to 80 bytes

### DIFF
--- a/zjit/src/backend/arm64/mod.rs
+++ b/zjit/src/backend/arm64/mod.rs
@@ -1773,7 +1773,7 @@ mod tests {
 
         let val64 = asm.add(CFP, Opnd::UImm(64));
         asm.store(Opnd::mem(64, SP, 0x10), val64);
-        let side_exit = Target::SideExit { reason: SideExitReason::Interrupt, exit: SideExit { pc: 0.into(), iseq: std::ptr::null(), stack: vec![], locals: vec![], recompile: None } };
+        let side_exit = Target::SideExit { reason: SideExitReason::Interrupt, exit: Box::new(SideExit { pc: 0.into(), iseq: std::ptr::null(), stack: vec![], locals: vec![], recompile: None }) };
         asm.push_insn(Insn::Joz(val64, side_exit));
         asm.mov(C_ARG_OPNDS[0], C_RET_OPND.with_num_bits(32));
         asm.mov(C_ARG_OPNDS[1], Opnd::mem(64, SP, -8));

--- a/zjit/src/backend/arm64/mod.rs
+++ b/zjit/src/backend/arm64/mod.rs
@@ -1431,7 +1431,8 @@ impl Assembler {
                     // First operand is popped from the lower stack address
                     ldp_post(cb, first_pop, second_pop, A64Opnd::new_mem(64, C_SP_REG, C_SP_STEP));
                 },
-                Insn::CCall { fptr, .. } => {
+                Insn::CCall { data, .. } => {
+                    let fptr = &data.fptr;
                     match fptr {
                         Opnd::UImm(fptr) => {
                             // The offset to the call target in bytes

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -3837,6 +3837,11 @@ mod tests {
     }
 
     #[test]
+    fn test_size_of_insn() {
+        assert_eq!(std::mem::size_of::<Insn>(), 184);
+    }
+
+    #[test]
     fn test_for_each_operand() {
         let insn = Insn::Add { left: Opnd::None, right: Opnd::None, out: Opnd::None };
 

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -636,6 +636,25 @@ impl From<CodePtr> for Target {
 
 type PosMarkerFn = Rc<dyn Fn(CodePtr, &CodeBlock)>;
 
+/// Cold fields of `Insn::CCall`, boxed to keep `Insn` small. The operand-bearing
+/// fields (`opnds`, `stack_map`) stay inline on the variant so the operand
+/// iteration macros can reach them by reference.
+#[derive(Clone)]
+pub struct CCallData {
+    /// The function pointer to be called. This should be Opnd::const_ptr
+    /// (Opnd::UImm) in most cases. gen_entry_trampoline() uses Opnd::Reg.
+    pub fptr: Opnd,
+    /// Optional PosMarker to remember the start address of the C call.
+    /// It's embedded here to insert the PosMarker after push instructions
+    /// that are split from this CCall during register assignment.
+    pub start_marker: Option<PosMarkerFn>,
+    /// Optional PosMarker to remember the end address of the C call.
+    /// It's embedded here to insert the PosMarker before pop instructions
+    /// that are split from this CCall during register assignment.
+    pub end_marker: Option<PosMarkerFn>,
+    pub out: Opnd,
+}
+
 /// ZJIT Low-level IR instruction
 #[derive(Clone)]
 pub enum Insn {
@@ -683,19 +702,9 @@ pub enum Insn {
     // C function call with N arguments (variadic)
     CCall {
         opnds: Vec<Opnd>,
-        /// The function pointer to be called. This should be Opnd::const_ptr
-        /// (Opnd::UImm) in most cases. gen_entry_trampoline() uses Opnd::Reg.
-        fptr: Opnd,
-        /// Optional PosMarker to remember the start address of the C call.
-        /// It's embedded here to insert the PosMarker after push instructions
-        /// that are split from this CCall during register assignment.
-        start_marker: Option<PosMarkerFn>,
-        /// Optional PosMarker to remember the end address of the C call.
-        /// It's embedded here to insert the PosMarker before pop instructions
-        /// that are split from this CCall during register assignment.
-        end_marker: Option<PosMarkerFn>,
-        out: Opnd,
         stack_map: Option<StackMap>,
+        /// Cold fields (fptr, markers, out), boxed to keep `Insn` small.
+        data: Box<CCallData>,
     },
 
     // C function return
@@ -1087,7 +1096,6 @@ impl Insn {
         match self {
             Insn::Add { out, .. } |
             Insn::And { out, .. } |
-            Insn::CCall { out, .. } |
             Insn::CPop { out, .. } |
             Insn::CSelE { out, .. } |
             Insn::CSelG { out, .. } |
@@ -1109,6 +1117,7 @@ impl Insn {
             Insn::Mul { out, .. } |
             Insn::URShift { out, .. } |
             Insn::Xor { out, .. } => Some(out),
+            Insn::CCall { data, .. } => Some(&data.out),
             _ => None
         }
     }
@@ -1119,7 +1128,6 @@ impl Insn {
         match self {
             Insn::Add { out, .. } |
             Insn::And { out, .. } |
-            Insn::CCall { out, .. } |
             Insn::CPop { out, .. } |
             Insn::CSelE { out, .. } |
             Insn::CSelG { out, .. } |
@@ -1141,6 +1149,7 @@ impl Insn {
             Insn::Mul { out, .. } |
             Insn::URShift { out, .. } |
             Insn::Xor { out, .. } => Some(out),
+            Insn::CCall { data, .. } => Some(&mut data.out),
             _ => None
         }
     }
@@ -2284,7 +2293,8 @@ impl Assembler
             let mut new_ids = Vec::with_capacity(old_ids.len());
 
             for (insn, insn_id) in old_insns.into_iter().zip(old_ids.into_iter()) {
-                if let Insn::CCall { opnds, out, start_marker, end_marker, fptr, stack_map } = insn {
+                if let Insn::CCall { opnds, stack_map, data } = insn {
+                    let CCallData { out, start_marker, end_marker, fptr } = *data;
                     let insn_number = insn_id.map(|id| id.0).unwrap_or(0);
                     // Do we have a case where a ccall is emitted, but nobody
                     // uses the result?
@@ -2409,13 +2419,15 @@ impl Assembler
 
                     // The CCall itself
                     new_insns.push(Insn::CCall {
-                        out: C_RET_OPND,
                         opnds: vec![],  // We've moved everything in to ccall regs, so this should
                                         // be empty now
-                        start_marker: None,
-                        end_marker: None,
-                        fptr,
                         stack_map: None,
+                        data: Box::new(CCallData {
+                            out: C_RET_OPND,
+                            start_marker: None,
+                            end_marker: None,
+                            fptr,
+                        }),
                     });
                     new_ids.push(insn_id);
 
@@ -3440,7 +3452,7 @@ impl Assembler {
         let out = self.new_vreg(Opnd::match_num_bits(&opnds));
         let fptr = Opnd::const_ptr(fptr);
         let stack_map = self.stack_map.take();
-        self.push_insn(Insn::CCall { fptr, opnds, start_marker: None, end_marker: None, out, stack_map });
+        self.push_insn(Insn::CCall { opnds, stack_map, data: Box::new(CCallData { fptr, start_marker: None, end_marker: None, out }) });
         self.clear_stack_canary(canary_opnd);
         out
     }
@@ -3450,7 +3462,7 @@ impl Assembler {
     pub fn ccall_into(&mut self, out: Opnd, fptr: *const u8, opnds: Vec<Opnd>) {
         let fptr = Opnd::const_ptr(fptr);
         let stack_map = self.stack_map.take();
-        self.push_insn(Insn::CCall { fptr, opnds, start_marker: None, end_marker: None, out, stack_map });
+        self.push_insn(Insn::CCall { opnds, stack_map, data: Box::new(CCallData { fptr, start_marker: None, end_marker: None, out }) });
     }
 
     /// Call a C function stored in a register
@@ -3458,7 +3470,7 @@ impl Assembler {
         assert!(matches!(fptr, Opnd::Reg(_)), "ccall_reg must be called with Opnd::Reg: {fptr:?}");
         let out = self.new_vreg(num_bits);
         let stack_map = self.stack_map.take();
-        self.push_insn(Insn::CCall { fptr, opnds: vec![], start_marker: None, end_marker: None, out, stack_map });
+        self.push_insn(Insn::CCall { opnds: vec![], stack_map, data: Box::new(CCallData { fptr, start_marker: None, end_marker: None, out }) });
         out
     }
 
@@ -3474,12 +3486,14 @@ impl Assembler {
         let out = self.new_vreg(Opnd::match_num_bits(&opnds));
         let stack_map = self.stack_map.take();
         self.push_insn(Insn::CCall {
-            fptr: Opnd::const_ptr(fptr),
             opnds,
-            start_marker: Some(Rc::new(start_marker)),
-            end_marker: Some(Rc::new(end_marker)),
-            out,
             stack_map,
+            data: Box::new(CCallData {
+                fptr: Opnd::const_ptr(fptr),
+                start_marker: Some(Rc::new(start_marker)),
+                end_marker: Some(Rc::new(end_marker)),
+                out,
+            }),
         });
         out
     }
@@ -3839,7 +3853,7 @@ mod tests {
 
     #[test]
     fn test_size_of_insn() {
-        assert_eq!(std::mem::size_of::<Insn>(), 144);
+        assert_eq!(std::mem::size_of::<Insn>(), 80);
     }
 
     #[test]
@@ -4632,11 +4646,13 @@ mod tests {
         let v3 = asm.new_vreg(64);
         asm.basic_blocks[b1.0].push_insn(Insn::CCall {
             opnds: vec![v2],
-            fptr: Opnd::UImm(0xF00),
-            start_marker: None,
-            end_marker: None,
-            out: v3,
             stack_map: None,
+            data: Box::new(CCallData {
+                fptr: Opnd::UImm(0xF00),
+                start_marker: None,
+                end_marker: None,
+                out: v3,
+            }),
         });
 
         // v4 = Add(v3, v1)

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -577,8 +577,9 @@ pub enum Target
     Block(BranchEdge),
     /// Side exit to the interpreter
     SideExit {
-        /// Context used for compiling the side exit
-        exit: SideExit,
+        /// Context used for compiling the side exit. Boxed to keep `Target`
+        /// (and every `Insn` variant that embeds it) small.
+        exit: Box<SideExit>,
         /// We use this to increment exit counters
         reason: SideExitReason,
     },
@@ -851,9 +852,9 @@ pub enum Insn {
 macro_rules! target_for_each_operand_impl {
     ($self:expr, $visit_many:ident) => {
         match $self {
-            Target::SideExit { exit: SideExit { stack, locals, .. }, .. } => {
-                visit_many!(stack);
-                visit_many!(locals);
+            Target::SideExit { exit, .. } => {
+                visit_many!(exit.stack);
+                visit_many!(exit.locals);
             }
             Target::Block(edge) => {
                 visit_many!(edge.args);
@@ -2711,7 +2712,7 @@ impl Assembler
         for ((block_id, idx), target) in targets {
             // Compile a side exit. Note that this is past register assignment,
             // so you can't use an instruction that returns a VReg.
-            if let Target::SideExit { exit: exit @ SideExit { pc, .. }, reason } = target {
+            if let Target::SideExit { exit, reason } = target {
                 // Only record the exit if `trace_side_exits` is defined and the counter is either the one specified
                 let should_record_exit = get_option!(trace_side_exits).map(|trace| match trace {
                     TraceExits::All => true,
@@ -2755,9 +2756,9 @@ impl Assembler
                 } else {
                     let new_exit = self.new_label("side_exit");
                     self.write_label(new_exit.clone());
-                    asm_comment!(self, "Exit: {pc}");
+                    asm_comment!(self, "Exit: {}", exit.pc);
                     compile_exit(self, &exit, None);
-                    compiled_exits.insert(exit, new_exit.unwrap_label());
+                    compiled_exits.insert(*exit, new_exit.unwrap_label());
                     new_exit
                 };
 
@@ -3838,7 +3839,7 @@ mod tests {
 
     #[test]
     fn test_size_of_insn() {
-        assert_eq!(std::mem::size_of::<Insn>(), 184);
+        assert_eq!(std::mem::size_of::<Insn>(), 144);
     }
 
     #[test]

--- a/zjit/src/backend/x86_64/mod.rs
+++ b/zjit/src/backend/x86_64/mod.rs
@@ -1387,7 +1387,7 @@ mod tests {
 
         let val64 = asm.add(CFP, Opnd::UImm(64));
         asm.store(Opnd::mem(64, SP, 0x10), val64);
-        let side_exit = Target::SideExit { reason: SideExitReason::Interrupt, exit: SideExit { pc: 0.into(), iseq: std::ptr::null(), stack: vec![], locals: vec![], recompile: None } };
+        let side_exit = Target::SideExit { reason: SideExitReason::Interrupt, exit: Box::new(SideExit { pc: 0.into(), iseq: std::ptr::null(), stack: vec![], locals: vec![], recompile: None }) };
         asm.push_insn(Insn::Joz(val64, side_exit));
         asm.mov(C_ARG_OPNDS[0], C_RET_OPND.with_num_bits(32));
         asm.mov(C_ARG_OPNDS[1], Opnd::mem(64, SP, -8));

--- a/zjit/src/backend/x86_64/mod.rs
+++ b/zjit/src/backend/x86_64/mod.rs
@@ -917,7 +917,8 @@ impl Assembler {
                 },
 
                 // C function call
-                Insn::CCall { fptr, .. } => {
+                Insn::CCall { data, .. } => {
+                    let fptr = &data.fptr;
                     match fptr {
                         Opnd::UImm(fptr) => {
                             call_ptr(cb, RAX, *fptr as *const u8);

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -968,7 +968,7 @@ fn gen_patch_point(jit: &mut JITState, asm: &mut Assembler, invariant: &Invarian
     let exit = build_side_exit(jit, state);
 
     // Let compile_exits compile a side exit. Let scratch_split lower it with split_patch_point.
-    asm.patch_point(Target::SideExit { exit, reason: PatchPoint(invariant) }, invariant, jit.version);
+    asm.patch_point(Target::SideExit { exit: Box::new(exit), reason: PatchPoint(invariant) }, invariant, jit.version);
 }
 
 /// This is used by scratch_split to lower PatchPoint into PadPatchPoint and PosMarker.
@@ -3179,7 +3179,7 @@ fn compile_iseq(iseq: IseqPtr) -> Result<Function, CompileError> {
 /// Build a Target::SideExit
 fn side_exit(jit: &JITState, state: &FrameState, reason: SideExitReason) -> Target {
     let exit = build_side_exit(jit, state);
-    Target::SideExit { exit, reason }
+    Target::SideExit { exit: Box::new(exit), reason }
 }
 
 /// Build a Target::SideExit that optionally triggers exit_recompile on the exit path.
@@ -3189,7 +3189,7 @@ fn side_exit_with_recompile(jit: &JITState, state: &FrameState, reason: SideExit
         compiled_iseq: Opnd::Value(VALUE::from(jit.iseq())),
         insn_idx: state.insn_idx() as u32,
     });
-    Target::SideExit { exit, reason }
+    Target::SideExit { exit: Box::new(exit), reason }
 }
 
 /// Build a side-exit context


### PR DESCRIPTION
Box SideExit and CCall data, which are both huge.

- **ZJIT: Add test for size of LIR Insn**
- **ZJIT: Box Target::SideExit**
- **ZJIT: Box lir::CCall data**

Next up, shrinking Opnd.