### PR TITLE
Use sharable middle substrings

### DIFF
--- a/include/ruby/internal/core/rstring.h
+++ b/include/ruby/internal/core/rstring.h
@@ -352,6 +352,11 @@ void rb_check_safe_str(VALUE);
  * @param[in]  func           The function name where encountered NULL pointer.
  */
 void rb_debug_rstring_null_ptr(const char *func);
+
+/**
+ * @private
+ */
+char *rb_str_terminate(VALUE str);
 RBIMPL_SYMBOL_EXPORT_END()
 
 RBIMPL_ATTR_PURE_UNLESS_DEBUG()
@@ -380,6 +385,10 @@ RBIMPL_ATTR_ARTIFICIAL()
 static inline char *
 RSTRING_PTR(VALUE str)
 {
+    if (RB_UNLIKELY(RB_FL_TEST_RAW(str, RUBY_FL_UNUSED10))) {
+        return rb_str_terminate(str);
+    }
+
     char *ptr = RB_FL_TEST_RAW(str, RSTRING_NOEMBED) ?
         RSTRING(str)->as.heap.ptr :
         RSTRING(str)->as.embed.ary;
@@ -408,6 +417,10 @@ RBIMPL_ATTR_ARTIFICIAL()
 static inline char *
 RSTRING_END(VALUE str)
 {
+    if (RB_UNLIKELY(RB_FL_TEST_RAW(str, RUBY_FL_UNUSED10))) {
+        return rb_str_terminate(str) + RSTRING_LEN(str);
+    }
+
     char *ptr = RB_FL_TEST_RAW(str, RSTRING_NOEMBED) ?
         RSTRING(str)->as.heap.ptr :
         RSTRING(str)->as.embed.ary;

--- a/include/ruby/internal/fl_type.h
+++ b/include/ruby/internal/fl_type.h
@@ -260,7 +260,8 @@ ruby_fl_type {
     RUBY_FL_WEAK_REFERENCE = (1<<9),
 
    /**
-    * This flag is no longer in use
+    * On a ::RString this flag (internally `STR_NO_TERM`) marks a view whose
+    * shared buffer is not NUL terminated.  Unused on other types.
     *
     * @internal
     */

--- a/internal/string.h
+++ b/internal/string.h
@@ -63,6 +63,14 @@ rb_str_enc_get(VALUE str)
     return rb_enc_from_index(ENCODING_GET(str));
 }
 
+static inline char *
+RSTRING_PTR_NO_TERM(VALUE str)
+{
+    return RB_FL_TEST_RAW(str, RSTRING_NOEMBED) ?
+        RSTRING(str)->as.heap.ptr :
+        RSTRING(str)->as.embed.ary;
+}
+
 /* string.c */
 VALUE rb_str_dup_m(VALUE str);
 VALUE rb_fstring(VALUE);

--- a/string.c
+++ b/string.c
@@ -83,6 +83,11 @@ VALUE rb_cSymbol;
 
 /* Flags of RString
  *
+ * RUBY_FL_UNUSED10: STR_NO_TERM
+ *            The string's buffer is not NUL terminated: ptr[len] belongs to a
+ *            shared parent buffer, letting mid-buffer "views" avoid copying.
+ *            The C API will materialize the NUL terminator, for backwards
+ *            compatibility, except for the RSTRING_PTR_NO_TERM function.
  * 0:     STR_SHARED (equal to ELTS_SHARED)
  *            The string is shared. The buffer this string points to is owned by
  *            another string (the shared root).
@@ -133,11 +138,13 @@ VALUE rb_cSymbol;
 #define STR_NOFREE FL_USER18
 #define STR_FAKESTR FL_USER19
 
+#define STR_NO_TERM RUBY_FL_UNUSED10
+
 #define STR_SET_NOEMBED(str) do {\
     FL_SET((str), STR_NOEMBED);\
     FL_UNSET((str), STR_SHARED | STR_SHARED_ROOT | STR_BORROWED);\
 } while (0)
-#define STR_SET_EMBED(str) FL_UNSET((str), STR_NOEMBED | STR_SHARED | STR_NOFREE)
+#define STR_SET_EMBED(str) FL_UNSET((str), STR_NOEMBED | STR_SHARED | STR_NOFREE | STR_NO_TERM)
 
 #define STR_SET_LEN(str, n) do { \
     RSTRING(str)->len = (n); \
@@ -205,7 +212,7 @@ zero_filled(const char *s, int n)
 }
 
 #if !defined SHARABLE_MIDDLE_SUBSTRING
-# define SHARABLE_MIDDLE_SUBSTRING 0
+# define SHARABLE_MIDDLE_SUBSTRING 1
 #endif
 
 static inline bool
@@ -1674,6 +1681,11 @@ str_new_frozen_buffer(VALUE klass, VALUE orig, int copy_encoding)
                 RUBY_ASSERT(!STR_EMBED_P(str));
                 RSTRING(str)->as.heap.ptr += ofs;
                 STR_SET_LEN(str, RSTRING_LEN(str) - (ofs + rest));
+
+                if (rest > 0 &&
+                    !zero_filled(RSTRING_PTR_NO_TERM(str) + RSTRING_LEN(str), termlen)) {
+                    str_make_independent_expand(str, RSTRING_LEN(str), 0L, termlen);
+                }
             }
             else {
                 if (RBASIC_CLASS(shared) == 0)
@@ -1833,11 +1845,14 @@ str_shared_replace(VALUE str, VALUE str2)
 
         STR_SET_NOEMBED(str);
         FL_UNSET(str, STR_SHARED);
-        RSTRING(str)->as.heap.ptr = RSTRING_PTR(str2);
+        RSTRING(str)->as.heap.ptr = RSTRING_PTR_NO_TERM(str2);
 
         if (FL_TEST(str2, STR_SHARED)) {
             VALUE shared = RSTRING(str2)->as.heap.aux.shared;
             STR_SET_SHARED(str, shared);
+            if (FL_TEST_RAW(str2, STR_NO_TERM)) {
+                FL_SET_RAW(str, STR_NO_TERM);
+            }
         }
         else {
             RSTRING(str)->as.heap.aux.capa = RSTRING(str2)->as.heap.aux.capa;
@@ -1883,8 +1898,11 @@ str_replace(VALUE str, VALUE str2)
         RUBY_ASSERT(OBJ_FROZEN(shared));
         STR_SET_NOEMBED(str);
         STR_SET_LEN(str, len);
-        RSTRING(str)->as.heap.ptr = RSTRING_PTR(str2);
+        RSTRING(str)->as.heap.ptr = RSTRING_PTR_NO_TERM(str2);
         STR_SET_SHARED(str, shared);
+        if (FL_TEST_RAW(str2, STR_NO_TERM)) {
+            FL_SET_RAW(str, STR_NO_TERM);
+        }
         rb_enc_cr_str_exact_copy(str, str2);
     }
     else {
@@ -1962,10 +1980,13 @@ str_duplicate_setup_heap(VALUE klass, VALUE str, VALUE dup)
     RUBY_ASSERT(!STR_SHARED_P(root));
     RUBY_ASSERT(RB_OBJ_FROZEN_RAW(root));
 
-    RSTRING(dup)->as.heap.ptr = RSTRING_PTR(str);
+    RSTRING(dup)->as.heap.ptr = RSTRING_PTR_NO_TERM(str);
     FL_SET_RAW(dup, RSTRING_NOEMBED);
     STR_SET_SHARED(dup, root);
     flags |= RSTRING_NOEMBED | STR_SHARED;
+    if (FL_TEST_RAW(str, STR_NO_TERM)) {
+        flags |= STR_NO_TERM;
+    }
 
     STR_SET_LEN(dup, RSTRING_LEN(str));
     return str_duplicate_setup_encoding(str, dup, flags);
@@ -2718,7 +2739,7 @@ str_make_independent_expand(VALUE str, long len, long expand, const int termlen)
     }
 
     ptr = ALLOC_N(char, (size_t)capa + termlen);
-    oldptr = RSTRING_PTR(str);
+    oldptr = RSTRING_PTR_NO_TERM(str);
     if (oldptr) {
         memcpy(ptr, oldptr, len);
     }
@@ -2726,7 +2747,7 @@ str_make_independent_expand(VALUE str, long len, long expand, const int termlen)
         SIZED_FREE_N(oldptr, STR_HEAP_SIZE(str));
     }
     STR_SET_NOEMBED(str);
-    FL_UNSET(str, STR_SHARED|STR_NOFREE);
+    FL_UNSET(str, STR_SHARED|STR_NOFREE|STR_NO_TERM);
     TERM_FILL(ptr + len, termlen);
     RSTRING(str)->as.heap.ptr = ptr;
     STR_SET_LEN(str, len);
@@ -2816,6 +2837,9 @@ rb_string_value(volatile VALUE *ptr)
         s = rb_str_to_str(s);
         *ptr = s;
     }
+    if (RB_UNLIKELY(FL_TEST_RAW(s, STR_NO_TERM))) {
+        rb_str_terminate(s);
+    }
     return s;
 }
 
@@ -2852,6 +2876,14 @@ str_fill_term(VALUE str, char *s, long len, int termlen)
         return s;
     }
     return RSTRING_PTR(str);
+}
+
+char *
+rb_str_terminate(VALUE str)
+{
+    FL_UNSET_RAW(str, STR_NO_TERM);
+    char *s = RSTRING_PTR_NO_TERM(str);
+    return str_fill_term(str, s, RSTRING_LEN(str), TERM_LEN(str));
 }
 
 void
@@ -3178,6 +3210,10 @@ str_subseq(VALUE str, long beg, long len)
         if (RSTRING_LEN(str2) > len) {
             STR_SET_LEN(str2, len);
         }
+
+        if (!zero_filled(RSTRING_PTR_NO_TERM(str2) + len, termlen)) {
+            FL_SET_RAW(str2, STR_NO_TERM);
+        }
     }
 
     return str2;
@@ -3316,6 +3352,7 @@ rb_str_freeze(VALUE str)
     }
 
     if (OBJ_FROZEN(str)) return str;
+    if (FL_TEST_RAW(str, STR_NO_TERM)) rb_str_terminate(str);
     rb_str_resize(str, RSTRING_LEN(str));
     return rb_obj_freeze(str);
 }


### PR DESCRIPTION
Commit 07cad43 added support for sharable middle substrings, but some system calls and C extensions expect the NUL terminator to exist, so fully enabling it is a compatibility issue.

This commit changes it so that we use sharable middle substrings, but we bail out and add the NUL terminator when the string is used in public API like RSTRING_PTR or when the string is frozen. It uses a new flag STR_NO_TERM to keep track of whether a string has a NUL terminator or not.

A potential issue is that this change makes RSTRING_PTR a potential GC point since the string may need to be unshared which may allocate memory.

However, we can see that in the following microbenchmark, this branch runs significantly faster:

```ruby
str = ("aaa".."zzz").to_a.join

i = 0
while i < 10_000_000
  a = str[1000, 5000]
  i += 1
end
```

Results:

    Benchmark 1: master
      Time (mean ± σ):      1.883 s ±  0.083 s    [User: 1.826 s, System: 0.044 s]
      Range (min … max):    1.801 s …  2.026 s    10 runs

    Benchmark 2: branch
      Time (mean ± σ):     395.4 ms ±   5.5 ms    [User: 385.7 ms, System: 8.1 ms]
      Range (min … max):   389.4 ms … 404.4 ms    10 runs

    Summary
      branch ran
        4.76 ± 0.22 times faster than master

However, on ruby-bench, we don't see significant performance changes. This is likely due to the heuristic we use right now where a slice into an embeddable string (which is any string <= 999 bytes) it will always copy instead of using a view. We may need to change this heuristic.

    --------------  -------------  ------------  ------------  ------------  --------------  -------------  -----------------
    bench             master (ms)     RSS (MiB)   branch (ms)     RSS (MiB)  branch 1st itr  master/branch  RSS master/branch
    activerecord     103.4 ± 3.0%   74.5 ± 0.8%  106.5 ± 3.2%   77.7 ± 3.5%           0.918          0.971              0.958
    chunky-png       341.7 ± 0.7%   83.4 ± 3.6%  347.7 ± 1.0%   90.3 ± 3.0%           0.996          0.983              0.924
    erubi-rails      466.3 ± 2.5%  140.0 ± 0.3%  458.7 ± 2.7%  135.0 ± 0.1%           1.156          1.017              1.037
    hexapdf          906.2 ± 0.8%  651.4 ± 1.7%  914.3 ± 1.2%  589.4 ± 1.0%           0.996          0.991              1.105
    liquid-c         24.2 ± 10.4%  71.5 ± 16.2%   23.8 ± 8.8%  67.9 ± 13.4%           1.078          1.018              1.053
    liquid-compile    21.4 ± 8.6%   46.8 ± 5.5%   22.2 ± 4.6%   42.2 ± 1.7%           0.898          0.963              1.108
    liquid-render     57.8 ± 3.6%   56.0 ± 7.5%   58.8 ± 4.2%  55.0 ± 10.0%           0.955          0.982              1.017
    lobsters        411.4 ± 10.1%  333.6 ± 0.1%  393.7 ± 2.0%  334.5 ± 0.2%           1.058          1.045              0.997
    mail              50.7 ± 2.7%   76.0 ± 2.6%   50.7 ± 3.5%   75.6 ± 2.0%           0.993          1.000              1.004
    psych-load       854.9 ± 1.0%   55.8 ± 0.4%  859.9 ± 1.1%   55.1 ± 0.5%           1.007          0.994              1.012
    railsbench       771.7 ± 1.1%  135.8 ± 1.1%  787.2 ± 3.1%  135.2 ± 1.0%           1.032          0.980              1.004
    rubocop           78.4 ± 6.3%  105.3 ± 1.1%   79.9 ± 7.4%  106.7 ± 2.0%           0.994          0.981              0.988
    ruby-lsp          69.6 ± 2.3%   71.5 ± 0.0%   70.3 ± 2.9%   70.8 ± 0.2%           1.013          0.990              1.009
    sequel            22.6 ± 4.9%   55.3 ± 1.3%   23.2 ± 5.5%   55.3 ± 1.3%           0.908          0.973              0.999
    shipit           666.8 ± 1.8%  160.0 ± 0.6%  671.4 ± 1.4%  159.8 ± 0.4%           1.012          0.993              1.002
    --------------  -------------  ------------  ------------  ------------  --------------  -------------  -----------------