### PR TITLE
Keep skipping test_port_receive_dnt_with_port_send on Windows

### DIFF
--- a/test/ruby/test_ractor.rb
+++ b/test/ruby/test_ractor.rb
@@ -276,8 +276,8 @@ class TestRactor < Test::Unit::TestCase
 
   # [Bug #21398]
   def test_port_receive_dnt_with_port_send
-    omit 'unstable on mingw and macos-14' if RUBY_PLATFORM =~ /mingw|darwin/
-    assert_ractor(<<~'RUBY', timeout: 120)
+    omit 'unstable on windows and macos-14' if RUBY_PLATFORM =~ /mswin|mingw|darwin/
+    assert_ractor(<<~'RUBY', timeout: 90)
       THREADS = 10
       JOBS_PER_THREAD = 50
       ARRAY_SIZE = 20_000

--- a/test/ruby/test_ractor.rb
+++ b/test/ruby/test_ractor.rb
@@ -277,7 +277,7 @@ class TestRactor < Test::Unit::TestCase
   # [Bug #21398]
   def test_port_receive_dnt_with_port_send
     omit 'unstable on macos-14' if RUBY_PLATFORM =~ /darwin/
-    assert_ractor(<<~'RUBY', timeout: 90)
+    assert_ractor(<<~'RUBY', timeout: 120)
       THREADS = 10
       JOBS_PER_THREAD = 50
       ARRAY_SIZE = 20_000

--- a/test/ruby/test_ractor.rb
+++ b/test/ruby/test_ractor.rb
@@ -276,7 +276,7 @@ class TestRactor < Test::Unit::TestCase
 
   # [Bug #21398]
   def test_port_receive_dnt_with_port_send
-    omit 'unstable on macos-14' if RUBY_PLATFORM =~ /darwin/
+    omit 'unstable on mingw and macos-14' if RUBY_PLATFORM =~ /mingw|darwin/
     assert_ractor(<<~'RUBY', timeout: 120)
       THREADS = 10
       JOBS_PER_THREAD = 50


### PR DESCRIPTION
Commit 815692018c6 removed the Windows omit guard from this test on the assumption that it had become stable. It has not. The test still times out on the mswin runner even after the timeout was raised to 120 seconds, and it also times out on MinGW. Restore the original Windows omit guard so the test stops running on Windows entirely, and keep the 90 second timeout.

https://github.com/ruby/ruby/actions/runs/28571046631/job/84709222125?pr=17625
