### PR TITLE
Stop including onigmo.h in rregexp.h

### DIFF
--- a/depend
+++ b/depend
@@ -3002,7 +3002,6 @@ debug_counter.$(OBJEXT): {$(VPATH)}internal/variable.h
 debug_counter.$(OBJEXT): {$(VPATH)}internal/warning_push.h
 debug_counter.$(OBJEXT): {$(VPATH)}internal/xmalloc.h
 debug_counter.$(OBJEXT): {$(VPATH)}missing.h
-debug_counter.$(OBJEXT): {$(VPATH)}onigmo.h
 debug_counter.$(OBJEXT): {$(VPATH)}st.h
 debug_counter.$(OBJEXT): {$(VPATH)}subst.h
 debug_counter.$(OBJEXT): {$(VPATH)}thread_native.h
@@ -3386,7 +3385,6 @@ dln.$(OBJEXT): {$(VPATH)}internal/variable.h
 dln.$(OBJEXT): {$(VPATH)}internal/warning_push.h
 dln.$(OBJEXT): {$(VPATH)}internal/xmalloc.h
 dln.$(OBJEXT): {$(VPATH)}missing.h
-dln.$(OBJEXT): {$(VPATH)}onigmo.h
 dln.$(OBJEXT): {$(VPATH)}st.h
 dln.$(OBJEXT): {$(VPATH)}subst.h
 dln_find.$(OBJEXT): $(hdrdir)/ruby/ruby.h
@@ -3546,7 +3544,6 @@ dln_find.$(OBJEXT): {$(VPATH)}internal/variable.h
 dln_find.$(OBJEXT): {$(VPATH)}internal/warning_push.h
 dln_find.$(OBJEXT): {$(VPATH)}internal/xmalloc.h
 dln_find.$(OBJEXT): {$(VPATH)}missing.h
-dln_find.$(OBJEXT): {$(VPATH)}onigmo.h
 dln_find.$(OBJEXT): {$(VPATH)}st.h
 dln_find.$(OBJEXT): {$(VPATH)}subst.h
 dmydln.$(OBJEXT): $(hdrdir)/ruby/ruby.h
@@ -3705,7 +3702,6 @@ dmydln.$(OBJEXT): {$(VPATH)}internal/variable.h
 dmydln.$(OBJEXT): {$(VPATH)}internal/warning_push.h
 dmydln.$(OBJEXT): {$(VPATH)}internal/xmalloc.h
 dmydln.$(OBJEXT): {$(VPATH)}missing.h
-dmydln.$(OBJEXT): {$(VPATH)}onigmo.h
 dmydln.$(OBJEXT): {$(VPATH)}st.h
 dmydln.$(OBJEXT): {$(VPATH)}subst.h
 dmyenc.$(OBJEXT): {$(VPATH)}dmyenc.c
@@ -7107,7 +7103,6 @@ inits.$(OBJEXT): {$(VPATH)}internal/variable.h
 inits.$(OBJEXT): {$(VPATH)}internal/warning_push.h
 inits.$(OBJEXT): {$(VPATH)}internal/xmalloc.h
 inits.$(OBJEXT): {$(VPATH)}missing.h
-inits.$(OBJEXT): {$(VPATH)}onigmo.h
 inits.$(OBJEXT): {$(VPATH)}prelude.rbinc
 inits.$(OBJEXT): {$(VPATH)}st.h
 inits.$(OBJEXT): {$(VPATH)}subst.h
@@ -8524,7 +8519,6 @@ loadpath.$(OBJEXT): {$(VPATH)}internal/warning_push.h
 loadpath.$(OBJEXT): {$(VPATH)}internal/xmalloc.h
 loadpath.$(OBJEXT): {$(VPATH)}loadpath.c
 loadpath.$(OBJEXT): {$(VPATH)}missing.h
-loadpath.$(OBJEXT): {$(VPATH)}onigmo.h
 loadpath.$(OBJEXT): {$(VPATH)}st.h
 loadpath.$(OBJEXT): {$(VPATH)}subst.h
 loadpath.$(OBJEXT): {$(VPATH)}verconf.h
@@ -8862,7 +8856,6 @@ main.$(OBJEXT): {$(VPATH)}internal/warning_push.h
 main.$(OBJEXT): {$(VPATH)}internal/xmalloc.h
 main.$(OBJEXT): {$(VPATH)}main.c
 main.$(OBJEXT): {$(VPATH)}missing.h
-main.$(OBJEXT): {$(VPATH)}onigmo.h
 main.$(OBJEXT): {$(VPATH)}st.h
 main.$(OBJEXT): {$(VPATH)}subst.h
 main.$(OBJEXT): {$(VPATH)}vm_debug.h
@@ -9269,7 +9262,6 @@ math.$(OBJEXT): {$(VPATH)}internal/warning_push.h
 math.$(OBJEXT): {$(VPATH)}internal/xmalloc.h
 math.$(OBJEXT): {$(VPATH)}math.c
 math.$(OBJEXT): {$(VPATH)}missing.h
-math.$(OBJEXT): {$(VPATH)}onigmo.h
 math.$(OBJEXT): {$(VPATH)}shape.h
 math.$(OBJEXT): {$(VPATH)}st.h
 math.$(OBJEXT): {$(VPATH)}subst.h
@@ -16660,7 +16652,6 @@ setproctitle.$(OBJEXT): {$(VPATH)}internal/variable.h
 setproctitle.$(OBJEXT): {$(VPATH)}internal/warning_push.h
 setproctitle.$(OBJEXT): {$(VPATH)}internal/xmalloc.h
 setproctitle.$(OBJEXT): {$(VPATH)}missing.h
-setproctitle.$(OBJEXT): {$(VPATH)}onigmo.h
 setproctitle.$(OBJEXT): {$(VPATH)}setproctitle.c
 setproctitle.$(OBJEXT): {$(VPATH)}st.h
 setproctitle.$(OBJEXT): {$(VPATH)}subst.h
@@ -19272,7 +19263,6 @@ util.$(OBJEXT): {$(VPATH)}internal/variable.h
 util.$(OBJEXT): {$(VPATH)}internal/warning_push.h
 util.$(OBJEXT): {$(VPATH)}internal/xmalloc.h
 util.$(OBJEXT): {$(VPATH)}missing.h
-util.$(OBJEXT): {$(VPATH)}onigmo.h
 util.$(OBJEXT): {$(VPATH)}ruby_atomic.h
 util.$(OBJEXT): {$(VPATH)}st.h
 util.$(OBJEXT): {$(VPATH)}subst.h

--- a/enc/depend
+++ b/enc/depend
@@ -5243,7 +5243,6 @@ enc/trans/big5.$(OBJEXT): internal/variable.h
 enc/trans/big5.$(OBJEXT): internal/warning_push.h
 enc/trans/big5.$(OBJEXT): internal/xmalloc.h
 enc/trans/big5.$(OBJEXT): missing.h
-enc/trans/big5.$(OBJEXT): onigmo.h
 enc/trans/big5.$(OBJEXT): st.h
 enc/trans/big5.$(OBJEXT): subst.h
 enc/trans/cesu_8.$(OBJEXT): $(hdrdir)/ruby/ruby.h
@@ -5404,7 +5403,6 @@ enc/trans/cesu_8.$(OBJEXT): internal/variable.h
 enc/trans/cesu_8.$(OBJEXT): internal/warning_push.h
 enc/trans/cesu_8.$(OBJEXT): internal/xmalloc.h
 enc/trans/cesu_8.$(OBJEXT): missing.h
-enc/trans/cesu_8.$(OBJEXT): onigmo.h
 enc/trans/cesu_8.$(OBJEXT): st.h
 enc/trans/cesu_8.$(OBJEXT): subst.h
 enc/trans/chinese.$(OBJEXT): $(hdrdir)/ruby/ruby.h
@@ -5565,7 +5563,6 @@ enc/trans/chinese.$(OBJEXT): internal/variable.h
 enc/trans/chinese.$(OBJEXT): internal/warning_push.h
 enc/trans/chinese.$(OBJEXT): internal/xmalloc.h
 enc/trans/chinese.$(OBJEXT): missing.h
-enc/trans/chinese.$(OBJEXT): onigmo.h
 enc/trans/chinese.$(OBJEXT): st.h
 enc/trans/chinese.$(OBJEXT): subst.h
 enc/trans/ebcdic.$(OBJEXT): $(hdrdir)/ruby/ruby.h
@@ -5726,7 +5723,6 @@ enc/trans/ebcdic.$(OBJEXT): internal/variable.h
 enc/trans/ebcdic.$(OBJEXT): internal/warning_push.h
 enc/trans/ebcdic.$(OBJEXT): internal/xmalloc.h
 enc/trans/ebcdic.$(OBJEXT): missing.h
-enc/trans/ebcdic.$(OBJEXT): onigmo.h
 enc/trans/ebcdic.$(OBJEXT): st.h
 enc/trans/ebcdic.$(OBJEXT): subst.h
 enc/trans/emoji.$(OBJEXT): $(hdrdir)/ruby/ruby.h
@@ -5887,7 +5883,6 @@ enc/trans/emoji.$(OBJEXT): internal/variable.h
 enc/trans/emoji.$(OBJEXT): internal/warning_push.h
 enc/trans/emoji.$(OBJEXT): internal/xmalloc.h
 enc/trans/emoji.$(OBJEXT): missing.h
-enc/trans/emoji.$(OBJEXT): onigmo.h
 enc/trans/emoji.$(OBJEXT): st.h
 enc/trans/emoji.$(OBJEXT): subst.h
 enc/trans/emoji_iso2022_kddi.$(OBJEXT): $(hdrdir)/ruby/ruby.h
@@ -6048,7 +6043,6 @@ enc/trans/emoji_iso2022_kddi.$(OBJEXT): internal/variable.h
 enc/trans/emoji_iso2022_kddi.$(OBJEXT): internal/warning_push.h
 enc/trans/emoji_iso2022_kddi.$(OBJEXT): internal/xmalloc.h
 enc/trans/emoji_iso2022_kddi.$(OBJEXT): missing.h
-enc/trans/emoji_iso2022_kddi.$(OBJEXT): onigmo.h
 enc/trans/emoji_iso2022_kddi.$(OBJEXT): st.h
 enc/trans/emoji_iso2022_kddi.$(OBJEXT): subst.h
 enc/trans/emoji_sjis_docomo.$(OBJEXT): $(hdrdir)/ruby/ruby.h
@@ -6209,7 +6203,6 @@ enc/trans/emoji_sjis_docomo.$(OBJEXT): internal/variable.h
 enc/trans/emoji_sjis_docomo.$(OBJEXT): internal/warning_push.h
 enc/trans/emoji_sjis_docomo.$(OBJEXT): internal/xmalloc.h
 enc/trans/emoji_sjis_docomo.$(OBJEXT): missing.h
-enc/trans/emoji_sjis_docomo.$(OBJEXT): onigmo.h
 enc/trans/emoji_sjis_docomo.$(OBJEXT): st.h
 enc/trans/emoji_sjis_docomo.$(OBJEXT): subst.h
 enc/trans/emoji_sjis_kddi.$(OBJEXT): $(hdrdir)/ruby/ruby.h
@@ -6370,7 +6363,6 @@ enc/trans/emoji_sjis_kddi.$(OBJEXT): internal/variable.h
 enc/trans/emoji_sjis_kddi.$(OBJEXT): internal/warning_push.h
 enc/trans/emoji_sjis_kddi.$(OBJEXT): internal/xmalloc.h
 enc/trans/emoji_sjis_kddi.$(OBJEXT): missing.h
-enc/trans/emoji_sjis_kddi.$(OBJEXT): onigmo.h
 enc/trans/emoji_sjis_kddi.$(OBJEXT): st.h
 enc/trans/emoji_sjis_kddi.$(OBJEXT): subst.h
 enc/trans/emoji_sjis_softbank.$(OBJEXT): $(hdrdir)/ruby/ruby.h
@@ -6531,7 +6523,6 @@ enc/trans/emoji_sjis_softbank.$(OBJEXT): internal/variable.h
 enc/trans/emoji_sjis_softbank.$(OBJEXT): internal/warning_push.h
 enc/trans/emoji_sjis_softbank.$(OBJEXT): internal/xmalloc.h
 enc/trans/emoji_sjis_softbank.$(OBJEXT): missing.h
-enc/trans/emoji_sjis_softbank.$(OBJEXT): onigmo.h
 enc/trans/emoji_sjis_softbank.$(OBJEXT): st.h
 enc/trans/emoji_sjis_softbank.$(OBJEXT): subst.h
 enc/trans/escape.$(OBJEXT): $(hdrdir)/ruby/ruby.h
@@ -6692,7 +6683,6 @@ enc/trans/escape.$(OBJEXT): internal/variable.h
 enc/trans/escape.$(OBJEXT): internal/warning_push.h
 enc/trans/escape.$(OBJEXT): internal/xmalloc.h
 enc/trans/escape.$(OBJEXT): missing.h
-enc/trans/escape.$(OBJEXT): onigmo.h
 enc/trans/escape.$(OBJEXT): st.h
 enc/trans/escape.$(OBJEXT): subst.h
 enc/trans/gb18030.$(OBJEXT): $(hdrdir)/ruby/ruby.h
@@ -6853,7 +6843,6 @@ enc/trans/gb18030.$(OBJEXT): internal/variable.h
 enc/trans/gb18030.$(OBJEXT): internal/warning_push.h
 enc/trans/gb18030.$(OBJEXT): internal/xmalloc.h
 enc/trans/gb18030.$(OBJEXT): missing.h
-enc/trans/gb18030.$(OBJEXT): onigmo.h
 enc/trans/gb18030.$(OBJEXT): st.h
 enc/trans/gb18030.$(OBJEXT): subst.h
 enc/trans/gbk.$(OBJEXT): $(hdrdir)/ruby/ruby.h
@@ -7014,7 +7003,6 @@ enc/trans/gbk.$(OBJEXT): internal/variable.h
 enc/trans/gbk.$(OBJEXT): internal/warning_push.h
 enc/trans/gbk.$(OBJEXT): internal/xmalloc.h
 enc/trans/gbk.$(OBJEXT): missing.h
-enc/trans/gbk.$(OBJEXT): onigmo.h
 enc/trans/gbk.$(OBJEXT): st.h
 enc/trans/gbk.$(OBJEXT): subst.h
 enc/trans/iso2022.$(OBJEXT): $(hdrdir)/ruby/ruby.h
@@ -7176,7 +7164,6 @@ enc/trans/iso2022.$(OBJEXT): internal/variable.h
 enc/trans/iso2022.$(OBJEXT): internal/warning_push.h
 enc/trans/iso2022.$(OBJEXT): internal/xmalloc.h
 enc/trans/iso2022.$(OBJEXT): missing.h
-enc/trans/iso2022.$(OBJEXT): onigmo.h
 enc/trans/iso2022.$(OBJEXT): st.h
 enc/trans/iso2022.$(OBJEXT): subst.h
 enc/trans/japanese.$(OBJEXT): $(hdrdir)/ruby/ruby.h
@@ -7337,7 +7324,6 @@ enc/trans/japanese.$(OBJEXT): internal/variable.h
 enc/trans/japanese.$(OBJEXT): internal/warning_push.h
 enc/trans/japanese.$(OBJEXT): internal/xmalloc.h
 enc/trans/japanese.$(OBJEXT): missing.h
-enc/trans/japanese.$(OBJEXT): onigmo.h
 enc/trans/japanese.$(OBJEXT): st.h
 enc/trans/japanese.$(OBJEXT): subst.h
 enc/trans/japanese_euc.$(OBJEXT): $(hdrdir)/ruby/ruby.h
@@ -7498,7 +7484,6 @@ enc/trans/japanese_euc.$(OBJEXT): internal/variable.h
 enc/trans/japanese_euc.$(OBJEXT): internal/warning_push.h
 enc/trans/japanese_euc.$(OBJEXT): internal/xmalloc.h
 enc/trans/japanese_euc.$(OBJEXT): missing.h
-enc/trans/japanese_euc.$(OBJEXT): onigmo.h
 enc/trans/japanese_euc.$(OBJEXT): st.h
 enc/trans/japanese_euc.$(OBJEXT): subst.h
 enc/trans/japanese_sjis.$(OBJEXT): $(hdrdir)/ruby/ruby.h
@@ -7659,7 +7644,6 @@ enc/trans/japanese_sjis.$(OBJEXT): internal/variable.h
 enc/trans/japanese_sjis.$(OBJEXT): internal/warning_push.h
 enc/trans/japanese_sjis.$(OBJEXT): internal/xmalloc.h
 enc/trans/japanese_sjis.$(OBJEXT): missing.h
-enc/trans/japanese_sjis.$(OBJEXT): onigmo.h
 enc/trans/japanese_sjis.$(OBJEXT): st.h
 enc/trans/japanese_sjis.$(OBJEXT): subst.h
 enc/trans/korean.$(OBJEXT): $(hdrdir)/ruby/ruby.h
@@ -7820,7 +7804,6 @@ enc/trans/korean.$(OBJEXT): internal/variable.h
 enc/trans/korean.$(OBJEXT): internal/warning_push.h
 enc/trans/korean.$(OBJEXT): internal/xmalloc.h
 enc/trans/korean.$(OBJEXT): missing.h
-enc/trans/korean.$(OBJEXT): onigmo.h
 enc/trans/korean.$(OBJEXT): st.h
 enc/trans/korean.$(OBJEXT): subst.h
 enc/trans/newline.$(OBJEXT): $(hdrdir)/ruby/ruby.h
@@ -7980,7 +7963,6 @@ enc/trans/newline.$(OBJEXT): internal/variable.h
 enc/trans/newline.$(OBJEXT): internal/warning_push.h
 enc/trans/newline.$(OBJEXT): internal/xmalloc.h
 enc/trans/newline.$(OBJEXT): missing.h
-enc/trans/newline.$(OBJEXT): onigmo.h
 enc/trans/newline.$(OBJEXT): st.h
 enc/trans/newline.$(OBJEXT): subst.h
 enc/trans/single_byte.$(OBJEXT): $(hdrdir)/ruby/ruby.h
@@ -8141,7 +8123,6 @@ enc/trans/single_byte.$(OBJEXT): internal/variable.h
 enc/trans/single_byte.$(OBJEXT): internal/warning_push.h
 enc/trans/single_byte.$(OBJEXT): internal/xmalloc.h
 enc/trans/single_byte.$(OBJEXT): missing.h
-enc/trans/single_byte.$(OBJEXT): onigmo.h
 enc/trans/single_byte.$(OBJEXT): st.h
 enc/trans/single_byte.$(OBJEXT): subst.h
 enc/trans/transdb.$(OBJEXT): $(hdrdir)/ruby.h
@@ -8302,7 +8283,6 @@ enc/trans/transdb.$(OBJEXT): internal/variable.h
 enc/trans/transdb.$(OBJEXT): internal/warning_push.h
 enc/trans/transdb.$(OBJEXT): internal/xmalloc.h
 enc/trans/transdb.$(OBJEXT): missing.h
-enc/trans/transdb.$(OBJEXT): onigmo.h
 enc/trans/transdb.$(OBJEXT): st.h
 enc/trans/transdb.$(OBJEXT): subst.h
 enc/trans/transdb.$(OBJEXT): transdb.h
@@ -8464,7 +8444,6 @@ enc/trans/utf8_mac.$(OBJEXT): internal/variable.h
 enc/trans/utf8_mac.$(OBJEXT): internal/warning_push.h
 enc/trans/utf8_mac.$(OBJEXT): internal/xmalloc.h
 enc/trans/utf8_mac.$(OBJEXT): missing.h
-enc/trans/utf8_mac.$(OBJEXT): onigmo.h
 enc/trans/utf8_mac.$(OBJEXT): st.h
 enc/trans/utf8_mac.$(OBJEXT): subst.h
 enc/trans/utf_16_32.$(OBJEXT): $(hdrdir)/ruby/ruby.h
@@ -8625,7 +8604,6 @@ enc/trans/utf_16_32.$(OBJEXT): internal/variable.h
 enc/trans/utf_16_32.$(OBJEXT): internal/warning_push.h
 enc/trans/utf_16_32.$(OBJEXT): internal/xmalloc.h
 enc/trans/utf_16_32.$(OBJEXT): missing.h
-enc/trans/utf_16_32.$(OBJEXT): onigmo.h
 enc/trans/utf_16_32.$(OBJEXT): st.h
 enc/trans/utf_16_32.$(OBJEXT): subst.h
 enc/unicode.$(OBJEXT): $(UNICODE_HDR_DIR)/casefold.h

--- a/ext/-test-/RUBY_ALIGNOF/depend
+++ b/ext/-test-/RUBY_ALIGNOF/depend
@@ -156,7 +156,6 @@ c.o: $(hdrdir)/ruby/internal/variable.h
 c.o: $(hdrdir)/ruby/internal/warning_push.h
 c.o: $(hdrdir)/ruby/internal/xmalloc.h
 c.o: $(hdrdir)/ruby/missing.h
-c.o: $(hdrdir)/ruby/onigmo.h
 c.o: $(hdrdir)/ruby/ruby.h
 c.o: $(hdrdir)/ruby/st.h
 c.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/arith_seq/beg_len_step/depend
+++ b/ext/-test-/arith_seq/beg_len_step/depend
@@ -155,7 +155,6 @@ beg_len_step.o: $(hdrdir)/ruby/internal/variable.h
 beg_len_step.o: $(hdrdir)/ruby/internal/warning_push.h
 beg_len_step.o: $(hdrdir)/ruby/internal/xmalloc.h
 beg_len_step.o: $(hdrdir)/ruby/missing.h
-beg_len_step.o: $(hdrdir)/ruby/onigmo.h
 beg_len_step.o: $(hdrdir)/ruby/ruby.h
 beg_len_step.o: $(hdrdir)/ruby/st.h
 beg_len_step.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/arith_seq/extract/depend
+++ b/ext/-test-/arith_seq/extract/depend
@@ -155,7 +155,6 @@ extract.o: $(hdrdir)/ruby/internal/variable.h
 extract.o: $(hdrdir)/ruby/internal/warning_push.h
 extract.o: $(hdrdir)/ruby/internal/xmalloc.h
 extract.o: $(hdrdir)/ruby/missing.h
-extract.o: $(hdrdir)/ruby/onigmo.h
 extract.o: $(hdrdir)/ruby/ruby.h
 extract.o: $(hdrdir)/ruby/st.h
 extract.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/array/concat/depend
+++ b/ext/-test-/array/concat/depend
@@ -156,7 +156,6 @@ to_ary_concat.o: $(hdrdir)/ruby/internal/variable.h
 to_ary_concat.o: $(hdrdir)/ruby/internal/warning_push.h
 to_ary_concat.o: $(hdrdir)/ruby/internal/xmalloc.h
 to_ary_concat.o: $(hdrdir)/ruby/missing.h
-to_ary_concat.o: $(hdrdir)/ruby/onigmo.h
 to_ary_concat.o: $(hdrdir)/ruby/ruby.h
 to_ary_concat.o: $(hdrdir)/ruby/st.h
 to_ary_concat.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/array/resize/depend
+++ b/ext/-test-/array/resize/depend
@@ -155,7 +155,6 @@ resize.o: $(hdrdir)/ruby/internal/variable.h
 resize.o: $(hdrdir)/ruby/internal/warning_push.h
 resize.o: $(hdrdir)/ruby/internal/xmalloc.h
 resize.o: $(hdrdir)/ruby/missing.h
-resize.o: $(hdrdir)/ruby/onigmo.h
 resize.o: $(hdrdir)/ruby/ruby.h
 resize.o: $(hdrdir)/ruby/st.h
 resize.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/bignum/depend
+++ b/ext/-test-/bignum/depend
@@ -156,7 +156,6 @@ big2str.o: $(hdrdir)/ruby/internal/variable.h
 big2str.o: $(hdrdir)/ruby/internal/warning_push.h
 big2str.o: $(hdrdir)/ruby/internal/xmalloc.h
 big2str.o: $(hdrdir)/ruby/missing.h
-big2str.o: $(hdrdir)/ruby/onigmo.h
 big2str.o: $(hdrdir)/ruby/ruby.h
 big2str.o: $(hdrdir)/ruby/st.h
 big2str.o: $(hdrdir)/ruby/subst.h
@@ -320,7 +319,6 @@ bigzero.o: $(hdrdir)/ruby/internal/variable.h
 bigzero.o: $(hdrdir)/ruby/internal/warning_push.h
 bigzero.o: $(hdrdir)/ruby/internal/xmalloc.h
 bigzero.o: $(hdrdir)/ruby/missing.h
-bigzero.o: $(hdrdir)/ruby/onigmo.h
 bigzero.o: $(hdrdir)/ruby/ruby.h
 bigzero.o: $(hdrdir)/ruby/st.h
 bigzero.o: $(hdrdir)/ruby/subst.h
@@ -484,7 +482,6 @@ div.o: $(hdrdir)/ruby/internal/variable.h
 div.o: $(hdrdir)/ruby/internal/warning_push.h
 div.o: $(hdrdir)/ruby/internal/xmalloc.h
 div.o: $(hdrdir)/ruby/missing.h
-div.o: $(hdrdir)/ruby/onigmo.h
 div.o: $(hdrdir)/ruby/ruby.h
 div.o: $(hdrdir)/ruby/st.h
 div.o: $(hdrdir)/ruby/subst.h
@@ -648,7 +645,6 @@ init.o: $(hdrdir)/ruby/internal/variable.h
 init.o: $(hdrdir)/ruby/internal/warning_push.h
 init.o: $(hdrdir)/ruby/internal/xmalloc.h
 init.o: $(hdrdir)/ruby/missing.h
-init.o: $(hdrdir)/ruby/onigmo.h
 init.o: $(hdrdir)/ruby/ruby.h
 init.o: $(hdrdir)/ruby/st.h
 init.o: $(hdrdir)/ruby/subst.h
@@ -810,7 +806,6 @@ intpack.o: $(hdrdir)/ruby/internal/variable.h
 intpack.o: $(hdrdir)/ruby/internal/warning_push.h
 intpack.o: $(hdrdir)/ruby/internal/xmalloc.h
 intpack.o: $(hdrdir)/ruby/missing.h
-intpack.o: $(hdrdir)/ruby/onigmo.h
 intpack.o: $(hdrdir)/ruby/ruby.h
 intpack.o: $(hdrdir)/ruby/st.h
 intpack.o: $(hdrdir)/ruby/subst.h
@@ -974,7 +969,6 @@ mul.o: $(hdrdir)/ruby/internal/variable.h
 mul.o: $(hdrdir)/ruby/internal/warning_push.h
 mul.o: $(hdrdir)/ruby/internal/xmalloc.h
 mul.o: $(hdrdir)/ruby/missing.h
-mul.o: $(hdrdir)/ruby/onigmo.h
 mul.o: $(hdrdir)/ruby/ruby.h
 mul.o: $(hdrdir)/ruby/st.h
 mul.o: $(hdrdir)/ruby/subst.h
@@ -1138,7 +1132,6 @@ str2big.o: $(hdrdir)/ruby/internal/variable.h
 str2big.o: $(hdrdir)/ruby/internal/warning_push.h
 str2big.o: $(hdrdir)/ruby/internal/xmalloc.h
 str2big.o: $(hdrdir)/ruby/missing.h
-str2big.o: $(hdrdir)/ruby/onigmo.h
 str2big.o: $(hdrdir)/ruby/ruby.h
 str2big.o: $(hdrdir)/ruby/st.h
 str2big.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/bug-14834/depend
+++ b/ext/-test-/bug-14834/depend
@@ -156,7 +156,6 @@ bug-14834.o: $(hdrdir)/ruby/internal/variable.h
 bug-14834.o: $(hdrdir)/ruby/internal/warning_push.h
 bug-14834.o: $(hdrdir)/ruby/internal/xmalloc.h
 bug-14834.o: $(hdrdir)/ruby/missing.h
-bug-14834.o: $(hdrdir)/ruby/onigmo.h
 bug-14834.o: $(hdrdir)/ruby/ruby.h
 bug-14834.o: $(hdrdir)/ruby/st.h
 bug-14834.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/bug-3571/depend
+++ b/ext/-test-/bug-3571/depend
@@ -156,7 +156,6 @@ bug.o: $(hdrdir)/ruby/internal/variable.h
 bug.o: $(hdrdir)/ruby/internal/warning_push.h
 bug.o: $(hdrdir)/ruby/internal/xmalloc.h
 bug.o: $(hdrdir)/ruby/missing.h
-bug.o: $(hdrdir)/ruby/onigmo.h
 bug.o: $(hdrdir)/ruby/ruby.h
 bug.o: $(hdrdir)/ruby/st.h
 bug.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/bug-5832/depend
+++ b/ext/-test-/bug-5832/depend
@@ -156,7 +156,6 @@ bug.o: $(hdrdir)/ruby/internal/variable.h
 bug.o: $(hdrdir)/ruby/internal/warning_push.h
 bug.o: $(hdrdir)/ruby/internal/xmalloc.h
 bug.o: $(hdrdir)/ruby/missing.h
-bug.o: $(hdrdir)/ruby/onigmo.h
 bug.o: $(hdrdir)/ruby/ruby.h
 bug.o: $(hdrdir)/ruby/st.h
 bug.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/bug_reporter/depend
+++ b/ext/-test-/bug_reporter/depend
@@ -156,7 +156,6 @@ bug_reporter.o: $(hdrdir)/ruby/internal/variable.h
 bug_reporter.o: $(hdrdir)/ruby/internal/warning_push.h
 bug_reporter.o: $(hdrdir)/ruby/internal/xmalloc.h
 bug_reporter.o: $(hdrdir)/ruby/missing.h
-bug_reporter.o: $(hdrdir)/ruby/onigmo.h
 bug_reporter.o: $(hdrdir)/ruby/ruby.h
 bug_reporter.o: $(hdrdir)/ruby/st.h
 bug_reporter.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/class/depend
+++ b/ext/-test-/class/depend
@@ -155,7 +155,6 @@ class2name.o: $(hdrdir)/ruby/internal/variable.h
 class2name.o: $(hdrdir)/ruby/internal/warning_push.h
 class2name.o: $(hdrdir)/ruby/internal/xmalloc.h
 class2name.o: $(hdrdir)/ruby/missing.h
-class2name.o: $(hdrdir)/ruby/onigmo.h
 class2name.o: $(hdrdir)/ruby/ruby.h
 class2name.o: $(hdrdir)/ruby/st.h
 class2name.o: $(hdrdir)/ruby/subst.h
@@ -317,7 +316,6 @@ init.o: $(hdrdir)/ruby/internal/variable.h
 init.o: $(hdrdir)/ruby/internal/warning_push.h
 init.o: $(hdrdir)/ruby/internal/xmalloc.h
 init.o: $(hdrdir)/ruby/missing.h
-init.o: $(hdrdir)/ruby/onigmo.h
 init.o: $(hdrdir)/ruby/ruby.h
 init.o: $(hdrdir)/ruby/st.h
 init.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/debug/depend
+++ b/ext/-test-/debug/depend
@@ -156,7 +156,6 @@ init.o: $(hdrdir)/ruby/internal/variable.h
 init.o: $(hdrdir)/ruby/internal/warning_push.h
 init.o: $(hdrdir)/ruby/internal/xmalloc.h
 init.o: $(hdrdir)/ruby/missing.h
-init.o: $(hdrdir)/ruby/onigmo.h
 init.o: $(hdrdir)/ruby/ruby.h
 init.o: $(hdrdir)/ruby/st.h
 init.o: $(hdrdir)/ruby/subst.h
@@ -318,7 +317,6 @@ inspector.o: $(hdrdir)/ruby/internal/variable.h
 inspector.o: $(hdrdir)/ruby/internal/warning_push.h
 inspector.o: $(hdrdir)/ruby/internal/xmalloc.h
 inspector.o: $(hdrdir)/ruby/missing.h
-inspector.o: $(hdrdir)/ruby/onigmo.h
 inspector.o: $(hdrdir)/ruby/ruby.h
 inspector.o: $(hdrdir)/ruby/st.h
 inspector.o: $(hdrdir)/ruby/subst.h
@@ -480,7 +478,6 @@ profile_frames.o: $(hdrdir)/ruby/internal/variable.h
 profile_frames.o: $(hdrdir)/ruby/internal/warning_push.h
 profile_frames.o: $(hdrdir)/ruby/internal/xmalloc.h
 profile_frames.o: $(hdrdir)/ruby/missing.h
-profile_frames.o: $(hdrdir)/ruby/onigmo.h
 profile_frames.o: $(hdrdir)/ruby/ruby.h
 profile_frames.o: $(hdrdir)/ruby/st.h
 profile_frames.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/dln/empty/depend
+++ b/ext/-test-/dln/empty/depend
@@ -156,7 +156,6 @@ empty.o: $(hdrdir)/ruby/internal/variable.h
 empty.o: $(hdrdir)/ruby/internal/warning_push.h
 empty.o: $(hdrdir)/ruby/internal/xmalloc.h
 empty.o: $(hdrdir)/ruby/missing.h
-empty.o: $(hdrdir)/ruby/onigmo.h
 empty.o: $(hdrdir)/ruby/ruby.h
 empty.o: $(hdrdir)/ruby/st.h
 empty.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/econv/depend
+++ b/ext/-test-/econv/depend
@@ -329,7 +329,6 @@ init.o: $(hdrdir)/ruby/internal/variable.h
 init.o: $(hdrdir)/ruby/internal/warning_push.h
 init.o: $(hdrdir)/ruby/internal/xmalloc.h
 init.o: $(hdrdir)/ruby/missing.h
-init.o: $(hdrdir)/ruby/onigmo.h
 init.o: $(hdrdir)/ruby/ruby.h
 init.o: $(hdrdir)/ruby/st.h
 init.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/ensure_and_callcc/depend
+++ b/ext/-test-/ensure_and_callcc/depend
@@ -156,7 +156,6 @@ ensure_and_callcc.o: $(hdrdir)/ruby/internal/variable.h
 ensure_and_callcc.o: $(hdrdir)/ruby/internal/warning_push.h
 ensure_and_callcc.o: $(hdrdir)/ruby/internal/xmalloc.h
 ensure_and_callcc.o: $(hdrdir)/ruby/missing.h
-ensure_and_callcc.o: $(hdrdir)/ruby/onigmo.h
 ensure_and_callcc.o: $(hdrdir)/ruby/ruby.h
 ensure_and_callcc.o: $(hdrdir)/ruby/st.h
 ensure_and_callcc.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/enumerator_kw/depend
+++ b/ext/-test-/enumerator_kw/depend
@@ -156,7 +156,6 @@ enumerator_kw.o: $(hdrdir)/ruby/internal/variable.h
 enumerator_kw.o: $(hdrdir)/ruby/internal/warning_push.h
 enumerator_kw.o: $(hdrdir)/ruby/internal/xmalloc.h
 enumerator_kw.o: $(hdrdir)/ruby/missing.h
-enumerator_kw.o: $(hdrdir)/ruby/onigmo.h
 enumerator_kw.o: $(hdrdir)/ruby/ruby.h
 enumerator_kw.o: $(hdrdir)/ruby/st.h
 enumerator_kw.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/eval/depend
+++ b/ext/-test-/eval/depend
@@ -155,7 +155,6 @@ eval.o: $(hdrdir)/ruby/internal/variable.h
 eval.o: $(hdrdir)/ruby/internal/warning_push.h
 eval.o: $(hdrdir)/ruby/internal/xmalloc.h
 eval.o: $(hdrdir)/ruby/missing.h
-eval.o: $(hdrdir)/ruby/onigmo.h
 eval.o: $(hdrdir)/ruby/ruby.h
 eval.o: $(hdrdir)/ruby/st.h
 eval.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/exception/depend
+++ b/ext/-test-/exception/depend
@@ -155,7 +155,6 @@ dataerror.o: $(hdrdir)/ruby/internal/variable.h
 dataerror.o: $(hdrdir)/ruby/internal/warning_push.h
 dataerror.o: $(hdrdir)/ruby/internal/xmalloc.h
 dataerror.o: $(hdrdir)/ruby/missing.h
-dataerror.o: $(hdrdir)/ruby/onigmo.h
 dataerror.o: $(hdrdir)/ruby/ruby.h
 dataerror.o: $(hdrdir)/ruby/st.h
 dataerror.o: $(hdrdir)/ruby/subst.h
@@ -490,7 +489,6 @@ ensured.o: $(hdrdir)/ruby/internal/variable.h
 ensured.o: $(hdrdir)/ruby/internal/warning_push.h
 ensured.o: $(hdrdir)/ruby/internal/xmalloc.h
 ensured.o: $(hdrdir)/ruby/missing.h
-ensured.o: $(hdrdir)/ruby/onigmo.h
 ensured.o: $(hdrdir)/ruby/ruby.h
 ensured.o: $(hdrdir)/ruby/st.h
 ensured.o: $(hdrdir)/ruby/subst.h
@@ -652,7 +650,6 @@ init.o: $(hdrdir)/ruby/internal/variable.h
 init.o: $(hdrdir)/ruby/internal/warning_push.h
 init.o: $(hdrdir)/ruby/internal/xmalloc.h
 init.o: $(hdrdir)/ruby/missing.h
-init.o: $(hdrdir)/ruby/onigmo.h
 init.o: $(hdrdir)/ruby/ruby.h
 init.o: $(hdrdir)/ruby/st.h
 init.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/fatal/depend
+++ b/ext/-test-/fatal/depend
@@ -157,7 +157,6 @@ init.o: $(hdrdir)/ruby/internal/variable.h
 init.o: $(hdrdir)/ruby/internal/warning_push.h
 init.o: $(hdrdir)/ruby/internal/xmalloc.h
 init.o: $(hdrdir)/ruby/missing.h
-init.o: $(hdrdir)/ruby/onigmo.h
 init.o: $(hdrdir)/ruby/ruby.h
 init.o: $(hdrdir)/ruby/st.h
 init.o: $(hdrdir)/ruby/subst.h
@@ -319,7 +318,6 @@ invalid.o: $(hdrdir)/ruby/internal/variable.h
 invalid.o: $(hdrdir)/ruby/internal/warning_push.h
 invalid.o: $(hdrdir)/ruby/internal/xmalloc.h
 invalid.o: $(hdrdir)/ruby/missing.h
-invalid.o: $(hdrdir)/ruby/onigmo.h
 invalid.o: $(hdrdir)/ruby/ruby.h
 invalid.o: $(hdrdir)/ruby/st.h
 invalid.o: $(hdrdir)/ruby/subst.h
@@ -481,7 +479,6 @@ rb_fatal.o: $(hdrdir)/ruby/internal/variable.h
 rb_fatal.o: $(hdrdir)/ruby/internal/warning_push.h
 rb_fatal.o: $(hdrdir)/ruby/internal/xmalloc.h
 rb_fatal.o: $(hdrdir)/ruby/missing.h
-rb_fatal.o: $(hdrdir)/ruby/onigmo.h
 rb_fatal.o: $(hdrdir)/ruby/ruby.h
 rb_fatal.o: $(hdrdir)/ruby/st.h
 rb_fatal.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/file/depend
+++ b/ext/-test-/file/depend
@@ -329,7 +329,6 @@ init.o: $(hdrdir)/ruby/internal/variable.h
 init.o: $(hdrdir)/ruby/internal/warning_push.h
 init.o: $(hdrdir)/ruby/internal/xmalloc.h
 init.o: $(hdrdir)/ruby/missing.h
-init.o: $(hdrdir)/ruby/onigmo.h
 init.o: $(hdrdir)/ruby/ruby.h
 init.o: $(hdrdir)/ruby/st.h
 init.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/float/depend
+++ b/ext/-test-/float/depend
@@ -159,7 +159,6 @@ init.o: $(hdrdir)/ruby/internal/variable.h
 init.o: $(hdrdir)/ruby/internal/warning_push.h
 init.o: $(hdrdir)/ruby/internal/xmalloc.h
 init.o: $(hdrdir)/ruby/missing.h
-init.o: $(hdrdir)/ruby/onigmo.h
 init.o: $(hdrdir)/ruby/ruby.h
 init.o: $(hdrdir)/ruby/st.h
 init.o: $(hdrdir)/ruby/subst.h
@@ -321,7 +320,6 @@ nextafter.o: $(hdrdir)/ruby/internal/variable.h
 nextafter.o: $(hdrdir)/ruby/internal/warning_push.h
 nextafter.o: $(hdrdir)/ruby/internal/xmalloc.h
 nextafter.o: $(hdrdir)/ruby/missing.h
-nextafter.o: $(hdrdir)/ruby/onigmo.h
 nextafter.o: $(hdrdir)/ruby/ruby.h
 nextafter.o: $(hdrdir)/ruby/st.h
 nextafter.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/funcall/depend
+++ b/ext/-test-/funcall/depend
@@ -156,7 +156,6 @@ funcall.o: $(hdrdir)/ruby/internal/variable.h
 funcall.o: $(hdrdir)/ruby/internal/warning_push.h
 funcall.o: $(hdrdir)/ruby/internal/xmalloc.h
 funcall.o: $(hdrdir)/ruby/missing.h
-funcall.o: $(hdrdir)/ruby/onigmo.h
 funcall.o: $(hdrdir)/ruby/ruby.h
 funcall.o: $(hdrdir)/ruby/st.h
 funcall.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/gvl/call_without_gvl/depend
+++ b/ext/-test-/gvl/call_without_gvl/depend
@@ -155,7 +155,6 @@ call_without_gvl.o: $(hdrdir)/ruby/internal/variable.h
 call_without_gvl.o: $(hdrdir)/ruby/internal/warning_push.h
 call_without_gvl.o: $(hdrdir)/ruby/internal/xmalloc.h
 call_without_gvl.o: $(hdrdir)/ruby/missing.h
-call_without_gvl.o: $(hdrdir)/ruby/onigmo.h
 call_without_gvl.o: $(hdrdir)/ruby/ruby.h
 call_without_gvl.o: $(hdrdir)/ruby/st.h
 call_without_gvl.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/hash/depend
+++ b/ext/-test-/hash/depend
@@ -156,7 +156,6 @@ delete.o: $(hdrdir)/ruby/internal/variable.h
 delete.o: $(hdrdir)/ruby/internal/warning_push.h
 delete.o: $(hdrdir)/ruby/internal/xmalloc.h
 delete.o: $(hdrdir)/ruby/missing.h
-delete.o: $(hdrdir)/ruby/onigmo.h
 delete.o: $(hdrdir)/ruby/ruby.h
 delete.o: $(hdrdir)/ruby/st.h
 delete.o: $(hdrdir)/ruby/subst.h
@@ -318,7 +317,6 @@ init.o: $(hdrdir)/ruby/internal/variable.h
 init.o: $(hdrdir)/ruby/internal/warning_push.h
 init.o: $(hdrdir)/ruby/internal/xmalloc.h
 init.o: $(hdrdir)/ruby/missing.h
-init.o: $(hdrdir)/ruby/onigmo.h
 init.o: $(hdrdir)/ruby/ruby.h
 init.o: $(hdrdir)/ruby/st.h
 init.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/integer/depend
+++ b/ext/-test-/integer/depend
@@ -156,7 +156,6 @@ core_ext.o: $(hdrdir)/ruby/internal/variable.h
 core_ext.o: $(hdrdir)/ruby/internal/warning_push.h
 core_ext.o: $(hdrdir)/ruby/internal/xmalloc.h
 core_ext.o: $(hdrdir)/ruby/missing.h
-core_ext.o: $(hdrdir)/ruby/onigmo.h
 core_ext.o: $(hdrdir)/ruby/ruby.h
 core_ext.o: $(hdrdir)/ruby/st.h
 core_ext.o: $(hdrdir)/ruby/subst.h
@@ -329,7 +328,6 @@ init.o: $(hdrdir)/ruby/internal/variable.h
 init.o: $(hdrdir)/ruby/internal/warning_push.h
 init.o: $(hdrdir)/ruby/internal/xmalloc.h
 init.o: $(hdrdir)/ruby/missing.h
-init.o: $(hdrdir)/ruby/onigmo.h
 init.o: $(hdrdir)/ruby/ruby.h
 init.o: $(hdrdir)/ruby/st.h
 init.o: $(hdrdir)/ruby/subst.h
@@ -491,7 +489,6 @@ my_integer.o: $(hdrdir)/ruby/internal/variable.h
 my_integer.o: $(hdrdir)/ruby/internal/warning_push.h
 my_integer.o: $(hdrdir)/ruby/internal/xmalloc.h
 my_integer.o: $(hdrdir)/ruby/missing.h
-my_integer.o: $(hdrdir)/ruby/onigmo.h
 my_integer.o: $(hdrdir)/ruby/ruby.h
 my_integer.o: $(hdrdir)/ruby/st.h
 my_integer.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/iseq_load/depend
+++ b/ext/-test-/iseq_load/depend
@@ -156,7 +156,6 @@ iseq_load.o: $(hdrdir)/ruby/internal/variable.h
 iseq_load.o: $(hdrdir)/ruby/internal/warning_push.h
 iseq_load.o: $(hdrdir)/ruby/internal/xmalloc.h
 iseq_load.o: $(hdrdir)/ruby/missing.h
-iseq_load.o: $(hdrdir)/ruby/onigmo.h
 iseq_load.o: $(hdrdir)/ruby/ruby.h
 iseq_load.o: $(hdrdir)/ruby/st.h
 iseq_load.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/iter/depend
+++ b/ext/-test-/iter/depend
@@ -156,7 +156,6 @@ break.o: $(hdrdir)/ruby/internal/variable.h
 break.o: $(hdrdir)/ruby/internal/warning_push.h
 break.o: $(hdrdir)/ruby/internal/xmalloc.h
 break.o: $(hdrdir)/ruby/missing.h
-break.o: $(hdrdir)/ruby/onigmo.h
 break.o: $(hdrdir)/ruby/ruby.h
 break.o: $(hdrdir)/ruby/st.h
 break.o: $(hdrdir)/ruby/subst.h
@@ -318,7 +317,6 @@ init.o: $(hdrdir)/ruby/internal/variable.h
 init.o: $(hdrdir)/ruby/internal/warning_push.h
 init.o: $(hdrdir)/ruby/internal/xmalloc.h
 init.o: $(hdrdir)/ruby/missing.h
-init.o: $(hdrdir)/ruby/onigmo.h
 init.o: $(hdrdir)/ruby/ruby.h
 init.o: $(hdrdir)/ruby/st.h
 init.o: $(hdrdir)/ruby/subst.h
@@ -480,7 +478,6 @@ yield.o: $(hdrdir)/ruby/internal/variable.h
 yield.o: $(hdrdir)/ruby/internal/warning_push.h
 yield.o: $(hdrdir)/ruby/internal/xmalloc.h
 yield.o: $(hdrdir)/ruby/missing.h
-yield.o: $(hdrdir)/ruby/onigmo.h
 yield.o: $(hdrdir)/ruby/ruby.h
 yield.o: $(hdrdir)/ruby/st.h
 yield.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/load/dot.dot/depend
+++ b/ext/-test-/load/dot.dot/depend
@@ -156,7 +156,6 @@ dot.dot.o: $(hdrdir)/ruby/internal/variable.h
 dot.dot.o: $(hdrdir)/ruby/internal/warning_push.h
 dot.dot.o: $(hdrdir)/ruby/internal/xmalloc.h
 dot.dot.o: $(hdrdir)/ruby/missing.h
-dot.dot.o: $(hdrdir)/ruby/onigmo.h
 dot.dot.o: $(hdrdir)/ruby/ruby.h
 dot.dot.o: $(hdrdir)/ruby/st.h
 dot.dot.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/load/protect/depend
+++ b/ext/-test-/load/protect/depend
@@ -156,7 +156,6 @@ protect.o: $(hdrdir)/ruby/internal/variable.h
 protect.o: $(hdrdir)/ruby/internal/warning_push.h
 protect.o: $(hdrdir)/ruby/internal/xmalloc.h
 protect.o: $(hdrdir)/ruby/missing.h
-protect.o: $(hdrdir)/ruby/onigmo.h
 protect.o: $(hdrdir)/ruby/ruby.h
 protect.o: $(hdrdir)/ruby/st.h
 protect.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/load/resolve_symbol_resolver/depend
+++ b/ext/-test-/load/resolve_symbol_resolver/depend
@@ -156,7 +156,6 @@ resolve_symbol_resolver.o: $(hdrdir)/ruby/internal/variable.h
 resolve_symbol_resolver.o: $(hdrdir)/ruby/internal/warning_push.h
 resolve_symbol_resolver.o: $(hdrdir)/ruby/internal/xmalloc.h
 resolve_symbol_resolver.o: $(hdrdir)/ruby/missing.h
-resolve_symbol_resolver.o: $(hdrdir)/ruby/onigmo.h
 resolve_symbol_resolver.o: $(hdrdir)/ruby/ruby.h
 resolve_symbol_resolver.o: $(hdrdir)/ruby/st.h
 resolve_symbol_resolver.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/load/resolve_symbol_target/depend
+++ b/ext/-test-/load/resolve_symbol_target/depend
@@ -156,7 +156,6 @@ resolve_symbol_target.o: $(hdrdir)/ruby/internal/variable.h
 resolve_symbol_target.o: $(hdrdir)/ruby/internal/warning_push.h
 resolve_symbol_target.o: $(hdrdir)/ruby/internal/xmalloc.h
 resolve_symbol_target.o: $(hdrdir)/ruby/missing.h
-resolve_symbol_target.o: $(hdrdir)/ruby/onigmo.h
 resolve_symbol_target.o: $(hdrdir)/ruby/ruby.h
 resolve_symbol_target.o: $(hdrdir)/ruby/st.h
 resolve_symbol_target.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/load/stringify_symbols/depend
+++ b/ext/-test-/load/stringify_symbols/depend
@@ -156,7 +156,6 @@ stringify_symbols.o: $(hdrdir)/ruby/internal/variable.h
 stringify_symbols.o: $(hdrdir)/ruby/internal/warning_push.h
 stringify_symbols.o: $(hdrdir)/ruby/internal/xmalloc.h
 stringify_symbols.o: $(hdrdir)/ruby/missing.h
-stringify_symbols.o: $(hdrdir)/ruby/onigmo.h
 stringify_symbols.o: $(hdrdir)/ruby/ruby.h
 stringify_symbols.o: $(hdrdir)/ruby/st.h
 stringify_symbols.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/load/stringify_target/depend
+++ b/ext/-test-/load/stringify_target/depend
@@ -156,7 +156,6 @@ stringify_target.o: $(hdrdir)/ruby/internal/variable.h
 stringify_target.o: $(hdrdir)/ruby/internal/warning_push.h
 stringify_target.o: $(hdrdir)/ruby/internal/xmalloc.h
 stringify_target.o: $(hdrdir)/ruby/missing.h
-stringify_target.o: $(hdrdir)/ruby/onigmo.h
 stringify_target.o: $(hdrdir)/ruby/ruby.h
 stringify_target.o: $(hdrdir)/ruby/st.h
 stringify_target.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/marshal/compat/depend
+++ b/ext/-test-/marshal/compat/depend
@@ -156,7 +156,6 @@ usrcompat.o: $(hdrdir)/ruby/internal/variable.h
 usrcompat.o: $(hdrdir)/ruby/internal/warning_push.h
 usrcompat.o: $(hdrdir)/ruby/internal/xmalloc.h
 usrcompat.o: $(hdrdir)/ruby/missing.h
-usrcompat.o: $(hdrdir)/ruby/onigmo.h
 usrcompat.o: $(hdrdir)/ruby/ruby.h
 usrcompat.o: $(hdrdir)/ruby/st.h
 usrcompat.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/marshal/internal_ivar/depend
+++ b/ext/-test-/marshal/internal_ivar/depend
@@ -156,7 +156,6 @@ internal_ivar.o: $(hdrdir)/ruby/internal/variable.h
 internal_ivar.o: $(hdrdir)/ruby/internal/warning_push.h
 internal_ivar.o: $(hdrdir)/ruby/internal/xmalloc.h
 internal_ivar.o: $(hdrdir)/ruby/missing.h
-internal_ivar.o: $(hdrdir)/ruby/onigmo.h
 internal_ivar.o: $(hdrdir)/ruby/ruby.h
 internal_ivar.o: $(hdrdir)/ruby/st.h
 internal_ivar.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/marshal/usr/depend
+++ b/ext/-test-/marshal/usr/depend
@@ -156,7 +156,6 @@ usrmarshal.o: $(hdrdir)/ruby/internal/variable.h
 usrmarshal.o: $(hdrdir)/ruby/internal/warning_push.h
 usrmarshal.o: $(hdrdir)/ruby/internal/xmalloc.h
 usrmarshal.o: $(hdrdir)/ruby/missing.h
-usrmarshal.o: $(hdrdir)/ruby/onigmo.h
 usrmarshal.o: $(hdrdir)/ruby/ruby.h
 usrmarshal.o: $(hdrdir)/ruby/st.h
 usrmarshal.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/memory_view/depend
+++ b/ext/-test-/memory_view/depend
@@ -157,7 +157,6 @@ memory_view.o: $(hdrdir)/ruby/internal/warning_push.h
 memory_view.o: $(hdrdir)/ruby/internal/xmalloc.h
 memory_view.o: $(hdrdir)/ruby/memory_view.h
 memory_view.o: $(hdrdir)/ruby/missing.h
-memory_view.o: $(hdrdir)/ruby/onigmo.h
 memory_view.o: $(hdrdir)/ruby/ruby.h
 memory_view.o: $(hdrdir)/ruby/st.h
 memory_view.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/method/depend
+++ b/ext/-test-/method/depend
@@ -156,7 +156,6 @@ arity.o: $(hdrdir)/ruby/internal/variable.h
 arity.o: $(hdrdir)/ruby/internal/warning_push.h
 arity.o: $(hdrdir)/ruby/internal/xmalloc.h
 arity.o: $(hdrdir)/ruby/missing.h
-arity.o: $(hdrdir)/ruby/onigmo.h
 arity.o: $(hdrdir)/ruby/ruby.h
 arity.o: $(hdrdir)/ruby/st.h
 arity.o: $(hdrdir)/ruby/subst.h
@@ -318,7 +317,6 @@ init.o: $(hdrdir)/ruby/internal/variable.h
 init.o: $(hdrdir)/ruby/internal/warning_push.h
 init.o: $(hdrdir)/ruby/internal/xmalloc.h
 init.o: $(hdrdir)/ruby/missing.h
-init.o: $(hdrdir)/ruby/onigmo.h
 init.o: $(hdrdir)/ruby/ruby.h
 init.o: $(hdrdir)/ruby/st.h
 init.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/notimplement/depend
+++ b/ext/-test-/notimplement/depend
@@ -156,7 +156,6 @@ bug.o: $(hdrdir)/ruby/internal/variable.h
 bug.o: $(hdrdir)/ruby/internal/warning_push.h
 bug.o: $(hdrdir)/ruby/internal/xmalloc.h
 bug.o: $(hdrdir)/ruby/missing.h
-bug.o: $(hdrdir)/ruby/onigmo.h
 bug.o: $(hdrdir)/ruby/ruby.h
 bug.o: $(hdrdir)/ruby/st.h
 bug.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/num2int/depend
+++ b/ext/-test-/num2int/depend
@@ -156,7 +156,6 @@ num2int.o: $(hdrdir)/ruby/internal/variable.h
 num2int.o: $(hdrdir)/ruby/internal/warning_push.h
 num2int.o: $(hdrdir)/ruby/internal/xmalloc.h
 num2int.o: $(hdrdir)/ruby/missing.h
-num2int.o: $(hdrdir)/ruby/onigmo.h
 num2int.o: $(hdrdir)/ruby/ruby.h
 num2int.o: $(hdrdir)/ruby/st.h
 num2int.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/path_to_class/depend
+++ b/ext/-test-/path_to_class/depend
@@ -156,7 +156,6 @@ path_to_class.o: $(hdrdir)/ruby/internal/variable.h
 path_to_class.o: $(hdrdir)/ruby/internal/warning_push.h
 path_to_class.o: $(hdrdir)/ruby/internal/xmalloc.h
 path_to_class.o: $(hdrdir)/ruby/missing.h
-path_to_class.o: $(hdrdir)/ruby/onigmo.h
 path_to_class.o: $(hdrdir)/ruby/ruby.h
 path_to_class.o: $(hdrdir)/ruby/st.h
 path_to_class.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/popen_deadlock/depend
+++ b/ext/-test-/popen_deadlock/depend
@@ -156,7 +156,6 @@ infinite_loop_dlsym.o: $(hdrdir)/ruby/internal/variable.h
 infinite_loop_dlsym.o: $(hdrdir)/ruby/internal/warning_push.h
 infinite_loop_dlsym.o: $(hdrdir)/ruby/internal/xmalloc.h
 infinite_loop_dlsym.o: $(hdrdir)/ruby/missing.h
-infinite_loop_dlsym.o: $(hdrdir)/ruby/onigmo.h
 infinite_loop_dlsym.o: $(hdrdir)/ruby/ruby.h
 infinite_loop_dlsym.o: $(hdrdir)/ruby/st.h
 infinite_loop_dlsym.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/postponed_job/depend
+++ b/ext/-test-/postponed_job/depend
@@ -157,7 +157,6 @@ postponed_job.o: $(hdrdir)/ruby/internal/variable.h
 postponed_job.o: $(hdrdir)/ruby/internal/warning_push.h
 postponed_job.o: $(hdrdir)/ruby/internal/xmalloc.h
 postponed_job.o: $(hdrdir)/ruby/missing.h
-postponed_job.o: $(hdrdir)/ruby/onigmo.h
 postponed_job.o: $(hdrdir)/ruby/ruby.h
 postponed_job.o: $(hdrdir)/ruby/st.h
 postponed_job.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/proc/depend
+++ b/ext/-test-/proc/depend
@@ -156,7 +156,6 @@ init.o: $(hdrdir)/ruby/internal/variable.h
 init.o: $(hdrdir)/ruby/internal/warning_push.h
 init.o: $(hdrdir)/ruby/internal/xmalloc.h
 init.o: $(hdrdir)/ruby/missing.h
-init.o: $(hdrdir)/ruby/onigmo.h
 init.o: $(hdrdir)/ruby/ruby.h
 init.o: $(hdrdir)/ruby/st.h
 init.o: $(hdrdir)/ruby/subst.h
@@ -318,7 +317,6 @@ receiver.o: $(hdrdir)/ruby/internal/variable.h
 receiver.o: $(hdrdir)/ruby/internal/warning_push.h
 receiver.o: $(hdrdir)/ruby/internal/xmalloc.h
 receiver.o: $(hdrdir)/ruby/missing.h
-receiver.o: $(hdrdir)/ruby/onigmo.h
 receiver.o: $(hdrdir)/ruby/ruby.h
 receiver.o: $(hdrdir)/ruby/st.h
 receiver.o: $(hdrdir)/ruby/subst.h
@@ -480,7 +478,6 @@ super.o: $(hdrdir)/ruby/internal/variable.h
 super.o: $(hdrdir)/ruby/internal/warning_push.h
 super.o: $(hdrdir)/ruby/internal/xmalloc.h
 super.o: $(hdrdir)/ruby/missing.h
-super.o: $(hdrdir)/ruby/onigmo.h
 super.o: $(hdrdir)/ruby/ruby.h
 super.o: $(hdrdir)/ruby/st.h
 super.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/random/depend
+++ b/ext/-test-/random/depend
@@ -155,7 +155,6 @@ bad_version.o: $(hdrdir)/ruby/internal/variable.h
 bad_version.o: $(hdrdir)/ruby/internal/warning_push.h
 bad_version.o: $(hdrdir)/ruby/internal/xmalloc.h
 bad_version.o: $(hdrdir)/ruby/missing.h
-bad_version.o: $(hdrdir)/ruby/onigmo.h
 bad_version.o: $(hdrdir)/ruby/random.h
 bad_version.o: $(hdrdir)/ruby/ruby.h
 bad_version.o: $(hdrdir)/ruby/st.h
@@ -318,7 +317,6 @@ init.o: $(hdrdir)/ruby/internal/variable.h
 init.o: $(hdrdir)/ruby/internal/warning_push.h
 init.o: $(hdrdir)/ruby/internal/xmalloc.h
 init.o: $(hdrdir)/ruby/missing.h
-init.o: $(hdrdir)/ruby/onigmo.h
 init.o: $(hdrdir)/ruby/ruby.h
 init.o: $(hdrdir)/ruby/st.h
 init.o: $(hdrdir)/ruby/subst.h
@@ -479,7 +477,6 @@ loop.o: $(hdrdir)/ruby/internal/variable.h
 loop.o: $(hdrdir)/ruby/internal/warning_push.h
 loop.o: $(hdrdir)/ruby/internal/xmalloc.h
 loop.o: $(hdrdir)/ruby/missing.h
-loop.o: $(hdrdir)/ruby/onigmo.h
 loop.o: $(hdrdir)/ruby/random.h
 loop.o: $(hdrdir)/ruby/ruby.h
 loop.o: $(hdrdir)/ruby/st.h

--- a/ext/-test-/rational/depend
+++ b/ext/-test-/rational/depend
@@ -160,7 +160,6 @@ rat.o: $(hdrdir)/ruby/internal/variable.h
 rat.o: $(hdrdir)/ruby/internal/warning_push.h
 rat.o: $(hdrdir)/ruby/internal/xmalloc.h
 rat.o: $(hdrdir)/ruby/missing.h
-rat.o: $(hdrdir)/ruby/onigmo.h
 rat.o: $(hdrdir)/ruby/ruby.h
 rat.o: $(hdrdir)/ruby/st.h
 rat.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/rb_call_super_kw/depend
+++ b/ext/-test-/rb_call_super_kw/depend
@@ -156,7 +156,6 @@ rb_call_super_kw.o: $(hdrdir)/ruby/internal/variable.h
 rb_call_super_kw.o: $(hdrdir)/ruby/internal/warning_push.h
 rb_call_super_kw.o: $(hdrdir)/ruby/internal/xmalloc.h
 rb_call_super_kw.o: $(hdrdir)/ruby/missing.h
-rb_call_super_kw.o: $(hdrdir)/ruby/onigmo.h
 rb_call_super_kw.o: $(hdrdir)/ruby/ruby.h
 rb_call_super_kw.o: $(hdrdir)/ruby/st.h
 rb_call_super_kw.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/recursion/depend
+++ b/ext/-test-/recursion/depend
@@ -156,7 +156,6 @@ recursion.o: $(hdrdir)/ruby/internal/variable.h
 recursion.o: $(hdrdir)/ruby/internal/warning_push.h
 recursion.o: $(hdrdir)/ruby/internal/xmalloc.h
 recursion.o: $(hdrdir)/ruby/missing.h
-recursion.o: $(hdrdir)/ruby/onigmo.h
 recursion.o: $(hdrdir)/ruby/ruby.h
 recursion.o: $(hdrdir)/ruby/st.h
 recursion.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/regexp/depend
+++ b/ext/-test-/regexp/depend
@@ -156,7 +156,6 @@ init.o: $(hdrdir)/ruby/internal/variable.h
 init.o: $(hdrdir)/ruby/internal/warning_push.h
 init.o: $(hdrdir)/ruby/internal/xmalloc.h
 init.o: $(hdrdir)/ruby/missing.h
-init.o: $(hdrdir)/ruby/onigmo.h
 init.o: $(hdrdir)/ruby/ruby.h
 init.o: $(hdrdir)/ruby/st.h
 init.o: $(hdrdir)/ruby/subst.h
@@ -318,7 +317,6 @@ new.o: $(hdrdir)/ruby/internal/variable.h
 new.o: $(hdrdir)/ruby/internal/warning_push.h
 new.o: $(hdrdir)/ruby/internal/xmalloc.h
 new.o: $(hdrdir)/ruby/missing.h
-new.o: $(hdrdir)/ruby/onigmo.h
 new.o: $(hdrdir)/ruby/ruby.h
 new.o: $(hdrdir)/ruby/st.h
 new.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/sanitizers/depend
+++ b/ext/-test-/sanitizers/depend
@@ -155,7 +155,6 @@ sanitizers.o: $(hdrdir)/ruby/internal/variable.h
 sanitizers.o: $(hdrdir)/ruby/internal/warning_push.h
 sanitizers.o: $(hdrdir)/ruby/internal/xmalloc.h
 sanitizers.o: $(hdrdir)/ruby/missing.h
-sanitizers.o: $(hdrdir)/ruby/onigmo.h
 sanitizers.o: $(hdrdir)/ruby/ruby.h
 sanitizers.o: $(hdrdir)/ruby/st.h
 sanitizers.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/scan_args/depend
+++ b/ext/-test-/scan_args/depend
@@ -156,7 +156,6 @@ scan_args.o: $(hdrdir)/ruby/internal/variable.h
 scan_args.o: $(hdrdir)/ruby/internal/warning_push.h
 scan_args.o: $(hdrdir)/ruby/internal/xmalloc.h
 scan_args.o: $(hdrdir)/ruby/missing.h
-scan_args.o: $(hdrdir)/ruby/onigmo.h
 scan_args.o: $(hdrdir)/ruby/ruby.h
 scan_args.o: $(hdrdir)/ruby/st.h
 scan_args.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/st/foreach/depend
+++ b/ext/-test-/st/foreach/depend
@@ -156,7 +156,6 @@ foreach.o: $(hdrdir)/ruby/internal/variable.h
 foreach.o: $(hdrdir)/ruby/internal/warning_push.h
 foreach.o: $(hdrdir)/ruby/internal/xmalloc.h
 foreach.o: $(hdrdir)/ruby/missing.h
-foreach.o: $(hdrdir)/ruby/onigmo.h
 foreach.o: $(hdrdir)/ruby/ruby.h
 foreach.o: $(hdrdir)/ruby/st.h
 foreach.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/st/numhash/depend
+++ b/ext/-test-/st/numhash/depend
@@ -156,7 +156,6 @@ numhash.o: $(hdrdir)/ruby/internal/variable.h
 numhash.o: $(hdrdir)/ruby/internal/warning_push.h
 numhash.o: $(hdrdir)/ruby/internal/xmalloc.h
 numhash.o: $(hdrdir)/ruby/missing.h
-numhash.o: $(hdrdir)/ruby/onigmo.h
 numhash.o: $(hdrdir)/ruby/ruby.h
 numhash.o: $(hdrdir)/ruby/st.h
 numhash.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/st/update/depend
+++ b/ext/-test-/st/update/depend
@@ -156,7 +156,6 @@ update.o: $(hdrdir)/ruby/internal/variable.h
 update.o: $(hdrdir)/ruby/internal/warning_push.h
 update.o: $(hdrdir)/ruby/internal/xmalloc.h
 update.o: $(hdrdir)/ruby/missing.h
-update.o: $(hdrdir)/ruby/onigmo.h
 update.o: $(hdrdir)/ruby/ruby.h
 update.o: $(hdrdir)/ruby/st.h
 update.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/string/depend
+++ b/ext/-test-/string/depend
@@ -842,7 +842,6 @@ ellipsize.o: $(hdrdir)/ruby/internal/variable.h
 ellipsize.o: $(hdrdir)/ruby/internal/warning_push.h
 ellipsize.o: $(hdrdir)/ruby/internal/xmalloc.h
 ellipsize.o: $(hdrdir)/ruby/missing.h
-ellipsize.o: $(hdrdir)/ruby/onigmo.h
 ellipsize.o: $(hdrdir)/ruby/ruby.h
 ellipsize.o: $(hdrdir)/ruby/st.h
 ellipsize.o: $(hdrdir)/ruby/subst.h
@@ -1699,7 +1698,6 @@ init.o: $(hdrdir)/ruby/internal/variable.h
 init.o: $(hdrdir)/ruby/internal/warning_push.h
 init.o: $(hdrdir)/ruby/internal/xmalloc.h
 init.o: $(hdrdir)/ruby/missing.h
-init.o: $(hdrdir)/ruby/onigmo.h
 init.o: $(hdrdir)/ruby/ruby.h
 init.o: $(hdrdir)/ruby/st.h
 init.o: $(hdrdir)/ruby/subst.h
@@ -1861,7 +1859,6 @@ modify.o: $(hdrdir)/ruby/internal/variable.h
 modify.o: $(hdrdir)/ruby/internal/warning_push.h
 modify.o: $(hdrdir)/ruby/internal/xmalloc.h
 modify.o: $(hdrdir)/ruby/missing.h
-modify.o: $(hdrdir)/ruby/onigmo.h
 modify.o: $(hdrdir)/ruby/ruby.h
 modify.o: $(hdrdir)/ruby/st.h
 modify.o: $(hdrdir)/ruby/subst.h
@@ -2196,7 +2193,6 @@ nofree.o: $(hdrdir)/ruby/internal/variable.h
 nofree.o: $(hdrdir)/ruby/internal/warning_push.h
 nofree.o: $(hdrdir)/ruby/internal/xmalloc.h
 nofree.o: $(hdrdir)/ruby/missing.h
-nofree.o: $(hdrdir)/ruby/onigmo.h
 nofree.o: $(hdrdir)/ruby/ruby.h
 nofree.o: $(hdrdir)/ruby/st.h
 nofree.o: $(hdrdir)/ruby/subst.h
@@ -2705,7 +2701,6 @@ rb_interned_str.o: $(hdrdir)/ruby/internal/variable.h
 rb_interned_str.o: $(hdrdir)/ruby/internal/warning_push.h
 rb_interned_str.o: $(hdrdir)/ruby/internal/xmalloc.h
 rb_interned_str.o: $(hdrdir)/ruby/missing.h
-rb_interned_str.o: $(hdrdir)/ruby/onigmo.h
 rb_interned_str.o: $(hdrdir)/ruby/ruby.h
 rb_interned_str.o: $(hdrdir)/ruby/st.h
 rb_interned_str.o: $(hdrdir)/ruby/subst.h
@@ -2867,7 +2862,6 @@ rb_str_dup.o: $(hdrdir)/ruby/internal/variable.h
 rb_str_dup.o: $(hdrdir)/ruby/internal/warning_push.h
 rb_str_dup.o: $(hdrdir)/ruby/internal/xmalloc.h
 rb_str_dup.o: $(hdrdir)/ruby/missing.h
-rb_str_dup.o: $(hdrdir)/ruby/onigmo.h
 rb_str_dup.o: $(hdrdir)/ruby/ruby.h
 rb_str_dup.o: $(hdrdir)/ruby/st.h
 rb_str_dup.o: $(hdrdir)/ruby/subst.h
@@ -3029,7 +3023,6 @@ set_len.o: $(hdrdir)/ruby/internal/variable.h
 set_len.o: $(hdrdir)/ruby/internal/warning_push.h
 set_len.o: $(hdrdir)/ruby/internal/xmalloc.h
 set_len.o: $(hdrdir)/ruby/missing.h
-set_len.o: $(hdrdir)/ruby/onigmo.h
 set_len.o: $(hdrdir)/ruby/ruby.h
 set_len.o: $(hdrdir)/ruby/st.h
 set_len.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/struct/depend
+++ b/ext/-test-/struct/depend
@@ -156,7 +156,6 @@ data.o: $(hdrdir)/ruby/internal/variable.h
 data.o: $(hdrdir)/ruby/internal/warning_push.h
 data.o: $(hdrdir)/ruby/internal/xmalloc.h
 data.o: $(hdrdir)/ruby/missing.h
-data.o: $(hdrdir)/ruby/onigmo.h
 data.o: $(hdrdir)/ruby/ruby.h
 data.o: $(hdrdir)/ruby/st.h
 data.o: $(hdrdir)/ruby/subst.h
@@ -318,7 +317,6 @@ duplicate.o: $(hdrdir)/ruby/internal/variable.h
 duplicate.o: $(hdrdir)/ruby/internal/warning_push.h
 duplicate.o: $(hdrdir)/ruby/internal/xmalloc.h
 duplicate.o: $(hdrdir)/ruby/missing.h
-duplicate.o: $(hdrdir)/ruby/onigmo.h
 duplicate.o: $(hdrdir)/ruby/ruby.h
 duplicate.o: $(hdrdir)/ruby/st.h
 duplicate.o: $(hdrdir)/ruby/subst.h
@@ -480,7 +478,6 @@ init.o: $(hdrdir)/ruby/internal/variable.h
 init.o: $(hdrdir)/ruby/internal/warning_push.h
 init.o: $(hdrdir)/ruby/internal/xmalloc.h
 init.o: $(hdrdir)/ruby/missing.h
-init.o: $(hdrdir)/ruby/onigmo.h
 init.o: $(hdrdir)/ruby/ruby.h
 init.o: $(hdrdir)/ruby/st.h
 init.o: $(hdrdir)/ruby/subst.h
@@ -642,7 +639,6 @@ len.o: $(hdrdir)/ruby/internal/variable.h
 len.o: $(hdrdir)/ruby/internal/warning_push.h
 len.o: $(hdrdir)/ruby/internal/xmalloc.h
 len.o: $(hdrdir)/ruby/missing.h
-len.o: $(hdrdir)/ruby/onigmo.h
 len.o: $(hdrdir)/ruby/ruby.h
 len.o: $(hdrdir)/ruby/st.h
 len.o: $(hdrdir)/ruby/subst.h
@@ -804,7 +800,6 @@ member.o: $(hdrdir)/ruby/internal/variable.h
 member.o: $(hdrdir)/ruby/internal/warning_push.h
 member.o: $(hdrdir)/ruby/internal/xmalloc.h
 member.o: $(hdrdir)/ruby/missing.h
-member.o: $(hdrdir)/ruby/onigmo.h
 member.o: $(hdrdir)/ruby/ruby.h
 member.o: $(hdrdir)/ruby/st.h
 member.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/symbol/depend
+++ b/ext/-test-/symbol/depend
@@ -156,7 +156,6 @@ init.o: $(hdrdir)/ruby/internal/variable.h
 init.o: $(hdrdir)/ruby/internal/warning_push.h
 init.o: $(hdrdir)/ruby/internal/xmalloc.h
 init.o: $(hdrdir)/ruby/missing.h
-init.o: $(hdrdir)/ruby/onigmo.h
 init.o: $(hdrdir)/ruby/ruby.h
 init.o: $(hdrdir)/ruby/st.h
 init.o: $(hdrdir)/ruby/subst.h
@@ -318,7 +317,6 @@ type.o: $(hdrdir)/ruby/internal/variable.h
 type.o: $(hdrdir)/ruby/internal/warning_push.h
 type.o: $(hdrdir)/ruby/internal/xmalloc.h
 type.o: $(hdrdir)/ruby/missing.h
-type.o: $(hdrdir)/ruby/onigmo.h
 type.o: $(hdrdir)/ruby/ruby.h
 type.o: $(hdrdir)/ruby/st.h
 type.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/thread/id/depend
+++ b/ext/-test-/thread/id/depend
@@ -156,7 +156,6 @@ id.o: $(hdrdir)/ruby/internal/variable.h
 id.o: $(hdrdir)/ruby/internal/warning_push.h
 id.o: $(hdrdir)/ruby/internal/xmalloc.h
 id.o: $(hdrdir)/ruby/missing.h
-id.o: $(hdrdir)/ruby/onigmo.h
 id.o: $(hdrdir)/ruby/ruby.h
 id.o: $(hdrdir)/ruby/st.h
 id.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/thread/instrumentation/depend
+++ b/ext/-test-/thread/instrumentation/depend
@@ -156,7 +156,6 @@ instrumentation.o: $(hdrdir)/ruby/internal/variable.h
 instrumentation.o: $(hdrdir)/ruby/internal/warning_push.h
 instrumentation.o: $(hdrdir)/ruby/internal/xmalloc.h
 instrumentation.o: $(hdrdir)/ruby/missing.h
-instrumentation.o: $(hdrdir)/ruby/onigmo.h
 instrumentation.o: $(hdrdir)/ruby/ruby.h
 instrumentation.o: $(hdrdir)/ruby/st.h
 instrumentation.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/thread/lock_native_thread/depend
+++ b/ext/-test-/thread/lock_native_thread/depend
@@ -155,7 +155,6 @@ lock_native_thread.o: $(hdrdir)/ruby/internal/variable.h
 lock_native_thread.o: $(hdrdir)/ruby/internal/warning_push.h
 lock_native_thread.o: $(hdrdir)/ruby/internal/xmalloc.h
 lock_native_thread.o: $(hdrdir)/ruby/missing.h
-lock_native_thread.o: $(hdrdir)/ruby/onigmo.h
 lock_native_thread.o: $(hdrdir)/ruby/ruby.h
 lock_native_thread.o: $(hdrdir)/ruby/st.h
 lock_native_thread.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/time/depend
+++ b/ext/-test-/time/depend
@@ -156,7 +156,6 @@ init.o: $(hdrdir)/ruby/internal/variable.h
 init.o: $(hdrdir)/ruby/internal/warning_push.h
 init.o: $(hdrdir)/ruby/internal/xmalloc.h
 init.o: $(hdrdir)/ruby/missing.h
-init.o: $(hdrdir)/ruby/onigmo.h
 init.o: $(hdrdir)/ruby/ruby.h
 init.o: $(hdrdir)/ruby/st.h
 init.o: $(hdrdir)/ruby/subst.h
@@ -484,7 +483,6 @@ new.o: $(hdrdir)/ruby/internal/variable.h
 new.o: $(hdrdir)/ruby/internal/warning_push.h
 new.o: $(hdrdir)/ruby/internal/xmalloc.h
 new.o: $(hdrdir)/ruby/missing.h
-new.o: $(hdrdir)/ruby/onigmo.h
 new.o: $(hdrdir)/ruby/ruby.h
 new.o: $(hdrdir)/ruby/st.h
 new.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/tracepoint/depend
+++ b/ext/-test-/tracepoint/depend
@@ -156,7 +156,6 @@ gc_hook.o: $(hdrdir)/ruby/internal/variable.h
 gc_hook.o: $(hdrdir)/ruby/internal/warning_push.h
 gc_hook.o: $(hdrdir)/ruby/internal/xmalloc.h
 gc_hook.o: $(hdrdir)/ruby/missing.h
-gc_hook.o: $(hdrdir)/ruby/onigmo.h
 gc_hook.o: $(hdrdir)/ruby/ruby.h
 gc_hook.o: $(hdrdir)/ruby/st.h
 gc_hook.o: $(hdrdir)/ruby/subst.h
@@ -318,7 +317,6 @@ tracepoint.o: $(hdrdir)/ruby/internal/variable.h
 tracepoint.o: $(hdrdir)/ruby/internal/warning_push.h
 tracepoint.o: $(hdrdir)/ruby/internal/xmalloc.h
 tracepoint.o: $(hdrdir)/ruby/missing.h
-tracepoint.o: $(hdrdir)/ruby/onigmo.h
 tracepoint.o: $(hdrdir)/ruby/ruby.h
 tracepoint.o: $(hdrdir)/ruby/st.h
 tracepoint.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/typeddata/depend
+++ b/ext/-test-/typeddata/depend
@@ -156,7 +156,6 @@ typeddata.o: $(hdrdir)/ruby/internal/variable.h
 typeddata.o: $(hdrdir)/ruby/internal/warning_push.h
 typeddata.o: $(hdrdir)/ruby/internal/xmalloc.h
 typeddata.o: $(hdrdir)/ruby/missing.h
-typeddata.o: $(hdrdir)/ruby/onigmo.h
 typeddata.o: $(hdrdir)/ruby/ruby.h
 typeddata.o: $(hdrdir)/ruby/st.h
 typeddata.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/vm/depend
+++ b/ext/-test-/vm/depend
@@ -155,7 +155,6 @@ at_exit.o: $(hdrdir)/ruby/internal/variable.h
 at_exit.o: $(hdrdir)/ruby/internal/warning_push.h
 at_exit.o: $(hdrdir)/ruby/internal/xmalloc.h
 at_exit.o: $(hdrdir)/ruby/missing.h
-at_exit.o: $(hdrdir)/ruby/onigmo.h
 at_exit.o: $(hdrdir)/ruby/ruby.h
 at_exit.o: $(hdrdir)/ruby/st.h
 at_exit.o: $(hdrdir)/ruby/subst.h

--- a/ext/continuation/depend
+++ b/ext/continuation/depend
@@ -155,7 +155,6 @@ continuation.o: $(hdrdir)/ruby/internal/variable.h
 continuation.o: $(hdrdir)/ruby/internal/warning_push.h
 continuation.o: $(hdrdir)/ruby/internal/xmalloc.h
 continuation.o: $(hdrdir)/ruby/missing.h
-continuation.o: $(hdrdir)/ruby/onigmo.h
 continuation.o: $(hdrdir)/ruby/ruby.h
 continuation.o: $(hdrdir)/ruby/st.h
 continuation.o: $(hdrdir)/ruby/subst.h

--- a/ext/date/depend
+++ b/ext/date/depend
@@ -508,7 +508,6 @@ date_strftime.o: $(hdrdir)/ruby/internal/variable.h
 date_strftime.o: $(hdrdir)/ruby/internal/warning_push.h
 date_strftime.o: $(hdrdir)/ruby/internal/xmalloc.h
 date_strftime.o: $(hdrdir)/ruby/missing.h
-date_strftime.o: $(hdrdir)/ruby/onigmo.h
 date_strftime.o: $(hdrdir)/ruby/ruby.h
 date_strftime.o: $(hdrdir)/ruby/st.h
 date_strftime.o: $(hdrdir)/ruby/subst.h

--- a/ext/digest/bubblebabble/depend
+++ b/ext/digest/bubblebabble/depend
@@ -156,7 +156,6 @@ bubblebabble.o: $(hdrdir)/ruby/internal/variable.h
 bubblebabble.o: $(hdrdir)/ruby/internal/warning_push.h
 bubblebabble.o: $(hdrdir)/ruby/internal/xmalloc.h
 bubblebabble.o: $(hdrdir)/ruby/missing.h
-bubblebabble.o: $(hdrdir)/ruby/onigmo.h
 bubblebabble.o: $(hdrdir)/ruby/ruby.h
 bubblebabble.o: $(hdrdir)/ruby/st.h
 bubblebabble.o: $(hdrdir)/ruby/subst.h

--- a/ext/digest/depend
+++ b/ext/digest/depend
@@ -156,7 +156,6 @@ digest.o: $(hdrdir)/ruby/internal/variable.h
 digest.o: $(hdrdir)/ruby/internal/warning_push.h
 digest.o: $(hdrdir)/ruby/internal/xmalloc.h
 digest.o: $(hdrdir)/ruby/missing.h
-digest.o: $(hdrdir)/ruby/onigmo.h
 digest.o: $(hdrdir)/ruby/ruby.h
 digest.o: $(hdrdir)/ruby/st.h
 digest.o: $(hdrdir)/ruby/subst.h

--- a/ext/digest/md5/depend
+++ b/ext/digest/md5/depend
@@ -159,7 +159,6 @@ md5.o: $(hdrdir)/ruby/internal/variable.h
 md5.o: $(hdrdir)/ruby/internal/warning_push.h
 md5.o: $(hdrdir)/ruby/internal/xmalloc.h
 md5.o: $(hdrdir)/ruby/missing.h
-md5.o: $(hdrdir)/ruby/onigmo.h
 md5.o: $(hdrdir)/ruby/ruby.h
 md5.o: $(hdrdir)/ruby/st.h
 md5.o: $(hdrdir)/ruby/subst.h
@@ -323,7 +322,6 @@ md5init.o: $(hdrdir)/ruby/internal/variable.h
 md5init.o: $(hdrdir)/ruby/internal/warning_push.h
 md5init.o: $(hdrdir)/ruby/internal/xmalloc.h
 md5init.o: $(hdrdir)/ruby/missing.h
-md5init.o: $(hdrdir)/ruby/onigmo.h
 md5init.o: $(hdrdir)/ruby/ruby.h
 md5init.o: $(hdrdir)/ruby/st.h
 md5init.o: $(hdrdir)/ruby/subst.h

--- a/ext/digest/rmd160/depend
+++ b/ext/digest/rmd160/depend
@@ -159,7 +159,6 @@ rmd160.o: $(hdrdir)/ruby/internal/variable.h
 rmd160.o: $(hdrdir)/ruby/internal/warning_push.h
 rmd160.o: $(hdrdir)/ruby/internal/xmalloc.h
 rmd160.o: $(hdrdir)/ruby/missing.h
-rmd160.o: $(hdrdir)/ruby/onigmo.h
 rmd160.o: $(hdrdir)/ruby/ruby.h
 rmd160.o: $(hdrdir)/ruby/st.h
 rmd160.o: $(hdrdir)/ruby/subst.h
@@ -323,7 +322,6 @@ rmd160init.o: $(hdrdir)/ruby/internal/variable.h
 rmd160init.o: $(hdrdir)/ruby/internal/warning_push.h
 rmd160init.o: $(hdrdir)/ruby/internal/xmalloc.h
 rmd160init.o: $(hdrdir)/ruby/missing.h
-rmd160init.o: $(hdrdir)/ruby/onigmo.h
 rmd160init.o: $(hdrdir)/ruby/ruby.h
 rmd160init.o: $(hdrdir)/ruby/st.h
 rmd160init.o: $(hdrdir)/ruby/subst.h

--- a/ext/digest/sha1/depend
+++ b/ext/digest/sha1/depend
@@ -159,7 +159,6 @@ sha1.o: $(hdrdir)/ruby/internal/variable.h
 sha1.o: $(hdrdir)/ruby/internal/warning_push.h
 sha1.o: $(hdrdir)/ruby/internal/xmalloc.h
 sha1.o: $(hdrdir)/ruby/missing.h
-sha1.o: $(hdrdir)/ruby/onigmo.h
 sha1.o: $(hdrdir)/ruby/ruby.h
 sha1.o: $(hdrdir)/ruby/st.h
 sha1.o: $(hdrdir)/ruby/subst.h
@@ -323,7 +322,6 @@ sha1init.o: $(hdrdir)/ruby/internal/variable.h
 sha1init.o: $(hdrdir)/ruby/internal/warning_push.h
 sha1init.o: $(hdrdir)/ruby/internal/xmalloc.h
 sha1init.o: $(hdrdir)/ruby/missing.h
-sha1init.o: $(hdrdir)/ruby/onigmo.h
 sha1init.o: $(hdrdir)/ruby/ruby.h
 sha1init.o: $(hdrdir)/ruby/st.h
 sha1init.o: $(hdrdir)/ruby/subst.h

--- a/ext/digest/sha2/depend
+++ b/ext/digest/sha2/depend
@@ -159,7 +159,6 @@ sha2.o: $(hdrdir)/ruby/internal/variable.h
 sha2.o: $(hdrdir)/ruby/internal/warning_push.h
 sha2.o: $(hdrdir)/ruby/internal/xmalloc.h
 sha2.o: $(hdrdir)/ruby/missing.h
-sha2.o: $(hdrdir)/ruby/onigmo.h
 sha2.o: $(hdrdir)/ruby/ruby.h
 sha2.o: $(hdrdir)/ruby/st.h
 sha2.o: $(hdrdir)/ruby/subst.h
@@ -323,7 +322,6 @@ sha2init.o: $(hdrdir)/ruby/internal/variable.h
 sha2init.o: $(hdrdir)/ruby/internal/warning_push.h
 sha2init.o: $(hdrdir)/ruby/internal/xmalloc.h
 sha2init.o: $(hdrdir)/ruby/missing.h
-sha2init.o: $(hdrdir)/ruby/onigmo.h
 sha2init.o: $(hdrdir)/ruby/ruby.h
 sha2init.o: $(hdrdir)/ruby/st.h
 sha2init.o: $(hdrdir)/ruby/subst.h

--- a/ext/fcntl/depend
+++ b/ext/fcntl/depend
@@ -156,7 +156,6 @@ fcntl.o: $(hdrdir)/ruby/internal/variable.h
 fcntl.o: $(hdrdir)/ruby/internal/warning_push.h
 fcntl.o: $(hdrdir)/ruby/internal/xmalloc.h
 fcntl.o: $(hdrdir)/ruby/missing.h
-fcntl.o: $(hdrdir)/ruby/onigmo.h
 fcntl.o: $(hdrdir)/ruby/ruby.h
 fcntl.o: $(hdrdir)/ruby/st.h
 fcntl.o: $(hdrdir)/ruby/subst.h

--- a/ext/rbconfig/sizeof/depend
+++ b/ext/rbconfig/sizeof/depend
@@ -170,7 +170,6 @@ limits.o: $(hdrdir)/ruby/internal/variable.h
 limits.o: $(hdrdir)/ruby/internal/warning_push.h
 limits.o: $(hdrdir)/ruby/internal/xmalloc.h
 limits.o: $(hdrdir)/ruby/missing.h
-limits.o: $(hdrdir)/ruby/onigmo.h
 limits.o: $(hdrdir)/ruby/ruby.h
 limits.o: $(hdrdir)/ruby/st.h
 limits.o: $(hdrdir)/ruby/subst.h
@@ -331,7 +330,6 @@ sizes.o: $(hdrdir)/ruby/internal/variable.h
 sizes.o: $(hdrdir)/ruby/internal/warning_push.h
 sizes.o: $(hdrdir)/ruby/internal/xmalloc.h
 sizes.o: $(hdrdir)/ruby/missing.h
-sizes.o: $(hdrdir)/ruby/onigmo.h
 sizes.o: $(hdrdir)/ruby/ruby.h
 sizes.o: $(hdrdir)/ruby/st.h
 sizes.o: $(hdrdir)/ruby/subst.h

--- a/ext/ripper/depend
+++ b/ext/ripper/depend
@@ -209,7 +209,6 @@ eventids1.o: $(hdrdir)/ruby/internal/variable.h
 eventids1.o: $(hdrdir)/ruby/internal/warning_push.h
 eventids1.o: $(hdrdir)/ruby/internal/xmalloc.h
 eventids1.o: $(hdrdir)/ruby/missing.h
-eventids1.o: $(hdrdir)/ruby/onigmo.h
 eventids1.o: $(hdrdir)/ruby/ruby.h
 eventids1.o: $(hdrdir)/ruby/st.h
 eventids1.o: $(hdrdir)/ruby/subst.h

--- a/include/ruby/internal/core/rregexp.h
+++ b/include/ruby/internal/core/rregexp.h
@@ -27,7 +27,6 @@
 #include "ruby/internal/core/rstring.h"
 #include "ruby/internal/value.h"
 #include "ruby/internal/value_type.h"
-#include "ruby/onigmo.h"
 
 /**
  * Convenient casting macro.
@@ -37,13 +36,6 @@
  */
 #define RREGEXP(obj)     RBIMPL_CAST((struct RRegexp *)(obj))
 
-/**
- * Convenient accessor macro.
- *
- * @param   obj  An object, which is in fact an ::RRegexp.
- * @return  The passed object's pattern buffer.
- */
-#define RREGEXP_PTR(obj) (&RREGEXP(obj)->pattern)
 /** @cond INTERNAL_MACRO */
 #define RREGEXP_SRC      RREGEXP_SRC
 #define RREGEXP_SRC_PTR  RREGEXP_SRC_PTR
@@ -79,15 +71,23 @@ struct RRegexp {
      *           catastrophic effects.  Just leave it.
      */
     unsigned long usecnt;
-
-   /**
-    * The pattern buffer.   This is a quasi-opaque struct  that holds compiled
-    * intermediate representation of the regular expression.
-    *
-    * @note  Compilation of a regexp could be delayed until actual match.
-    */
-   struct re_pattern_buffer pattern; /* a.k.a. OnigRegexType, defined in onigmo.h */
 };
+
+RBIMPL_ATTR_PURE_UNLESS_DEBUG()
+RBIMPL_ATTR_ARTIFICIAL()
+/**
+ * Convenient getter function.
+ *
+ * @param[in]  rexp  The regular expression in question.
+ * @return     The pattern buffer of the regular expression.
+ * @pre        `rexp` must be of ::RRegexp.
+ */
+static inline struct re_pattern_buffer *
+RREGEXP_PTR(VALUE rexp)
+{
+    RBIMPL_ASSERT_TYPE(rexp, RUBY_T_REGEXP);
+    return (struct re_pattern_buffer *)(((struct RRegexp *)rexp) + 1);
+}
 
 RBIMPL_ATTR_PURE_UNLESS_DEBUG()
 RBIMPL_ATTR_ARTIFICIAL()

--- a/re.c
+++ b/re.c
@@ -32,6 +32,11 @@
 #include "ruby/util.h"
 #include "ractor_core.h"
 
+struct RRegexp_and_re_pattern_buffer {
+    struct RRegexp re;
+    struct re_pattern_buffer pattern; /* a.k.a. OnigRegexType, defined in onigmo.h */
+};
+
 /* Flags of RRegexp
  *
  * 4:     KCODE_FIXED
@@ -3502,10 +3507,10 @@ rb_reg_initialize_str(VALUE obj, VALUE str, int options, onig_errmsg_buffer err,
 VALUE
 rb_reg_s_alloc(VALUE klass)
 {
-    NEWOBJ_OF(re, struct RRegexp, klass, T_REGEXP, sizeof(struct RRegexp));
+    NEWOBJ_OF(re, struct RRegexp, klass, T_REGEXP, sizeof(struct RRegexp_and_re_pattern_buffer));
 
-    MEMZERO(RREGEXP_PTR(re), struct re_pattern_buffer, 1);
-    RB_OBJ_WRITE(re, &re->src, 0);
+    MEMZERO(RREGEXP_PTR((VALUE)re), struct re_pattern_buffer, 1);
+    RB_OBJ_WRITE((VALUE)re, &re->src, 0);
     re->usecnt = 0;
 
     return (VALUE)re;


### PR DESCRIPTION
Followup: https://github.com/ruby/ruby/pull/17671

[[Bug #22184]](https://bugs.ruby-lang.org/issues/22184)

`onigmo.h` contains a lot of declarations that can easily conflict with third party code, hence it's better to keep it opaque. That however requires a few hacks.