### PR TITLE
[Bug #21995] Exclude C extension build artifacts from installed bundled gems

### DIFF
--- a/tool/rbinstall.rb
+++ b/tool/rbinstall.rb
@@ -689,7 +689,7 @@ module RbInstall
         # in its published .gem, so excluding those two by extension is safe.
         def build_artifact?(name)
           case name
-          when "mkmf.log", "gem_make.out", "Makefile"
+          when "mkmf.log", "gem_make.out", "Makefile", "exts.mk"
             true
           else
             /\Aconftest(?:\.|\z)/.match?(name) ||
@@ -1306,10 +1306,7 @@ install?(:ext, :comm, :gem, :'bundled-gems') do
     ins = RbInstall::UnpackedInstaller.new(package, options)
     puts "#{INDENT}#{spec.name} #{spec.version}"
     ins.install
-    # This installs the built extension, so the shared library and other
-    # products must stay. Only the build logs are noise here, unlike collect
-    # which strips the in-tree build leftovers from the gem directory.
-    install_recursive("#{build_dir}/#{gem_name}", "#{extensions_dir}/#{gem_name}", no_install: %w[mkmf.log gem_make.out]) do |src, dest|
+    install_recursive("#{build_dir}/#{gem_name}", "#{extensions_dir}/#{gem_name}") do |src, dest|
       # puts "#{INDENT}    #{dest[extensions_dir.size+gem_name.size+2..-1]}"
       install src, dest, :mode => (File.executable?(src) ? $prog_mode : $data_mode)
     end

--- a/tool/rbinstall.rb
+++ b/tool/rbinstall.rb
@@ -668,7 +668,23 @@ module RbInstall
           Dir.glob("**/*", File::FNM_DOTMATCH, base: base).select do |n|
             next if n == "."
             next if File.fnmatch?("*.gemspec", n, File::FNM_DOTMATCH|File::FNM_PATHNAME)
+            next if build_artifact?(File.basename(n))
             !File.directory?(File.join(base, n))
+          end
+        end
+
+        private
+
+        # Files left behind by building C extensions in-place under
+        # .bundle/gems. They are non-reproducible and unused at run time, so
+        # they must not be packed into the installed gem directory.
+        def build_artifact?(name)
+          case name
+          when "mkmf.log", "gem_make.out", "Makefile"
+            true
+          else
+            /\Aconftest\b/.match?(name) ||
+              /\.(?:o|obj|so|bundle|dll|dylib|time)\z/.match?(name)
           end
         end
       end
@@ -1281,7 +1297,7 @@ install?(:ext, :comm, :gem, :'bundled-gems') do
     ins = RbInstall::UnpackedInstaller.new(package, options)
     puts "#{INDENT}#{spec.name} #{spec.version}"
     ins.install
-    install_recursive("#{build_dir}/#{gem_name}", "#{extensions_dir}/#{gem_name}") do |src, dest|
+    install_recursive("#{build_dir}/#{gem_name}", "#{extensions_dir}/#{gem_name}", no_install: %w[mkmf.log gem_make.out]) do |src, dest|
       # puts "#{INDENT}    #{dest[extensions_dir.size+gem_name.size+2..-1]}"
       install src, dest, :mode => (File.executable?(src) ? $prog_mode : $data_mode)
     end

--- a/tool/rbinstall.rb
+++ b/tool/rbinstall.rb
@@ -675,15 +675,19 @@ module RbInstall
 
         private
 
-        # Files left behind by building C extensions in-place under
+        # Files left behind by building a C extension in place under
         # .bundle/gems. They are non-reproducible and unused at run time, so
-        # they must not be packed into the installed gem directory.
+        # they must not be packed into the installed gem directory. The built
+        # extension itself is installed separately into extensions_dir, so
+        # dropping the in-tree shared library here does not affect loading.
+        # This matches by base name, so a source file that happens to share
+        # one of these names would be excluded too.
         def build_artifact?(name)
           case name
           when "mkmf.log", "gem_make.out", "Makefile"
             true
           else
-            /\Aconftest\b/.match?(name) ||
+            /\Aconftest(?:\.|\z)/.match?(name) ||
               /\.(?:o|obj|so|bundle|dll|dylib|time)\z/.match?(name)
           end
         end
@@ -1297,6 +1301,9 @@ install?(:ext, :comm, :gem, :'bundled-gems') do
     ins = RbInstall::UnpackedInstaller.new(package, options)
     puts "#{INDENT}#{spec.name} #{spec.version}"
     ins.install
+    # This installs the built extension, so the shared library and other
+    # products must stay. Only the build logs are noise here, unlike collect
+    # which strips the in-tree build leftovers from the gem directory.
     install_recursive("#{build_dir}/#{gem_name}", "#{extensions_dir}/#{gem_name}", no_install: %w[mkmf.log gem_make.out]) do |src, dest|
       # puts "#{INDENT}    #{dest[extensions_dir.size+gem_name.size+2..-1]}"
       install src, dest, :mode => (File.executable?(src) ? $prog_mode : $data_mode)

--- a/tool/rbinstall.rb
+++ b/tool/rbinstall.rb
@@ -681,14 +681,19 @@ module RbInstall
         # extension itself is installed separately into extensions_dir, so
         # dropping the in-tree shared library here does not affect loading.
         # This matches by base name, so a source file that happens to share
-        # one of these names would be excluded too.
+        # one of these names would be excluded too. The extensions cover
+        # Unix/macOS (.o/.so/.bundle/.dylib) and Windows/MSVC, which also
+        # leaves an import library (.lib), export files (.exp/.def), debug
+        # databases (.pdb, including vc*.pdb), and .ilk/.pch/.res/.manifest
+        # beside the built DLL. No bundled gem ships a .lib or .def of its own
+        # in its published .gem, so excluding those two by extension is safe.
         def build_artifact?(name)
           case name
           when "mkmf.log", "gem_make.out", "Makefile"
             true
           else
             /\Aconftest(?:\.|\z)/.match?(name) ||
-              /\.(?:o|obj|so|bundle|dll|dylib|time)\z/.match?(name)
+              /\.(?:o|obj|so|bundle|dll|dylib|time|lib|exp|def|pdb|ilk|pch|res|manifest)\z/.match?(name)
           end
         end
       end


### PR DESCRIPTION
Bundled gem extensions are built in place under .bundle/gems, which leaves build artifacts such as mkmf.log, Makefile, object files and the in-tree shared library behind. UnpackedGem#collect globs the extracted gem tree and packs those artifacts into the installed gem directory, where they are non-reproducible and unused at run time. This breaks bit-for-bit reproducibility for distributions such as Guix and Nix that ship Ruby with these gems.

This change filters the build artifacts out at collection so only the gem sources and the compiled extension under extensions/ get installed. The build tree under .bundle is left untouched so a failed build keeps its logs for inspection.

This covers the bundled gem install path. The gem install path on the RubyGems side is handled separately.

https://bugs.ruby-lang.org/issues/21995
