### PR TITLE
ZJIT: Don't side-effect in assert!()

### DIFF
--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -2073,8 +2073,9 @@ impl Assembler
                 } else {
                     if let Some(allocation) = assignment[active_interval.id] {
                         if let Some(reg) = allocation.alloc_pool_index(num_registers) {
+                            let was_not_there_before = free_registers.insert(reg);
                             assert!(
-                                free_registers.insert(reg),
+                                was_not_there_before,
                                 "attempted to return allocator register {:?} to the free pool more than once",
                                 allocation.assigned_reg().unwrap(),
                             );


### PR DESCRIPTION
This is a footgun, less bad than the C version, whereby an `assert!`
could reasonably be changed into a `debug_assert!` and cause a problem
because the condition no longer executes in release builds.

This one would probably be instantly noticeable, but still.
