### PR TITLE
Fix identity preservation in Set operations

### DIFF
--- a/set.c
+++ b/set.c
@@ -926,7 +926,7 @@ set_classify_i(st_data_t key, st_data_t tmp)
     VALUE hash_key = rb_yield(key);
     VALUE set = rb_hash_lookup2(hash, hash_key, Qundef);
     if (set == Qundef) {
-        set = set_alloc_with_size(args[1], 0);
+        set = set_s_alloc(args[1]);
         if (RTEST(args[2])) {
             set_i_compare_by_identity(set);
         }
@@ -1026,7 +1026,7 @@ set_divide_arity2(VALUE set)
         long root = set_divide_union_find_root(uf_parents, i, tmp_array);
         VALUE subset = rb_hash_aref(hash, LONG2FIX(root));
         if (subset == Qnil) {
-            subset = set_alloc_with_size(set_class, 0);
+            subset = set_s_alloc(set_class);
             if (RSET_COMPARE_BY_IDENTITY(set)) {
                 set_i_compare_by_identity(subset);
             }
@@ -1175,7 +1175,7 @@ set_intersection_block(RB_BLOCK_CALL_FUNC_ARGLIST(i, data))
 static VALUE
 set_i_intersection(VALUE set, VALUE other)
 {
-    VALUE new_set = set_alloc_with_size(rb_obj_class(set), 0);
+    VALUE new_set = set_s_alloc(rb_obj_class(set));
     if (RSET_COMPARE_BY_IDENTITY(set)) {
         set_i_compare_by_identity(new_set);
     }
@@ -1484,7 +1484,7 @@ set_i_xor(VALUE set, VALUE other)
         set_iter(other, set_xor_i, (st_data_t)new_set);
     }
     else {
-        VALUE tmp = set_alloc_with_size(rb_obj_class(new_set), 0);
+        VALUE tmp = set_s_alloc(rb_obj_class(new_set));
         if (RSET_COMPARE_BY_IDENTITY(new_set)) {
             set_i_compare_by_identity(tmp);
         }
@@ -1647,7 +1647,7 @@ set_i_collect(VALUE set)
     RETURN_SIZED_ENUMERATOR(set, 0, 0, set_enum_size);
     rb_check_frozen(set);
 
-    VALUE new_set = set_alloc_with_size(rb_obj_class(set), 0);
+    VALUE new_set = set_s_alloc(rb_obj_class(set));
     if (RSET_COMPARE_BY_IDENTITY(set)) {
         set_i_compare_by_identity(new_set);
     }
@@ -1852,7 +1852,7 @@ set_flatten_merge(VALUE set, VALUE from, VALUE hash)
 static VALUE
 set_i_flatten(VALUE set)
 {
-    VALUE new_set = set_alloc_with_size(rb_obj_class(set), 0);
+    VALUE new_set = set_s_alloc(rb_obj_class(set));
     if (RSET_COMPARE_BY_IDENTITY(set)) {
         set_i_compare_by_identity(new_set);
     }

--- a/set.c
+++ b/set.c
@@ -921,7 +921,7 @@ set_classify_i(st_data_t key, st_data_t tmp)
     VALUE hash_key = rb_yield(key);
     VALUE set = rb_hash_lookup2(hash, hash_key, Qundef);
     if (set == Qundef) {
-        set = set_alloc_with_size(args[1], 0);
+        set = set_s_alloc(args[1]);
         if (RTEST(args[2])) {
             set_i_compare_by_identity(set);
         }
@@ -1021,7 +1021,7 @@ set_divide_arity2(VALUE set)
         long root = set_divide_union_find_root(uf_parents, i, tmp_array);
         VALUE subset = rb_hash_aref(hash, LONG2FIX(root));
         if (subset == Qnil) {
-            subset = set_alloc_with_size(set_class, 0);
+            subset = set_s_alloc(set_class);
             if (RSET_COMPARE_BY_IDENTITY(set)) {
                 set_i_compare_by_identity(subset);
             }
@@ -1170,7 +1170,7 @@ set_intersection_block(RB_BLOCK_CALL_FUNC_ARGLIST(i, data))
 static VALUE
 set_i_intersection(VALUE set, VALUE other)
 {
-    VALUE new_set = set_alloc_with_size(rb_obj_class(set), 0);
+    VALUE new_set = set_s_alloc(rb_obj_class(set));
     if (RSET_COMPARE_BY_IDENTITY(set)) {
         set_i_compare_by_identity(new_set);
     }
@@ -1479,7 +1479,7 @@ set_i_xor(VALUE set, VALUE other)
         set_iter(other, set_xor_i, (st_data_t)new_set);
     }
     else {
-        VALUE tmp = set_alloc_with_size(rb_obj_class(new_set), 0);
+        VALUE tmp = set_s_alloc(rb_obj_class(new_set));
         if (RSET_COMPARE_BY_IDENTITY(new_set)) {
             set_i_compare_by_identity(tmp);
         }
@@ -1642,7 +1642,7 @@ set_i_collect(VALUE set)
     RETURN_SIZED_ENUMERATOR(set, 0, 0, set_enum_size);
     rb_check_frozen(set);
 
-    VALUE new_set = set_alloc_with_size(rb_obj_class(set), 0);
+    VALUE new_set = set_s_alloc(rb_obj_class(set));
     if (RSET_COMPARE_BY_IDENTITY(set)) {
         set_i_compare_by_identity(new_set);
     }
@@ -1847,7 +1847,7 @@ set_flatten_merge(VALUE set, VALUE from, VALUE hash)
 static VALUE
 set_i_flatten(VALUE set)
 {
-    VALUE new_set = set_alloc_with_size(rb_obj_class(set), 0);
+    VALUE new_set = set_s_alloc(rb_obj_class(set));
     if (RSET_COMPARE_BY_IDENTITY(set)) {
         set_i_compare_by_identity(new_set);
     }

--- a/set.c
+++ b/set.c
@@ -96,6 +96,7 @@ static const struct st_hash_type objhash = {
 };
 
 VALUE rb_cSet;
+static VALUE set_i_compare_by_identity(VALUE set);
 
 #define id_each idEach
 static ID id_each_entry;
@@ -925,7 +926,10 @@ set_classify_i(st_data_t key, st_data_t tmp)
     VALUE hash_key = rb_yield(key);
     VALUE set = rb_hash_lookup2(hash, hash_key, Qundef);
     if (set == Qundef) {
-        set = set_s_alloc(args[1]);
+        set = set_alloc_with_size(args[1], 0);
+        if (RTEST(args[2])) {
+            set_i_compare_by_identity(set);
+        }
         rb_hash_aset(hash, hash_key, set);
     }
     set_i_add(set, key);
@@ -957,9 +961,10 @@ static VALUE
 set_i_classify(VALUE set)
 {
     RETURN_SIZED_ENUMERATOR(set, 0, 0, set_enum_size);
-    VALUE args[2];
+    VALUE args[3];
     args[0] = rb_hash_new();
     args[1] = rb_obj_class(set);
+    args[2] = RBOOL(RSET_COMPARE_BY_IDENTITY(set));
     set_iter(set, set_classify_i, (st_data_t)args);
     return args[0];
 }
@@ -1019,13 +1024,16 @@ set_divide_arity2(VALUE set)
     for (long i = 0; i < size; i++) {
         VALUE v = RARRAY_AREF(items, i);
         long root = set_divide_union_find_root(uf_parents, i, tmp_array);
-        VALUE set = rb_hash_aref(hash, LONG2FIX(root));
-        if (set == Qnil) {
-            set = set_s_create(0, 0, set_class);
-            rb_hash_aset(hash, LONG2FIX(root), set);
-            set_i_add(final_set, set);
+        VALUE subset = rb_hash_aref(hash, LONG2FIX(root));
+        if (subset == Qnil) {
+            subset = set_alloc_with_size(set_class, 0);
+            if (RSET_COMPARE_BY_IDENTITY(set)) {
+                set_i_compare_by_identity(subset);
+            }
+            rb_hash_aset(hash, LONG2FIX(root), subset);
+            set_i_add(final_set, subset);
         }
-        set_i_add(set, v);
+        set_i_add(subset, v);
     }
     ALLOCV_END(tmp);
     ALLOCV_END(uf);
@@ -1167,7 +1175,10 @@ set_intersection_block(RB_BLOCK_CALL_FUNC_ARGLIST(i, data))
 static VALUE
 set_i_intersection(VALUE set, VALUE other)
 {
-    VALUE new_set = set_s_alloc(rb_obj_class(set));
+    VALUE new_set = set_alloc_with_size(rb_obj_class(set), 0);
+    if (RSET_COMPARE_BY_IDENTITY(set)) {
+        set_i_compare_by_identity(new_set);
+    }
     set_table *stable = RSET_TABLE(set);
     set_table *ntable = RSET_TABLE(new_set);
 
@@ -1473,7 +1484,10 @@ set_i_xor(VALUE set, VALUE other)
         set_iter(other, set_xor_i, (st_data_t)new_set);
     }
     else {
-        VALUE tmp = set_s_alloc(rb_cSet);
+        VALUE tmp = set_alloc_with_size(rb_obj_class(new_set), 0);
+        if (RSET_COMPARE_BY_IDENTITY(new_set)) {
+            set_i_compare_by_identity(tmp);
+        }
         set_merge_enum_into(tmp, other);
         set_iter(tmp, set_xor_i, (st_data_t)new_set);
     }
@@ -1633,7 +1647,10 @@ set_i_collect(VALUE set)
     RETURN_SIZED_ENUMERATOR(set, 0, 0, set_enum_size);
     rb_check_frozen(set);
 
-    VALUE new_set = set_s_alloc(rb_obj_class(set));
+    VALUE new_set = set_alloc_with_size(rb_obj_class(set), 0);
+    if (RSET_COMPARE_BY_IDENTITY(set)) {
+        set_i_compare_by_identity(new_set);
+    }
     set_iter(set, set_collect_i, (st_data_t)new_set);
     set_i_initialize_copy(set, new_set);
 
@@ -1835,7 +1852,10 @@ set_flatten_merge(VALUE set, VALUE from, VALUE hash)
 static VALUE
 set_i_flatten(VALUE set)
 {
-    VALUE new_set = set_s_alloc(rb_obj_class(set));
+    VALUE new_set = set_alloc_with_size(rb_obj_class(set), 0);
+    if (RSET_COMPARE_BY_IDENTITY(set)) {
+        set_i_compare_by_identity(new_set);
+    }
     set_flatten_merge(new_set, set, rb_hash_new());
     return new_set;
 }

--- a/set.c
+++ b/set.c
@@ -96,6 +96,7 @@ static const struct st_hash_type objhash = {
 };
 
 VALUE rb_cSet;
+static VALUE set_i_compare_by_identity(VALUE set);
 
 #define id_each idEach
 static ID id_each_entry;
@@ -920,7 +921,10 @@ set_classify_i(st_data_t key, st_data_t tmp)
     VALUE hash_key = rb_yield(key);
     VALUE set = rb_hash_lookup2(hash, hash_key, Qundef);
     if (set == Qundef) {
-        set = set_s_alloc(args[1]);
+        set = set_alloc_with_size(args[1], 0);
+        if (RTEST(args[2])) {
+            set_i_compare_by_identity(set);
+        }
         rb_hash_aset(hash, hash_key, set);
     }
     set_i_add(set, key);
@@ -952,9 +956,10 @@ static VALUE
 set_i_classify(VALUE set)
 {
     RETURN_SIZED_ENUMERATOR(set, 0, 0, set_enum_size);
-    VALUE args[2];
+    VALUE args[3];
     args[0] = rb_hash_new();
     args[1] = rb_obj_class(set);
+    args[2] = RBOOL(RSET_COMPARE_BY_IDENTITY(set));
     set_iter(set, set_classify_i, (st_data_t)args);
     return args[0];
 }
@@ -1014,13 +1019,16 @@ set_divide_arity2(VALUE set)
     for (long i = 0; i < size; i++) {
         VALUE v = RARRAY_AREF(items, i);
         long root = set_divide_union_find_root(uf_parents, i, tmp_array);
-        VALUE set = rb_hash_aref(hash, LONG2FIX(root));
-        if (set == Qnil) {
-            set = set_s_create(0, 0, set_class);
-            rb_hash_aset(hash, LONG2FIX(root), set);
-            set_i_add(final_set, set);
+        VALUE subset = rb_hash_aref(hash, LONG2FIX(root));
+        if (subset == Qnil) {
+            subset = set_alloc_with_size(set_class, 0);
+            if (RSET_COMPARE_BY_IDENTITY(set)) {
+                set_i_compare_by_identity(subset);
+            }
+            rb_hash_aset(hash, LONG2FIX(root), subset);
+            set_i_add(final_set, subset);
         }
-        set_i_add(set, v);
+        set_i_add(subset, v);
     }
     ALLOCV_END(tmp);
     ALLOCV_END(uf);
@@ -1162,7 +1170,10 @@ set_intersection_block(RB_BLOCK_CALL_FUNC_ARGLIST(i, data))
 static VALUE
 set_i_intersection(VALUE set, VALUE other)
 {
-    VALUE new_set = set_s_alloc(rb_obj_class(set));
+    VALUE new_set = set_alloc_with_size(rb_obj_class(set), 0);
+    if (RSET_COMPARE_BY_IDENTITY(set)) {
+        set_i_compare_by_identity(new_set);
+    }
     set_table *stable = RSET_TABLE(set);
     set_table *ntable = RSET_TABLE(new_set);
 
@@ -1468,7 +1479,10 @@ set_i_xor(VALUE set, VALUE other)
         set_iter(other, set_xor_i, (st_data_t)new_set);
     }
     else {
-        VALUE tmp = set_s_alloc(rb_cSet);
+        VALUE tmp = set_alloc_with_size(rb_obj_class(new_set), 0);
+        if (RSET_COMPARE_BY_IDENTITY(new_set)) {
+            set_i_compare_by_identity(tmp);
+        }
         set_merge_enum_into(tmp, other);
         set_iter(tmp, set_xor_i, (st_data_t)new_set);
     }
@@ -1628,7 +1642,10 @@ set_i_collect(VALUE set)
     RETURN_SIZED_ENUMERATOR(set, 0, 0, set_enum_size);
     rb_check_frozen(set);
 
-    VALUE new_set = set_s_alloc(rb_obj_class(set));
+    VALUE new_set = set_alloc_with_size(rb_obj_class(set), 0);
+    if (RSET_COMPARE_BY_IDENTITY(set)) {
+        set_i_compare_by_identity(new_set);
+    }
     set_iter(set, set_collect_i, (st_data_t)new_set);
     set_i_initialize_copy(set, new_set);
 
@@ -1830,7 +1847,10 @@ set_flatten_merge(VALUE set, VALUE from, VALUE hash)
 static VALUE
 set_i_flatten(VALUE set)
 {
-    VALUE new_set = set_s_alloc(rb_obj_class(set));
+    VALUE new_set = set_alloc_with_size(rb_obj_class(set), 0);
+    if (RSET_COMPARE_BY_IDENTITY(set)) {
+        set_i_compare_by_identity(new_set);
+    }
     set_flatten_merge(new_set, set, rb_hash_new());
     return new_set;
 }

--- a/test/ruby/test_set.rb
+++ b/test/ruby/test_set.rb
@@ -700,6 +700,32 @@ class TC_Set < Test::Unit::TestCase
       ret2 = set2 ^ [2,4,5,5]
       assert_instance_of(klass, ret2)
       assert_equal(klass[1,3,5], ret2)
+
+      # Set ^ Set should not mutate either operand and should be symmetric
+      a = klass[1,2,3,4]
+      b = klass[2,4,5]
+      a_copy = a.dup
+      b_copy = b.dup
+      ret3 = a ^ b
+      ret4 = b ^ a
+      assert_equal(klass[1,3,5], ret3)
+      assert_equal(ret3, ret4)
+      assert_equal(a_copy, a)
+      assert_equal(b_copy, b)
+      assert_instance_of(klass, ret3)
+      assert_instance_of(klass, ret4)
+
+      # compare_by_identity should keep distinct objects from enumerable RHS
+      iset = Set.new.compare_by_identity
+      x1 = +"x"
+      x2 = +"x"
+      ret5 = iset ^ [x1, x2]
+      assert_equal(2, ret5.size)
+      arr = ret5.to_a
+      assert_include(arr, x1)
+      assert_include(arr, x2)
+      assert_not_predicate(x1, :frozen?)
+      assert_not_predicate(x2, :frozen?)
     }
   end
 
@@ -980,6 +1006,95 @@ class TC_Set < Test::Unit::TestCase
       end
     end
     assert_equal([2, 1], c[2].to_a)
+  end
+
+  def test_iteration_mutation_guards
+    set = Set[1, 2]
+    assert_raise(RuntimeError) { set.each { set.add(3) } }
+    assert_raise(RuntimeError) { set.each { set.merge([3]) } }
+    assert_raise(RuntimeError) { set.each { set.compare_by_identity } }
+    assert_raise(RuntimeError) { set.each { set.reset } }
+  end
+
+  def test_string_freezing_semantics
+    s = "foo"
+    set = Set.new
+    set << s
+    stored = set.to_a.first
+    assert_not_same(s, stored)
+    assert_predicate(stored, :frozen?)
+
+    s2 = "bar"
+    iset = Set.new.compare_by_identity
+    iset << s2
+    stored2 = iset.to_a.first
+    assert_same(s2, stored2)
+    assert_not_predicate(stored2, :frozen?)
+
+    sf = "baz".freeze
+    set2 = Set.new
+    set2 << sf
+    assert_same(sf, set2.to_a.first)
+  end
+
+  def test_compare_by_identity_hash_and_eq
+    a1, a2 = "a", "a"
+    set_default1 = Set[a1]
+    set_default2 = Set[a2]
+    assert_equal(set_default1, set_default2)
+    assert_equal(set_default1.hash, set_default2.hash)
+
+    iset = Set.new.compare_by_identity
+    iset.merge([a1, a2])
+    assert_not_equal(set_default1, iset)
+    refute_equal(set_default1.hash, iset.hash)
+  end
+
+  def test_insertion_order_preserved
+    set = Set[3, 1, 2]
+    assert_equal([3, 1, 2], set.to_a)
+
+    iset = Set.new.compare_by_identity
+    iset.merge([3, 1, 2])
+    assert_equal([3, 1, 2], iset.to_a)
+  end
+
+  def test_compare_by_identity_preservation
+    iset = Set.new.compare_by_identity
+
+    # 1. Intersection (&)
+    assert_predicate(iset & [1, 2], :compare_by_identity?)
+
+    # 2. Collect! / Map!
+    iset_collect = Set["a", "b"].compare_by_identity
+    iset_collect.collect! { |x| x }
+    assert_predicate(iset_collect, :compare_by_identity?)
+
+    # 3. Flatten / Flatten!
+    iset_flat = Set[Set[1, 2]].compare_by_identity
+    assert_predicate(iset_flat.flatten, :compare_by_identity?)
+    iset_flat.flatten!
+    assert_predicate(iset_flat, :compare_by_identity?)
+
+    # 4. Classify
+    iset_classify = Set["a", "b"].compare_by_identity
+    classified = iset_classify.classify { |x| x }
+    classified.each_value do |subset|
+      assert_predicate(subset, :compare_by_identity?)
+    end
+
+    # 5. Divide (arity 1 and arity 2)
+    iset_divide1 = Set["a", "b"].compare_by_identity
+    divided1 = iset_divide1.divide { |x| x }
+    divided1.each do |subset|
+      assert_predicate(subset, :compare_by_identity?)
+    end
+
+    iset_divide2 = Set["a", "b"].compare_by_identity
+    divided2 = iset_divide2.divide { |x, y| x == y }
+    divided2.each do |subset|
+      assert_predicate(subset, :compare_by_identity?)
+    end
   end
 
 end


### PR DESCRIPTION
### Description
Since Set was transitioned to a C-level core class in Ruby, several operations that allocate new sets or partition subsets (`&`, `^`, `collect!`, `flatten`, `classify`, and `divide`) lost the `compare_by_identity` state of the receiver set or its subsets.

This PR fixes those gaps by propagating the `compare_by_identity` state to:
1. `Set#^` (XOR) when XORing with a generic Enumerable.
2. `Set#&` (Intersection).
3. `Set#collect!` / `map!`.
4. `Set#flatten`.
5. `Set#classify` (propagated to inner subsets).
6. `Set#divide` (propagated to inner subsets).

### Changes
- **`set.c`**: Added forward declaration for `set_i_compare_by_identity` and updated set allocation calls to copy the identity state. Fixed local variable shadowing in `set_divide_arity2`.
- **`test/ruby/test_set.rb`**: Added comprehensive test cases under `test_compare_by_identity_preservation` and a regression test for XOR.