### PR TITLE
Add ruby-devel package and install fiddle gem for Cygwin CI

### DIFF
--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -47,9 +47,14 @@ jobs:
       - name: Setup Cygwin
         uses: cygwin/cygwin-install-action@3f0a3f9f988f7e96b8c18098ae05eaec175f5b52 # v6.1
         with:
-          packages: ruby gcc-core make autoconf libtool libssl-devel libyaml-devel libffi-devel zlib-devel rubygems
+          packages: ruby gcc-core make autoconf libtool libssl-devel libyaml-devel libffi-devel zlib-devel rubygems ruby-devel
           site: |
             https://cygwin.osuosl.org/
+
+      - name: Install fiddle
+        run: |
+          gem install fiddle
+        shell: C:\cygwin\bin\bash.EXE --noprofile --norc -e -o igncr -o pipefail {0}
 
       - name: configure
         run: |


### PR DESCRIPTION
Since the Ruby version distributed by the official Cygwin repository was updated from 3.4.7 to 4.0.5 ( [ruby 4\.0\.5\-1 \(TEST\)](https://cygwin.com/pipermail/cygwin-announce/2026-July/013103.html) ), some libraries are no longer bundled with the `ruby` package and need to be installed explicitly.

- `ruby-devel` is now required to build native extensions (headers that used to ship with `ruby` are now split out into this package).
- `fiddle` is no longer bundled as a default gem, so it needs to be installed explicitly via `gem install fiddle` before configuring.
