### PR TITLE
test/unit: optionally verify GC consistency after each test

### DIFF
--- a/tool/lib/test/unit.rb
+++ b/tool/lib/test/unit.rb
@@ -1677,6 +1677,19 @@ module Test
 
           leakchecker.check("#{inst.class}\##{inst.__name__}")
 
+          # Optionally verify GC internal consistency after each test. An
+          # integer >= 2 samples once every N tests (use a prime so a
+          # randomized test order samples a different set each run); any other
+          # non-empty value verifies every test (O(heap) per test, so only
+          # practical for small runs).
+          if (interval = ENV["RUBY_TEST_GC_VERIFY"])
+            n = interval.to_i
+            @__gc_verify_tick = (@__gc_verify_tick || 0) + 1
+            if n <= 1 || (@__gc_verify_tick % n).zero?
+              GC.verify_internal_consistency
+            end
+          end
+
           _end_method(inst)
 
           inst._assertions


### PR DESCRIPTION
Set RUBY_TEST_GC_VERIFY to call GC.verify_internal_consistency after each test. An integer >= 2 samples once every N tests; any other non-empty value verifies every test. Useful for pinning down which test corrupts the heap.