### PR TITLE
Prohibit at_exit and END{} in non-main Ractors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -145,6 +145,10 @@ Ruby 4.0 bundled RubyGems and Bundler version 4. see the following links for det
 
 ## Compatibility issues
 
+* `Kernel#at_exit` and `END {}` now raise `Ractor::IsolationError` when called
+  in a non-main Ractor.  Previously the registered handler ran in the main
+  Ractor at process exit, which was confusing. [[Feature #22139]]
+
 ## Stdlib compatibility issues
 
 ## C API updates
@@ -202,6 +206,7 @@ A lot of work has gone into making Ractors more stable, performant, and usable. 
 [Feature #21861]: https://bugs.ruby-lang.org/issues/21861
 [Feature #21932]: https://bugs.ruby-lang.org/issues/21932
 [Feature #21981]: https://bugs.ruby-lang.org/issues/21981
+[Feature #22139]: https://bugs.ruby-lang.org/issues/22139
 [PR #17201]: https://github.com/ruby/ruby/pull/17201
 [RubyGems-v4.0.4]: https://github.com/rubygems/rubygems/releases/tag/v4.0.4
 [RubyGems-v4.0.5]: https://github.com/rubygems/rubygems/releases/tag/v4.0.5

--- a/depend
+++ b/depend
@@ -5451,6 +5451,7 @@ eval.$(OBJEXT): $(top_srcdir)/internal/imemo.h
 eval.$(OBJEXT): $(top_srcdir)/internal/inits.h
 eval.$(OBJEXT): $(top_srcdir)/internal/io.h
 eval.$(OBJEXT): $(top_srcdir)/internal/object.h
+eval.$(OBJEXT): $(top_srcdir)/internal/ractor.h
 eval.$(OBJEXT): $(top_srcdir)/internal/sanitizers.h
 eval.$(OBJEXT): $(top_srcdir)/internal/serial.h
 eval.$(OBJEXT): $(top_srcdir)/internal/set_table.h
@@ -19734,6 +19735,7 @@ vm.$(OBJEXT): $(top_srcdir)/internal/numeric.h
 vm.$(OBJEXT): $(top_srcdir)/internal/object.h
 vm.$(OBJEXT): $(top_srcdir)/internal/parse.h
 vm.$(OBJEXT): $(top_srcdir)/internal/proc.h
+vm.$(OBJEXT): $(top_srcdir)/internal/ractor.h
 vm.$(OBJEXT): $(top_srcdir)/internal/random.h
 vm.$(OBJEXT): $(top_srcdir)/internal/rational.h
 vm.$(OBJEXT): $(top_srcdir)/internal/re.h

--- a/eval_jump.c
+++ b/eval_jump.c
@@ -4,6 +4,7 @@
  */
 
 #include "eval_intern.h"
+#include "internal/ractor.h"
 
 /* exit */
 
@@ -42,6 +43,7 @@ rb_f_at_exit(VALUE _)
     if (!rb_block_given_p()) {
         rb_raise(rb_eArgError, "called without a block");
     }
+    rb_ractor_ensure_main_ractor("can not call at_exit from non-main Ractors");
     proc = rb_block_proc();
     rb_set_end_proc(rb_call_end_proc, proc);
     return proc;

--- a/test/ruby/test_ractor.rb
+++ b/test/ruby/test_ractor.rb
@@ -240,6 +240,28 @@ class TestRactor < Test::Unit::TestCase
     RUBY
   end if Process.respond_to?(:fork)
 
+  def test_at_exit_raise_isolation_error
+    assert_ractor(<<~'RUBY')
+      ractor = Ractor.new do
+        at_exit { }
+      rescue Ractor::IsolationError => e
+        e
+      end
+      assert_equal Ractor::IsolationError, ractor.value.class
+    RUBY
+  end
+
+  def test_END_raise_isolation_error
+    assert_ractor(<<~'RUBY', ignore_stderr: true)
+      ractor = Ractor.new do
+        END { nil }
+      rescue Ractor::IsolationError => e
+        e
+      end
+      assert_equal Ractor::IsolationError, ractor.value.class
+    RUBY
+  end
+
   def test_require_raises_and_no_ractor_belonging_issue
     assert_ractor(<<~'RUBY')
       require "tempfile"

--- a/vm.c
+++ b/vm.c
@@ -24,6 +24,7 @@
 #include "internal/missing.h"
 #include "internal/object.h"
 #include "internal/proc.h"
+#include "internal/ractor.h"
 #include "internal/re.h"
 #include "internal/ruby_parser.h"
 #include "internal/st.h"
@@ -4096,6 +4097,7 @@ m_core_undef_method(VALUE self, VALUE cbase, VALUE sym)
 static VALUE
 m_core_set_postexe(VALUE self)
 {
+    rb_ractor_ensure_main_ractor("can not use END{} in non-main Ractors");
     rb_set_end_proc(rb_call_end_proc, rb_block_proc());
     return Qnil;
 }


### PR DESCRIPTION
Registering an exit handler with Kernel#at_exit or END{} in a non-main Ractor behaved confusingly: the block ran in the main Ractor at process exit even though it was registered from another Ractor. Raise Ractor::IsolationError instead.

[Feature #22139]