### PR TITLE
Dynamically determine max shape capacity

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -625,6 +625,7 @@ typedef struct gc_function_map {
     size_t (*obj_slot_size)(VALUE obj);
     size_t (*size_slot_size)(void *objspace_ptr, size_t size);
     bool (*size_allocatable_p)(size_t size);
+    size_t (*max_allocation_size)(void);
     // Malloc
     void *(*malloc)(void *objspace_ptr, size_t size, bool gc_allowed);
     void *(*calloc)(void *objspace_ptr, size_t size, bool gc_allowed);
@@ -803,6 +804,7 @@ ruby_modular_gc_init(void)
     load_modular_gc_func(obj_slot_size);
     load_modular_gc_func(size_slot_size);
     load_modular_gc_func(size_allocatable_p);
+    load_modular_gc_func(max_allocation_size);
     // Malloc
     load_modular_gc_func(malloc);
     load_modular_gc_func(calloc);
@@ -890,6 +892,7 @@ ruby_modular_gc_init(void)
 # define rb_gc_impl_obj_slot_size rb_gc_functions.obj_slot_size
 # define rb_gc_impl_size_slot_size rb_gc_functions.size_slot_size
 # define rb_gc_impl_size_allocatable_p rb_gc_functions.size_allocatable_p
+# define rb_gc_impl_max_allocation_size rb_gc_functions.max_allocation_size
 // Malloc
 # define rb_gc_impl_malloc rb_gc_functions.malloc
 # define rb_gc_impl_calloc rb_gc_functions.calloc
@@ -1106,8 +1109,8 @@ rb_class_allocate_instance(VALUE klass)
     VALUE obj;
 
     // Directly start as COMPLEX if we know we're over the limit.
-    RUBY_ASSERT(SHAPE_MAX_CAPACITY > 0);
-    if (RB_UNLIKELY(index_tbl_num_entries > SHAPE_MAX_CAPACITY)) {
+    RUBY_ASSERT(rb_shape_max_capacity() > 0);
+    if (RB_UNLIKELY(index_tbl_num_entries > rb_shape_max_capacity())) {
         obj = class_allocate_complex_instance(klass, index_tbl_num_entries);
     }
     else {
@@ -4007,6 +4010,12 @@ bool
 rb_gc_size_allocatable_p(size_t size)
 {
     return rb_gc_impl_size_allocatable_p(size);
+}
+
+size_t
+rb_gc_max_allocation_size(void)
+{
+    return rb_gc_impl_max_allocation_size();
 }
 
 static enum rb_id_table_iterator_result

--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -2458,10 +2458,16 @@ heap_slot_size(unsigned char pool_id)
     return pool_slot_sizes[pool_id] - RVALUE_OVERHEAD;
 }
 
+size_t
+rb_gc_impl_max_allocation_size(void)
+{
+    return heap_slot_size(HEAP_COUNT - 1);
+}
+
 bool
 rb_gc_impl_size_allocatable_p(size_t size)
 {
-    return size + RVALUE_OVERHEAD <= pool_slot_sizes[HEAP_COUNT - 1];
+    return size <= rb_gc_impl_max_allocation_size();
 }
 
 static const size_t ALLOCATED_COUNT_STEP = 1024;
@@ -10332,7 +10338,7 @@ rb_gc_impl_init(void)
     rb_hash_aset(gc_constants, ID2SYM(rb_intern("HEAP_PAGE_BITMAP_SIZE")), SIZET2NUM(HEAP_PAGE_BITMAP_SIZE));
     rb_hash_aset(gc_constants, ID2SYM(rb_intern("HEAP_PAGE_SIZE")), SIZET2NUM(HEAP_PAGE_SIZE));
     rb_hash_aset(gc_constants, ID2SYM(rb_intern("HEAP_COUNT")), LONG2FIX(HEAP_COUNT));
-    rb_hash_aset(gc_constants, ID2SYM(rb_intern("RVARGC_MAX_ALLOCATE_SIZE")), LONG2FIX(heap_slot_size(HEAP_COUNT - 1)));
+    rb_hash_aset(gc_constants, ID2SYM(rb_intern("RVARGC_MAX_ALLOCATE_SIZE")), SIZET2NUM(rb_gc_impl_max_allocation_size()));
     rb_hash_aset(gc_constants, ID2SYM(rb_intern("RVALUE_OLD_AGE")), LONG2FIX(RVALUE_OLD_AGE));
     if (RB_BUG_INSTEAD_OF_RB_MEMERROR+0) {
         rb_hash_aset(gc_constants, ID2SYM(rb_intern("RB_BUG_INSTEAD_OF_RB_MEMERROR")), Qtrue);

--- a/gc/gc_impl.h
+++ b/gc/gc_impl.h
@@ -59,6 +59,7 @@ GC_IMPL_FN VALUE rb_gc_impl_new_obj(void *objspace_ptr, void *cache_ptr, VALUE k
 GC_IMPL_FN size_t rb_gc_impl_obj_slot_size(VALUE obj);
 GC_IMPL_FN size_t rb_gc_impl_size_slot_size(void *objspace_ptr, size_t size);
 GC_IMPL_FN bool rb_gc_impl_size_allocatable_p(size_t size);
+GC_IMPL_FN size_t rb_gc_impl_max_allocation_size(void);
 // Malloc
 /*
  * BEWARE: These functions may or may not run under GVL.

--- a/gc/mmtk/mmtk.c
+++ b/gc/mmtk/mmtk.c
@@ -670,7 +670,7 @@ rb_gc_impl_init(void)
     rb_hash_aset(gc_constants, ID2SYM(rb_intern("RVALUE_SIZE")), SIZET2NUM(SIZEOF_VALUE >= 8 ? 64 : 32));
     rb_hash_aset(gc_constants, ID2SYM(rb_intern("RBASIC_SIZE")), SIZET2NUM(sizeof(struct RBasic)));
     rb_hash_aset(gc_constants, ID2SYM(rb_intern("RVALUE_OVERHEAD")), INT2NUM(0));
-    rb_hash_aset(gc_constants, ID2SYM(rb_intern("RVARGC_MAX_ALLOCATE_SIZE")), LONG2FIX(MMTK_MAX_OBJ_SIZE));
+    rb_hash_aset(gc_constants, ID2SYM(rb_intern("RVARGC_MAX_ALLOCATE_SIZE")), SIZET2NUM(rb_gc_impl_max_allocation_size()));
     rb_hash_aset(gc_constants, ID2SYM(rb_intern("HEAP_COUNT")), LONG2FIX(MMTK_HEAP_COUNT));
     // TODO: correctly set RVALUE_OLD_AGE when we have generational GC support
     rb_hash_aset(gc_constants, ID2SYM(rb_intern("RVALUE_OLD_AGE")), INT2FIX(0));
@@ -969,7 +969,13 @@ rb_gc_impl_size_slot_size(void *objspace_ptr, size_t size)
 bool
 rb_gc_impl_size_allocatable_p(size_t size)
 {
-    return size <= MMTK_MAX_OBJ_SIZE;
+    return size <= rb_gc_impl_max_allocation_size();
+}
+
+size_t
+rb_gc_impl_max_allocation_size(void)
+{
+    return MMTK_MAX_OBJ_SIZE;
 }
 
 // Malloc

--- a/gc/wbcheck/wbcheck.c
+++ b/gc/wbcheck/wbcheck.c
@@ -518,7 +518,7 @@ rb_gc_impl_init(void)
     rb_hash_aset(gc_constants, ID2SYM(rb_intern("RVALUE_SIZE")), SIZET2NUM(sizeof(struct RBasic) + sizeof(VALUE[RBIMPL_RVALUE_EMBED_LEN_MAX])));
     rb_hash_aset(gc_constants, ID2SYM(rb_intern("RBASIC_SIZE")), SIZET2NUM(sizeof(struct RBasic)));
     rb_hash_aset(gc_constants, ID2SYM(rb_intern("RVALUE_OVERHEAD")), INT2NUM(0));
-    rb_hash_aset(gc_constants, ID2SYM(rb_intern("RVARGC_MAX_ALLOCATE_SIZE")), LONG2FIX(MAX_HEAP_SIZE));
+    rb_hash_aset(gc_constants, ID2SYM(rb_intern("RVARGC_MAX_ALLOCATE_SIZE")), SIZET2NUM(rb_gc_impl_max_allocation_size()));
     rb_hash_aset(gc_constants, ID2SYM(rb_intern("HEAP_COUNT")), LONG2FIX(HEAP_COUNT));
     rb_hash_aset(gc_constants, ID2SYM(rb_intern("SIZE_POOL_COUNT")), LONG2FIX(HEAP_COUNT));
     rb_hash_aset(gc_constants, ID2SYM(rb_intern("RVALUE_OLD_AGE")), INT2FIX(3));
@@ -1127,7 +1127,13 @@ bool
 rb_gc_impl_size_allocatable_p(size_t size)
 {
     // Only allow sizes up to the largest heap size
-    return size <= MAX_HEAP_SIZE;
+    return size <= rb_gc_impl_max_allocation_size();
+}
+
+size_t
+rb_gc_impl_max_allocation_size(void)
+{
+    return MAX_HEAP_SIZE;
 }
 
 // Malloc

--- a/internal/gc.h
+++ b/internal/gc.h
@@ -206,6 +206,7 @@ void rb_gc_ractor_cache_free(void *cache);
 
 bool rb_gc_size_allocatable_p(size_t size);
 size_t rb_gc_size_slot_size(size_t size);
+size_t rb_gc_max_allocation_size(void);
 
 void rb_gc_mark_and_move(VALUE *ptr);
 

--- a/shape.c
+++ b/shape.c
@@ -516,7 +516,7 @@ shape_grow_capa(attr_index_t current_capa)
 {
     size_t next_size = rb_obj_embedded_size(current_capa + 1);
     if (UNLIKELY(!rb_gc_size_allocatable_p(next_size))) {
-        return SHAPE_MAX_CAPACITY;
+        return rb_shape_max_capacity();
     }
 
     attr_index_t next_capa = rb_shape_capacity_for_slot_size(rb_gc_size_slot_size(next_size));
@@ -700,7 +700,7 @@ rb_shape_transition_object_id(shape_id_t original_shape_id)
 
     bool dont_care;
     rb_shape_t *shape = NULL;
-    if (LIKELY(original_shape->next_field_index < SHAPE_MAX_CAPACITY)) {
+    if (LIKELY(original_shape->next_field_index < rb_shape_max_capacity())) {
         shape = get_next_shape_internal(original_shape, id_object_id, SHAPE_OBJ_ID, &dont_care, true);
     }
     if (!shape) {
@@ -765,8 +765,9 @@ shape_get_next(rb_shape_t *shape, enum shape_type shape_type, VALUE klass, ID id
     }
 #endif
 
-    RUBY_ASSERT(SHAPE_MAX_CAPACITY > 0);
-    if (UNLIKELY(shape->next_field_index >= SHAPE_MAX_CAPACITY)) {
+    RUBY_ASSERT(SHAPE_ID_CAPACITY_MAX > 0);
+    RUBY_ASSERT(rb_shape_max_capacity() > 0);
+    if (UNLIKELY(shape->next_field_index >= rb_shape_max_capacity())) {
         return NULL;
     }
 
@@ -1558,6 +1559,10 @@ rb_shape_find_by_id(VALUE mod, VALUE id)
 void
 Init_default_shapes(void)
 {
+    attr_index_t max_capacity = (attr_index_t)((rb_gc_max_allocation_size() - sizeof(struct RBasic)) / sizeof(VALUE));
+    if (max_capacity > SHAPE_ID_CAPACITY_MAX) max_capacity = SHAPE_ID_CAPACITY_MAX;
+    rb_shape_tree.max_capacity = max_capacity;
+
 #ifdef HAVE_MMAP
     size_t shape_list_mmap_size = rb_size_mul_or_raise(SHAPE_BUFFER_SIZE, sizeof(rb_shape_t), rb_eRuntimeError);
     rb_shape_tree.shape_list = (rb_shape_t *)mmap(NULL, shape_list_mmap_size,
@@ -1651,7 +1656,7 @@ Init_shape(void)
     rb_define_const(rb_cShape, "SHAPE_ID_NUM_BITS", INT2NUM(SHAPE_ID_NUM_BITS));
     rb_define_const(rb_cShape, "SHAPE_FLAG_SHIFT", INT2NUM(SHAPE_FLAG_SHIFT));
     rb_define_const(rb_cShape, "SHAPE_MAX_VARIATIONS", INT2NUM(SHAPE_MAX_VARIATIONS));
-    rb_define_const(rb_cShape, "SHAPE_MAX_FIELDS", INT2NUM(SHAPE_MAX_CAPACITY));
+    rb_define_const(rb_cShape, "SHAPE_MAX_FIELDS", INT2NUM(rb_shape_max_capacity()));
     rb_define_const(rb_cShape, "SIZEOF_RB_SHAPE_T", INT2NUM(sizeof(rb_shape_t)));
     rb_define_const(rb_cShape, "SIZEOF_REDBLACK_NODE_T", INT2NUM(sizeof(redblack_node_t)));
     rb_define_const(rb_cShape, "SHAPE_BUFFER_SIZE", INT2NUM(sizeof(rb_shape_t) * SHAPE_BUFFER_SIZE));

--- a/shape.h
+++ b/shape.h
@@ -89,17 +89,8 @@ typedef uint32_t redblack_id_t;
 
 #define SHAPE_MAX_VARIATIONS 8
 
-// TODO: Fix this so that the max capacity does not depend on the CPU architecture
-#if RBASIC_SHAPE_ID_FIELD
-# define SHAPE_MAX_CAPACITY 125
-#else
-# define SHAPE_MAX_CAPACITY 126
-#endif
-
 #define INVALID_SHAPE_ID (SHAPE_BUFFER_SIZE - 1)
 #define ATTR_INDEX_NOT_SET ((attr_index_t)-1)
-
-STATIC_ASSERT(shape_max_capacity, SHAPE_MAX_CAPACITY <= SHAPE_ID_CAPACITY_MAX);
 
 #define ROOT_SHAPE_ID                   0x0
 #define ROOT_SHAPE_WITH_OBJ_ID          0x1
@@ -134,6 +125,7 @@ enum shape_flags {
 
 typedef struct {
     rb_shape_t *shape_list;
+    attr_index_t max_capacity;
 } rb_shape_tree_t;
 
 RUBY_SYMBOL_EXPORT_BEGIN
@@ -142,6 +134,12 @@ RUBY_SYMBOL_EXPORT_END
 
 size_t rb_shapes_cache_size(void);
 size_t rb_shapes_count(void);
+
+static inline attr_index_t
+rb_shape_max_capacity(void)
+{
+    return rb_shape_tree.max_capacity;
+}
 
 static inline shape_id_t
 RBASIC_SHAPE_ID(VALUE obj)


### PR DESCRIPTION
SHAPE_MAX_CAPACITY needed to be below or equal to the maximum capacity allocatable by the GC otherwise it would crash. This commit decouples that by adding back max_capacity in the rb_shape_tree_t and adding a new GC API function rb_gc_impl_max_allocation_size to report the maximum size allocatable by the GC.