### PR TITLE
Decouple Test_StrSetLen from slot size

### DIFF
--- a/test/-ext-/string/test_set_len.rb
+++ b/test/-ext-/string/test_set_len.rb
@@ -4,8 +4,7 @@ require "-test-/string"
 
 class Test_StrSetLen < Test::Unit::TestCase
   def setup
-    # Make string long enough so that it is not embedded
-    @range_end = ("0".ord + GC.stat_heap(0, :slot_size)).chr
+    @range_end = ("0".ord + 40).chr
     @s0 = [*"0"..@range_end].join("").freeze
     @s1 = Bug::String.new(@s0)
   end


### PR DESCRIPTION
Array#join now pre-calculates the length, so the string created in the tests were embedded anyways.