### PR TITLE
Initialize ruby_current_ec_key before calling rb_objspace_alloc

### DIFF
--- a/thread_none.c
+++ b/thread_none.c
@@ -125,10 +125,18 @@ ruby_thread_set_native(rb_thread_t *th)
     return 1; // always succeed
 }
 
+#ifndef RB_THREAD_LOCAL_SPECIFIER
+void
+Init_thread_local_key(void)
+{
+    // no TLS setup
+}
+#endif
+
 void
 Init_native_thread(rb_thread_t *main_th)
 {
-    // no TLS setup and no thread id setup
+    // no thread id setup
     ruby_thread_set_native(main_th);
 }
 

--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -1735,6 +1735,19 @@ ruby_thread_set_native(rb_thread_t *th)
 #endif
 }
 
+#ifndef RB_THREAD_LOCAL_SPECIFIER
+void
+Init_thread_local_key(void)
+{
+    if (pthread_key_create(&ruby_native_thread_key, 0) == EAGAIN) {
+        rb_bug("pthread_key_create failed (ruby_native_thread_key)");
+    }
+    if (pthread_key_create(&ruby_current_ec_key, 0) == EAGAIN) {
+        rb_bug("pthread_key_create failed (ruby_current_ec_key)");
+    }
+}
+#endif
+
 static void native_thread_setup(struct rb_native_thread *nt);
 static void native_thread_setup_on_thread(struct rb_native_thread *nt);
 
@@ -1757,14 +1770,6 @@ Init_native_thread(rb_thread_t *main_th)
     }
 #endif
 
-#ifndef RB_THREAD_LOCAL_SPECIFIER
-    if (pthread_key_create(&ruby_native_thread_key, 0) == EAGAIN) {
-        rb_bug("pthread_key_create failed (ruby_native_thread_key)");
-    }
-    if (pthread_key_create(&ruby_current_ec_key, 0) == EAGAIN) {
-        rb_bug("pthread_key_create failed (ruby_current_ec_key)");
-    }
-#endif
     ruby_posix_signal(SIGVTALRM, null_func);
 
     // setup vm

--- a/thread_win32.c
+++ b/thread_win32.c
@@ -185,7 +185,7 @@ ruby_thread_set_native(rb_thread_t *th)
 }
 
 void
-Init_native_thread(rb_thread_t *main_th)
+Init_thread_local_key(void)
 {
     if ((ruby_current_ec_key = TlsAlloc()) == TLS_OUT_OF_INDEXES) {
         rb_bug("TlsAlloc() for ruby_current_ec_key fails");
@@ -193,7 +193,11 @@ Init_native_thread(rb_thread_t *main_th)
     if ((ruby_native_thread_key = TlsAlloc()) == TLS_OUT_OF_INDEXES) {
         rb_bug("TlsAlloc() for ruby_native_thread_key fails");
     }
+}
 
+void
+Init_native_thread(rb_thread_t *main_th)
+{
     // setup main thread
 
     ruby_thread_set_native(main_th);

--- a/vm.c
+++ b/vm.c
@@ -4660,6 +4660,7 @@ Init_BareVM(void)
     vm_init2(vm);
 
     ruby_current_vm_ptr = vm;
+    Init_thread_local_key();
     rb_objspace_alloc();
     rb_id_table_init(&vm->negative_cme_table, 16);
     st_init_existing_numtable_with_size(&vm->overloaded_cme_table, 0);

--- a/vm_core.h
+++ b/vm_core.h
@@ -2269,6 +2269,11 @@ void rb_ec_error_print(rb_execution_context_t * volatile ec, volatile VALUE erri
 void rb_execution_context_update(rb_execution_context_t *ec);
 void rb_execution_context_mark(const rb_execution_context_t *ec);
 void rb_fiber_close(rb_fiber_t *fib);
+#ifndef RB_THREAD_LOCAL_SPECIFIER
+void Init_thread_local_key(void);
+#else
+#define Init_thread_local_key() ((void)0)
+#endif
 void Init_native_thread(rb_thread_t *th);
 int rb_vm_check_ints_blocking(rb_execution_context_t *ec);
 


### PR DESCRIPTION
rb_objspace_alloc uses ruby_current_ec_key if RB_THREAD_LOCAL_SPECIFIER not defined.
Currently, ruby_current_ec_key is initialized in Init_native_thread, is called after rb_objspace_alloc in Init_BareVM.
Microsoft's Application Verifier pointed this out.

miniruby.exe!native_tls_get(unsigned long key) line 44
miniruby.exe!rb_current_execution_context(bool expect_ec) line 2145
miniruby.exe!rb_current_ractor_raw(bool expect) line 2165
miniruby.exe!malloc_gc_allowed() line 5422
miniruby.exe!ruby_xmalloc_body(unsigned __int64 size) line 5434
miniruby.exe!ruby_xmalloc(unsigned __int64 size) line 5416
miniruby.exe!rb_st_init_table_with_size(const st_hash_type * type, unsigned __int64 size) line 625
miniruby.exe!rb_st_init_table(const st_hash_type * type) line 655
miniruby.exe!rb_st_init_numtable() line 663
miniruby.exe!rb_gc_impl_objspace_init(void * objspace_ptr) line 10316
miniruby.exe!rb_objspace_alloc() line 966
miniruby.exe!Init_BareVM() line 4664
miniruby.exe!ruby_setup() line 81
miniruby.exe!ruby_init() line 101
miniruby.exe!rb_main(int argc, char * * argv) line 42
miniruby.exe!w32_main(int argc, char * * argv) line 63
miniruby.exe!wmain() line 48