### PR TITLE
Disable git background maintenance in bundler specs

### DIFF
--- a/spec/bundler/spec_helper.rb
+++ b/spec/bundler/spec_helper.rb
@@ -147,6 +147,16 @@ RSpec.configure do |config|
       ENV["GIT_CONFIG_NOSYSTEM"] = "1"
     end
 
+    # Disable git background maintenance. Since Git 2.46, commands like
+    # `git commit` spawn a detached `git maintenance run --auto` process,
+    # which briefly creates `.git/objects/maintenance.lock`. That races with
+    # specs copying repositories with FileUtils.cp_r, causing flaky ENOENT
+    # failures. GIT_CONFIG_COUNT is available since Git 2.31 and silently
+    # ignored by older versions.
+    ENV["GIT_CONFIG_COUNT"] = "1"
+    ENV["GIT_CONFIG_KEY_0"] = "maintenance.auto"
+    ENV["GIT_CONFIG_VALUE_0"] = "false"
+
     # Don't wrap output in tests
     ENV["THOR_COLUMNS"] = "10000"
 


### PR DESCRIPTION
`test-bundler-parallel` on macos-15 and macos-26 has been failing intermittently since 2026-07-02. The local override examples in `spec/bundler/install/gemfile/git_spec.rb` copy a just-committed git repository with `FileUtils.cp_r` and fail with `Errno::ENOENT` on `.git/objects/maintenance.lock` during the `.git` traversal.

https://github.com/ruby/ruby/actions/runs/28764006107/job/85284933867
https://github.com/ruby/ruby/actions/runs/28764006107/job/85284933859

Since Git 2.46, auto maintenance spawned after commands like `git commit` runs as a detached `git maintenance run --auto` process. That process briefly creates `.git/objects/maintenance.lock` and removes it when done, so the file can disappear between the readdir and the `lstat` of `FileUtils.cp_r`. The macos-14 runner ships an older Git that does not detach, which is why it keeps passing.

This change injects `maintenance.auto=false` via the `GIT_CONFIG_COUNT` environment variables in `spec_helper.rb` so the maintenance process is never spawned. Disabling only `gc.auto` would not help because the lock file is created before the maintenance tasks evaluate their conditions. The environment variables reach every git invocation made by the specs and by bundler subprocesses, and Git older than 2.31 silently ignores them.

Verified with `GIT_TRACE=1` that the injection suppresses the `git maintenance run --auto --quiet --detach` spawn on Git 2.50, and confirmed the 12 local override examples in `git_spec.rb` pass with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
