### PR TITLE
Exercise the malicious extensions check on Windows

### DIFF
--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1901,22 +1901,14 @@ class TestGemInstaller < Gem::InstallerTestCase
   end
 
   def test_pre_install_checks_malicious_extensions_before_eval
-    pend "mswin environment disallow to create file contained the carriage return code." if Gem.win_platform?
-
     spec = util_spec "malicious", "1"
-    def spec.full_name # so the spec is buildable
-      "malicious-1"
-    end
-
     def spec.validate(*args); end
     spec.extensions = ["malicious\n``"]
 
-    util_build_gem spec
-
-    gem = File.join(@gemhome, "cache", spec.file_name)
+    installer = Gem::Installer.for_spec spec
+    installer.gem_home = @gemhome
 
     use_ui @ui do
-      installer = Gem::Installer.at gem
       e = assert_raise Gem::InstallError do
         installer.pre_install_checks
       end


### PR DESCRIPTION
The `test_pre_install_checks_malicious_extensions_before_eval` example was skipped on Windows. It built a gem on disk to feed the installer, and `util_build_gem` writes every entry of `spec.files`, which includes `spec.extensions`. The malicious extension name embeds a newline, and Windows cannot turn that into a file name, so the whole example was skipped and the check went uncovered.

This builds the installer from the spec in memory with `Gem::Installer.for_spec` instead, matching the sibling non_string checks in the same file. The newline extension never reaches the filesystem, and `pre_install_checks` still runs `verify_spec` before the spec is eval'd, so the security intent is preserved and the example now runs on Windows too.
