### PR TITLE
ZJIT: Trace icache invalidation and mprotect

### DIFF
--- a/zjit/src/backend/arm64/mod.rs
+++ b/zjit/src/backend/arm64/mod.rs
@@ -110,7 +110,9 @@ fn emit_jmp_ptr_with_invalidation(cb: &mut CodeBlock, dst_ptr: CodePtr) {
     let start = cb.get_write_ptr();
     emit_jmp_ptr(cb, dst_ptr, true);
     let end = cb.get_write_ptr();
-    unsafe { rb_jit_icache_invalidate(start.raw_ptr(cb) as _, end.raw_ptr(cb) as _) };
+    trace_compile_phase("invalidate_icache", || {
+        unsafe { rb_jit_icache_invalidate(start.raw_ptr(cb) as _, end.raw_ptr(cb) as _) };
+    });
 }
 
 fn emit_jmp_ptr(cb: &mut CodeBlock, dst_ptr: CodePtr, padding: bool) {
@@ -1729,8 +1731,10 @@ impl Assembler {
 
             cb.link_labels().or(Err(CompileError::LabelLinkingFailure))?;
 
-            // Invalidate icache for newly written out region so we don't run stale code.
-            unsafe { rb_jit_icache_invalidate(start_ptr.raw_ptr(cb) as _, cb.get_write_ptr().raw_ptr(cb) as _) };
+            trace_compile_phase("invalidate_icache", || {
+                // Invalidate icache for newly written out region so we don't run stale code.
+                unsafe { rb_jit_icache_invalidate(start_ptr.raw_ptr(cb) as _, cb.get_write_ptr().raw_ptr(cb) as _) };
+            });
 
             Ok((start_ptr, gc_offsets))
         })

--- a/zjit/src/options.rs
+++ b/zjit/src/options.rs
@@ -336,6 +336,9 @@ macro_rules! get_option {
     ($option_name:ident) => {
         unsafe { crate::options::OPTIONS.as_ref() }.unwrap().$option_name
     };
+    ($option_name:ident, $default:expr) => {
+        unsafe { crate::options::OPTIONS.as_ref() }.map(|opts| opts.$option_name).unwrap_or($default)
+    };
 }
 pub(crate) use get_option;
 

--- a/zjit/src/stats.rs
+++ b/zjit/src/stats.rs
@@ -1024,7 +1024,7 @@ pub fn zjit_alloc_bytes() -> usize {
 /// Record a Perfetto duration event spanning the execution of `func`.
 /// Uses Begin/End pairs so nested calls produce properly nested slices.
 pub fn trace_compile_phase<F, R>(name: &str, func: F) -> R where F: FnOnce() -> R {
-    if !get_option!(trace_compiles) {
+    if !get_option!(trace_compiles, /*default=*/false) {
         return func();
     }
     if let Some(tracer) = ZJITState::get_tracer() {

--- a/zjit/src/virtualmem.rs
+++ b/zjit/src/virtualmem.rs
@@ -333,15 +333,21 @@ pub mod sys {
 
     impl super::Allocator for SystemAllocator {
         fn mark_writable(&mut self, ptr: *const u8, size: u32) -> bool {
-            unsafe { rb_jit_mark_writable(ptr as VoidPtr, size) }
+            crate::stats::trace_compile_phase("mark_writable", || {
+                unsafe { rb_jit_mark_writable(ptr as VoidPtr, size) }
+            })
         }
 
         fn mark_executable(&mut self, ptr: *const u8, size: u32) {
-            unsafe { rb_jit_mark_executable(ptr as VoidPtr, size) }
+            crate::stats::trace_compile_phase("mark_executable", || {
+                unsafe { rb_jit_mark_executable(ptr as VoidPtr, size) }
+            })
         }
 
         fn mark_unused(&mut self, ptr: *const u8, size: u32) -> bool {
-            unsafe { rb_jit_mark_unused(ptr as VoidPtr, size) }
+            crate::stats::trace_compile_phase("mark_unused", || {
+                unsafe { rb_jit_mark_unused(ptr as VoidPtr, size) }
+            })
         }
     }
 }


### PR DESCRIPTION
We do these frequently, so we should see how much time they are actually taking up.
