### PR TITLE
remove unused rb_gc_vm_context->lock

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -194,7 +194,6 @@ rb_gc_get_ractor_newobj_cache(void)
 void
 rb_gc_initialize_vm_context(struct rb_gc_vm_context *context)
 {
-    rb_native_mutex_initialize(&context->lock);
     context->ec = GET_EC();
 }
 

--- a/gc/gc.h
+++ b/gc/gc.h
@@ -38,8 +38,6 @@ struct rb_gc_obj_suffix {
 #endif
 
 struct rb_gc_vm_context {
-    rb_nativethread_lock_t lock;
-
     struct rb_execution_context_struct *ec;
 };
 


### PR DESCRIPTION
Follow up to GH-PR #16914
rb_gc_vm_context->lock is no longer used.

Notably, this patch masks the fact that `rb_gc_initialize_vm_context` is called multiple times during garbage collection.
From `heap_prepare` via `gc_continue` and `gc_start`
From `garbage_collect` via `gc_rest` and `gc_start`
I am unable to determine whether these actually cause any issues.

Microsoft's Application Verifier reported this as `Critical section is already initialized.` (Before this patch)

The Application Verifier log is here.
```xml
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<avrf:logfile xmlns:avrf="Application Verifier">
	<avrf:logSession TimeStarted="2026-07-07 : 12:08:13" PID="25008" Version="2">
		<avrf:logEntry Time="2026-07-07 : 12:08:15" LayerName="Locks" StopCode="0x211" Severity="Error">
			<avrf:message>Critical section is already initialized.</avrf:message>
			<avrf:parameter1>c046fd0 - Critical section address. Run !cs -s &lt;address&gt; to get more information.</avrf:parameter1>
			<avrf:parameter2>db62fd0 - Critical section debug info address.</avrf:parameter2>
			<avrf:parameter3>8652d0 - First initialization stack trace. Use dps to dump it if non-NULL.</avrf:parameter3>
			<avrf:parameter4>0 - Not used.</avrf:parameter4>
			<avrf:stackTrace>
				<avrf:trace>vfbasics!+7ffb1b7d5fd5 ( @ 0)</avrf:trace>
				<avrf:trace>miniruby!rb_native_mutex_initialize+17 (S:\ruby\thread_win32.c @ 414)</avrf:trace>
				<avrf:trace>miniruby!rb_gc_initialize_vm_context+16 (S:\ruby\gc.c @ 198)</avrf:trace>
				<avrf:trace>miniruby!gc_marking_enter+7a (S:\ruby\gc\default\default.c @ 7208)</avrf:trace>
				<avrf:trace>miniruby!gc_marks+17 (S:\ruby\gc\default\default.c @ 6247)</avrf:trace>
				<avrf:trace>miniruby!gc_start+517 (S:\ruby\gc\default\default.c @ 6946)</avrf:trace>
				<avrf:trace>miniruby!garbage_collect+3a (S:\ruby\gc\default\default.c @ 6826)</avrf:trace>
				<avrf:trace>miniruby!garbage_collect_with_gvl+9b (S:\ruby\gc\default\default.c @ 7294)</avrf:trace>
				<avrf:trace>miniruby!objspace_malloc_increase_body+b1 (S:\ruby\gc\default\default.c @ 8644)</avrf:trace>
				<avrf:trace>miniruby!objspace_malloc_fixup+85 (S:\ruby\gc\default\default.c @ 8722)</avrf:trace>
				<avrf:trace>miniruby!rb_gc_impl_calloc+d4 (S:\ruby\gc\default\default.c @ 8849)</avrf:trace>
				<avrf:trace>miniruby!ruby_xcalloc_body+47 (S:\ruby\gc.c @ 5479)</avrf:trace>
				<avrf:trace>miniruby!ruby_xcalloc+1d (S:\ruby\gc.c @ 5472)</avrf:trace>
				<avrf:trace>miniruby!Init_default_shapes+13 (S:\ruby\shape.c @ 1572)</avrf:trace>
				<avrf:trace>miniruby!rb_call_inits+9 (S:\ruby\inits.c @ 23)</avrf:trace>
				<avrf:trace>miniruby!ruby_setup+e0 (S:\ruby\eval.c @ 90)</avrf:trace>
				<avrf:trace>miniruby!ruby_init+9 (S:\ruby\eval.c @ 101)</avrf:trace>
				<avrf:trace>miniruby!rb_main+1c (S:\ruby\main.c @ 42)</avrf:trace>
				<avrf:trace>miniruby!w32_main+2a (S:\ruby\main.c @ 63)</avrf:trace>
				<avrf:trace>miniruby!wmain+d (S:\ruby\main.c @ 48)</avrf:trace>
				<avrf:trace>miniruby!__scrt_common_main_seh+10f (D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl @ 288)</avrf:trace>
				<avrf:trace>KERNEL32!BaseThreadInitThunk+17 ( @ 0)</avrf:trace>
				<avrf:trace>ntdll!RtlUserThreadStart+2c ( @ 0)</avrf:trace>
			</avrf:stackTrace>
		</avrf:logEntry>
	</avrf:logSession>
</avrf:logfile>
```

The stack trace is here.
```
vrfcore!VerifierStopMessageEx + 0x858
vfbasics + 0x5fd5
miniruby!rb_native_mutex_initialize + 0x17
miniruby!rb_gc_initialize_vm_context + 0x16
miniruby!gc_marking_enter + 0x7a
miniruby!gc_marks + 0x17
miniruby!gc_start + 0x517
miniruby!garbage_collect + 0x3a
miniruby!garbage_collect_with_gvl + 0x9b
miniruby!objspace_malloc_increase_body + 0xb1
miniruby!objspace_malloc_fixup + 0x85
miniruby!rb_gc_impl_calloc + 0xd4
miniruby!ruby_xcalloc_body + 0x47
miniruby!ruby_xcalloc + 0x1d
miniruby!Init_default_shapes + 0x13
miniruby!rb_call_inits + 0x9
miniruby!ruby_setup + 0xe0
miniruby!ruby_init + 0x9
miniruby!rb_main + 0x1c
miniruby!w32_main + 0x2a
miniruby!wmain + 0xd
miniruby!invoke_main + 0x22
miniruby!__scrt_common_main_seh + 0x10f
```
