### PR TITLE
iseq: use RB_OBJ_WRITE for the lazy-load loader object

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -14972,7 +14972,7 @@ ibf_load_iseq(const struct ibf_load *load, const rb_iseq_t *index_iseq)
             fprintf(stderr, "ibf_load_iseq: new iseq=%p\n", (void *)iseq);
 #endif
             FL_SET((VALUE)iseq, ISEQ_NOT_LOADED_YET);
-            iseq->aux.loader.obj = load->loader_obj;
+            RB_OBJ_WRITE((VALUE)iseq, &iseq->aux.loader.obj, load->loader_obj);
             iseq->aux.loader.index = iseq_index;
 #if IBF_ISEQ_DEBUG
             fprintf(stderr, "ibf_load_iseq: iseq=%p loader_obj=%p index=%d\n",


### PR DESCRIPTION
iseq->aux.loader.obj holds the ibf loader while an iseq is ISEQ_NOT_LOADED_YET, and iseq_mark marks it, so the store into it is a GC-managed reference and should go through the write barrier rather than a raw assignment.