### PR TITLE
Inline fastpath for rb_check_convert_type_with_id

### DIFF
--- a/internal/object.h
+++ b/internal/object.h
@@ -20,8 +20,15 @@ VALUE rb_obj_dig(int argc, VALUE *argv, VALUE self, VALUE notfound);
 VALUE rb_obj_clone_setup(VALUE obj, VALUE clone, VALUE kwfreeze);
 VALUE rb_obj_dup_setup(VALUE obj, VALUE dup);
 VALUE rb_immutable_obj_clone(int, VALUE *, VALUE);
-VALUE rb_check_convert_type_with_id(VALUE,int,const char*,ID);
+VALUE rb_check_convert_type_with_id_slow(VALUE,int,const char*,ID);
 int rb_bool_expected(VALUE, const char *, int raise);
+
+static inline VALUE
+rb_check_convert_type_with_id(VALUE val, int type, const char *tname, ID method)
+{
+    if (RB_TYPE_P(val, type) && type != T_DATA) return val;
+    return rb_check_convert_type_with_id_slow(val, type, tname, method);
+}
 static inline void RBASIC_CLEAR_CLASS(VALUE obj);
 static inline void RBASIC_SET_CLASS_RAW(VALUE obj, VALUE klass);
 static inline void RBASIC_SET_CLASS(VALUE obj, VALUE klass);

--- a/object.c
+++ b/object.c
@@ -3351,13 +3351,9 @@ rb_check_convert_type(VALUE val, int type, const char *tname, const char *method
 
 /*! \private */
 VALUE
-rb_check_convert_type_with_id(VALUE val, int type, const char *tname, ID method)
+rb_check_convert_type_with_id_slow(VALUE val, int type, const char *tname, ID method)
 {
-    VALUE v;
-
-    /* always convert T_DATA */
-    if (TYPE(val) == type && type != T_DATA) return val;
-    v = convert_type_with_id(val, tname, method, FALSE, -1);
+    VALUE v = convert_type_with_id(val, tname, method, FALSE, -1);
     if (NIL_P(v)) return Qnil;
     if (TYPE(v) != type) {
         rb_cant_convert_invalid_return(val, tname, rb_id2name(method), v);


### PR DESCRIPTION
This is an often-called internal function that has a fastpath, so the fastpath should be inlined.

Benchmark:

```ruby
require 'benchmark/ips'

ARR = [1, 2, 3]

Benchmark.ips(quiet: true) do |x|
  x.config(time: 2, warmup: 1)

  # Control: C method, does not route through rb_check_convert_type_with_id. Detects drift.
  x.report("control itself") do |t|
    a = ARR
    i = 0; while i < t; a.itself; i += 1; end
  end

  # Target: Array(arr) -> rb_Array -> rb_check_array_type -> inlined RB_TYPE_P fast path
  x.report("Array(arr)") do |t|
    a = ARR
    i = 0; while i < t; Array(a); i += 1; end
  end
end
```

When run 10 times, we see a 4% average improvement.