### PR TITLE
Suppress unused-function warnings

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -3720,6 +3720,7 @@ bool
 rb_gc_zjit_new_obj_fastpath(size_t alloc_size, VALUE flags, VALUE klass, struct rb_gc_zjit_fastpath *fastpath)
 {
 #if RACTOR_CHECK_MODE || defined(RUBY_ASAN_ENABLED)
+    (void)rb_gc_impl_zjit_new_obj_fastpath;
     return false;
 #else
     return rb_gc_impl_zjit_new_obj_fastpath(rb_gc_get_objspace(), alloc_size, flags, klass, fastpath);

--- a/process.c
+++ b/process.c
@@ -3852,6 +3852,7 @@ getresgid(rb_gid_t *rgid, rb_gid_t *egid, rb_gid_t *sgid)
 #define HAVE_GETRESGID
 #endif
 
+#if !defined(RUBY_ASAN_ENABLED)
 static int
 has_privilege(void)
 {
@@ -3913,6 +3914,7 @@ has_privilege(void)
 
     return 0;
 }
+#endif
 #endif
 
 struct child_handler_disabler_state


### PR DESCRIPTION
```
../src/process.c:3856:1: warning: unused function 'has_privilege' [-Wunused-function]
 3856 | has_privilege(void)
      | ^~~~~~~~~~~~~
```
```
In file included from ../src/gc.c:592:
../src/gc/default/default.c:2670:1: warning: unused function 'rb_gc_impl_zjit_new_obj_fastpath' [-Wunused-function]
 2670 | rb_gc_impl_zjit_new_obj_fastpath(void *objspace_ptr, size_t alloc_size, VALUE flags, VALUE klass,
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```