### PR TITLE
Fix the gemspec error snippet on Windows drive-letter paths

### DIFF
--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -671,8 +671,11 @@ module Bundler
 
           trace_line = backtrace.find {|l| l.include?(dsl_path) } || trace_line
           return m unless trace_line
-          line_number = trace_line.split(":")[1].to_i - 1
+          # Match the line number right before `:in` or the end of the line so a
+          # Windows drive letter like `C:` does not get mistaken for the number.
+          line_number = trace_line[/:(\d+)(?::in\b|\z)/, 1]
           return m unless line_number
+          line_number = line_number.to_i - 1
 
           lines      = contents.lines.to_a
           indent     = " #  "

--- a/spec/bundler/runtime/setup_spec.rb
+++ b/spec/bundler/runtime/setup_spec.rb
@@ -1162,8 +1162,6 @@ end
     end
 
     it "error intelligently if the gemspec has a LoadError" do
-      skip "whitespace issue?" if Gem.win_platform?
-
       ref = update_git "bar", gemspec: false do |s|
         s.write "bar.gemspec", "require 'foobarbaz'"
       end.ref_for("HEAD")


### PR DESCRIPTION
When a Gemfile or gemspec raises, `Bundler::DSLError#to_s` renders the offending source line. It found the line number with `trace_line.split(":")[1]`, which assumes the path before it has no colon. On Windows the backtrace path starts with a drive letter such as `C:`, so that field is a slice of the path rather than the number, and the negative index it produces garbles the snippet.

This reads the number that sits right before `:in` or at the end of the backtrace line instead, so the drive-letter colon is ignored. The result is unchanged on platforms without drive letters.
