### PR TITLE
[DOC] Restore glob documentation lost in GH-17265

### DIFF
--- a/dir.rb
+++ b/dir.rb
@@ -213,18 +213,29 @@ class Dir
   end
 
   # call-seq:
-  #   Dir[patterns, base: nil, sort: true] -> array
+  #   Dir[*patterns, base: nil, sort: true] -> array
   #
-  # Like Dir.glob, but does not accept keyword argument +flags+.
+  # Like Dir.glob, but does not accept keyword argument +flags+,
+  # and may take multiple patterns as arguments:
+  #
+  #   Dir['*.rb', '*.h'].take(3) # => ["KNOWNBUGS.rb", "array.rb", "ast.rb"]
+  #
   def self.[](*args, base: nil, sort: true)
     Primitive.dir_s_aref(args, base, sort)
   end
 
   # call-seq:
   #   Dir.glob(patterns, flags: 0, base: '.', sort: true) -> array_of_entries
+  #   Dir.glob(patterns, flags: 0, base: '.', sort: true) {|entry_name| ... } -> nil
   #
   # Returns an array of filesystem entries;
   # see {Filename Globbing}[rdoc-ref:file/filename_globbing.md].
+  #
+  # With a block given, calls the block with each of the selected entry names
+  # and returns +nil+:
+  #
+  #   Dir.glob('*.rb') {|entry_name| puts entry_name } # => nil
+  #
   def self.glob(pattern, _flags = 0, flags: _flags, base: nil, sort: true)
     Primitive.attr! :use_block
     Primitive.dir_s_glob(pattern, flags, base, sort)

--- a/doc/file/filename_globbing.md
+++ b/doc/file/filename_globbing.md
@@ -33,7 +33,10 @@ Inputs to the filename-globbing methods:
 
 Their return values:
 
-- Each of the methods `Dir[]` and Dir.glob returns an array of the selected string entries.
+- \Method `Dir[]` returns an array of the selected string entries.
+- \Method Dir.glob with no block returns an array of the selected string entries.
+- \Method Dir.glob with a block calls the block with each selected string entry
+  and returns `nil`.
 - \Method Pathname#glob with no block returns an array of Pathname objects
   each based on a selected string entry.
 - \Method Pathname#glob with a block calls the block with each pathname
@@ -44,8 +47,13 @@ Examples:
 ```ruby
 Dir['*'].take(3)
 # => ["BSDL", "CONTRIBUTING.md", "COPYING"]
+Dir['*.rb', '*.h'].take(3)
+# => ["KNOWNBUGS.rb", "array.rb", "ast.rb"]
 Dir.glob('*').take(3)
 # => ["BSDL", "CONTRIBUTING.md", "COPYING"]
+Dir.glob(['*.rb', '*.h']).take(3)
+# => ["KNOWNBUGS.rb", "array.rb", "ast.rb"]
+Dir.glob('*.rb') {|entry_name| puts entry_name } # => nil
 Pathname('.').glob('*').take(3)
 # => [#<Pathname:BSDL>, #<Pathname:CONTRIBUTING.md>, #<Pathname:COPYING>]
 a = []
@@ -297,6 +305,25 @@ Pathname('.').glob('test/ruby/**/*.rb').take(3)
 # [#<Pathname:test/ruby/allpairs.rb>,
 #     #<Pathname:test/ruby/beginmainend.rb>,
 #     #<Pathname:test/ruby/box/a.1_1_0.rb>]
+```
+
+The double-asterisk pattern matches directories recursively
+only when followed by the slash character `'/'`;
+otherwise it is equivalent to pattern `'*'`:
+
+```ruby
+Dir.glob('**') == Dir.glob('*') # => true
+```
+
+A pattern ending with `'/'` matches directory names only;
+each matched name ends with `'/'`:
+
+```ruby
+# Find the directories at the top level.
+Dir.glob('*/').take(3)  # => ["basictest/", "benchmark/", "bin/"]
+
+# Find all directories everywhere.
+Dir.glob('**/').take(3) # => ["basictest/", "benchmark/", "benchmark/gc/"]
 ```
 
 The pattern may be escaped:

--- a/doc/file/filename_globbing.md
+++ b/doc/file/filename_globbing.md
@@ -325,6 +325,22 @@ Pathname('.').glob('\[k-m][h-j][a-c]') # => []
 Pathname('.').glob('\**/*.rb')         # => []
 ```
 
+Note that the backslash escapes the following character on Windows as well,
+and therefore cannot be used as a path separator in the pattern;
+`Dir.glob('C:\Users\*')` matches nothing.
+Write the pattern with forward slashes instead:
+
+```ruby
+Dir.glob('C:/Users/*')
+```
+
+A Windows path taken from an external source (such as an environment variable)
+may be converted for use as a pattern:
+
+```ruby
+pattern = path.tr('\\', '/')
+```
+
 ## Keyword Arguments
 
 | Keyword           | Value                    | Default | Meaning                                 |
@@ -416,6 +432,11 @@ Pathname('.').glob('*').size                      # => 241
 Pathname('.').glob('\*').size                     # => 0
 Pathname('.').glob('\*', File::FNM_NOESCAPE).size # => 0
 ```
+
+Note that on Windows this flag does not make the backslash usable
+as a path separator in the pattern;
+the backslash is then matched as an ordinary character,
+which cannot occur in an entry name.
 
 #### Constant File::FNM_SHORTNAME
 


### PR DESCRIPTION
On Windows, a backslash in a glob pattern always escapes the following character, so a pattern like `Dir['C:\foo*']` silently matches nothing and forward slashes must be used instead. This had been documented in `Dir.glob` since [Bug #2625](https://bugs.ruby-lang.org/issues/2625), and the documented behavior was also the ground on which [Bug #4404](https://bugs.ruby-lang.org/issues/4404) was rejected, but the note was lost when the glob documentation was consolidated into `doc/file/filename_globbing.md` in #17265. This restores it, with a hint to convert a Windows path taken from an external source with `path.tr('\\', '/')`, and a note under `File::FNM_NOESCAPE` that the flag does not make the backslash usable as a path separator.

Reviewing that consolidation surfaced more descriptions that were dropped along with it. `Dir.glob`'s block form, `Dir[]`'s multiple pattern arguments, matching only directories with a trailing slash, and the equivalence of `'**'` without a following slash to `'*'` are restored as well, with examples verified against the current source tree.
