### PR TITLE
encoding.c: use RB_OBJ_SET_SHAREABLE instead of raw FL_SET_RAW

### DIFF
--- a/encoding.c
+++ b/encoding.c
@@ -158,7 +158,7 @@ enc_list_update(int index, rb_raw_encoding *encoding)
         /* initialize encoding data */
         rb_ary_store(new_list, index, enc_new(encoding));
         rb_ary_freeze(new_list);
-        FL_SET_RAW(new_list, RUBY_FL_SHAREABLE);
+        RB_OBJ_SET_SHAREABLE(new_list);
         RUBY_ATOMIC_VALUE_SET(rb_encoding_list, new_list);
     }
 }


### PR DESCRIPTION
enc_list_update makes the frozen encoding list shareable by setting RUBY_FL_SHAREABLE directly. Use the public RB_OBJ_SET_SHAREABLE() helper instead, which is the intended way to mark an object shareable (rb_obj_set_shareable). No behavioural change on the shared interpreter; it keeps the encoding-list sharing off the raw-flag path.