### PR TITLE
Separate test-spec tmpdir

### DIFF
--- a/tool/lib/_tmpdir.rb
+++ b/tool/lib/_tmpdir.rb
@@ -110,4 +110,5 @@ END {
   end
 }
 
-ENV["TMPDIR"] = ENV["SPEC_TEMP_DIR"] = ENV["GEM_TEST_TMPDIR"] = tmpdir
+ENV["TMPDIR"] = ENV["GEM_TEST_TMPDIR"] = tmpdir
+ENV["SPEC_TEMP_DIR"] = File.join(tmpdir, "spec")


### PR DESCRIPTION
spec/mspec/lib/mspec/helpers/tmp.rb also tries to remove SPEC_TEMP_DIR at exit, before this `END`.  At that time, the "tmp" marker directory causes an ENOTEMPTY.