### PR TITLE
Remove obsolete Windows skip guards from core tests

### DIFF
--- a/test/objspace/test_objspace.rb
+++ b/test/objspace/test_objspace.rb
@@ -135,7 +135,6 @@ class TestObjSpace < Test::Unit::TestCase
   end
 
   def test_reachable_objects_during_iteration
-    omit 'flaky on Visual Studio with: [BUG] Unnormalized Fixnum value' if /mswin/ =~ RUBY_PLATFORM
     opts = %w[--disable-gem --disable=frozen-string-literal -robjspace]
     assert_ruby_status opts, "#{<<-"begin;"}\n#{<<-'end;'}"
     begin;

--- a/test/ruby/test_box.rb
+++ b/test/ruby/test_box.rb
@@ -1075,7 +1075,6 @@ class TestBox < Test::Unit::TestCase
   end
 
   def test_loading_extension_libs_in_main_box_1
-    pend if /mswin|mingw/ =~ RUBY_PLATFORM # timeout on windows environments
     assert_separately([ENV_ENABLE_BOX], __FILE__, __LINE__, "#{<<~"begin;"}\n#{<<~'end;'}", ignore_stderr: true)
     begin;
       require "prism"

--- a/test/ruby/test_box.rb
+++ b/test/ruby/test_box.rb
@@ -1075,7 +1075,7 @@ class TestBox < Test::Unit::TestCase
   end
 
   def test_loading_extension_libs_in_main_box_1
-    assert_separately([ENV_ENABLE_BOX], __FILE__, __LINE__, "#{<<~"begin;"}\n#{<<~'end;'}", ignore_stderr: true)
+    assert_separately([ENV_ENABLE_BOX], __FILE__, __LINE__, "#{<<~"begin;"}\n#{<<~'end;'}", ignore_stderr: true, timeout: 60)
     begin;
       require "prism"
       require "optparse"

--- a/test/ruby/test_ractor.rb
+++ b/test/ruby/test_ractor.rb
@@ -276,7 +276,7 @@ class TestRactor < Test::Unit::TestCase
 
   # [Bug #21398]
   def test_port_receive_dnt_with_port_send
-    omit 'unstable on windows and macos-14' if RUBY_PLATFORM =~ /mswin|mingw|darwin/
+    omit 'unstable on macos-14' if RUBY_PLATFORM =~ /darwin/
     assert_ractor(<<~'RUBY', timeout: 90)
       THREADS = 10
       JOBS_PER_THREAD = 50

--- a/test/ruby/test_stack.rb
+++ b/test/ruby/test_stack.rb
@@ -65,8 +65,6 @@ class TestStack < Test::Unit::TestCase
 
   # Depending on OS, machine stack size may not change size.
   def test_machine_stack_size
-    return if /mswin|mingw/ =~ RUBY_PLATFORM
-
     script = '$stdout.sync=true; def rec; print "."; 1.times{1.times{1.times{rec}}}; end; Fiber.new{rec}.resume'
 
     vm_stack_size = 1024 * 1024

--- a/test/ruby/test_thread.rb
+++ b/test/ruby/test_thread.rb
@@ -1480,8 +1480,6 @@ q.pop
   end
 
   def test_thread_interrupt_for_killed_thread
-    pend "hang-up" if /mswin|mingw/ =~ RUBY_PLATFORM
-
     opts = { timeout: 5, timeout_error: nil }
 
     assert_normal_exit(<<-_end, '[Bug #8996]', **opts)

--- a/test/ruby/test_thread_queue.rb
+++ b/test/ruby/test_thread_queue.rb
@@ -656,9 +656,6 @@ class TestThreadQueue < Test::Unit::TestCase
   end
 
   def test_queue_with_trap
-    if ENV['APPVEYOR'] == 'True' && RUBY_PLATFORM.match?(/mswin/)
-      omit 'This test fails too often on AppVeyor vs140'
-    end
     if RUBY_PLATFORM.match?(/mingw/)
       omit 'This test fails too often on MinGW'
     end

--- a/test/ruby/test_transcode.rb
+++ b/test/ruby/test_transcode.rb
@@ -2347,7 +2347,7 @@ class TestTranscode < Test::Unit::TestCase
   end
 
   def test_ractor_lazy_load_encoding_random
-    omit 'unstable on s390x and windows' if RUBY_PLATFORM =~ /s390x|mswin/
+    omit 'unstable on s390x' if RUBY_PLATFORM =~ /s390x/
     assert_ractor("#{<<~"begin;"}\n#{<<~'end;'}", timeout: 30)
     begin;
       rs = []


### PR DESCRIPTION
Several `pend`, `omit`, and `return` guards under `test/` skip core tests on mswin for conditions that no longer hold. This removes those stale mswin conditions after confirming the tests pass on a current x64-mswin64_140 build.

Each affected test was run against the build with zero skips and zero failures. The four with a flaky history (`test_reachable_objects_during_iteration`, `test_port_receive_dnt_with_port_send`, `test_ractor_lazy_load_encoding_random`, and `test_queue_with_trap`) were each run five times individually and three more times together under `-j16`, all green.

Only the mswin conditions are dropped. `test_port_receive_dnt_with_port_send` in `test_ractor.rb` keeps its `darwin` guard because macos-14 remains unstable and was not re-verified here. `test_ractor_lazy_load_encoding_random` in `test_transcode.rb` keeps its `s390x` guard. `test_queue_with_trap` in `test_thread_queue.rb` keeps the MinGW omit and drops only the dead AppVeyor branch, since `ENV['APPVEYOR']` is never set now that AppVeyor is retired.

`test_box.rb` re-enables `test_loading_extension_libs_in_main_box_1` only. `test_loading_extension_libs_in_main_box_2` is left pended on purpose, because under mswin its `require "openssl"` still triggers a SEGV at process exit (`rb_gc_impl_shutdown_call_finalizer` to `rb_obj_is_thread`). That is a separate core bug to be reported and fixed independently.
