### PR TITLE
thread: a new Ractor must not inherit the creating thread's fiber storage

### DIFF
--- a/thread.c
+++ b/thread.c
@@ -845,7 +845,12 @@ thread_create_core(VALUE thval, struct thread_create_params *params)
                  "can't start a new thread (frozen ThreadGroup)");
     }
 
-    rb_fiber_inherit_storage(ec, th->ec->fiber_ptr);
+    /* A new Ractor must not inherit the creating thread's fiber storage: its
+     * entries may be objects owned by the creating Ractor. Only threads created
+     * within the same Ractor inherit it. */
+    if (params->type != thread_invoke_type_ractor_proc) {
+        rb_fiber_inherit_storage(ec, th->ec->fiber_ptr);
+    }
 
     switch (params->type) {
       case thread_invoke_type_proc:


### PR DESCRIPTION
thread_create_core inherited fiber storage unconditionally, so a new Ractor's main fiber received the creating thread's fiber-local storage, whose entries may be objects owned by the creating Ractor. Skip the inheritance for Ractor main threads.