### PR TITLE
Group test-bundler-parallel workers by recorded runtime

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -1716,10 +1716,13 @@ yes-test-bundler-parallel: $(PREPARE_BUNDLER)
 	$(gnumake_recursive)$(XRUBY) \
 		-r./$(arch)-fake \
 		-r$(tooldir)/lib/_tmpdir \
+		-r$(tooldir)/lib/bundler_runtime_grouping \
 		-I$(srcdir)/spec/bundler \
 		-e "ruby = ENV['RUBY']" \
 		-e "ARGV[-1] = File.expand_path(ARGV[-1])" \
 		-e "ENV['RSPEC_EXECUTABLE'] = ruby + ARGV.shift" \
+		-e "require 'support/setup'" \
+		-e "BundlerRuntimeGrouping.install!" \
 		-e "load ARGV.shift" \
 		-s -- -no-report-tmpdir -- \
 		" -C $(srcdir) -Ispec/bundler -Ispec/lib .bundle/bin/rspec -r spec_helper" \

--- a/spec/bundler/spec_helper.rb
+++ b/spec/bundler/spec_helper.rb
@@ -175,26 +175,6 @@ RSpec.configure do |config|
     reset!
   end
 
-  # Opt-in per-example runtime log (set BUNDLER_SPEC_RUNTIME_LOG to a file path).
-  # Each parallel worker appends one "<seconds>\t<file>" line per example to its
-  # own "<path>.<TEST_ENV_NUMBER>" file (a single shared file would hit Windows
-  # cross-process sharing violations), so the heaviest specs can be found after a
-  # full run. turbo_tests only writes its own --runtime-log when invoked with the
-  # bare "spec" path, which the build never does, so it produces no log otherwise.
-  if (runtime_log = ENV["BUNDLER_SPEC_RUNTIME_LOG"])
-    worker = ENV["TEST_ENV_NUMBER"].to_s
-    worker = "1" if worker.empty?
-    runtime_log = "#{runtime_log}.#{worker}"
-    config.before(:each) { @__runtime_start = Process.clock_gettime(Process::CLOCK_MONOTONIC) }
-    config.after(:each) do |example|
-      next unless @__runtime_start
-      dt = Process.clock_gettime(Process::CLOCK_MONOTONIC) - @__runtime_start
-      File.write(runtime_log, "#{format("%.4f", dt)}\t#{example.metadata[:file_path]}\n", mode: "a")
-    rescue StandardError
-      # never let runtime logging break a test run
-    end
-  end
-
   Spec::Shards::EXAMPLE_MAPPINGS.each do |tag, file_paths|
     file_pattern = Regexp.union(file_paths.map {|path| Regexp.new(Regexp.escape(path) + "$") })
 

--- a/tool/lib/bundler_runtime_grouping.rb
+++ b/tool/lib/bundler_runtime_grouping.rb
@@ -78,7 +78,7 @@ module BundlerRuntimeGrouping
       recorder = File.expand_path("bundler_runtime_recorder.rb", __dir__)
       ENV["RSPEC_EXECUTABLE"] = "#{ENV["RSPEC_EXECUTABLE"]} -r#{recorder}"
     end
-  rescue StandardError => e
+  rescue StandardError, LoadError => e
     warn "parallel_rspec: runtime-based grouping disabled (#{e.class}: #{e.message})"
   end
 

--- a/tool/lib/bundler_runtime_grouping.rb
+++ b/tool/lib/bundler_runtime_grouping.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+# Distribute the parallel bundler-spec workers by measured per-file runtime
+# instead of file size, with no change to turbo_tests or parallel_tests and
+# without touching the synced spec/bin/parallel_rspec. The test-bundler-parallel
+# recipe requires this file and calls install! just before loading the stock
+# parallel_rspec; install! prepends the grouper (parent) and appends the recorder
+# to RSPEC_EXECUTABLE so each worker records (see bundler_runtime_recorder.rb).
+# The grouping/recording logic lives under tool/, which sync-default-gems never
+# copies, so the rubygems side stays untouched.
+#
+# turbo_tests only feeds a runtime log to the grouper when invoked with the bare
+# "spec" path (TurboTests::CLI passes files: ["spec"] only when given no
+# positional arg), which the build never does: the recipe passes an absolute
+# spec/bundler path, so grouping falls back to file size and the single heaviest
+# file becomes the long pole. We reopen the one grouper hook that size path uses,
+# ParallelTests::RSpec::Runner.sort_by_filesize, and return runtime weights when
+# the previous run left us data. Its argument is the already-expanded file list,
+# so nothing here re-globs or re-reads it.
+
+module BundlerRuntimeGrouping
+  WORKER_LOGS = ".[0-9]*"
+
+  module_function
+
+  # Per-worker log base. Under the (gitignored) source tmp so it survives between
+  # runs; overridable via BUNDLER_SPEC_RUNTIME_LOG.
+  def log_base
+    ENV["BUNDLER_SPEC_RUNTIME_LOG"] ||
+      File.expand_path("../../tmp/bundler_runtime_rspec.log", __dir__)
+  end
+
+  # Append one "<seconds>\t<file>" line for a finished example to this worker's
+  # own log ("<base>.<TEST_ENV_NUMBER>"); a single shared file would hit Windows
+  # cross-process sharing violations. Called from the worker (see recorder).
+  def record(example, seconds)
+    worker = ENV["TEST_ENV_NUMBER"].to_s
+    worker = "1" if worker.empty?
+    File.write("#{log_base}.#{worker}",
+               "#{format("%.4f", seconds)}\t#{example.metadata[:file_path]}\n", mode: "a")
+  rescue StandardError
+    # never let runtime logging break a test run
+  end
+
+  # {canonical_path => seconds} summed across the previous run's worker logs,
+  # memoized before this run overwrites them. Empty on the first run.
+  def runtimes
+    @runtimes ||= Dir.glob(log_base + WORKER_LOGS).each_with_object(Hash.new(0.0)) do |path, sums|
+      File.foreach(path) do |line|
+        seconds, tab, file = line.chomp.partition("\t")
+        sums[canonical(file)] += seconds.to_f unless tab.empty?
+      end
+    rescue StandardError
+      sums
+    end
+  end
+
+  # cwd-independent key: from "spec/bundler/" on, forward slashes. Recorded paths
+  # are rspec-relative ("./spec/bundler/..."); grouped paths are absolute.
+  def canonical(path)
+    normalized = path.tr("\\", "/")
+    i = normalized.index("spec/bundler/")
+    i ? normalized[i..] : normalized
+  end
+
+  # Called once in the parent before parallel_rspec loads (spec/bundler/support
+  # must already be required so parallel_tests is on the load path). Reads the
+  # previous run, clears the logs, prepends the grouper, and arranges for each
+  # worker to record by appending the recorder to RSPEC_EXECUTABLE.
+  def install!
+    require "fileutils"
+    require "parallel_tests/rspec/runner"
+    FileUtils.mkdir_p(File.dirname(log_base))
+    runtimes # capture the previous run before clearing
+    Dir.glob(log_base + WORKER_LOGS).each { |f| File.delete(f) rescue nil }
+    ParallelTests::RSpec::Runner.singleton_class.prepend(SortHook)
+    if ENV["RSPEC_EXECUTABLE"]
+      recorder = File.expand_path("bundler_runtime_recorder.rb", __dir__)
+      ENV["RSPEC_EXECUTABLE"] = "#{ENV["RSPEC_EXECUTABLE"]} -r#{recorder}"
+    end
+  rescue StandardError => e
+    warn "parallel_rspec: runtime-based grouping disabled (#{e.class}: #{e.message})"
+  end
+
+  module SortHook
+    def sort_by_filesize(tests)
+      rt = BundlerRuntimeGrouping.runtimes
+      return super if rt.empty?
+      tests.sort!
+      known = tests.map { |t| rt[BundlerRuntimeGrouping.canonical(t)] }.select(&:positive?)
+      return super unless known.size * 1.5 > tests.size # parallel_tests' own threshold
+      average = known.sum / known.size
+      tests.map! do |t|
+        seconds = rt[BundlerRuntimeGrouping.canonical(t)]
+        [t, seconds.positive? ? seconds : average]
+      end
+    end
+  end
+end

--- a/tool/lib/bundler_runtime_recorder.rb
+++ b/tool/lib/bundler_runtime_recorder.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Loaded into each parallel worker (via -r appended to RSPEC_EXECUTABLE by
+# tool/lib/bundler_parallel_rspec.rb) to record per-example runtimes that the
+# next run groups by. Kept in tool/ so recording does not depend on
+# spec/bundler/spec_helper.rb (which is synced from rubygems/rubygems).
+
+require_relative "bundler_runtime_grouping"
+
+RSpec.configure do |config|
+  config.before(:each) { @__runtime_start = Process.clock_gettime(Process::CLOCK_MONOTONIC) }
+  config.after(:each) do |example|
+    next unless @__runtime_start
+    BundlerRuntimeGrouping.record(example, Process.clock_gettime(Process::CLOCK_MONOTONIC) - @__runtime_start)
+  end
+end

--- a/tool/lib/bundler_runtime_recorder.rb
+++ b/tool/lib/bundler_runtime_recorder.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Loaded into each parallel worker (via -r appended to RSPEC_EXECUTABLE by
-# tool/lib/bundler_parallel_rspec.rb) to record per-example runtimes that the
+# BundlerRuntimeGrouping.install!) to record per-example runtimes that the
 # next run groups by. Kept in tool/ so recording does not depend on
 # spec/bundler/spec_helper.rb (which is synced from rubygems/rubygems).
 


### PR DESCRIPTION
`turbo_tests` only hands a recorded runtime log to its grouper when it is invoked with the bare `spec` path. This build never does that because the recipe passes an absolute `spec/bundler` path. As a result the workers are balanced by file size and the single heaviest file such as `install/gemfile/git_spec.rb` becomes the long pole of the whole run.

This adds a small patch under `tool/lib` that the `test-bundler-parallel` recipe loads just before the stock `spec/bin/parallel_rspec`. Each worker records its per-example runtimes to its own log, and the next run reorders the grouper to distribute files by that recorded runtime instead of by file size. The logic lives under `tool/`, which `sync-default-gems` never copies, so the synced `spec/bin/parallel_rspec` and the rubygems side stay untouched. The per-example logger that previously lived in `spec/bundler/spec_helper.rb` is removed because the new recorder replaces it.

The first run records and falls back to file size, and every run after that groups by the previous run's data. I verified this on mswin by running the `commands` subset twice, where the second run distributed all of its files by recorded runtime and both runs stayed green.

```
# first run records per-file runtimes and groups by file size
nmake test-bundler-parallel BUNDLER_SPECS=commands

# every run after that groups workers by the recorded runtime
nmake test-bundler-parallel BUNDLER_SPECS=commands

# the recorded log defaults to tmp and can be pointed elsewhere
BUNDLER_SPEC_RUNTIME_LOG=/path/to/runtime.log make test-bundler-parallel
```
