### PR TITLE
Set `rb_nogvl` `errno` to `EINTR` when callback is skipped.

### DIFF
--- a/spec/ruby/optional/capi/ext/thread_spec.c
+++ b/spec/ruby/optional/capi/ext/thread_spec.c
@@ -172,6 +172,30 @@ static VALUE thread_spec_ruby_thread_has_gvl_p(VALUE self) {
 }
 #endif
 
+struct nogvl_intr_fail_data {
+  int called;
+};
+
+static void *nogvl_intr_fail_func(void *ptr) {
+  struct nogvl_intr_fail_data *data = ptr;
+
+  data->called = 1;
+
+  return (void *)Qtrue;
+}
+
+static VALUE thread_spec_rb_nogvl_intr_fail(VALUE self) {
+  struct nogvl_intr_fail_data data = {0};
+  void *ret;
+  int saved_errno;
+
+  errno = 0;
+  ret = rb_nogvl(nogvl_intr_fail_func, &data, RUBY_UBF_IO, 0, RB_NOGVL_INTR_FAIL);
+  saved_errno = errno;
+
+  return rb_ary_new_from_args(3, data.called ? Qtrue : Qfalse, (VALUE)ret, INT2FIX(saved_errno));
+}
+
 void Init_thread_spec(void) {
   VALUE cls = rb_define_class("CApiThreadSpecs", rb_cObject);
   rb_define_method(cls, "rb_thread_alone", thread_spec_rb_thread_alone, 0);
@@ -188,6 +212,7 @@ void Init_thread_spec(void) {
 #ifdef RUBY_VERSION_IS_4_0
   rb_define_method(cls,  "ruby_thread_has_gvl_p", thread_spec_ruby_thread_has_gvl_p, 0);
 #endif
+  rb_define_method(cls,  "rb_nogvl_intr_fail", thread_spec_rb_nogvl_intr_fail, 0);
 }
 
 #ifdef __cplusplus

--- a/spec/ruby/optional/capi/thread_spec.rb
+++ b/spec/ruby/optional/capi/thread_spec.rb
@@ -185,6 +185,26 @@ describe "C-API Thread function" do
     end
   end
 
+  ruby_version_is "4.1" do
+    describe "rb_nogvl with RB_NOGVL_INTR_FAIL" do
+      it "sets errno to EINTR when an interrupt prevents the blocking region from running" do
+        interrupted = false
+
+        begin
+          Thread.handle_interrupt(Interrupt => :never) do
+            Thread.current.raise(Interrupt)
+
+            @t.rb_nogvl_intr_fail.should == [false, nil, Errno::EINTR::Errno]
+          end
+        rescue Interrupt
+          interrupted = true
+        end
+
+        interrupted.should == true
+      end
+    end
+  end
+
   ruby_version_is "4.0" do
     describe "ruby_thread_has_gvl_p" do
       it "returns true if the current thread has the GVL" do

--- a/thread.c
+++ b/thread.c
@@ -1615,7 +1615,7 @@ rb_nogvl(void *(*func)(void *), void *data1,
     rb_thread_t *th = rb_ec_thread_ptr(ec);
     rb_vm_t *vm = rb_ec_vm_ptr(ec);
     bool is_main_thread = vm->ractor.main_thread == th;
-    int saved_errno = 0;
+    int saved_errno = EINTR;
 
     rb_thread_resolve_unblock_function(&ubf, &data2, th);
 


### PR DESCRIPTION
When `rb_nogvl` is called with a fail-before-blocking flag such as `RB_NOGVL_INTR_FAIL`, the blocking callback may not be invoked. In that path, `saved_errno` currently remains `0`, so callers that use a native-result sentinel can observe a skipped callback as an error with `errno == 0`.

Initialize `saved_errno` to `EINTR` so the skipped-callback path reports the same errno as an interrupted native wait. If the callback does run, `saved_errno` is still overwritten with the callback's actual errno value.

This is split out from #17553 so the broader errno behavior can be reviewed independently from the new `RB_NOGVL_PENDING_INTERRUPT_FAIL` flag.

Tested with:

```
make -C build -j8 ruby && make -C build test-spec MSPECOPT=../spec/ruby/optional/capi/thread_spec.rb
```
