### PR TITLE
[DOC] Fix Thread::Mutex#unlock doc

### DIFF
--- a/thread_sync.c
+++ b/thread_sync.c
@@ -504,13 +504,6 @@ do_mutex_unlock_safe(VALUE args)
     return Qnil;
 }
 
-/*
- * call-seq:
- *    mutex.unlock    -> self
- *
- * Releases the lock.
- * Raises +ThreadError+ if +mutex+ wasn't locked by the current thread.
- */
 VALUE
 rb_mutex_unlock(VALUE self)
 {

--- a/thread_sync.rb
+++ b/thread_sync.rb
@@ -371,10 +371,10 @@ class Thread
     end
 
     # call-seq:
-    #    mutex.lock  -> self
+    #    mutex.unlock  -> self
     #
-    # Attempts to grab the lock and waits if it isn't available.
-    # Raises +ThreadError+ if +mutex+ was locked by the current thread.
+    # Releases the lock.
+    # Raises +ThreadError+ if +mutex+ wasn't locked by the current thread.
     def unlock
       Primitive.rb_mut_unlock
     end


### PR DESCRIPTION
It was [previously][1] moved from C to Ruby, but the doc on the Ruby method was copied from `#lock` while the correct doc was left in C.

[1]: https://github.com/ruby/ruby/commit/07b2356a6ad314b9a7b2bb9fc0527b440f004faa