### PR TITLE
gc: take the VM barrier inside rb_objspace_each_objects

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -3802,6 +3802,12 @@ gc_start_internal(rb_execution_context_t *ec, VALUE self, VALUE full_mark, VALUE
  *
  * If callback() returns non-zero, the iteration will be stopped.
  *
+ * This takes the VM barrier for the whole walk, stopping every other
+ * Ractor: the set of heap pages must not change under the callback, and a
+ * GC is stop-the-world.  Because of that, the callback must not wait on
+ * another Ractor (e.g. send/receive) -- they are all suspended and it
+ * would deadlock.
+ *
  * This is a sample callback code to iterate liveness objects:
  *
  *   static int
@@ -3829,7 +3835,10 @@ gc_start_internal(rb_execution_context_t *ec, VALUE self, VALUE full_mark, VALUE
 void
 rb_objspace_each_objects(int (*callback)(void *, void *, size_t, void *), void *data)
 {
-    rb_gc_impl_each_objects(rb_gc_get_objspace(), callback, data);
+    RB_VM_LOCKING() {
+        rb_vm_barrier();
+        rb_gc_impl_each_objects(rb_gc_get_objspace(), callback, data);
+    }
 }
 
 static void

--- a/iseq.c
+++ b/iseq.c
@@ -4261,10 +4261,7 @@ clear_attr_ccs_i(void *vstart, void *vend, size_t stride, void *data)
 void
 rb_clear_attr_ccs(void)
 {
-    RB_VM_LOCKING() {
-        rb_vm_barrier();
-        rb_objspace_each_objects(clear_attr_ccs_i, NULL);
-    }
+    rb_objspace_each_objects(clear_attr_ccs_i, NULL);
 }
 
 static int
@@ -4283,7 +4280,6 @@ clear_bf_ccs_i(void *vstart, void *vend, size_t stride, void *data)
 void
 rb_clear_bf_ccs(void)
 {
-    ASSERT_vm_locking_with_barrier();
     rb_objspace_each_objects(clear_bf_ccs_i, NULL);
 }
 
@@ -4313,10 +4309,7 @@ trace_set_i(void *vstart, void *vend, size_t stride, void *data)
 void
 rb_iseq_trace_set_all(rb_event_flag_t turnon_events)
 {
-    RB_VM_LOCKING() {
-        rb_vm_barrier();
-        rb_objspace_each_objects(trace_set_i, &turnon_events);
-    }
+    rb_objspace_each_objects(trace_set_i, &turnon_events);
 }
 
 VALUE


### PR DESCRIPTION
Walking the heap needs a stable set of pages: a concurrent GC on another Ractor is stop-the-world and would otherwise pause the walk mid-iteration and free or move objects out from under the callback. Callers that mutate what they visit (rb_iseq_trace_set_all, rb_clear_attr_ccs, rb_clear_bf_ccs) also relied on the barrier for atomicity and took it by hand; move it into the callee so every caller is covered and drop the now-redundant wrappers.

This also gives rb_iseq_remove_coverage_all the barrier it was missing -- it mutates iseqs (ISEQ_COVERAGE_SET) just like its siblings but walked without stopping other Ractors.