### PR TITLE
ZJIT: Fix extended basic block typo

### DIFF
--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -2322,7 +2322,7 @@ impl std::fmt::Display for Insn {
     }
 }
 
-/// An extended basic block in a [`Function`].
+/// A basic block in a [`Function`].
 #[derive(Default, Debug)]
 pub struct Block {
     /// The index of the first YARV instruction for the Block in the ISEQ


### PR DESCRIPTION
This PR fixes a comment that calls ZJIT basic blocks extended. They have been traditional basic blocks since #16888.
