### PR TITLE
ZJIT: Specialize send with param_rest

### DIFF
--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -648,11 +648,11 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
         &Insn::Send { cd, block: Some(BlockHandler::BlockArg), state, reason, .. } => gen_send(jit, asm, function, cd, std::ptr::null(), &function.frame_state(state), reason),
         &Insn::SendForward { cd, blockiseq, state, reason, .. } => gen_send_forward(jit, asm, function, cd, blockiseq, &function.frame_state(state), reason),
         Insn::SendDirect(insn) => {
-            let SendDirectData { cme, iseq, recv, args, kw_bits, block, state, .. } = &**insn;
+            let SendDirectData { cme, iseq, recv, args, kw_bits, jit_entry_idx, block, state, .. } = &**insn;
             gen_send_iseq_direct(
                 cb, jit, asm,
                 function, *cme, *iseq, opnd!(recv), opnds!(args),
-                *kw_bits, &function.frame_state(*state), *block,
+                *kw_bits, *jit_entry_idx, &function.frame_state(*state), *block,
             )
         }
         Insn::PushInlineFrame { cme, iseq, recv, args, blockiseq, state, .. } => {
@@ -1685,6 +1685,7 @@ fn gen_send_iseq_direct(
     recv: Opnd,
     args: Vec<Opnd>,
     kw_bits: u32,
+    jit_entry_idx: u16,
     state: &FrameState,
     block: Option<BlockHandler>,
 ) -> lir::Opnd {
@@ -1788,25 +1789,8 @@ fn gen_send_iseq_direct(
         }
     }
 
-    let num_optionals_passed = if params.flags.has_opt() != 0 {
-        // See vm_call_iseq_setup_normal_opt_start in vm_inshelper.c
-        let lead_num = params.lead_num as u32;
-        let opt_num = params.opt_num as u32;
-        let post_num = params.post_num as u32;
-        let keyword = params.keyword;
-        let kw_total_num = if keyword.is_null() { 0 } else { unsafe { (*keyword).num } } as u32;
-        assert!(args.len() as u32 <= lead_num + opt_num + post_num + kw_total_num);
-        // For computing optional positional entry point, only count positional args
-        // and exclude the always-present lead and post slots.
-        let positional_argc = args.len() as u32 - kw_total_num;
-        let num_optionals_passed = positional_argc.saturating_sub(lead_num + post_num);
-        num_optionals_passed
-    } else {
-        0
-    };
-
     // Make a method call. The target address will be rewritten once compiled.
-    let iseq_call = IseqCall::new(iseq, num_optionals_passed.try_into().expect("checked in HIR"), args.len().try_into().expect("checked in HIR"));
+    let iseq_call = IseqCall::new(iseq, jit_entry_idx, args.len().try_into().expect("checked in HIR"));
     let dummy_ptr = cb.get_write_ptr().raw_ptr(cb);
     jit.iseq_calls.push(iseq_call.clone());
     let ret = asm.ccall_with_iseq_call(dummy_ptr, c_args, &iseq_call);

--- a/zjit/src/codegen_tests.rs
+++ b/zjit/src/codegen_tests.rs
@@ -975,6 +975,96 @@ fn test_send_optional_arguments() {
 }
 
 #[test]
+fn test_send_rest_arguments() {
+    eval("
+        def test(*args) = args
+        def entry = test(1, 2, 3)
+        entry
+    ");
+    assert_snapshot!(assert_compiles("entry"), @"[1, 2, 3]");
+}
+
+#[test]
+fn test_send_many_rest_arguments() {
+    eval("
+        def test(*args) = args.length
+        def entry = test(1, 2, 3, 4, 5, 6, 7)
+        entry
+    ");
+    assert_snapshot!(assert_compiles("entry"), @"7");
+}
+
+#[test]
+fn test_send_rest_arguments_with_post() {
+    eval("
+        def test(a, *args, z) = [a, args, z]
+        def entry = test(1, 2, 3, 4)
+        entry
+    ");
+    assert_snapshot!(assert_compiles("entry"), @"[1, [2, 3], 4]");
+}
+
+#[test]
+fn test_send_rest_arguments_with_keyword() {
+    eval("
+        def test(*args, k:) = [args, k]
+        def entry = test(1, 2, k: 40)
+        entry
+    ");
+    assert_snapshot!(assert_compiles("entry"), @"[[1, 2], 40]");
+}
+
+#[test]
+fn test_send_rest_arguments_with_optional_keyword_default() {
+    eval("
+        def test(*args, k: 40) = [args, k]
+        def entry = test(1, 2)
+        entry
+    ");
+    assert_snapshot!(assert_compiles("entry"), @"[[1, 2], 40]");
+}
+
+#[test]
+fn test_send_optional_and_rest_arguments() {
+    eval("
+        def test(a, b = 2, *rest) = [a, b, rest]
+        def entry = [test(1), test(3, 4), test(5, 6, 7, 8)]
+        entry
+    ");
+    assert_snapshot!(assert_compiles("entry"), @"[[1, 2, []], [3, 4, []], [5, 6, [7, 8]]]");
+}
+
+#[test]
+fn test_send_rest_arguments_with_keyword_to_positional_hash() {
+    eval("
+        def test(*args) = args
+        def entry = test(k: 1)
+        entry
+    ");
+    assert_snapshot!(assert_compiles("entry"), @"[{k: 1}]");
+}
+
+#[test]
+fn test_send_rest_arguments_with_block_literal() {
+    eval("
+        def test(*args) = yield args.length
+        def entry = test(1, 2, 3) { |n| n + 4 }
+        entry
+    ");
+    assert_snapshot!(assert_compiles("entry"), @"7");
+}
+
+#[test]
+fn test_send_rest_arguments_with_block_param() {
+    eval("
+        def test(*args, &block) = block.call(args.length)
+        def entry = test(1, 2, 3) { |n| n + 5 }
+        entry
+    ");
+    assert_snapshot!(assert_compiles("entry"), @"8");
+}
+
+#[test]
 fn test_send_nil_block_arg() {
     assert_snapshot!(inspect("
         def test = block_given?

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -2593,9 +2593,8 @@ fn can_direct_send(function: &mut Function, block: BlockId, iseq: *const rb_iseq
         return false
     }
 
-    // When the callee has no keyword parameter table, VM dispatch may convert
-    // caller keywords into a positional hash. SendDirect only models explicit
-    // keyword slots for now, so leave that conversion to VM dispatch.
+    // SendDirect only models explicit keyword slots for now, so leave this
+    // conversion to VM dispatch.
     if keywords_as_positional_hash {
         function.count(block, complex_arg_pass_keyword_to_positional_hash);
         function.set_dynamic_send_reason(send_insn, ComplexArgPass);
@@ -2619,6 +2618,8 @@ fn can_direct_send(function: &mut Function, block: BlockId, iseq: *const rb_iseq
     // We may remove it, remove the block_arg addition to match
     // See: https://github.com/ruby/ruby/pull/15911#discussion_r2710544982
     let block_arg = if 0 != params.flags.has_block() { 1 } else { 0 };
+    // With *rest, SendDirect receives one rest-array slot instead of each rest
+    // element, so cap positional argc at required/post + filled opts + rest slot.
     let passed_opt_num = (caller_positional_i32 - min_positional).min(opt_num) as usize;
     let send_positional_argc = if has_rest { min_positional as usize + passed_opt_num + 1 } else { caller_positional };
     let send_argc = send_positional_argc + kw_total_num as usize;
@@ -3608,6 +3609,9 @@ impl Function {
 
     /// Compute the positional optional entry index and pack positional arguments
     /// into a rest array when the callee has a *rest parameter.
+    /// Mirrors vm_args.c's setup_parameters_complex / args_setup_rest_parameter:
+    /// positional arguments between required/optional and post parameters become
+    /// the callee's *rest array before entering the method body.
     ///
     /// The input args must already have keyword arguments normalized to the callee's
     /// keyword table order by setup_keyword_arguments. This function only reshapes
@@ -3634,9 +3638,10 @@ impl Function {
         let min_positional_argc = lead_num + post_num;
         if positional_argc < min_positional_argc { return Err(ArgcParamMismatch); }
 
-        // See vm_call_iseq_setup_normal_opt_start in vm_inshelper.c.
-        // For computing the optional positional entry point, only count positional args
-        // and exclude the always-present lead and post slots.
+        // For computing the optional positional entry point, only count positional
+        // args and exclude the always-present lead and post slots. Do this before
+        // rest packing changes the SendDirect argument count.
+        // See: vm_args.c's setup_parameters_complex and args_setup_opt_parameters.
         let passed_opt_num = (positional_argc - min_positional_argc).min(opt_num);
         let jit_entry_idx = passed_opt_num.try_into().map_err(|_| TooManyArgsForLir)?;
 
@@ -3646,9 +3651,9 @@ impl Function {
             return Ok((args, jit_entry_idx));
         }
 
-        // Rebuild [lead, filled opts, rest elements..., post, kw...] into
-        // [lead, filled opts, rest array, post, kw...]. Keyword args were
-        // already normalized to the callee's keyword table order.
+        // Rebuild [lead, filled opts, rest elements..., post, kw...] into the
+        // argument shape expected by SendDirect:
+        // [lead, filled opts, rest array, post, kw...].
         let rest_start = lead_num + passed_opt_num;
         let rest_end = positional_argc - post_num;
         let (prefix, rest_and_suffix) = args.split_at(rest_start);

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -2570,16 +2570,12 @@ fn can_direct_send(function: &mut Function, block: BlockId, iseq: *const rb_iseq
         }
     };
 
-    // When the callee has no keyword parameter table, VM dispatch may convert
-    // caller keywords into a positional hash. DirectSend only models explicit
-    // keyword slots for now, so leave that conversion to VM dispatch.
-    if caller_kw_count != 0 && keyword.is_null() {
-        function.count(block, complex_arg_pass_keyword_to_positional_hash);
-        function.set_dynamic_send_reason(send_insn, ComplexArgPass);
-        return false;
-    }
-
-    let caller_positional_i32 = match c_int::try_from(caller_positional) {
+    // Match vm_args.c's setup_parameters_complex via args_kw_argv_to_hash:
+    // keywords passed to a method with no keyword parameters can become one
+    // positional hash before the argument count check.
+    let keywords_as_positional_hash = caller_kw_count != 0 && keyword.is_null();
+    let effective_positional = caller_positional + usize::from(keywords_as_positional_hash);
+    let caller_positional_i32 = match c_int::try_from(effective_positional) {
         Ok(argc) => argc,
         Err(_) => {
             function.set_dynamic_send_reason(send_insn, ArgcParamMismatch);
@@ -2592,11 +2588,25 @@ fn can_direct_send(function: &mut Function, block: BlockId, iseq: *const rb_iseq
     } else {
         (min_positional..=min_positional + opt_num).contains(&caller_positional_i32)
     };
+    if !positional_ok {
+        function.set_dynamic_send_reason(send_insn, ArgcParamMismatch);
+        return false
+    }
+
+    // When the callee has no keyword parameter table, VM dispatch may convert
+    // caller keywords into a positional hash. SendDirect only models explicit
+    // keyword slots for now, so leave that conversion to VM dispatch.
+    if keywords_as_positional_hash {
+        function.count(block, complex_arg_pass_keyword_to_positional_hash);
+        function.set_dynamic_send_reason(send_insn, ComplexArgPass);
+        return false;
+    }
+
     let keyword_ok = c_int::try_from(caller_kw_count)
         .as_ref()
         .map(|argc| (kw_req_num..=kw_total_num).contains(argc))
         .unwrap_or(false);
-    if !positional_ok || !keyword_ok {
+    if !keyword_ok {
         function.set_dynamic_send_reason(send_insn, ArgcParamMismatch);
         return false
     }

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -875,6 +875,7 @@ pub struct SendDirectData {
     pub iseq: IseqPtr,
     pub args: Vec<InsnId>,
     pub kw_bits: u32,
+    pub jit_entry_idx: u16,
     pub block: Option<BlockHandler>,
     pub state: InsnId,
 }
@@ -2078,10 +2079,13 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
             Insn::Jump(target) => { write!(f, "Jump {target}") }
             Insn::CondBranch { val, if_true, if_false } => { write!(f, "CondBranch {val}, {if_true}, {if_false}") },
             Insn::SendDirect(insn) => {
-                let SendDirectData { recv, cme, iseq, args, block, .. } = &**insn;
+                let SendDirectData { recv, cme, iseq, args, block, jit_entry_idx, .. } = &**insn;
                 let blockiseq = block.map(|bh| match bh { BlockHandler::BlockIseq(iseq) => iseq, BlockHandler::BlockArg => unreachable!() });
                 let method_name = unsafe { (**cme).called_id };
                 write!(f, "SendDirect {recv}, {:p}, :{} ({:?})", self.ptr_map.map_ptr(&blockiseq), method_name, self.ptr_map.map_ptr(iseq))?;
+                if *jit_entry_idx != 0 {
+                    write!(f, ", jit_entry_idx={jit_entry_idx}")?;
+                }
                 write_separated!(f, ", ", ", ", args);
                 Ok(())
             }
@@ -2529,7 +2533,6 @@ fn can_direct_send(function: &mut Function, block: BlockId, iseq: *const rb_iseq
     let caller_passes_block_arg = (unsafe { rb_vm_ci_flag(ci) } & VM_CALL_ARGS_BLOCKARG) != 0;
 
     use Counter::*;
-    if 0 != params.flags.has_rest()    { count_failure(complex_arg_pass_param_rest) }
     if 0 != params.flags.forwardable() { count_failure(complex_arg_pass_param_forwardable) }
     if callee_has_block_param && caller_passes_block_arg
                                        { count_failure(complex_arg_pass_param_block) }
@@ -2558,6 +2561,7 @@ fn can_direct_send(function: &mut Function, block: BlockId, iseq: *const rb_iseq
     let kw_total_num = if keyword.is_null() { 0 } else { unsafe { (*keyword).num } };
     let kwarg = unsafe { rb_vm_ci_kwarg(ci) };
     let caller_kw_count = if kwarg.is_null() { 0 } else { (unsafe { get_cikw_keyword_len(kwarg) }) as usize };
+    let has_rest = 0 != params.flags.has_rest();
     let caller_positional = match args.len().checked_sub(caller_kw_count) {
         Some(count) => count,
         None => {
@@ -2566,10 +2570,28 @@ fn can_direct_send(function: &mut Function, block: BlockId, iseq: *const rb_iseq
         }
     };
 
-    let positional_ok = c_int::try_from(caller_positional)
-        .as_ref()
-        .map(|argc| (lead_num + post_num..=lead_num + opt_num + post_num).contains(argc))
-        .unwrap_or(false);
+    // When the callee has no keyword parameter table, VM dispatch may convert
+    // caller keywords into a positional hash. DirectSend only models explicit
+    // keyword slots for now, so leave that conversion to VM dispatch.
+    if caller_kw_count != 0 && keyword.is_null() {
+        function.count(block, complex_arg_pass_keyword_to_positional_hash);
+        function.set_dynamic_send_reason(send_insn, ComplexArgPass);
+        return false;
+    }
+
+    let caller_positional_i32 = match c_int::try_from(caller_positional) {
+        Ok(argc) => argc,
+        Err(_) => {
+            function.set_dynamic_send_reason(send_insn, ArgcParamMismatch);
+            return false;
+        }
+    };
+    let min_positional = lead_num + post_num;
+    let positional_ok = if has_rest {
+        (min_positional..).contains(&caller_positional_i32)
+    } else {
+        (min_positional..=min_positional + opt_num).contains(&caller_positional_i32)
+    };
     let keyword_ok = c_int::try_from(caller_kw_count)
         .as_ref()
         .map(|argc| (kw_req_num..=kw_total_num).contains(argc))
@@ -2579,21 +2601,27 @@ fn can_direct_send(function: &mut Function, block: BlockId, iseq: *const rb_iseq
         return false
     }
 
-    // asm.ccall() doesn't support 6+ args. Compute the final argc after keyword setup:
-    // final_argc = caller's positional args + callee's total keywords (all kw slots are filled).
+    // asm.ccall() doesn't support 6+ args. Compute the final argc after keyword setup
+    // and rest packing:
+    // send_argc = packed positional args + callee's total keywords (all kw slots are filled).
+    // c_argc = self + send_argc + synthetic block handler arg.
     // Right now, the JIT entrypoint accepts the block as an param
     // We may remove it, remove the block_arg addition to match
     // See: https://github.com/ruby/ruby/pull/15911#discussion_r2710544982
     let block_arg = if 0 != params.flags.has_block() { 1 } else { 0 };
-    let final_argc = caller_positional + kw_total_num as usize + block_arg;
+    let passed_opt_num = (caller_positional_i32 - min_positional).min(opt_num) as usize;
+    let send_positional_argc = if has_rest { min_positional as usize + passed_opt_num + 1 } else { caller_positional };
+    let send_argc = send_positional_argc + kw_total_num as usize;
+    let c_argc = 1 + send_argc + block_arg; // +1 for self
+
     // TODO: Support passing arguments on the stack in C calls
-    if final_argc + 1 > C_ARG_OPNDS.len() { // +1 for self
+    if c_argc > C_ARG_OPNDS.len() {
         function.set_dynamic_send_reason(send_insn, TooManyArgsForLir);
         return false;
     }
 
-    // IseqCall stores num_optionals_passed and argc as u16
-    if u16::try_from(args.len()).is_err() {
+    // IseqCall stores the JIT entry index and argc as u16.
+    if u16::try_from(send_argc).is_err() {
         function.set_dynamic_send_reason(send_insn, TooManyArgsForLir);
         return false;
     }
@@ -2668,6 +2696,14 @@ enum IseqReturn {
     Receiver,
     // Builtin descriptor and return type
     InvokeLeafBuiltin(*const rb_builtin_function, Type),
+}
+
+/// Arguments and metadata prepared for lowering an ISEQ call to `SendDirect`.
+struct SendDirectArgs {
+    state: InsnId,
+    args: Vec<InsnId>,
+    kw_bits: u32,
+    jit_entry_idx: u16,
 }
 
 unsafe extern "C" {
@@ -3400,8 +3436,9 @@ impl Function {
         }
     }
 
-    /// Prepare arguments for a direct send, handling keyword argument reordering and default synthesis.
-    /// Returns the (state, processed_args, kw_bits) to use for the SendDirect instruction,
+    /// Prepare arguments for a direct send, handling keyword argument reordering,
+    /// default synthesis, and rest parameter packing.
+    /// Returns the arguments to use for the SendDirect instruction,
     /// or Err with the fallback reason if direct send isn't possible.
     fn prepare_direct_send_args(
         &mut self,
@@ -3410,9 +3447,10 @@ impl Function {
         ci: *const rb_callinfo,
         iseq: IseqPtr,
         state: InsnId,
-    ) -> Result<(InsnId, Vec<InsnId>, u32), SendFallbackReason> {
+    ) -> Result<SendDirectArgs, SendFallbackReason> {
         let kwarg = unsafe { rb_vm_ci_kwarg(ci) };
         let (processed_args, caller_argc, kw_bits) = self.setup_keyword_arguments(block, args, kwarg, iseq)?;
+        let (processed_args, jit_entry_idx) = self.setup_rest_parameter(block, processed_args, iseq, state)?;
 
         // If args were reordered or synthesized, create a new snapshot with the updated stack
         let send_state = if processed_args != args {
@@ -3422,7 +3460,12 @@ impl Function {
             state
         };
 
-        Ok((send_state, processed_args, kw_bits))
+        Ok(SendDirectArgs {
+            state: send_state,
+            args: processed_args,
+            kw_bits,
+            jit_entry_idx,
+        })
     }
 
     /// Reorder keyword arguments to match the callee's expected order, and synthesize
@@ -3551,6 +3594,67 @@ impl Function {
         let mut processed_args = args[..kw_args_start].to_vec();
         processed_args.extend(reordered_kw_args);
         Ok((processed_args, caller_argc, kw_bits))
+    }
+
+    /// Compute the positional optional entry index and pack positional arguments
+    /// into a rest array when the callee has a *rest parameter.
+    ///
+    /// The input args must already have keyword arguments normalized to the callee's
+    /// keyword table order by setup_keyword_arguments. This function only reshapes
+    /// the positional section before those keyword slots.
+    ///
+    /// Returns Ok with (processed_args, jit_entry_idx) if successful, or Err with
+    /// the fallback reason if direct send isn't possible.
+    /// - processed_args: arguments to use for SendDirect after optional rest packing
+    /// - jit_entry_idx: number of positional optional parameters provided by the caller
+    fn setup_rest_parameter(
+        &mut self,
+        block: BlockId,
+        args: Vec<InsnId>,
+        iseq: IseqPtr,
+        state: InsnId,
+    ) -> Result<(Vec<InsnId>, u16), SendFallbackReason> {
+        let params = unsafe { iseq.params() };
+        let lead_num = params.lead_num as usize;
+        let opt_num = params.opt_num as usize;
+        let post_num = params.post_num as usize;
+        let kw_num = callee_kw_num(iseq);
+
+        let positional_argc = args.len().checked_sub(kw_num).ok_or(ArgcParamMismatch)?;
+        let min_positional_argc = lead_num + post_num;
+        if positional_argc < min_positional_argc { return Err(ArgcParamMismatch); }
+
+        // See vm_call_iseq_setup_normal_opt_start in vm_inshelper.c.
+        // For computing the optional positional entry point, only count positional args
+        // and exclude the always-present lead and post slots.
+        let passed_opt_num = (positional_argc - min_positional_argc).min(opt_num);
+        let jit_entry_idx = passed_opt_num.try_into().map_err(|_| TooManyArgsForLir)?;
+
+        // Methods without *rest still need the jit_entry_idx computed above,
+        // but their positional args do not need repacking.
+        if params.flags.has_rest() == 0 {
+            return Ok((args, jit_entry_idx));
+        }
+
+        // Rebuild [lead, filled opts, rest elements..., post, kw...] into
+        // [lead, filled opts, rest array, post, kw...]. Keyword args were
+        // already normalized to the callee's keyword table order.
+        let rest_start = lead_num + passed_opt_num;
+        let rest_end = positional_argc - post_num;
+        let (prefix, rest_and_suffix) = args.split_at(rest_start);
+        let (rest_elements, suffix) = rest_and_suffix.split_at(rest_end - rest_start);
+
+        let rest = self.push_insn(block, Insn::NewArray {
+            elements: rest_elements.to_vec(),
+            state,
+        });
+
+        let mut packed_args = Vec::with_capacity(prefix.len() + 1 + suffix.len());
+        packed_args.extend_from_slice(prefix);
+        packed_args.push(rest);
+        packed_args.extend_from_slice(suffix);
+
+        Ok((packed_args, jit_entry_idx))
     }
 
     /// Resolve the receiver type for method dispatch optimization.
@@ -3996,7 +4100,7 @@ impl Function {
                             }
 
                             // Check if the args are compatible before emitting any assmptions
-                            let Ok((send_state, processed_args, kw_bits)) = self.prepare_direct_send_args(block, &args, ci, iseq, state)
+                            let Ok(SendDirectArgs { state: send_state, args: send_args, kw_bits, jit_entry_idx }) = self.prepare_direct_send_args(block, &args, ci, iseq, state)
                                 .inspect_err(|&reason| self.set_dynamic_send_reason(insn_id, reason)) else {
                                 self.push_insn_id(block, insn_id); continue;
                             };
@@ -4016,7 +4120,7 @@ impl Function {
                                 self.insn_types[recv.0] = self.infer_type(recv);
                             }
 
-                            let replacement = self.try_inline_send_direct(block, Insn::SendDirect(Box::new(SendDirectData { recv, cd, cme, iseq, args: processed_args, kw_bits, state: send_state, block: send_block })));
+                            let replacement = self.try_inline_send_direct(block, Insn::SendDirect(Box::new(SendDirectData { recv, cd, cme, iseq, args: send_args, kw_bits, jit_entry_idx, state: send_state, block: send_block })));
                             self.make_equal_to(insn_id, replacement);
                         } else if !has_block && def_type == VM_METHOD_TYPE_BMETHOD {
                             let procv = unsafe { rb_get_def_bmethod_proc((*cme).def) };
@@ -4036,7 +4140,7 @@ impl Function {
                             }
 
                             // Check if the args are compatible before emitting any assmptions
-                            let Ok((send_state, processed_args, kw_bits)) = self.prepare_direct_send_args(block, &args, ci, iseq, state)
+                            let Ok(SendDirectArgs { state: send_state, args: send_args, kw_bits, jit_entry_idx }) = self.prepare_direct_send_args(block, &args, ci, iseq, state)
                                 .inspect_err(|&reason| self.set_dynamic_send_reason(insn_id, reason)) else {
                                 self.push_insn_id(block, insn_id); continue;
                             };
@@ -4059,7 +4163,7 @@ impl Function {
                                 recv = self.guard_type_recompile(block, recv, Type::from_profiled_type(profiled_type), state, Recompile);
                             }
 
-                            let replacement = self.try_inline_send_direct(block, Insn::SendDirect(Box::new(SendDirectData { recv, cd, cme, iseq, args: processed_args, kw_bits, state: send_state, block: None })));
+                            let replacement = self.try_inline_send_direct(block, Insn::SendDirect(Box::new(SendDirectData { recv, cd, cme, iseq, args: send_args, kw_bits, jit_entry_idx, state: send_state, block: None })));
                             self.make_equal_to(insn_id, replacement);
                         } else if !has_block && def_type == VM_METHOD_TYPE_IVAR && args.is_empty() {
                             // Check if we're accessing ivars of a Class or Module object as they require single-ractor mode.
@@ -4589,7 +4693,7 @@ impl Function {
                             }
 
                             // Check if the args are compatible before emitting any assmptions
-                            let Ok((send_state, processed_args, kw_bits)) = self.prepare_direct_send_args(block, &args, ci, super_iseq, state)
+                            let Ok(SendDirectArgs { state: send_state, args: send_args, kw_bits, jit_entry_idx }) = self.prepare_direct_send_args(block, &args, ci, super_iseq, state)
                                 .inspect_err(|&reason| self.set_dynamic_send_reason(insn_id, reason)) else {
                                 self.push_insn_id(block, insn_id); continue;
                             };
@@ -4602,8 +4706,9 @@ impl Function {
                                 cd,
                                 cme: super_cme,
                                 iseq: super_iseq,
-                                args: processed_args,
+                                args: send_args,
                                 kw_bits,
+                                jit_entry_idx,
                                 state: send_state,
                                 block: None,
                             })));
@@ -4760,8 +4865,8 @@ impl Function {
     fn can_inline(callee_iseq: IseqPtr) -> bool {
         // Inline callees with required, optional, post-required positional, keyword, and
         // block parameters, including callees that dispatch to a passed block with `yield`.
-        // Rest params, double-splat (kwrest), and forwardable params are rejected because
-        // `can_direct_send` rejects them -- we only inline direct sends.
+        // Rest params, double-splat (kwrest), and forwardable params stay out of the
+        // general inliner for now; rest-aware direct sends are still handled by codegen.
         let params = unsafe { callee_iseq.params() };
         if params.flags.has_rest() != 0
             || params.flags.forwardable() != 0
@@ -4887,7 +4992,7 @@ impl Function {
                 else {
                     unreachable!("position {send_insn_id} is not a SendDirect");
                 };
-                let SendDirectData { recv, cme, iseq, args, kw_bits, block: call_block, state, .. } = *data;
+                let SendDirectData { recv, cme, iseq, args, kw_bits, jit_entry_idx, block: call_block, state, .. } = *data;
                 // SendDirect invariant: block is either None or BlockIseq.
                 // BlockArg is rejected upstream during type specialization.
                 let blockiseq: Option<IseqPtr> = call_block.map(|bh| match bh {
@@ -4923,20 +5028,16 @@ impl Function {
                 // passed: it runs the default-init code for the remaining
                 // `opt_num - k` optionals (if any) before falling through into the
                 // post-default body. SendDirect emission already guarantees
-                // args.len() lies in `lead_num + post_num + kw_num..=lead_num +
-                // opt_num + post_num + kw_num`, with `kw_num` being the callee's
-                // full keyword count (zero when the callee has no keywords). After
-                // `prepare_direct_send_args` runs, the caller's arg list has a slot
-                // for every callee keyword (filled in callee table order, padded
-                // with defaults for omitted optional keywords), so the keyword tail
-                // is a fixed-size addition we subtract off before recovering the
-                // optional-positional count.
+                // `prepare_direct_send_args` records the matching `jit_entry_idx`
+                // when it packs the caller args, so do not recover the optional
+                // positional count from args.len() here.
                 let callee_params = unsafe { iseq.params() };
                 let lead_num = callee_params.lead_num as usize;
                 let opt_num = callee_params.opt_num as usize;
                 let post_num = callee_params.post_num as usize;
                 let kw_num = callee_kw_num(iseq);
-                let passed_opt_num = args.len() - lead_num - post_num - kw_num;
+                let rest_slots = usize::from(callee_params.flags.has_rest() != 0);
+                let passed_opt_num = jit_entry_idx as usize;
 
                 // Create the continuation block before translating the callee so it
                 // can serve as the return_block argument; the callee's leaves become
@@ -4992,7 +5093,7 @@ impl Function {
                 debug_assert!(matches!(self.find(tail[0]), Insn::SendDirect(..)));
 
                 let omitted_opt_num = opt_num - passed_opt_num;
-                let positional_kw_end = lead_num + opt_num + post_num + kw_num;
+                let positional_kw_end = lead_num + opt_num + rest_slots + post_num + kw_num;
                 let kw_bits_local_idx = callee_kw_bits_local_idx(iseq);
                 let callee_entry_body_block = add_result.body_entry_block
                     .expect("inlined compilation always produces a body entry block");

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -4618,6 +4618,32 @@ mod hir_opt_tests {
     }
 
     #[test]
+    fn dont_classify_keyword_to_positional_hash_argc_mismatch_as_complex_arg_pass() {
+        eval("
+            def foo(a, b) = a
+            def test = foo(k: 1)
+            begin; test; rescue ArgumentError; end
+            begin; test; rescue ArgumentError; end
+        ");
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:3:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          Jump bb3(v1)
+        bb2():
+          EntryPoint JIT(0)
+          v4:BasicObject = LoadArg :self@0
+          Jump bb3(v4)
+        bb3(v6:BasicObject):
+          v11:Fixnum[1] = Const Value(1)
+          v13:BasicObject = Send v6, :foo, v11 # SendFallbackReason: Argument count does not match parameter count
+          CheckInterrupts
+          Return v13
+        ");
+    }
+
+    #[test]
     fn test_send_call_to_iseq_with_optional_kw() {
         eval("
             def foo(a: 1) = a

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -4009,11 +4009,10 @@ mod hir_opt_tests {
     }
 
     #[test]
-    fn dont_specialize_call_to_iseq_with_rest() {
-        enable_zjit_stats();
+    fn specialize_call_to_iseq_with_rest() {
         eval("
-            def foo(*args) = 1
-            def test = foo 1
+            def foo(*args) = args.length
+            def test = foo 1, 2, 3
             test
             test
         ");
@@ -4026,18 +4025,240 @@ mod hir_opt_tests {
         bb2():
           EntryPoint JIT(0)
           v4:BasicObject = LoadArg :self@0
-          IncrCounterPtr
           Jump bb3(v4)
-        bb3(v7:BasicObject):
-          IncrCounter zjit_insn_count
-          IncrCounter zjit_insn_count
-          v14:Fixnum[1] = Const Value(1)
-          IncrCounter zjit_insn_count
-          IncrCounter complex_arg_pass_param_rest
-          v17:BasicObject = Send v7, :foo, v14 # SendFallbackReason: Complex argument passing
-          IncrCounter zjit_insn_count
+        bb3(v6:BasicObject):
+          v11:Fixnum[1] = Const Value(1)
+          v13:Fixnum[2] = Const Value(2)
+          v15:Fixnum[3] = Const Value(3)
+          v23:ArrayExact = NewArray v11, v13, v15
+          PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
+          v26:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
+          v27:BasicObject = SendDirect v26, 0x1038, :foo (0x1048), v23
           CheckInterrupts
-          Return v17
+          Return v27
+        ");
+    }
+
+    #[test]
+    fn specialize_call_to_iseq_with_many_rest_arguments() {
+        eval("
+            def foo(*args) = args.length
+            def test = foo 1, 2, 3, 4, 5, 6, 7
+            test
+            test
+        ");
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:3:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          Jump bb3(v1)
+        bb2():
+          EntryPoint JIT(0)
+          v4:BasicObject = LoadArg :self@0
+          Jump bb3(v4)
+        bb3(v6:BasicObject):
+          v11:Fixnum[1] = Const Value(1)
+          v13:Fixnum[2] = Const Value(2)
+          v15:Fixnum[3] = Const Value(3)
+          v17:Fixnum[4] = Const Value(4)
+          v19:Fixnum[5] = Const Value(5)
+          v21:Fixnum[6] = Const Value(6)
+          v23:Fixnum[7] = Const Value(7)
+          v31:ArrayExact = NewArray v11, v13, v15, v17, v19, v21, v23
+          PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
+          v34:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
+          v35:BasicObject = SendDirect v34, 0x1038, :foo (0x1048), v31
+          CheckInterrupts
+          Return v35
+        ");
+    }
+
+    #[test]
+    fn specialize_call_to_iseq_with_rest_and_block_literal() {
+        eval("
+            def foo(*args) = yield args.length
+            def test = foo(1, 2, 3) { |n| n + 1 }
+            test
+            test
+        ");
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:3:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          Jump bb3(v1)
+        bb2():
+          EntryPoint JIT(0)
+          v4:BasicObject = LoadArg :self@0
+          Jump bb3(v4)
+        bb3(v6:BasicObject):
+          v11:Fixnum[1] = Const Value(1)
+          v13:Fixnum[2] = Const Value(2)
+          v15:Fixnum[3] = Const Value(3)
+          v23:ArrayExact = NewArray v11, v13, v15
+          PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
+          v26:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
+          v27:BasicObject = SendDirect v26, 0x1038, :foo (0x1048), v23
+          CheckInterrupts
+          Return v27
+        ");
+    }
+
+    #[test]
+    fn specialize_call_to_iseq_with_rest_and_block_param() {
+        eval("
+            def foo(*args, &block) = block.call(args.length)
+            def test = foo(1, 2, 3) { |n| n + 1 }
+            test
+            test
+        ");
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:3:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          Jump bb3(v1)
+        bb2():
+          EntryPoint JIT(0)
+          v4:BasicObject = LoadArg :self@0
+          Jump bb3(v4)
+        bb3(v6:BasicObject):
+          v11:Fixnum[1] = Const Value(1)
+          v13:Fixnum[2] = Const Value(2)
+          v15:Fixnum[3] = Const Value(3)
+          v23:ArrayExact = NewArray v11, v13, v15
+          PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
+          v26:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
+          v27:BasicObject = SendDirect v26, 0x1038, :foo (0x1048), v23
+          CheckInterrupts
+          Return v27
+        ");
+    }
+
+    #[test]
+    fn specialize_call_to_iseq_with_rest_and_post() {
+        eval("
+            def foo(a, *args, z) = args.length + a + z
+            def test = foo 1, 2, 3, 4
+            test
+            test
+        ");
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:3:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          Jump bb3(v1)
+        bb2():
+          EntryPoint JIT(0)
+          v4:BasicObject = LoadArg :self@0
+          Jump bb3(v4)
+        bb3(v6:BasicObject):
+          v11:Fixnum[1] = Const Value(1)
+          v13:Fixnum[2] = Const Value(2)
+          v15:Fixnum[3] = Const Value(3)
+          v17:Fixnum[4] = Const Value(4)
+          v25:ArrayExact = NewArray v13, v15
+          PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
+          v28:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
+          v29:BasicObject = SendDirect v28, 0x1038, :foo (0x1048), v11, v25, v17
+          CheckInterrupts
+          Return v29
+        ");
+    }
+
+    #[test]
+    fn specialize_call_to_iseq_with_rest_and_keyword() {
+        eval("
+            def foo(*args, k:) = args.length + k
+            def test = foo 1, 2, k: 40
+            test
+            test
+        ");
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:3:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          Jump bb3(v1)
+        bb2():
+          EntryPoint JIT(0)
+          v4:BasicObject = LoadArg :self@0
+          Jump bb3(v4)
+        bb3(v6:BasicObject):
+          v11:Fixnum[1] = Const Value(1)
+          v13:Fixnum[2] = Const Value(2)
+          v15:Fixnum[40] = Const Value(40)
+          v23:ArrayExact = NewArray v11, v13
+          PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
+          v26:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
+          v27:BasicObject = SendDirect v26, 0x1038, :foo (0x1048), v23, v15
+          CheckInterrupts
+          Return v27
+        ");
+    }
+
+    #[test]
+    fn specialize_call_to_iseq_with_rest_and_optional_keyword_default() {
+        eval("
+            def foo(*args, k: 40) = args.length + k
+            def test = foo 1, 2
+            test
+            test
+        ");
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:3:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          Jump bb3(v1)
+        bb2():
+          EntryPoint JIT(0)
+          v4:BasicObject = LoadArg :self@0
+          Jump bb3(v4)
+        bb3(v6:BasicObject):
+          v11:Fixnum[1] = Const Value(1)
+          v13:Fixnum[2] = Const Value(2)
+          v21:Fixnum[40] = Const Value(40)
+          v22:ArrayExact = NewArray v11, v13
+          PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
+          v25:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
+          v26:BasicObject = SendDirect v25, 0x1038, :foo (0x1048), v22, v21
+          CheckInterrupts
+          Return v26
+        ");
+    }
+
+    #[test]
+    fn specialize_call_to_iseq_with_optional_and_rest() {
+        eval("
+            def foo(a, b = 1, *rest) = [a, b, rest]
+            def test = foo(10, 20, 30, 40)
+            test
+            test
+        ");
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:3:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          Jump bb3(v1)
+        bb2():
+          EntryPoint JIT(0)
+          v4:BasicObject = LoadArg :self@0
+          Jump bb3(v4)
+        bb3(v6:BasicObject):
+          v11:Fixnum[10] = Const Value(10)
+          v13:Fixnum[20] = Const Value(20)
+          v15:Fixnum[30] = Const Value(30)
+          v17:Fixnum[40] = Const Value(40)
+          v25:ArrayExact = NewArray v15, v17
+          PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
+          v28:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
+          v29:BasicObject = SendDirect v28, 0x1038, :foo (0x1048), jit_entry_idx=1, v11, v13, v25
+          CheckInterrupts
+          Return v29
         ");
     }
 
@@ -4349,7 +4570,7 @@ mod hir_opt_tests {
           v20:Fixnum[30] = Const Value(30)
           v22:Fixnum[6] = Const Value(6)
           PatchPoint MethodRedefined(Object@0x1000, target@0x1008, cme:0x1010)
-          v52:BasicObject = SendDirect v48, 0x1038, :target (0x1048), v16, v18, v20, v22
+          v52:BasicObject = SendDirect v48, 0x1038, :target (0x1048), jit_entry_idx=3, v16, v18, v20, v22
           v27:Fixnum[10] = Const Value(10)
           v29:Fixnum[20] = Const Value(20)
           v31:Fixnum[30] = Const Value(30)
@@ -4360,6 +4581,39 @@ mod hir_opt_tests {
           v41:ArrayExact = NewArray v49, v52, v39
           CheckInterrupts
           Return v41
+        ");
+    }
+
+    #[test]
+    fn dont_specialize_call_to_rest_with_keyword_to_positional_hash() {
+        enable_zjit_stats();
+        eval("
+            def foo(*args) = args
+            def test = foo(k: 1)
+            test
+            test
+        ");
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:3:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          Jump bb3(v1)
+        bb2():
+          EntryPoint JIT(0)
+          v4:BasicObject = LoadArg :self@0
+          IncrCounterPtr
+          Jump bb3(v4)
+        bb3(v7:BasicObject):
+          IncrCounter zjit_insn_count
+          IncrCounter zjit_insn_count
+          v14:Fixnum[1] = Const Value(1)
+          IncrCounter zjit_insn_count
+          IncrCounter complex_arg_pass_keyword_to_positional_hash
+          v17:BasicObject = Send v7, :foo, v14 # SendFallbackReason: Complex argument passing
+          IncrCounter zjit_insn_count
+          CheckInterrupts
+          Return v17
         ");
     }
 

--- a/zjit/src/stats.rs
+++ b/zjit/src/stats.rs
@@ -434,7 +434,6 @@ make_counters! {
     unspecialized_super_def_type_null,
 
     // Unsupported parameter features
-    complex_arg_pass_param_rest,
     complex_arg_pass_param_post,
     complex_arg_pass_param_kwrest,
     complex_arg_pass_param_block,
@@ -451,6 +450,9 @@ make_counters! {
     complex_arg_pass_caller_super,
     complex_arg_pass_caller_zsuper,
     complex_arg_pass_caller_forwarding,
+
+    // Unsupported argument conversions
+    complex_arg_pass_keyword_to_positional_hash,
 
     // Writes to the VM frame
     vm_write_jit_frame_count,


### PR DESCRIPTION
Related: https://github.com/Shopify/ruby/issues/1003

As a first step toward optimizing sends with complex argument passing, allow SendDirect for callees with `*rest` by packing the positional arguments into a rest array before the call. 

Track the selected optional argument JIT entry as `jit_entry_idx` explicitly so packed rest arguments do not confuse entry-point selection for optional, post, and keyword parameter layouts. Rest array allocation elision is left for a further follow-up, since it requires proving that the rest array does not escape.

Also split keyword-to-positional-hash conversion out into its own complex argument passing counter, since it is valid Ruby semantics rather than an argc/parameter mismatch.

## Benchmark
On `erubi-rails`
```diff
Top-20 send fallback reasons:
- one_or_more_complex_arg_pass: 7,763,226 (24.5%)
+ one_or_more_complex_arg_pass: 5,257,840 (18.1%)
...
- argc_param_mismatch:   249,971 ( 0.8%)
```
```diff
Top-7 popular complex argument-parameter features not optimized:
-        param_rest: 4,505,288 (42.9%)
     caller_blockarg: 2,753,239 (26.2%)
+ keyword_to_positional_hash: 1,999,826 (25.0%)
   param_forwardable: 1,749,797 (16.7%)
      caller_splat: 1,250,817 (11.9%)
      caller_kwarg:   249,973 ( 2.4%)

note: keyword_to_positional_hash becomes visible after removing the param_rest bucket;
it is a remaining fallback class, not a regression from this change.
```

<details>

<summary>before patch</summary>

```
Top-1 not optimized method types for send (100.0% of total 243):
  optimized: 243 (100.0%)
Top-2 not optimized method types for send_without_block (100.0% of total 71,659):
  optimized_send: 71,607 (99.9%)
            null:     52 ( 0.1%)
Top-1 not optimized method types for super (100.0% of total 529):
  attrset: 529 (100.0%)
Top-1 instructions with uncategorized fallback reason (100.0% of total 3,518,132):
  opt_send_without_block: 3,518,132 (100.0%)
Top-20 send fallback reasons (100.0% of total 31,733,583):
                            one_or_more_complex_arg_pass: 7,763,226 (24.5%)
                             invokeblock_not_specialized: 7,407,426 (23.3%)
                          send_without_block_polymorphic: 5,253,272 (16.6%)
                          send_without_block_no_profiles: 3,689,202 (11.6%)
                                           uncategorized: 3,518,132 (11.1%)
                                   too_many_args_for_lir: 1,015,532 ( 3.2%)
                                        send_polymorphic:   506,278 ( 1.6%)
                             sendforward_not_specialized:   499,997 ( 1.6%)
                                   super_call_with_block:   499,986 ( 1.6%)
                      invokesuperforward_not_specialized:   499,943 ( 1.6%)
                                       super_polymorphic:   250,624 ( 0.8%)
                          super_target_complex_args_pass:   250,139 ( 0.8%)
                                 super_complex_args_pass:   250,139 ( 0.8%)
                                     argc_param_mismatch:   249,971 ( 0.8%)
  send_without_block_not_optimized_method_type_optimized:    71,607 ( 0.2%)
        send_without_block_not_optimized_need_permission:     2,898 ( 0.0%)
                          send_without_block_megamorphic:     1,906 ( 0.0%)
                                        send_no_profiles:     1,836 ( 0.0%)
                         super_not_optimized_method_type:       529 ( 0.0%)
                                    singleton_class_seen:       353 ( 0.0%)
Top-3 setivar fallback reasons (100.0% of total 2,260,251):
               not_t_object: 2,250,828 (99.6%)
              no_side_exits:     9,227 ( 0.4%)
  new_shape_needs_extension:       196 ( 0.0%)
Top-3 getivar fallback reasons (100.0% of total 19,346,164):
          no_side_exits: 18,800,632 (97.2%)
             no_profile:    528,782 ( 2.7%)
  no_profile_missing_ic:     16,750 ( 0.1%)
Top-4 invokeblock handler (100.0% of total 9,751,742):
  monomorphic_ifunc: 6,181,431 (63.4%)
        polymorphic: 2,057,826 (21.1%)
   monomorphic_iseq: 1,260,812 (12.9%)
  monomorphic_other:   251,673 ( 2.6%)
Top-5 getblockparamproxy handler (100.0% of total 2,002,293):
         iseq: 1,000,632 (50.0%)
  polymorphic:   500,784 (25.0%)
          nil:   500,191 (25.0%)
  megamorphic:       668 ( 0.0%)
  no_profiles:        18 ( 0.0%)
Top-3 HIR-level inlining rejection reasons (100.0% of total 1,073):
  budget_exceeded: 627 (58.4%)
        too_large: 442 (41.2%)
       ep_escapes:   4 ( 0.4%)
Top-7 popular complex argument-parameter features not optimized (100.0% of total 10,509,278):
         param_rest: 4,505,288 (42.9%)
    caller_blockarg: 2,753,239 (26.2%)
  param_forwardable: 1,749,797 (16.7%)
       caller_splat: 1,250,817 (11.9%)
       caller_kwarg:   249,973 ( 2.4%)
       param_kwrest:       133 ( 0.0%)
    caller_kw_splat:        31 ( 0.0%)
Top-1 compile error reasons (100.0% of total 529):
  exception_handler: 529 (100.0%)
Top-1 unhandled HIR insns (100.0% of total 250,578):
  throw: 250,578 (100.0%)
Top-14 side exit reasons (100.0% of total 325,159):
                   unhandled_hir_insn: 250,578 (77.1%)
                too_many_args_for_lir:  35,235 (10.8%)
     patchpoint_stable_constant_names:  10,719 ( 3.3%)
               fixnum_lshift_overflow:  10,042 ( 3.1%)
        patchpoint_no_singleton_class:   9,490 ( 2.9%)
                   guard_type_failure:   3,104 ( 1.0%)
          patchpoint_method_redefined:   2,877 ( 0.9%)
                      no_profile_send:   1,617 ( 0.5%)
                  guard_shape_failure:     687 ( 0.2%)
                        compile_error:     529 ( 0.2%)
                  unhandled_block_arg:     138 ( 0.0%)
      block_param_proxy_fallback_miss:      99 ( 0.0%)
  block_param_proxy_not_iseq_or_ifunc:      43 ( 0.0%)
                            interrupt:       1 ( 0.0%)
                             send_count: 402,853,226
                     dynamic_send_count:  31,733,583 ( 7.9%)
                   optimized_send_count: 371,119,643 (92.1%)
              iseq_optimized_send_count:  90,632,601 (22.5%)
      inline_cfunc_optimized_send_count: 167,562,028 (41.6%)
       inline_iseq_optimized_send_count:  52,272,686 (13.0%)
                    inline_method_count:         588 ( 0.0%)
non_variadic_cfunc_optimized_send_count:  44,620,310 (11.1%)
    variadic_cfunc_optimized_send_count:  16,032,018 ( 4.0%)
dynamic_setivar_count:                            2,260,251
dynamic_getivar_count:                           19,346,164
dynamic_definedivar_count:                                0
compiled_iseq_count:                                  1,374
compiled_side_exit_count:                            24,878
failed_iseq_count:                                        0
compile_time:                                         551ms
compile_side_exit_time:                                27ms
compile_side_exit_time_ratio:                          5.0%
compile_hir_time:                                     198ms
compile_hir_build_time:                                62ms
compile_hir_strength_reduce_time:                      39ms
compile_hir_inline_methods_time:                       10ms
compile_hir_canonicalize_time:                         16ms
compile_hir_fold_constants_time:                       14ms
compile_hir_clean_cfg_time:                            10ms
compile_hir_eliminate_dead_code_time:                   9ms
compile_lir_time:                                     329ms
profile_time:                                           2ms
gc_time:                                               23ms
invalidation_time:                                      5ms
vm_write_jit_frame_count:                       327,891,740
vm_write_sp_count:                              327,891,740
vm_write_locals_count:                          309,667,861
vm_write_stack_count:                           126,447,472
vm_write_to_parent_iseq_local_count:                649,900
guard_type_count:                               294,151,281
guard_type_exit_ratio:                                 0.0%
guard_shape_count:                              143,566,944
guard_shape_exit_ratio:                                0.0%
load_field_count:                               437,019,829
store_field_count:                               38,159,503
side_exit_size:                                   4,187,856
code_region_bytes:                                9,469,952
side_exit_size_ratio:                                 44.2%
zjit_alloc_bytes:                                 5,397,163
total_mem_bytes:                                 14,867,115
side_exit_count:                                    325,159
total_insn_count:                             1,821,865,899
vm_insn_count:                                    2,013,728
zjit_insn_count:                              1,819,852,171
ratio_in_zjit:                                        99.9%
```

</details>

<details>

<summary>after patch</summary>

```
Top-2 not optimized method types for send_without_block (100.0% of total 71,711):
  optimized_send: 71,607 (99.9%)
            null:    104 ( 0.1%)
Top-1 not optimized method types for super (100.0% of total 339):
  attrset: 339 (100.0%)
Top-1 instructions with uncategorized fallback reason (100.0% of total 3,517,841):
  opt_send_without_block: 3,517,841 (100.0%)
Top-20 send fallback reasons (100.0% of total 28,975,253):
                             invokeblock_not_specialized: 7,406,116 (25.6%)
                            one_or_more_complex_arg_pass: 5,257,840 (18.1%)
                          send_without_block_polymorphic: 5,253,249 (18.1%)
                          send_without_block_no_profiles: 3,688,929 (12.7%)
                                           uncategorized: 3,517,841 (12.1%)
                                   too_many_args_for_lir: 1,015,532 ( 3.5%)
                                        send_polymorphic:   505,691 ( 1.7%)
                             sendforward_not_specialized:   499,997 ( 1.7%)
                                   super_call_with_block:   499,986 ( 1.7%)
                      invokesuperforward_not_specialized:   499,943 ( 1.7%)
                                       super_polymorphic:   250,624 ( 0.9%)
                                 super_complex_args_pass:   250,139 ( 0.9%)
                          super_target_complex_args_pass:   249,971 ( 0.9%)
  send_without_block_not_optimized_method_type_optimized:    71,607 ( 0.2%)
        send_without_block_not_optimized_need_permission:     2,958 ( 0.0%)
                          send_without_block_megamorphic:     1,906 ( 0.0%)
                                        send_no_profiles:     1,836 ( 0.0%)
                                    singleton_class_seen:       353 ( 0.0%)
                         super_not_optimized_method_type:       339 ( 0.0%)
                                        super_from_block:       232 ( 0.0%)
Top-3 setivar fallback reasons (100.0% of total 2,259,219):
               not_t_object: 2,250,828 (99.6%)
              no_side_exits:     8,291 ( 0.4%)
  new_shape_needs_extension:       100 ( 0.0%)
Top-3 getivar fallback reasons (100.0% of total 19,324,241):
          no_side_exits: 18,782,191 (97.2%)
             no_profile:    528,053 ( 2.7%)
  no_profile_missing_ic:     13,997 ( 0.1%)
Top-4 invokeblock handler (100.0% of total 9,750,313):
  monomorphic_ifunc: 6,180,247 (63.4%)
        polymorphic: 2,058,152 (21.1%)
   monomorphic_iseq: 1,260,241 (12.9%)
  monomorphic_other:   251,673 ( 2.6%)
Top-5 getblockparamproxy handler (100.0% of total 2,001,947):
         iseq: 1,000,398 (50.0%)
  polymorphic:   500,690 (25.0%)
          nil:   499,948 (25.0%)
  megamorphic:       668 ( 0.0%)
  no_profiles:       243 ( 0.0%)
Top-4 HIR-level inlining rejection reasons (100.0% of total 1,082):
  budget_exceeded: 625 (57.8%)
        too_large: 449 (41.5%)
   complex_params:   4 ( 0.4%)
       ep_escapes:   4 ( 0.4%)
Top-7 popular complex argument-parameter features not optimized (100.0% of total 8,004,016):
             caller_blockarg: 2,753,440 (34.4%)
  keyword_to_positional_hash: 1,999,826 (25.0%)
           param_forwardable: 1,749,797 (21.9%)
                caller_splat: 1,250,817 (15.6%)
                caller_kwarg:   249,973 ( 3.1%)
                param_kwrest:       133 ( 0.0%)
             caller_kw_splat:        30 ( 0.0%)
Top-1 compile error reasons (100.0% of total 541):
  exception_handler: 541 (100.0%)
Top-1 unhandled HIR insns (100.0% of total 250,590):
  throw: 250,590 (100.0%)
Top-13 side exit reasons (100.0% of total 324,010):
                   unhandled_hir_insn: 250,590 (77.3%)
                too_many_args_for_lir:  35,235 (10.9%)
               fixnum_lshift_overflow:  10,042 ( 3.1%)
     patchpoint_stable_constant_names:   9,852 ( 3.0%)
        patchpoint_no_singleton_class:   9,192 ( 2.8%)
                   guard_type_failure:   3,090 ( 1.0%)
          patchpoint_method_redefined:   2,681 ( 0.8%)
                      no_profile_send:   1,563 ( 0.5%)
                  guard_shape_failure:     729 ( 0.2%)
                        compile_error:     541 ( 0.2%)
      block_param_proxy_fallback_miss:     324 ( 0.1%)
                  unhandled_block_arg:     126 ( 0.0%)
  block_param_proxy_not_iseq_or_ifunc:      45 ( 0.0%)
                             send_count: 402,783,845
                     dynamic_send_count:  28,975,253 ( 7.2%)
                   optimized_send_count: 373,808,592 (92.8%)
              iseq_optimized_send_count:  93,360,348 (23.2%)
      inline_cfunc_optimized_send_count: 167,543,023 (41.6%)
       inline_iseq_optimized_send_count:  52,263,576 (13.0%)
                    inline_method_count:         584 ( 0.0%)
non_variadic_cfunc_optimized_send_count:  44,612,903 (11.1%)
    variadic_cfunc_optimized_send_count:  16,028,742 ( 4.0%)
dynamic_setivar_count:                            2,259,219
dynamic_getivar_count:                           19,324,241
dynamic_definedivar_count:                                0
compiled_iseq_count:                                  1,365
compiled_side_exit_count:                            24,892
failed_iseq_count:                                        0
compile_time:                                         550ms
compile_side_exit_time:                                27ms
compile_side_exit_time_ratio:                          4.9%
compile_hir_time:                                     196ms
compile_hir_build_time:                                61ms
compile_hir_strength_reduce_time:                      39ms
compile_hir_inline_methods_time:                       10ms
compile_hir_canonicalize_time:                         16ms
compile_hir_fold_constants_time:                       14ms
compile_hir_clean_cfg_time:                            10ms
compile_hir_eliminate_dead_code_time:                   9ms
compile_lir_time:                                     329ms
profile_time:                                           2ms
gc_time:                                               63ms
invalidation_time:                                      6ms
vm_write_jit_frame_count:                       330,580,979
vm_write_sp_count:                              330,580,979
vm_write_locals_count:                          309,607,837
vm_write_stack_count:                           123,669,628
vm_write_to_parent_iseq_local_count:                649,595
guard_type_count:                               296,860,699
guard_type_exit_ratio:                                 0.0%
guard_shape_count:                              143,551,718
guard_shape_exit_ratio:                                0.0%
load_field_count:                               434,212,714
store_field_count:                               38,140,355
side_exit_size:                                   4,191,172
code_region_bytes:                                9,469,952
side_exit_size_ratio:                                 44.3%
zjit_alloc_bytes:                                 5,424,159
total_mem_bytes:                                 14,894,111
side_exit_count:                                    324,010
total_insn_count:                             1,821,505,534
vm_insn_count:                                    2,027,303
zjit_insn_count:                              1,819,478,231
ratio_in_zjit:                                        99.9%
```

</details>