### PR TITLE
Add Fiber.exit for a directed final transfer.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -29,6 +29,14 @@ Note: We're only listing outstanding class updates.
       given names, raising `KeyError` for missing names unless a block is
       given. [[Feature #21781]]
 
+* Fiber
+
+    * `Fiber.exit` is added. It terminates the current fiber and, if a fiber is
+      given, transfers control to it (passing any arguments). Unlike falling off
+      the end of a fiber, it performs a directed transfer to a specific fiber,
+      which is useful for fiber schedulers that drive tasks using
+      `Fiber#transfer`. [[Bug #20081]]
+
 * Kernel
 
     * `Kernel#autoload_relative` and `Module#autoload_relative` are added.
@@ -192,6 +200,7 @@ A lot of work has gone into making Ractors more stable, performant, and usable. 
 
 ## JIT
 
+[Bug #20081]: https://bugs.ruby-lang.org/issues/20081
 [Feature #8948]: https://bugs.ruby-lang.org/issues/8948
 [Feature #15330]: https://bugs.ruby-lang.org/issues/15330
 [Feature #21390]: https://bugs.ruby-lang.org/issues/21390

--- a/cont.c
+++ b/cont.c
@@ -3462,6 +3462,92 @@ rb_fiber_m_kill(VALUE self)
 
 /*
  *  call-seq:
+ *     Fiber.exit(fiber = nil, *arguments)
+ *
+ *  Terminates the current fiber. If +fiber+ is given, control is transferred to
+ *  it (like Fiber#transfer), passing +arguments+; otherwise control returns to
+ *  the fiber that would normally be resumed when the current fiber ends.
+ *
+ *  Unlike ending a fiber normally, this is a directed transfer: the current
+ *  fiber becomes dead and control resumes in +fiber+ regardless of how the
+ *  current fiber was entered (resume or transfer). This is useful for
+ *  transfer-based fiber schedulers that need to hand control back to the
+ *  scheduler when a task finishes.
+ *
+ *  The current fiber is terminated immediately and does not unwind, so its
+ *  +ensure+ blocks are not run. Use Fiber#kill (or run cleanup before calling
+ *  Fiber.exit) if unwinding is required.
+ *
+ *  Raises FiberError if +fiber+ is the current fiber, is already terminated, or
+ *  belongs to another thread.
+ */
+static VALUE
+rb_fiber_s_exit(int argc, VALUE *argv, VALUE klass)
+{
+    rb_fiber_t *current = fiber_current();
+    rb_fiber_t *target = NULL;
+
+    // The first argument is the optional target fiber; the remaining arguments
+    // are passed to it.
+    if (argc >= 1 && !NIL_P(argv[0])) {
+        target = fiber_ptr(argv[0]);
+
+        if (target == current) {
+            rb_raise(rb_eFiberError, "attempt to exit to the current fiber");
+        }
+
+        if (FIBER_TERMINATED_P(target)) {
+            rb_raise(rb_eFiberError, "attempt to exit to a terminated fiber");
+        }
+
+        if (cont_thread_value(&target->cont) != GET_THREAD()->self) {
+            rb_raise(rb_eFiberError, "fiber called across threads");
+        }
+
+        // As with Fiber#transfer, we cannot switch into a fiber that is
+        // suspended in Fiber.yield, nor one that is in the middle of resuming
+        // another fiber - except our own resumer (target->resuming_fiber ==
+        // current), which is the natural place to return to:
+        if (target->yielding) {
+            rb_raise(rb_eFiberError, "attempt to exit to a yielding fiber");
+        }
+
+        if (target->resuming_fiber && target->resuming_fiber != current) {
+            rb_raise(rb_eFiberError, "attempt to exit to a resuming fiber");
+        }
+    }
+
+    VALUE value = argc > 0 ? make_passing_arg(argc - 1, argv + 1) : Qnil;
+
+    // Mark the current fiber as terminated and transfer directly to the target.
+    // The current fiber does not unwind (ensure blocks do not run); it simply
+    // becomes dead once we switch away.
+    rb_fiber_close(current);
+    current->cont.machine.stack = NULL;
+    current->cont.machine.stack_size = 0;
+
+    if (target) {
+        // We are not returning to our resumer, so detach from it (mirroring
+        // return_fiber) - otherwise it would be left marked as resuming a
+        // terminated fiber:
+        if (current->prev) {
+            current->prev->resuming_fiber = NULL;
+            current->prev = NULL;
+        }
+    }
+    else {
+        // Without an explicit target, fall back to the fiber we would normally
+        // return to when terminating:
+        target = return_fiber(true);
+    }
+
+    fiber_switch(target, 1, &value, RB_NO_KEYWORDS, NULL, false);
+
+    UNREACHABLE_RETURN(Qnil);
+}
+
+/*
+ *  call-seq:
  *     Fiber.current -> fiber
  *
  *  Returns the current fiber. If you are not running in the context of
@@ -3690,6 +3776,7 @@ Init_Cont(void)
     rb_define_method(rb_cFiber, "resume", rb_fiber_m_resume, -1);
     rb_define_method(rb_cFiber, "raise", rb_fiber_m_raise, -1);
     rb_define_method(rb_cFiber, "kill", rb_fiber_m_kill, 0);
+    rb_define_singleton_method(rb_cFiber, "exit", rb_fiber_s_exit, -1);
     rb_define_method(rb_cFiber, "backtrace", rb_fiber_backtrace, -1);
     rb_define_method(rb_cFiber, "backtrace_locations", rb_fiber_backtrace_locations, -1);
     rb_define_method(rb_cFiber, "to_s", fiber_to_s, 0);

--- a/spec/ruby/core/fiber/exit_spec.rb
+++ b/spec/ruby/core/fiber/exit_spec.rb
@@ -1,0 +1,124 @@
+require_relative '../../spec_helper'
+
+ruby_version_is "4.1" do
+  describe "Fiber.exit" do
+    it "terminates the current fiber and transfers to the given fiber with the arguments" do
+      log = []
+      target = worker = nil
+      target = Fiber.new do
+        worker = Fiber.new do
+          log << :worker
+          Fiber.exit(target, :from_worker)
+          log << :unreachable
+        end
+        log << worker.transfer
+        log << worker.alive?
+      end
+      target.resume
+      log.should == [:worker, :from_worker, false]
+    end
+
+    it "terminates the current fiber and returns to the resumer without a target" do
+      log = []
+      captured = nil
+      fiber = Fiber.new do
+        captured = Fiber.current
+        Fiber.exit
+        log << :unreachable
+      end
+      fiber.resume
+      captured.alive?.should == false
+      log.should == []
+    end
+
+    it "does not run ensure blocks of the exiting fiber" do
+      log = []
+      target = nil
+      target = Fiber.new do
+        worker = Fiber.new do
+          begin
+            Fiber.exit(target)
+          ensure
+            log << :ensure
+          end
+        end
+        worker.transfer
+        log << :resumed
+      end
+      target.resume
+      log.should == [:resumed]
+    end
+
+    it "works when the current fiber was entered via resume" do
+      log = []
+      a = b = target = nil
+      target = Fiber.new { log << :target }
+      b = Fiber.new do
+        log << :b
+        Fiber.exit(target)
+        log << :unreachable
+      end
+      a = Fiber.new do
+        log << :a_before
+        b.resume
+        log << :a_after
+      end
+      a.resume
+      log.should == [:a_before, :b, :target, :a_after]
+    end
+
+    it "transfers to the target even when it was entered via transfer" do
+      result = nil
+      loop_fiber = Fiber.new do
+        task = Fiber.new do
+          Fiber.exit(loop_fiber, :done)
+        end
+        result = task.transfer
+      end
+      loop_fiber.transfer
+      result.should == :done
+    end
+
+    it "allows exiting to the current fiber's resumer" do
+      log = []
+      outer = nil
+      outer = Fiber.new do
+        inner = Fiber.new do
+          log << :inner
+          Fiber.exit(outer)
+        end
+        inner.resume
+        log << :outer_after
+      end
+      outer.resume
+      log.should == [:inner, :outer_after]
+    end
+
+    it "raises a FiberError when exiting to a fiber that is resuming another fiber" do
+      root = Fiber.current
+      a = Fiber.new do
+        b = Fiber.new { Fiber.exit(root) }
+        b.resume
+      end
+      -> { a.resume }.should raise_error(FiberError)
+    end
+
+    it "raises a FiberError when exiting to a yielding fiber" do
+      yielding = Fiber.new { Fiber.yield }
+      yielding.resume
+      f = Fiber.new { Fiber.exit(yielding) }
+      -> { f.resume }.should raise_error(FiberError)
+    end
+
+    it "raises a FiberError when exiting to the current fiber" do
+      -> { Fiber.exit(Fiber.current) }.should raise_error(FiberError)
+    end
+
+    it "raises a FiberError when exiting to a terminated fiber" do
+      dead = Fiber.new {}
+      dead.resume
+      f = Fiber.new { Fiber.exit(dead) }
+      -> { f.resume }.should raise_error(FiberError)
+    end
+  end
+end

--- a/test/ruby/test_fiber.rb
+++ b/test/ruby/test_fiber.rb
@@ -195,6 +195,188 @@ class TestFiber < Test::Unit::TestCase
     assert_equal([:baz], ary)
   end
 
+  def test_exit
+    log = []
+    target = worker = nil
+    target = Fiber.new do
+      worker = Fiber.new do
+        log << :worker
+        Fiber.exit(target, :from_worker)
+        log << :unreachable
+      end
+      log << worker.transfer
+      log << worker.alive?
+    end
+    target.resume
+    assert_equal([:worker, :from_worker, false], log)
+  end
+
+  def test_exit_without_target
+    # Without a target, Fiber.exit terminates the current fiber and returns to
+    # the fiber it would normally return to (here, the resumer):
+    log = []
+    captured = nil
+    fiber = Fiber.new do
+      captured = Fiber.current
+      log << :before
+      Fiber.exit
+      log << :unreachable
+    end
+    fiber.resume
+    log << :resumed
+    refute_predicate(captured, :alive?)
+    assert_equal([:before, :resumed], log)
+  end
+
+  def test_exit_to_resumer
+    # Exiting to your own resumer is allowed and behaves like a return:
+    log = []
+    outer = nil
+    outer = Fiber.new do
+      inner = Fiber.new do
+        log << :inner
+        Fiber.exit(outer)
+        log << :unreachable
+      end
+      inner.resume
+      log << :outer_after
+    end
+    outer.resume
+    assert_equal([:inner, :outer_after], log)
+  end
+
+  def test_exit_to_resuming_fiber
+    # Exiting to a fiber that is resuming another fiber (an ancestor in the
+    # resume chain, other than our own resumer) is forbidden, like transfer:
+    root = Fiber.current
+    a = Fiber.new do
+      b = Fiber.new{Fiber.exit(root)}
+      b.resume
+    end
+    assert_raise(FiberError) do
+      a.resume
+    end
+  end
+
+  def test_exit_to_yielding_fiber
+    yielding = Fiber.new{Fiber.yield}
+    yielding.resume
+    f = Fiber.new{Fiber.exit(yielding)}
+    assert_raise(FiberError) do
+      f.resume
+    end
+  end
+
+  def test_exit_from_resumed_fiber
+    # Exiting to a target from a fiber that was entered via resume must detach
+    # from the resumer cleanly (no dangling resume link):
+    log = []
+    a = b = target = nil
+    target = Fiber.new { log << :target }
+    b = Fiber.new do
+      log << :b
+      Fiber.exit(target)
+      log << :unreachable
+    end
+    a = Fiber.new do
+      log << :a_before
+      b.resume
+      log << :a_after
+    end
+    a.resume
+    log << :main
+    assert_equal([:a_before, :b, :target, :a_after, :main], log)
+  end
+
+  def test_exit_does_not_run_ensure
+    # `exit` transfers immediately without unwinding, so ensure blocks in the
+    # exiting fiber are not run:
+    log = []
+    target = nil
+    target = Fiber.new do
+      worker = Fiber.new do
+        begin
+          Fiber.exit(target)
+        ensure
+          log << :ensure
+        end
+      end
+      worker.transfer
+      log << :resumed
+    end
+    target.resume
+    assert_equal([:resumed], log)
+  end
+
+  def test_exit_marks_fiber_terminated
+    captured = nil
+    target = nil
+    target = Fiber.new do
+      worker = Fiber.new do
+        captured = Fiber.current
+        Fiber.exit(target)
+      end
+      worker.transfer
+    end
+    target.resume
+    refute_predicate(captured, :alive?)
+  end
+
+  def test_exit_stress
+    # Repeatedly exit to make sure terminating the current fiber mid-stack and
+    # transferring is stable under GC:
+    begin
+      GC.stress = true
+      50.times do
+        result = nil
+        driver = nil
+        driver = Fiber.new do
+          worker = Fiber.new do
+            [1, 2, 3].map {|x| x.to_s}  # some frames/allocations on the stack
+            Fiber.exit(driver, :ok)
+          end
+          result = worker.transfer
+        end
+        driver.resume
+        assert_equal(:ok, result)
+      end
+    ensure
+      GC.stress = false
+    end
+  end
+
+  def test_exit_returns_across_transfer
+    # `exit` is a directed transfer, so it returns to the target even when the
+    # target was itself entered via transfer (off the resume chain):
+    result = nil
+    loop_fiber = Fiber.new do
+      task = Fiber.new do
+        Fiber.exit(loop_fiber, :done)
+      end
+      result = task.transfer
+    end
+    loop_fiber.transfer
+    assert_equal(:done, result)
+  end
+
+  def test_exit_to_current_fiber
+    assert_raise(FiberError) do
+      Fiber.exit(Fiber.current)
+    end
+  end
+
+  def test_exit_to_terminated_fiber
+    dead = Fiber.new{}
+    dead.resume
+    refute_predicate(dead, :alive?)
+    f = Fiber.new do
+      Fiber.exit(dead)
+    end
+    assert_raise(FiberError) do
+      f.resume
+    end
+  end
+
   def test_terminate_transferred_fiber
     log = []
     fa1 = fa2 = fb1 = r1 = nil


### PR DESCRIPTION
## Summary

Adds `Fiber.exit(fiber = nil, *arguments)`: it terminates the current fiber and, if a fiber is given, transfers control to it (passing `arguments`) — like `Fiber#transfer`, but the current fiber is left **terminated** rather than suspended. Without a target it terminates the current fiber and returns to the fiber it would normally return to.

```ruby
scheduler = Fiber.new do
  task = Fiber.new do
    # ... do work ...
    Fiber.exit(scheduler, result)   # hand control back to the scheduler, and die
  end
  value = task.transfer             # value == result; task.alive? == false
end
scheduler.transfer
```

## Motivation

`transfer` is uni-directional: when a transferred-to fiber ends, control returns to the thread's root fiber (see [Bug #20081]), not to the fiber that transferred into it. This makes it awkward for transfer-based fiber schedulers (which drive tasks with `transfer`, since `resume` would build an unbounded resume stack) to regain control when a task finishes — and there's no way to detect or avoid it, because the embedding fiber chain is outside the scheduler's control.

`Fiber.exit` provides the missing "final transfer to a specific fiber" (discussed in [ruby-core:125905]): the current fiber becomes dead and control resumes in the target — **regardless of how the current fiber was entered** (resume or transfer).

## Naming

It is a singleton method — the subject is the *current* fiber, mirroring `Thread.exit`, `Fiber.yield`, and `Kernel#exit`. `Fiber.exit(target)` reads as "the current fiber exits, to `target`," which avoids the confusion of an instance form (`target.exit`) where the receiver is the survivor rather than the fiber that exits.

## Semantics

- With a target: transfers to it with `arguments` (like `transfer`); without a target: returns to the default return fiber.
- Leaves the current fiber terminated (`alive? == false`).
- Terminates immediately and does **not** unwind — `ensure` blocks in the current fiber are not run. Use `Fiber#kill` if you need unwinding, or run cleanup (e.g. via `begin/ensure`) before calling `Fiber.exit`.
- Raises `FiberError` if the target is the current fiber, already terminated, or on another thread.
- Does not change `transfer`/`resume`/`yield`/termination semantics — purely additive.

## Implementation

Self-contained in `cont.c`: `Fiber.exit` closes the current fiber (marking it terminated) and transfers directly to the target — the same `rb_fiber_close` + `fiber_switch` steps as normal termination, with an explicit destination.

## Tests

- `test/ruby/test_fiber.rb`: directed transfer + value, no-target form, `alive? == false` after exit, ensure blocks not run, return across a transfer boundary, error cases, and a GC-stress loop.
- `spec/ruby/core/fiber/exit_spec.rb`: mspec coverage (guarded `ruby_version_is "4.1"`).

All fiber suites pass: `test/ruby/test_fiber` (43) + `test/fiber/*` (94), `spec/ruby/core/fiber` (176 examples), and `bootstraptest/test_fiber.rb` — 0 failures, including under `GC.stress`.

[Bug #20081]: https://bugs.ruby-lang.org/issues/20081
[ruby-core:125905]: https://blade.ruby-lang.org/ruby-core/125905
