### PR TITLE
Make T_REGEXP embedded

### DIFF
--- a/depend
+++ b/depend
@@ -3002,6 +3002,7 @@ debug_counter.$(OBJEXT): {$(VPATH)}internal/variable.h
 debug_counter.$(OBJEXT): {$(VPATH)}internal/warning_push.h
 debug_counter.$(OBJEXT): {$(VPATH)}internal/xmalloc.h
 debug_counter.$(OBJEXT): {$(VPATH)}missing.h
+debug_counter.$(OBJEXT): {$(VPATH)}onigmo.h
 debug_counter.$(OBJEXT): {$(VPATH)}st.h
 debug_counter.$(OBJEXT): {$(VPATH)}subst.h
 debug_counter.$(OBJEXT): {$(VPATH)}thread_native.h
@@ -3385,6 +3386,7 @@ dln.$(OBJEXT): {$(VPATH)}internal/variable.h
 dln.$(OBJEXT): {$(VPATH)}internal/warning_push.h
 dln.$(OBJEXT): {$(VPATH)}internal/xmalloc.h
 dln.$(OBJEXT): {$(VPATH)}missing.h
+dln.$(OBJEXT): {$(VPATH)}onigmo.h
 dln.$(OBJEXT): {$(VPATH)}st.h
 dln.$(OBJEXT): {$(VPATH)}subst.h
 dln_find.$(OBJEXT): $(hdrdir)/ruby/ruby.h
@@ -3544,6 +3546,7 @@ dln_find.$(OBJEXT): {$(VPATH)}internal/variable.h
 dln_find.$(OBJEXT): {$(VPATH)}internal/warning_push.h
 dln_find.$(OBJEXT): {$(VPATH)}internal/xmalloc.h
 dln_find.$(OBJEXT): {$(VPATH)}missing.h
+dln_find.$(OBJEXT): {$(VPATH)}onigmo.h
 dln_find.$(OBJEXT): {$(VPATH)}st.h
 dln_find.$(OBJEXT): {$(VPATH)}subst.h
 dmydln.$(OBJEXT): $(hdrdir)/ruby/ruby.h
@@ -3702,6 +3705,7 @@ dmydln.$(OBJEXT): {$(VPATH)}internal/variable.h
 dmydln.$(OBJEXT): {$(VPATH)}internal/warning_push.h
 dmydln.$(OBJEXT): {$(VPATH)}internal/xmalloc.h
 dmydln.$(OBJEXT): {$(VPATH)}missing.h
+dmydln.$(OBJEXT): {$(VPATH)}onigmo.h
 dmydln.$(OBJEXT): {$(VPATH)}st.h
 dmydln.$(OBJEXT): {$(VPATH)}subst.h
 dmyenc.$(OBJEXT): {$(VPATH)}dmyenc.c
@@ -7103,6 +7107,7 @@ inits.$(OBJEXT): {$(VPATH)}internal/variable.h
 inits.$(OBJEXT): {$(VPATH)}internal/warning_push.h
 inits.$(OBJEXT): {$(VPATH)}internal/xmalloc.h
 inits.$(OBJEXT): {$(VPATH)}missing.h
+inits.$(OBJEXT): {$(VPATH)}onigmo.h
 inits.$(OBJEXT): {$(VPATH)}prelude.rbinc
 inits.$(OBJEXT): {$(VPATH)}st.h
 inits.$(OBJEXT): {$(VPATH)}subst.h
@@ -8519,6 +8524,7 @@ loadpath.$(OBJEXT): {$(VPATH)}internal/warning_push.h
 loadpath.$(OBJEXT): {$(VPATH)}internal/xmalloc.h
 loadpath.$(OBJEXT): {$(VPATH)}loadpath.c
 loadpath.$(OBJEXT): {$(VPATH)}missing.h
+loadpath.$(OBJEXT): {$(VPATH)}onigmo.h
 loadpath.$(OBJEXT): {$(VPATH)}st.h
 loadpath.$(OBJEXT): {$(VPATH)}subst.h
 loadpath.$(OBJEXT): {$(VPATH)}verconf.h
@@ -8856,6 +8862,7 @@ main.$(OBJEXT): {$(VPATH)}internal/warning_push.h
 main.$(OBJEXT): {$(VPATH)}internal/xmalloc.h
 main.$(OBJEXT): {$(VPATH)}main.c
 main.$(OBJEXT): {$(VPATH)}missing.h
+main.$(OBJEXT): {$(VPATH)}onigmo.h
 main.$(OBJEXT): {$(VPATH)}st.h
 main.$(OBJEXT): {$(VPATH)}subst.h
 main.$(OBJEXT): {$(VPATH)}vm_debug.h
@@ -9262,6 +9269,7 @@ math.$(OBJEXT): {$(VPATH)}internal/warning_push.h
 math.$(OBJEXT): {$(VPATH)}internal/xmalloc.h
 math.$(OBJEXT): {$(VPATH)}math.c
 math.$(OBJEXT): {$(VPATH)}missing.h
+math.$(OBJEXT): {$(VPATH)}onigmo.h
 math.$(OBJEXT): {$(VPATH)}shape.h
 math.$(OBJEXT): {$(VPATH)}st.h
 math.$(OBJEXT): {$(VPATH)}subst.h
@@ -16652,6 +16660,7 @@ setproctitle.$(OBJEXT): {$(VPATH)}internal/variable.h
 setproctitle.$(OBJEXT): {$(VPATH)}internal/warning_push.h
 setproctitle.$(OBJEXT): {$(VPATH)}internal/xmalloc.h
 setproctitle.$(OBJEXT): {$(VPATH)}missing.h
+setproctitle.$(OBJEXT): {$(VPATH)}onigmo.h
 setproctitle.$(OBJEXT): {$(VPATH)}setproctitle.c
 setproctitle.$(OBJEXT): {$(VPATH)}st.h
 setproctitle.$(OBJEXT): {$(VPATH)}subst.h
@@ -19263,6 +19272,7 @@ util.$(OBJEXT): {$(VPATH)}internal/variable.h
 util.$(OBJEXT): {$(VPATH)}internal/warning_push.h
 util.$(OBJEXT): {$(VPATH)}internal/xmalloc.h
 util.$(OBJEXT): {$(VPATH)}missing.h
+util.$(OBJEXT): {$(VPATH)}onigmo.h
 util.$(OBJEXT): {$(VPATH)}ruby_atomic.h
 util.$(OBJEXT): {$(VPATH)}st.h
 util.$(OBJEXT): {$(VPATH)}subst.h

--- a/enc/depend
+++ b/enc/depend
@@ -5243,6 +5243,7 @@ enc/trans/big5.$(OBJEXT): internal/variable.h
 enc/trans/big5.$(OBJEXT): internal/warning_push.h
 enc/trans/big5.$(OBJEXT): internal/xmalloc.h
 enc/trans/big5.$(OBJEXT): missing.h
+enc/trans/big5.$(OBJEXT): onigmo.h
 enc/trans/big5.$(OBJEXT): st.h
 enc/trans/big5.$(OBJEXT): subst.h
 enc/trans/cesu_8.$(OBJEXT): $(hdrdir)/ruby/ruby.h
@@ -5403,6 +5404,7 @@ enc/trans/cesu_8.$(OBJEXT): internal/variable.h
 enc/trans/cesu_8.$(OBJEXT): internal/warning_push.h
 enc/trans/cesu_8.$(OBJEXT): internal/xmalloc.h
 enc/trans/cesu_8.$(OBJEXT): missing.h
+enc/trans/cesu_8.$(OBJEXT): onigmo.h
 enc/trans/cesu_8.$(OBJEXT): st.h
 enc/trans/cesu_8.$(OBJEXT): subst.h
 enc/trans/chinese.$(OBJEXT): $(hdrdir)/ruby/ruby.h
@@ -5563,6 +5565,7 @@ enc/trans/chinese.$(OBJEXT): internal/variable.h
 enc/trans/chinese.$(OBJEXT): internal/warning_push.h
 enc/trans/chinese.$(OBJEXT): internal/xmalloc.h
 enc/trans/chinese.$(OBJEXT): missing.h
+enc/trans/chinese.$(OBJEXT): onigmo.h
 enc/trans/chinese.$(OBJEXT): st.h
 enc/trans/chinese.$(OBJEXT): subst.h
 enc/trans/ebcdic.$(OBJEXT): $(hdrdir)/ruby/ruby.h
@@ -5723,6 +5726,7 @@ enc/trans/ebcdic.$(OBJEXT): internal/variable.h
 enc/trans/ebcdic.$(OBJEXT): internal/warning_push.h
 enc/trans/ebcdic.$(OBJEXT): internal/xmalloc.h
 enc/trans/ebcdic.$(OBJEXT): missing.h
+enc/trans/ebcdic.$(OBJEXT): onigmo.h
 enc/trans/ebcdic.$(OBJEXT): st.h
 enc/trans/ebcdic.$(OBJEXT): subst.h
 enc/trans/emoji.$(OBJEXT): $(hdrdir)/ruby/ruby.h
@@ -5883,6 +5887,7 @@ enc/trans/emoji.$(OBJEXT): internal/variable.h
 enc/trans/emoji.$(OBJEXT): internal/warning_push.h
 enc/trans/emoji.$(OBJEXT): internal/xmalloc.h
 enc/trans/emoji.$(OBJEXT): missing.h
+enc/trans/emoji.$(OBJEXT): onigmo.h
 enc/trans/emoji.$(OBJEXT): st.h
 enc/trans/emoji.$(OBJEXT): subst.h
 enc/trans/emoji_iso2022_kddi.$(OBJEXT): $(hdrdir)/ruby/ruby.h
@@ -6043,6 +6048,7 @@ enc/trans/emoji_iso2022_kddi.$(OBJEXT): internal/variable.h
 enc/trans/emoji_iso2022_kddi.$(OBJEXT): internal/warning_push.h
 enc/trans/emoji_iso2022_kddi.$(OBJEXT): internal/xmalloc.h
 enc/trans/emoji_iso2022_kddi.$(OBJEXT): missing.h
+enc/trans/emoji_iso2022_kddi.$(OBJEXT): onigmo.h
 enc/trans/emoji_iso2022_kddi.$(OBJEXT): st.h
 enc/trans/emoji_iso2022_kddi.$(OBJEXT): subst.h
 enc/trans/emoji_sjis_docomo.$(OBJEXT): $(hdrdir)/ruby/ruby.h
@@ -6203,6 +6209,7 @@ enc/trans/emoji_sjis_docomo.$(OBJEXT): internal/variable.h
 enc/trans/emoji_sjis_docomo.$(OBJEXT): internal/warning_push.h
 enc/trans/emoji_sjis_docomo.$(OBJEXT): internal/xmalloc.h
 enc/trans/emoji_sjis_docomo.$(OBJEXT): missing.h
+enc/trans/emoji_sjis_docomo.$(OBJEXT): onigmo.h
 enc/trans/emoji_sjis_docomo.$(OBJEXT): st.h
 enc/trans/emoji_sjis_docomo.$(OBJEXT): subst.h
 enc/trans/emoji_sjis_kddi.$(OBJEXT): $(hdrdir)/ruby/ruby.h
@@ -6363,6 +6370,7 @@ enc/trans/emoji_sjis_kddi.$(OBJEXT): internal/variable.h
 enc/trans/emoji_sjis_kddi.$(OBJEXT): internal/warning_push.h
 enc/trans/emoji_sjis_kddi.$(OBJEXT): internal/xmalloc.h
 enc/trans/emoji_sjis_kddi.$(OBJEXT): missing.h
+enc/trans/emoji_sjis_kddi.$(OBJEXT): onigmo.h
 enc/trans/emoji_sjis_kddi.$(OBJEXT): st.h
 enc/trans/emoji_sjis_kddi.$(OBJEXT): subst.h
 enc/trans/emoji_sjis_softbank.$(OBJEXT): $(hdrdir)/ruby/ruby.h
@@ -6523,6 +6531,7 @@ enc/trans/emoji_sjis_softbank.$(OBJEXT): internal/variable.h
 enc/trans/emoji_sjis_softbank.$(OBJEXT): internal/warning_push.h
 enc/trans/emoji_sjis_softbank.$(OBJEXT): internal/xmalloc.h
 enc/trans/emoji_sjis_softbank.$(OBJEXT): missing.h
+enc/trans/emoji_sjis_softbank.$(OBJEXT): onigmo.h
 enc/trans/emoji_sjis_softbank.$(OBJEXT): st.h
 enc/trans/emoji_sjis_softbank.$(OBJEXT): subst.h
 enc/trans/escape.$(OBJEXT): $(hdrdir)/ruby/ruby.h
@@ -6683,6 +6692,7 @@ enc/trans/escape.$(OBJEXT): internal/variable.h
 enc/trans/escape.$(OBJEXT): internal/warning_push.h
 enc/trans/escape.$(OBJEXT): internal/xmalloc.h
 enc/trans/escape.$(OBJEXT): missing.h
+enc/trans/escape.$(OBJEXT): onigmo.h
 enc/trans/escape.$(OBJEXT): st.h
 enc/trans/escape.$(OBJEXT): subst.h
 enc/trans/gb18030.$(OBJEXT): $(hdrdir)/ruby/ruby.h
@@ -6843,6 +6853,7 @@ enc/trans/gb18030.$(OBJEXT): internal/variable.h
 enc/trans/gb18030.$(OBJEXT): internal/warning_push.h
 enc/trans/gb18030.$(OBJEXT): internal/xmalloc.h
 enc/trans/gb18030.$(OBJEXT): missing.h
+enc/trans/gb18030.$(OBJEXT): onigmo.h
 enc/trans/gb18030.$(OBJEXT): st.h
 enc/trans/gb18030.$(OBJEXT): subst.h
 enc/trans/gbk.$(OBJEXT): $(hdrdir)/ruby/ruby.h
@@ -7003,6 +7014,7 @@ enc/trans/gbk.$(OBJEXT): internal/variable.h
 enc/trans/gbk.$(OBJEXT): internal/warning_push.h
 enc/trans/gbk.$(OBJEXT): internal/xmalloc.h
 enc/trans/gbk.$(OBJEXT): missing.h
+enc/trans/gbk.$(OBJEXT): onigmo.h
 enc/trans/gbk.$(OBJEXT): st.h
 enc/trans/gbk.$(OBJEXT): subst.h
 enc/trans/iso2022.$(OBJEXT): $(hdrdir)/ruby/ruby.h
@@ -7164,6 +7176,7 @@ enc/trans/iso2022.$(OBJEXT): internal/variable.h
 enc/trans/iso2022.$(OBJEXT): internal/warning_push.h
 enc/trans/iso2022.$(OBJEXT): internal/xmalloc.h
 enc/trans/iso2022.$(OBJEXT): missing.h
+enc/trans/iso2022.$(OBJEXT): onigmo.h
 enc/trans/iso2022.$(OBJEXT): st.h
 enc/trans/iso2022.$(OBJEXT): subst.h
 enc/trans/japanese.$(OBJEXT): $(hdrdir)/ruby/ruby.h
@@ -7324,6 +7337,7 @@ enc/trans/japanese.$(OBJEXT): internal/variable.h
 enc/trans/japanese.$(OBJEXT): internal/warning_push.h
 enc/trans/japanese.$(OBJEXT): internal/xmalloc.h
 enc/trans/japanese.$(OBJEXT): missing.h
+enc/trans/japanese.$(OBJEXT): onigmo.h
 enc/trans/japanese.$(OBJEXT): st.h
 enc/trans/japanese.$(OBJEXT): subst.h
 enc/trans/japanese_euc.$(OBJEXT): $(hdrdir)/ruby/ruby.h
@@ -7484,6 +7498,7 @@ enc/trans/japanese_euc.$(OBJEXT): internal/variable.h
 enc/trans/japanese_euc.$(OBJEXT): internal/warning_push.h
 enc/trans/japanese_euc.$(OBJEXT): internal/xmalloc.h
 enc/trans/japanese_euc.$(OBJEXT): missing.h
+enc/trans/japanese_euc.$(OBJEXT): onigmo.h
 enc/trans/japanese_euc.$(OBJEXT): st.h
 enc/trans/japanese_euc.$(OBJEXT): subst.h
 enc/trans/japanese_sjis.$(OBJEXT): $(hdrdir)/ruby/ruby.h
@@ -7644,6 +7659,7 @@ enc/trans/japanese_sjis.$(OBJEXT): internal/variable.h
 enc/trans/japanese_sjis.$(OBJEXT): internal/warning_push.h
 enc/trans/japanese_sjis.$(OBJEXT): internal/xmalloc.h
 enc/trans/japanese_sjis.$(OBJEXT): missing.h
+enc/trans/japanese_sjis.$(OBJEXT): onigmo.h
 enc/trans/japanese_sjis.$(OBJEXT): st.h
 enc/trans/japanese_sjis.$(OBJEXT): subst.h
 enc/trans/korean.$(OBJEXT): $(hdrdir)/ruby/ruby.h
@@ -7804,6 +7820,7 @@ enc/trans/korean.$(OBJEXT): internal/variable.h
 enc/trans/korean.$(OBJEXT): internal/warning_push.h
 enc/trans/korean.$(OBJEXT): internal/xmalloc.h
 enc/trans/korean.$(OBJEXT): missing.h
+enc/trans/korean.$(OBJEXT): onigmo.h
 enc/trans/korean.$(OBJEXT): st.h
 enc/trans/korean.$(OBJEXT): subst.h
 enc/trans/newline.$(OBJEXT): $(hdrdir)/ruby/ruby.h
@@ -7963,6 +7980,7 @@ enc/trans/newline.$(OBJEXT): internal/variable.h
 enc/trans/newline.$(OBJEXT): internal/warning_push.h
 enc/trans/newline.$(OBJEXT): internal/xmalloc.h
 enc/trans/newline.$(OBJEXT): missing.h
+enc/trans/newline.$(OBJEXT): onigmo.h
 enc/trans/newline.$(OBJEXT): st.h
 enc/trans/newline.$(OBJEXT): subst.h
 enc/trans/single_byte.$(OBJEXT): $(hdrdir)/ruby/ruby.h
@@ -8123,6 +8141,7 @@ enc/trans/single_byte.$(OBJEXT): internal/variable.h
 enc/trans/single_byte.$(OBJEXT): internal/warning_push.h
 enc/trans/single_byte.$(OBJEXT): internal/xmalloc.h
 enc/trans/single_byte.$(OBJEXT): missing.h
+enc/trans/single_byte.$(OBJEXT): onigmo.h
 enc/trans/single_byte.$(OBJEXT): st.h
 enc/trans/single_byte.$(OBJEXT): subst.h
 enc/trans/transdb.$(OBJEXT): $(hdrdir)/ruby.h
@@ -8283,6 +8302,7 @@ enc/trans/transdb.$(OBJEXT): internal/variable.h
 enc/trans/transdb.$(OBJEXT): internal/warning_push.h
 enc/trans/transdb.$(OBJEXT): internal/xmalloc.h
 enc/trans/transdb.$(OBJEXT): missing.h
+enc/trans/transdb.$(OBJEXT): onigmo.h
 enc/trans/transdb.$(OBJEXT): st.h
 enc/trans/transdb.$(OBJEXT): subst.h
 enc/trans/transdb.$(OBJEXT): transdb.h
@@ -8444,6 +8464,7 @@ enc/trans/utf8_mac.$(OBJEXT): internal/variable.h
 enc/trans/utf8_mac.$(OBJEXT): internal/warning_push.h
 enc/trans/utf8_mac.$(OBJEXT): internal/xmalloc.h
 enc/trans/utf8_mac.$(OBJEXT): missing.h
+enc/trans/utf8_mac.$(OBJEXT): onigmo.h
 enc/trans/utf8_mac.$(OBJEXT): st.h
 enc/trans/utf8_mac.$(OBJEXT): subst.h
 enc/trans/utf_16_32.$(OBJEXT): $(hdrdir)/ruby/ruby.h
@@ -8604,6 +8625,7 @@ enc/trans/utf_16_32.$(OBJEXT): internal/variable.h
 enc/trans/utf_16_32.$(OBJEXT): internal/warning_push.h
 enc/trans/utf_16_32.$(OBJEXT): internal/xmalloc.h
 enc/trans/utf_16_32.$(OBJEXT): missing.h
+enc/trans/utf_16_32.$(OBJEXT): onigmo.h
 enc/trans/utf_16_32.$(OBJEXT): st.h
 enc/trans/utf_16_32.$(OBJEXT): subst.h
 enc/unicode.$(OBJEXT): $(UNICODE_HDR_DIR)/casefold.h

--- a/ext/-test-/RUBY_ALIGNOF/depend
+++ b/ext/-test-/RUBY_ALIGNOF/depend
@@ -156,6 +156,7 @@ c.o: $(hdrdir)/ruby/internal/variable.h
 c.o: $(hdrdir)/ruby/internal/warning_push.h
 c.o: $(hdrdir)/ruby/internal/xmalloc.h
 c.o: $(hdrdir)/ruby/missing.h
+c.o: $(hdrdir)/ruby/onigmo.h
 c.o: $(hdrdir)/ruby/ruby.h
 c.o: $(hdrdir)/ruby/st.h
 c.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/arith_seq/beg_len_step/depend
+++ b/ext/-test-/arith_seq/beg_len_step/depend
@@ -155,6 +155,7 @@ beg_len_step.o: $(hdrdir)/ruby/internal/variable.h
 beg_len_step.o: $(hdrdir)/ruby/internal/warning_push.h
 beg_len_step.o: $(hdrdir)/ruby/internal/xmalloc.h
 beg_len_step.o: $(hdrdir)/ruby/missing.h
+beg_len_step.o: $(hdrdir)/ruby/onigmo.h
 beg_len_step.o: $(hdrdir)/ruby/ruby.h
 beg_len_step.o: $(hdrdir)/ruby/st.h
 beg_len_step.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/arith_seq/extract/depend
+++ b/ext/-test-/arith_seq/extract/depend
@@ -155,6 +155,7 @@ extract.o: $(hdrdir)/ruby/internal/variable.h
 extract.o: $(hdrdir)/ruby/internal/warning_push.h
 extract.o: $(hdrdir)/ruby/internal/xmalloc.h
 extract.o: $(hdrdir)/ruby/missing.h
+extract.o: $(hdrdir)/ruby/onigmo.h
 extract.o: $(hdrdir)/ruby/ruby.h
 extract.o: $(hdrdir)/ruby/st.h
 extract.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/array/concat/depend
+++ b/ext/-test-/array/concat/depend
@@ -156,6 +156,7 @@ to_ary_concat.o: $(hdrdir)/ruby/internal/variable.h
 to_ary_concat.o: $(hdrdir)/ruby/internal/warning_push.h
 to_ary_concat.o: $(hdrdir)/ruby/internal/xmalloc.h
 to_ary_concat.o: $(hdrdir)/ruby/missing.h
+to_ary_concat.o: $(hdrdir)/ruby/onigmo.h
 to_ary_concat.o: $(hdrdir)/ruby/ruby.h
 to_ary_concat.o: $(hdrdir)/ruby/st.h
 to_ary_concat.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/array/resize/depend
+++ b/ext/-test-/array/resize/depend
@@ -155,6 +155,7 @@ resize.o: $(hdrdir)/ruby/internal/variable.h
 resize.o: $(hdrdir)/ruby/internal/warning_push.h
 resize.o: $(hdrdir)/ruby/internal/xmalloc.h
 resize.o: $(hdrdir)/ruby/missing.h
+resize.o: $(hdrdir)/ruby/onigmo.h
 resize.o: $(hdrdir)/ruby/ruby.h
 resize.o: $(hdrdir)/ruby/st.h
 resize.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/bignum/depend
+++ b/ext/-test-/bignum/depend
@@ -156,6 +156,7 @@ big2str.o: $(hdrdir)/ruby/internal/variable.h
 big2str.o: $(hdrdir)/ruby/internal/warning_push.h
 big2str.o: $(hdrdir)/ruby/internal/xmalloc.h
 big2str.o: $(hdrdir)/ruby/missing.h
+big2str.o: $(hdrdir)/ruby/onigmo.h
 big2str.o: $(hdrdir)/ruby/ruby.h
 big2str.o: $(hdrdir)/ruby/st.h
 big2str.o: $(hdrdir)/ruby/subst.h
@@ -319,6 +320,7 @@ bigzero.o: $(hdrdir)/ruby/internal/variable.h
 bigzero.o: $(hdrdir)/ruby/internal/warning_push.h
 bigzero.o: $(hdrdir)/ruby/internal/xmalloc.h
 bigzero.o: $(hdrdir)/ruby/missing.h
+bigzero.o: $(hdrdir)/ruby/onigmo.h
 bigzero.o: $(hdrdir)/ruby/ruby.h
 bigzero.o: $(hdrdir)/ruby/st.h
 bigzero.o: $(hdrdir)/ruby/subst.h
@@ -482,6 +484,7 @@ div.o: $(hdrdir)/ruby/internal/variable.h
 div.o: $(hdrdir)/ruby/internal/warning_push.h
 div.o: $(hdrdir)/ruby/internal/xmalloc.h
 div.o: $(hdrdir)/ruby/missing.h
+div.o: $(hdrdir)/ruby/onigmo.h
 div.o: $(hdrdir)/ruby/ruby.h
 div.o: $(hdrdir)/ruby/st.h
 div.o: $(hdrdir)/ruby/subst.h
@@ -645,6 +648,7 @@ init.o: $(hdrdir)/ruby/internal/variable.h
 init.o: $(hdrdir)/ruby/internal/warning_push.h
 init.o: $(hdrdir)/ruby/internal/xmalloc.h
 init.o: $(hdrdir)/ruby/missing.h
+init.o: $(hdrdir)/ruby/onigmo.h
 init.o: $(hdrdir)/ruby/ruby.h
 init.o: $(hdrdir)/ruby/st.h
 init.o: $(hdrdir)/ruby/subst.h
@@ -806,6 +810,7 @@ intpack.o: $(hdrdir)/ruby/internal/variable.h
 intpack.o: $(hdrdir)/ruby/internal/warning_push.h
 intpack.o: $(hdrdir)/ruby/internal/xmalloc.h
 intpack.o: $(hdrdir)/ruby/missing.h
+intpack.o: $(hdrdir)/ruby/onigmo.h
 intpack.o: $(hdrdir)/ruby/ruby.h
 intpack.o: $(hdrdir)/ruby/st.h
 intpack.o: $(hdrdir)/ruby/subst.h
@@ -969,6 +974,7 @@ mul.o: $(hdrdir)/ruby/internal/variable.h
 mul.o: $(hdrdir)/ruby/internal/warning_push.h
 mul.o: $(hdrdir)/ruby/internal/xmalloc.h
 mul.o: $(hdrdir)/ruby/missing.h
+mul.o: $(hdrdir)/ruby/onigmo.h
 mul.o: $(hdrdir)/ruby/ruby.h
 mul.o: $(hdrdir)/ruby/st.h
 mul.o: $(hdrdir)/ruby/subst.h
@@ -1132,6 +1138,7 @@ str2big.o: $(hdrdir)/ruby/internal/variable.h
 str2big.o: $(hdrdir)/ruby/internal/warning_push.h
 str2big.o: $(hdrdir)/ruby/internal/xmalloc.h
 str2big.o: $(hdrdir)/ruby/missing.h
+str2big.o: $(hdrdir)/ruby/onigmo.h
 str2big.o: $(hdrdir)/ruby/ruby.h
 str2big.o: $(hdrdir)/ruby/st.h
 str2big.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/bug-14834/depend
+++ b/ext/-test-/bug-14834/depend
@@ -156,6 +156,7 @@ bug-14834.o: $(hdrdir)/ruby/internal/variable.h
 bug-14834.o: $(hdrdir)/ruby/internal/warning_push.h
 bug-14834.o: $(hdrdir)/ruby/internal/xmalloc.h
 bug-14834.o: $(hdrdir)/ruby/missing.h
+bug-14834.o: $(hdrdir)/ruby/onigmo.h
 bug-14834.o: $(hdrdir)/ruby/ruby.h
 bug-14834.o: $(hdrdir)/ruby/st.h
 bug-14834.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/bug-3571/depend
+++ b/ext/-test-/bug-3571/depend
@@ -156,6 +156,7 @@ bug.o: $(hdrdir)/ruby/internal/variable.h
 bug.o: $(hdrdir)/ruby/internal/warning_push.h
 bug.o: $(hdrdir)/ruby/internal/xmalloc.h
 bug.o: $(hdrdir)/ruby/missing.h
+bug.o: $(hdrdir)/ruby/onigmo.h
 bug.o: $(hdrdir)/ruby/ruby.h
 bug.o: $(hdrdir)/ruby/st.h
 bug.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/bug-5832/depend
+++ b/ext/-test-/bug-5832/depend
@@ -156,6 +156,7 @@ bug.o: $(hdrdir)/ruby/internal/variable.h
 bug.o: $(hdrdir)/ruby/internal/warning_push.h
 bug.o: $(hdrdir)/ruby/internal/xmalloc.h
 bug.o: $(hdrdir)/ruby/missing.h
+bug.o: $(hdrdir)/ruby/onigmo.h
 bug.o: $(hdrdir)/ruby/ruby.h
 bug.o: $(hdrdir)/ruby/st.h
 bug.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/bug_reporter/depend
+++ b/ext/-test-/bug_reporter/depend
@@ -156,6 +156,7 @@ bug_reporter.o: $(hdrdir)/ruby/internal/variable.h
 bug_reporter.o: $(hdrdir)/ruby/internal/warning_push.h
 bug_reporter.o: $(hdrdir)/ruby/internal/xmalloc.h
 bug_reporter.o: $(hdrdir)/ruby/missing.h
+bug_reporter.o: $(hdrdir)/ruby/onigmo.h
 bug_reporter.o: $(hdrdir)/ruby/ruby.h
 bug_reporter.o: $(hdrdir)/ruby/st.h
 bug_reporter.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/class/depend
+++ b/ext/-test-/class/depend
@@ -155,6 +155,7 @@ class2name.o: $(hdrdir)/ruby/internal/variable.h
 class2name.o: $(hdrdir)/ruby/internal/warning_push.h
 class2name.o: $(hdrdir)/ruby/internal/xmalloc.h
 class2name.o: $(hdrdir)/ruby/missing.h
+class2name.o: $(hdrdir)/ruby/onigmo.h
 class2name.o: $(hdrdir)/ruby/ruby.h
 class2name.o: $(hdrdir)/ruby/st.h
 class2name.o: $(hdrdir)/ruby/subst.h
@@ -316,6 +317,7 @@ init.o: $(hdrdir)/ruby/internal/variable.h
 init.o: $(hdrdir)/ruby/internal/warning_push.h
 init.o: $(hdrdir)/ruby/internal/xmalloc.h
 init.o: $(hdrdir)/ruby/missing.h
+init.o: $(hdrdir)/ruby/onigmo.h
 init.o: $(hdrdir)/ruby/ruby.h
 init.o: $(hdrdir)/ruby/st.h
 init.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/debug/depend
+++ b/ext/-test-/debug/depend
@@ -156,6 +156,7 @@ init.o: $(hdrdir)/ruby/internal/variable.h
 init.o: $(hdrdir)/ruby/internal/warning_push.h
 init.o: $(hdrdir)/ruby/internal/xmalloc.h
 init.o: $(hdrdir)/ruby/missing.h
+init.o: $(hdrdir)/ruby/onigmo.h
 init.o: $(hdrdir)/ruby/ruby.h
 init.o: $(hdrdir)/ruby/st.h
 init.o: $(hdrdir)/ruby/subst.h
@@ -317,6 +318,7 @@ inspector.o: $(hdrdir)/ruby/internal/variable.h
 inspector.o: $(hdrdir)/ruby/internal/warning_push.h
 inspector.o: $(hdrdir)/ruby/internal/xmalloc.h
 inspector.o: $(hdrdir)/ruby/missing.h
+inspector.o: $(hdrdir)/ruby/onigmo.h
 inspector.o: $(hdrdir)/ruby/ruby.h
 inspector.o: $(hdrdir)/ruby/st.h
 inspector.o: $(hdrdir)/ruby/subst.h
@@ -478,6 +480,7 @@ profile_frames.o: $(hdrdir)/ruby/internal/variable.h
 profile_frames.o: $(hdrdir)/ruby/internal/warning_push.h
 profile_frames.o: $(hdrdir)/ruby/internal/xmalloc.h
 profile_frames.o: $(hdrdir)/ruby/missing.h
+profile_frames.o: $(hdrdir)/ruby/onigmo.h
 profile_frames.o: $(hdrdir)/ruby/ruby.h
 profile_frames.o: $(hdrdir)/ruby/st.h
 profile_frames.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/dln/empty/depend
+++ b/ext/-test-/dln/empty/depend
@@ -156,6 +156,7 @@ empty.o: $(hdrdir)/ruby/internal/variable.h
 empty.o: $(hdrdir)/ruby/internal/warning_push.h
 empty.o: $(hdrdir)/ruby/internal/xmalloc.h
 empty.o: $(hdrdir)/ruby/missing.h
+empty.o: $(hdrdir)/ruby/onigmo.h
 empty.o: $(hdrdir)/ruby/ruby.h
 empty.o: $(hdrdir)/ruby/st.h
 empty.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/econv/depend
+++ b/ext/-test-/econv/depend
@@ -329,6 +329,7 @@ init.o: $(hdrdir)/ruby/internal/variable.h
 init.o: $(hdrdir)/ruby/internal/warning_push.h
 init.o: $(hdrdir)/ruby/internal/xmalloc.h
 init.o: $(hdrdir)/ruby/missing.h
+init.o: $(hdrdir)/ruby/onigmo.h
 init.o: $(hdrdir)/ruby/ruby.h
 init.o: $(hdrdir)/ruby/st.h
 init.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/ensure_and_callcc/depend
+++ b/ext/-test-/ensure_and_callcc/depend
@@ -156,6 +156,7 @@ ensure_and_callcc.o: $(hdrdir)/ruby/internal/variable.h
 ensure_and_callcc.o: $(hdrdir)/ruby/internal/warning_push.h
 ensure_and_callcc.o: $(hdrdir)/ruby/internal/xmalloc.h
 ensure_and_callcc.o: $(hdrdir)/ruby/missing.h
+ensure_and_callcc.o: $(hdrdir)/ruby/onigmo.h
 ensure_and_callcc.o: $(hdrdir)/ruby/ruby.h
 ensure_and_callcc.o: $(hdrdir)/ruby/st.h
 ensure_and_callcc.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/enumerator_kw/depend
+++ b/ext/-test-/enumerator_kw/depend
@@ -156,6 +156,7 @@ enumerator_kw.o: $(hdrdir)/ruby/internal/variable.h
 enumerator_kw.o: $(hdrdir)/ruby/internal/warning_push.h
 enumerator_kw.o: $(hdrdir)/ruby/internal/xmalloc.h
 enumerator_kw.o: $(hdrdir)/ruby/missing.h
+enumerator_kw.o: $(hdrdir)/ruby/onigmo.h
 enumerator_kw.o: $(hdrdir)/ruby/ruby.h
 enumerator_kw.o: $(hdrdir)/ruby/st.h
 enumerator_kw.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/eval/depend
+++ b/ext/-test-/eval/depend
@@ -155,6 +155,7 @@ eval.o: $(hdrdir)/ruby/internal/variable.h
 eval.o: $(hdrdir)/ruby/internal/warning_push.h
 eval.o: $(hdrdir)/ruby/internal/xmalloc.h
 eval.o: $(hdrdir)/ruby/missing.h
+eval.o: $(hdrdir)/ruby/onigmo.h
 eval.o: $(hdrdir)/ruby/ruby.h
 eval.o: $(hdrdir)/ruby/st.h
 eval.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/exception/depend
+++ b/ext/-test-/exception/depend
@@ -155,6 +155,7 @@ dataerror.o: $(hdrdir)/ruby/internal/variable.h
 dataerror.o: $(hdrdir)/ruby/internal/warning_push.h
 dataerror.o: $(hdrdir)/ruby/internal/xmalloc.h
 dataerror.o: $(hdrdir)/ruby/missing.h
+dataerror.o: $(hdrdir)/ruby/onigmo.h
 dataerror.o: $(hdrdir)/ruby/ruby.h
 dataerror.o: $(hdrdir)/ruby/st.h
 dataerror.o: $(hdrdir)/ruby/subst.h
@@ -489,6 +490,7 @@ ensured.o: $(hdrdir)/ruby/internal/variable.h
 ensured.o: $(hdrdir)/ruby/internal/warning_push.h
 ensured.o: $(hdrdir)/ruby/internal/xmalloc.h
 ensured.o: $(hdrdir)/ruby/missing.h
+ensured.o: $(hdrdir)/ruby/onigmo.h
 ensured.o: $(hdrdir)/ruby/ruby.h
 ensured.o: $(hdrdir)/ruby/st.h
 ensured.o: $(hdrdir)/ruby/subst.h
@@ -650,6 +652,7 @@ init.o: $(hdrdir)/ruby/internal/variable.h
 init.o: $(hdrdir)/ruby/internal/warning_push.h
 init.o: $(hdrdir)/ruby/internal/xmalloc.h
 init.o: $(hdrdir)/ruby/missing.h
+init.o: $(hdrdir)/ruby/onigmo.h
 init.o: $(hdrdir)/ruby/ruby.h
 init.o: $(hdrdir)/ruby/st.h
 init.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/fatal/depend
+++ b/ext/-test-/fatal/depend
@@ -157,6 +157,7 @@ init.o: $(hdrdir)/ruby/internal/variable.h
 init.o: $(hdrdir)/ruby/internal/warning_push.h
 init.o: $(hdrdir)/ruby/internal/xmalloc.h
 init.o: $(hdrdir)/ruby/missing.h
+init.o: $(hdrdir)/ruby/onigmo.h
 init.o: $(hdrdir)/ruby/ruby.h
 init.o: $(hdrdir)/ruby/st.h
 init.o: $(hdrdir)/ruby/subst.h
@@ -318,6 +319,7 @@ invalid.o: $(hdrdir)/ruby/internal/variable.h
 invalid.o: $(hdrdir)/ruby/internal/warning_push.h
 invalid.o: $(hdrdir)/ruby/internal/xmalloc.h
 invalid.o: $(hdrdir)/ruby/missing.h
+invalid.o: $(hdrdir)/ruby/onigmo.h
 invalid.o: $(hdrdir)/ruby/ruby.h
 invalid.o: $(hdrdir)/ruby/st.h
 invalid.o: $(hdrdir)/ruby/subst.h
@@ -479,6 +481,7 @@ rb_fatal.o: $(hdrdir)/ruby/internal/variable.h
 rb_fatal.o: $(hdrdir)/ruby/internal/warning_push.h
 rb_fatal.o: $(hdrdir)/ruby/internal/xmalloc.h
 rb_fatal.o: $(hdrdir)/ruby/missing.h
+rb_fatal.o: $(hdrdir)/ruby/onigmo.h
 rb_fatal.o: $(hdrdir)/ruby/ruby.h
 rb_fatal.o: $(hdrdir)/ruby/st.h
 rb_fatal.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/file/depend
+++ b/ext/-test-/file/depend
@@ -329,6 +329,7 @@ init.o: $(hdrdir)/ruby/internal/variable.h
 init.o: $(hdrdir)/ruby/internal/warning_push.h
 init.o: $(hdrdir)/ruby/internal/xmalloc.h
 init.o: $(hdrdir)/ruby/missing.h
+init.o: $(hdrdir)/ruby/onigmo.h
 init.o: $(hdrdir)/ruby/ruby.h
 init.o: $(hdrdir)/ruby/st.h
 init.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/float/depend
+++ b/ext/-test-/float/depend
@@ -159,6 +159,7 @@ init.o: $(hdrdir)/ruby/internal/variable.h
 init.o: $(hdrdir)/ruby/internal/warning_push.h
 init.o: $(hdrdir)/ruby/internal/xmalloc.h
 init.o: $(hdrdir)/ruby/missing.h
+init.o: $(hdrdir)/ruby/onigmo.h
 init.o: $(hdrdir)/ruby/ruby.h
 init.o: $(hdrdir)/ruby/st.h
 init.o: $(hdrdir)/ruby/subst.h
@@ -320,6 +321,7 @@ nextafter.o: $(hdrdir)/ruby/internal/variable.h
 nextafter.o: $(hdrdir)/ruby/internal/warning_push.h
 nextafter.o: $(hdrdir)/ruby/internal/xmalloc.h
 nextafter.o: $(hdrdir)/ruby/missing.h
+nextafter.o: $(hdrdir)/ruby/onigmo.h
 nextafter.o: $(hdrdir)/ruby/ruby.h
 nextafter.o: $(hdrdir)/ruby/st.h
 nextafter.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/funcall/depend
+++ b/ext/-test-/funcall/depend
@@ -156,6 +156,7 @@ funcall.o: $(hdrdir)/ruby/internal/variable.h
 funcall.o: $(hdrdir)/ruby/internal/warning_push.h
 funcall.o: $(hdrdir)/ruby/internal/xmalloc.h
 funcall.o: $(hdrdir)/ruby/missing.h
+funcall.o: $(hdrdir)/ruby/onigmo.h
 funcall.o: $(hdrdir)/ruby/ruby.h
 funcall.o: $(hdrdir)/ruby/st.h
 funcall.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/gvl/call_without_gvl/depend
+++ b/ext/-test-/gvl/call_without_gvl/depend
@@ -155,6 +155,7 @@ call_without_gvl.o: $(hdrdir)/ruby/internal/variable.h
 call_without_gvl.o: $(hdrdir)/ruby/internal/warning_push.h
 call_without_gvl.o: $(hdrdir)/ruby/internal/xmalloc.h
 call_without_gvl.o: $(hdrdir)/ruby/missing.h
+call_without_gvl.o: $(hdrdir)/ruby/onigmo.h
 call_without_gvl.o: $(hdrdir)/ruby/ruby.h
 call_without_gvl.o: $(hdrdir)/ruby/st.h
 call_without_gvl.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/hash/depend
+++ b/ext/-test-/hash/depend
@@ -156,6 +156,7 @@ delete.o: $(hdrdir)/ruby/internal/variable.h
 delete.o: $(hdrdir)/ruby/internal/warning_push.h
 delete.o: $(hdrdir)/ruby/internal/xmalloc.h
 delete.o: $(hdrdir)/ruby/missing.h
+delete.o: $(hdrdir)/ruby/onigmo.h
 delete.o: $(hdrdir)/ruby/ruby.h
 delete.o: $(hdrdir)/ruby/st.h
 delete.o: $(hdrdir)/ruby/subst.h
@@ -317,6 +318,7 @@ init.o: $(hdrdir)/ruby/internal/variable.h
 init.o: $(hdrdir)/ruby/internal/warning_push.h
 init.o: $(hdrdir)/ruby/internal/xmalloc.h
 init.o: $(hdrdir)/ruby/missing.h
+init.o: $(hdrdir)/ruby/onigmo.h
 init.o: $(hdrdir)/ruby/ruby.h
 init.o: $(hdrdir)/ruby/st.h
 init.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/integer/depend
+++ b/ext/-test-/integer/depend
@@ -156,6 +156,7 @@ core_ext.o: $(hdrdir)/ruby/internal/variable.h
 core_ext.o: $(hdrdir)/ruby/internal/warning_push.h
 core_ext.o: $(hdrdir)/ruby/internal/xmalloc.h
 core_ext.o: $(hdrdir)/ruby/missing.h
+core_ext.o: $(hdrdir)/ruby/onigmo.h
 core_ext.o: $(hdrdir)/ruby/ruby.h
 core_ext.o: $(hdrdir)/ruby/st.h
 core_ext.o: $(hdrdir)/ruby/subst.h
@@ -328,6 +329,7 @@ init.o: $(hdrdir)/ruby/internal/variable.h
 init.o: $(hdrdir)/ruby/internal/warning_push.h
 init.o: $(hdrdir)/ruby/internal/xmalloc.h
 init.o: $(hdrdir)/ruby/missing.h
+init.o: $(hdrdir)/ruby/onigmo.h
 init.o: $(hdrdir)/ruby/ruby.h
 init.o: $(hdrdir)/ruby/st.h
 init.o: $(hdrdir)/ruby/subst.h
@@ -489,6 +491,7 @@ my_integer.o: $(hdrdir)/ruby/internal/variable.h
 my_integer.o: $(hdrdir)/ruby/internal/warning_push.h
 my_integer.o: $(hdrdir)/ruby/internal/xmalloc.h
 my_integer.o: $(hdrdir)/ruby/missing.h
+my_integer.o: $(hdrdir)/ruby/onigmo.h
 my_integer.o: $(hdrdir)/ruby/ruby.h
 my_integer.o: $(hdrdir)/ruby/st.h
 my_integer.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/iseq_load/depend
+++ b/ext/-test-/iseq_load/depend
@@ -156,6 +156,7 @@ iseq_load.o: $(hdrdir)/ruby/internal/variable.h
 iseq_load.o: $(hdrdir)/ruby/internal/warning_push.h
 iseq_load.o: $(hdrdir)/ruby/internal/xmalloc.h
 iseq_load.o: $(hdrdir)/ruby/missing.h
+iseq_load.o: $(hdrdir)/ruby/onigmo.h
 iseq_load.o: $(hdrdir)/ruby/ruby.h
 iseq_load.o: $(hdrdir)/ruby/st.h
 iseq_load.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/iter/depend
+++ b/ext/-test-/iter/depend
@@ -156,6 +156,7 @@ break.o: $(hdrdir)/ruby/internal/variable.h
 break.o: $(hdrdir)/ruby/internal/warning_push.h
 break.o: $(hdrdir)/ruby/internal/xmalloc.h
 break.o: $(hdrdir)/ruby/missing.h
+break.o: $(hdrdir)/ruby/onigmo.h
 break.o: $(hdrdir)/ruby/ruby.h
 break.o: $(hdrdir)/ruby/st.h
 break.o: $(hdrdir)/ruby/subst.h
@@ -317,6 +318,7 @@ init.o: $(hdrdir)/ruby/internal/variable.h
 init.o: $(hdrdir)/ruby/internal/warning_push.h
 init.o: $(hdrdir)/ruby/internal/xmalloc.h
 init.o: $(hdrdir)/ruby/missing.h
+init.o: $(hdrdir)/ruby/onigmo.h
 init.o: $(hdrdir)/ruby/ruby.h
 init.o: $(hdrdir)/ruby/st.h
 init.o: $(hdrdir)/ruby/subst.h
@@ -478,6 +480,7 @@ yield.o: $(hdrdir)/ruby/internal/variable.h
 yield.o: $(hdrdir)/ruby/internal/warning_push.h
 yield.o: $(hdrdir)/ruby/internal/xmalloc.h
 yield.o: $(hdrdir)/ruby/missing.h
+yield.o: $(hdrdir)/ruby/onigmo.h
 yield.o: $(hdrdir)/ruby/ruby.h
 yield.o: $(hdrdir)/ruby/st.h
 yield.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/load/dot.dot/depend
+++ b/ext/-test-/load/dot.dot/depend
@@ -156,6 +156,7 @@ dot.dot.o: $(hdrdir)/ruby/internal/variable.h
 dot.dot.o: $(hdrdir)/ruby/internal/warning_push.h
 dot.dot.o: $(hdrdir)/ruby/internal/xmalloc.h
 dot.dot.o: $(hdrdir)/ruby/missing.h
+dot.dot.o: $(hdrdir)/ruby/onigmo.h
 dot.dot.o: $(hdrdir)/ruby/ruby.h
 dot.dot.o: $(hdrdir)/ruby/st.h
 dot.dot.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/load/protect/depend
+++ b/ext/-test-/load/protect/depend
@@ -156,6 +156,7 @@ protect.o: $(hdrdir)/ruby/internal/variable.h
 protect.o: $(hdrdir)/ruby/internal/warning_push.h
 protect.o: $(hdrdir)/ruby/internal/xmalloc.h
 protect.o: $(hdrdir)/ruby/missing.h
+protect.o: $(hdrdir)/ruby/onigmo.h
 protect.o: $(hdrdir)/ruby/ruby.h
 protect.o: $(hdrdir)/ruby/st.h
 protect.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/load/resolve_symbol_resolver/depend
+++ b/ext/-test-/load/resolve_symbol_resolver/depend
@@ -156,6 +156,7 @@ resolve_symbol_resolver.o: $(hdrdir)/ruby/internal/variable.h
 resolve_symbol_resolver.o: $(hdrdir)/ruby/internal/warning_push.h
 resolve_symbol_resolver.o: $(hdrdir)/ruby/internal/xmalloc.h
 resolve_symbol_resolver.o: $(hdrdir)/ruby/missing.h
+resolve_symbol_resolver.o: $(hdrdir)/ruby/onigmo.h
 resolve_symbol_resolver.o: $(hdrdir)/ruby/ruby.h
 resolve_symbol_resolver.o: $(hdrdir)/ruby/st.h
 resolve_symbol_resolver.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/load/resolve_symbol_target/depend
+++ b/ext/-test-/load/resolve_symbol_target/depend
@@ -156,6 +156,7 @@ resolve_symbol_target.o: $(hdrdir)/ruby/internal/variable.h
 resolve_symbol_target.o: $(hdrdir)/ruby/internal/warning_push.h
 resolve_symbol_target.o: $(hdrdir)/ruby/internal/xmalloc.h
 resolve_symbol_target.o: $(hdrdir)/ruby/missing.h
+resolve_symbol_target.o: $(hdrdir)/ruby/onigmo.h
 resolve_symbol_target.o: $(hdrdir)/ruby/ruby.h
 resolve_symbol_target.o: $(hdrdir)/ruby/st.h
 resolve_symbol_target.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/load/stringify_symbols/depend
+++ b/ext/-test-/load/stringify_symbols/depend
@@ -156,6 +156,7 @@ stringify_symbols.o: $(hdrdir)/ruby/internal/variable.h
 stringify_symbols.o: $(hdrdir)/ruby/internal/warning_push.h
 stringify_symbols.o: $(hdrdir)/ruby/internal/xmalloc.h
 stringify_symbols.o: $(hdrdir)/ruby/missing.h
+stringify_symbols.o: $(hdrdir)/ruby/onigmo.h
 stringify_symbols.o: $(hdrdir)/ruby/ruby.h
 stringify_symbols.o: $(hdrdir)/ruby/st.h
 stringify_symbols.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/load/stringify_target/depend
+++ b/ext/-test-/load/stringify_target/depend
@@ -156,6 +156,7 @@ stringify_target.o: $(hdrdir)/ruby/internal/variable.h
 stringify_target.o: $(hdrdir)/ruby/internal/warning_push.h
 stringify_target.o: $(hdrdir)/ruby/internal/xmalloc.h
 stringify_target.o: $(hdrdir)/ruby/missing.h
+stringify_target.o: $(hdrdir)/ruby/onigmo.h
 stringify_target.o: $(hdrdir)/ruby/ruby.h
 stringify_target.o: $(hdrdir)/ruby/st.h
 stringify_target.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/marshal/compat/depend
+++ b/ext/-test-/marshal/compat/depend
@@ -156,6 +156,7 @@ usrcompat.o: $(hdrdir)/ruby/internal/variable.h
 usrcompat.o: $(hdrdir)/ruby/internal/warning_push.h
 usrcompat.o: $(hdrdir)/ruby/internal/xmalloc.h
 usrcompat.o: $(hdrdir)/ruby/missing.h
+usrcompat.o: $(hdrdir)/ruby/onigmo.h
 usrcompat.o: $(hdrdir)/ruby/ruby.h
 usrcompat.o: $(hdrdir)/ruby/st.h
 usrcompat.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/marshal/internal_ivar/depend
+++ b/ext/-test-/marshal/internal_ivar/depend
@@ -156,6 +156,7 @@ internal_ivar.o: $(hdrdir)/ruby/internal/variable.h
 internal_ivar.o: $(hdrdir)/ruby/internal/warning_push.h
 internal_ivar.o: $(hdrdir)/ruby/internal/xmalloc.h
 internal_ivar.o: $(hdrdir)/ruby/missing.h
+internal_ivar.o: $(hdrdir)/ruby/onigmo.h
 internal_ivar.o: $(hdrdir)/ruby/ruby.h
 internal_ivar.o: $(hdrdir)/ruby/st.h
 internal_ivar.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/marshal/usr/depend
+++ b/ext/-test-/marshal/usr/depend
@@ -156,6 +156,7 @@ usrmarshal.o: $(hdrdir)/ruby/internal/variable.h
 usrmarshal.o: $(hdrdir)/ruby/internal/warning_push.h
 usrmarshal.o: $(hdrdir)/ruby/internal/xmalloc.h
 usrmarshal.o: $(hdrdir)/ruby/missing.h
+usrmarshal.o: $(hdrdir)/ruby/onigmo.h
 usrmarshal.o: $(hdrdir)/ruby/ruby.h
 usrmarshal.o: $(hdrdir)/ruby/st.h
 usrmarshal.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/memory_view/depend
+++ b/ext/-test-/memory_view/depend
@@ -157,6 +157,7 @@ memory_view.o: $(hdrdir)/ruby/internal/warning_push.h
 memory_view.o: $(hdrdir)/ruby/internal/xmalloc.h
 memory_view.o: $(hdrdir)/ruby/memory_view.h
 memory_view.o: $(hdrdir)/ruby/missing.h
+memory_view.o: $(hdrdir)/ruby/onigmo.h
 memory_view.o: $(hdrdir)/ruby/ruby.h
 memory_view.o: $(hdrdir)/ruby/st.h
 memory_view.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/method/depend
+++ b/ext/-test-/method/depend
@@ -156,6 +156,7 @@ arity.o: $(hdrdir)/ruby/internal/variable.h
 arity.o: $(hdrdir)/ruby/internal/warning_push.h
 arity.o: $(hdrdir)/ruby/internal/xmalloc.h
 arity.o: $(hdrdir)/ruby/missing.h
+arity.o: $(hdrdir)/ruby/onigmo.h
 arity.o: $(hdrdir)/ruby/ruby.h
 arity.o: $(hdrdir)/ruby/st.h
 arity.o: $(hdrdir)/ruby/subst.h
@@ -317,6 +318,7 @@ init.o: $(hdrdir)/ruby/internal/variable.h
 init.o: $(hdrdir)/ruby/internal/warning_push.h
 init.o: $(hdrdir)/ruby/internal/xmalloc.h
 init.o: $(hdrdir)/ruby/missing.h
+init.o: $(hdrdir)/ruby/onigmo.h
 init.o: $(hdrdir)/ruby/ruby.h
 init.o: $(hdrdir)/ruby/st.h
 init.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/notimplement/depend
+++ b/ext/-test-/notimplement/depend
@@ -156,6 +156,7 @@ bug.o: $(hdrdir)/ruby/internal/variable.h
 bug.o: $(hdrdir)/ruby/internal/warning_push.h
 bug.o: $(hdrdir)/ruby/internal/xmalloc.h
 bug.o: $(hdrdir)/ruby/missing.h
+bug.o: $(hdrdir)/ruby/onigmo.h
 bug.o: $(hdrdir)/ruby/ruby.h
 bug.o: $(hdrdir)/ruby/st.h
 bug.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/num2int/depend
+++ b/ext/-test-/num2int/depend
@@ -156,6 +156,7 @@ num2int.o: $(hdrdir)/ruby/internal/variable.h
 num2int.o: $(hdrdir)/ruby/internal/warning_push.h
 num2int.o: $(hdrdir)/ruby/internal/xmalloc.h
 num2int.o: $(hdrdir)/ruby/missing.h
+num2int.o: $(hdrdir)/ruby/onigmo.h
 num2int.o: $(hdrdir)/ruby/ruby.h
 num2int.o: $(hdrdir)/ruby/st.h
 num2int.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/path_to_class/depend
+++ b/ext/-test-/path_to_class/depend
@@ -156,6 +156,7 @@ path_to_class.o: $(hdrdir)/ruby/internal/variable.h
 path_to_class.o: $(hdrdir)/ruby/internal/warning_push.h
 path_to_class.o: $(hdrdir)/ruby/internal/xmalloc.h
 path_to_class.o: $(hdrdir)/ruby/missing.h
+path_to_class.o: $(hdrdir)/ruby/onigmo.h
 path_to_class.o: $(hdrdir)/ruby/ruby.h
 path_to_class.o: $(hdrdir)/ruby/st.h
 path_to_class.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/popen_deadlock/depend
+++ b/ext/-test-/popen_deadlock/depend
@@ -156,6 +156,7 @@ infinite_loop_dlsym.o: $(hdrdir)/ruby/internal/variable.h
 infinite_loop_dlsym.o: $(hdrdir)/ruby/internal/warning_push.h
 infinite_loop_dlsym.o: $(hdrdir)/ruby/internal/xmalloc.h
 infinite_loop_dlsym.o: $(hdrdir)/ruby/missing.h
+infinite_loop_dlsym.o: $(hdrdir)/ruby/onigmo.h
 infinite_loop_dlsym.o: $(hdrdir)/ruby/ruby.h
 infinite_loop_dlsym.o: $(hdrdir)/ruby/st.h
 infinite_loop_dlsym.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/postponed_job/depend
+++ b/ext/-test-/postponed_job/depend
@@ -157,6 +157,7 @@ postponed_job.o: $(hdrdir)/ruby/internal/variable.h
 postponed_job.o: $(hdrdir)/ruby/internal/warning_push.h
 postponed_job.o: $(hdrdir)/ruby/internal/xmalloc.h
 postponed_job.o: $(hdrdir)/ruby/missing.h
+postponed_job.o: $(hdrdir)/ruby/onigmo.h
 postponed_job.o: $(hdrdir)/ruby/ruby.h
 postponed_job.o: $(hdrdir)/ruby/st.h
 postponed_job.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/proc/depend
+++ b/ext/-test-/proc/depend
@@ -156,6 +156,7 @@ init.o: $(hdrdir)/ruby/internal/variable.h
 init.o: $(hdrdir)/ruby/internal/warning_push.h
 init.o: $(hdrdir)/ruby/internal/xmalloc.h
 init.o: $(hdrdir)/ruby/missing.h
+init.o: $(hdrdir)/ruby/onigmo.h
 init.o: $(hdrdir)/ruby/ruby.h
 init.o: $(hdrdir)/ruby/st.h
 init.o: $(hdrdir)/ruby/subst.h
@@ -317,6 +318,7 @@ receiver.o: $(hdrdir)/ruby/internal/variable.h
 receiver.o: $(hdrdir)/ruby/internal/warning_push.h
 receiver.o: $(hdrdir)/ruby/internal/xmalloc.h
 receiver.o: $(hdrdir)/ruby/missing.h
+receiver.o: $(hdrdir)/ruby/onigmo.h
 receiver.o: $(hdrdir)/ruby/ruby.h
 receiver.o: $(hdrdir)/ruby/st.h
 receiver.o: $(hdrdir)/ruby/subst.h
@@ -478,6 +480,7 @@ super.o: $(hdrdir)/ruby/internal/variable.h
 super.o: $(hdrdir)/ruby/internal/warning_push.h
 super.o: $(hdrdir)/ruby/internal/xmalloc.h
 super.o: $(hdrdir)/ruby/missing.h
+super.o: $(hdrdir)/ruby/onigmo.h
 super.o: $(hdrdir)/ruby/ruby.h
 super.o: $(hdrdir)/ruby/st.h
 super.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/random/depend
+++ b/ext/-test-/random/depend
@@ -155,6 +155,7 @@ bad_version.o: $(hdrdir)/ruby/internal/variable.h
 bad_version.o: $(hdrdir)/ruby/internal/warning_push.h
 bad_version.o: $(hdrdir)/ruby/internal/xmalloc.h
 bad_version.o: $(hdrdir)/ruby/missing.h
+bad_version.o: $(hdrdir)/ruby/onigmo.h
 bad_version.o: $(hdrdir)/ruby/random.h
 bad_version.o: $(hdrdir)/ruby/ruby.h
 bad_version.o: $(hdrdir)/ruby/st.h
@@ -317,6 +318,7 @@ init.o: $(hdrdir)/ruby/internal/variable.h
 init.o: $(hdrdir)/ruby/internal/warning_push.h
 init.o: $(hdrdir)/ruby/internal/xmalloc.h
 init.o: $(hdrdir)/ruby/missing.h
+init.o: $(hdrdir)/ruby/onigmo.h
 init.o: $(hdrdir)/ruby/ruby.h
 init.o: $(hdrdir)/ruby/st.h
 init.o: $(hdrdir)/ruby/subst.h
@@ -477,6 +479,7 @@ loop.o: $(hdrdir)/ruby/internal/variable.h
 loop.o: $(hdrdir)/ruby/internal/warning_push.h
 loop.o: $(hdrdir)/ruby/internal/xmalloc.h
 loop.o: $(hdrdir)/ruby/missing.h
+loop.o: $(hdrdir)/ruby/onigmo.h
 loop.o: $(hdrdir)/ruby/random.h
 loop.o: $(hdrdir)/ruby/ruby.h
 loop.o: $(hdrdir)/ruby/st.h

--- a/ext/-test-/rational/depend
+++ b/ext/-test-/rational/depend
@@ -160,6 +160,7 @@ rat.o: $(hdrdir)/ruby/internal/variable.h
 rat.o: $(hdrdir)/ruby/internal/warning_push.h
 rat.o: $(hdrdir)/ruby/internal/xmalloc.h
 rat.o: $(hdrdir)/ruby/missing.h
+rat.o: $(hdrdir)/ruby/onigmo.h
 rat.o: $(hdrdir)/ruby/ruby.h
 rat.o: $(hdrdir)/ruby/st.h
 rat.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/rb_call_super_kw/depend
+++ b/ext/-test-/rb_call_super_kw/depend
@@ -156,6 +156,7 @@ rb_call_super_kw.o: $(hdrdir)/ruby/internal/variable.h
 rb_call_super_kw.o: $(hdrdir)/ruby/internal/warning_push.h
 rb_call_super_kw.o: $(hdrdir)/ruby/internal/xmalloc.h
 rb_call_super_kw.o: $(hdrdir)/ruby/missing.h
+rb_call_super_kw.o: $(hdrdir)/ruby/onigmo.h
 rb_call_super_kw.o: $(hdrdir)/ruby/ruby.h
 rb_call_super_kw.o: $(hdrdir)/ruby/st.h
 rb_call_super_kw.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/recursion/depend
+++ b/ext/-test-/recursion/depend
@@ -156,6 +156,7 @@ recursion.o: $(hdrdir)/ruby/internal/variable.h
 recursion.o: $(hdrdir)/ruby/internal/warning_push.h
 recursion.o: $(hdrdir)/ruby/internal/xmalloc.h
 recursion.o: $(hdrdir)/ruby/missing.h
+recursion.o: $(hdrdir)/ruby/onigmo.h
 recursion.o: $(hdrdir)/ruby/ruby.h
 recursion.o: $(hdrdir)/ruby/st.h
 recursion.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/regexp/depend
+++ b/ext/-test-/regexp/depend
@@ -156,6 +156,7 @@ init.o: $(hdrdir)/ruby/internal/variable.h
 init.o: $(hdrdir)/ruby/internal/warning_push.h
 init.o: $(hdrdir)/ruby/internal/xmalloc.h
 init.o: $(hdrdir)/ruby/missing.h
+init.o: $(hdrdir)/ruby/onigmo.h
 init.o: $(hdrdir)/ruby/ruby.h
 init.o: $(hdrdir)/ruby/st.h
 init.o: $(hdrdir)/ruby/subst.h
@@ -317,6 +318,7 @@ new.o: $(hdrdir)/ruby/internal/variable.h
 new.o: $(hdrdir)/ruby/internal/warning_push.h
 new.o: $(hdrdir)/ruby/internal/xmalloc.h
 new.o: $(hdrdir)/ruby/missing.h
+new.o: $(hdrdir)/ruby/onigmo.h
 new.o: $(hdrdir)/ruby/ruby.h
 new.o: $(hdrdir)/ruby/st.h
 new.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/sanitizers/depend
+++ b/ext/-test-/sanitizers/depend
@@ -155,6 +155,7 @@ sanitizers.o: $(hdrdir)/ruby/internal/variable.h
 sanitizers.o: $(hdrdir)/ruby/internal/warning_push.h
 sanitizers.o: $(hdrdir)/ruby/internal/xmalloc.h
 sanitizers.o: $(hdrdir)/ruby/missing.h
+sanitizers.o: $(hdrdir)/ruby/onigmo.h
 sanitizers.o: $(hdrdir)/ruby/ruby.h
 sanitizers.o: $(hdrdir)/ruby/st.h
 sanitizers.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/scan_args/depend
+++ b/ext/-test-/scan_args/depend
@@ -156,6 +156,7 @@ scan_args.o: $(hdrdir)/ruby/internal/variable.h
 scan_args.o: $(hdrdir)/ruby/internal/warning_push.h
 scan_args.o: $(hdrdir)/ruby/internal/xmalloc.h
 scan_args.o: $(hdrdir)/ruby/missing.h
+scan_args.o: $(hdrdir)/ruby/onigmo.h
 scan_args.o: $(hdrdir)/ruby/ruby.h
 scan_args.o: $(hdrdir)/ruby/st.h
 scan_args.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/st/foreach/depend
+++ b/ext/-test-/st/foreach/depend
@@ -156,6 +156,7 @@ foreach.o: $(hdrdir)/ruby/internal/variable.h
 foreach.o: $(hdrdir)/ruby/internal/warning_push.h
 foreach.o: $(hdrdir)/ruby/internal/xmalloc.h
 foreach.o: $(hdrdir)/ruby/missing.h
+foreach.o: $(hdrdir)/ruby/onigmo.h
 foreach.o: $(hdrdir)/ruby/ruby.h
 foreach.o: $(hdrdir)/ruby/st.h
 foreach.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/st/numhash/depend
+++ b/ext/-test-/st/numhash/depend
@@ -156,6 +156,7 @@ numhash.o: $(hdrdir)/ruby/internal/variable.h
 numhash.o: $(hdrdir)/ruby/internal/warning_push.h
 numhash.o: $(hdrdir)/ruby/internal/xmalloc.h
 numhash.o: $(hdrdir)/ruby/missing.h
+numhash.o: $(hdrdir)/ruby/onigmo.h
 numhash.o: $(hdrdir)/ruby/ruby.h
 numhash.o: $(hdrdir)/ruby/st.h
 numhash.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/st/update/depend
+++ b/ext/-test-/st/update/depend
@@ -156,6 +156,7 @@ update.o: $(hdrdir)/ruby/internal/variable.h
 update.o: $(hdrdir)/ruby/internal/warning_push.h
 update.o: $(hdrdir)/ruby/internal/xmalloc.h
 update.o: $(hdrdir)/ruby/missing.h
+update.o: $(hdrdir)/ruby/onigmo.h
 update.o: $(hdrdir)/ruby/ruby.h
 update.o: $(hdrdir)/ruby/st.h
 update.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/string/depend
+++ b/ext/-test-/string/depend
@@ -842,6 +842,7 @@ ellipsize.o: $(hdrdir)/ruby/internal/variable.h
 ellipsize.o: $(hdrdir)/ruby/internal/warning_push.h
 ellipsize.o: $(hdrdir)/ruby/internal/xmalloc.h
 ellipsize.o: $(hdrdir)/ruby/missing.h
+ellipsize.o: $(hdrdir)/ruby/onigmo.h
 ellipsize.o: $(hdrdir)/ruby/ruby.h
 ellipsize.o: $(hdrdir)/ruby/st.h
 ellipsize.o: $(hdrdir)/ruby/subst.h
@@ -1698,6 +1699,7 @@ init.o: $(hdrdir)/ruby/internal/variable.h
 init.o: $(hdrdir)/ruby/internal/warning_push.h
 init.o: $(hdrdir)/ruby/internal/xmalloc.h
 init.o: $(hdrdir)/ruby/missing.h
+init.o: $(hdrdir)/ruby/onigmo.h
 init.o: $(hdrdir)/ruby/ruby.h
 init.o: $(hdrdir)/ruby/st.h
 init.o: $(hdrdir)/ruby/subst.h
@@ -1859,6 +1861,7 @@ modify.o: $(hdrdir)/ruby/internal/variable.h
 modify.o: $(hdrdir)/ruby/internal/warning_push.h
 modify.o: $(hdrdir)/ruby/internal/xmalloc.h
 modify.o: $(hdrdir)/ruby/missing.h
+modify.o: $(hdrdir)/ruby/onigmo.h
 modify.o: $(hdrdir)/ruby/ruby.h
 modify.o: $(hdrdir)/ruby/st.h
 modify.o: $(hdrdir)/ruby/subst.h
@@ -2193,6 +2196,7 @@ nofree.o: $(hdrdir)/ruby/internal/variable.h
 nofree.o: $(hdrdir)/ruby/internal/warning_push.h
 nofree.o: $(hdrdir)/ruby/internal/xmalloc.h
 nofree.o: $(hdrdir)/ruby/missing.h
+nofree.o: $(hdrdir)/ruby/onigmo.h
 nofree.o: $(hdrdir)/ruby/ruby.h
 nofree.o: $(hdrdir)/ruby/st.h
 nofree.o: $(hdrdir)/ruby/subst.h
@@ -2701,6 +2705,7 @@ rb_interned_str.o: $(hdrdir)/ruby/internal/variable.h
 rb_interned_str.o: $(hdrdir)/ruby/internal/warning_push.h
 rb_interned_str.o: $(hdrdir)/ruby/internal/xmalloc.h
 rb_interned_str.o: $(hdrdir)/ruby/missing.h
+rb_interned_str.o: $(hdrdir)/ruby/onigmo.h
 rb_interned_str.o: $(hdrdir)/ruby/ruby.h
 rb_interned_str.o: $(hdrdir)/ruby/st.h
 rb_interned_str.o: $(hdrdir)/ruby/subst.h
@@ -2862,6 +2867,7 @@ rb_str_dup.o: $(hdrdir)/ruby/internal/variable.h
 rb_str_dup.o: $(hdrdir)/ruby/internal/warning_push.h
 rb_str_dup.o: $(hdrdir)/ruby/internal/xmalloc.h
 rb_str_dup.o: $(hdrdir)/ruby/missing.h
+rb_str_dup.o: $(hdrdir)/ruby/onigmo.h
 rb_str_dup.o: $(hdrdir)/ruby/ruby.h
 rb_str_dup.o: $(hdrdir)/ruby/st.h
 rb_str_dup.o: $(hdrdir)/ruby/subst.h
@@ -3023,6 +3029,7 @@ set_len.o: $(hdrdir)/ruby/internal/variable.h
 set_len.o: $(hdrdir)/ruby/internal/warning_push.h
 set_len.o: $(hdrdir)/ruby/internal/xmalloc.h
 set_len.o: $(hdrdir)/ruby/missing.h
+set_len.o: $(hdrdir)/ruby/onigmo.h
 set_len.o: $(hdrdir)/ruby/ruby.h
 set_len.o: $(hdrdir)/ruby/st.h
 set_len.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/struct/depend
+++ b/ext/-test-/struct/depend
@@ -156,6 +156,7 @@ data.o: $(hdrdir)/ruby/internal/variable.h
 data.o: $(hdrdir)/ruby/internal/warning_push.h
 data.o: $(hdrdir)/ruby/internal/xmalloc.h
 data.o: $(hdrdir)/ruby/missing.h
+data.o: $(hdrdir)/ruby/onigmo.h
 data.o: $(hdrdir)/ruby/ruby.h
 data.o: $(hdrdir)/ruby/st.h
 data.o: $(hdrdir)/ruby/subst.h
@@ -317,6 +318,7 @@ duplicate.o: $(hdrdir)/ruby/internal/variable.h
 duplicate.o: $(hdrdir)/ruby/internal/warning_push.h
 duplicate.o: $(hdrdir)/ruby/internal/xmalloc.h
 duplicate.o: $(hdrdir)/ruby/missing.h
+duplicate.o: $(hdrdir)/ruby/onigmo.h
 duplicate.o: $(hdrdir)/ruby/ruby.h
 duplicate.o: $(hdrdir)/ruby/st.h
 duplicate.o: $(hdrdir)/ruby/subst.h
@@ -478,6 +480,7 @@ init.o: $(hdrdir)/ruby/internal/variable.h
 init.o: $(hdrdir)/ruby/internal/warning_push.h
 init.o: $(hdrdir)/ruby/internal/xmalloc.h
 init.o: $(hdrdir)/ruby/missing.h
+init.o: $(hdrdir)/ruby/onigmo.h
 init.o: $(hdrdir)/ruby/ruby.h
 init.o: $(hdrdir)/ruby/st.h
 init.o: $(hdrdir)/ruby/subst.h
@@ -639,6 +642,7 @@ len.o: $(hdrdir)/ruby/internal/variable.h
 len.o: $(hdrdir)/ruby/internal/warning_push.h
 len.o: $(hdrdir)/ruby/internal/xmalloc.h
 len.o: $(hdrdir)/ruby/missing.h
+len.o: $(hdrdir)/ruby/onigmo.h
 len.o: $(hdrdir)/ruby/ruby.h
 len.o: $(hdrdir)/ruby/st.h
 len.o: $(hdrdir)/ruby/subst.h
@@ -800,6 +804,7 @@ member.o: $(hdrdir)/ruby/internal/variable.h
 member.o: $(hdrdir)/ruby/internal/warning_push.h
 member.o: $(hdrdir)/ruby/internal/xmalloc.h
 member.o: $(hdrdir)/ruby/missing.h
+member.o: $(hdrdir)/ruby/onigmo.h
 member.o: $(hdrdir)/ruby/ruby.h
 member.o: $(hdrdir)/ruby/st.h
 member.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/symbol/depend
+++ b/ext/-test-/symbol/depend
@@ -156,6 +156,7 @@ init.o: $(hdrdir)/ruby/internal/variable.h
 init.o: $(hdrdir)/ruby/internal/warning_push.h
 init.o: $(hdrdir)/ruby/internal/xmalloc.h
 init.o: $(hdrdir)/ruby/missing.h
+init.o: $(hdrdir)/ruby/onigmo.h
 init.o: $(hdrdir)/ruby/ruby.h
 init.o: $(hdrdir)/ruby/st.h
 init.o: $(hdrdir)/ruby/subst.h
@@ -317,6 +318,7 @@ type.o: $(hdrdir)/ruby/internal/variable.h
 type.o: $(hdrdir)/ruby/internal/warning_push.h
 type.o: $(hdrdir)/ruby/internal/xmalloc.h
 type.o: $(hdrdir)/ruby/missing.h
+type.o: $(hdrdir)/ruby/onigmo.h
 type.o: $(hdrdir)/ruby/ruby.h
 type.o: $(hdrdir)/ruby/st.h
 type.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/thread/id/depend
+++ b/ext/-test-/thread/id/depend
@@ -156,6 +156,7 @@ id.o: $(hdrdir)/ruby/internal/variable.h
 id.o: $(hdrdir)/ruby/internal/warning_push.h
 id.o: $(hdrdir)/ruby/internal/xmalloc.h
 id.o: $(hdrdir)/ruby/missing.h
+id.o: $(hdrdir)/ruby/onigmo.h
 id.o: $(hdrdir)/ruby/ruby.h
 id.o: $(hdrdir)/ruby/st.h
 id.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/thread/instrumentation/depend
+++ b/ext/-test-/thread/instrumentation/depend
@@ -156,6 +156,7 @@ instrumentation.o: $(hdrdir)/ruby/internal/variable.h
 instrumentation.o: $(hdrdir)/ruby/internal/warning_push.h
 instrumentation.o: $(hdrdir)/ruby/internal/xmalloc.h
 instrumentation.o: $(hdrdir)/ruby/missing.h
+instrumentation.o: $(hdrdir)/ruby/onigmo.h
 instrumentation.o: $(hdrdir)/ruby/ruby.h
 instrumentation.o: $(hdrdir)/ruby/st.h
 instrumentation.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/thread/lock_native_thread/depend
+++ b/ext/-test-/thread/lock_native_thread/depend
@@ -155,6 +155,7 @@ lock_native_thread.o: $(hdrdir)/ruby/internal/variable.h
 lock_native_thread.o: $(hdrdir)/ruby/internal/warning_push.h
 lock_native_thread.o: $(hdrdir)/ruby/internal/xmalloc.h
 lock_native_thread.o: $(hdrdir)/ruby/missing.h
+lock_native_thread.o: $(hdrdir)/ruby/onigmo.h
 lock_native_thread.o: $(hdrdir)/ruby/ruby.h
 lock_native_thread.o: $(hdrdir)/ruby/st.h
 lock_native_thread.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/time/depend
+++ b/ext/-test-/time/depend
@@ -156,6 +156,7 @@ init.o: $(hdrdir)/ruby/internal/variable.h
 init.o: $(hdrdir)/ruby/internal/warning_push.h
 init.o: $(hdrdir)/ruby/internal/xmalloc.h
 init.o: $(hdrdir)/ruby/missing.h
+init.o: $(hdrdir)/ruby/onigmo.h
 init.o: $(hdrdir)/ruby/ruby.h
 init.o: $(hdrdir)/ruby/st.h
 init.o: $(hdrdir)/ruby/subst.h
@@ -483,6 +484,7 @@ new.o: $(hdrdir)/ruby/internal/variable.h
 new.o: $(hdrdir)/ruby/internal/warning_push.h
 new.o: $(hdrdir)/ruby/internal/xmalloc.h
 new.o: $(hdrdir)/ruby/missing.h
+new.o: $(hdrdir)/ruby/onigmo.h
 new.o: $(hdrdir)/ruby/ruby.h
 new.o: $(hdrdir)/ruby/st.h
 new.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/tracepoint/depend
+++ b/ext/-test-/tracepoint/depend
@@ -156,6 +156,7 @@ gc_hook.o: $(hdrdir)/ruby/internal/variable.h
 gc_hook.o: $(hdrdir)/ruby/internal/warning_push.h
 gc_hook.o: $(hdrdir)/ruby/internal/xmalloc.h
 gc_hook.o: $(hdrdir)/ruby/missing.h
+gc_hook.o: $(hdrdir)/ruby/onigmo.h
 gc_hook.o: $(hdrdir)/ruby/ruby.h
 gc_hook.o: $(hdrdir)/ruby/st.h
 gc_hook.o: $(hdrdir)/ruby/subst.h
@@ -317,6 +318,7 @@ tracepoint.o: $(hdrdir)/ruby/internal/variable.h
 tracepoint.o: $(hdrdir)/ruby/internal/warning_push.h
 tracepoint.o: $(hdrdir)/ruby/internal/xmalloc.h
 tracepoint.o: $(hdrdir)/ruby/missing.h
+tracepoint.o: $(hdrdir)/ruby/onigmo.h
 tracepoint.o: $(hdrdir)/ruby/ruby.h
 tracepoint.o: $(hdrdir)/ruby/st.h
 tracepoint.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/typeddata/depend
+++ b/ext/-test-/typeddata/depend
@@ -156,6 +156,7 @@ typeddata.o: $(hdrdir)/ruby/internal/variable.h
 typeddata.o: $(hdrdir)/ruby/internal/warning_push.h
 typeddata.o: $(hdrdir)/ruby/internal/xmalloc.h
 typeddata.o: $(hdrdir)/ruby/missing.h
+typeddata.o: $(hdrdir)/ruby/onigmo.h
 typeddata.o: $(hdrdir)/ruby/ruby.h
 typeddata.o: $(hdrdir)/ruby/st.h
 typeddata.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/vm/depend
+++ b/ext/-test-/vm/depend
@@ -155,6 +155,7 @@ at_exit.o: $(hdrdir)/ruby/internal/variable.h
 at_exit.o: $(hdrdir)/ruby/internal/warning_push.h
 at_exit.o: $(hdrdir)/ruby/internal/xmalloc.h
 at_exit.o: $(hdrdir)/ruby/missing.h
+at_exit.o: $(hdrdir)/ruby/onigmo.h
 at_exit.o: $(hdrdir)/ruby/ruby.h
 at_exit.o: $(hdrdir)/ruby/st.h
 at_exit.o: $(hdrdir)/ruby/subst.h

--- a/ext/continuation/depend
+++ b/ext/continuation/depend
@@ -155,6 +155,7 @@ continuation.o: $(hdrdir)/ruby/internal/variable.h
 continuation.o: $(hdrdir)/ruby/internal/warning_push.h
 continuation.o: $(hdrdir)/ruby/internal/xmalloc.h
 continuation.o: $(hdrdir)/ruby/missing.h
+continuation.o: $(hdrdir)/ruby/onigmo.h
 continuation.o: $(hdrdir)/ruby/ruby.h
 continuation.o: $(hdrdir)/ruby/st.h
 continuation.o: $(hdrdir)/ruby/subst.h

--- a/ext/date/depend
+++ b/ext/date/depend
@@ -508,6 +508,7 @@ date_strftime.o: $(hdrdir)/ruby/internal/variable.h
 date_strftime.o: $(hdrdir)/ruby/internal/warning_push.h
 date_strftime.o: $(hdrdir)/ruby/internal/xmalloc.h
 date_strftime.o: $(hdrdir)/ruby/missing.h
+date_strftime.o: $(hdrdir)/ruby/onigmo.h
 date_strftime.o: $(hdrdir)/ruby/ruby.h
 date_strftime.o: $(hdrdir)/ruby/st.h
 date_strftime.o: $(hdrdir)/ruby/subst.h

--- a/ext/digest/bubblebabble/depend
+++ b/ext/digest/bubblebabble/depend
@@ -156,6 +156,7 @@ bubblebabble.o: $(hdrdir)/ruby/internal/variable.h
 bubblebabble.o: $(hdrdir)/ruby/internal/warning_push.h
 bubblebabble.o: $(hdrdir)/ruby/internal/xmalloc.h
 bubblebabble.o: $(hdrdir)/ruby/missing.h
+bubblebabble.o: $(hdrdir)/ruby/onigmo.h
 bubblebabble.o: $(hdrdir)/ruby/ruby.h
 bubblebabble.o: $(hdrdir)/ruby/st.h
 bubblebabble.o: $(hdrdir)/ruby/subst.h

--- a/ext/digest/depend
+++ b/ext/digest/depend
@@ -156,6 +156,7 @@ digest.o: $(hdrdir)/ruby/internal/variable.h
 digest.o: $(hdrdir)/ruby/internal/warning_push.h
 digest.o: $(hdrdir)/ruby/internal/xmalloc.h
 digest.o: $(hdrdir)/ruby/missing.h
+digest.o: $(hdrdir)/ruby/onigmo.h
 digest.o: $(hdrdir)/ruby/ruby.h
 digest.o: $(hdrdir)/ruby/st.h
 digest.o: $(hdrdir)/ruby/subst.h

--- a/ext/digest/md5/depend
+++ b/ext/digest/md5/depend
@@ -159,6 +159,7 @@ md5.o: $(hdrdir)/ruby/internal/variable.h
 md5.o: $(hdrdir)/ruby/internal/warning_push.h
 md5.o: $(hdrdir)/ruby/internal/xmalloc.h
 md5.o: $(hdrdir)/ruby/missing.h
+md5.o: $(hdrdir)/ruby/onigmo.h
 md5.o: $(hdrdir)/ruby/ruby.h
 md5.o: $(hdrdir)/ruby/st.h
 md5.o: $(hdrdir)/ruby/subst.h
@@ -322,6 +323,7 @@ md5init.o: $(hdrdir)/ruby/internal/variable.h
 md5init.o: $(hdrdir)/ruby/internal/warning_push.h
 md5init.o: $(hdrdir)/ruby/internal/xmalloc.h
 md5init.o: $(hdrdir)/ruby/missing.h
+md5init.o: $(hdrdir)/ruby/onigmo.h
 md5init.o: $(hdrdir)/ruby/ruby.h
 md5init.o: $(hdrdir)/ruby/st.h
 md5init.o: $(hdrdir)/ruby/subst.h

--- a/ext/digest/rmd160/depend
+++ b/ext/digest/rmd160/depend
@@ -159,6 +159,7 @@ rmd160.o: $(hdrdir)/ruby/internal/variable.h
 rmd160.o: $(hdrdir)/ruby/internal/warning_push.h
 rmd160.o: $(hdrdir)/ruby/internal/xmalloc.h
 rmd160.o: $(hdrdir)/ruby/missing.h
+rmd160.o: $(hdrdir)/ruby/onigmo.h
 rmd160.o: $(hdrdir)/ruby/ruby.h
 rmd160.o: $(hdrdir)/ruby/st.h
 rmd160.o: $(hdrdir)/ruby/subst.h
@@ -322,6 +323,7 @@ rmd160init.o: $(hdrdir)/ruby/internal/variable.h
 rmd160init.o: $(hdrdir)/ruby/internal/warning_push.h
 rmd160init.o: $(hdrdir)/ruby/internal/xmalloc.h
 rmd160init.o: $(hdrdir)/ruby/missing.h
+rmd160init.o: $(hdrdir)/ruby/onigmo.h
 rmd160init.o: $(hdrdir)/ruby/ruby.h
 rmd160init.o: $(hdrdir)/ruby/st.h
 rmd160init.o: $(hdrdir)/ruby/subst.h

--- a/ext/digest/sha1/depend
+++ b/ext/digest/sha1/depend
@@ -159,6 +159,7 @@ sha1.o: $(hdrdir)/ruby/internal/variable.h
 sha1.o: $(hdrdir)/ruby/internal/warning_push.h
 sha1.o: $(hdrdir)/ruby/internal/xmalloc.h
 sha1.o: $(hdrdir)/ruby/missing.h
+sha1.o: $(hdrdir)/ruby/onigmo.h
 sha1.o: $(hdrdir)/ruby/ruby.h
 sha1.o: $(hdrdir)/ruby/st.h
 sha1.o: $(hdrdir)/ruby/subst.h
@@ -322,6 +323,7 @@ sha1init.o: $(hdrdir)/ruby/internal/variable.h
 sha1init.o: $(hdrdir)/ruby/internal/warning_push.h
 sha1init.o: $(hdrdir)/ruby/internal/xmalloc.h
 sha1init.o: $(hdrdir)/ruby/missing.h
+sha1init.o: $(hdrdir)/ruby/onigmo.h
 sha1init.o: $(hdrdir)/ruby/ruby.h
 sha1init.o: $(hdrdir)/ruby/st.h
 sha1init.o: $(hdrdir)/ruby/subst.h

--- a/ext/digest/sha2/depend
+++ b/ext/digest/sha2/depend
@@ -159,6 +159,7 @@ sha2.o: $(hdrdir)/ruby/internal/variable.h
 sha2.o: $(hdrdir)/ruby/internal/warning_push.h
 sha2.o: $(hdrdir)/ruby/internal/xmalloc.h
 sha2.o: $(hdrdir)/ruby/missing.h
+sha2.o: $(hdrdir)/ruby/onigmo.h
 sha2.o: $(hdrdir)/ruby/ruby.h
 sha2.o: $(hdrdir)/ruby/st.h
 sha2.o: $(hdrdir)/ruby/subst.h
@@ -322,6 +323,7 @@ sha2init.o: $(hdrdir)/ruby/internal/variable.h
 sha2init.o: $(hdrdir)/ruby/internal/warning_push.h
 sha2init.o: $(hdrdir)/ruby/internal/xmalloc.h
 sha2init.o: $(hdrdir)/ruby/missing.h
+sha2init.o: $(hdrdir)/ruby/onigmo.h
 sha2init.o: $(hdrdir)/ruby/ruby.h
 sha2init.o: $(hdrdir)/ruby/st.h
 sha2init.o: $(hdrdir)/ruby/subst.h

--- a/ext/fcntl/depend
+++ b/ext/fcntl/depend
@@ -156,6 +156,7 @@ fcntl.o: $(hdrdir)/ruby/internal/variable.h
 fcntl.o: $(hdrdir)/ruby/internal/warning_push.h
 fcntl.o: $(hdrdir)/ruby/internal/xmalloc.h
 fcntl.o: $(hdrdir)/ruby/missing.h
+fcntl.o: $(hdrdir)/ruby/onigmo.h
 fcntl.o: $(hdrdir)/ruby/ruby.h
 fcntl.o: $(hdrdir)/ruby/st.h
 fcntl.o: $(hdrdir)/ruby/subst.h

--- a/ext/rbconfig/sizeof/depend
+++ b/ext/rbconfig/sizeof/depend
@@ -170,6 +170,7 @@ limits.o: $(hdrdir)/ruby/internal/variable.h
 limits.o: $(hdrdir)/ruby/internal/warning_push.h
 limits.o: $(hdrdir)/ruby/internal/xmalloc.h
 limits.o: $(hdrdir)/ruby/missing.h
+limits.o: $(hdrdir)/ruby/onigmo.h
 limits.o: $(hdrdir)/ruby/ruby.h
 limits.o: $(hdrdir)/ruby/st.h
 limits.o: $(hdrdir)/ruby/subst.h
@@ -330,6 +331,7 @@ sizes.o: $(hdrdir)/ruby/internal/variable.h
 sizes.o: $(hdrdir)/ruby/internal/warning_push.h
 sizes.o: $(hdrdir)/ruby/internal/xmalloc.h
 sizes.o: $(hdrdir)/ruby/missing.h
+sizes.o: $(hdrdir)/ruby/onigmo.h
 sizes.o: $(hdrdir)/ruby/ruby.h
 sizes.o: $(hdrdir)/ruby/st.h
 sizes.o: $(hdrdir)/ruby/subst.h

--- a/ext/ripper/depend
+++ b/ext/ripper/depend
@@ -209,6 +209,7 @@ eventids1.o: $(hdrdir)/ruby/internal/variable.h
 eventids1.o: $(hdrdir)/ruby/internal/warning_push.h
 eventids1.o: $(hdrdir)/ruby/internal/xmalloc.h
 eventids1.o: $(hdrdir)/ruby/missing.h
+eventids1.o: $(hdrdir)/ruby/onigmo.h
 eventids1.o: $(hdrdir)/ruby/ruby.h
 eventids1.o: $(hdrdir)/ruby/st.h
 eventids1.o: $(hdrdir)/ruby/subst.h

--- a/gc.c
+++ b/gc.c
@@ -1625,8 +1625,8 @@ rb_gc_obj_free(void *objspace, VALUE obj)
         rb_hash_free(obj);
         break;
       case T_REGEXP:
-        if (RREGEXP(obj)->ptr) {
-            onig_free(RREGEXP(obj)->ptr);
+        if (FL_TEST_RAW(obj, RREGEXP_INITIALIZED)) {
+            onig_free_body(RREGEXP_PTR(obj));
             RB_DEBUG_COUNTER_INC(obj_regexp_ptr);
         }
         break;

--- a/include/ruby/internal/core/rregexp.h
+++ b/include/ruby/internal/core/rregexp.h
@@ -27,6 +27,7 @@
 #include "ruby/internal/core/rstring.h"
 #include "ruby/internal/value.h"
 #include "ruby/internal/value_type.h"
+#include "ruby/onigmo.h"
 
 /**
  * Convenient casting macro.
@@ -42,15 +43,13 @@
  * @param   obj  An object, which is in fact an ::RRegexp.
  * @return  The passed object's pattern buffer.
  */
-#define RREGEXP_PTR(obj) (RREGEXP(obj)->ptr)
+#define RREGEXP_PTR(obj) (&RREGEXP(obj)->pattern)
 /** @cond INTERNAL_MACRO */
 #define RREGEXP_SRC      RREGEXP_SRC
 #define RREGEXP_SRC_PTR  RREGEXP_SRC_PTR
 #define RREGEXP_SRC_LEN  RREGEXP_SRC_LEN
 #define RREGEXP_SRC_END  RREGEXP_SRC_END
 /** @endcond */
-
-struct re_patter_buffer;  /* a.k.a. OnigRegexType, defined in onigmo.h */
 
 /**
  * Ruby's regular expression.   A regexp is compiled into  its own intermediate
@@ -61,14 +60,6 @@ struct RRegexp {
 
     /** Basic part, including flags and class. */
     struct RBasic basic;
-
-    /**
-     * The pattern buffer.   This is a quasi-opaque struct  that holds compiled
-     * intermediate representation of the regular expression.
-     *
-     * @note  Compilation of a regexp could be delayed until actual match.
-     */
-    struct re_pattern_buffer *ptr;
 
     /** Source code of this expression. */
     const VALUE src;
@@ -88,6 +79,14 @@ struct RRegexp {
      *           catastrophic effects.  Just leave it.
      */
     unsigned long usecnt;
+
+   /**
+    * The pattern buffer.   This is a quasi-opaque struct  that holds compiled
+    * intermediate representation of the regular expression.
+    *
+    * @note  Compilation of a regexp could be delayed until actual match.
+    */
+   struct re_pattern_buffer pattern; /* a.k.a. OnigRegexType, defined in onigmo.h */
 };
 
 RBIMPL_ATTR_PURE_UNLESS_DEBUG()

--- a/include/ruby/onigmo.h
+++ b/include/ruby/onigmo.h
@@ -849,6 +849,8 @@ void onig_free_body(OnigRegex);
 ONIG_EXTERN
 int onig_reg_copy(OnigRegex* reg, OnigRegex orig_reg);
 ONIG_EXTERN
+int onig_reg_copy_body(OnigRegex reg, OnigRegex orig_reg);
+ONIG_EXTERN
 OnigPosition onig_scan(OnigRegex reg, const OnigUChar* str, const OnigUChar* end, OnigRegion* region, OnigOptionType option, int (*scan_callback)(OnigPosition, OnigPosition, OnigRegion*, void*), void* callback_arg);
 ONIG_EXTERN
 OnigPosition onig_search(OnigRegex, const OnigUChar* str, const OnigUChar* end, const OnigUChar* start, const OnigUChar* range, OnigRegion* region, OnigOptionType option);

--- a/internal/re.h
+++ b/internal/re.h
@@ -12,6 +12,8 @@
 #include "ruby/ruby.h"          /* for VALUE */
 #include "ruby/re.h"            /* for struct RMatch and struct re_registers */
 
+#define RREGEXP_INITIALIZED FL_USER5
+
 #define RMATCH_ONIG FL_USER1
 #define RMATCH_OFFSETS_EXTERNAL FL_USER2
 

--- a/re.c
+++ b/re.c
@@ -36,6 +36,8 @@
  *
  * 4:     KCODE_FIXED
  *            The regexp has "fixed encoding", meaning it can't be match against any ASCII-compatible string.
+ * 5:     RREGEXP_INITIALIZED
+ *            The regexp has been fully initialized and can be used.
  * 6:     REG_ENCODING_NONE
  *            The regexp has no encoding. Means the `n` modifier was used.
  */
@@ -370,10 +372,16 @@ rb_char_to_option_kcode(int c, int *option, int *kcode)
     return 1;
 }
 
+static bool
+reg_initialized_p(VALUE re)
+{
+    return FL_TEST_RAW(re, RREGEXP_INITIALIZED) && RREGEXP_SRC(re) && RREGEXP_SRC_PTR(re);
+}
+
 static void
 rb_reg_check(VALUE re)
 {
-    if (!RREGEXP_PTR(re) || !RREGEXP_SRC(re) || !RREGEXP_SRC_PTR(re)) {
+    if (!reg_initialized_p(re)) {
         rb_raise(rb_eTypeError, "uninitialized Regexp");
     }
 }
@@ -541,7 +549,7 @@ rb_reg_source(VALUE re)
 static VALUE
 rb_reg_inspect(VALUE re)
 {
-    if (!RREGEXP_PTR(re) || !RREGEXP_SRC(re) || !RREGEXP_SRC_PTR(re)) {
+    if (!reg_initialized_p(re)) {
         return rb_any_to_s(re);
     }
     return rb_reg_desc(re);
@@ -884,32 +892,29 @@ rb_reg_named_captures(VALUE re)
 }
 
 static int
-onig_new_with_source(regex_t** reg, const UChar* pattern, const UChar* pattern_end,
+onig_new_with_source(regex_t* reg, const UChar* pattern, const UChar* pattern_end,
                      OnigOptionType option, OnigEncoding enc, const OnigSyntaxType* syntax,
                      OnigErrorInfo* einfo, const char *sourcefile, int sourceline)
 {
     int r;
 
-    *reg = (regex_t* )malloc(sizeof(regex_t));
-    if (IS_NULL(*reg)) return ONIGERR_MEMORY;
+    if (IS_NULL(reg)) return ONIGERR_MEMORY;
 
-    r = onig_reg_init(*reg, option, ONIGENC_CASE_FOLD_DEFAULT, enc, syntax);
+    r = onig_reg_init(reg, option, ONIGENC_CASE_FOLD_DEFAULT, enc, syntax);
     if (r) goto err;
 
-    r = onig_compile_ruby(*reg, pattern, pattern_end, einfo, sourcefile, sourceline);
+    r = onig_compile_ruby(reg, pattern, pattern_end, einfo, sourcefile, sourceline);
     if (r) {
       err:
-        onig_free(*reg);
-        *reg = NULL;
+        onig_free_body(reg);
     }
     return r;
 }
 
-static Regexp*
-make_regexp(const char *s, long len, rb_encoding *enc, int flags, onig_errmsg_buffer err,
+static bool
+make_regexp(Regexp *rp, const char *s, long len, rb_encoding *enc, int flags, onig_errmsg_buffer err,
         const char *sourcefile, int sourceline)
 {
-    Regexp *rp;
     int r;
     OnigErrorInfo einfo;
 
@@ -920,13 +925,13 @@ make_regexp(const char *s, long len, rb_encoding *enc, int flags, onig_errmsg_bu
        from that.
     */
 
-    r = onig_new_with_source(&rp, (UChar*)s, (UChar*)(s + len), flags,
+    r = onig_new_with_source(rp, (UChar*)s, (UChar*)(s + len), flags,
                  enc, OnigDefaultSyntax, &einfo, sourcefile, sourceline);
     if (r) {
         onig_error_code_to_str((UChar*)err, r, &einfo);
-        return 0;
+        return false;
     }
-    return rp;
+    return true;
 }
 
 
@@ -2558,7 +2563,7 @@ match_named_captures(int argc, VALUE *argv, VALUE match)
     hash = rb_hash_new();
     struct named_captures_data data = { hash, match, symbolize_names };
 
-    onig_foreach_name(RREGEXP(RMATCH(match)->regexp)->ptr, match_named_captures_iter, &data);
+    onig_foreach_name(RREGEXP_PTR(RMATCH(match)->regexp), match_named_captures_iter, &data);
 
     return hash;
 }
@@ -3395,7 +3400,7 @@ static void
 rb_reg_initialize_check(VALUE obj)
 {
     rb_check_frozen(obj);
-    if (RREGEXP_PTR(obj)) {
+    if (FL_TEST_RAW(obj, RREGEXP_INITIALIZED)) {
         rb_raise(rb_eTypeError, "already initialized regexp");
     }
 }
@@ -3444,10 +3449,12 @@ rb_reg_initialize(VALUE obj, const char *s, long len, rb_encoding *enc,
         re->basic.flags |= REG_ENCODING_NONE;
     }
 
-    re->ptr = make_regexp(RSTRING_PTR(unescaped), RSTRING_LEN(unescaped), enc,
+    bool success = make_regexp(RREGEXP_PTR(obj), RSTRING_PTR(unescaped), RSTRING_LEN(unescaped), enc,
                           options & ARG_REG_OPTION_MASK, err,
                           sourcefile, sourceline);
-    if (!re->ptr) return -1;
+    if (!success) return -1;
+    FL_SET_RAW(obj, RREGEXP_INITIALIZED);
+
     if (RBASIC_CLASS(obj) == rb_cRegexp) {
         OBJ_FREEZE(obj);
     }
@@ -3495,7 +3502,7 @@ rb_reg_s_alloc(VALUE klass)
 {
     NEWOBJ_OF(re, struct RRegexp, klass, T_REGEXP, sizeof(struct RRegexp));
 
-    re->ptr = 0;
+    MEMZERO(RREGEXP_PTR(re), struct re_pattern_buffer, 1);
     RB_OBJ_WRITE(re, &re->src, 0);
     re->usecnt = 0;
 
@@ -4108,14 +4115,13 @@ static VALUE
 reg_copy(VALUE copy, VALUE orig)
 {
     int r;
-    regex_t *re;
-
     rb_reg_initialize_check(copy);
-    if ((r = onig_reg_copy(&re, RREGEXP_PTR(orig))) != 0) {
+    if ((r = onig_reg_copy_body(RREGEXP_PTR(copy), RREGEXP_PTR(orig))) != 0) {
         /* ONIGERR_MEMORY only */
         rb_raise(rb_eRegexpError, "%s", onig_error_code_to_format(r));
     }
-    RREGEXP_PTR(copy) = re;
+    FL_SET_RAW(copy, RREGEXP_INITIALIZED);
+
     RB_OBJ_WRITE(copy, &RREGEXP(copy)->src, RREGEXP(orig)->src);
     RREGEXP_PTR(copy)->timelimit = RREGEXP_PTR(orig)->timelimit;
     rb_enc_copy(copy, orig);

--- a/regcomp.c
+++ b/regcomp.c
@@ -5604,53 +5604,62 @@ dup_copy(const void *ptr, size_t size)
 }
 
 extern int
-onig_reg_copy(regex_t** nreg, regex_t* oreg)
+onig_reg_copy_body(regex_t* nreg, regex_t* oreg)
 {
   if (IS_NOT_NULL(oreg)) {
-    regex_t *reg = *nreg = (regex_t* )xmalloc(sizeof(regex_t));
-    if (IS_NULL(reg)) return ONIGERR_MEMORY;
+    *nreg = *oreg;
 
-    *reg = *oreg;
+# define COPY_FAILED(mem, size) IS_NULL(nreg->mem = dup_copy(oreg->mem, size))
 
-# define COPY_FAILED(mem, size) IS_NULL(reg->mem = dup_copy(reg->mem, size))
-
-    if (IS_NOT_NULL(reg->exact)) {
-      size_t exact_size = reg->exact_end - reg->exact;
+    if (IS_NOT_NULL(oreg->exact)) {
+      size_t exact_size = oreg->exact_end - oreg->exact;
       if (COPY_FAILED(exact, exact_size))
         goto err;
-      (reg)->exact_end = (reg)->exact + exact_size;
+      (nreg)->exact_end = (oreg)->exact + exact_size;
     }
 
-    if (IS_NOT_NULL(reg->p)) {
-      if (COPY_FAILED(p, reg->alloc))
+    if (IS_NOT_NULL(oreg->p)) {
+      if (COPY_FAILED(p, oreg->alloc))
         goto err_p;
     }
-    if (IS_NOT_NULL(reg->repeat_range)) {
-      if (COPY_FAILED(repeat_range, reg->repeat_range_alloc * sizeof(OnigRepeatRange)))
+    if (IS_NOT_NULL(oreg->repeat_range)) {
+      if (COPY_FAILED(repeat_range, oreg->repeat_range_alloc * sizeof(OnigRepeatRange)))
         goto err_repeat_range;
     }
-    if (IS_NOT_NULL(reg->name_table)) {
-      if (onig_names_copy(reg, oreg))
+    if (IS_NOT_NULL(oreg->name_table)) {
+      if (onig_names_copy(nreg, oreg))
         goto err_name_table;
     }
-    if (IS_NOT_NULL(reg->chain)) {
-      if (onig_reg_copy(&reg->chain, reg->chain))
+    if (IS_NOT_NULL(oreg->chain)) {
+      if (onig_reg_copy(&nreg->chain, oreg->chain))
         goto err_chain;
     }
     return 0;
 # undef COPY_FAILED
 
   err_chain:
-    onig_names_free(reg);
+    onig_names_free(nreg);
   err_name_table:
-    xfree(reg->repeat_range);
+    xfree(nreg->repeat_range);
   err_repeat_range:
-    xfree(reg->p);
+    xfree(nreg->p);
   err_p:
-    xfree(reg->exact);
+    xfree(nreg->exact);
   err:
-    xfree(reg);
+    xfree(nreg);
     return ONIGERR_MEMORY;
+  }
+  return 0;
+}
+
+extern int
+onig_reg_copy(regex_t** nreg, regex_t* oreg)
+{
+  if (IS_NOT_NULL(oreg)) {
+    regex_t *reg = *nreg = (regex_t* )xmalloc(sizeof(regex_t));
+    if (IS_NULL(reg)) return ONIGERR_MEMORY;
+
+    return onig_reg_copy_body(reg, oreg);
   }
   return 0;
 }


### PR DESCRIPTION
When embeddeding `struct re_pattern_buffer`, `RRegexp` end up 488B large, which result in a rather minimal 24B waste in 512B slots.

Considering that out of these 24B, 8B were previously the pointer, and the other 16B were likely used by internal allocator metadata overhead, this is likely neutral in term of memory usage.

This however requires a few changes:
  - Stop relying on `RREGEXP_PTR == NULL` to check for initialization.
  - `reg_copy` requires a new `onig_reg_copy_body` API. (To be upstreamed)