### PR TITLE
Re-enable four Windows-skipped RubyGems and Bundler specs

### DIFF
--- a/spec/bundler/bundler/mirror_spec.rb
+++ b/spec/bundler/bundler/mirror_spec.rb
@@ -298,15 +298,13 @@ RSpec.describe Bundler::Settings::TCPSocketProbe do
 
   context "with a listening TCP Server" do
     def with_server_and_mirror
-      server = TCPServer.new("0.0.0.0", 0)
-      mirror = Bundler::Settings::Mirror.new("http://0.0.0.0:#{server.addr[1]}", 1)
+      server = TCPServer.new("127.0.0.1", 0)
+      mirror = Bundler::Settings::Mirror.new("http://127.0.0.1:#{server.addr[1]}", 1)
       yield server, mirror
       server.close unless server.closed?
     end
 
     it "probes the server correctly" do
-      skip "obscure error" if Gem.win_platform?
-
       with_server_and_mirror do |server, mirror|
         expect(server.closed?).to be_falsey
         expect(probe.replies?(mirror)).to be_truthy

--- a/spec/bundler/install/git_spec.rb
+++ b/spec/bundler/install/git_spec.rb
@@ -40,8 +40,6 @@ RSpec.describe "bundle install" do
     end
 
     it "displays the ref of the gem repository when using branch~num as a ref" do
-      skip "maybe branch~num notation doesn't work on Windows' git" if Gem.win_platform?
-
       build_git "foo", "1.0", path: lib_path("foo")
       rev = revision_for(lib_path("foo"))[0..6]
       update_git "foo", "2.0", path: lib_path("foo"), gemspec: true

--- a/test/rubygems/test_gem_compact_index_client_cache_file.rb
+++ b/test/rubygems/test_gem_compact_index_client_cache_file.rb
@@ -123,13 +123,12 @@ class TestGemCompactIndexClientCacheFile < Gem::TestCase
   end
 
   def test_write_preserves_permissions
-    pend "chmod is unreliable on Windows" if Gem.win_platform?
-
     @path.binwrite "old"
-    @path.chmod 0o600
+    @path.chmod 0o400
 
     CacheFile.write(@path, "new")
 
-    assert_equal 0o600, @path.stat.mode & 0o777
+    assert_equal "new", @path.binread
+    assert_equal 0, @path.stat.mode & 0o200, "expected CacheFile.write to preserve the original read-only permission"
   end
 end

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -3159,14 +3159,14 @@ duplicate dependency on c (>= 1.2.3, development), (~> 1.2) use:
   end
 
   def test_validate_files
-    pend "test_validate_files skipped on MS Windows (symlink)" if Gem.win_platform?
+    pend "Symlinks not supported or not enabled" unless symlink_supported?
     util_setup_validate
 
     @a1.files += ["lib", "lib2"]
     @a1.extensions << "ext/a/extconf.rb"
 
     Dir.chdir @tempdir do
-      FileUtils.ln_s "lib/code.rb", "lib2" unless vc_windows?
+      FileUtils.ln_s "lib/code.rb", "lib2"
 
       use_ui @ui do
         @a1.validate


### PR DESCRIPTION
These four specs were skipped on Windows, but each one exercises behavior that is actually platform-independent or relied on a stale assumption. I verified each on a real mswin build (`nmake test-bundler` and `nmake test-all` on `x64-mswin64_140`) and they all pass.

The mirror socket probe spec bound and probed `0.0.0.0`, which only behaves as loopback on Linux. On Windows `connect(0.0.0.0)` fails with an invalid address, so the example was skipped. Probing `127.0.0.1` works on every platform.

`test_validate_files` only needs a working symlink to exercise the platform-independent "is a symlink" validation warning, so it now gates on `symlink_supported?` instead of a blanket Windows skip and runs on Windows with Developer Mode enabled.

The CacheFile permission-preservation spec asserted an exact `0o600` mode that Windows cannot express. It now asserts that the read-only bit survives the temp-file-and-rename, which holds on every platform.

The `branch~num` git ref spec carried a never-confirmed "maybe branch~num notation doesn't work on Windows' git" skip. `main~2` ancestry refs resolve fine on current Windows git, so the skip is removed.

These files are vendored from rubygems/rubygems, so the same changes should also land upstream.
