### PR TITLE
Re-enable DTrace on FreeBSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3820,9 +3820,6 @@ AS_CASE(["${enable_dtrace}"],
 ], [
     rb_cv_dtrace_available=no
 ])
-AS_CASE(["$target_os"],[freebsd*],[
-         rb_cv_dtrace_available=no
-	 ])
 AS_IF([test "${enable_dtrace}" = yes], [dnl
     AS_IF([test -z "$DTRACE"], [dnl
 	AC_MSG_ERROR([dtrace(1) is missing])


### PR DESCRIPTION
## Summary

This PR re-enables DTrace USDT probes on FreeBSD, which have been unconditionally disabled since Ruby 3.0.0. The change removes a three-line `target_os=freebsd*` override in `configure.ac` that hard-forced `rb_cv_dtrace_available=no`, so FreeBSD once again goes through the normal `RUBY_DTRACE_AVAILABLE` autodetection like every other platform.

```diff
 ], [
     rb_cv_dtrace_available=no
 ])
-AS_CASE(["$target_os"],[freebsd*],[
-         rb_cv_dtrace_available=no
-	 ])
 AS_IF([test "${enable_dtrace}" = yes], [dnl
```

No other change is required: the rest of the FreeBSD DTrace machinery is already present in the tree.

## Background

DTrace was disabled on FreeBSD in commit 78677f105d ("Disable DTrace in FreeBSD (#3999)", 2020-12-25). That commit was a **release un-blocker for Ruby 3.0.0**, not a root-cause fix — its message simply states "The latest ruby cannot compile with FreeBSD Dtrace enabled." The underlying report is [Bug #17212](https://bugs.ruby-lang.org/issues/17212) ("Building 3.0.0-preview1 fails on FreeBSD"). A follow-up attempt to keep the flag usable, #4005 ("Allow `--enable-dtrace` on FreeBSD"), was closed as not working as intended, so FreeBSD has been stuck with DTrace off-by-default and unbuildable-when-forced ever since.

## Root cause of the 2020 breakage (and why it is now obsolete)

The 2020 failure was **not** a compile error, an executable-stack/`.note.GNU-stack` problem, or a relocation problem. It was a link failure at the DTrace *glommed / static-library* stage:

- FreeBSD 12.1: `ld: error: attempted static link of dynamic object /usr/lib/libgcc_s.so`
- FreeBSD 11.4: `/usr/bin/ld: cannot find -lgcc_s`

On modern FreeBSD toolchains this stage links cleanly, so the blanket override is obsolete. On the test system below, the full DTrace build — including the `ld -r` glommed object and the static-library link that failed in 2020 — completes without error.

## What already works and is reused (no new code needed)

- `tool/m4/ruby_dtrace_available.m4` autodetects USDT and already prefers `-xnolibs` (recorded in `DTRACE_OPT`), which is exactly what FreeBSD needs so the build does not require the kernel DTrace modules to be loaded.
- `tool/m4/ruby_dtrace_postprocess.m4` detects that FreeBSD's `dtrace -G` rewrites input objects in place and sets `rb_cv_prog_dtrace_g=rebuild`.
- `configure.ac` already adds `-lelf` for `freebsd*` (required because the `drti.o` linked into `probes.o` calls `elf_*`/`gelf_*` at DOF-init time).
- `template/Makefile.in` already has the full rebuild path: `probes.stamp`, the `probes.$(OBJEXT)` rule (`$(DTRACE) -G -C … -s probes.d -o probes.o $(DTRACE_REBUILD_OBJS)`), and `ruby-glommed.$(OBJEXT)`.

## Verification

Tested on **FreeBSD 14.4-RELEASE amd64**, `dtrace` "Sun D 1.13", `clang` 19.1.7 / `lld`.

**Build** (`./configure --enable-dtrace`):
- `checking whether dtrace USDT is available... yes(-xnolibs)`
- `checking whether dtrace needs post processing... rebuild`
- Full `make` succeeds; `probes.h` generation, `dtrace -G` post-processing of `probes.o`, the `ruby-glommed.o` link, the static library, and the final executable all build.
- `configure` behaves correctly on all three paths: `--enable-dtrace` (on), default/auto (on, since `dtrace(1)` is in the FreeBSD base system), and `--disable-dtrace` (off, dummy probes).

**Probes embedded in the binary:**
- The `ruby` executable gets a `.SUNW_dof` section, the provider `ruby`, all 22 `ruby:::` USDT probes, and 44 `__dtrace_ruby___*` / `__dtraceenabled_ruby___*` symbols, with the probe sites correctly instrumented by `dtrace -G`.
- The final binary's `PT_GNU_STACK` is `RW` (non-executable).

**Live tracing** (as root, with `kldload dtraceall`):
- `dtrace -l -P ruby<pid>` lists the whole provider, e.g. `gc_marking_enter → gc-mark-begin`, `gc_sweep_step → gc-sweep-end`, `vm_trace_hook → method-entry`, `rb_class_alloc → object-create`, `ary_new → array-create`, `setup_exception → raise`, `yycompile0 → parse-begin/end`, `require_internal → require-entry`, …
- Probes actually **fire** at runtime (verified `gc-mark-begin` and `gc-sweep-end` firing while running a short script under `dtrace -q`).

## Scope / caveats

The build verified above uses the default configuration (`ENABLE_SHARED=no`, no YJIT/ZJIT, no LTO). The following surfaces are known-fragile for `dtrace -G` in general and were **not** exercised here; they are worth testing before relying on them on FreeBSD:

- Shared `libruby.so` / PIE builds (`dtrace -G` NOPs probe sites in the shared objects; PHP builds both PIC and non-PIC provider objects to cope).
- `dtrace -G` over the YJIT/ZJIT **Rust** objects that are now part of `DTRACE_DEPENDENT_OBJS`.
- LTO should be disabled together with DTrace (LTO bitcode objects are not valid input to `dtrace -G`).
- Use the base-system `libelf`, not `devel/libelf` from ports.

These are orthogonal to this change; if any of them breaks it fails at build time and can be addressed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
