### PR TITLE
ZJIT: Fix problem with Empty/num_bits

### DIFF
--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -768,8 +768,8 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
         Insn::LoadSP => gen_load_sp(),
         &Insn::GetEP { level } => gen_get_ep(asm, level),
         Insn::LoadSelf => gen_load_self(asm),
-        &Insn::LoadField { recv, id, offset, return_type } => gen_load_field(asm, opnd!(recv), id, offset, return_type),
-        &Insn::StoreField { recv, id, offset, val } => no_output!(gen_store_field(asm, opnd!(recv), id, offset, opnd!(val), function.type_of(val))),
+        &Insn::LoadField { recv, id, offset, return_type: _, num_bits } => gen_load_field(asm, opnd!(recv), id, offset, num_bits),
+        &Insn::StoreField { recv, id, offset, val, num_bits } => no_output!(gen_store_field(asm, opnd!(recv), id, offset, opnd!(val), num_bits)),
         &Insn::WriteBarrier { recv, val } => no_output!(gen_write_barrier(jit, asm, opnd!(recv), opnd!(val), function.type_of(val))),
         &Insn::IsBlockGiven { lep } => gen_is_block_given(asm, opnd!(lep)),
         Insn::ArrayInclude { elements, target, state } => gen_array_include(jit, asm, function, opnds!(elements), opnd!(target), &function.frame_state(*state)),
@@ -1370,18 +1370,18 @@ fn gen_load_self(asm: &mut Assembler) -> Opnd {
     asm.load(Opnd::mem(64, CFP, RUBY_OFFSET_CFP_SELF))
 }
 
-fn gen_load_field(asm: &mut Assembler, recv: Opnd, id: FieldName, offset: i32, return_type: Type) -> Opnd {
+fn gen_load_field(asm: &mut Assembler, recv: Opnd, id: FieldName, offset: i32, num_bits: u8) -> Opnd {
     gen_incr_counter(asm, Counter::load_field_count);
     asm_comment!(asm, "Load field id={id} offset={offset}");
     let recv = asm.load_mem(recv);
-    asm.load(Opnd::mem(return_type.num_bits(), recv, offset))
+    asm.load(Opnd::mem(num_bits, recv, offset))
 }
 
-fn gen_store_field(asm: &mut Assembler, recv: Opnd, id: FieldName, offset: i32, val: Opnd, val_type: Type) {
+fn gen_store_field(asm: &mut Assembler, recv: Opnd, id: FieldName, offset: i32, val: Opnd, num_bits: u8) {
     gen_incr_counter(asm, Counter::store_field_count);
     asm_comment!(asm, "Store field id={id} offset={offset}");
     let recv = asm.load_mem(recv);
-    asm.store(Opnd::mem(val_type.num_bits(), recv, offset), val);
+    asm.store(Opnd::mem(num_bits, recv, offset), val);
 }
 
 fn gen_write_barrier(jit: &mut JITState, asm: &mut Assembler, recv: Opnd, val: Opnd, val_type: Type) {

--- a/zjit/src/cruby_methods.rs
+++ b/zjit/src/cruby_methods.rs
@@ -322,20 +322,10 @@ fn inline_string_to_s(fun: &mut hir::Function, block: hir::BlockId, recv: hir::I
 fn inline_thread_current(fun: &mut hir::Function, block: hir::BlockId, _recv: hir::InsnId, args: &[hir::InsnId], _state: hir::InsnId) -> Option<hir::InsnId> {
     let &[] = args else { return None; };
     let ec = fun.push_insn(block, hir::Insn::LoadEC);
-    let thread_ptr = fun.push_insn(block, hir::Insn::LoadField {
-        recv: ec,
-        id: FieldName::thread_ptr,
-        offset: RUBY_OFFSET_EC_THREAD_PTR,
-        return_type: types::CPtr,
-    });
-    let thread_self = fun.push_insn(block, hir::Insn::LoadField {
-        recv: thread_ptr,
-        id: FieldName::SelfParam,
-        offset: RUBY_OFFSET_THREAD_SELF,
-        // TODO(max): Add Thread type. But Thread.current is not guaranteed to be an exact Thread.
-        // You can make subclasses...
-        return_type: types::BasicObject,
-    });
+    let thread_ptr = fun.load_field(block, ec, FieldName::thread_ptr, RUBY_OFFSET_EC_THREAD_PTR, types::CPtr);
+    // TODO(max): Add Thread type. But Thread.current is not guaranteed to be an exact Thread.
+    // You can make subclasses...
+    let thread_self = fun.load_field(block, thread_ptr, FieldName::SelfParam, RUBY_OFFSET_THREAD_SELF, types::BasicObject);
     Some(thread_self)
 }
 
@@ -468,12 +458,7 @@ fn inline_hash_aset(fun: &mut hir::Function, block: hir::BlockId, recv: hir::Ins
 fn inline_string_bytesize(fun: &mut hir::Function, block: hir::BlockId, recv: hir::InsnId, args: &[hir::InsnId], state: hir::InsnId) -> Option<hir::InsnId> {
     if args.is_empty() && fun.likely_a(recv, types::String, state) {
         let recv = fun.coerce_to(block, recv, types::String, state);
-        let len = fun.push_insn(block, hir::Insn::LoadField {
-            recv,
-            id: FieldName::len,
-            offset: RUBY_OFFSET_RSTRING_LEN,
-            return_type: types::CInt64,
-        });
+        let len = fun.load_string_length(block, recv);
 
         let result = fun.push_insn(block, hir::Insn::BoxFixnum {
             val: len,
@@ -492,12 +477,7 @@ fn inline_string_getbyte(fun: &mut hir::Function, block: hir::BlockId, recv: hir
         // when converting the index to a C integer.
         let index = fun.coerce_to(block, index, types::Fixnum, state);
         let unboxed_index = fun.push_insn(block, hir::Insn::UnboxFixnum { val: index });
-        let len = fun.push_insn(block, hir::Insn::LoadField {
-            recv,
-            id: FieldName::len,
-            offset: RUBY_OFFSET_RSTRING_LEN,
-            return_type: types::CInt64,
-        });
+        let len = fun.load_string_length(block, recv);
         // TODO(max): Find a way to mark these guards as not needed for correctness... as in, once
         // the data dependency is gone (say, the StringGetbyte is elided), they can also be elided.
         //
@@ -520,12 +500,7 @@ fn inline_string_setbyte(fun: &mut hir::Function, block: hir::BlockId, recv: hir
         let value = fun.coerce_to(block, value, types::Fixnum, state);
 
         let unboxed_index = fun.push_insn(block, hir::Insn::UnboxFixnum { val: index });
-        let len = fun.push_insn(block, hir::Insn::LoadField {
-            recv,
-            id: FieldName::len,
-            offset: RUBY_OFFSET_RSTRING_LEN,
-            return_type: types::CInt64,
-        });
+        let len = fun.load_string_length(block, recv);
         let unboxed_index = fun.push_insn(block, hir::Insn::GuardLess { left: unboxed_index, right: len, reason: Box::new(SideExitReason::GuardLess), state });
         let unboxed_index = fun.push_insn(block, hir::Insn::AdjustBounds { index: unboxed_index, length: len });
         let zero = fun.push_insn(block, hir::Insn::Const { val: hir::Const::CInt64(0) });
@@ -543,12 +518,7 @@ fn inline_string_setbyte(fun: &mut hir::Function, block: hir::BlockId, recv: hir
 
 fn inline_string_empty_p(fun: &mut hir::Function, block: hir::BlockId, recv: hir::InsnId, args: &[hir::InsnId], _state: hir::InsnId) -> Option<hir::InsnId> {
     let &[] = args else { return None; };
-    let len = fun.push_insn(block, hir::Insn::LoadField {
-        recv,
-        id: FieldName::len,
-        offset: RUBY_OFFSET_RSTRING_LEN,
-        return_type: types::CInt64,
-    });
+    let len = fun.load_string_length(block, recv);
     let zero = fun.push_insn(block, hir::Insn::Const { val: hir::Const::CInt64(0) });
     let is_zero = fun.push_insn(block, hir::Insn::IsBitEqual { left: len, right: zero });
     let result = fun.push_insn(block, hir::Insn::BoxBool { val: is_zero });

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5530,19 +5530,6 @@ impl Function {
             let mut new_insns = vec![];
             for insn_id in old_insns {
                 let replacement_id = match self.find(insn_id) {
-                    // TODO (nirvdrum 2026-06-26): Folding the guard to a SideExit is a workaround,
-                    // not a proper fix. It relies on constant folding to keep an Empty-typed value
-                    // (see below) from reaching codegen; disabling this pass would let that value
-                    // through and the program would fail to compile on x86-64. Compilation correctness
-                    // should not depend on an optimization pass, so this should be replaced by a
-                    // comprehensive fix.
-                    Insn::GuardType { val, guard_type, state, recompile } if !self.type_of(val).could_be(guard_type) => {
-                        // The value's type is disjoint from the guard type, so the guard can never
-                        // pass. Every execution would side-exit here, so we replace the guard with an
-                        // unconditional exit. The terminator handling below then drops the rest of
-                        // the block, which is now unreachable.
-                        self.new_insn(Insn::SideExit { state, reason: Box::new(SideExitReason::GuardType(guard_type)), recompile })
-                    }
                     Insn::GuardType { val, guard_type, .. } if self.is_a(val, guard_type) => {
                         self.make_equal_to(insn_id, val);
                         // Don't bother re-inferring the type of val; we already know it.

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -2793,6 +2793,10 @@ impl Function {
         self.push_insn(block, Insn::LoadField { recv, id, offset, return_type })
     }
 
+    pub fn load_string_length(&mut self, block: BlockId, str: InsnId) -> InsnId {
+        self.load_field(block, str, FieldName::len, RUBY_OFFSET_RSTRING_LEN, types::CInt64)
+    }
+
     // Add an instruction to an SSA block
     fn push_insn_id(&mut self, block: BlockId, insn_id: InsnId) -> InsnId {
         self.blocks[block.0].insns.push(insn_id);

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -1022,10 +1022,10 @@ pub enum Insn {
     LoadSP,
     /// Load cfp->self
     LoadSelf,
-    LoadField { recv: InsnId, id: FieldName, offset: i32, return_type: Type },
+    LoadField { recv: InsnId, id: FieldName, offset: i32, return_type: Type, num_bits: u8 },
     /// Write `val` at an offset of `recv`.
     /// When writing a Ruby object to a Ruby object, one must use GuardNotFrozen (or equivalent) before and WriteBarrier after.
-    StoreField { recv: InsnId, id: FieldName, offset: i32, val: InsnId },
+    StoreField { recv: InsnId, id: FieldName, offset: i32, val: InsnId, num_bits: u8 },
     WriteBarrier { recv: InsnId, val: InsnId },
 
     /// Check whether VM_FRAME_FLAG_MODIFIED_BLOCK_PARAM is set in the (already loaded) environment flags.
@@ -2269,10 +2269,10 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
             Insn::LoadSP => write!(f, "LoadSP"),
             &Insn::GetEP { level } => write!(f, "GetEP {level}"),
             Insn::LoadSelf => write!(f, "LoadSelf"),
-            &Insn::LoadField { recv, id, offset, return_type: _ } => {
+            &Insn::LoadField { recv, id, offset, return_type: _, num_bits: _ } => {
                 write!(f, "LoadField {recv}, :{id}@{:#x}", self.ptr_map.map_offset(offset))
             }
-            &Insn::StoreField { recv, id, offset, val } => write!(f, "StoreField {recv}, :{id}@{:#x}, {val}", self.ptr_map.map_offset(offset)),
+            &Insn::StoreField { recv, id, offset, val, num_bits: _ } => write!(f, "StoreField {recv}, :{id}@{:#x}, {val}", self.ptr_map.map_offset(offset)),
             &Insn::WriteBarrier { recv, val } => write!(f, "WriteBarrier {recv}, {val}"),
             Insn::SetIvar { self_val, id, val, .. } => write!(f, "SetIvar {self_val}, :{}, {val}", id.contents_lossy()),
             Insn::GetGlobal { id, .. } => write!(f, "GetGlobal :{}", id.contents_lossy()),
@@ -2790,7 +2790,8 @@ impl Function {
     }
 
     pub fn load_field(&mut self, block: BlockId, recv: InsnId, id: FieldName, offset: i32, return_type: Type) -> InsnId {
-        self.push_insn(block, Insn::LoadField { recv, id, offset, return_type })
+        let num_bits = return_type.num_bits();
+        self.push_insn(block, Insn::LoadField { recv, id, offset, return_type, num_bits })
     }
 
     pub fn load_string_length(&mut self, block: BlockId, str: InsnId) -> InsnId {
@@ -4100,7 +4101,7 @@ impl Function {
                                     };
 
                                     let replacement = if let (OptimizedMethodType::StructAset, &[val]) = (opt_type, args.as_slice()) {
-                                        self.push_insn(block, Insn::StoreField { recv: target, id: mid.into(), offset, val });
+                                        self.push_insn(block, Insn::StoreField { recv: target, id: mid.into(), offset, val, num_bits: types::BasicObject.num_bits() });
                                         self.push_insn(block, Insn::WriteBarrier { recv, val });
                                         val
                                     } else { // StructAref
@@ -5229,13 +5230,13 @@ impl Function {
             let offset = SIZEOF_VALUE_I32 * ivar_index as i32;
             (as_heap, offset)
         };
-        self.push_insn(block, Insn::StoreField { recv: ivar_storage, id: id.into(), offset, val });
+        self.push_insn(block, Insn::StoreField { recv: ivar_storage, id: id.into(), offset, val, num_bits: types::BasicObject.num_bits() });
         self.push_insn(block, Insn::WriteBarrier { recv: self_val, val });
         if next_shape_id != profiled_type.shape() {
             // Write the new shape ID
             let shape_id = self.push_insn(block, Insn::Const { val: Const::CShape(next_shape_id) });
             let shape_id_offset = unsafe { rb_shape_id_offset() };
-            self.push_insn(block, Insn::StoreField { recv: self_val, id: FieldName::shape_id, offset: shape_id_offset, val: shape_id });
+            self.push_insn(block, Insn::StoreField { recv: self_val, id: FieldName::shape_id, offset: shape_id_offset, val: shape_id, num_bits: types::CShape.num_bits() });
         }
         Ok(())
     }
@@ -8181,6 +8182,7 @@ fn add_iseq_to_hir(
                         id: FieldName::VM_ENV_DATA_INDEX_FLAGS,
                         offset: SIZEOF_VALUE_I32 * (VM_ENV_DATA_INDEX_FLAGS as i32),
                         val: modified,
+                        num_bits: types::CInt64.num_bits(),
                     });
                 }
                 YARVINSN_getblockparamproxy => {
@@ -9414,6 +9416,7 @@ fn compile_jit_entry_state(fun: &mut Function, jit_entry_block: BlockId, jit_ent
                 id: local_id.into(),
                 offset: -(SIZEOF_VALUE_I32 * ep_offset),
                 val: local,
+                num_bits: types::BasicObject.num_bits(),
             });
         }
     }

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -2440,41 +2440,6 @@ mod hir_opt_tests {
         assert!(!insns.contains(&dead_const));
     }
 
-    // A GuardType whose value type is disjoint from the guard type can never pass, so every
-    // execution side-exits there. fold_constants should replace the guard with an unconditional
-    // SideExit and drop the now-unreachable instructions that follow.
-    #[test]
-    fn test_fold_guard_type_that_can_never_pass_into_side_exit() {
-        let mut function = Function::new(std::ptr::null());
-        let entry = function.entry_block;
-
-        let state = function.push_insn(entry, Insn::Snapshot { state: Box::new(FrameState::new(std::ptr::null())) });
-        // A nil constant is a NilClass, which is disjoint from Fixnum, so the guard below can
-        // never pass and the optimizer infers its result as Empty.
-        let nil = function.push_insn(entry, Insn::Const { val: Const::Value(Qnil) });
-        let guard = function.push_insn(entry, Insn::GuardType { val: nil, guard_type: types::Fixnum, state, recompile: None });
-        function.push_insn(entry, Insn::StoreField { recv: nil, id: FieldName::len, offset: 0, val: guard });
-        function.push_insn(entry, Insn::Return { val: guard });
-        function.seal_entries();
-
-        function.infer_types();
-        function.fold_constants();
-
-        let insns: Vec<Insn> = function.blocks[entry.0].insns.iter().map(|&id| function.find(id)).collect();
-        assert!(
-            insns.iter().any(|insn| matches!(insn, Insn::SideExit { .. })),
-            "expected the always-failing guard to be folded into a SideExit, got {insns:?}",
-        );
-        assert!(
-            !insns.iter().any(|insn| matches!(insn, Insn::GuardType { .. })),
-            "the always-failing GuardType should have been removed, got {insns:?}",
-        );
-        assert!(
-            !insns.iter().any(|insn| matches!(insn, Insn::StoreField { .. } | Insn::Return { .. })),
-            "instructions after the unconditional SideExit are unreachable and should have been dropped, got {insns:?}",
-        );
-    }
-
     #[test]
     fn test_eliminate_new_array() {
         eval("

--- a/zjit/src/hir_type/mod.rs
+++ b/zjit/src/hir_type/mod.rs
@@ -641,9 +641,6 @@ impl Type {
     }
 
     pub fn num_bytes(&self) -> u8 {
-        assert!(!self.bit_equal(types::Empty),
-                "a value of type Empty is unreachable and should have been eliminated before codegen");
-
         if self.is_subtype(types::CUInt8) || self.is_subtype(types::CInt8) { return 1; }
         if self.is_subtype(types::CUInt16) || self.is_subtype(types::CInt16) { return 2; }
         if self.is_subtype(types::CUInt32) || self.is_subtype(types::CInt32) { return 4; }


### PR DESCRIPTION
Best reviewed as individual commits.

Plumb sizes down because they are known at HIR emit time. Do not try to rediscover sizes from (potentially Empty) types.