### PR TITLE
Convert Time to declarative marking

### DIFF
--- a/time.c
+++ b/time.c
@@ -256,18 +256,41 @@ divmodv(VALUE n, VALUE d, VALUE *q, VALUE *r)
 #define FIXWV_P(w) FIXWINT_P(WIDEVAL_GET(w))
 #define MUL_OVERFLOW_FIXWV_P(a, b) MUL_OVERFLOW_SIGNED_INTEGER_P(a, b, FIXWV_MIN, FIXWV_MAX)
 
-/* #define STRUCT_WIDEVAL */
-#ifdef STRUCT_WIDEVAL
-    /* for type checking */
+/* .value holds the markable VALUE; on 32-bit the wide int's high bits go in .hi */
+#if WIDEVALUE_IS_WIDER && SIZEOF_VALUE < SIZEOF_INT64_T
     typedef struct {
-        WIDEVALUE value;
+        VALUE value;
+        uint32_t hi;
     } wideval_t;
-    static inline wideval_t WIDEVAL_WRAP(WIDEVALUE v) { wideval_t w = { v }; return w; }
-#   define WIDEVAL_GET(w) ((w).value)
+    static inline wideval_t
+    WIDEVAL_WRAP(WIDEVALUE v)
+    {
+        wideval_t w;
+        w.value = (VALUE)(uint32_t)v;
+        w.hi = (uint32_t)(v >> 32);
+        return w;
+    }
+    static inline WIDEVALUE
+    WIDEVAL_GET(wideval_t w)
+    {
+        return ((WIDEVALUE)w.hi << 32) | (uint32_t)w.value;
+    }
 #else
-    typedef WIDEVALUE wideval_t;
-#   define WIDEVAL_WRAP(v) (v)
-#   define WIDEVAL_GET(w) (w)
+    typedef struct {
+        VALUE value;
+    } wideval_t;
+    static inline wideval_t
+    WIDEVAL_WRAP(WIDEVALUE v)
+    {
+        wideval_t w;
+        w.value = (VALUE)v;
+        return w;
+    }
+    static inline WIDEVALUE
+    WIDEVAL_GET(wideval_t w)
+    {
+        return (WIDEVALUE)w.value;
+    }
 #endif
 
 #if WIDEVALUE_IS_WIDER
@@ -1888,28 +1911,23 @@ force_make_tm(VALUE time, struct time_object *tobj)
     time_get_tm(time, tobj);
 }
 
-static void
-time_mark_and_move(void *ptr)
-{
-    struct time_object *tobj = ptr;
-    if (!WIDEVALUE_IS_WIDER || !FIXWV_P(tobj->timew)) {
-        rb_gc_mark_and_move((VALUE *)&WIDEVAL_GET(tobj->timew));
-    }
-    rb_gc_mark_and_move(&tobj->vtm.year);
-    rb_gc_mark_and_move(&tobj->vtm.subsecx);
-    rb_gc_mark_and_move(&tobj->vtm.utc_offset);
-    rb_gc_mark_and_move(&tobj->vtm.zone);
-}
+RUBY_REFERENCES(time_refs) = {
+    RUBY_REF_EDGE(struct time_object, timew.value),
+    RUBY_REF_EDGE(struct time_object, vtm.year),
+    RUBY_REF_EDGE(struct time_object, vtm.subsecx),
+    RUBY_REF_EDGE(struct time_object, vtm.utc_offset),
+    RUBY_REF_EDGE(struct time_object, vtm.zone),
+    RUBY_REF_END
+};
 
 static const rb_data_type_t time_data_type = {
     .wrap_struct_name = "time",
     .function = {
-        .dmark = time_mark_and_move,
+        RUBY_REFS_LIST_PTR(time_refs),
         .dfree = RUBY_TYPED_DEFAULT_FREE,
         .dsize = NULL,
-        .dcompact = time_mark_and_move,
     },
-    .flags = RUBY_TYPED_THREAD_SAFE_FREE | RUBY_TYPED_FROZEN_SHAREABLE | RUBY_TYPED_WB_PROTECTED | RUBY_TYPED_EMBEDDABLE,
+    .flags = RUBY_TYPED_THREAD_SAFE_FREE | RUBY_TYPED_FROZEN_SHAREABLE | RUBY_TYPED_WB_PROTECTED | RUBY_TYPED_EMBEDDABLE | RUBY_TYPED_DECL_MARKING,
 };
 
 static VALUE
@@ -5786,9 +5804,9 @@ tm_from_time(VALUE klass, VALUE time)
     ttm = RTYPEDDATA_GET_DATA(tm);
     v = &vtm;
 
-    WIDEVALUE timew = tobj->timew;
+    wideval_t timew = tobj->timew;
     GMTIMEW(timew, v);
-    time_set_timew(tm, ttm, wsub(timew, v->subsecx));
+    time_set_timew(tm, ttm, wsub(timew, v2w(v->subsecx)));
     v->subsecx = INT2FIX(0);
     v->zone = Qnil;
     time_set_vtm(tm, ttm, *v);


### PR DESCRIPTION
This splits the 32-bit implementation of the `wideval_t` struct into a proper VALUE sized field and a separate "hi" field. This allows us to declaratively mark the VALUE field.

The reason I want this is that I think we should take advantage of declarative marking in `rb_objspace_reachable_objects_from`, without relying on hooking into the mark_func callback.

---

A quick benchmark seems to suggest this is slightly faster than non-declarative marking and I didn't see a difference in building Time objects (I'm on a 64 bit machine, where there really shouldn't be a difference).


```ruby
times = Array.new(1000) { |i| Array.new(1000) { |j| Time.at(1782000000 + i * 1000 + j) } }

IPS.ips do |x|
  x.report("GC.start") { GC.start }
end
```

```
ruby 4.1.0dev (2026-06-24T06:17:34Z master 815710fc27) +YJIT dev_nodebug +PRISM [x86_64-linux]
scratch/bench_time_gc.rb:3: warning: assigned but unused variable - times
            GC.start:     68.592 i/s (± 0.7%, GC 99.9%)

ruby 4.1.0dev (2026-06-30T05:32:04Z time_wideval 92aa64e877) +YJIT dev_nodebug +PRISM [x86_64-linux]
scratch/bench_time_gc.rb:3: warning: assigned but unused variable - times
            GC.start:     87.753 i/s (± 1.1%, GC 99.9%)


Summary
  ruby ./ruby ran
    1.28 ± 0.02 times faster than ruby dev
```