### PR TITLE
[Feature #22102] Add rb_str_cstr() to the C API

### DIFF
--- a/include/ruby/internal/core/rstring.h
+++ b/include/ruby/internal/core/rstring.h
@@ -302,6 +302,18 @@ char *rb_string_value_ptr(volatile VALUE *ptr);
 char *rb_string_value_cstr(volatile VALUE *ptr);
 
 /**
+ * Returns a pointer to the string contents as a C string. This checks that the
+ * string does not contain embedded NUL bytes and that it is properly
+ * NUL-terminated.
+ *
+ * @param[in]  str             String in question.
+ * @exception  rb_eArgError    The contents include a NUL byte in the middle.
+ * @return     Pointer to its contents.
+ * @pre        `str` must be an instance of ::RString.
+ */
+const char *rb_str_cstr(VALUE str);
+
+/**
  * Identical  to rb_str_to_str(),  except it  additionally converts  the string
  * into default  external encoding.   Ruby has a  concept called  encodings.  A
  * string can  have different encoding  than the environment  expects.  Someone

--- a/spec/ruby/optional/capi/ext/string_spec.c
+++ b/spec/ruby/optional/capi/ext/string_spec.c
@@ -445,6 +445,13 @@ VALUE string_spec_RSTRING_PTR_null_terminate(VALUE self, VALUE str, VALUE min_le
   return rb_str_new(end, FIX2LONG(min_length));
 }
 
+#ifdef RUBY_VERSION_IS_4_1
+static VALUE string_spec_rb_str_cstr(VALUE self, VALUE str) {
+  const char *ptr = rb_str_cstr(str);
+  return rb_str_new_cstr(ptr);
+}
+#endif
+
 VALUE string_spec_StringValue(VALUE self, VALUE str) {
   return StringValue(str);
 }
@@ -696,6 +703,9 @@ void Init_string_spec(void) {
   rb_define_method(cls, "RSTRING_PTR_after_yield", string_spec_RSTRING_PTR_after_yield, 1);
   rb_define_method(cls, "RSTRING_PTR_read", string_spec_RSTRING_PTR_read, 2);
   rb_define_method(cls, "RSTRING_PTR_null_terminate", string_spec_RSTRING_PTR_null_terminate, 2);
+#ifdef RUBY_VERSION_IS_4_1
+  rb_define_method(cls, "rb_str_cstr", string_spec_rb_str_cstr, 1);
+#endif
   rb_define_method(cls, "StringValue", string_spec_StringValue, 1);
   rb_define_method(cls, "SafeStringValue", string_spec_SafeStringValue, 1);
   rb_define_method(cls, "rb_str_hash", string_spec_rb_str_hash, 1);

--- a/spec/ruby/optional/capi/string_spec.rb
+++ b/spec/ruby/optional/capi/string_spec.rb
@@ -685,6 +685,18 @@ describe "C-API String function" do
     end
   end
 
+  ruby_version_is "4.1" do
+    describe "rb_str_cstr" do
+      it "returns a NUL-terminated C string for a simple string" do
+        @s.rb_str_cstr("Hello").should == "Hello"
+      end
+
+      it "raises an ArgumentError if a string contains a null" do
+        -> { @s.rb_str_cstr("Hello\0 with a null.") }.should.raise(ArgumentError)
+      end
+    end
+  end
+
   describe "RSTRING_LEN" do
     it "returns the size of the string" do
       @s.RSTRING_LEN("gumdrops").should == 8

--- a/string.c
+++ b/string.c
@@ -2943,6 +2943,12 @@ rb_str_to_cstr(VALUE str)
     return str_null_check(str, &w);
 }
 
+const char *
+rb_str_cstr(VALUE str)
+{
+    return str_to_cstr(str);
+}
+
 char *
 rb_string_value_cstr(volatile VALUE *ptr)
 {


### PR DESCRIPTION
Add a new utility function to get a C string from Ruby String.

---

Note that there is a very similarly named internal function `rb_str_to_cstr()`, which should probably be renamed.