### PR TITLE
Change test_capacity_embedded for dynamic slot size

### DIFF
--- a/test/-ext-/string/test_capacity.rb
+++ b/test/-ext-/string/test_capacity.rb
@@ -8,7 +8,7 @@ class Test_StringCapacity < Test::Unit::TestCase
   def test_capacity_embedded
     assert_equal pool_slot_size(0) - embed_header_size - 1, capa('foo')
     assert_equal max_embed_len, capa('1' * max_embed_len)
-    assert_equal max_embed_len, capa('1' * (max_embed_len - 1))
+    assert_include ((max_embed_len - 1)..max_embed_len), capa('1' * (max_embed_len - 1))
   end
 
   def test_capacity_shared


### PR DESCRIPTION
If the slot size is dynamic, a string of length (max_embed_len - 1) will have exact capacity rather than rounded up to max_embed_len.