### PR TITLE
Return to the transferring fiber when a transferred fiber terminates. [Bug #20081]

### DIFF
--- a/cont.c
+++ b/cont.c
@@ -2755,32 +2755,42 @@ return_fiber(bool terminate)
     rb_fiber_t *fiber = fiber_current();
     rb_fiber_t *prev = fiber->prev;
 
-    if (prev && (!terminate || !FIBER_TERMINATED_P(prev))) {
+    if (!terminate) {
+        // Yield: only a live resume back-pointer is a valid target.
+        // `prev->resuming_fiber == fiber` identifies a genuine resume; a transfer
+        // fallback (set in fiber_switch for termination) is *not* resumable via
+        // yield, so we leave it intact and raise, as if `prev` were not set.
+        if (prev && prev->resuming_fiber == fiber) {
+            fiber->prev = NULL;
+            prev->resuming_fiber = NULL;
+            return prev;
+        }
+
+        rb_raise(rb_eFiberError, "attempt to yield on a not resumed fiber");
+    }
+
+    // Terminate: return to the fiber that resumed or (most recently) transferred
+    // into us, provided it is still alive:
+    if (prev && !FIBER_TERMINATED_P(prev)) {
         fiber->prev = NULL;
         prev->resuming_fiber = NULL;
         return prev;
     }
-    else {
-        if (!terminate) {
-            rb_raise(rb_eFiberError, "attempt to yield on a not resumed fiber");
-        }
 
-        // A transfer fallback (see fiber_switch) may point at an
-        // already-terminated fiber; drop it and fall back to the root fiber's
-        // resuming chain below.
-        fiber->prev = NULL;
+    // Otherwise (no prev, or a transfer fallback pointing at an already-terminated
+    // fiber), fall back to the root fiber's resuming chain:
+    fiber->prev = NULL;
 
-        rb_thread_t *th = GET_THREAD();
-        rb_fiber_t *root_fiber = th->root_fiber;
+    rb_thread_t *th = GET_THREAD();
+    rb_fiber_t *root_fiber = th->root_fiber;
 
-        VM_ASSERT(root_fiber != NULL);
+    VM_ASSERT(root_fiber != NULL);
 
-        // search resuming fiber
-        for (fiber = root_fiber; fiber->resuming_fiber; fiber = fiber->resuming_fiber) {
-        }
-
-        return fiber;
+    // search resuming fiber
+    for (fiber = root_fiber; fiber->resuming_fiber; fiber = fiber->resuming_fiber) {
     }
+
+    return fiber;
 }
 
 VALUE

--- a/cont.c
+++ b/cont.c
@@ -2755,7 +2755,7 @@ return_fiber(bool terminate)
     rb_fiber_t *fiber = fiber_current();
     rb_fiber_t *prev = fiber->prev;
 
-    if (prev) {
+    if (prev && (!terminate || !FIBER_TERMINATED_P(prev))) {
         fiber->prev = NULL;
         prev->resuming_fiber = NULL;
         return prev;
@@ -2764,6 +2764,11 @@ return_fiber(bool terminate)
         if (!terminate) {
             rb_raise(rb_eFiberError, "attempt to yield on a not resumed fiber");
         }
+
+        // A transfer fallback (see fiber_switch) may point at an
+        // already-terminated fiber; drop it and fall back to the root fiber's
+        // resuming chain below.
+        fiber->prev = NULL;
 
         rb_thread_t *th = GET_THREAD();
         rb_fiber_t *root_fiber = th->root_fiber;
@@ -2872,6 +2877,24 @@ fiber_switch(rb_fiber_t *fiber, int argc, const VALUE *argv, int kw_splat, rb_fi
         current_fiber->resuming_fiber = resuming_fiber;
         fiber->prev = fiber_current();
         fiber->yielding = 0;
+    }
+    else if (!yielding && !FIBER_TERMINATED_P(current_fiber) && fiber != th->root_fiber) {
+        // Transfer: record the transferring fiber as a fallback return target,
+        // so that a transferred fiber which terminates without an explicit
+        // transfer returns to whoever transferred into it, rather than the
+        // thread's root fiber. [Bug #20081]
+        //
+        // `prev->resuming_fiber == fiber` identifies a live resume back-pointer,
+        // which `Fiber.yield` relies on and must never be overwritten. Any other
+        // `prev` is a stale transfer fallback and is replaced, so that
+        // termination unwinds to the most-recent transferring fiber.
+        //
+        // The root fiber is never given a fallback: it does not terminate via
+        // return_fiber (so the fallback would leak), and it is already the
+        // terminal target of the resuming-chain search below.
+        if (!fiber->prev || fiber->prev->resuming_fiber != fiber) {
+            fiber->prev = current_fiber;
+        }
     }
 
     VM_ASSERT(!current_fiber->yielding);

--- a/spec/ruby/core/fiber/current_spec.rb
+++ b/spec/ruby/core/fiber/current_spec.rb
@@ -34,7 +34,9 @@ describe "Fiber.current" do
     fiber2 = Fiber.new do
       states << :fiber2
       fiber.transfer
-      flunk
+      # When `fiber` terminates it returns here, to the fiber that transferred
+      # into it, which then terminates and returns to `fiber3`. [Bug #20081]
+      states << :fiber2_terminated
     end
 
     fiber3 = Fiber.new do
@@ -45,6 +47,6 @@ describe "Fiber.current" do
 
     fiber3.resume
 
-    states.should == [:fiber3, :fiber2, :fiber, :fiber3_terminated]
+    states.should == [:fiber3, :fiber2, :fiber, :fiber2_terminated, :fiber3_terminated]
   end
 end

--- a/spec/ruby/core/fiber/transfer_spec.rb
+++ b/spec/ruby/core/fiber/transfer_spec.rb
@@ -12,12 +12,47 @@ describe "Fiber#transfer" do
     fiber2.resume.should == :fiber2
   end
 
-  it "returns to the root Fiber when finished" do
-    f1 = Fiber.new { :fiber_1 }
-    f2 = Fiber.new { f1.transfer; :fiber_2 }
+  ruby_version_is ""..."4.1" do
+    it "returns to the root Fiber when finished" do
+      f1 = Fiber.new { :fiber_1 }
+      f2 = Fiber.new { f1.transfer; :fiber_2 }
 
-    f2.transfer.should == :fiber_1
-    f2.transfer.should == :fiber_2
+      f2.transfer.should == :fiber_1
+      f2.transfer.should == :fiber_2
+    end
+  end
+
+  ruby_version_is "4.1" do
+    it "returns to the transferring Fiber when finished" do
+      states = []
+      f1 = Fiber.new { states << :f1 }
+      f2 = Fiber.new { f1.transfer; states << :f2 }
+
+      f2.transfer
+      states.should == [:f1, :f2]
+    end
+
+    it "unwinds to the most recent transferring Fiber when finished" do
+      states = []
+      a = b = nil
+      a = Fiber.new { states << :a1; b.transfer; states << :a2 }
+      b = Fiber.new { states << :b1; a.transfer; states << :b2 }
+
+      a.transfer
+      states.should == [:a1, :b1, :a2, :b2]
+    end
+
+    it "does not clobber the resume caller when a resumed Fiber transfers and is transferred back" do
+      states = []
+      a = b = nil
+      a = Fiber.new { states << :a_start; b.transfer; states << :a_resumed; Fiber.yield; states << :a_after_yield }
+      b = Fiber.new { states << :b_start; a.transfer; states << :b_never }
+
+      a.resume
+      states << :back_in_caller
+      a.resume
+      states.should == [:a_start, :b_start, :a_resumed, :back_in_caller, :a_after_yield]
+    end
   end
 
   it "can be invoked from the same Fiber it transfers control to" do

--- a/test/ruby/test_fiber.rb
+++ b/test/ruby/test_fiber.rb
@@ -191,8 +191,10 @@ class TestFiber < Test::Unit::TestCase
       ary << f1.transfer(:baz)
       :ng
     }
-    assert_equal(:ok, f1.transfer)
-    assert_equal([:baz], ary)
+    # When f1 terminates it returns to the fiber that transferred into it (f2),
+    # which then resumes and terminates, returning to the root fiber. [Bug #20081]
+    assert_equal(:ng, f1.transfer)
+    assert_equal([:baz, :ok], ary)
   end
 
   def test_terminate_transferred_fiber
@@ -219,7 +221,58 @@ class TestFiber < Test::Unit::TestCase
     r1.resume
     log << :root_terminate
 
-    assert_equal [:fa2_terminate, :fa1_terminate, :r1_terminate, :root_terminate], log
+    assert_equal [:fa2_terminate, :fa1_terminate, :fb1_terminate, :r1_terminate, :root_terminate], log
+  end
+
+  def test_terminate_unwinds_to_most_recent_transferring_fiber
+    # A transferred fiber that terminates returns to the fiber that most recently
+    # transferred into it, unwinding the transfer chain instead of jumping back
+    # to the root fiber. [Bug #20081]
+    log = []
+    a = b = nil
+
+    a = Fiber.new{
+      log << :a1
+      b.transfer
+      log << :a2 # b transferred back into a
+    }
+    b = Fiber.new{
+      log << :b1
+      a.transfer
+      log << :b2 # a terminated and returned control to b
+    }
+
+    a.transfer # a.prev = root
+    log << :root
+
+    assert_equal [:a1, :b1, :a2, :b2, :root], log
+  end
+
+  def test_yield_returns_to_resumer_across_transfer
+    # Fiber.yield must return to the resumer even when the resumed fiber
+    # transfers away and is transferred back before yielding: an intervening
+    # transfer must not clobber the resume back-pointer. [Bug #20081]
+    log = []
+    a = b = nil
+
+    a = Fiber.new{
+      log << :a_start
+      b.transfer
+      log << :a_resumed
+      Fiber.yield # must return to the resumer (root), not b
+      log << :a_after_yield
+    }
+    b = Fiber.new{
+      log << :b_start
+      a.transfer
+      log << :b_never
+    }
+
+    a.resume
+    log << :back_in_root
+    a.resume
+
+    assert_equal [:a_start, :b_start, :a_resumed, :back_in_root, :a_after_yield], log
   end
 
   def test_tls


### PR DESCRIPTION
## Summary

Fixes [Bug #20081]: when a fiber entered via `Fiber#transfer` terminates without an explicit transfer, control returns to the thread's **root fiber** rather than to the fiber that transferred into it. This makes transfer-based control flow (fiber schedulers) impossible to compose with code that creates and terminates its own fibers.

```ruby
loop_fiber = Fiber.new do
  Fiber.new { }.transfer     # task terminates
  puts "loop: after task"    # never runs on master
end
loop_fiber.transfer
puts "root: done"
# master:   task-termination escapes to root, "loop: after task" is skipped
# this PR:  control returns to loop_fiber
```

## Design

The fix is deliberately minimal and preserves existing semantics:

- **`transfer` sets only `prev`, never `resuming_fiber`.** `resuming_fiber` therefore remains a pure *resume* relationship. Because you cannot resume an already-resumed fiber, the `resuming_fiber` chain can never form a cycle, so the fallback root-walk in `return_fiber` remains safe.
- **`Fiber.yield` is unchanged.** Yield-legality is gated by `prev->resuming_fiber == fiber`: `resume` sets the *bidirectional* link (`resumer.resuming_fiber = resumed`, `resumed.prev = resumer`), whereas `transfer` sets only `prev`. So a transfer-entered fiber still raises `attempt to yield on a not resumed fiber` — no new flag, no behavior change. A resumed fiber that transfers away and is transferred back still yields to its resumer (the resume `prev` is never overwritten by a transfer).
- **Termination returns via `prev` as a single step**, so a bounce (`loop ⇄ task`) that forms a `prev` cycle is harmless — `prev` is followed once, never walked. If `prev` points at an already-terminated fiber, we fall back to the root resuming-chain search.
- **The root fiber never receives a fallback** (it does not terminate through `return_fiber`, and is already the terminal target of the search).

Net effect: `resuming_fiber` + `yield` semantics are untouched; the only observable change is that a transferred fiber, on termination, unwinds to the fiber that transferred into it instead of jumping to the root fiber.

## What this does and does not fix

- **Fixes:** the transfer *gap* — a terminating fiber (or its reactor's transfer-driven tasks) crossing a `transfer` boundary now unwinds to the transferrer. This is what fiber schedulers need (they use `transfer`, since `resume` would build an unbounded resume stack).
- **Does not fix (by design):** an abandoned transfer *branch* — a fiber that transfers away and is never returned to by anyone (e.g. `worker1` in [ruby-core:125902]). That fiber is orphaned in stock Ruby too; it is inherent to one-way transfer, not the transfer gap. This PR neither fixes nor worsens it (it only additionally prints `manager: end`).

## Verification

Built and run on this branch vs. stock:

Pure fibers:

| Case | master | this PR |
| --- | --- | --- |
| loop drives task via `transfer`, terminates | `loop: after task` skipped | reaches `loop: after task` |
| same, loop `resume`d inside a transferred fiber | skipped | reaches it |
| loop drives task via `resume` | works | works |
| `Fiber.yield` in a transfer-entered fiber | `FiberError` | `FiberError` (unchanged) |
| resumed fiber transfers away and back, then `yield`s | yields to resumer | yields to resumer |

Suites (all pass): `test/ruby/test_fiber` (37), `spec/ruby/core/fiber` (172 examples), `test/fiber/*` incl. the fiber scheduler suite + `test/ruby/test_enumerator` (164 tests).

Downstream: with this change, [socketry/async](https://github.com/socketry/async) runs `Sync`/`Async` correctly beneath a `transfer` boundary using only its scheduler's normal `transfer`-based task fibers — no task-lifecycle workaround required.

## Tests included

- `test/ruby/test_fiber.rb`: `test_transfer`, `test_terminate_transferred_fiber` updated to the new unwinding behavior; added `test_terminate_unwinds_to_most_recent_transferring_fiber` and `test_yield_returns_to_resumer_across_transfer`.
- `spec/ruby/core/fiber/transfer_spec.rb`: "returns to the root Fiber when finished" version-guarded (`< 4.1`), with new `>= 4.1` specs; `current_spec.rb` transfer-chain example updated.

[Bug #20081]: https://bugs.ruby-lang.org/issues/20081
[ruby-core:125902]: https://blade.ruby-lang.org/ruby-core/125902
