### PR TITLE
[Bug #22183] Preserve `lpar_beg` across interpolation

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -6063,6 +6063,10 @@ string_content	: tSTRING_CONTENT[content]
                         p->lex.brace_nest = 0;
                     }[brace]<num>
                     {
+                        $$ = p->lex.lpar_beg;
+                        p->lex.lpar_beg = -1;
+                    }[lpar]<num>
+                    {
                         $$ = p->heredoc_indent;
                         p->heredoc_indent = 0;
                     }[indent]<num>
@@ -6073,6 +6077,7 @@ string_content	: tSTRING_CONTENT[content]
                         p->lex.strterm = $term;
                         SET_LEX_STATE($state);
                         p->lex.brace_nest = $brace;
+                        p->lex.lpar_beg = $lpar;
                         p->heredoc_indent = $indent;
                         p->heredoc_line_indent = -1;
                         if ($compstmt) nd_unset_fl_newline($compstmt);

--- a/test/ruby/test_parse.rb
+++ b/test/ruby/test_parse.rb
@@ -323,6 +323,12 @@ class TestParse < Test::Unit::TestCase
     end
     a.call
     assert_equal(42, b)
+
+    obj = BasicObject.new
+    assert_nothing_raised do
+      a = obj.instance_eval('-> a = "#{foo do end}" do end', __FILE__, __LINE__)
+    end
+    assert_raise_with_message(NoMethodError, /foo/) {a.call}
   end
 
   def test_block_call_colon2


### PR DESCRIPTION
Fix unexpected `keyword_do_LAMBDA` inside string interpolation within default argument of lambda.