### PR TITLE
Fix win32/rm.bat failing to remove directories recursively

### DIFF
--- a/win32/rm.bat
+++ b/win32/rm.bat
@@ -48,7 +48,7 @@ if "%sub:\=%" == "%sub%" goto :remove_plain
 goto :remove_end
 :remove_plain
     set p=%2%1
-    if not exist "%1" goto :remove_end
+    if not exist "%p%" goto :remove_end
     if not "%dryrun%" == "" (
         echo Removing %p:\=/%
         goto :remove_end

--- a/win32/rm.bat
+++ b/win32/rm.bat
@@ -55,10 +55,13 @@ goto :remove_end
     )
     ::- Try `rd` first for symlink to a directory; `del` attemps to remove all
     ::- files under the target directory, instead of the symlink itself.
-    (rd /q "%p%" || del /q "%p%") 2> nul && goto :remove_end
+    rd /q "%p%" 2> nul && goto :remove_end
 
+    ::- `del` exits with 0 even when nothing matched, so its result cannot
+    ::- tell whether directories remain; remove them first.
     if "%recursive%" == "-r" for /D %%I in (%p%) do (
         rd /s /q %%I || call set error=%%ERRORLEVEL%%
     )
+    if exist "%p%" del /q "%p%" 2> nul
 :remove_end
 endlocal & set "error=%error%" & goto :EOF


### PR DESCRIPTION
On Windows, `$(RMALL)` (`win32/rm.bat -f -r`) silently fails to remove directories. A directory whose top level contains no plain files is left completely untouched, and a directory that does contain files keeps its whole subdirectory tree. Clean targets using `$(RMALL)` on directories, such as `distclean-rdoc` or `clean-rubyspec`, leave stale trees behind with exit status 0.

```bat
> mkdir t\sub
> cmd /c win32\rm.bat -f -r t
> dir /b t
sub
```

The cause is in `:remove_plain`. `del` exits with 0 even when it removed nothing, so `(rd /q "%p%" || del /q "%p%") 2> nul && goto :remove_end` short-circuits before the recursive `rd /s /q` is ever reached. The first commit removes directories with `rd /s /q` before falling back to `del`, keeping the `rd /q` first attempt that protects targets of directory symlinks.

The second commit fixes another silent no-op in the same label. The existence check used `%1`, which is relative to the expanded wildcard parent rather than the full path `%p%`, so removal through a wildcard in the middle of a path (for example `rm.bat -f -r foo*\bar`) never removed anything.

Verified on Windows 11 by comparing both versions over the same matrix. Before the fix these cases fail: a directory containing only subdirectories, a directory containing files and subdirectories, `dir\*` leaving subdirectories, a directory containing a directory symlink, and mid-path wildcards. After the fix all of them pass, and the existing behaviors are preserved: a symlink to a directory is removed without touching its target, `-n` dry-run removes nothing, a missing path exits with 0, and `dir\*` keeps the directory itself.
