### PR TITLE
mark internal cross-Ractor structures as shareable

### DIFF
--- a/concurrent_set.c
+++ b/concurrent_set.c
@@ -2,6 +2,7 @@
 #include "internal/gc.h"
 #include "internal/concurrent_set.h"
 #include "ruby/atomic.h"
+#include "ruby/ractor.h"
 #include "vm_sync.h"
 
 #define CONCURRENT_SET_CONTINUATION_BIT ((VALUE)1 << (sizeof(VALUE) * CHAR_BIT - 1))
@@ -102,6 +103,9 @@ rb_concurrent_set_new(const struct rb_concurrent_set_funcs *funcs, int capacity)
     set->funcs = funcs;
     set->entries = ZALLOC_N(struct concurrent_set_entry, capacity);
     set->capacity = capacity;
+    /* The set is reachable from every Ractor (e.g. via C globals such as the
+     * frozen-string and symbol tables), so mark it shareable. */
+    RB_OBJ_SET_SHAREABLE(obj);
     return obj;
 }
 

--- a/depend
+++ b/depend
@@ -2353,6 +2353,7 @@ concurrent_set.$(OBJEXT): {$(VPATH)}missing.h
 concurrent_set.$(OBJEXT): {$(VPATH)}node.h
 concurrent_set.$(OBJEXT): {$(VPATH)}onigmo.h
 concurrent_set.$(OBJEXT): {$(VPATH)}oniguruma.h
+concurrent_set.$(OBJEXT): {$(VPATH)}ractor.h
 concurrent_set.$(OBJEXT): {$(VPATH)}ruby_assert.h
 concurrent_set.$(OBJEXT): {$(VPATH)}ruby_atomic.h
 concurrent_set.$(OBJEXT): {$(VPATH)}rubyparser.h

--- a/id_table.c
+++ b/id_table.c
@@ -390,6 +390,10 @@ rb_managed_id_table_dup(VALUE old_table)
 {
     struct rb_id_table *new_tbl;
     VALUE obj = TypedData_Make_Struct(0, struct rb_id_table, RTYPEDDATA_TYPE(old_table), new_tbl);
+    /* A managed id table hangs off VM-global state (e.g. a shape tree's edge
+     * table grows via this dup) and is reachable from every Ractor, so mark it
+     * shareable. */
+    RB_OBJ_SET_SHAREABLE(obj);
     struct rb_id_table *old_tbl = managed_id_table_ptr(old_table);
     rb_id_table_init(new_tbl, old_tbl->num + 1);
     rb_id_table_foreach(old_tbl, managed_id_table_dup_i, new_tbl);

--- a/symbol.c
+++ b/symbol.c
@@ -278,6 +278,9 @@ set_id_entry(rb_symbols_t *symbols, rb_id_serial_t num, VALUE str, VALUE sym)
     if (idx >= (size_t)RARRAY_LEN(ids) || NIL_P(id_entry_list = rb_ary_entry(ids, (long)idx))) {
         rb_darray_make(&entries, ID_ENTRY_UNIT);
         id_entry_list = TypedData_Wrap_Struct(0, &sym_id_entry_list_type, entries);
+        /* Reachable from every Ractor via the global symbol table, so mark it
+         * shareable. */
+        RB_OBJ_SET_SHAREABLE(id_entry_list);
         rb_ary_store(ids, (long)idx, id_entry_list);
     }
     else {


### PR DESCRIPTION
The concurrent set, managed id-table dups and symbol id-entry buckets are reachable from every Ractor via VM-global state (the frozen-string/symbol tables, shape-tree edge tables, the symbol table), so flag them shareable -- as enc_list_update already does for the encoding list.