### PR TITLE
ZJIT: Widen Float operations to operate on HeapFloat too

### DIFF
--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -2577,6 +2577,8 @@ fn gen_test(asm: &mut Assembler, val: lir::Opnd) -> lir::Opnd {
 }
 
 fn gen_has_type(jit: &mut JITState, asm: &mut Assembler, val: lir::Opnd, val_type: Type, ty: Type) -> lir::Opnd {
+    // TODO(max): Add case for Integer, which could either be Fixnum or Bignum
+    // TODO(max): Add case for Float, which could either be Flonum or Float
     if ty.is_subtype(types::Fixnum) {
         asm.test(val, Opnd::UImm(RUBY_FIXNUM_FLAG as u64));
         asm.csel_nz(Opnd::Imm(1), Opnd::Imm(0))
@@ -2688,18 +2690,63 @@ fn gen_has_type(jit: &mut JITState, asm: &mut Assembler, val: lir::Opnd, val_typ
     }
 }
 
+fn gen_check_class_or_jmp(jit: &mut JITState, asm: &mut Assembler, val: lir::Opnd, expected_class: VALUE, target: Target) {
+    // Load the class from the object's klass field
+    let val = asm.load_mem(val);
+    let klass = asm.load(Opnd::mem(64, val, RUBY_OFFSET_RBASIC_KLASS));
+    asm.cmp(klass, Opnd::Value(expected_class));
+    asm.jne(jit, target);
+}
+
+fn gen_guard_split_type(jit: &mut JITState, asm: &mut Assembler, test_immediate_or_jmp: impl Fn(&mut JITState, &mut Assembler, Opnd, Target), val: Opnd, expected_class: VALUE, guard_type: Type, recompile: Option<Recompile>, state: &FrameState) {
+    let hir_block_id = asm.current_block().hir_block_id;
+    let rpo_idx = asm.current_block().rpo_index;
+
+    let heap_block = asm.new_block(hir_block_id, false, rpo_idx);
+    let heap_target = Target::Block(Box::new(lir::BranchEdge { target: heap_block, args: vec![] }));
+
+    let join_block = asm.new_block(hir_block_id, false, rpo_idx);
+    let join_target = Target::Block(Box::new(lir::BranchEdge { target: join_block, args: vec![] }));
+
+    test_immediate_or_jmp(jit, asm, val, heap_target);
+    asm.jmp(join_target.clone());
+
+    asm.set_current_block(heap_block);
+    let heap_label = jit.get_label(asm, heap_block, hir_block_id);
+    asm.write_label(heap_label);
+    let side_exit = side_exit_with_recompile(jit, state, GuardType(guard_type), recompile);
+    gen_check_class_or_jmp(jit, asm, val, expected_class, side_exit);
+    asm.jmp(join_target);
+
+    asm.set_current_block(join_block);
+    let join_label = jit.get_label(asm, join_block, hir_block_id);
+    asm.write_label(join_label);
+}
+
+fn gen_check_fixnum_or_jmp(jit: &mut JITState, asm: &mut Assembler, val: lir::Opnd, target: Target) {
+    asm.test(val, Opnd::UImm(RUBY_FIXNUM_FLAG as u64));
+    asm.jz(jit, target);
+}
+
+fn gen_check_flonum_or_jmp(jit: &mut JITState, asm: &mut Assembler, val: lir::Opnd, target: Target) {
+    // Flonum: (val & RUBY_FLONUM_MASK) == RUBY_FLONUM_FLAG
+    let masked = asm.and(val, Opnd::UImm(RUBY_FLONUM_MASK as u64));
+    asm.cmp(masked, Opnd::UImm(RUBY_FLONUM_FLAG as u64));
+    asm.jne(jit, target);
+}
+
 /// Compile a type check with a side exit
 fn gen_guard_type(jit: &mut JITState, asm: &mut Assembler, val: lir::Opnd, val_type: Type, guard_type: Type, recompile: Option<Recompile>, state: &FrameState) -> lir::Opnd {
     let is_known_heap_basic_object = val_type.is_subtype(types::HeapBasicObject);
     gen_incr_counter(asm, Counter::guard_type_count);
     if guard_type.is_subtype(types::Fixnum) {
-        asm.test(val, Opnd::UImm(RUBY_FIXNUM_FLAG as u64));
-        asm.jz(jit, side_exit_with_recompile(jit, state, GuardType(guard_type), recompile));
+        gen_check_fixnum_or_jmp(jit, asm, val, side_exit_with_recompile(jit, state, GuardType(guard_type), recompile));
+    } else if guard_type.is_subtype(types::Integer) {
+        gen_guard_split_type(jit, asm, gen_check_fixnum_or_jmp, val, unsafe { rb_cInteger }, guard_type, recompile, state);
     } else if guard_type.is_subtype(types::Flonum) {
-        // Flonum: (val & RUBY_FLONUM_MASK) == RUBY_FLONUM_FLAG
-        let masked = asm.and(val, Opnd::UImm(RUBY_FLONUM_MASK as u64));
-        asm.cmp(masked, Opnd::UImm(RUBY_FLONUM_FLAG as u64));
-        asm.jne(jit, side_exit_with_recompile(jit, state, GuardType(guard_type), recompile));
+        gen_check_flonum_or_jmp(jit, asm, val, side_exit_with_recompile(jit, state, GuardType(guard_type), recompile));
+    } else if guard_type.is_subtype(types::Float) {
+        gen_guard_split_type(jit, asm, gen_check_flonum_or_jmp, val, unsafe { rb_cFloat }, guard_type, recompile, state);
     } else if guard_type.is_subtype(types::StaticSymbol) {
         // Static symbols have (val & 0xff) == RUBY_SYMBOL_FLAG
         // Use 8-bit comparison like YJIT does.
@@ -2737,11 +2784,7 @@ fn gen_guard_type(jit: &mut JITState, asm: &mut Assembler, val: lir::Opnd, val_t
             asm.je(jit, side_exit.clone());
         }
 
-        // Load the class from the object's klass field
-        let klass = asm.load(Opnd::mem(64, val, RUBY_OFFSET_RBASIC_KLASS));
-
-        asm.cmp(klass, Opnd::Value(expected_class));
-        asm.jne(jit, side_exit);
+        gen_check_class_or_jmp(jit, asm, val, expected_class, side_exit);
     } else if let Some(builtin_type) = guard_type.builtin_type_equivalent() {
         let side = side_exit_with_recompile(jit, state, GuardType(guard_type), recompile);
 

--- a/zjit/src/cruby_methods.rs
+++ b/zjit/src/cruby_methods.rs
@@ -674,15 +674,15 @@ fn try_inline_float_op(fun: &mut hir::Function, block: hir::BlockId, f: &dyn Fn(
     if !unsafe { rb_BASIC_OP_UNREDEFINED_P(bop, FLOAT_REDEFINED_OP_FLAG) } {
         return None;
     }
-    // Receiver must be Flonum (cheap tag check: (val & 3) == 2).
-    // The other operand can be Flonum or Fixnum since rb_float_plus/minus/mul/div
+    // Receiver must be Float.
+    // The other operand can be Float or Fixnum since rb_float_plus/minus/mul/div
     // handle both via fast paths (FIXNUM_P check + cast to double).
     // HeapFloat falls back to CCallWithFrame via the default Send path.
-    if fun.likely_a(recv, types::Flonum, state)
-        && (fun.likely_a(other, types::Flonum, state) || fun.likely_a(other, types::Fixnum, state))
+    if fun.likely_a(recv, types::Float, state)
+        && (fun.likely_a(other, types::Float, state) || fun.likely_a(other, types::Fixnum, state))
     {
-        let recv = fun.coerce_to(block, recv, types::Flonum, state);
-        let other_type = if fun.likely_a(other, types::Flonum, state) { types::Flonum } else { types::Fixnum };
+        let recv = fun.coerce_to(block, recv, types::Float, state);
+        let other_type = if fun.likely_a(other, types::Float, state) { types::Float } else { types::Fixnum };
         let other = fun.coerce_to(block, other, other_type, state);
         return Some(fun.push_insn(block, f(recv, other)));
     }
@@ -711,8 +711,8 @@ fn inline_float_div(fun: &mut hir::Function, block: hir::BlockId, recv: hir::Ins
 
 fn inline_float_to_i(fun: &mut hir::Function, block: hir::BlockId, recv: hir::InsnId, args: &[hir::InsnId], state: hir::InsnId) -> Option<hir::InsnId> {
     let &[] = args else { return None; };
-    if fun.likely_a(recv, types::Flonum, state) {
-        let recv = fun.coerce_to(block, recv, types::Flonum, state);
+    if fun.likely_a(recv, types::Float, state) {
+        let recv = fun.coerce_to(block, recv, types::Float, state);
         return Some(fun.push_insn(block, hir::Insn::FloatToInt { recv, state }));
     }
     None

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -6653,12 +6653,12 @@ impl Function {
             | Insn::FloatMul { recv, other, .. }
             | Insn::FloatDiv { recv, other, .. }
             => {
-                self.assert_subtype(insn_id, recv, types::Flonum)?;
-                // other can be Flonum or Fixnum (rb_float_plus etc. handle both)
-                self.assert_subtype(insn_id, other, types::Flonum.union(types::Fixnum))
+                self.assert_subtype(insn_id, recv, types::Float)?;
+                // other can be Float or Fixnum (rb_float_plus etc. handle both)
+                self.assert_subtype(insn_id, other, types::Float.union(types::Fixnum))
             }
             Insn::FloatToInt { recv, .. } => {
-                self.assert_subtype(insn_id, recv, types::Flonum)
+                self.assert_subtype(insn_id, recv, types::Float)
             }
             Insn::FixnumLShift { left, right, .. }
             | Insn::FixnumRShift { left, right, .. } => {

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -17572,7 +17572,7 @@ mod hir_opt_tests {
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint MethodRedefined(Float@0x1008, +@0x1010, cme:0x1018)
           v28:Flonum = GuardType v12, Flonum recompile
-          v29:Flonum = GuardType v13, Flonum
+          v29:Float = GuardType v13, Float
           v30:Float = FloatAdd v28, v29
           CheckInterrupts
           Return v30
@@ -17603,7 +17603,7 @@ mod hir_opt_tests {
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint MethodRedefined(Float@0x1008, *@0x1010, cme:0x1018)
           v28:Flonum = GuardType v12, Flonum recompile
-          v29:Flonum = GuardType v13, Flonum
+          v29:Float = GuardType v13, Float
           v30:Float = FloatMul v28, v29
           CheckInterrupts
           Return v30
@@ -17634,7 +17634,7 @@ mod hir_opt_tests {
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint MethodRedefined(Float@0x1008, -@0x1010, cme:0x1018)
           v28:Flonum = GuardType v12, Flonum recompile
-          v29:Flonum = GuardType v13, Flonum
+          v29:Float = GuardType v13, Float
           v30:Float = FloatSub v28, v29
           CheckInterrupts
           Return v30
@@ -17665,7 +17665,7 @@ mod hir_opt_tests {
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint MethodRedefined(Float@0x1008, /@0x1010, cme:0x1018)
           v28:Flonum = GuardType v12, Flonum recompile
-          v29:Flonum = GuardType v13, Flonum
+          v29:Float = GuardType v13, Float
           v30:Float = FloatDiv v28, v29
           CheckInterrupts
           Return v30


### PR DESCRIPTION
Unlike with Fixnum, Float values are not as commonly in the Flonum
(immediate) range. Until we can do more intelligent prediction of float
ranges, widen the operations to operate on full Float, which can be
heap-allocated.
