### PR TITLE
Re-enable DTrace on FreeBSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3820,9 +3820,6 @@ AS_CASE(["${enable_dtrace}"],
 ], [
     rb_cv_dtrace_available=no
 ])
-AS_CASE(["$target_os"],[freebsd*],[
-         rb_cv_dtrace_available=no
-	 ])
 AS_IF([test "${enable_dtrace}" = yes], [dnl
     AS_IF([test -z "$DTRACE"], [dnl
 	AC_MSG_ERROR([dtrace(1) is missing])


### PR DESCRIPTION
Remove the unconditional target_os=freebsd* override that forced rb_cv_dtrace_available=no, which was added in commit 78677f105d ("Disable DTrace in FreeBSD (#3999)") as a Ruby 3.0.0 release unblocker for the build failure reported in Bug #17212.

That failure was a link error at the DTrace glommed/static-library stage ("attempted static link of dynamic object libgcc_s.so" on FreeBSD 12.x, "cannot find -lgcc_s" on 11.x), not an exec-stack or relocation problem. On modern FreeBSD (14.4, dtrace Sun D 1.13, clang 19 / lld) that stage links cleanly, so the override is obsolete.

With it removed, FreeBSD goes through the normal RUBY_DTRACE_AVAILABLE detection. The rest of the FreeBSD DTrace machinery is already in place (-xnolibs autodetect, -lelf link, and the dtrace -G rebuild/glommed-object path), so no other change is needed.

Verified on FreeBSD 14.4/amd64: a --enable-dtrace build succeeds; the ruby binary gets a .SUNW_dof section with the provider "ruby" and all 22 ruby::: USDT probes; and the probes register and fire under a live dtrace(1) (e.g. gc-mark-begin, gc-sweep-end, method-entry).