### PR TITLE
io.c: use a write barrier when storing IO#timeout=

### DIFF
--- a/io.c
+++ b/io.c
@@ -895,7 +895,7 @@ rb_io_set_timeout(VALUE self, VALUE timeout)
 
     rb_io_t *fptr = rb_io_get_fptr(self);
 
-    fptr->timeout = timeout;
+    RB_OBJ_WRITE(self, &fptr->timeout, timeout);
 
     return self;
 }


### PR DESCRIPTION
rb_io_set_timeout stores the timeout VALUE into the IO's fptr with a plain assignment, missing the generational write barrier for the old->young reference. Use RB_OBJ_WRITE.