### PR TITLE
[Tests] Add test cases for String#insert

### DIFF
--- a/test/ruby/test_string.rb
+++ b/test/ruby/test_string.rb
@@ -1482,6 +1482,16 @@ CODE
     assert_equal("abcdX", S("abcd").insert(4, 'X'))
     assert_equal("abXcd", S("abcd").insert(-3, 'X'))
     assert_equal("abcdX", S("abcd").insert(-1, 'X'))
+    assert_equal("Xabcd", S("abcd").insert(-5, 'X'))
+    assert_equal("こんbarにちは", S("こんにちは").insert(2, 'bar'))
+
+    str = S("abcd")
+    assert_same(str, str.insert(2, 'X'))
+
+    assert_raise(IndexError) { S("abcd").insert(5, 'X') }
+    assert_raise(IndexError) { S("abcd").insert(-6, 'X') }
+    assert_raise(TypeError) { S("abcd").insert(2, 42) }
+    assert_raise(FrozenError) { S("abcd").freeze.insert(2, 'X') }
   end
 
   def test_intern


### PR DESCRIPTION
Cover behavior documented in rdoc but not asserted in test/ruby/test_string.rb:

* insert returns self
* boundary negative index -(length + 1) prepends
* out-of-range index (positive and negative) raises IndexError
* non-string argument raises TypeError
* frozen string raises FrozenError
* multibyte: index counts characters, not bytes