### PR TITLE
CI shape comparison needs to take into account # of kwargs given

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -1962,6 +1962,10 @@ iseq_set_arguments_keywords(rb_iseq_t *iseq, LINK_ANCHOR *const optargs,
         kw++;
         node = node->nd_next;
     }
+    if (kw > VM_CALL_KW_LEN_MAX) {
+        COMPILE_ERROR(ERROR_ARGS_AT(RNODE(args->kw_args)) "too many keyword parameters (%d, maximum is %d)",
+                      kw, (int)VM_CALL_KW_LEN_MAX);
+    }
     arg_size += kw;
     keyword->bits_start = arg_size++;
 
@@ -5070,6 +5074,12 @@ compile_keyword_arg(rb_iseq_t *iseq, LINK_ANCHOR *const ret,
         {
             int len = 0;
             VALUE key_index = node_hash_unique_key_index(iseq, RNODE_HASH(root_node), &len);
+
+            if (len > VM_CALL_KW_LEN_MAX) {
+                COMPILE_ERROR(ERROR_ARGS_AT(root_node) "too many keyword arguments (%d, maximum is %d)",
+                              len, (int)VM_CALL_KW_LEN_MAX);
+            }
+
             struct rb_callinfo_kwarg *kw_arg =
                 rb_xmalloc_mul_add(len, sizeof(VALUE), sizeof(struct rb_callinfo_kwarg));
             VALUE *keywords = kw_arg->keywords;

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -1776,6 +1776,11 @@ pm_setup_args_core(const pm_arguments_node_t *arguments_node, const pm_node_t *b
                             size++;
                         }
 
+                        if (size > VM_CALL_KW_LEN_MAX) {
+                            COMPILE_ERROR(iseq, node_location->line, "too many keyword arguments (%d, maximum is %d)",
+                                          (int) size, (int) VM_CALL_KW_LEN_MAX);
+                        }
+
                         *kw_arg = rb_xmalloc_mul_add(size, sizeof(VALUE), sizeof(struct rb_callinfo_kwarg));
                         *flags |= VM_CALL_KWARG;
 
@@ -6597,6 +6602,11 @@ pm_compile_scope_node(rb_iseq_t *iseq, pm_scope_node_t *scope_node, const pm_nod
     //                                                   ^^^^^^^^
     // Keywords create an internal variable on the parse tree
     if (keywords_list && keywords_list->size) {
+        if (keywords_list->size > VM_CALL_KW_LEN_MAX) {
+            COMPILE_ERROR(iseq, node_location->line, "too many keyword parameters (%d, maximum is %d)",
+                          (int) keywords_list->size, (int) VM_CALL_KW_LEN_MAX);
+        }
+
         keyword = ZALLOC_N(struct rb_iseq_param_keyword, 1);
         keyword->num = (int) keywords_list->size;
 

--- a/test/ruby/test_keyword.rb
+++ b/test/ruby/test_keyword.rb
@@ -4587,6 +4587,64 @@ class TestKeywordArgumentsSymProcRefinements < Test::Unit::TestCase
     assert_equal([1, 2], m_bug20570(*[1, 2], **nil))
   end
 
+  def test_keyword_only_method_rejects_positional_after_cache_primed_bug_22099
+    c = Class.new do
+      def bar(a: nil, b: nil)
+        [a, b]
+      end
+    end
+    obj = c.new
+
+    # Prime the per-class call cache with a valid keyword-only call.
+    assert_equal([1, 2], obj.bar(a: 1, b: 2))
+
+    # Different call sites with the same argc/flag but a positional argument
+    # must still raise, not reuse the cached keyword-setup fastpath and bind
+    # the positional value to the first keyword.
+    assert_raise(ArgumentError) { obj.bar(99, a: 0) }
+    assert_raise(ArgumentError) { obj.bar(99, b: 0) }
+
+    # The cache must compare argc and keyword count separately, not their sum.
+    assert_raise(ArgumentError) { obj.bar(7, 8, a: 1) }
+  end
+
+  def test_keyword_call_cache_resolves_keywords_by_name_bug_22099
+    c = Class.new do
+      def bar(a: nil, b: nil, cc: nil)
+        [a, b, cc]
+      end
+    end
+    obj = c.new
+
+    # Call sites sharing argc/flag/keyword-count must still bind each keyword
+    # by name (the cached fastpath reads the keyword names from the live call).
+    assert_equal([1, nil, nil], obj.bar(a: 1))
+    assert_equal([nil, 2, nil], obj.bar(b: 2))
+    assert_equal([nil, nil, 3], obj.bar(cc: 3))
+    assert_equal([1, 2, nil], obj.bar(a: 1, b: 2))
+    assert_equal([8, 9, nil], obj.bar(b: 9, a: 8))
+    assert_raise(ArgumentError) { obj.bar(z: 1) }
+  end
+
+  def test_too_many_keywords_rejected_at_compile_time
+    # The per-class call cache stores the keyword count in an unsigned short
+    # (rb_class_cc_entries_entry.kw_len), so a call site or method may not use
+    # more than that many keyword arguments. It is rejected when compiling.
+    max = 65535
+
+    over_def = "def m(" + Array.new(max + 1) {|i| "k#{i}:" }.join(", ") + "); end"
+    err = assert_raise(SyntaxError) { RubyVM::InstructionSequence.compile(over_def) }
+    assert_match(/too many keyword parameters/, err.message)
+
+    over_call = "m(" + Array.new(max + 1) {|i| "k#{i}: 0" }.join(", ") + ")"
+    err = assert_raise(SyntaxError) { RubyVM::InstructionSequence.compile(over_call) }
+    assert_match(/too many keyword arguments/, err.message)
+
+    # The maximum itself is still accepted.
+    ok_def = "def m(" + Array.new(max) {|i| "k#{i}:" }.join(", ") + "); end"
+    assert_nothing_raised(SyntaxError) { RubyVM::InstructionSequence.compile(ok_def) }
+  end
+
   private def one
     1
   end

--- a/vm_callinfo.h
+++ b/vm_callinfo.h
@@ -587,11 +587,19 @@ struct rb_class_cc_entries {
     int len;
     const struct rb_callable_method_entry_struct *cme;
     struct rb_class_cc_entries_entry {
-        unsigned int argc;
-        unsigned int flag;
         const struct rb_callcache *cc;
+        unsigned int argc;
+        unsigned short flag;
+        unsigned short kw_len;
     } entries[FLEX_ARY_LEN];
 };
+
+/* entries[].flag is an unsigned short, so every VM_CALL flag bit must fit in 16 bits. */
+STATIC_ASSERT(cc_entries_flag_fits_in_short, VM_CALL__END <= 16);
+
+/* entries[].kw_len is an unsigned short, so a call site cannot carry, nor a method
+   declare, more keyword arguments than this.  Enforced at compile time. */
+#define VM_CALL_KW_LEN_MAX UINT16_MAX
 
 static inline size_t
 vm_ccs_alloc_size(size_t capa)

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1954,9 +1954,11 @@ vm_ccs_push(VALUE cc_tbl, ID mid, struct rb_class_cc_entries *ccs, const struct 
     }
     VM_ASSERT(ccs->len < ccs->capa);
 
+    const struct rb_callinfo_kwarg *kwarg = vm_ci_kwarg(ci);
     const int pos = ccs->len++;
     ccs->entries[pos].argc = vm_ci_argc(ci);
-    ccs->entries[pos].flag = vm_ci_flag(ci);
+    ccs->entries[pos].flag = (unsigned short)vm_ci_flag(ci);
+    ccs->entries[pos].kw_len = (unsigned short)(kwarg ? kwarg->keyword_len : 0);
     RB_OBJ_WRITE(cc_tbl, &ccs->entries[pos].cc, cc);
 
     if (RB_DEBUG_COUNTER_SETMAX(ccs_maxlen, ccs->len)) {
@@ -1971,9 +1973,10 @@ rb_vm_ccs_dump(struct rb_class_cc_entries *ccs)
 {
     ruby_debug_printf("ccs:%p (%d,%d)\n", (void *)ccs, ccs->len, ccs->capa);
     for (int i=0; i<ccs->len; i++) {
-        ruby_debug_printf("CCS CI ID:flag:%x argc:%u\n",
+        ruby_debug_printf("CCS CI ID:flag:%x argc:%u kw_len:%u\n",
                 ccs->entries[i].flag,
-                ccs->entries[i].argc);
+                ccs->entries[i].argc,
+                ccs->entries[i].kw_len);
         rp(ccs->entries[i].cc);
     }
 }
@@ -2118,19 +2121,25 @@ retry:
                 VM_ASSERT(vm_ccs_verify(ccs, mid, klass));
 
                 // We already know the method id is correct because we had
-                // to look up the ccs_data by method id.  All we need to
-                // compare is argc and flag
+                // to look up the ccs_data by method id.  We compare argc and
+                // flag, plus the keyword argument count: two call sites with
+                // the same argc and flag can still differ in how many of the
+                // arguments are keywords (e.g. `m(a: 1, b: 2)` vs `m(1, b: 2)`),
+                // which selects a different argument setup fastpath.
+                const struct rb_callinfo_kwarg *kwarg = vm_ci_kwarg(ci);
                 unsigned int argc = vm_ci_argc(ci);
                 unsigned int flag = vm_ci_flag(ci);
+                unsigned int kw_len = kwarg ? kwarg->keyword_len : 0;
 
                 for (int i=0; i<ccs_len; i++) {
                     unsigned int ccs_ci_argc = ccs->entries[i].argc;
                     unsigned int ccs_ci_flag = ccs->entries[i].flag;
+                    unsigned int ccs_ci_kw_len = ccs->entries[i].kw_len;
                     const struct rb_callcache *ccs_cc = ccs->entries[i].cc;
 
                     VM_ASSERT(IMEMO_TYPE_P(ccs_cc, imemo_callcache));
 
-                    if (ccs_ci_argc == argc && ccs_ci_flag == flag) {
+                    if (ccs_ci_argc == argc && ccs_ci_flag == flag && ccs_ci_kw_len == kw_len) {
                         RB_DEBUG_COUNTER_INC(cc_found_in_ccs);
 
                         VM_ASSERT(vm_cc_cme(ccs_cc)->called_id == mid);


### PR DESCRIPTION
If number of keyword arguments are not taken into account when comparing CI shapes, invalid bindings happen:

```
class Foo
  def bar(a: nil, b: nil)
    p [:body, a: a, b: b]
  end
end

foo = Foo.new

foo.bar(a: 1, b: 2)   #=> [:body, {a: 1, b: 2}] # prime CC
foo.bar(99, a: 0)     #=> [:body, {a: 99, b: nil}] # BAD!
```

Fixes [Bug #22099]