### PR TITLE
Remove stale Windows skips in bundler specs

### DIFF
--- a/spec/bundler/install/deploy_spec.rb
+++ b/spec/bundler/install/deploy_spec.rb
@@ -44,8 +44,6 @@ RSpec.describe "install in deployment or frozen mode" do
   end
 
   it "works when you bundle exec bundle" do
-    skip "doesn't find bundle" if Gem.win_platform?
-
     bundle :install
     bundle_config "deployment true"
     bundle :install

--- a/spec/bundler/install/gemfile/git_spec.rb
+++ b/spec/bundler/install/gemfile/git_spec.rb
@@ -427,8 +427,6 @@ RSpec.describe "bundle install with git sources" do
     context "when the branch starts with a `#`" do
       let(:branch) { "#149/redirect-url-fragment" }
       it "works" do
-        skip "git does not accept this" if Gem.win_platform?
-
         update_git("foo", path: repo, branch: branch)
 
         install_gemfile <<-G
@@ -481,8 +479,6 @@ RSpec.describe "bundle install with git sources" do
     context "when the tag starts with a `#`" do
       let(:tag) { "#149/redirect-url-fragment" }
       it "works" do
-        skip "git does not accept this" if Gem.win_platform?
-
         update_git("foo", path: repo, tag: tag)
 
         install_gemfile <<-G

--- a/spec/bundler/install/yanked_spec.rb
+++ b/spec/bundler/install/yanked_spec.rb
@@ -54,8 +54,6 @@ RSpec.context "when installing a bundle that includes yanked gems" do
     end
 
     before do
-      skip "Materialization on Windows is not yet strict, so the example does not detect the gem has been yanked" if Gem.win_platform?
-
       build_repo4 do
         build_gem "foo", "1.0.0"
         build_gem "foo", "1.0.1"


### PR DESCRIPTION
These Windows skips no longer reflect reality, so this removes them and lets the examples run. Verified on an actual mswin build, where each of them passes as is.

The yanked_spec examples were skipped because materialization on Windows was not strict enough to detect that a platform-specific locked spec had been yanked. It now falls back to the generic variant and reports the yank the same as other platforms. The deploy_spec example works because `bundle exec bundle` resolves the bundle executable on Windows now. The git_spec examples work because git on Windows accepts branch and tag names starting with `#`. The neighboring skips for branch and tag names containing quotes are kept, since NTFS cannot represent those refs on disk.
