### PR TITLE
onig_reg_copy_body: fix copying of exact_end

### DIFF
--- a/regcomp.c
+++ b/regcomp.c
@@ -5615,7 +5615,7 @@ onig_reg_copy_body(regex_t* nreg, regex_t* oreg)
       size_t exact_size = oreg->exact_end - oreg->exact;
       if (COPY_FAILED(exact, exact_size))
         goto err;
-      (nreg)->exact_end = (oreg)->exact + exact_size;
+      (nreg)->exact_end = (nreg)->exact + exact_size;
     }
 
     if (IS_NOT_NULL(oreg->p)) {

--- a/test/ruby/test_regexp.rb
+++ b/test/ruby/test_regexp.rb
@@ -740,6 +740,7 @@ class TestRegexp < Test::Unit::TestCase
     assert_equal(/foo/, assert_warning(/ignored/) {Regexp.new(/foo/, Regexp::IGNORECASE)})
     assert_equal(/foo/, assert_no_warning(/ignored/) {Regexp.new(/foo/)})
     assert_equal(/foo/, assert_no_warning(/ignored/) {Regexp.new(/foo/, timeout: nil)})
+    assert_equal(/foo/, Regexp.new(Regexp.new("foo")))
 
     arg_encoding_none = //n.options # ARG_ENCODING_NONE is implementation defined value
 


### PR DESCRIPTION
Followup: https://github.com/ruby/ruby/pull/17671