### PR TITLE
auto_review_pr.rb: Fix link to Onigmo

### DIFF
--- a/tool/auto_review_pr.rb
+++ b/tool/auto_review_pr.rb
@@ -155,7 +155,7 @@ class AutoReviewPR
     comment << "#{UPSTREAM_COMMENT_PREFIX}\n\n"
 
     upstream_repos.each do |upstream_repo, files|
-      comment << "* https://github.com/ruby/#{upstream_repo}\n"
+      comment << "* https://github.com/#{upstream_repo}\n"
       files.each do |file|
         comment << "    * #{file}\n"
       end

--- a/tool/sync_default_gems.rb
+++ b/tool/sync_default_gems.rb
@@ -314,7 +314,7 @@ module SyncDefaultGems
       return if NO_UPSTREAM.any? {|dst| file.start_with?(dst) }
       REPOSITORIES.find do |repo_name, repository|
         if repository.mappings.any? {|_src, dst| file.start_with?(dst) }
-          break repo_name
+          break repository.upstream
         end
       end
     end

--- a/tool/test/test_sync_default_gems.rb
+++ b/tool/test/test_sync_default_gems.rb
@@ -369,8 +369,8 @@ module Test_SyncDefaultGems
           lib/net/https.rb
       ])
       expected = {
-        "un" => %w[lib/un.rb],
-        "net-http" => %w[lib/net/https.rb],
+        "ruby/un" => %w[lib/un.rb],
+        "ruby/net-http" => %w[lib/net/https.rb],
         nil => %w[lib/unicode_normalize/normalize.rb lib/unicode_normalize/tables.rb],
       }
       assert_equal(expected, group)


### PR DESCRIPTION
It's incorrectly pointing to `ruby/Onigmo` which doesn't exist.

Fix: https://github.com/ruby/ruby/pull/17671#issuecomment-4890876274