### PR TITLE
Initialize the new gem's git repo without a subshell

### DIFF
--- a/lib/bundler/cli/gem.rb
+++ b/lib/bundler/cli/gem.rb
@@ -247,8 +247,7 @@ module Bundler
 
       if use_git
         Bundler.ui.info "\nInitializing git repo in #{target}"
-        require "shellwords"
-        `git init #{target.to_s.shellescape}`
+        IO.popen(["git", "init", target.to_s], &:read)
 
         config[:git_default_branch] = File.read("#{target}/.git/HEAD").split("/").last.chomp
       end

--- a/spec/bundler/commands/newgem_spec.rb
+++ b/spec/bundler/commands/newgem_spec.rb
@@ -88,8 +88,6 @@ RSpec.describe "bundle gem" do
       end
 
       it "properly initializes git repo" do
-        skip "path with spaces needs special handling on Windows" if Gem.win_platform?
-
         bundle "gem #{gem_name}", dir: bundled_app("path with spaces")
         expect(bundled_app("path with spaces/#{gem_name}/.git")).to exist
       end


### PR DESCRIPTION
`bundle gem` initialized the new gem's git repository by running `git init` through a backtick subshell with POSIX shell quoting applied to the target path. On Windows the backtick invokes cmd.exe, which does not honor the POSIX escaping, so a path containing spaces was split and the repository ended up in the wrong location. The following read of `.git/HEAD` then failed. Spawning git directly with an argument array avoids the shell entirely, needs no quoting, and matches the `git add` invocation a few lines below.

The newgem spec covering git initialization on a path with spaces was skipped on Windows for this reason. It runs and passes now, so the skip is removed.
