### PR TITLE
`RBASIC_SET_SHAPE_ID`: also strip the layout bits

### DIFF
--- a/array.c
+++ b/array.c
@@ -902,7 +902,7 @@ init_fake_ary_flags(void)
     struct RArray fake_ary = {0};
     fake_ary.basic.flags = T_ARRAY;
     VALUE ary = (VALUE)&fake_ary;
-    RBASIC_SET_SHAPE_ID(ary, ROOT_SHAPE_ID | SHAPE_ID_LAYOUT_OTHER);
+    RBASIC_SET_FULL_SHAPE_ID(ary, ROOT_SHAPE_ID | SHAPE_ID_LAYOUT_OTHER);
     rb_ary_freeze(ary);
     return fake_ary.basic.flags;
 }

--- a/gc.c
+++ b/gc.c
@@ -378,7 +378,7 @@ rb_gc_obj_changed_slot_size(VALUE obj, size_t slot_size)
 {
     RUBY_ASSERT(RB_TYPE_P(obj, T_OBJECT));
 
-    RBASIC_SET_FULL_SHAPE_ID(obj, rb_obj_shape_transition_capacity(obj, rb_shape_capacity_for_slot_size(slot_size)));
+    RBASIC_SET_FULL_SHAPE_ID(obj, rb_obj_shape_transition_slot_size(obj, slot_size));
 }
 
 void rb_vm_update_references(void *ptr);
@@ -1036,7 +1036,7 @@ rb_newobj(rb_execution_context_t *ec, VALUE klass, VALUE flags, shape_id_t shape
     VALUE obj = rb_gc_impl_new_obj(rb_gc_get_objspace(), cr->newobj_cache, klass, flags, wb_protected, size, &actual_alloc_size);
 
     GC_ASSERT(actual_alloc_size >= size);
-    shape_id = rb_shape_transition_capacity(shape_id, rb_shape_capacity_for_slot_size(actual_alloc_size));
+    shape_id = rb_shape_transition_slot_size(shape_id, actual_alloc_size);
 
 #if RACTOR_CHECK_MODE
     void rb_ractor_setup_belonging(VALUE obj);

--- a/gc.c
+++ b/gc.c
@@ -378,7 +378,7 @@ rb_gc_obj_changed_slot_size(VALUE obj, size_t slot_size)
 {
     RUBY_ASSERT(RB_TYPE_P(obj, T_OBJECT));
 
-    RBASIC_SET_SHAPE_ID_WITH_CAPACITY(obj, rb_obj_shape_transition_capacity(obj, rb_shape_capacity_for_slot_size(slot_size)));
+    RBASIC_SET_FULL_SHAPE_ID(obj, rb_obj_shape_transition_capacity(obj, rb_shape_capacity_for_slot_size(slot_size)));
 }
 
 void rb_vm_update_references(void *ptr);
@@ -1043,7 +1043,7 @@ rb_newobj(rb_execution_context_t *ec, VALUE klass, VALUE flags, shape_id_t shape
     rb_ractor_setup_belonging(obj);
 #endif
 
-    RBASIC_SET_SHAPE_ID_NO_CHECKS(obj, shape_id);
+    RBASIC_SET_FULL_SHAPE_ID_NO_CHECKS(obj, shape_id);
 
     gc_validate_pc(obj);
 
@@ -1095,7 +1095,7 @@ rb_newobj_of(VALUE klass, VALUE flags, size_t size)
 static
 VALUE class_allocate_complex_instance(VALUE klass, uint32_t capacity)
 {
-    shape_id_t initial_shape_id = rb_shape_id_with_robject_layout(0);
+    shape_id_t initial_shape_id = rb_shape_transition_robject(0);
     VALUE obj = rb_newobj_of_with_shape(klass, T_OBJECT, initial_shape_id, sizeof(struct RObject));
     rb_obj_init_complex(obj, rb_st_init_numtable_with_size(capacity));
     return obj;
@@ -1120,7 +1120,7 @@ rb_class_allocate_instance(VALUE klass)
 
         // There might be a NEWOBJ tracepoint callback, and it may set fields.
         // So the shape must be passed to `NEWOBJ_OF`.
-        obj = rb_newobj_of_with_shape(klass, T_OBJECT, rb_shape_id_with_robject_layout(0), size);
+        obj = rb_newobj_of_with_shape(klass, T_OBJECT, rb_shape_transition_robject(0), size);
 
         #if RUBY_DEBUG
             VALUE *ptr = ROBJECT_FIELDS(obj);
@@ -4232,7 +4232,7 @@ vm_weak_table_gen_fields_foreach(st_data_t key, st_data_t value, st_data_t data)
         // set the shape on it so that the GC finalizer won't try to remove
         // it again.  A "root shape" indicates to the GC that this object
         // has no fields on it, hence it won't be in the gen fields table.
-        RBASIC_SET_SHAPE_ID((VALUE)key, ROOT_SHAPE_ID | SHAPE_ID_LAYOUT_OTHER);
+        RBASIC_SET_SHAPE_ID((VALUE)key, ROOT_SHAPE_ID);
         return ST_DELETE;
 
       case ST_REPLACE: {

--- a/gc.c
+++ b/gc.c
@@ -1036,7 +1036,7 @@ rb_newobj(rb_execution_context_t *ec, VALUE klass, VALUE flags, shape_id_t shape
     VALUE obj = rb_gc_impl_new_obj(rb_gc_get_objspace(), cr->newobj_cache, klass, flags, wb_protected, size, &actual_alloc_size);
 
     GC_ASSERT(actual_alloc_size >= size);
-    shape_id = (shape_id & ~SHAPE_ID_CAPACITY_MASK) | rb_shape_id_with_capacity(rb_shape_capacity_for_slot_size(actual_alloc_size));
+    shape_id = rb_shape_transition_capacity(shape_id, rb_shape_capacity_for_slot_size(actual_alloc_size));
 
 #if RACTOR_CHECK_MODE
     void rb_ractor_setup_belonging(VALUE obj);

--- a/imemo.c
+++ b/imemo.c
@@ -130,33 +130,40 @@ rb_imemo_cdhash_new(size_t size, const struct st_hash_type *type)
     return (VALUE)memo;
 }
 
+static VALUE
+imemo_fields_new(VALUE owner, VALUE flags, shape_id_t shape_id, size_t size, bool is_shareable)
+{
+    RUBY_ASSERT(rb_gc_size_allocatable_p(size));
+
+    flags |= T_IMEMO | (imemo_fields << FL_USHIFT) | (is_shareable ? FL_SHAREABLE : 0);
+    // imemo fields objects should always have "RObject" layout.  The
+    // layout in the shape describes the layout of the thing on which it is set.
+    // Imemo fields have the same layout as robject, therefore the layout
+    // should reflect that fact.
+    shape_id = rb_shape_transition_robject(shape_id);
+    return rb_newobj(GET_EC(), owner, flags, shape_id, true, size);
+}
+
 VALUE
 rb_imemo_fields_new(VALUE owner, shape_id_t shape_id, bool shareable)
 {
     size_t capa = RSHAPE(shape_id)->capacity;
     size_t embedded_size = offsetof(struct rb_fields, as.embed) + capa * sizeof(VALUE);
-    RUBY_ASSERT(rb_gc_size_allocatable_p(embedded_size));
-    VALUE fields = rb_imemo_new(imemo_fields, owner, embedded_size, shareable);
-    // imemo fields objects should always have "RObject" layout.  The
-    // layout in the shape describes the layout of the thing on which it is set.
-    // Imemo fields have the same layout as robject, therefore the layout
-    // should reflect that fact.
-    RBASIC_SET_FULL_SHAPE_ID(fields, rb_shape_transition_robject(shape_id));
+
+    VALUE fields = imemo_fields_new(owner, 0, shape_id, embedded_size, shareable);
+
     RUBY_ASSERT(IMEMO_TYPE_P(fields, imemo_fields));
+    RUBY_ASSERT(rb_shape_embedded_capacity(RBASIC_SHAPE_ID(fields)) >= capa);
+
     return fields;
 }
 
 VALUE
 rb_imemo_fields_new_complex(VALUE owner, shape_id_t shape_id, size_t capa, bool shareable)
 {
-    VALUE fields = rb_imemo_new(imemo_fields, owner, sizeof(struct rb_fields), shareable);
-    IMEMO_OBJ_FIELDS(fields)->as.complex.table = st_init_numtable_with_size(capa);
-    FL_SET_RAW(fields, OBJ_FIELD_HEAP);
-    // imemo fields objects should always have "RObject" layout.  The
-    // layout in the shape describes the layout of the thing on which it is set.
-    // Imemo fields have the same layout as robject, therefore the layout
-    // should reflect that fact.
-    RBASIC_SET_FULL_SHAPE_ID(fields, rb_shape_transition_robject(shape_id));
+    st_table *tbl = st_init_numtable_with_size(capa);
+    VALUE fields = imemo_fields_new(owner, OBJ_FIELD_HEAP, shape_id, sizeof(struct rb_fields), shareable);
+    IMEMO_OBJ_FIELDS(fields)->as.complex.table = tbl;
     return fields;
 }
 
@@ -178,14 +185,8 @@ imemo_fields_complex_wb_i(st_data_t key, st_data_t value, st_data_t arg)
 VALUE
 rb_imemo_fields_new_complex_tbl(VALUE owner, shape_id_t shape_id, st_table *tbl, bool shareable)
 {
-    VALUE fields = rb_imemo_new(imemo_fields, owner, sizeof(struct rb_fields), shareable);
+    VALUE fields = imemo_fields_new(owner, OBJ_FIELD_HEAP, shape_id, sizeof(struct rb_fields), shareable);
     IMEMO_OBJ_FIELDS(fields)->as.complex.table = tbl;
-    FL_SET_RAW(fields, OBJ_FIELD_HEAP);
-    // imemo fields objects should always have "RObject" layout.  The
-    // layout in the shape describes the layout of the thing on which it is set.
-    // Imemo fields have the same layout as robject, therefore the layout
-    // should reflect that fact.
-    RBASIC_SET_FULL_SHAPE_ID(fields, rb_shape_transition_robject(shape_id));
     st_foreach(tbl, imemo_fields_trigger_wb_i, (st_data_t)fields);
     return fields;
 }

--- a/imemo.c
+++ b/imemo.c
@@ -141,7 +141,7 @@ rb_imemo_fields_new(VALUE owner, shape_id_t shape_id, bool shareable)
     // layout in the shape describes the layout of the thing on which it is set.
     // Imemo fields have the same layout as robject, therefore the layout
     // should reflect that fact.
-    RBASIC_SET_SHAPE_ID(fields, rb_shape_id_with_robject_layout(shape_id));
+    RBASIC_SET_FULL_SHAPE_ID(fields, rb_shape_transition_robject(shape_id));
     RUBY_ASSERT(IMEMO_TYPE_P(fields, imemo_fields));
     return fields;
 }
@@ -156,7 +156,7 @@ rb_imemo_fields_new_complex(VALUE owner, shape_id_t shape_id, size_t capa, bool 
     // layout in the shape describes the layout of the thing on which it is set.
     // Imemo fields have the same layout as robject, therefore the layout
     // should reflect that fact.
-    RBASIC_SET_SHAPE_ID(fields, rb_shape_id_with_robject_layout(shape_id));
+    RBASIC_SET_FULL_SHAPE_ID(fields, rb_shape_transition_robject(shape_id));
     return fields;
 }
 
@@ -185,7 +185,7 @@ rb_imemo_fields_new_complex_tbl(VALUE owner, shape_id_t shape_id, st_table *tbl,
     // layout in the shape describes the layout of the thing on which it is set.
     // Imemo fields have the same layout as robject, therefore the layout
     // should reflect that fact.
-    RBASIC_SET_SHAPE_ID(fields, rb_shape_id_with_robject_layout(shape_id));
+    RBASIC_SET_FULL_SHAPE_ID(fields, rb_shape_transition_robject(shape_id));
     st_foreach(tbl, imemo_fields_trigger_wb_i, (st_data_t)fields);
     return fields;
 }

--- a/shape.c
+++ b/shape.c
@@ -1305,7 +1305,7 @@ rb_shape_verify_consistency(VALUE obj, shape_id_t shape_id)
         }
     }
 
-    attr_index_t shape_id_capacity = rb_shape_capacity(shape_id);
+    attr_index_t shape_id_capacity = rb_shape_embedded_capacity(shape_id);
     if (RB_TYPE_P(obj, T_OBJECT)) {
         RUBY_ASSERT(shape_id_capacity > 0);
         size_t shape_id_slot_size = shape_id_capacity * sizeof(VALUE) + sizeof(struct RBasic);
@@ -1389,7 +1389,7 @@ shape_id_t_to_rb_cShape(shape_id_t shape_id)
             INT2NUM(shape->parent_offset),
             rb_shape_edge_name(shape),
             INT2NUM(shape->next_field_index),
-            INT2NUM(rb_shape_capacity(shape_id)),
+            INT2NUM(rb_shape_embedded_capacity(shape_id)),
             INT2NUM(shape->type),
             INT2NUM(RSHAPE_CAPACITY(shape_id)));
     rb_obj_freeze(obj);

--- a/shape.c
+++ b/shape.c
@@ -1306,8 +1306,9 @@ rb_shape_verify_consistency(VALUE obj, shape_id_t shape_id)
     }
 
     attr_index_t shape_id_capacity = rb_shape_embedded_capacity(shape_id);
-    if (RB_TYPE_P(obj, T_OBJECT)) {
+    if (RB_TYPE_P(obj, T_OBJECT) || IMEMO_TYPE_P(obj, imemo_fields)) {
         RUBY_ASSERT(shape_id_capacity > 0);
+
         size_t shape_id_slot_size = shape_id_capacity * sizeof(VALUE) + sizeof(struct RBasic);
         size_t actual_slot_size = rb_gc_obj_slot_size(obj);
 

--- a/shape.h
+++ b/shape.h
@@ -286,18 +286,6 @@ rb_shape_embedded_capacity(shape_id_t shape_id)
     return (attr_index_t)((shape_id & SHAPE_ID_CAPACITY_MASK) >> SHAPE_ID_CAPACITY_OFFSET);
 }
 
-static inline shape_id_t
-rb_shape_id_with_capacity(size_t capacity)
-{
-    shape_id_t capacity_flags = (shape_id_t)capacity << SHAPE_ID_CAPACITY_OFFSET;
-
-    RUBY_ASSERT(capacity <= SHAPE_ID_CAPACITY_MAX);
-    RUBY_ASSERT((capacity_flags & SHAPE_ID_CAPACITY_MASK) == capacity_flags);
-    RUBY_ASSERT(rb_shape_embedded_capacity(capacity_flags) == capacity);
-
-    return ROOT_SHAPE_ID | capacity_flags;
-}
-
 static inline attr_index_t
 rb_shape_capacity_for_slot_size(size_t slot_size)
 {
@@ -526,7 +514,10 @@ rb_shape_transition_offset(shape_id_t shape_id, shape_id_t offset)
 static inline shape_id_t
 rb_shape_transition_capacity(shape_id_t shape_id, size_t capacity)
 {
-    return (shape_id & (~SHAPE_ID_CAPACITY_MASK)) | rb_shape_id_with_capacity(capacity);
+    RUBY_ASSERT(capacity <= SHAPE_ID_CAPACITY_MAX);
+
+    shape_id_t capacity_flags = (shape_id_t)capacity << SHAPE_ID_CAPACITY_OFFSET;
+    return (shape_id & (~SHAPE_ID_CAPACITY_MASK)) | capacity_flags;
 }
 
 shape_id_t rb_shape_transition_object_id(shape_id_t shape_id);

--- a/shape.h
+++ b/shape.h
@@ -166,7 +166,7 @@ bool rb_shape_verify_consistency(VALUE obj, shape_id_t shape_id);
 #endif
 
 static inline void
-RBASIC_SET_SHAPE_ID_NO_CHECKS(VALUE obj, shape_id_t shape_id)
+RBASIC_SET_FULL_SHAPE_ID_NO_CHECKS(VALUE obj, shape_id_t shape_id)
 {
 #if RBASIC_SHAPE_ID_FIELD
     RBASIC(obj)->shape_id = (VALUE)shape_id;
@@ -183,14 +183,20 @@ rb_shape_layout(shape_id_t shape_id)
     return shape_id & SHAPE_ID_LAYOUT_MASK;
 }
 
+// Assigns the entire shape_id.
+// shape_id_t is composed of two parts:
+//  - The layout and capacity part, which never changes except on GC compaction.
+//  - All the other bits that regularly change.
+// In the overwhelming majority of cases, you want to use RBASIC_SET_SHAPE_ID
+// which preserves the object's layout and capacity bits.
+// In rare cases you may want to set all bits.
 static inline void
-RBASIC_SET_SHAPE_ID_WITH_CAPACITY(VALUE obj, shape_id_t shape_id)
+RBASIC_SET_FULL_SHAPE_ID(VALUE obj, shape_id_t shape_id)
 {
     RUBY_ASSERT(!RB_SPECIAL_CONST_P(obj));
     RUBY_ASSERT(!RB_TYPE_P(obj, T_IMEMO) || IMEMO_TYPE_P(obj, imemo_fields));
-    RUBY_ASSERT(!IMEMO_TYPE_P(obj, imemo_fields) || rb_shape_layout(shape_id) == SHAPE_ID_LAYOUT_ROBJECT);
 
-    RBASIC_SET_SHAPE_ID_NO_CHECKS(obj, shape_id);
+    RBASIC_SET_FULL_SHAPE_ID_NO_CHECKS(obj, shape_id);
 
     RUBY_ASSERT(rb_shape_verify_consistency(obj, shape_id));
 }
@@ -200,8 +206,11 @@ RBASIC_SET_SHAPE_ID(VALUE obj, shape_id_t shape_id)
 {
     RUBY_ASSERT(!RB_SPECIAL_CONST_P(obj));
 
-    shape_id = (shape_id & ~SHAPE_ID_CAPACITY_MASK) | (RBASIC_SHAPE_ID(obj) & SHAPE_ID_CAPACITY_MASK);
-    RBASIC_SET_SHAPE_ID_WITH_CAPACITY(obj, shape_id);
+    shape_id = (
+        (shape_id & ~(SHAPE_ID_CAPACITY_MASK|SHAPE_ID_LAYOUT_MASK)) |
+        (RBASIC_SHAPE_ID(obj) & (SHAPE_ID_CAPACITY_MASK|SHAPE_ID_LAYOUT_MASK))
+    );
+    RBASIC_SET_FULL_SHAPE_ID(obj, shape_id);
 }
 
 static inline shape_id_t
@@ -269,12 +278,6 @@ static inline bool
 rb_shape_canonical_p(shape_id_t shape_id)
 {
     return !(shape_id & SHAPE_ID_FL_NON_CANONICAL_MASK);
-}
-
-static inline shape_id_t
-rb_shape_id_with_robject_layout(shape_id_t shape_id)
-{
-    return (shape_id & ~SHAPE_ID_LAYOUT_MASK) | SHAPE_ID_LAYOUT_ROBJECT;
 }
 
 static inline attr_index_t
@@ -482,6 +485,12 @@ rb_obj_using_gen_fields_table_p(VALUE obj)
     }
 
     return rb_obj_gen_fields_p(obj);
+}
+
+static inline shape_id_t
+rb_shape_transition_robject(shape_id_t shape_id)
+{
+    return (shape_id & ~SHAPE_ID_LAYOUT_MASK) | SHAPE_ID_LAYOUT_ROBJECT;
 }
 
 static inline shape_id_t

--- a/shape.h
+++ b/shape.h
@@ -520,6 +520,12 @@ rb_shape_transition_capacity(shape_id_t shape_id, size_t capacity)
     return (shape_id & (~SHAPE_ID_CAPACITY_MASK)) | capacity_flags;
 }
 
+static inline shape_id_t
+rb_shape_transition_slot_size(shape_id_t shape_id, size_t slot_size)
+{
+    return rb_shape_transition_capacity(shape_id, rb_shape_capacity_for_slot_size(slot_size));
+}
+
 shape_id_t rb_shape_transition_object_id(shape_id_t shape_id);
 
 static inline shape_id_t
@@ -539,6 +545,12 @@ static inline shape_id_t
 rb_obj_shape_transition_capacity(VALUE obj, size_t capacity)
 {
     return rb_shape_transition_capacity(RBASIC_SHAPE_ID(obj), capacity);
+}
+
+static inline shape_id_t
+rb_obj_shape_transition_slot_size(VALUE obj, size_t slot_size)
+{
+    return rb_shape_transition_slot_size(RBASIC_SHAPE_ID(obj), slot_size);
 }
 
 static inline shape_id_t

--- a/shape.h
+++ b/shape.h
@@ -278,7 +278,7 @@ rb_shape_id_with_robject_layout(shape_id_t shape_id)
 }
 
 static inline attr_index_t
-rb_shape_capacity(shape_id_t shape_id)
+rb_shape_embedded_capacity(shape_id_t shape_id)
 {
     return (attr_index_t)((shape_id & SHAPE_ID_CAPACITY_MASK) >> SHAPE_ID_CAPACITY_OFFSET);
 }
@@ -290,7 +290,7 @@ rb_shape_id_with_capacity(size_t capacity)
 
     RUBY_ASSERT(capacity <= SHAPE_ID_CAPACITY_MAX);
     RUBY_ASSERT((capacity_flags & SHAPE_ID_CAPACITY_MASK) == capacity_flags);
-    RUBY_ASSERT(rb_shape_capacity(capacity_flags) == capacity);
+    RUBY_ASSERT(rb_shape_embedded_capacity(capacity_flags) == capacity);
 
     return ROOT_SHAPE_ID | capacity_flags;
 }
@@ -330,7 +330,7 @@ RSHAPE_TYPE_P(shape_id_t shape_id, enum shape_type type)
 static inline attr_index_t
 RSHAPE_CAPACITY(shape_id_t shape_id)
 {
-    attr_index_t embedded_capacity = rb_shape_capacity(shape_id);
+    attr_index_t embedded_capacity = rb_shape_embedded_capacity(shape_id);
 
     if (embedded_capacity > RSHAPE(shape_id)->capacity) {
         return embedded_capacity;

--- a/string.c
+++ b/string.c
@@ -630,7 +630,7 @@ static VALUE
 setup_fake_str(struct RString *fake_str, const char *name, long len, int encidx)
 {
     fake_str->basic.flags = T_STRING|RSTRING_NOEMBED|STR_NOFREE|STR_FAKESTR;
-    RBASIC_SET_SHAPE_ID((VALUE)fake_str, ROOT_SHAPE_ID | SHAPE_ID_LAYOUT_OTHER);
+    RBASIC_SET_FULL_SHAPE_ID((VALUE)fake_str, ROOT_SHAPE_ID | SHAPE_ID_LAYOUT_OTHER);
 
     if (!name) {
         RUBY_ASSERT_ALWAYS(len == 0);

--- a/variable.c
+++ b/variable.c
@@ -1343,7 +1343,7 @@ rb_free_generic_ivar(VALUE obj)
                 }
             }
         }
-        RBASIC_SET_SHAPE_ID(obj, rb_shape_layout(RBASIC_SHAPE_ID(obj)) | ROOT_SHAPE_ID);
+        RBASIC_SET_SHAPE_ID(obj, ROOT_SHAPE_ID);
     }
 }
 
@@ -1395,7 +1395,7 @@ rb_obj_set_fields(VALUE obj, VALUE fields_obj, ID field_name, VALUE original_fie
         }
     }
 
-    RBASIC_SET_SHAPE_ID(obj, rb_shape_layout(RBASIC_SHAPE_ID(obj)) | RBASIC_SHAPE_ID(fields_obj));
+    RBASIC_SET_SHAPE_ID(obj, RBASIC_SHAPE_ID(fields_obj));
 }
 
 void
@@ -1710,7 +1710,6 @@ rb_ivar_delete(VALUE obj, ID id, VALUE undef)
             size_t trailing_fields = new_fields_count - removed_index;
 
             MEMMOVE(&fields[removed_index], &fields[removed_index + 1], VALUE, trailing_fields);
-            RUBY_ASSERT(rb_shape_layout(next_shape_id) == SHAPE_ID_LAYOUT_ROBJECT);
             RBASIC_SET_SHAPE_ID(fields_obj, next_shape_id);
 
             if (FL_TEST_RAW(fields_obj, OBJ_FIELD_HEAP)) {
@@ -1733,7 +1732,7 @@ rb_ivar_delete(VALUE obj, ID id, VALUE undef)
         }
     }
 
-    RBASIC_SET_SHAPE_ID(obj, rb_shape_layout(RBASIC_SHAPE_ID(obj)) | next_shape_id);
+    RBASIC_SET_SHAPE_ID(obj, next_shape_id);
     if (fields_obj != original_fields_obj) {
         switch (type) {
           case T_OBJECT:
@@ -1844,7 +1843,7 @@ imemo_fields_set(VALUE owner, VALUE fields_obj, shape_id_t target_shape_id, ID f
         RUBY_ASSERT(field_name);
         st_insert(table, (st_data_t)field_name, (st_data_t)val);
         RB_OBJ_WRITTEN(fields_obj, Qundef, val);
-        RBASIC_SET_SHAPE_ID(fields_obj, rb_shape_id_with_robject_layout(target_shape_id));
+        RBASIC_SET_SHAPE_ID(fields_obj, target_shape_id);
     }
     else {
         attr_index_t index = RSHAPE_INDEX(target_shape_id);
@@ -1856,7 +1855,7 @@ imemo_fields_set(VALUE owner, VALUE fields_obj, shape_id_t target_shape_id, ID f
         RB_OBJ_WRITE(fields_obj, &table[index], val);
 
         if (index >= RSHAPE_LEN(current_shape_id)) {
-            RBASIC_SET_SHAPE_ID(fields_obj, rb_shape_id_with_robject_layout(target_shape_id));
+            RBASIC_SET_SHAPE_ID(fields_obj, target_shape_id);
         }
     }
 
@@ -2305,7 +2304,7 @@ rb_copy_generic_ivar(VALUE dest, VALUE obj)
         }
 
         if (!RSHAPE_LEN(dest_shape_id)) {
-            RBASIC_SET_SHAPE_ID(dest, rb_shape_layout(RBASIC_SHAPE_ID(dest)) | dest_shape_id);
+            RBASIC_SET_SHAPE_ID(dest, dest_shape_id);
             return;
         }
 
@@ -4688,7 +4687,7 @@ class_ivar_set(VALUE obj, ID id, VALUE val, bool *new_ivar)
     // TODO: What should we set as the T_CLASS shape_id?
     // In most case we can replicate the single `fields_obj` shape
     // but in namespaced case? Perhaps INVALID_SHAPE_ID?
-    RBASIC_SET_SHAPE_ID(obj, rb_shape_layout(RBASIC_SHAPE_ID(obj)) | RBASIC_SHAPE_ID(new_fields_obj));
+    RBASIC_SET_SHAPE_ID(obj, RBASIC_SHAPE_ID(new_fields_obj));
     return index;
 }
 
@@ -4713,7 +4712,7 @@ rb_fields_tbl_copy(VALUE dst, VALUE src)
     VALUE fields_obj = RCLASS_WRITABLE_FIELDS_OBJ(src);
     if (fields_obj) {
         RCLASS_WRITABLE_SET_FIELDS_OBJ(dst, rb_imemo_fields_clone(fields_obj));
-        RBASIC_SET_SHAPE_ID(dst, rb_shape_layout(RBASIC_SHAPE_ID(dst)) | RBASIC_SHAPE_ID(src));
+        RBASIC_SET_SHAPE_ID(dst, RBASIC_SHAPE_ID(src));
     }
 }
 

--- a/variable.c
+++ b/variable.c
@@ -1847,6 +1847,7 @@ imemo_fields_set(VALUE owner, VALUE fields_obj, shape_id_t target_shape_id, ID f
     }
     else {
         attr_index_t index = RSHAPE_INDEX(target_shape_id);
+
         if (concurrent || index >= RSHAPE_CAPACITY(current_shape_id)) {
             return imemo_fields_copy_append(owner, original_fields_obj, current_shape_id, target_shape_id, val);
         }

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1412,8 +1412,7 @@ vm_setivar_class(VALUE obj, VALUE val, rb_setivar_cache cache)
     RB_OBJ_WRITE(fields_obj, &rb_imemo_fields_ptr(fields_obj)[cache.index], val);
 
     if (shape_id != dest_shape_id) {
-        // The dest_shape_id comes from the fields_obj
-        RBASIC_SET_SHAPE_ID(obj, SHAPE_ID_LAYOUT_RCLASS | (dest_shape_id & ~SHAPE_ID_LAYOUT_MASK));
+        RBASIC_SET_SHAPE_ID(obj, dest_shape_id);
         RBASIC_SET_SHAPE_ID(fields_obj, dest_shape_id);
     }
 
@@ -1441,9 +1440,7 @@ vm_setivar_default(VALUE obj, ID id, VALUE val, rb_setivar_cache cache)
 
     if (shape_id != dest_shape_id) {
         RBASIC_SET_SHAPE_ID(obj, dest_shape_id);
-        // The dest_shape_id comes from the owner, but fields_obj must always
-        // have layout RObject, so give the fields_object the right layout.
-        RBASIC_SET_SHAPE_ID(fields_obj, rb_shape_id_with_robject_layout(dest_shape_id));
+        RBASIC_SET_SHAPE_ID(fields_obj, dest_shape_id);
     }
 
     RB_DEBUG_COUNTER_INC(ivar_set_ic_hit);


### PR DESCRIPTION
Extracted from: https://github.com/ruby/ruby/pull/17631

Like the capacity part, the layout part of an object shape almost never changes. The few exceptions are:

  - On allocation.
  - On being compacted by GC.
  - When RObject oberflows.
    
As such it simplifies a lot of code if `RBASIC_SET_SHAPE_ID` strips the layout bits, as we often copy the shape from IMEMO/fields to the owner object and vice-versa.

Also change `RBASIC_SET_SHAPE_ID_WITH_CAPACITY` into `RBASIC_SET_FULL_SHAPE_ID` so it can be used for assigning both capacity and layout.

Also rename `rb_shape_capacity` into `rb_shape_embedded_capacity` to avoid confusion with the actual capacity which may be larger if the object has been extended (`ROBJECT_HEAP`).