### PR TITLE
ZJIT: Always specialize monomorphic getivar

### DIFF
--- a/zjit/src/distribution.rs
+++ b/zjit/src/distribution.rs
@@ -81,6 +81,10 @@ pub struct DistributionSummary<T: Copy + PartialEq + Default + std::fmt::Debug, 
 const SKEW_THRESHOLD: f64 = 0.75;
 
 impl<T: Copy + PartialEq + Default + std::fmt::Debug, const N: usize> DistributionSummary<T, N> {
+    pub fn empty() -> Self {
+        Self { kind: DistributionKind::Empty, buckets: [Default::default(); N] }
+    }
+
     pub fn new(dist: &Distribution<T, N>) -> Self {
         #[cfg(debug_assertions)]
         {

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -570,6 +570,7 @@ pub enum SideExitReason {
     DirectiveInduced,
     SendWhileTracing,
     NoProfileSend,
+    NoProfileGetIvar,
     InvokeBlockNotIfunc,
 }
 
@@ -3489,6 +3490,19 @@ impl Function {
             }
             resolution => resolution,
         }
+    }
+
+    fn profile_summary(&self, profiles: &ProfileOracle, recv: InsnId, state: InsnId) -> Option<TypeDistributionSummary> {
+        let Some(entries) = profiles.get(state) else {
+            return None;
+        };
+        let recv = self.chase_insn(recv);
+        for (entry_insn, entry_type_summary) in entries {
+            if self.chase_insn(*entry_insn) == recv {
+                return Some(entry_type_summary.clone());
+            }
+        }
+        None
     }
 
     fn polymorphic_summary(&self, profiles: &ProfileOracle, recv: InsnId, state: InsnId) -> Option<TypeDistributionSummary> {
@@ -6777,6 +6791,78 @@ impl Function {
         self.validate_types()?;
         Ok(())
     }
+
+    /// Return Some(InsnId) if we generated any code to load an ivar and None if we only generated
+    /// an unconditional SideExit (in which case we should end the block).
+    fn dispatch_getivar(
+        &mut self,
+        profiled_types: &Vec<ProfiledType>,
+        mut block: BlockId,
+        insn_idx: u32,
+        self_param: InsnId,
+        id: ID,
+        ic: *const iseq_inline_iv_cache_entry,
+        exit_id: InsnId,
+    ) -> Option<(BlockId, InsnId)> {
+        // 0 profiled_types: Generate a recompile exit or a fallback. No need for new HIR blocks.
+        if profiled_types.is_empty() {
+            if self.policy.no_side_exits {
+                self.count(block, Counter::getivar_fallback_no_side_exits);
+                let result = self.push_insn(block, Insn::GetIvar { self_val: self_param, id, ic, state: exit_id });
+                return Some((block, result));
+            } else {
+                self.push_insn(block, Insn::SideExit { state: exit_id, reason: Box::new(SideExitReason::NoProfileGetIvar), recompile: Some(Recompile) });
+                return None;
+            }
+        }
+        // 1 profiled_types: Generate a monomorphic getivar with a guard if allowed by policy. No need for new HIR blocks.
+        if profiled_types.len() == 1 && !self.policy.no_side_exits {
+            // 0 profiled_types: Generate a recompile exit or a fallback.
+            let actual = self.load_shape(block, self_param);
+            self.guard_shape(block, actual, profiled_types[0].shape(), exit_id, Some(Recompile));
+            let result = self.load_ivar(block, self_param, profiled_types[0], id);
+            return Some((block, result));
+        }
+
+        // Otherwise, make HIR blocks to handle different shapes or a fallback, and let them jump to join_block.
+        let edge = |target: BlockId| BranchEdge { target, args: vec![] };
+        let branch = |cond: InsnId, if_true: BlockId, if_false: BlockId| Insn::CondBranch { val: cond, if_true: edge(if_true), if_false: edge(if_false) };
+        let actual = self.load_shape(block, self_param);
+        let last_shape_index = profiled_types.len() - 1;
+        let join_block = self.new_block(insn_idx);
+        let result = self.push_insn(join_block, Insn::Param);
+        for (i, &profiled_type) in profiled_types.iter().enumerate() {
+            let load_optimized_block = self.new_block(insn_idx);
+            if i == last_shape_index {
+                if self.policy.no_side_exits {
+                    // If the policy doesn't allow exits, make a fallback block and jump to it if the shape doesn't match.
+                    let expected = self.push_insn(block, Insn::Const { val: Const::CShape(profiled_type.shape()) });
+                    let val = self.push_insn(block, Insn::IsBitEqual { left: actual, right: expected });
+                    let load_fallback_block = self.new_block(insn_idx);
+                    self.push_insn(block, branch(val, load_optimized_block, load_fallback_block));
+                    self.count(load_fallback_block, Counter::getivar_fallback_no_side_exits);
+                    let result = self.push_insn(load_fallback_block, Insn::GetIvar { self_val: self_param, id, ic, state: exit_id });
+                    self.push_insn(load_fallback_block, Insn::Jump(BranchEdge { target: join_block, args: vec![result] }));
+                } else {
+                    // If the policy allows exits, exit to the interpreter if the shape doesn't match.
+                    self.guard_shape(block, actual, profiled_type.shape(), exit_id, Some(Recompile));
+                    // TODO(max): Don't make a new block in this case
+                    self.push_insn(block, Insn::Jump(BranchEdge { target: load_optimized_block, args: vec![] }));
+                }
+            } else {
+                // If this is not the last profiled shape, let the guard jump to the next block.
+                let expected = self.push_insn(block, Insn::Const { val: Const::CShape(profiled_type.shape()) });
+                let val = self.push_insn(block, Insn::IsBitEqual { left: actual, right: expected});
+                let next_block = self.new_block(insn_idx);
+                self.push_insn(block, branch(val, load_optimized_block, next_block));
+                block = next_block;
+            }
+            // Generate the optimized getivar for the profiled_type and jump to join_block
+            let result = self.load_ivar(load_optimized_block, self_param, profiled_type, id);
+            self.push_insn(load_optimized_block, Insn::Jump(BranchEdge { target: join_block, args: vec![result] }));
+        }
+        Some((join_block, result))
+    }
 }
 
 impl<'a> std::fmt::Display for FunctionPrinter<'a> {
@@ -8907,68 +8993,44 @@ fn add_iseq_to_hir(
                         fun.push_insn(block, Insn::SideExit { state: exit_id, reason: Box::new(SideExitReason::UnhandledYARVInsn(opcode)), recompile: None });
                         break;  // End the block
                     }
-                    if let Some(summary) = fun.polymorphic_summary(&profiles, self_param, exit_id) {
-                        self_param = fun.push_insn(block, Insn::GuardType { val: self_param, guard_type: types::HeapBasicObject, state: exit_id, recompile: None });
-                        let join_block = fun.new_block(insn_idx);
-                        let join_param = fun.push_insn(join_block, Insn::Param);
-                        // Dedup by expected shape so objects with different classes but the same shape can share code
-                        // TODO(max): De-duplicate further by checking ivar offsets to allow
-                        // different shapes with the same ivar layout to share code
-                        let mut seen_shape = Vec::with_capacity(summary.buckets().len());
-                        for &profiled_type in summary.buckets() {
-                            // End of the buckets
-                            if profiled_type.is_empty() { break; }
-                            // Instance variable lookups on immediate values are always nil; don't bother
-                            if profiled_type.flags().is_immediate() { continue; }
-                            let profiled_shape = profiled_type.shape();
-                            assert!(profiled_shape.is_valid());
-                            // Too-complex shapes use hash tables for ivars;
-                            // rb_shape_get_iv_index doesn't work for them.
-                            // Let the fallthrough GetIvar handle these.
-                            if profiled_shape.is_complex() { continue; }
-                            if seen_shape.contains(&profiled_shape) { continue; }
-                            seen_shape.push(profiled_shape);
-                            let actual_shape = fun.load_shape(block, self_param);
-                            // Load the expected shape to a variable
-                            let expected_shape = fun.push_insn(block, Insn::Const { val: Const::CShape(profiled_shape) });
-                            let has_shape = fun.push_insn(block, Insn::IsBitEqual { left: actual_shape, right: expected_shape });
-                            let iftrue_block = fun.new_block(insn_idx);
-                            let target = BranchEdge { target: iftrue_block, args: vec![] };
-                            let fall_through = fun.new_block(insn_idx);
-
-                            fun.push_insn(block, Insn::CondBranch { val: has_shape,
-                                if_true: target,
-                                if_false: BranchEdge { target: fall_through, args: vec![] }
-                            });
-
-                            block = fall_through;
-                            let result = fun.load_ivar(iftrue_block, self_param, profiled_type, id);
-                            fun.push_insn(iftrue_block, Insn::Jump(BranchEdge { target: join_block, args: vec![result] }));
+                    let summary = fun.profile_summary(&profiles, self_param, exit_id).unwrap_or_else(|| {
+                        TypeDistributionSummary::empty()
+                    });
+                    let self_param = fun.guard_heap(block, self_param, exit_id);
+                    // Filter out profiled types we don't care to optimize
+                    let profiled_types = summary.buckets().iter().filter(|profiled_type| {
+                        // Don't read past the end of the profiled types
+                        !profiled_type.is_empty()
+                        // Instance variable lookups on immediate values are always nil; don't bother
+                        && !profiled_type.flags().is_immediate()
+                        // Too-complex shapes use hash tables for ivars;
+                        // rb_shape_get_iv_index doesn't work for them.
+                        // Let the fallthrough GetIvar handle these.
+                        && !profiled_type.shape().is_complex()
+                    }).collect::<Vec<_>>();
+                    // We might have two objects of class A and B with the same shape; de-duplicate
+                    // profiled types by shape. This is just an optimization to reduce code size.
+                    let mut profiled_types_unique_shapes = Vec::with_capacity(profiled_types.len());
+                    for &profiled_type in profiled_types {
+                        if profiled_types_unique_shapes.iter().any(|t: &ProfiledType| t.shape() == profiled_type.shape()) {
+                            continue;
                         }
-                        // In the fallthrough case, do a generic interpreter getivar and then join.
-                        let result = fun.push_insn(block, Insn::GetIvar { self_val: self_param, id, ic, state: exit_id });
-                        fun.push_insn(block, Insn::Jump(BranchEdge { target: join_block, args: vec![result] }));
-                        state.stack_push(join_param);
-                        // Continue compilation from the join block at the next instruction.
-                        // Make a copy of the current state without the args (pop the receiver
-                        // and push the result) because we just use the locals/stack sizes to
-                        // make the right number of Params
-                        block = join_block;
-                    } else {
-                        if let Some(profiled_type) = fun.monomorphic_summary(&profiles, self_param, exit_id) {
-                            let result = fun.try_emit_optimized_getivar(block, self_param, id, profiled_type, exit_id).unwrap_or_else(|counter| {
-                                fun.count(block, counter);
-                                fun.push_insn(block, Insn::GetIvar { self_val: self_param, id, ic, state: exit_id })
-                            });
-                            state.stack_push(result);
-                        } else {
-                            let resolution = fun.resolve_receiver_type_from_profile(self_param, exit_id);
-                            let counter = Function::getivar_fallback_reason(resolution, ic);
-                            fun.count(block, counter);
-                            let result = fun.push_insn(block, Insn::GetIvar { self_val: self_param, id, ic, state: exit_id });
-                            state.stack_push(result);
-                        }
+                        profiled_types_unique_shapes.push(profiled_type);
                     }
+                    let Some((new_block, result)) = fun.dispatch_getivar(
+                        &profiled_types_unique_shapes,
+                        block,
+                        insn_idx,
+                        self_param,
+                        id,
+                        ic,
+                        exit_id,
+                    ) else {
+                        // Side-exiting unconditionally; end the block
+                        break;
+                    };
+                    block = new_block;
+                    state.stack_push(result);
                 }
                 YARVINSN_setinstancevariable => {
                     let id = ID(get_arg(pc, 0).as_u64());

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -3492,17 +3492,17 @@ impl Function {
         }
     }
 
-    fn profile_summary(&self, profiles: &ProfileOracle, recv: InsnId, state: InsnId) -> Option<TypeDistributionSummary> {
+    fn profile_summary(&self, profiles: &ProfileOracle, recv: InsnId, state: InsnId) -> TypeDistributionSummary {
         let Some(entries) = profiles.get(state) else {
-            return None;
+            return TypeDistributionSummary::empty();
         };
         let recv = self.chase_insn(recv);
         for (entry_insn, entry_type_summary) in entries {
             if self.chase_insn(*entry_insn) == recv {
-                return Some(entry_type_summary.clone());
+                return entry_type_summary.clone();
             }
         }
-        None
+        TypeDistributionSummary::empty()
     }
 
     fn polymorphic_summary(&self, profiles: &ProfileOracle, recv: InsnId, state: InsnId) -> Option<TypeDistributionSummary> {
@@ -8993,9 +8993,7 @@ fn add_iseq_to_hir(
                         fun.push_insn(block, Insn::SideExit { state: exit_id, reason: Box::new(SideExitReason::UnhandledYARVInsn(opcode)), recompile: None });
                         break;  // End the block
                     }
-                    let summary = fun.profile_summary(&profiles, self_param, exit_id).unwrap_or_else(|| {
-                        TypeDistributionSummary::empty()
-                    });
+                    let summary = fun.profile_summary(&profiles, self_param, exit_id);
                     let self_param = fun.guard_heap(block, self_param, exit_id);
                     // Filter out profiled types we don't care to optimize
                     let profiled_types = summary.buckets().iter().filter(|profiled_type| {

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -5651,9 +5651,8 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
-          v11:BasicObject = GetIvar v6, :@foo
-          CheckInterrupts
-          Return v11
+          v11:HeapBasicObject = GuardType v6, HeapBasicObject
+          SideExit NoProfileGetIvar recompile
         ");
     }
 
@@ -8325,27 +8324,20 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:HeapBasicObject):
           PatchPoint SingleRactorMode
-          v13:CShape = LoadField v6, :shape_id@0x1000
+          v12:CShape = LoadField v6, :shape_id@0x1000
           v14:CShape[0x1001] = Const CShape(0x1001)
-          v15:CBool = IsBitEqual v13, v14
+          v15:CBool = IsBitEqual v12, v14
           CondBranch v15, bb5(), bb6()
         bb5():
           v17:BasicObject = LoadField v6, :@foo@0x1002
           Jump bb4(v17)
         bb6():
-          v19:CShape = LoadField v6, :shape_id@0x1000
-          v20:CShape[0x1003] = Const CShape(0x1003)
-          v21:CBool = IsBitEqual v19, v20
-          CondBranch v21, bb7(), bb8()
-        bb7():
-          v23:BasicObject = LoadField v6, :@foo@0x1004
-          Jump bb4(v23)
-        bb8():
-          v25:BasicObject = GetIvar v6, :@foo
-          Jump bb4(v25)
-        bb4(v12:BasicObject):
+          v19:CShape[0x1003] = GuardBitEquals v12, CShape(0x1003) recompile
+          v21:BasicObject = LoadField v6, :@foo@0x1004
+          Jump bb4(v21)
+        bb4(v13:BasicObject):
           CheckInterrupts
-          Return v12
+          Return v13
         ");
     }
 
@@ -8378,9 +8370,8 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
-          v11:BasicObject = GetIvar v6, :@foo
-          CheckInterrupts
-          Return v11
+          v11:HeapBasicObject = GuardType v6, HeapBasicObject
+          SideExit NoProfileGetIvar recompile
         ");
     }
 
@@ -8404,9 +8395,8 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
-          v11:BasicObject = GetIvar v6, :@foo
-          CheckInterrupts
-          Return v11
+          v11:HeapBasicObject = GuardType v6, HeapBasicObject
+          SideExit NoProfileGetIvar recompile
         ");
     }
 
@@ -8430,9 +8420,8 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
-          v11:BasicObject = GetIvar v6, :@foo
-          CheckInterrupts
-          Return v11
+          v11:HeapBasicObject = GuardType v6, HeapBasicObject
+          SideExit NoProfileGetIvar recompile
         ");
     }
 
@@ -8456,9 +8445,8 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
-          v11:BasicObject = GetIvar v6, :@foo
-          CheckInterrupts
-          Return v11
+          v11:HeapBasicObject = GuardType v6, HeapBasicObject
+          SideExit NoProfileGetIvar recompile
         ");
     }
 
@@ -8482,9 +8470,8 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
-          v11:BasicObject = GetIvar v6, :@foo
-          CheckInterrupts
-          Return v11
+          v11:HeapBasicObject = GuardType v6, HeapBasicObject
+          SideExit NoProfileGetIvar recompile
         ");
     }
 
@@ -8508,9 +8495,8 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
-          v11:BasicObject = GetIvar v6, :@foo
-          CheckInterrupts
-          Return v11
+          v11:HeapBasicObject = GuardType v6, HeapBasicObject
+          SideExit NoProfileGetIvar recompile
         ");
     }
 
@@ -8600,9 +8586,8 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
-          v11:BasicObject = GetIvar v6, :@foo
-          CheckInterrupts
-          Return v11
+          v11:HeapBasicObject = GuardType v6, HeapBasicObject
+          SideExit NoProfileGetIvar recompile
         ");
     }
 
@@ -8809,9 +8794,8 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
-          v11:BasicObject = GetIvar v6, :@foo
-          CheckInterrupts
-          Return v11
+          v11:HeapBasicObject = GuardType v6, HeapBasicObject
+          SideExit NoProfileGetIvar recompile
         ");
     }
 
@@ -8880,9 +8864,8 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
-          v11:BasicObject = GetIvar v6, :@foo
-          CheckInterrupts
-          Return v11
+          v11:HeapBasicObject = GuardType v6, HeapBasicObject
+          SideExit NoProfileGetIvar recompile
         ");
     }
 
@@ -8981,9 +8964,8 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
-          v11:BasicObject = GetIvar v6, :@var1000
-          CheckInterrupts
-          Return v11
+          v11:HeapBasicObject = GuardType v6, HeapBasicObject
+          SideExit NoProfileGetIvar recompile
         ");
     }
 
@@ -9082,32 +9064,25 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           v11:HeapBasicObject = GuardType v6, HeapBasicObject
-          v13:CShape = LoadField v11, :shape_id@0x1000
+          v12:CShape = LoadField v11, :shape_id@0x1000
           v14:CShape[0x1001] = Const CShape(0x1001)
-          v15:CBool = IsBitEqual v13, v14
+          v15:CBool = IsBitEqual v12, v14
           CondBranch v15, bb5(), bb6()
         bb5():
           v17:BasicObject = LoadField v11, :@foo@0x1002
           Jump bb4(v17)
         bb6():
-          v19:CShape = LoadField v11, :shape_id@0x1000
-          v20:CShape[0x1003] = Const CShape(0x1003)
-          v21:CBool = IsBitEqual v19, v20
-          CondBranch v21, bb7(), bb8()
-        bb7():
-          v23:CPtr = LoadField v11, :as_heap@0x1004
-          v24:BasicObject = LoadField v23, :@foo@0x1005
-          Jump bb4(v24)
-        bb8():
-          v26:BasicObject = GetIvar v11, :@foo
-          Jump bb4(v26)
-        bb4(v12:BasicObject):
-          v29:Fixnum[1] = Const Value(1)
+          v19:CShape[0x1003] = GuardBitEquals v12, CShape(0x1003) recompile
+          v21:CPtr = LoadField v11, :as_heap@0x1004
+          v22:BasicObject = LoadField v21, :@foo@0x1005
+          Jump bb4(v22)
+        bb4(v13:BasicObject):
+          v25:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Integer@0x1008, +@0x1010, cme:0x1018)
-          v40:Fixnum = GuardType v12, Fixnum recompile
-          v41:Fixnum = FixnumAdd v40, v29
+          v36:Fixnum = GuardType v13, Fixnum recompile
+          v37:Fixnum = FixnumAdd v36, v25
           CheckInterrupts
-          Return v41
+          Return v37
         ");
     }
 
@@ -9156,32 +9131,25 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           v11:HeapBasicObject = GuardType v6, HeapBasicObject
-          v13:CShape = LoadField v11, :shape_id@0x1000
+          v12:CShape = LoadField v11, :shape_id@0x1000
           v14:CShape[0x1001] = Const CShape(0x1001)
-          v15:CBool = IsBitEqual v13, v14
+          v15:CBool = IsBitEqual v12, v14
           CondBranch v15, bb5(), bb6()
         bb5():
           v17:CPtr = LoadField v11, :as_heap@0x1002
           v18:BasicObject = LoadField v17, :@foo@0x1003
           Jump bb4(v18)
         bb6():
-          v20:CShape = LoadField v11, :shape_id@0x1000
-          v21:CShape[0x1004] = Const CShape(0x1004)
-          v22:CBool = IsBitEqual v20, v21
-          CondBranch v22, bb7(), bb8()
-        bb7():
-          v24:BasicObject = LoadField v11, :@foo@0x1005
-          Jump bb4(v24)
-        bb8():
-          v26:BasicObject = GetIvar v11, :@foo
-          Jump bb4(v26)
-        bb4(v12:BasicObject):
-          v29:Fixnum[1] = Const Value(1)
+          v20:CShape[0x1004] = GuardBitEquals v12, CShape(0x1004) recompile
+          v22:BasicObject = LoadField v11, :@foo@0x1005
+          Jump bb4(v22)
+        bb4(v13:BasicObject):
+          v25:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Integer@0x1008, +@0x1010, cme:0x1018)
-          v40:Fixnum = GuardType v12, Fixnum recompile
-          v41:Fixnum = FixnumAdd v40, v29
+          v36:Fixnum = GuardType v13, Fixnum recompile
+          v37:Fixnum = FixnumAdd v36, v25
           CheckInterrupts
-          Return v41
+          Return v37
         ");
     }
 
@@ -9222,31 +9190,24 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           v11:HeapBasicObject = GuardType v6, HeapBasicObject
-          v13:CShape = LoadField v11, :shape_id@0x1000
+          v12:CShape = LoadField v11, :shape_id@0x1000
           v14:CShape[0x1001] = Const CShape(0x1001)
-          v15:CBool = IsBitEqual v13, v14
+          v15:CBool = IsBitEqual v12, v14
           CondBranch v15, bb5(), bb6()
         bb5():
           v17:BasicObject = LoadField v11, :@foo@0x1002
           Jump bb4(v17)
         bb6():
-          v19:CShape = LoadField v11, :shape_id@0x1000
-          v20:CShape[0x1003] = Const CShape(0x1003)
-          v21:CBool = IsBitEqual v19, v20
-          CondBranch v21, bb7(), bb8()
-        bb7():
-          v23:BasicObject = LoadField v11, :@foo@0x1002
-          Jump bb4(v23)
-        bb8():
-          v25:BasicObject = GetIvar v11, :@foo
-          Jump bb4(v25)
-        bb4(v12:BasicObject):
-          v28:Fixnum[1] = Const Value(1)
+          v19:CShape[0x1003] = GuardBitEquals v12, CShape(0x1003) recompile
+          v21:BasicObject = LoadField v11, :@foo@0x1002
+          Jump bb4(v21)
+        bb4(v13:BasicObject):
+          v24:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Integer@0x1008, +@0x1010, cme:0x1018)
-          v39:Fixnum = GuardType v12, Fixnum recompile
-          v40:Fixnum = FixnumAdd v39, v28
+          v35:Fixnum = GuardType v13, Fixnum recompile
+          v36:Fixnum = FixnumAdd v35, v24
           CheckInterrupts
-          Return v40
+          Return v36
         ");
     }
 
@@ -9285,29 +9246,22 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           v11:HeapBasicObject = GuardType v6, HeapBasicObject
-          v13:CShape = LoadField v11, :shape_id@0x1000
+          v12:CShape = LoadField v11, :shape_id@0x1000
           v14:CShape[0x1001] = Const CShape(0x1001)
-          v15:CBool = IsBitEqual v13, v14
+          v15:CBool = IsBitEqual v12, v14
           CondBranch v15, bb5(), bb6()
         bb5():
           v17:RubyValue = LoadField v11, :fields_obj@0x1002
           v18:BasicObject = LoadField v17, :@a@0x1002
           Jump bb4(v18)
         bb6():
-          v20:CShape = LoadField v11, :shape_id@0x1000
-          v21:CShape[0x1003] = Const CShape(0x1003)
-          v22:CBool = IsBitEqual v20, v21
-          CondBranch v22, bb7(), bb8()
-        bb7():
-          v24:RubyValue = LoadField v11, :fields_obj@0x1004
-          v25:BasicObject = LoadField v24, :@a@0x1002
-          Jump bb4(v25)
-        bb8():
-          v27:BasicObject = GetIvar v11, :@a
-          Jump bb4(v27)
-        bb4(v12:BasicObject):
+          v20:CShape[0x1003] = GuardBitEquals v12, CShape(0x1003) recompile
+          v22:RubyValue = LoadField v11, :fields_obj@0x1004
+          v23:BasicObject = LoadField v22, :@a@0x1002
+          Jump bb4(v23)
+        bb4(v13:BasicObject):
           CheckInterrupts
-          Return v12
+          Return v13
         ");
     }
 
@@ -17274,50 +17228,43 @@ mod hir_opt_tests {
         bb6(v19:HeapBasicObject, v20:Fixnum):
           v24:Fixnum[10] = Const Value(10)
           PatchPoint MethodRedefined(Integer@0x1000, <@0x1008, cme:0x1010)
-          v100:BoolExact = FixnumLt v20, v24
+          v96:BoolExact = FixnumLt v20, v24
           CheckInterrupts
-          v30:CBool = Test v100
+          v30:CBool = Test v96
           CondBranch v30, bb4(v19, v20), bb7()
         bb4(v40:HeapBasicObject, v41:Fixnum):
           PatchPoint SingleRactorMode
-          v48:CShape = LoadField v40, :shape_id@0x1038
+          v47:CShape = LoadField v40, :shape_id@0x1038
           v49:CShape[0x1039] = Const CShape(0x1039)
-          v50:CBool = IsBitEqual v48, v49
+          v50:CBool = IsBitEqual v47, v49
           CondBranch v50, bb9(), bb10()
         bb9():
           v52:BasicObject = LoadField v40, :@levar@0x103a
           Jump bb8(v52)
         bb10():
-          v54:CShape = LoadField v40, :shape_id@0x1038
-          v55:CShape[0x103b] = Const CShape(0x103b)
-          v56:CBool = IsBitEqual v54, v55
-          CondBranch v56, bb11(), bb12()
-        bb11():
-          v58:NilClass = Const Value(nil)
-          Jump bb8(v58)
-        bb12():
-          v60:BasicObject = GetIvar v40, :@levar
-          Jump bb8(v60)
-        bb8(v47:BasicObject):
+          v54:CShape[0x103b] = GuardBitEquals v47, CShape(0x103b) recompile
+          v56:NilClass = Const Value(nil)
+          Jump bb8(v56)
+        bb8(v48:BasicObject):
           CheckInterrupts
-          v64:CBool = Test v47
-          CondBranch v64, bb5(v40, v41), bb13()
-        bb13():
+          v60:CBool = Test v48
+          CondBranch v60, bb5(v40, v41), bb12()
+        bb12():
           PatchPoint NoEPEscape(set_value_loop)
           PatchPoint SingleRactorMode
-          v74:CShape = LoadField v40, :shape_id@0x1038
-          v75:CShape[0x103b] = GuardBitEquals v74, CShape(0x103b) recompile
+          v70:CShape = LoadField v40, :shape_id@0x1038
+          v71:CShape[0x103b] = GuardBitEquals v70, CShape(0x103b) recompile
           StoreField v40, :@levar@0x103a, v41
           WriteBarrier v40, v41
-          v78:CShape[0x1039] = Const CShape(0x1039)
-          StoreField v40, :shape_id@0x1038, v78
+          v74:CShape[0x1039] = Const CShape(0x1039)
+          StoreField v40, :shape_id@0x1038, v74
           Jump bb5(v40, v41)
-        bb5(v82:HeapBasicObject, v83:Fixnum):
+        bb5(v78:HeapBasicObject, v79:Fixnum):
           PatchPoint NoEPEscape(set_value_loop)
-          v90:Fixnum[1] = Const Value(1)
+          v86:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Integer@0x1000, +@0x103c, cme:0x1040)
-          v104:Fixnum = FixnumAdd v83, v90
-          Jump bb6(v82, v104)
+          v100:Fixnum = FixnumAdd v79, v86
+          Jump bb6(v78, v100)
         bb7():
           v35:NilClass = Const Value(nil)
           CheckInterrupts

--- a/zjit/src/hir/tests.rs
+++ b/zjit/src/hir/tests.rs
@@ -4818,15 +4818,8 @@ pub(crate) mod hir_build_tests {
           Jump bb3(v7, v8, v9, v10)
         bb3(v12:BasicObject, v13:NilClass, v14:NilClass, v15:NilClass):
           PatchPoint SingleRactorMode
-          v20:BasicObject = GetIvar v12, :@a
-          PatchPoint SingleRactorMode
-          v23:BasicObject = GetIvar v12, :@b
-          PatchPoint SingleRactorMode
-          v26:BasicObject = GetIvar v12, :@c
-          PatchPoint NoEPEscape(reverse_odd)
-          v38:ArrayExact = NewArray v20, v23, v26
-          CheckInterrupts
-          Return v38
+          v20:HeapBasicObject = GuardType v12, HeapBasicObject
+          SideExit NoProfileGetIvar recompile
 
         fn reverse_even@<compiled>:8:
         bb1():
@@ -4847,17 +4840,8 @@ pub(crate) mod hir_build_tests {
           Jump bb3(v8, v9, v10, v11, v12)
         bb3(v14:BasicObject, v15:NilClass, v16:NilClass, v17:NilClass, v18:NilClass):
           PatchPoint SingleRactorMode
-          v23:BasicObject = GetIvar v14, :@a
-          PatchPoint SingleRactorMode
-          v26:BasicObject = GetIvar v14, :@b
-          PatchPoint SingleRactorMode
-          v29:BasicObject = GetIvar v14, :@c
-          PatchPoint SingleRactorMode
-          v32:BasicObject = GetIvar v14, :@d
-          PatchPoint NoEPEscape(reverse_even)
-          v46:ArrayExact = NewArray v23, v26, v29, v32
-          CheckInterrupts
-          Return v46
+          v23:HeapBasicObject = GuardType v14, HeapBasicObject
+          SideExit NoProfileGetIvar recompile
         ");
     }
 

--- a/zjit/src/stats.rs
+++ b/zjit/src/stats.rs
@@ -235,6 +235,7 @@ make_counters! {
         exit_too_many_keyword_parameters,
         exit_too_many_args_for_lir,
         exit_no_profile_send,
+        exit_no_profile_getivar,
         exit_splatkw_not_nil_or_hash,
         exit_splatkw_polymorphic,
         exit_splatkw_not_profiled,
@@ -659,6 +660,7 @@ pub fn side_exit_counter(reason: crate::hir::SideExitReason) -> Counter {
                                       => exit_patchpoint_root_box_only,
         SendWhileTracing              => exit_send_while_tracing,
         NoProfileSend                 => exit_no_profile_send,
+        NoProfileGetIvar              => exit_no_profile_getivar,
         InvokeBlockNotIfunc           => exit_invokeblock_not_ifunc,
     }
 }


### PR DESCRIPTION
Closes https://github.com/Shopify/ruby/issues/984

This PR fixes monomorphic getivar on the last version to specialize the profiled shape.

Prior to this PR, when the last version for an ISEQ was compiled and there was only one profiled shape for a getivar, ZJIT ignored the profiled shape (because `polymorphic_summary` does) and only generated a fallback. This PR turns such a callsite into a specialized getivar for the profiled shape, followed by a fallback.

## --zjit-max-versions=2 (current default)

```
$ ./run_benchmarks.rb optcarrot --chruby 'before::ruby-1-before --zjit-max-versions=2;after::ruby-1-after --zjit-max-versions=2'

before: ruby 4.1.0dev (2026-07-02T20:04:38Z master f289b0d688) +ZJIT +PRISM [x86_64-linux]
after: ruby 4.1.0dev (2026-07-02T21:38:13Z zjit-fix-monomorph.. d617e1d2ae) +ZJIT +PRISM [x86_64-linux]

---------  -------------  -------------  -------------  ------------
bench        before (ms)     after (ms)  after 1st itr  before/after
optcarrot  2146.8 ± 2.0%  1976.1 ± 2.1%          1.056         1.086
---------  -------------  -------------  -------------  ------------
```

<details>

<summary>ZJIT stats</summary>

### Before

```
Top-20 calls to C functions from JIT code (100.0% of total 342,557,929):
     rb_vm_getinstancevariable: 242,355,594 (70.7%)
     rb_vm_setinstancevariable:  43,768,655 (12.8%)
  rb_vm_opt_send_without_block:  13,241,858 ( 3.9%)

Top-2 getivar fallback reasons (100.0% of total 242,369,379):
  no_side_exits: 226,375,786 (93.4%)
     no_profile:  15,993,593 ( 6.6%)
```

### After

```
Top-20 calls to C functions from JIT code (100.0% of total 174,350,314):
     rb_vm_getinstancevariable: 57,334,763 (32.9%)
     rb_vm_setinstancevariable: 43,767,115 (25.1%)
  rb_vm_opt_send_without_block: 42,154,763 (24.2%)

Top-1 getivar fallback reasons (100.0% of total 57,339,434):
  no_side_exits: 57,339,434 (100.0%)
```

</details>

## --zjit-max-versions=4 (future default)

```
$ ./run_benchmarks.rb optcarrot --chruby 'before::ruby-1-before --zjit-max-versions=4;after::ruby-1-after --zjit-max-versions=4'

before: ruby 4.1.0dev (2026-07-02T20:04:38Z master f289b0d688) +ZJIT +PRISM [x86_64-linux]
after: ruby 4.1.0dev (2026-07-02T21:38:13Z zjit-fix-monomorph.. d617e1d2ae) +ZJIT +PRISM [x86_64-linux]

---------  -------------  -------------  -------------  ------------
bench        before (ms)     after (ms)  after 1st itr  before/after
optcarrot  1183.3 ± 3.4%  1139.2 ± 4.1%          1.011         1.039
---------  -------------  -------------  -------------  ------------
```

<details>

<summary>ZJIT stats</summary>

### Before

```
Top-20 calls to C functions from JIT code (100.0% of total 93,135,391):
     rb_vm_getinstancevariable: 28,603,965 (30.7%)
     rb_vm_setinstancevariable: 15,099,223 (16.2%)
                   rb_ary_push: 12,447,073 (13.4%)

Top-2 getivar fallback reasons (100.0% of total 28,704,654):
     no_profile: 17,756,507 (61.9%)
  no_side_exits: 10,948,147 (38.1%)
```

### After

```
Top-20 calls to C functions from JIT code (100.0% of total 70,634,231):
                   rb_ary_push: 12,446,516 (17.6%)
                rb_fix_mod_fix: 12,226,463 (17.3%)
     rb_vm_setinstancevariable: 11,611,460 (16.4%)
  rb_vm_opt_send_without_block:  7,833,596 (11.1%)
                   rb_fix_aref:  7,157,466 (10.1%)
     rb_vm_getinstancevariable:  4,491,652 ( 6.4%)

Top-1 getivar fallback reasons (100.0% of total 4,505,327):
  no_side_exits: 4,505,327 (100.0%)
```

</details>