### PR TITLE
Trivial refactor around rb_ary_subseq_step

### DIFF
--- a/array.c
+++ b/array.c
@@ -1740,32 +1740,29 @@ rb_ary_entry(VALUE ary, long offset)
     return rb_ary_entry_internal(ary, offset);
 }
 
-static VALUE
-rb_ary_subseq_step(VALUE ary, long beg, long len, long step)
+static long
+ary_subseq_len(VALUE ary, long beg, long len)
 {
-    VALUE klass;
     long alen = RARRAY_LEN(ary);
 
-    if (beg > alen) return Qnil;
-    if (beg < 0 || len < 0) return Qnil;
+    if (beg > alen) return -1;
+    if (beg < 0 || len < 0) return -1;
 
     if (alen < len || alen < beg + len) {
         len = alen - beg;
     }
-    klass = rb_cArray;
-    if (len == 0) return ary_new(klass, 0);
-    if (step == 0)
-        rb_raise(rb_eArgError, "slice step cannot be zero");
-    if (step == 1)
-        return ary_make_partial(ary, klass, beg, len);
-    else
-        return ary_make_partial_step(ary, klass, beg, len, step);
+    ASSUME(len >= 0);
+    return len;
 }
 
 VALUE
 rb_ary_subseq(VALUE ary, long beg, long len)
 {
-    return rb_ary_subseq_step(ary, beg, len, 1);
+    const VALUE klass = rb_cArray;
+    len = ary_subseq_len(ary, beg, len);
+    if (len < 0) return Qnil;
+    if (len == 0) return ary_new(klass, 0);
+    return ary_make_partial(ary, klass, beg, len);
 }
 
 static VALUE rb_ary_aref2(VALUE ary, VALUE b, VALUE e);
@@ -1913,6 +1910,7 @@ VALUE
 rb_ary_aref1(VALUE ary, VALUE arg)
 {
     long beg, len, step;
+    const VALUE klass = rb_cArray;
 
     /* special case - speeding up */
     if (FIXNUM_P(arg)) {
@@ -1925,7 +1923,11 @@ rb_ary_aref1(VALUE ary, VALUE arg)
       case Qnil:
         return Qnil;
       default:
-        return rb_ary_subseq_step(ary, beg, len, step);
+        if (step == 0) rb_raise(rb_eArgError, "slice step cannot be zero");
+        len = ary_subseq_len(ary, beg, len);
+        if (len == 0) return ary_new(klass, 0);
+        if (step == 1) return ary_make_partial(ary, klass, beg, len);
+        return ary_make_partial_step(ary, klass, beg, len, step);
     }
 
     return rb_ary_entry(ary, NUM2LONG(arg));


### PR DESCRIPTION
Check for `step` before the length, although it looks impossible to create 0-step `ArithmeticSequence` currently.