### PR TITLE
sprintf.c: don't raise "too many arguments" errors when $DEBUG is set

### DIFF
--- a/spec/ruby/core/string/modulo_spec.rb
+++ b/spec/ruby/core/string/modulo_spec.rb
@@ -112,18 +112,20 @@ describe "String#%" do
     end
   end
 
-  it "raises an ArgumentError for unused arguments when $DEBUG is true" do
-    begin
-      old_debug = $DEBUG
-      $DEBUG = true
-      s = $stderr
-      $stderr = IOStub.new
+  ruby_version_is ""..."4.1" do
+    it "raises an ArgumentError for unused arguments when $DEBUG is true" do
+      begin
+        old_debug = $DEBUG
+        $DEBUG = true
+        s = $stderr
+        $stderr = IOStub.new
 
-      -> { "" % [1, 2, 3]   }.should.raise(ArgumentError)
-      -> { "%s" % [1, 2, 3] }.should.raise(ArgumentError)
-    ensure
-      $DEBUG = old_debug
-      $stderr = s
+        -> { "" % [1, 2, 3]   }.should.raise(ArgumentError)
+        -> { "%s" % [1, 2, 3] }.should.raise(ArgumentError)
+      ensure
+        $DEBUG = old_debug
+        $stderr = s
+      end
     end
   end
 

--- a/sprintf.c
+++ b/sprintf.c
@@ -947,7 +947,6 @@ rb_str_format(int argc, const VALUE *argv, VALUE fmt)
      */
     if (posarg >= 0 && nextarg < argc && !(argc == 2 && RB_TYPE_P(argv[1], T_HASH))) {
         const char *mesg = "too many arguments for format string";
-        if (RTEST(ruby_debug)) rb_raise(rb_eArgError, "%s", mesg);
         if (RTEST(ruby_verbose)) rb_warn("%s", mesg);
     }
     rb_str_resize(result, blen);


### PR DESCRIPTION
[[Feature #22136]](https://bugs.ruby-lang.org/issues/22136)

This is as far as I can tell the only method that changes its behavior in debug mode, and that's all but helpful because it might cause the program to abort.

Usually when you run a program with $DEBUG set, it is to find some error that may have been swallowed, so aside from the extra output you would expect Ruby to behave the same than in normal mode.