### PR TITLE
Preserve CRLF lockfile line endings on Windows

### DIFF
--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -427,7 +427,9 @@ module Bundler
       # `git config core.autocrlf=true`. Detect from the bytes on disk because
       # reading in text mode strips carriage returns on Windows, which would
       # otherwise defeat this check and rewrite a `\r\n` lockfile with `\n`.
-      contents.gsub!(/\n/, "\r\n") if File.exist?(file) && File.binread(file).include?("\r\n")
+      if File.exist?(file) && SharedHelpers.filesystem_access(file, :read) {|p| File.binread(p).include?("\r\n") }
+        contents.gsub!(/\n/, "\r\n")
+      end
 
       begin
         SharedHelpers.filesystem_access(file) do |p|

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -403,10 +403,6 @@ module Bundler
 
       contents = to_lock
 
-      # Convert to \r\n if the existing lock has them
-      # i.e., Windows with `git config core.autocrlf=true`
-      contents.gsub!(/\n/, "\r\n") if @lockfile_contents.match?("\r\n")
-
       if @locked_bundler_version
         locked_major = @locked_bundler_version.segments.first
         current_major = bundler_version_to_lock.segments.first
@@ -426,6 +422,12 @@ module Bundler
         Bundler.ui.error "Cannot write a changed lockfile while frozen."
         return
       end
+
+      # Convert to \r\n if the existing lock has them, i.e., Windows with
+      # `git config core.autocrlf=true`. Detect from the bytes on disk because
+      # reading in text mode strips carriage returns on Windows, which would
+      # otherwise defeat this check and rewrite a `\r\n` lockfile with `\n`.
+      contents.gsub!(/\n/, "\r\n") if File.exist?(file) && File.binread(file).include?("\r\n")
 
       begin
         SharedHelpers.filesystem_access(file) do |p|

--- a/spec/bundler/lock/lockfile_spec.rb
+++ b/spec/bundler/lock/lockfile_spec.rb
@@ -2336,8 +2336,6 @@ RSpec.describe "the lockfile format" do
       end
 
       it "preserves Gemfile.lock \\n\\r line endings" do
-        skip "needs to be adapted" if Gem.win_platform?
-
         update_repo2 do
           build_gem "myrack", "1.2" do |s|
             s.executables = "myrackup"
@@ -2349,7 +2347,7 @@ RSpec.describe "the lockfile format" do
         set_lockfile_mtime_to_known_value
 
         expect { bundle "update", all: true }.to change { File.mtime(bundled_app_lock) }
-        expect(File.read(bundled_app_lock)).to match("\r\n")
+        expect(File.binread(bundled_app_lock)).to match("\r\n")
 
         expect(the_bundle).to include_gems "myrack 1.2"
       end

--- a/spec/bundler/lock/lockfile_spec.rb
+++ b/spec/bundler/lock/lockfile_spec.rb
@@ -2335,7 +2335,7 @@ RSpec.describe "the lockfile format" do
         expect(the_bundle).to include_gems "myrack 1.2"
       end
 
-      it "preserves Gemfile.lock \\n\\r line endings" do
+      it "preserves Gemfile.lock \\r\\n line endings" do
         update_repo2 do
           build_gem "myrack", "1.2" do |s|
             s.executables = "myrackup"
@@ -2363,7 +2363,7 @@ RSpec.describe "the lockfile format" do
         end.not_to change { File.mtime(bundled_app_lock) }
       end
 
-      it "preserves Gemfile.lock \\n\\r line endings" do
+      it "preserves Gemfile.lock \\r\\n line endings" do
         win_lock = File.read(bundled_app_lock).gsub(/\n/, "\r\n")
         File.open(bundled_app_lock, "wb") {|f| f.puts(win_lock) }
         set_lockfile_mtime_to_known_value


### PR DESCRIPTION
When write_lock rewrites Gemfile.lock it decides whether to emit `\r\n` from the copy of the lockfile it read into memory. That copy is read in text mode, which drops carriage returns on Windows, so the check never sees the `\r\n` and a `\r\n` lockfile was rewritten with `\n`.

This detects the existing line ending from the raw bytes on disk instead. The conversion also moves after the equality check so the comparison keeps operating on `\n` content, which is what preserves an untouched lockfile when nothing changed. The spec covering this was skipped on Windows and now runs, reading the file in binary so text mode does not hide the carriage returns being asserted.
