### PR TITLE
ZJIT: Shrink lir::Insn from 80 to 56 bytes

### DIFF
--- a/zjit/src/backend/arm64/mod.rs
+++ b/zjit/src/backend/arm64/mod.rs
@@ -815,11 +815,11 @@ impl Assembler {
                     asm.push_insn(insn);
                 }
                 // For compile_exits, support splitting simple C arguments here
-                Insn::CCall { opnds, .. } if !opnds.is_empty() => {
-                    for (i, opnd) in opnds.iter().enumerate() {
+                Insn::CCall { data } if !data.opnds.is_empty() => {
+                    for (i, opnd) in data.opnds.iter().enumerate() {
                         asm.load_into(C_ARG_OPNDS[i], *opnd);
                     }
-                    *opnds = vec![];
+                    data.opnds = vec![];
                     asm.push_insn(insn);
                 }
                 // For compile_exits, support splitting simple return values here

--- a/zjit/src/backend/arm64/mod.rs
+++ b/zjit/src/backend/arm64/mod.rs
@@ -476,7 +476,7 @@ impl Assembler {
                     same_opnd_if_test && if let Some(
                             Insn::Jz(target) | Insn::Je(target) | Insn::Jnz(target) | Insn::Jne(target)
                         ) = iterator.peek() {
-                            matches!(target, Target::SideExit { .. })
+                            matches!(target, Target::SideExit(..))
                         } else {
                             false
                         }
@@ -987,7 +987,7 @@ impl Assembler {
                 },
                 Target::Label(l) => l,
                 Target::Block(ref edge) => asm.block_label(edge.target),
-                Target::SideExit { .. } => {
+                Target::SideExit(..) => {
                     unreachable!("Target::SideExit should have been compiled by compile_exits")
                 },
             };
@@ -1499,7 +1499,7 @@ impl Assembler {
                                 }
                             });
                         },
-                        Target::SideExit { .. } => {
+                        Target::SideExit(..) => {
                             unreachable!("Target::SideExit should have been compiled by compile_exits")
                         },
                     };
@@ -1774,7 +1774,7 @@ mod tests {
 
         let val64 = asm.add(CFP, Opnd::UImm(64));
         asm.store(Opnd::mem(64, SP, 0x10), val64);
-        let side_exit = Target::SideExit { reason: SideExitReason::Interrupt, exit: Box::new(SideExit { pc: 0.into(), iseq: std::ptr::null(), stack: vec![], locals: vec![], recompile: None }) };
+        let side_exit = Target::SideExit(Box::new(SideExitTarget { reason: SideExitReason::Interrupt, exit: SideExit { pc: 0.into(), iseq: std::ptr::null(), stack: vec![], locals: vec![], recompile: None } }));
         asm.push_insn(Insn::Joz(val64, side_exit));
         asm.mov(C_ARG_OPNDS[0], C_RET_OPND.with_num_bits(32));
         asm.mov(C_ARG_OPNDS[1], Opnd::mem(64, SP, -8));

--- a/zjit/src/backend/arm64/mod.rs
+++ b/zjit/src/backend/arm64/mod.rs
@@ -890,8 +890,8 @@ impl Assembler {
                         _ => asm.push_insn(insn),
                     }
                 }
-                &mut Insn::PatchPoint { ref target, invariant, version } => {
-                    split_patch_point(asm, target, invariant, version);
+                &mut Insn::PatchPoint(ref data) => {
+                    split_patch_point(asm, &data.target, data.invariant, data.version);
                 }
                 _ => {
                     asm.push_insn(insn);
@@ -1534,7 +1534,7 @@ impl Assembler {
                 Insn::Jonz(opnd, target) => {
                     emit_cmp_zero_jump(cb, opnd.into(), false, target.clone());
                 },
-                Insn::PatchPoint { .. } => unreachable!("PatchPoint should have been lowered to PadPatchPoint in arm64_scratch_split"),
+                Insn::PatchPoint(..) => unreachable!("PatchPoint should have been lowered to PadPatchPoint in arm64_scratch_split"),
                 Insn::PadPatchPoint => {
                     // If patch points are too close to each other or the end of the block, fill nop instructions
                     if let Some(last_patch_pos) = last_patch_pos {

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -14,14 +14,32 @@ use crate::stats::{exit_counter_ptr, exit_counter_ptr_for_opcode, side_exit_coun
 use crate::virtualmem::CodePtr;
 use crate::asm::{CodeBlock, Label};
 use crate::state::{ZJITState, rb_zjit_record_exit_stack};
+use crate::cast::IntoUsize;
 
 /// LIR Block ID. Unique ID for each block, and also defined in LIR so
 /// we can differentiate it from HIR block ids.
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, PartialOrd, Ord)]
 pub struct BlockId(pub usize);
 
+/// Underlying integer width of a virtual-register id. Narrow to keep `Opnd`/`Mem` small.
+pub type VRegIdBase = u32;
+/// Width of a stack-slot index inside `MemBase`. Separate id space from `VRegId`.
+pub type StackIdx = u32;
+
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, PartialOrd, Ord)]
-pub struct VRegId(pub usize);
+pub struct VRegId(pub VRegIdBase);
+
+impl IntoUsize for VRegId {
+    fn to_usize(self) -> usize {
+        self.0.to_usize()
+    }
+}
+
+impl From<usize> for VRegId {
+    fn from(val: usize) -> Self {
+        VRegId(val.try_into().unwrap())
+    }
+}
 
 impl From<BlockId> for usize {
     fn from(val: BlockId) -> Self {
@@ -29,10 +47,23 @@ impl From<BlockId> for usize {
     }
 }
 
-impl From<VRegId> for usize {
-    fn from(val: VRegId) -> Self {
-        val.0
-    }
+impl<T> std::ops::Index<VRegId> for [T] {
+    type Output = T;
+    #[inline]
+    fn index(&self, i: VRegId) -> &T { &self[i.to_usize()] }
+}
+impl<T> std::ops::IndexMut<VRegId> for [T] {
+    #[inline]
+    fn index_mut(&mut self, i: VRegId) -> &mut T { &mut self[i.to_usize()] }
+}
+impl<T> std::ops::Index<VRegId> for Vec<T> {
+    type Output = T;
+    #[inline]
+    fn index(&self, i: VRegId) -> &T { &self[i.to_usize()] }
+}
+impl<T> std::ops::IndexMut<VRegId> for Vec<T> {
+    #[inline]
+    fn index_mut(&mut self, i: VRegId) -> &mut T { &mut self[i.to_usize()] }
 }
 
 impl std::fmt::Display for BlockId {
@@ -220,13 +251,13 @@ pub enum MemBase
     /// Stack slot: a direct stack access. `stack_membase_to_mem()` turns this
     /// into `[NATIVE_BASE_PTR + disp]`, so scratch splitting can use it as a
     /// normal memory operand without first loading a pointer from the stack.
-    Stack { stack_idx: usize, num_bits: u8 },
+    Stack { stack_idx: StackIdx, num_bits: u8 },
     /// A pointer stored in a stack slot, used as a memory base.
     /// Unlike Stack, this first loads the pointer value from the stack slot
     /// into a scratch register, then uses that register as the base for the
     /// memory access with the Mem's displacement.
     /// Created when a VReg used as MemBase is spilled to the stack.
-    StackIndirect { stack_idx: usize },
+    StackIndirect { stack_idx: StackIdx },
 }
 
 // Memory location
@@ -422,6 +453,11 @@ impl Opnd
         }
     }
 
+    /// Unwrap the index of a VReg as a `usize`, for raw-`usize` APIs (bitsets, etc.).
+    pub fn vreg_idx_usize(&self) -> usize {
+        self.vreg_idx().to_usize()
+    }
+
     /// Extract VReg indices from this operand, including memory base VRegs.
     /// Returns an iterator over all VRegIds referenced by this operand.
     pub fn vreg_ids(&self) -> impl Iterator<Item = VRegId> {
@@ -466,10 +502,10 @@ impl Opnd
     pub fn map_index(self, indices: &[usize]) -> Opnd {
         match self {
             Opnd::VReg { idx, num_bits } => {
-                Opnd::VReg { idx: VRegId(indices[idx.0]), num_bits }
+                Opnd::VReg { idx: indices[idx].into(), num_bits }
             }
             Opnd::Mem(Mem { base: MemBase::VReg(idx), disp, num_bits }) => {
-                Opnd::Mem(Mem { base: MemBase::VReg(VRegId(indices[idx.0])), disp, num_bits })
+                Opnd::Mem(Mem { base: MemBase::VReg(indices[idx].into()), disp, num_bits })
             },
             _ => self
         }
@@ -1272,12 +1308,12 @@ impl LiveRange {
 #[derive(Clone)]
 pub struct Interval {
     pub range: LiveRange,
-    pub id: usize,
+    pub id: VRegId,
 }
 
 impl Interval {
     /// Create a new Interval with no range
-    pub fn new(i: usize) -> Self {
+    pub fn new(i: VRegId) -> Self {
         Self {
             range: LiveRange {
                 start: None,
@@ -1480,8 +1516,8 @@ impl StackState {
     }
 
     /// Convert a stack index to the `disp` of the stack slot
-    fn stack_idx_to_disp(&self, stack_idx: usize) -> i32 {
-        (self.stack_base_idx + stack_idx + 1) as i32 * -SIZEOF_VALUE_I32
+    fn stack_idx_to_disp(&self, stack_idx: StackIdx) -> i32 {
+        (self.stack_base_idx + stack_idx.to_usize() + 1) as i32 * -SIZEOF_VALUE_I32
     }
 
     /// Convert MemBase::Stack to Mem
@@ -1850,7 +1886,7 @@ impl Assembler
 
     /// Build an Opnd::VReg
     pub fn new_vreg(&mut self, num_bits: u8) -> Opnd {
-        let vreg = Opnd::VReg { idx: VRegId(self.num_vregs), num_bits };
+        let vreg = Opnd::VReg { idx: self.num_vregs.into(), num_bits };
         self.num_vregs += 1;
         vreg
     }
@@ -1953,10 +1989,10 @@ impl Assembler
                     {
                         if let Some(Opnd::VReg { idx: out_idx, .. }) = prev.out_opnd() {
                             if out_idx == idx
-                                && intervals[idx.0].born_at(prev_id.0)
-                                && intervals[idx.0].dies_at(insn_id.0)
+                                && intervals[*idx].born_at(prev_id.0)
+                                && intervals[*idx].dies_at(insn_id.0)
                             {
-                                preferred[idx.0].get_or_insert(*dest_reg);
+                                preferred[*idx].get_or_insert(*dest_reg);
                             }
                         }
                     }
@@ -2127,7 +2163,7 @@ impl Assembler
                 let reg_copies: Vec<parcopy::RegisterCopy<Opnd>> = edge.args
                     .iter()
                     .zip(params.iter())
-                    .filter(|(_arg, param)| assignments[param.vreg_idx().0].is_some() )
+                    .filter(|(_arg, param)| assignments[param.vreg_idx()].is_some() )
                     .map(|(arg, param)| parcopy::RegisterCopy::<Opnd> {
                         destination: Self::rewritten_opnd(*param, assignments),
                         source: Self::rewritten_opnd(*arg, assignments),
@@ -2299,15 +2335,15 @@ impl Assembler
                     // Do we have a case where a ccall is emitted, but nobody
                     // uses the result?
                     let call_result_live = out.is_vreg()
-                        && intervals[out.vreg_idx().0]
+                        && intervals[out.vreg_idx()]
                             .range
                             .end
                             .is_some_and(|end| end > insn_number);
 
                     // Build a set of VRegIds that can be referenced by JITFrame for materializing the VM stack
-                    let stack_vreg_ids: HashSet<usize> = if let Some(StackMap { stack, .. }) = &stack_map {
+                    let stack_vreg_ids: HashSet<VRegId> = if let Some(StackMap { stack, .. }) = &stack_map {
                         stack.iter().filter_map(|opnd| match opnd {
-                            Opnd::VReg { idx: VRegId(vreg_id), .. } => Some(*vreg_id),
+                            Opnd::VReg { idx, .. } => Some(*idx),
                             _ => None,
                         }).collect()
                     } else {
@@ -2318,7 +2354,7 @@ impl Assembler
                     // We need to preserve the "surviving" registers past the ccall,
                     // so we're going to push them all on the stack, then pop
                     // after we make the ccall
-                    let survivors: Vec<usize> = intervals.iter()
+                    let survivors: Vec<VRegId> = intervals.iter()
                         .filter(|interval| {
                             // We need to spill register intervals on this CCall in two cases:
                             // 1) The VReg is referenced in an instruction after the CCall
@@ -2359,10 +2395,10 @@ impl Assembler
                                     assert!(value.special_const_p(), "StackMap should only materialize immediate VALUEs, but got: {value:?}");
                                     value
                                 }
-                                Opnd::VReg { idx: VRegId(vreg_id), .. } => {
-                                    let vreg_stack_index = match assignments[*vreg_id].expect("StackMap VReg should have an allocation") {
+                                Opnd::VReg { idx: vreg, .. } => {
+                                    let vreg_stack_index = match assignments[*vreg].expect("StackMap VReg should have an allocation") {
                                         Allocation::Reg(_) | Allocation::Fixed(_) => {
-                                            let caller_saved_reg_idx = survivors.iter().position(|&survivor_id| survivor_id == *vreg_id).unwrap();
+                                            let caller_saved_reg_idx = survivors.iter().position(|&survivor_id| survivor_id == *vreg).unwrap();
                                             let stack_idx = self.stack_state.stack_idx_for_caller_saved_reg(caller_saved_reg_idx);
                                             self.stack_state.stack_map_index_for_spill(stack_idx, frame_depth)
                                         }
@@ -2507,7 +2543,7 @@ impl Assembler
 
         match opnd {
             Opnd::VReg { idx, num_bits } => {
-                if let Some(assignment) = assignments[idx.0] {
+                if let Some(assignment) = assignments[*idx] {
                     match assignment {
                         Allocation::Reg(n) => {
                             let mut reg = regs[n];
@@ -2521,7 +2557,7 @@ impl Assembler
                         Allocation::Stack(n) => {
                             let num_bits = *num_bits;
                             *opnd = Opnd::Mem(Mem {
-                                base: MemBase::Stack { stack_idx: n, num_bits },
+                                base: MemBase::Stack { stack_idx: n.try_into().unwrap(), num_bits },
                                 disp: 0,
                                 num_bits,
                             });
@@ -2532,7 +2568,7 @@ impl Assembler
                 }
             }
             Opnd::Mem(Mem { base: MemBase::VReg(idx), .. }) => {
-                match assignments[idx.0].unwrap() {
+                match assignments[*idx].unwrap() {
                     Allocation::Reg(n) => {
                         if let Opnd::Mem(mem) = opnd {
                             mem.base = MemBase::Reg(regs[n].reg_no);
@@ -2548,7 +2584,7 @@ impl Assembler
                         // Mark it as StackIndirect so arm64_scratch_split can load
                         // the pointer from the stack into a scratch register.
                         if let Opnd::Mem(mem) = opnd {
-                            mem.base = MemBase::StackIndirect { stack_idx: n };
+                            mem.base = MemBase::StackIndirect { stack_idx: n.try_into().unwrap() };
                         }
                     }
                 }
@@ -2896,15 +2932,15 @@ impl Assembler
                 // If the instruction has an output that is a VReg, add to kill set
                 if let Some(out) = insn.out_opnd() {
                     if let Opnd::VReg { idx, .. } = out {
-                        kill_set.insert(idx.0);
+                        kill_set.insert(idx.to_usize());
                     }
                 }
 
                 // For all input operands that are VRegs (including memory base VRegs), add to gen set
                 insn.for_each_operand(|opnd| {
                     for idx in opnd.vreg_ids() {
-                        assert!(!kill_set.get(idx.0));
-                        gen_set.insert(idx.0);
+                        assert!(!kill_set.get(idx.to_usize()));
+                        gen_set.insert(idx.to_usize());
                     }
                 });
             }
@@ -2912,7 +2948,7 @@ impl Assembler
             // Add block parameters to kill set
             for param in &block.parameters {
                 if let Opnd::VReg { idx, .. } = param {
-                    kill_set.insert(idx.0);
+                    kill_set.insert(idx.to_usize());
                 }
             }
 
@@ -2929,7 +2965,7 @@ impl Assembler
     pub fn build_intervals(&self, live_in: Vec<BitSet<usize>>) -> Vec<Interval> {
         let num_vregs = self.num_vregs;
         let mut intervals: Vec<Interval> = (0..num_vregs)
-            .map(|i| Interval::new(i))
+            .map(|i| Interval::new(i.into()))
             .collect();
 
         let blocks = self.block_order();
@@ -2945,7 +2981,7 @@ impl Assembler
 
             // Add out_vregs to live set
             for idx in block.out_vregs() {
-                live.insert(idx.0);
+                live.insert(idx.to_usize());
             }
 
             // For each live vreg, add entire block range
@@ -2961,14 +2997,14 @@ impl Assembler
                 // If instruction has VReg output, set_from
                 if let Some(out) = insn.out_opnd() {
                     if let Opnd::VReg { idx, .. } = out {
-                        intervals[idx.0].set_from(insn_id.0);
+                        intervals[*idx].set_from(insn_id.0);
                     }
                 }
 
                 // For each VReg input (including memory base VRegs), add_range from block start to insn
                 insn.for_each_operand(|opnd| {
                     for idx in opnd.vreg_ids() {
-                        intervals[idx.0].add_range(block.from.0, insn_id.0);
+                        intervals[idx].add_range(block.from.0, insn_id.0);
                     }
                 });
             }
@@ -3857,6 +3893,14 @@ mod tests {
     }
 
     #[test]
+    fn test_size_of_opnd() {
+        assert_eq!(std::mem::size_of::<VRegId>(), 4);
+        assert_eq!(std::mem::size_of::<MemBase>(), 8);
+        assert_eq!(std::mem::size_of::<Mem>(), 16);
+        assert_eq!(std::mem::size_of::<Opnd>(), 16);
+    }
+
+    #[test]
     fn test_for_each_operand() {
         let insn = Insn::Add { left: Opnd::None, right: Opnd::None, out: Opnd::None };
 
@@ -4075,18 +4119,18 @@ mod tests {
         assert_eq!(bitset_to_vreg_indices(&live_in[b1.0], num_vregs), vec![]);
 
         // b2: [r10] - r10 is live-in (used in b4 which is reachable)
-        assert_eq!(bitset_to_vreg_indices(&live_in[b2.0], num_vregs), vec![r10.vreg_idx().0]);
+        assert_eq!(bitset_to_vreg_indices(&live_in[b2.0], num_vregs), vec![r10.vreg_idx_usize()]);
 
         // b3: [r10, r12, r13] - all are live-in
         assert_eq!(
             bitset_to_vreg_indices(&live_in[b3.0], num_vregs),
-            vec![r10.vreg_idx().0, r12.vreg_idx().0, r13.vreg_idx().0]
+            vec![r10.vreg_idx_usize(), r12.vreg_idx_usize(), r13.vreg_idx_usize()]
         );
 
         // b4: [r10, r12] - both are live-in
         assert_eq!(
             bitset_to_vreg_indices(&live_in[b4.0], num_vregs),
-            vec![r10.vreg_idx().0, r12.vreg_idx().0]
+            vec![r10.vreg_idx_usize(), r12.vreg_idx_usize()]
         );
     }
 
@@ -4161,7 +4205,7 @@ mod tests {
 
     #[test]
     fn test_interval_add_range() {
-        let mut interval = Interval::new(1);
+        let mut interval = Interval::new(VRegId(1));
 
         // Add range to empty interval
         interval.add_range(5, 10);
@@ -4181,7 +4225,7 @@ mod tests {
 
     #[test]
     fn test_interval_survives() {
-        let mut interval = Interval::new(1);
+        let mut interval = Interval::new(VRegId(1));
         interval.add_range(3, 10);
 
         assert!(!interval.survives(2));  // Before range
@@ -4193,7 +4237,7 @@ mod tests {
 
     #[test]
     fn test_interval_set_from() {
-        let mut interval = Interval::new(1);
+        let mut interval = Interval::new(VRegId(1));
 
         // With no range, sets both start and end
         interval.set_from(10);
@@ -4210,14 +4254,14 @@ mod tests {
     #[test]
     #[should_panic(expected = "Invalid range")]
     fn test_interval_add_range_invalid() {
-        let mut interval = Interval::new(1);
+        let mut interval = Interval::new(VRegId(1));
         interval.add_range(10, 5);
     }
 
     #[test]
     #[should_panic(expected = "survives called on interval with no range")]
     fn test_interval_survives_panics_without_range() {
-        let interval = Interval::new(1);
+        let interval = Interval::new(VRegId(1));
         interval.survives(5);
     }
 
@@ -4244,23 +4288,23 @@ mod tests {
 
         // Assert expected ranges
         // Note: Rust CFG differs from Ruby due to conditional branches requiring two instructions (Jl + Jmp)
-        assert_eq!(intervals[r10_idx.0].range.start, Some(16));
-        assert_eq!(intervals[r10_idx.0].range.end, Some(38));
+        assert_eq!(intervals[r10_idx].range.start, Some(16));
+        assert_eq!(intervals[r10_idx].range.end, Some(38));
 
-        assert_eq!(intervals[r11_idx.0].range.start, Some(16));
-        assert_eq!(intervals[r11_idx.0].range.end, Some(20));
+        assert_eq!(intervals[r11_idx].range.start, Some(16));
+        assert_eq!(intervals[r11_idx].range.end, Some(20));
 
-        assert_eq!(intervals[r12_idx.0].range.start, Some(20));
-        assert_eq!(intervals[r12_idx.0].range.end, Some(38));
+        assert_eq!(intervals[r12_idx].range.start, Some(20));
+        assert_eq!(intervals[r12_idx].range.end, Some(38));
 
-        assert_eq!(intervals[r13_idx.0].range.start, Some(20));
-        assert_eq!(intervals[r13_idx.0].range.end, Some(32));
+        assert_eq!(intervals[r13_idx].range.start, Some(20));
+        assert_eq!(intervals[r13_idx].range.end, Some(32));
 
-        assert_eq!(intervals[r14_idx.0].range.start, Some(30));
-        assert_eq!(intervals[r14_idx.0].range.end, Some(36));
+        assert_eq!(intervals[r14_idx].range.start, Some(30));
+        assert_eq!(intervals[r14_idx].range.end, Some(36));
 
-        assert_eq!(intervals[r15_idx.0].range.start, Some(32));
-        assert_eq!(intervals[r15_idx.0].range.end, Some(36));
+        assert_eq!(intervals[r15_idx].range.start, Some(32));
+        assert_eq!(intervals[r15_idx].range.end, Some(36));
     }
 
     #[test]
@@ -4299,12 +4343,12 @@ mod tests {
         // r13: [20,38) gets Reg(2)
         // r14: [36,42) gets Reg(1) (r12 expired, reuses its register)
         // r15: [38,42) gets Reg(2) (r13 expired, reuses its register)
-        assert_eq!(assignments[r10_idx.0], Some(Allocation::Reg(0)));
-        assert_eq!(assignments[r11_idx.0], Some(Allocation::Reg(1)));
-        assert_eq!(assignments[r12_idx.0], Some(Allocation::Reg(1)));
-        assert_eq!(assignments[r13_idx.0], Some(Allocation::Reg(2)));
-        assert_eq!(assignments[r14_idx.0], Some(Allocation::Reg(3)));
-        assert_eq!(assignments[r15_idx.0], Some(Allocation::Reg(2)));
+        assert_eq!(assignments[r10_idx], Some(Allocation::Reg(0)));
+        assert_eq!(assignments[r11_idx], Some(Allocation::Reg(1)));
+        assert_eq!(assignments[r12_idx], Some(Allocation::Reg(1)));
+        assert_eq!(assignments[r13_idx], Some(Allocation::Reg(2)));
+        assert_eq!(assignments[r14_idx], Some(Allocation::Reg(3)));
+        assert_eq!(assignments[r15_idx], Some(Allocation::Reg(2)));
     }
 
     #[test]
@@ -4327,12 +4371,12 @@ mod tests {
         let r15_idx = if let Opnd::VReg { idx, .. } = r15 { idx } else { panic!() };
 
         assert_eq!(num_stack_slots, 1);
-        assert_eq!(assignments[r10_idx.0], Some(Allocation::Stack(0)));
-        assert_eq!(assignments[r11_idx.0], Some(Allocation::Reg(1)));
-        assert_eq!(assignments[r12_idx.0], Some(Allocation::Reg(1)));
-        assert_eq!(assignments[r13_idx.0], Some(Allocation::Reg(2)));
-        assert_eq!(assignments[r14_idx.0], Some(Allocation::Reg(0)));
-        assert_eq!(assignments[r15_idx.0], Some(Allocation::Reg(2)));
+        assert_eq!(assignments[r10_idx], Some(Allocation::Stack(0)));
+        assert_eq!(assignments[r11_idx], Some(Allocation::Reg(1)));
+        assert_eq!(assignments[r12_idx], Some(Allocation::Reg(1)));
+        assert_eq!(assignments[r13_idx], Some(Allocation::Reg(2)));
+        assert_eq!(assignments[r14_idx], Some(Allocation::Reg(0)));
+        assert_eq!(assignments[r15_idx], Some(Allocation::Reg(2)));
     }
 
     #[test]
@@ -4355,12 +4399,12 @@ mod tests {
         let r15_idx = if let Opnd::VReg { idx, .. } = r15 { idx } else { panic!() };
 
         assert_eq!(num_stack_slots, 3);
-        assert_eq!(assignments[r10_idx.0], Some(Allocation::Stack(0)));
-        assert_eq!(assignments[r11_idx.0], Some(Allocation::Reg(0)));
-        assert_eq!(assignments[r12_idx.0], Some(Allocation::Stack(1)));
-        assert_eq!(assignments[r13_idx.0], Some(Allocation::Reg(0)));
-        assert_eq!(assignments[r14_idx.0], Some(Allocation::Stack(2)));
-        assert_eq!(assignments[r15_idx.0], Some(Allocation::Reg(0)));
+        assert_eq!(assignments[r10_idx], Some(Allocation::Stack(0)));
+        assert_eq!(assignments[r11_idx], Some(Allocation::Reg(0)));
+        assert_eq!(assignments[r12_idx], Some(Allocation::Stack(1)));
+        assert_eq!(assignments[r13_idx], Some(Allocation::Reg(0)));
+        assert_eq!(assignments[r14_idx], Some(Allocation::Stack(2)));
+        assert_eq!(assignments[r15_idx], Some(Allocation::Reg(0)));
     }
 
     #[test]
@@ -4382,11 +4426,11 @@ mod tests {
         let preferred_registers = asm.preferred_register_assignments(&intervals);
 
         let vreg_idx = new_sp.vreg_idx();
-        assert_eq!(preferred_registers[vreg_idx.0], Some(sp.unwrap_reg()));
+        assert_eq!(preferred_registers[vreg_idx], Some(sp.unwrap_reg()));
 
         let (assignments, num_stack_slots) = asm.linear_scan(intervals, 0, &preferred_registers);
         assert_eq!(num_stack_slots, 0);
-        assert_eq!(assignments[vreg_idx.0], Some(Allocation::Fixed(sp.unwrap_reg())));
+        assert_eq!(assignments[vreg_idx], Some(Allocation::Fixed(sp.unwrap_reg())));
     }
 
     #[test]
@@ -4573,8 +4617,8 @@ mod tests {
         assert_eq!(asm.basic_blocks.len(), 3);
 
         // Verify v1 and v4 have different allocations (so moves are needed)
-        let v1_alloc = assignments[v1.vreg_idx().0].unwrap();
-        let v4_alloc = assignments[v4.vreg_idx().0].unwrap();
+        let v1_alloc = assignments[v1.vreg_idx()].unwrap();
+        let v4_alloc = assignments[v4.vreg_idx()].unwrap();
         assert_ne!(v1_alloc, v4_alloc, "Test setup: v1 and v4 should have different allocations");
 
         asm.resolve_ssa(&intervals, &assignments);
@@ -4609,7 +4653,7 @@ mod tests {
         assert!(has_mov, "Expected Mov in split block for v1->v4");
 
         // b2->b3 is not a critical edge (b2 has single succ), so moves go before Jmp in b2
-        let v3_alloc = assignments[v3.vreg_idx().0].unwrap();
+        let v3_alloc = assignments[v3.vreg_idx()].unwrap();
         let b2_insns = &asm.basic_blocks[b2.0].insns;
         if v3_alloc != v4_alloc {
             // Check that a Mov was inserted before the Jmp in b2
@@ -4678,10 +4722,10 @@ mod tests {
         let regs = &ALLOC_REGS[..num_regs];
 
         // v0 should be spilled (long-lived, only 2 regs)
-        assert!(matches!(assignments[v0.vreg_idx().0], Some(Allocation::Stack(_))),
+        assert!(matches!(assignments[v0.vreg_idx()], Some(Allocation::Stack(_))),
             "v0 should be spilled to stack");
         // v1 should be in a register
-        assert!(matches!(assignments[v1.vreg_idx().0], Some(Allocation::Reg(_))),
+        assert!(matches!(assignments[v1.vreg_idx()], Some(Allocation::Reg(_))),
             "v1 should be in a register");
 
         // Run the pipeline: handle_caller_saved_regs then resolve_ssa
@@ -4697,7 +4741,7 @@ mod tests {
         assert!(!pushes.is_empty(), "Expected at least one saved register across CCall");
 
         // The survivor register should match v1's allocation
-        let v1_reg = match assignments[v1.vreg_idx().0].unwrap() {
+        let v1_reg = match assignments[v1.vreg_idx()].unwrap() {
             Allocation::Reg(n) => Opnd::Reg(regs[n]),
             Allocation::Fixed(reg) => Opnd::Reg(reg),
             _ => unreachable!(),

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -691,6 +691,21 @@ pub struct CCallData {
     pub out: Opnd,
 }
 
+/// Cold fields of `Insn::PatchPoint`, boxed to keep `Insn` small. `target` is
+/// operand-bearing (it's a `Target::SideExit` until `compile_exits` lowers it to
+/// a `Target::Label`), so the operand-iteration macros reach it through the box
+/// via a per-iterator reborrow -- the same idea as `CCallData` and the HIR
+/// `CCallWithFrame` pattern.
+#[derive(Clone)]
+pub struct PatchPointData {
+    /// Patch point target. Rewritten to a jump to a side exit on invalidation.
+    pub target: Target,
+    /// The invariant whose violation triggers invalidation of this patch point.
+    pub invariant: Invariant,
+    /// ISEQ version invalidated to force a recompile when the invariant breaks.
+    pub version: IseqVersionRef,
+}
+
 /// ZJIT Low-level IR instruction
 #[derive(Clone)]
 pub enum Insn {
@@ -861,7 +876,8 @@ pub enum Insn {
     Or { left: Opnd, right: Opnd, out: Opnd },
 
     /// Patch point that will be rewritten to a jump to a side exit on invalidation.
-    PatchPoint { target: Target, invariant: Invariant, version: IseqVersionRef },
+    /// Cold fields are boxed (see `PatchPointData`) to keep `Insn` small.
+    PatchPoint(Box<PatchPointData>),
 
     /// Make sure the last PatchPoint has enough space to insert a jump.
     /// We insert this instruction at the end of each block so that the jump
@@ -913,7 +929,7 @@ macro_rules! target_for_each_operand_impl {
 /// macro for a single `Opnd` field and `$visit_many` macro for a slice/`Vec` of `Opnd`s. Used by
 /// both `for_each_operand` and `for_each_operand_mut`.
 macro_rules! for_each_operand_impl {
-    ($self:expr, $visit_one:ident, $visit_many:ident $(, $const:expr)?) => {
+    ($self:expr, $visit_one:ident, $visit_many:ident, $reborrow:ident $(, $const:expr)?) => {
         match $self {
             Insn::Jbe(target) |
             Insn::Jb(target) |
@@ -928,9 +944,13 @@ macro_rules! for_each_operand_impl {
             Insn::JoMul(target) |
             Insn::Jz(target) |
             Insn::Label(target) |
-            Insn::LeaJumpTarget { target, .. } |
-            Insn::PatchPoint { target, .. } => {
+            Insn::LeaJumpTarget { target, .. } => {
                 target_for_each_operand_impl!(target, $visit_many);
+            }
+            // `target` is behind a Box. `$reborrow` turns the box field into a `&`/`&mut Target`
+            // matching the iterator, so the same operand-walk works for both.
+            Insn::PatchPoint(data) => {
+                target_for_each_operand_impl!($reborrow!(data.target), $visit_many);
             }
             Insn::Joz(opnd, target) |
             Insn::Jonz(opnd, target) => {
@@ -1013,23 +1033,26 @@ impl Insn {
     pub fn for_each_operand(&self, mut f: impl FnMut(Opnd)) {
         macro_rules! visit_one { ($id:expr) => { f(*$id) }; }
         macro_rules! visit_many { ($s:expr) => { for id in ($s).iter() { f(*id) } }; }
+        macro_rules! reborrow { ($e:expr) => { & $e }; }
         // Extra () is a throw-away parameter to avoid iterating over FrameSetup/FrameTeardown
         // preserved in the mutable iterator.
-        for_each_operand_impl!(self, visit_one, visit_many, ());
+        for_each_operand_impl!(self, visit_one, visit_many, reborrow, ());
     }
 
     /// Call `f` on a mutable reference to each operand (Opnd) of this instruction.
     pub fn for_each_operand_mut(&mut self, mut f: impl FnMut(&mut Opnd)) {
         macro_rules! visit_one { ($id:expr) => { f($id) }; }
         macro_rules! visit_many { ($s:expr) => { for id in ($s).iter_mut() { f(id) } }; }
-        for_each_operand_impl!(self, visit_one, visit_many);
+        macro_rules! reborrow { ($e:expr) => { &mut $e }; }
+        for_each_operand_impl!(self, visit_one, visit_many, reborrow);
     }
 
     /// Call `f` on each operand, short-circuiting on the first error.
     pub fn try_for_each_operand<E>(&self, mut f: impl FnMut(Opnd) -> Result<(), E>) -> Result<(), E> {
         macro_rules! visit_one { ($id:expr) => { f(*$id)? }; }
         macro_rules! visit_many { ($s:expr) => { for id in ($s).iter() { f(*id)? } }; }
-        for_each_operand_impl!(self, visit_one, visit_many, ());
+        macro_rules! reborrow { ($e:expr) => { & $e }; }
+        for_each_operand_impl!(self, visit_one, visit_many, reborrow, ());
         Ok(())
     }
 
@@ -1051,10 +1074,10 @@ impl Insn {
             Insn::Joz(_, target) |
             Insn::Jonz(_, target) |
             Insn::Label(target) |
-            Insn::LeaJumpTarget { target, .. } |
-            Insn::PatchPoint { target, .. } => {
+            Insn::LeaJumpTarget { target, .. } => {
                 Some(target)
             }
+            Insn::PatchPoint(data) => Some(&mut data.target),
             _ => None,
         }
     }
@@ -1113,7 +1136,7 @@ impl Insn {
             Insn::Mov { .. } => "Mov",
             Insn::Not { .. } => "Not",
             Insn::Or { .. } => "Or",
-            Insn::PatchPoint { .. } => "PatchPoint",
+            Insn::PatchPoint(..) => "PatchPoint",
             Insn::PadPatchPoint => "PadPatchPoint",
             Insn::PosMarker(_) => "PosMarker",
             Insn::RShift { .. } => "RShift",
@@ -1208,8 +1231,8 @@ impl Insn {
             Insn::Joz(_, target) |
             Insn::Jonz(_, target) |
             Insn::Label(target) |
-            Insn::LeaJumpTarget { target, .. } |
-            Insn::PatchPoint { target, .. } => Some(target),
+            Insn::LeaJumpTarget { target, .. } => Some(target),
+            Insn::PatchPoint(data) => Some(&data.target),
             _ => None
         }
     }
@@ -3740,7 +3763,7 @@ impl Assembler {
     }
 
     pub fn patch_point(&mut self, target: Target, invariant: Invariant, version: IseqVersionRef) {
-        self.push_insn(Insn::PatchPoint { target, invariant, version });
+        self.push_insn(Insn::PatchPoint(Box::new(PatchPointData { target, invariant, version })));
     }
 
     pub fn pad_patch_point(&mut self) {
@@ -3889,7 +3912,9 @@ mod tests {
 
     #[test]
     fn test_size_of_insn() {
-        assert_eq!(std::mem::size_of::<Insn>(), 80);
+        // PatchPoint's cold fields are boxed (see `PatchPointData`), so it no longer
+        // dominates the enum size.
+        assert_eq!(std::mem::size_of::<Insn>(), 72);
     }
 
     #[test]

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -171,7 +171,7 @@ impl BasicBlock {
         assert!(self.insns.last().unwrap().is_terminator());
         let extract_edge = |insn: &Insn| -> Option<BranchEdge> {
             if let Some(Target::Block(edge)) = insn.target() {
-                Some(edge.clone())
+                Some((**edge).clone())
             } else {
                 None
             }
@@ -600,6 +600,16 @@ pub struct SideExitRecompile {
     pub insn_idx: u32,
 }
 
+/// Payload of `Target::SideExit`, boxed to keep `Target` (and every `Insn`
+/// variant that embeds it) small.
+#[derive(Clone)]
+pub struct SideExitTarget {
+    /// Context used for compiling the side exit.
+    pub exit: SideExit,
+    /// We use this to increment exit counters.
+    pub reason: SideExitReason,
+}
+
 /// Branch target (something that we can jump to)
 /// for branch instructions
 #[derive(Clone)]
@@ -609,16 +619,10 @@ pub enum Target
     CodePtr(CodePtr),
     /// A label within the generated code
     Label(Label),
-    /// An LIR branch edge
-    Block(BranchEdge),
-    /// Side exit to the interpreter
-    SideExit {
-        /// Context used for compiling the side exit. Boxed to keep `Target`
-        /// (and every `Insn` variant that embeds it) small.
-        exit: Box<SideExit>,
-        /// We use this to increment exit counters
-        reason: SideExitReason,
-    },
+    /// An LIR branch edge. Boxed to keep `Target` small.
+    Block(Box<BranchEdge>),
+    /// Side exit to the interpreter. Boxed (see `SideExitTarget`) to keep `Target` small.
+    SideExit(Box<SideExitTarget>),
 }
 
 impl fmt::Debug for Target {
@@ -640,8 +644,8 @@ impl fmt::Debug for Target {
                     write!(f, "))")
                 }
             }
-            Target::SideExit { exit, reason } => {
-                write!(f, "SideExit {{ exit: {:?}, reason: {:?} }}", exit, reason)
+            Target::SideExit(data) => {
+                write!(f, "SideExit {{ exit: {:?}, reason: {:?} }}", data.exit, data.reason)
             }
         }
     }
@@ -916,9 +920,9 @@ pub enum Insn {
 macro_rules! target_for_each_operand_impl {
     ($self:expr, $visit_many:ident) => {
         match $self {
-            Target::SideExit { exit, .. } => {
-                visit_many!(exit.stack);
-                visit_many!(exit.locals);
+            Target::SideExit(data) => {
+                visit_many!(data.exit.stack);
+                visit_many!(data.exit.locals);
             }
             Target::Block(edge) => {
                 visit_many!(edge.args);
@@ -2227,10 +2231,10 @@ impl Assembler
                     for mov in moves {
                         self.basic_blocks[new_block_id.0].push_insn(mov);
                     }
-                    self.basic_blocks[new_block_id.0].push_insn(Insn::Jmp(Target::Block(BranchEdge {
+                    self.basic_blocks[new_block_id.0].push_insn(Insn::Jmp(Target::Block(Box::new(BranchEdge {
                         target: successor,
                         args: vec![],
-                    })));
+                    }))));
 
                     // Redirect predecessor's branch to the new block
                     let pred_insns = &mut self.basic_blocks[pred_id.0].insns;
@@ -2751,7 +2755,7 @@ impl Assembler
         for block_id in self.block_order() {
             let block = &self.basic_blocks[block_id.0];
             for (idx, insn) in block.insns.iter().enumerate() {
-                if let Some(target @ Target::SideExit { .. }) = insn.target() {
+                if let Some(target @ Target::SideExit(..)) = insn.target() {
                     targets.insert((block_id.0, idx), target.clone());
                 }
             }
@@ -2789,7 +2793,8 @@ impl Assembler
         for ((block_id, idx), target) in targets {
             // Compile a side exit. Note that this is past register assignment,
             // so you can't use an instruction that returns a VReg.
-            if let Target::SideExit { exit, reason } = target {
+            if let Target::SideExit(data) = target {
+                let SideExitTarget { exit, reason } = *data;
                 // Only record the exit if `trace_side_exits` is defined and the counter is either the one specified
                 let should_record_exit = get_option!(trace_side_exits).map(|trace| match trace {
                     TraceExits::All => true,
@@ -2835,7 +2840,7 @@ impl Assembler
                     self.write_label(new_exit.clone());
                     asm_comment!(self, "Exit: {}", exit.pc);
                     compile_exit(self, &exit, None);
-                    compiled_exits.insert(*exit, new_exit.unwrap_label());
+                    compiled_exits.insert(exit, new_exit.unwrap_label());
                     new_exit
                 };
 
@@ -3217,7 +3222,7 @@ fn format_insn_compact(asm: &Assembler, insn: &Insn) -> String {
         match target {
             Target::CodePtr(code_ptr) => output.push_str(&format!(" {code_ptr:?}")),
             Target::Label(Label(label_idx)) => output.push_str(&format!(" {}", asm.label_names[*label_idx])),
-            Target::SideExit { reason, .. } => output.push_str(&format!(" Exit({reason})")),
+            Target::SideExit(data) => output.push_str(&format!(" Exit({})", data.reason)),
             Target::Block(edge) => {
                 let label = asm.block_label(edge.target);
                 let name = &asm.label_names[label.0];
@@ -3238,7 +3243,7 @@ fn format_insn_compact(asm: &Assembler, insn: &Insn) -> String {
     }
 
     // Print operands (but skip branch args since they're already printed with target)
-    if let Some(Target::SideExit { .. }) = insn.target() {
+    if let Some(Target::SideExit(..)) = insn.target() {
         match insn {
             Insn::Joz(opnd, _) |
             Insn::Jonz(opnd, _) |
@@ -3342,7 +3347,7 @@ impl fmt::Display for Assembler {
                             match target {
                                 Target::CodePtr(code_ptr) => write!(f, " {code_ptr:?}")?,
                                 Target::Label(Label(label_idx)) => write!(f, " {}", label_name(self, *label_idx, &label_counts))?,
-                                Target::SideExit { reason, .. } => write!(f, " Exit({reason})")?,
+                                Target::SideExit(data) => write!(f, " Exit({})", data.reason)?,
                                 Target::Block(edge) => {
                                     let label = self.block_label(edge.target);
                                     let name = label_name(self, label.0, &label_counts);
@@ -3363,7 +3368,7 @@ impl fmt::Display for Assembler {
                         }
 
                         // Print list of operands
-                        if let Some(Target::SideExit { .. }) = insn.target() {
+                        if let Some(Target::SideExit(..)) = insn.target() {
                             // If the instruction has a SideExit, avoid using opnd_iter(), which has stack/locals.
                             // Here, only handle instructions that have both Opnd and Target.
                             match insn {
@@ -3918,9 +3923,11 @@ mod tests {
 
     #[test]
     fn test_size_of_insn() {
-        // PatchPoint (see `PatchPointData`) and CCall (see `CCallData`) box their
-        // fields, so neither dominates the enum size any longer.
-        assert_eq!(std::mem::size_of::<Insn>(), 64);
+        // PatchPoint (PatchPointData), CCall (CCallData), and Target (Block/SideExit
+        // payloads) are all boxed, so none dominates the enum. The floor is now the
+        // 3-operand arithmetic/CSel variants: 3 * Opnd (48) + 8 discriminant (Opnd has
+        // no niche to absorb it) = 56. Going lower means boxing the hottest insns.
+        assert_eq!(std::mem::size_of::<Insn>(), 56);
     }
 
     #[test]
@@ -3929,6 +3936,7 @@ mod tests {
         assert_eq!(std::mem::size_of::<MemBase>(), 8);
         assert_eq!(std::mem::size_of::<Mem>(), 16);
         assert_eq!(std::mem::size_of::<Opnd>(), 16);
+        assert_eq!(std::mem::size_of::<Target>(), 16);
     }
 
     #[test]
@@ -4100,10 +4108,10 @@ mod tests {
         asm.write_label(label_b1);
         asm.basic_blocks[b1.0].add_parameter(r10);
         asm.basic_blocks[b1.0].add_parameter(r11);
-        asm.basic_blocks[b1.0].push_insn(Insn::Jmp(Target::Block(BranchEdge {
+        asm.basic_blocks[b1.0].push_insn(Insn::Jmp(Target::Block(Box::new(BranchEdge {
             target: b2,
             args: vec![Opnd::UImm(1), r11],
-        })));
+        }))));
 
         // Build b2: define(r12, r13) { cmp(r13, imm(1)); blt(...) }
         asm.set_current_block(b2);
@@ -4112,8 +4120,8 @@ mod tests {
         asm.basic_blocks[b2.0].add_parameter(r12);
         asm.basic_blocks[b2.0].add_parameter(r13);
         asm.basic_blocks[b2.0].push_insn(Insn::Cmp { left: r13, right: Opnd::UImm(1) });
-        asm.basic_blocks[b2.0].push_insn(Insn::Jl(Target::Block(BranchEdge { target: b4, args: vec![] })));
-        asm.basic_blocks[b2.0].push_insn(Insn::Jmp(Target::Block(BranchEdge { target: b3, args: vec![] })));
+        asm.basic_blocks[b2.0].push_insn(Insn::Jl(Target::Block(Box::new(BranchEdge { target: b4, args: vec![] }))));
+        asm.basic_blocks[b2.0].push_insn(Insn::Jmp(Target::Block(Box::new(BranchEdge { target: b3, args: vec![] }))));
 
         // Build b3: r14 = mul(r12, r13); r15 = sub(r13, imm(1)); jump(edge(b2, [r14, r15]))
         asm.set_current_block(b3);
@@ -4123,10 +4131,10 @@ mod tests {
         let r15 = asm.new_vreg(64);
         asm.basic_blocks[b3.0].push_insn(Insn::Mul { left: r12, right: r13, out: r14 });
         asm.basic_blocks[b3.0].push_insn(Insn::Sub { left: r13, right: Opnd::UImm(1), out: r15 });
-        asm.basic_blocks[b3.0].push_insn(Insn::Jmp(Target::Block(BranchEdge {
+        asm.basic_blocks[b3.0].push_insn(Insn::Jmp(Target::Block(Box::new(BranchEdge {
             target: b2,
             args: vec![r14, r15],
-        })));
+        }))));
 
         // Build b4: out = add(r10, r12); ret out
         asm.set_current_block(b4);
@@ -4225,10 +4233,10 @@ mod tests {
         asm.set_current_block(b1);
         let label_b1 = asm.new_label("bb0");
         asm.write_label(label_b1);
-        asm.basic_blocks[b1.0].push_insn(Insn::Jmp(Target::Block(BranchEdge {
+        asm.basic_blocks[b1.0].push_insn(Insn::Jmp(Target::Block(Box::new(BranchEdge {
             target: b2,
             args: vec![Opnd::mem(64, base, 8)],
-        })));
+        }))));
 
         let out_vregs = asm.basic_blocks[b1.0].out_vregs();
         assert_eq!(out_vregs, vec![base.vreg_idx()]);
@@ -4610,8 +4618,8 @@ mod tests {
         asm.basic_blocks[b1.0].push_insn(Insn::Add { left: Opnd::UImm(123), right: Opnd::UImm(0), out: v0 });
         asm.basic_blocks[b1.0].push_insn(Insn::Add { left: v0, right: Opnd::UImm(456), out: v1 });
         asm.basic_blocks[b1.0].push_insn(Insn::Cmp { left: v1, right: Opnd::UImm(0) });
-        asm.basic_blocks[b1.0].push_insn(Insn::Jl(Target::Block(BranchEdge { target: b2, args: vec![v0] })));
-        asm.basic_blocks[b1.0].push_insn(Insn::Jmp(Target::Block(BranchEdge { target: b3, args: vec![v1] })));
+        asm.basic_blocks[b1.0].push_insn(Insn::Jl(Target::Block(Box::new(BranchEdge { target: b2, args: vec![v0] }))));
+        asm.basic_blocks[b1.0].push_insn(Insn::Jmp(Target::Block(Box::new(BranchEdge { target: b3, args: vec![v1] }))));
 
         // b2(v2): v3 = Add(v2, 789), Jmp(b3, [v3])
         asm.set_current_block(b2);
@@ -4621,7 +4629,7 @@ mod tests {
         asm.basic_blocks[b2.0].add_parameter(v2);
         let v3 = asm.new_vreg(64);
         asm.basic_blocks[b2.0].push_insn(Insn::Add { left: v2, right: Opnd::UImm(789), out: v3 });
-        asm.basic_blocks[b2.0].push_insn(Insn::Jmp(Target::Block(BranchEdge { target: b3, args: vec![v3] })));
+        asm.basic_blocks[b2.0].push_insn(Insn::Jmp(Target::Block(Box::new(BranchEdge { target: b3, args: vec![v3] }))));
 
         // b3(v4): CRet(v4)
         asm.set_current_block(b3);

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -672,11 +672,16 @@ impl From<CodePtr> for Target {
 
 type PosMarkerFn = Rc<dyn Fn(CodePtr, &CodeBlock)>;
 
-/// Cold fields of `Insn::CCall`, boxed to keep `Insn` small. The operand-bearing
-/// fields (`opnds`, `stack_map`) stay inline on the variant so the operand
-/// iteration macros can reach them by reference.
+/// All fields of `Insn::CCall`, boxed to keep `Insn` small. The operand-bearing
+/// fields (`opnds`, `stack_map`) are reached through the box by the operand
+/// iteration macros -- `opnds` directly (via `.iter()`/`.iter_mut()`) and
+/// `stack_map` via a per-iterator reborrow, the same idea as `PatchPointData`.
 #[derive(Clone)]
 pub struct CCallData {
+    /// The arguments to the C call.
+    pub opnds: Vec<Opnd>,
+    /// VM stack contents to materialize a JIT frame if the call side-exits.
+    pub stack_map: Option<StackMap>,
     /// The function pointer to be called. This should be Opnd::const_ptr
     /// (Opnd::UImm) in most cases. gen_entry_trampoline() uses Opnd::Reg.
     pub fptr: Opnd,
@@ -751,10 +756,8 @@ pub enum Insn {
     CPushPair(Opnd, Opnd),
 
     // C function call with N arguments (variadic)
+    // All fields are boxed (see `CCallData`) to keep `Insn` small.
     CCall {
-        opnds: Vec<Opnd>,
-        stack_map: Option<StackMap>,
-        /// Cold fields (fptr, markers, out), boxed to keep `Insn` small.
         data: Box<CCallData>,
     },
 
@@ -1003,9 +1006,12 @@ macro_rules! for_each_operand_impl {
                 visit_one!(opnd0);
                 visit_one!(opnd1);
             }
-            Insn::CCall { opnds, stack_map, .. } => {
-                visit_many!(opnds);
-                if let Some(StackMap { stack, .. }) = stack_map {
+            Insn::CCall { data } => {
+                visit_many!(data.opnds);
+                // `data` is behind a Box. `$reborrow` turns the box field into a `&`/`&mut
+                // Option<StackMap>` matching the iterator, so the same operand-walk works for
+                // both.
+                if let Some(StackMap { stack, .. }) = $reborrow!(data.stack_map) {
                     visit_many!(stack);
                 }
             }
@@ -2352,8 +2358,8 @@ impl Assembler
             let mut new_ids = Vec::with_capacity(old_ids.len());
 
             for (insn, insn_id) in old_insns.into_iter().zip(old_ids.into_iter()) {
-                if let Insn::CCall { opnds, stack_map, data } = insn {
-                    let CCallData { out, start_marker, end_marker, fptr } = *data;
+                if let Insn::CCall { data } = insn {
+                    let CCallData { opnds, stack_map, out, start_marker, end_marker, fptr } = *data;
                     let insn_number = insn_id.map(|id| id.0).unwrap_or(0);
                     // Do we have a case where a ccall is emitted, but nobody
                     // uses the result?
@@ -2478,10 +2484,10 @@ impl Assembler
 
                     // The CCall itself
                     new_insns.push(Insn::CCall {
-                        opnds: vec![],  // We've moved everything in to ccall regs, so this should
-                                        // be empty now
-                        stack_map: None,
                         data: Box::new(CCallData {
+                            opnds: vec![],  // We've moved everything in to ccall regs, so this should
+                                            // be empty now
+                            stack_map: None,
                             out: C_RET_OPND,
                             start_marker: None,
                             end_marker: None,
@@ -3511,7 +3517,7 @@ impl Assembler {
         let out = self.new_vreg(Opnd::match_num_bits(&opnds));
         let fptr = Opnd::const_ptr(fptr);
         let stack_map = self.stack_map.take();
-        self.push_insn(Insn::CCall { opnds, stack_map, data: Box::new(CCallData { fptr, start_marker: None, end_marker: None, out }) });
+        self.push_insn(Insn::CCall { data: Box::new(CCallData { opnds, stack_map, fptr, start_marker: None, end_marker: None, out }) });
         self.clear_stack_canary(canary_opnd);
         out
     }
@@ -3521,7 +3527,7 @@ impl Assembler {
     pub fn ccall_into(&mut self, out: Opnd, fptr: *const u8, opnds: Vec<Opnd>) {
         let fptr = Opnd::const_ptr(fptr);
         let stack_map = self.stack_map.take();
-        self.push_insn(Insn::CCall { opnds, stack_map, data: Box::new(CCallData { fptr, start_marker: None, end_marker: None, out }) });
+        self.push_insn(Insn::CCall { data: Box::new(CCallData { opnds, stack_map, fptr, start_marker: None, end_marker: None, out }) });
     }
 
     /// Call a C function stored in a register
@@ -3529,7 +3535,7 @@ impl Assembler {
         assert!(matches!(fptr, Opnd::Reg(_)), "ccall_reg must be called with Opnd::Reg: {fptr:?}");
         let out = self.new_vreg(num_bits);
         let stack_map = self.stack_map.take();
-        self.push_insn(Insn::CCall { opnds: vec![], stack_map, data: Box::new(CCallData { fptr, start_marker: None, end_marker: None, out }) });
+        self.push_insn(Insn::CCall { data: Box::new(CCallData { opnds: vec![], stack_map, fptr, start_marker: None, end_marker: None, out }) });
         out
     }
 
@@ -3545,9 +3551,9 @@ impl Assembler {
         let out = self.new_vreg(Opnd::match_num_bits(&opnds));
         let stack_map = self.stack_map.take();
         self.push_insn(Insn::CCall {
-            opnds,
-            stack_map,
             data: Box::new(CCallData {
+                opnds,
+                stack_map,
                 fptr: Opnd::const_ptr(fptr),
                 start_marker: Some(Rc::new(start_marker)),
                 end_marker: Some(Rc::new(end_marker)),
@@ -3912,9 +3918,9 @@ mod tests {
 
     #[test]
     fn test_size_of_insn() {
-        // PatchPoint's cold fields are boxed (see `PatchPointData`), so it no longer
-        // dominates the enum size.
-        assert_eq!(std::mem::size_of::<Insn>(), 72);
+        // PatchPoint (see `PatchPointData`) and CCall (see `CCallData`) box their
+        // fields, so neither dominates the enum size any longer.
+        assert_eq!(std::mem::size_of::<Insn>(), 64);
     }
 
     #[test]
@@ -4714,9 +4720,9 @@ mod tests {
         // v3 = CCall { fptr: UImm(0xF00), opnds: [v2] }
         let v3 = asm.new_vreg(64);
         asm.basic_blocks[b1.0].push_insn(Insn::CCall {
-            opnds: vec![v2],
-            stack_map: None,
             data: Box::new(CCallData {
+                opnds: vec![v2],
+                stack_map: None,
                 fptr: Opnd::UImm(0xF00),
                 start_marker: None,
                 end_marker: None,
@@ -4778,8 +4784,8 @@ mod tests {
 
         // The CCall should have empty opnds and out = C_RET_OPND (rewritten to regs[0])
         let ccall = insns.iter().find(|i| matches!(i, Insn::CCall { .. })).unwrap();
-        if let Insn::CCall { opnds, .. } = ccall {
-            assert!(opnds.is_empty(), "CCall opnds should be empty after handle_caller_saved_regs");
+        if let Insn::CCall { data } = ccall {
+            assert!(data.opnds.is_empty(), "CCall opnds should be empty after handle_caller_saved_regs");
         }
 
         // v0 should be rewritten to a Stack operand

--- a/zjit/src/backend/x86_64/mod.rs
+++ b/zjit/src/backend/x86_64/mod.rs
@@ -959,7 +959,7 @@ impl Assembler {
                         Target::CodePtr(code_ptr) => jmp_ptr(cb, code_ptr),
                         Target::Label(label) => jmp_label(cb, label),
                         Target::Block(ref edge) => jmp_label(cb, self.block_label(edge.target)),
-                        Target::SideExit { .. } => unreachable!("Target::SideExit should have been compiled by compile_exits"),
+                        Target::SideExit(..) => unreachable!("Target::SideExit should have been compiled by compile_exits"),
                     }
                 }
 
@@ -968,7 +968,7 @@ impl Assembler {
                         Target::CodePtr(code_ptr) => je_ptr(cb, code_ptr),
                         Target::Label(label) => je_label(cb, label),
                         Target::Block(ref edge) => je_label(cb, self.block_label(edge.target)),
-                        Target::SideExit { .. } => unreachable!("Target::SideExit should have been compiled by compile_exits"),
+                        Target::SideExit(..) => unreachable!("Target::SideExit should have been compiled by compile_exits"),
                     }
                 }
 
@@ -977,7 +977,7 @@ impl Assembler {
                         Target::CodePtr(code_ptr) => jne_ptr(cb, code_ptr),
                         Target::Label(label) => jne_label(cb, label),
                         Target::Block(ref edge) => jne_label(cb, self.block_label(edge.target)),
-                        Target::SideExit { .. } => unreachable!("Target::SideExit should have been compiled by compile_exits"),
+                        Target::SideExit(..) => unreachable!("Target::SideExit should have been compiled by compile_exits"),
                     }
                 }
 
@@ -986,7 +986,7 @@ impl Assembler {
                         Target::CodePtr(code_ptr) => jl_ptr(cb, code_ptr),
                         Target::Label(label) => jl_label(cb, label),
                         Target::Block(ref edge) => jl_label(cb, self.block_label(edge.target)),
-                        Target::SideExit { .. } => unreachable!("Target::SideExit should have been compiled by compile_exits"),
+                        Target::SideExit(..) => unreachable!("Target::SideExit should have been compiled by compile_exits"),
                     }
                 },
 
@@ -995,7 +995,7 @@ impl Assembler {
                         Target::CodePtr(code_ptr) => jg_ptr(cb, code_ptr),
                         Target::Label(label) => jg_label(cb, label),
                         Target::Block(ref edge) => jg_label(cb, self.block_label(edge.target)),
-                        Target::SideExit { .. } => unreachable!("Target::SideExit should have been compiled by compile_exits"),
+                        Target::SideExit(..) => unreachable!("Target::SideExit should have been compiled by compile_exits"),
                     }
                 },
 
@@ -1004,7 +1004,7 @@ impl Assembler {
                         Target::CodePtr(code_ptr) => jge_ptr(cb, code_ptr),
                         Target::Label(label) => jge_label(cb, label),
                         Target::Block(ref edge) => jge_label(cb, self.block_label(edge.target)),
-                        Target::SideExit { .. } => unreachable!("Target::SideExit should have been compiled by compile_exits"),
+                        Target::SideExit(..) => unreachable!("Target::SideExit should have been compiled by compile_exits"),
                     }
                 },
 
@@ -1013,7 +1013,7 @@ impl Assembler {
                         Target::CodePtr(code_ptr) => jbe_ptr(cb, code_ptr),
                         Target::Label(label) => jbe_label(cb, label),
                         Target::Block(ref edge) => jbe_label(cb, self.block_label(edge.target)),
-                        Target::SideExit { .. } => unreachable!("Target::SideExit should have been compiled by compile_exits"),
+                        Target::SideExit(..) => unreachable!("Target::SideExit should have been compiled by compile_exits"),
                     }
                 },
 
@@ -1022,7 +1022,7 @@ impl Assembler {
                         Target::CodePtr(code_ptr) => jb_ptr(cb, code_ptr),
                         Target::Label(label) => jb_label(cb, label),
                         Target::Block(ref edge) => jb_label(cb, self.block_label(edge.target)),
-                        Target::SideExit { .. } => unreachable!("Target::SideExit should have been compiled by compile_exits"),
+                        Target::SideExit(..) => unreachable!("Target::SideExit should have been compiled by compile_exits"),
                     }
                 },
 
@@ -1031,7 +1031,7 @@ impl Assembler {
                         Target::CodePtr(code_ptr) => jz_ptr(cb, code_ptr),
                         Target::Label(label) => jz_label(cb, label),
                         Target::Block(ref edge) => jz_label(cb, self.block_label(edge.target)),
-                        Target::SideExit { .. } => unreachable!("Target::SideExit should have been compiled by compile_exits"),
+                        Target::SideExit(..) => unreachable!("Target::SideExit should have been compiled by compile_exits"),
                     }
                 }
 
@@ -1040,7 +1040,7 @@ impl Assembler {
                         Target::CodePtr(code_ptr) => jnz_ptr(cb, code_ptr),
                         Target::Label(label) => jnz_label(cb, label),
                         Target::Block(ref edge) => jnz_label(cb, self.block_label(edge.target)),
-                        Target::SideExit { .. } => unreachable!("Target::SideExit should have been compiled by compile_exits"),
+                        Target::SideExit(..) => unreachable!("Target::SideExit should have been compiled by compile_exits"),
                     }
                 }
 
@@ -1050,7 +1050,7 @@ impl Assembler {
                         Target::CodePtr(code_ptr) => jo_ptr(cb, code_ptr),
                         Target::Label(label) => jo_label(cb, label),
                         Target::Block(ref edge) => jo_label(cb, self.block_label(edge.target)),
-                        Target::SideExit { .. } => unreachable!("Target::SideExit should have been compiled by compile_exits"),
+                        Target::SideExit(..) => unreachable!("Target::SideExit should have been compiled by compile_exits"),
                     }
                 }
 
@@ -1388,7 +1388,7 @@ mod tests {
 
         let val64 = asm.add(CFP, Opnd::UImm(64));
         asm.store(Opnd::mem(64, SP, 0x10), val64);
-        let side_exit = Target::SideExit { reason: SideExitReason::Interrupt, exit: Box::new(SideExit { pc: 0.into(), iseq: std::ptr::null(), stack: vec![], locals: vec![], recompile: None }) };
+        let side_exit = Target::SideExit(Box::new(SideExitTarget { reason: SideExitReason::Interrupt, exit: SideExit { pc: 0.into(), iseq: std::ptr::null(), stack: vec![], locals: vec![], recompile: None } }));
         asm.push_insn(Insn::Joz(val64, side_exit));
         asm.mov(C_ARG_OPNDS[0], C_RET_OPND.with_num_bits(32));
         asm.mov(C_ARG_OPNDS[1], Opnd::mem(64, SP, -8));

--- a/zjit/src/backend/x86_64/mod.rs
+++ b/zjit/src/backend/x86_64/mod.rs
@@ -298,8 +298,8 @@ impl Assembler {
                     };
                     asm.push_insn(insn);
                 },
-                Insn::CCall { opnds, .. } => {
-                    assert!(opnds.len() <= C_ARG_OPNDS.len());
+                Insn::CCall { data } => {
+                    assert!(data.opnds.len() <= C_ARG_OPNDS.len());
                     // CCall argument setup is handled by handle_caller_saved_regs.
                     asm.push_insn(insn);
                 },
@@ -553,11 +553,11 @@ impl Assembler {
                     asm.push_insn(insn);
                 }
                 // For compile_exits, support splitting simple C arguments here
-                Insn::CCall { opnds, .. } if !opnds.is_empty() => {
-                    for (i, opnd) in opnds.iter().enumerate() {
+                Insn::CCall { data } if !data.opnds.is_empty() => {
+                    for (i, opnd) in data.opnds.iter().enumerate() {
                         asm.load_into(C_ARG_OPNDS[i], *opnd);
                     }
-                    *opnds = vec![];
+                    data.opnds = vec![];
                     asm.push_insn(insn);
                 }
                 Insn::CSelZ { truthy: left, falsy: right, out } |

--- a/zjit/src/backend/x86_64/mod.rs
+++ b/zjit/src/backend/x86_64/mod.rs
@@ -1260,7 +1260,7 @@ mod tests {
         (asm, CodeBlock::new_dummy())
     }
 
-    fn stack_mem(stack_idx: usize) -> Opnd {
+    fn stack_mem(stack_idx: StackIdx) -> Opnd {
         Opnd::Mem(Mem {
             base: MemBase::Stack { stack_idx, num_bits: 64 },
             disp: 0,
@@ -1268,7 +1268,7 @@ mod tests {
         })
     }
 
-    fn stack_indirect_mem(stack_idx: usize) -> Opnd {
+    fn stack_indirect_mem(stack_idx: StackIdx) -> Opnd {
         Opnd::Mem(Mem {
             base: MemBase::StackIndirect { stack_idx },
             disp: 0,

--- a/zjit/src/backend/x86_64/mod.rs
+++ b/zjit/src/backend/x86_64/mod.rs
@@ -658,8 +658,8 @@ impl Assembler {
                     };
                     asm.store(dest, src);
                 }
-                &mut Insn::PatchPoint { ref target, invariant, version } => {
-                    split_patch_point(asm, target, invariant, version);
+                &mut Insn::PatchPoint(ref data) => {
+                    split_patch_point(asm, &data.target, data.invariant, data.version);
                 }
                 _ => {
                     asm.push_insn(insn);
@@ -1056,7 +1056,7 @@ impl Assembler {
 
                 Insn::Joz(..) | Insn::Jonz(..) => unreachable!("Joz/Jonz should be unused for now"),
 
-                Insn::PatchPoint { .. } => unreachable!("PatchPoint should have been lowered to PadPatchPoint in x86_scratch_split"),
+                Insn::PatchPoint(..) => unreachable!("PatchPoint should have been lowered to PadPatchPoint in x86_scratch_split"),
                 Insn::PadPatchPoint => {
                     // If patch points are too close to each other or the end of the block, fill nop instructions
                     if let Some(last_patch_pos) = last_patch_pos {

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -19,7 +19,7 @@ use crate::state::ZJITState;
 use crate::stats::{CompileError, exit_counter_for_compile_error, exit_counter_for_unhandled_hir_insn, incr_counter, incr_counter_by, send_fallback_counter, send_fallback_counter_for_method_type, send_fallback_counter_for_super_method_type, send_fallback_counter_ptr_for_opcode, send_without_block_fallback_counter_for_method_type, send_without_block_fallback_counter_for_optimized_method_type};
 use crate::stats::{counter_ptr, with_time_stat, trace_compile_phase, Counter, Counter::{compile_time_ns, exit_compile_error}};
 use crate::{asm::CodeBlock, cruby::*, options::debug, virtualmem::CodePtr};
-use crate::backend::lir::{self, Assembler, C_ARG_OPNDS, C_RET_OPND, CFP, EC, NATIVE_BASE_PTR, Opnd, SP, SideExit, SideExitRecompile, Target, asm_ccall, asm_comment};
+use crate::backend::lir::{self, Assembler, C_ARG_OPNDS, C_RET_OPND, CFP, EC, NATIVE_BASE_PTR, Opnd, SP, SideExit, SideExitRecompile, SideExitTarget, Target, asm_ccall, asm_comment};
 use crate::hir::{iseq_to_hir, BlockId, Invariant, RangeType, SideExitReason::{self, *}, SpecialBackrefSymbol, SpecialObjectType};
 use crate::hir::{BlockHandler, CCallVariadicData, CCallWithFrameData, Const, FieldName, FrameState, Function, Insn, InsnId, Recompile, SendFallbackReason};
 use crate::hir_type::{types, Type};
@@ -122,7 +122,7 @@ impl Assembler {
             args: vec![],
         };
         emit(self, target);
-        self.jmp(Target::Block(fall_through_edge));
+        self.jmp(Target::Block(Box::new(fall_through_edge)));
 
         self.set_current_block(fall_through_target);
 
@@ -486,8 +486,8 @@ fn gen_function(cb: &mut CodeBlock, iseq: IseqPtr, version: IseqVersionRef, func
                         };
 
                         asm.test(val_opnd, val_opnd);
-                        asm.push_insn(lir::Insn::Jnz(Target::Block(true_branch)));
-                        asm.jmp(Target::Block(false_branch));
+                        asm.push_insn(lir::Insn::Jnz(Target::Block(Box::new(true_branch))));
+                        asm.jmp(Target::Block(Box::new(false_branch)));
 
                         assert!(asm.current_block().insns.last().unwrap().is_terminator());
                     }
@@ -497,7 +497,7 @@ fn gen_function(cb: &mut CodeBlock, iseq: IseqPtr, version: IseqVersionRef, func
                             target: lir_target,
                             args: target.args.iter().map(|insn_id| jit.get_opnd(*insn_id)).collect()
                         };
-                        asm.jmp(Target::Block(branch_edge));
+                        asm.jmp(Target::Block(Box::new(branch_edge)));
                         assert!(asm.current_block().insns.last().unwrap().is_terminator());
 
                         // Jump should always be the last instruction in an HIR block
@@ -968,7 +968,7 @@ fn gen_patch_point(jit: &mut JITState, asm: &mut Assembler, invariant: &Invarian
     let exit = build_side_exit(jit, state);
 
     // Let compile_exits compile a side exit. Let scratch_split lower it with split_patch_point.
-    asm.patch_point(Target::SideExit { exit: Box::new(exit), reason: PatchPoint(invariant) }, invariant, jit.version);
+    asm.patch_point(Target::SideExit(Box::new(SideExitTarget { exit, reason: PatchPoint(invariant) })), invariant, jit.version);
 }
 
 /// This is used by scratch_split to lower PatchPoint into PadPatchPoint and PosMarker.
@@ -1391,7 +1391,7 @@ fn gen_write_barrier(jit: &mut JITState, asm: &mut Assembler, recv: Opnd, val: O
         let hir_block_id = asm.current_block().hir_block_id;
         let rpo_idx = asm.current_block().rpo_index;
         let result_block = asm.new_block(hir_block_id, false, rpo_idx);
-        let result_edge = Target::Block(lir::BranchEdge { target: result_block, args: vec![] });
+        let result_edge = Target::Block(Box::new(lir::BranchEdge { target: result_block, args: vec![] }));
 
         // If non-false immediate, don't fire write barrier
         asm.test(val, Opnd::UImm(RUBY_IMMEDIATE_MASK as u64));
@@ -2218,10 +2218,10 @@ fn gen_is_a(jit: &mut JITState, asm: &mut Assembler, obj: Opnd, class: Opnd) -> 
 
         // Create a result block that all paths converge to
         let result_block = asm.new_block(hir_block_id, false, rpo_idx);
-        let result_edge = |v| Target::Block(lir::BranchEdge {
+        let result_edge = |v| Target::Block(Box::new(lir::BranchEdge {
             target: result_block,
             args: vec![v],
-        });
+        }));
 
         let val = asm.load_mem(obj);
 
@@ -2614,10 +2614,10 @@ fn gen_has_type(jit: &mut JITState, asm: &mut Assembler, val: lir::Opnd, val_typ
 
         // Create a result block that all paths converge to
         let result_block = asm.new_block(hir_block_id, false, rpo_idx);
-        let result_edge = |v| Target::Block(lir::BranchEdge {
+        let result_edge = |v| Target::Block(Box::new(lir::BranchEdge {
             target: result_block,
             args: vec![v],
-        });
+        }));
 
         // If val isn't in a register, load it to use it as the base of Opnd::mem later.
         // TODO: Max thinks codegen should not care about the shapes of the operands except to create them. (Shopify/ruby#685)
@@ -2653,10 +2653,10 @@ fn gen_has_type(jit: &mut JITState, asm: &mut Assembler, val: lir::Opnd, val_typ
 
         // Create a result block that all paths converge to
         let result_block = asm.new_block(hir_block_id, false, rpo_idx);
-        let result_edge = |v| Target::Block(lir::BranchEdge {
+        let result_edge = |v| Target::Block(Box::new(lir::BranchEdge {
             target: result_block,
             args: vec![v],
-        });
+        }));
 
         // If val isn't in a register, load it to use it as the base of Opnd::mem later.
         let val = asm.load_mem(val);
@@ -3179,7 +3179,7 @@ fn compile_iseq(iseq: IseqPtr) -> Result<Function, CompileError> {
 /// Build a Target::SideExit
 fn side_exit(jit: &JITState, state: &FrameState, reason: SideExitReason) -> Target {
     let exit = build_side_exit(jit, state);
-    Target::SideExit { exit: Box::new(exit), reason }
+    Target::SideExit(Box::new(SideExitTarget { exit, reason }))
 }
 
 /// Build a Target::SideExit that optionally triggers exit_recompile on the exit path.
@@ -3189,7 +3189,7 @@ fn side_exit_with_recompile(jit: &JITState, state: &FrameState, reason: SideExit
         compiled_iseq: Opnd::Value(VALUE::from(jit.iseq())),
         insn_idx: state.insn_idx() as u32,
     });
-    Target::SideExit { exit: Box::new(exit), reason }
+    Target::SideExit(Box::new(SideExitTarget { exit, reason }))
 }
 
 /// Build a side-exit context


### PR DESCRIPTION
The main things in this PR are:

* Boxing
* Little `reborrow` macro to do generic iteration over mutability
  * Please let me know if you have a better name for this
* Turning `VRegId` into a `u32`