### PR TITLE
ZJIT: Expand anytostring into CondBranch

### DIFF
--- a/zjit/bindgen/src/main.rs
+++ b/zjit/bindgen/src/main.rs
@@ -222,7 +222,7 @@ fn main() {
         .allowlist_type("ruby_rstring_private_flags")
         .allowlist_function("rb_ec_str_resurrect")
         .allowlist_function("rb_str_concat_literals")
-        .allowlist_function("rb_obj_as_string_result")
+        .allowlist_function("rb_any_to_s")
         .allowlist_function("rb_str_byte_substr")
         .allowlist_function("rb_str_substr_two_fixnums")
         .allowlist_function("rb_backref_get")

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -745,7 +745,7 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
         Insn::FixnumBitCheck { val, index } => gen_fixnum_bit_check(asm, opnd!(val), *index),
         Insn::SideExit { state, reason, recompile } => no_output!(gen_side_exit(jit, asm, function, reason, *recompile, &function.frame_state(*state))),
         Insn::PutSpecialObject { value_type, state } => gen_putspecialobject(jit, asm, function, *value_type, &function.frame_state(*state)),
-        Insn::AnyToString { val, str, state } => gen_anytostring(asm, opnd!(val), opnd!(str), &function.frame_state(*state)),
+        Insn::AnyToString { val, state } => gen_anytostring(asm, opnd!(val), &function.frame_state(*state)),
         Insn::Defined { op_type, obj, pushval, v, lep_level, state } => gen_defined(jit, asm, function, *op_type, *obj, *pushval, opnd!(v), *lep_level, &function.frame_state(*state)),
         Insn::CheckMatch { target, pattern, flag, state } => gen_checkmatch(jit, asm, function, opnd!(target), opnd!(pattern), *flag, &function.frame_state(*state)),
         Insn::GetSpecialSymbol { symbol_type, state } => gen_getspecial_symbol(asm, *symbol_type, &function.frame_state(*state)),
@@ -2604,10 +2604,10 @@ fn gen_box_fixnum(jit: &mut JITState, asm: &mut Assembler, function: &Function, 
     asm.or(shifted, Opnd::UImm(RUBY_FIXNUM_FLAG as u64))
 }
 
-fn gen_anytostring(asm: &mut Assembler, val: lir::Opnd, str: lir::Opnd, state: &FrameState) -> lir::Opnd {
+fn gen_anytostring(asm: &mut Assembler, val: lir::Opnd, state: &FrameState) -> lir::Opnd {
     gen_prepare_leaf_call_with_gc(asm, state);
 
-    asm_ccall!(asm, rb_obj_as_string_result, str, val)
+    asm_ccall!(asm, rb_any_to_s, val)
 }
 
 /// Evaluate if a value is truthy

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -2104,6 +2104,7 @@ unsafe extern "C" {
         argv: *const VALUE,
         klass: VALUE,
     ) -> VALUE;
+    pub fn rb_any_to_s(obj: VALUE) -> VALUE;
     pub fn rb_obj_is_kind_of(obj: VALUE, klass: VALUE) -> VALUE;
     pub fn rb_obj_alloc(klass: VALUE) -> VALUE;
     pub fn rb_obj_frozen_p(obj: VALUE) -> VALUE;
@@ -2199,7 +2200,6 @@ unsafe extern "C" {
         len: VALUE,
         empty: ::std::os::raw::c_int,
     ) -> VALUE;
-    pub fn rb_obj_as_string_result(str_: VALUE, obj: VALUE) -> VALUE;
     pub fn rb_str_concat_literals(num: usize, strary: *const VALUE) -> VALUE;
     pub fn rb_ec_str_resurrect(
         ec: *mut rb_execution_context_struct,

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -4331,13 +4331,6 @@ impl Function {
                             self.push_insn_id(block, insn_id); continue;
                         }
                     }
-                    Insn::AnyToString { str, .. } => {
-                        if self.is_a(str, types::String) {
-                            self.make_equal_to(insn_id, str);
-                        } else {
-                            self.push_insn_id(block, insn_id);
-                        }
-                    }
                     Insn::IsMethodCfunc { val, cd, cfunc, state } if self.type_of(val).ruby_object_known() => {
                         let class = self.type_of(val).ruby_object().unwrap();
                         let cme = unsafe { rb_zjit_vm_search_method(self.iseq.into(), cd as *mut rb_call_data, class) };
@@ -5622,11 +5615,6 @@ impl Function {
                         } else {
                             insn_id
                         }
-                    }
-                    Insn::AnyToString { str, .. } if self.is_a(str, types::String) => {
-                        self.make_equal_to(insn_id, str);
-                        // Don't bother re-inferring the type of str; we already know it.
-                        continue;
                     }
                     Insn::IsA { val, class } => 'is_a: {
                         let class_type = self.type_of(class);
@@ -9152,8 +9140,27 @@ fn add_iseq_to_hir(
                     let str = state.stack_pop()?;
                     let val = state.stack_pop()?;
 
-                    let anytostring = fun.push_insn(block, Insn::AnyToString { val, str, state: exit_id });
-                    state.stack_push(anytostring);
+                    // Mirror logic of rb_obj_as_string_result() (`anytostring` in insns.def)
+                    let has_type = fun.push_insn(block, Insn::HasType { val: str, expected: types::String });
+                    let iftrue_block = fun.new_block(insn_idx);
+                    let iffalse_block = fun.new_block(insn_idx);
+                    let join_block = fun.new_block(insn_idx);
+                    fun.push_insn(block, Insn::CondBranch {
+                        val: has_type,
+                        if_true: BranchEdge { target: iftrue_block, args: vec![] },
+                        if_false: BranchEdge { target: iffalse_block, args: vec![] }
+                    });
+                    // true block
+                    let refined = fun.push_insn(iftrue_block, Insn::RefineType { val: str, new_type: types::String });
+                    fun.push_insn(iftrue_block, Insn::Jump(BranchEdge { target: join_block, args: vec![refined] }));
+                    // false block
+                    let refined = fun.push_insn(iffalse_block, Insn::RefineType { val: str, new_type: types::NotString });
+                    let anytostring = fun.push_insn(iffalse_block, Insn::AnyToString { val, str: refined, state: exit_id });
+                    fun.push_insn(iffalse_block, Insn::Jump(BranchEdge { target: join_block, args: vec![anytostring] }));
+                    // join block
+                    block = join_block;
+                    let result = fun.push_insn(join_block, Insn::Param);
+                    state.stack_push(result);
                 }
                 YARVINSN_getspecial => {
                     let key = get_arg(pc, 0).as_u64();

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -3157,7 +3157,7 @@ impl Function {
             Insn::GetClassVar { .. } => types::BasicObject,
             Insn::ToNewArray { .. } => types::ArrayExact,
             Insn::ToArray { .. } => types::ArrayExact,
-            Insn::AnyToString { .. } => types::String,
+            Insn::AnyToString { .. } => types::StringExact,
             Insn::IsBlockParamModified { .. } => types::CBool,
             Insn::GetBlockParam { .. } => types::BasicObject,
             // The type of Snapshot doesn't really matter; it's never materialized. It's used only

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -1189,7 +1189,7 @@ pub enum Insn {
     /// Float#to_i: truncate float to integer via rb_jit_flo_to_i
     FloatToInt { recv: InsnId, state: InsnId },
 
-    AnyToString { val: InsnId, str: InsnId, state: InsnId },
+    AnyToString { val: InsnId, state: InsnId },
 
     /// Refine the known type information of with additional type information.
     /// Computes the intersection of the existing type and the new type.
@@ -1526,9 +1526,8 @@ macro_rules! for_each_operand_impl {
                 $visit_one!(*val);
                 $visit_one!(*state);
             }
-            Insn::AnyToString { val, str, state, .. } => {
+            Insn::AnyToString { val, state, .. } => {
                 $visit_one!(*val);
-                $visit_one!(*str);
                 $visit_one!(*state);
             }
             Insn::LoadField { recv, .. } => {
@@ -2294,7 +2293,7 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
             Insn::ArrayExtend { left, right, .. } => write!(f, "ArrayExtend {left}, {right}"),
             Insn::ArrayPush { array, val, .. } => write!(f, "ArrayPush {array}, {val}"),
             Insn::StringIntern { val, .. } => { write!(f, "StringIntern {val}") },
-            Insn::AnyToString { val, str, .. } => { write!(f, "AnyToString {val}, str: {str}") },
+            Insn::AnyToString { val, .. } => { write!(f, "AnyToString {val}") },
             Insn::SideExit { reason, recompile, .. } => {
                 if recompile.is_some() {
                     write!(f, "SideExit {reason} recompile")
@@ -6477,7 +6476,6 @@ impl Function {
             // Instructions with 2 Ruby object operands
             Insn::SetIvar { self_val: left, val: right, .. }
             | Insn::NewRange { low: left, high: right, .. }
-            | Insn::AnyToString { val: left, str: right, .. }
             | Insn::CheckMatch { target: left, pattern: right, .. }
             | Insn::WriteBarrier { recv: left, val: right } => {
                 self.assert_subtype(insn_id, left, types::BasicObject)?;
@@ -6486,6 +6484,9 @@ impl Function {
             Insn::GetConstant { klass, allow_nil, .. } => {
                 self.assert_subtype(insn_id, klass, types::BasicObject)?;
                 self.assert_subtype(insn_id, allow_nil, types::BoolExact)
+            }
+            Insn::AnyToString { val, .. } => {
+                self.assert_subtype(insn_id, val, types::BasicObject)
             }
             // Instructions with recv and a Vec of Ruby objects
             Insn::PushInlineFrame { recv, ref args, .. }
@@ -9154,8 +9155,7 @@ fn add_iseq_to_hir(
                     let refined = fun.push_insn(iftrue_block, Insn::RefineType { val: str, new_type: types::String });
                     fun.push_insn(iftrue_block, Insn::Jump(BranchEdge { target: join_block, args: vec![refined] }));
                     // false block
-                    let refined = fun.push_insn(iffalse_block, Insn::RefineType { val: str, new_type: types::NotString });
-                    let anytostring = fun.push_insn(iffalse_block, Insn::AnyToString { val, str: refined, state: exit_id });
+                    let anytostring = fun.push_insn(iffalse_block, Insn::AnyToString { val, state: exit_id });
                     fun.push_insn(iffalse_block, Insn::Jump(BranchEdge { target: join_block, args: vec![anytostring] }));
                     // join block
                     block = join_block;

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -7099,7 +7099,7 @@ mod hir_opt_tests {
           v23:String = RefineType v39, String
           Jump bb6(v23)
         bb5():
-          v25:String = AnyToString v10
+          v25:StringExact = AnyToString v10
           Jump bb6(v25)
         bb6(v27:String):
           v29:StringExact = StringConcat v14, v27

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -6966,9 +6966,9 @@ mod hir_opt_tests {
           v10:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
           v13:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           v14:StringExact = StringCopy v13
-          v35:StringExact = StringConcat v10, v14
+          v34:StringExact = StringConcat v10, v14
           CheckInterrupts
-          Return v35
+          Return v34
         ");
     }
 
@@ -6991,10 +6991,10 @@ mod hir_opt_tests {
           v10:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
           v12:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Integer@0x1008, to_s@0x1010, cme:0x1018)
-          v41:StringExact = CCallVariadic v12, :Integer#to_s@0x1040
-          v33:StringExact = StringConcat v10, v41
+          v40:StringExact = CCallVariadic v12, :Integer#to_s@0x1040
+          v32:StringExact = StringConcat v10, v40
           CheckInterrupts
-          Return v33
+          Return v32
         ");
     }
 
@@ -7024,9 +7024,9 @@ mod hir_opt_tests {
           v14:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           PatchPoint NoSingletonClass(String@0x1010)
           v19:String = GuardType v10, String
-          v30:StringExact = StringConcat v14, v19
+          v29:StringExact = StringConcat v14, v19
           CheckInterrupts
-          Return v30
+          Return v29
         ");
     }
 
@@ -7059,9 +7059,9 @@ mod hir_opt_tests {
           v14:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           PatchPoint NoSingletonClass(MyString@0x1010)
           v19:String = GuardType v10, String
-          v30:StringExact = StringConcat v14, v19
+          v29:StringExact = StringConcat v14, v19
           CheckInterrupts
-          Return v30
+          Return v29
         ");
     }
 
@@ -7092,20 +7092,19 @@ mod hir_opt_tests {
           v18:ArrayExact = GuardType v10, ArrayExact
           PatchPoint NoSingletonClass(Array@0x1010)
           PatchPoint MethodRedefined(Array@0x1010, to_s@0x1018, cme:0x1020)
-          v40:BasicObject = CCallWithFrame v18, :Array#to_s@0x1048
-          v21:CBool = HasType v40, String
+          v39:BasicObject = CCallWithFrame v18, :Array#to_s@0x1048
+          v21:CBool = HasType v39, String
           CondBranch v21, bb4(), bb5()
         bb4():
-          v23:String = RefineType v40, String
+          v23:String = RefineType v39, String
           Jump bb6(v23)
         bb5():
-          v25:NotString = RefineType v40, NotString
-          v26:String = AnyToString v10, str: v25
-          Jump bb6(v26)
-        bb6(v28:String):
-          v30:StringExact = StringConcat v14, v28
+          v25:String = AnyToString v10
+          Jump bb6(v25)
+        bb6(v27:String):
+          v29:StringExact = StringConcat v14, v27
           CheckInterrupts
-          Return v30
+          Return v29
         ");
     }
 
@@ -10375,10 +10374,10 @@ mod hir_opt_tests {
           v14:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           v18:Fixnum = GuardType v10, Fixnum
           PatchPoint MethodRedefined(Integer@0x1010, to_s@0x1018, cme:0x1020)
-          v39:StringExact = CCallVariadic v18, :Integer#to_s@0x1048
-          v30:StringExact = StringConcat v14, v39
+          v38:StringExact = CCallVariadic v18, :Integer#to_s@0x1048
+          v29:StringExact = StringConcat v14, v38
           CheckInterrupts
-          Return v30
+          Return v29
         ");
     }
 

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -6966,9 +6966,9 @@ mod hir_opt_tests {
           v10:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
           v13:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           v14:StringExact = StringCopy v13
-          v28:StringExact = StringConcat v10, v14
+          v35:StringExact = StringConcat v10, v14
           CheckInterrupts
-          Return v28
+          Return v35
         ");
     }
 
@@ -6991,10 +6991,10 @@ mod hir_opt_tests {
           v10:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
           v12:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Integer@0x1008, to_s@0x1010, cme:0x1018)
-          v34:StringExact = CCallVariadic v12, :Integer#to_s@0x1040
-          v26:StringExact = StringConcat v10, v34
+          v41:StringExact = CCallVariadic v12, :Integer#to_s@0x1040
+          v33:StringExact = StringConcat v10, v41
           CheckInterrupts
-          Return v26
+          Return v33
         ");
     }
 
@@ -7024,9 +7024,9 @@ mod hir_opt_tests {
           v14:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           PatchPoint NoSingletonClass(String@0x1010)
           v19:String = GuardType v10, String
-          v23:StringExact = StringConcat v14, v19
+          v30:StringExact = StringConcat v14, v19
           CheckInterrupts
-          Return v23
+          Return v30
         ");
     }
 
@@ -7059,9 +7059,9 @@ mod hir_opt_tests {
           v14:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           PatchPoint NoSingletonClass(MyString@0x1010)
           v19:String = GuardType v10, String
-          v23:StringExact = StringConcat v14, v19
+          v30:StringExact = StringConcat v14, v19
           CheckInterrupts
-          Return v23
+          Return v30
         ");
     }
 
@@ -7092,11 +7092,20 @@ mod hir_opt_tests {
           v18:ArrayExact = GuardType v10, ArrayExact
           PatchPoint NoSingletonClass(Array@0x1010)
           PatchPoint MethodRedefined(Array@0x1010, to_s@0x1018, cme:0x1020)
-          v33:BasicObject = CCallWithFrame v18, :Array#to_s@0x1048
-          v21:String = AnyToString v18, str: v33
-          v23:StringExact = StringConcat v14, v21
+          v40:BasicObject = CCallWithFrame v18, :Array#to_s@0x1048
+          v21:CBool = HasType v40, String
+          CondBranch v21, bb4(), bb5()
+        bb4():
+          v23:String = RefineType v40, String
+          Jump bb6(v23)
+        bb5():
+          v25:NotString = RefineType v40, NotString
+          v26:String = AnyToString v10, str: v25
+          Jump bb6(v26)
+        bb6(v28:String):
+          v30:StringExact = StringConcat v14, v28
           CheckInterrupts
-          Return v23
+          Return v30
         ");
     }
 
@@ -10366,10 +10375,10 @@ mod hir_opt_tests {
           v14:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           v18:Fixnum = GuardType v10, Fixnum
           PatchPoint MethodRedefined(Integer@0x1010, to_s@0x1018, cme:0x1020)
-          v32:StringExact = CCallVariadic v18, :Integer#to_s@0x1048
-          v23:StringExact = StringConcat v14, v32
+          v39:StringExact = CCallVariadic v18, :Integer#to_s@0x1048
+          v30:StringExact = StringConcat v14, v39
           CheckInterrupts
-          Return v23
+          Return v30
         ");
     }
 

--- a/zjit/src/hir/tests.rs
+++ b/zjit/src/hir/tests.rs
@@ -2325,14 +2325,13 @@ pub(crate) mod hir_build_tests {
           v26:String = RefineType v22, String
           Jump bb9(v26)
         bb8():
-          v28:NotString = RefineType v22, NotString
-          v29:String = AnyToString v12, str: v28
-          Jump bb9(v29)
-        bb9(v31:String):
-          v33:StringExact = StringConcat v10, v31
-          v35:Symbol = StringIntern v33
+          v28:String = AnyToString v12
+          Jump bb9(v28)
+        bb9(v30:String):
+          v32:StringExact = StringConcat v10, v30
+          v34:Symbol = StringIntern v32
           CheckInterrupts
-          Return v35
+          Return v34
         ");
     }
 
@@ -5363,13 +5362,12 @@ pub(crate) mod hir_build_tests {
           v26:String = RefineType v22, String
           Jump bb9(v26)
         bb8():
-          v28:NotString = RefineType v22, NotString
-          v29:String = AnyToString v12, str: v28
-          Jump bb9(v29)
-        bb9(v31:String):
-          v33:StringExact = StringConcat v10, v31
+          v28:String = AnyToString v12
+          Jump bb9(v28)
+        bb9(v30:String):
+          v32:StringExact = StringConcat v10, v30
           CheckInterrupts
-          Return v33
+          Return v32
         ");
     }
 
@@ -5407,55 +5405,52 @@ pub(crate) mod hir_build_tests {
           v24:String = RefineType v20, String
           Jump bb9(v24)
         bb8():
-          v26:NotString = RefineType v20, NotString
-          v27:String = AnyToString v10, str: v26
-          Jump bb9(v27)
-        bb9(v29:String):
-          v31:Fixnum[2] = Const Value(2)
-          v34:CBool[false] = HasType v31, String
-          CondBranch v34, bb10(), bb11()
+          v26:String = AnyToString v10
+          Jump bb9(v26)
+        bb9(v28:String):
+          v30:Fixnum[2] = Const Value(2)
+          v33:CBool[false] = HasType v30, String
+          CondBranch v33, bb10(), bb11()
         bb10():
-          v36 = RefineType v31, String
-          Jump bb12(v36)
+          v35 = RefineType v30, String
+          Jump bb12(v35)
         bb11():
-          v38:Fixnum[2] = RefineType v31, NotString
-          v39:BasicObject = Send v38, :to_s # SendFallbackReason: ObjToString: result is not a string
-          Jump bb12(v39)
-        bb12(v41:BasicObject):
-          v43:CBool = HasType v41, String
-          CondBranch v43, bb13(), bb14()
+          v37:Fixnum[2] = RefineType v30, NotString
+          v38:BasicObject = Send v37, :to_s # SendFallbackReason: ObjToString: result is not a string
+          Jump bb12(v38)
+        bb12(v40:BasicObject):
+          v42:CBool = HasType v40, String
+          CondBranch v42, bb13(), bb14()
         bb13():
-          v45:String = RefineType v41, String
-          Jump bb15(v45)
+          v44:String = RefineType v40, String
+          Jump bb15(v44)
         bb14():
-          v47:NotString = RefineType v41, NotString
-          v48:String = AnyToString v31, str: v47
-          Jump bb15(v48)
-        bb15(v50:String):
-          v52:Fixnum[3] = Const Value(3)
-          v55:CBool[false] = HasType v52, String
-          CondBranch v55, bb16(), bb17()
+          v46:String = AnyToString v30
+          Jump bb15(v46)
+        bb15(v48:String):
+          v50:Fixnum[3] = Const Value(3)
+          v53:CBool[false] = HasType v50, String
+          CondBranch v53, bb16(), bb17()
         bb16():
-          v57 = RefineType v52, String
-          Jump bb18(v57)
+          v55 = RefineType v50, String
+          Jump bb18(v55)
         bb17():
-          v59:Fixnum[3] = RefineType v52, NotString
-          v60:BasicObject = Send v59, :to_s # SendFallbackReason: ObjToString: result is not a string
-          Jump bb18(v60)
-        bb18(v62:BasicObject):
-          v64:CBool = HasType v62, String
-          CondBranch v64, bb19(), bb20()
+          v57:Fixnum[3] = RefineType v50, NotString
+          v58:BasicObject = Send v57, :to_s # SendFallbackReason: ObjToString: result is not a string
+          Jump bb18(v58)
+        bb18(v60:BasicObject):
+          v62:CBool = HasType v60, String
+          CondBranch v62, bb19(), bb20()
         bb19():
-          v66:String = RefineType v62, String
-          Jump bb21(v66)
+          v64:String = RefineType v60, String
+          Jump bb21(v64)
         bb20():
-          v68:NotString = RefineType v62, NotString
-          v69:String = AnyToString v52, str: v68
-          Jump bb21(v69)
-        bb21(v71:String):
-          v73:StringExact = StringConcat v29, v50, v71
+          v66:String = AnyToString v50
+          Jump bb21(v66)
+        bb21(v68:String):
+          v70:StringExact = StringConcat v28, v48, v68
           CheckInterrupts
-          Return v73
+          Return v70
         ");
     }
 
@@ -5494,13 +5489,12 @@ pub(crate) mod hir_build_tests {
           v26:String = RefineType v22, String
           Jump bb9(v26)
         bb8():
-          v28:NotString = RefineType v22, NotString
-          v29:String = AnyToString v12, str: v28
-          Jump bb9(v29)
-        bb9(v31:String):
-          v33:StringExact = StringConcat v10, v31
+          v28:String = AnyToString v12
+          Jump bb9(v28)
+        bb9(v30:String):
+          v32:StringExact = StringConcat v10, v30
           CheckInterrupts
-          Return v33
+          Return v32
         ");
     }
 
@@ -5538,55 +5532,52 @@ pub(crate) mod hir_build_tests {
           v24:String = RefineType v20, String
           Jump bb9(v24)
         bb8():
-          v26:NotString = RefineType v20, NotString
-          v27:String = AnyToString v10, str: v26
-          Jump bb9(v27)
-        bb9(v29:String):
-          v31:Fixnum[2] = Const Value(2)
-          v34:CBool[false] = HasType v31, String
-          CondBranch v34, bb10(), bb11()
+          v26:String = AnyToString v10
+          Jump bb9(v26)
+        bb9(v28:String):
+          v30:Fixnum[2] = Const Value(2)
+          v33:CBool[false] = HasType v30, String
+          CondBranch v33, bb10(), bb11()
         bb10():
-          v36 = RefineType v31, String
-          Jump bb12(v36)
+          v35 = RefineType v30, String
+          Jump bb12(v35)
         bb11():
-          v38:Fixnum[2] = RefineType v31, NotString
-          v39:BasicObject = Send v38, :to_s # SendFallbackReason: ObjToString: result is not a string
-          Jump bb12(v39)
-        bb12(v41:BasicObject):
-          v43:CBool = HasType v41, String
-          CondBranch v43, bb13(), bb14()
+          v37:Fixnum[2] = RefineType v30, NotString
+          v38:BasicObject = Send v37, :to_s # SendFallbackReason: ObjToString: result is not a string
+          Jump bb12(v38)
+        bb12(v40:BasicObject):
+          v42:CBool = HasType v40, String
+          CondBranch v42, bb13(), bb14()
         bb13():
-          v45:String = RefineType v41, String
-          Jump bb15(v45)
+          v44:String = RefineType v40, String
+          Jump bb15(v44)
         bb14():
-          v47:NotString = RefineType v41, NotString
-          v48:String = AnyToString v31, str: v47
-          Jump bb15(v48)
-        bb15(v50:String):
-          v52:Fixnum[3] = Const Value(3)
-          v55:CBool[false] = HasType v52, String
-          CondBranch v55, bb16(), bb17()
+          v46:String = AnyToString v30
+          Jump bb15(v46)
+        bb15(v48:String):
+          v50:Fixnum[3] = Const Value(3)
+          v53:CBool[false] = HasType v50, String
+          CondBranch v53, bb16(), bb17()
         bb16():
-          v57 = RefineType v52, String
-          Jump bb18(v57)
+          v55 = RefineType v50, String
+          Jump bb18(v55)
         bb17():
-          v59:Fixnum[3] = RefineType v52, NotString
-          v60:BasicObject = Send v59, :to_s # SendFallbackReason: ObjToString: result is not a string
-          Jump bb18(v60)
-        bb18(v62:BasicObject):
-          v64:CBool = HasType v62, String
-          CondBranch v64, bb19(), bb20()
+          v57:Fixnum[3] = RefineType v50, NotString
+          v58:BasicObject = Send v57, :to_s # SendFallbackReason: ObjToString: result is not a string
+          Jump bb18(v58)
+        bb18(v60:BasicObject):
+          v62:CBool = HasType v60, String
+          CondBranch v62, bb19(), bb20()
         bb19():
-          v66:String = RefineType v62, String
-          Jump bb21(v66)
+          v64:String = RefineType v60, String
+          Jump bb21(v64)
         bb20():
-          v68:NotString = RefineType v62, NotString
-          v69:String = AnyToString v52, str: v68
-          Jump bb21(v69)
-        bb21(v71:String):
-          v73:RegexpExact = ToRegexp v29, v50, v71
+          v66:String = AnyToString v50
+          Jump bb21(v66)
+        bb21(v68:String):
+          v70:RegexpExact = ToRegexp v28, v48, v68
           CheckInterrupts
-          Return v73
+          Return v70
         ");
     }
 
@@ -5624,34 +5615,32 @@ pub(crate) mod hir_build_tests {
           v24:String = RefineType v20, String
           Jump bb9(v24)
         bb8():
-          v26:NotString = RefineType v20, NotString
-          v27:String = AnyToString v10, str: v26
-          Jump bb9(v27)
-        bb9(v29:String):
-          v31:Fixnum[2] = Const Value(2)
-          v34:CBool[false] = HasType v31, String
-          CondBranch v34, bb10(), bb11()
+          v26:String = AnyToString v10
+          Jump bb9(v26)
+        bb9(v28:String):
+          v30:Fixnum[2] = Const Value(2)
+          v33:CBool[false] = HasType v30, String
+          CondBranch v33, bb10(), bb11()
         bb10():
-          v36 = RefineType v31, String
-          Jump bb12(v36)
+          v35 = RefineType v30, String
+          Jump bb12(v35)
         bb11():
-          v38:Fixnum[2] = RefineType v31, NotString
-          v39:BasicObject = Send v38, :to_s # SendFallbackReason: ObjToString: result is not a string
-          Jump bb12(v39)
-        bb12(v41:BasicObject):
-          v43:CBool = HasType v41, String
-          CondBranch v43, bb13(), bb14()
+          v37:Fixnum[2] = RefineType v30, NotString
+          v38:BasicObject = Send v37, :to_s # SendFallbackReason: ObjToString: result is not a string
+          Jump bb12(v38)
+        bb12(v40:BasicObject):
+          v42:CBool = HasType v40, String
+          CondBranch v42, bb13(), bb14()
         bb13():
-          v45:String = RefineType v41, String
-          Jump bb15(v45)
+          v44:String = RefineType v40, String
+          Jump bb15(v44)
         bb14():
-          v47:NotString = RefineType v41, NotString
-          v48:String = AnyToString v31, str: v47
-          Jump bb15(v48)
-        bb15(v50:String):
-          v52:RegexpExact = ToRegexp v29, v50, MULTILINE|IGNORECASE|EXTENDED|NOENCODING
+          v46:String = AnyToString v30
+          Jump bb15(v46)
+        bb15(v48:String):
+          v50:RegexpExact = ToRegexp v28, v48, MULTILINE|IGNORECASE|EXTENDED|NOENCODING
           CheckInterrupts
-          Return v52
+          Return v50
         ");
     }
 

--- a/zjit/src/hir/tests.rs
+++ b/zjit/src/hir/tests.rs
@@ -2325,7 +2325,7 @@ pub(crate) mod hir_build_tests {
           v26:String = RefineType v22, String
           Jump bb9(v26)
         bb8():
-          v28:String = AnyToString v12
+          v28:StringExact = AnyToString v12
           Jump bb9(v28)
         bb9(v30:String):
           v32:StringExact = StringConcat v10, v30
@@ -5362,7 +5362,7 @@ pub(crate) mod hir_build_tests {
           v26:String = RefineType v22, String
           Jump bb9(v26)
         bb8():
-          v28:String = AnyToString v12
+          v28:StringExact = AnyToString v12
           Jump bb9(v28)
         bb9(v30:String):
           v32:StringExact = StringConcat v10, v30
@@ -5405,7 +5405,7 @@ pub(crate) mod hir_build_tests {
           v24:String = RefineType v20, String
           Jump bb9(v24)
         bb8():
-          v26:String = AnyToString v10
+          v26:StringExact = AnyToString v10
           Jump bb9(v26)
         bb9(v28:String):
           v30:Fixnum[2] = Const Value(2)
@@ -5425,7 +5425,7 @@ pub(crate) mod hir_build_tests {
           v44:String = RefineType v40, String
           Jump bb15(v44)
         bb14():
-          v46:String = AnyToString v30
+          v46:StringExact = AnyToString v30
           Jump bb15(v46)
         bb15(v48:String):
           v50:Fixnum[3] = Const Value(3)
@@ -5445,7 +5445,7 @@ pub(crate) mod hir_build_tests {
           v64:String = RefineType v60, String
           Jump bb21(v64)
         bb20():
-          v66:String = AnyToString v50
+          v66:StringExact = AnyToString v50
           Jump bb21(v66)
         bb21(v68:String):
           v70:StringExact = StringConcat v28, v48, v68
@@ -5489,7 +5489,7 @@ pub(crate) mod hir_build_tests {
           v26:String = RefineType v22, String
           Jump bb9(v26)
         bb8():
-          v28:String = AnyToString v12
+          v28:StringExact = AnyToString v12
           Jump bb9(v28)
         bb9(v30:String):
           v32:StringExact = StringConcat v10, v30
@@ -5532,7 +5532,7 @@ pub(crate) mod hir_build_tests {
           v24:String = RefineType v20, String
           Jump bb9(v24)
         bb8():
-          v26:String = AnyToString v10
+          v26:StringExact = AnyToString v10
           Jump bb9(v26)
         bb9(v28:String):
           v30:Fixnum[2] = Const Value(2)
@@ -5552,7 +5552,7 @@ pub(crate) mod hir_build_tests {
           v44:String = RefineType v40, String
           Jump bb15(v44)
         bb14():
-          v46:String = AnyToString v30
+          v46:StringExact = AnyToString v30
           Jump bb15(v46)
         bb15(v48:String):
           v50:Fixnum[3] = Const Value(3)
@@ -5572,7 +5572,7 @@ pub(crate) mod hir_build_tests {
           v64:String = RefineType v60, String
           Jump bb21(v64)
         bb20():
-          v66:String = AnyToString v50
+          v66:StringExact = AnyToString v50
           Jump bb21(v66)
         bb21(v68:String):
           v70:RegexpExact = ToRegexp v28, v48, v68
@@ -5615,7 +5615,7 @@ pub(crate) mod hir_build_tests {
           v24:String = RefineType v20, String
           Jump bb9(v24)
         bb8():
-          v26:String = AnyToString v10
+          v26:StringExact = AnyToString v10
           Jump bb9(v26)
         bb9(v28:String):
           v30:Fixnum[2] = Const Value(2)
@@ -5635,7 +5635,7 @@ pub(crate) mod hir_build_tests {
           v44:String = RefineType v40, String
           Jump bb15(v44)
         bb14():
-          v46:String = AnyToString v30
+          v46:StringExact = AnyToString v30
           Jump bb15(v46)
         bb15(v48:String):
           v50:RegexpExact = ToRegexp v28, v48, MULTILINE|IGNORECASE|EXTENDED|NOENCODING

--- a/zjit/src/hir/tests.rs
+++ b/zjit/src/hir/tests.rs
@@ -2319,11 +2319,20 @@ pub(crate) mod hir_build_tests {
           v20:BasicObject = Send v19, :to_s # SendFallbackReason: ObjToString: result is not a string
           Jump bb6(v20)
         bb6(v22:BasicObject):
-          v24:String = AnyToString v12, str: v22
-          v26:StringExact = StringConcat v10, v24
-          v28:Symbol = StringIntern v26
+          v24:CBool = HasType v22, String
+          CondBranch v24, bb7(), bb8()
+        bb7():
+          v26:String = RefineType v22, String
+          Jump bb9(v26)
+        bb8():
+          v28:NotString = RefineType v22, NotString
+          v29:String = AnyToString v12, str: v28
+          Jump bb9(v29)
+        bb9(v31:String):
+          v33:StringExact = StringConcat v10, v31
+          v35:Symbol = StringIntern v33
           CheckInterrupts
-          Return v28
+          Return v35
         ");
     }
 
@@ -5348,10 +5357,19 @@ pub(crate) mod hir_build_tests {
           v20:BasicObject = Send v19, :to_s # SendFallbackReason: ObjToString: result is not a string
           Jump bb6(v20)
         bb6(v22:BasicObject):
-          v24:String = AnyToString v12, str: v22
-          v26:StringExact = StringConcat v10, v24
+          v24:CBool = HasType v22, String
+          CondBranch v24, bb7(), bb8()
+        bb7():
+          v26:String = RefineType v22, String
+          Jump bb9(v26)
+        bb8():
+          v28:NotString = RefineType v22, NotString
+          v29:String = AnyToString v12, str: v28
+          Jump bb9(v29)
+        bb9(v31:String):
+          v33:StringExact = StringConcat v10, v31
           CheckInterrupts
-          Return v26
+          Return v33
         ");
     }
 
@@ -5383,34 +5401,61 @@ pub(crate) mod hir_build_tests {
           v18:BasicObject = Send v17, :to_s # SendFallbackReason: ObjToString: result is not a string
           Jump bb6(v18)
         bb6(v20:BasicObject):
-          v22:String = AnyToString v10, str: v20
-          v24:Fixnum[2] = Const Value(2)
-          v27:CBool[false] = HasType v24, String
-          CondBranch v27, bb7(), bb8()
+          v22:CBool = HasType v20, String
+          CondBranch v22, bb7(), bb8()
         bb7():
-          v29 = RefineType v24, String
-          Jump bb9(v29)
+          v24:String = RefineType v20, String
+          Jump bb9(v24)
         bb8():
-          v31:Fixnum[2] = RefineType v24, NotString
-          v32:BasicObject = Send v31, :to_s # SendFallbackReason: ObjToString: result is not a string
-          Jump bb9(v32)
-        bb9(v34:BasicObject):
-          v36:String = AnyToString v24, str: v34
-          v38:Fixnum[3] = Const Value(3)
-          v41:CBool[false] = HasType v38, String
-          CondBranch v41, bb10(), bb11()
+          v26:NotString = RefineType v20, NotString
+          v27:String = AnyToString v10, str: v26
+          Jump bb9(v27)
+        bb9(v29:String):
+          v31:Fixnum[2] = Const Value(2)
+          v34:CBool[false] = HasType v31, String
+          CondBranch v34, bb10(), bb11()
         bb10():
-          v43 = RefineType v38, String
-          Jump bb12(v43)
+          v36 = RefineType v31, String
+          Jump bb12(v36)
         bb11():
-          v45:Fixnum[3] = RefineType v38, NotString
-          v46:BasicObject = Send v45, :to_s # SendFallbackReason: ObjToString: result is not a string
-          Jump bb12(v46)
-        bb12(v48:BasicObject):
-          v50:String = AnyToString v38, str: v48
-          v52:StringExact = StringConcat v22, v36, v50
+          v38:Fixnum[2] = RefineType v31, NotString
+          v39:BasicObject = Send v38, :to_s # SendFallbackReason: ObjToString: result is not a string
+          Jump bb12(v39)
+        bb12(v41:BasicObject):
+          v43:CBool = HasType v41, String
+          CondBranch v43, bb13(), bb14()
+        bb13():
+          v45:String = RefineType v41, String
+          Jump bb15(v45)
+        bb14():
+          v47:NotString = RefineType v41, NotString
+          v48:String = AnyToString v31, str: v47
+          Jump bb15(v48)
+        bb15(v50:String):
+          v52:Fixnum[3] = Const Value(3)
+          v55:CBool[false] = HasType v52, String
+          CondBranch v55, bb16(), bb17()
+        bb16():
+          v57 = RefineType v52, String
+          Jump bb18(v57)
+        bb17():
+          v59:Fixnum[3] = RefineType v52, NotString
+          v60:BasicObject = Send v59, :to_s # SendFallbackReason: ObjToString: result is not a string
+          Jump bb18(v60)
+        bb18(v62:BasicObject):
+          v64:CBool = HasType v62, String
+          CondBranch v64, bb19(), bb20()
+        bb19():
+          v66:String = RefineType v62, String
+          Jump bb21(v66)
+        bb20():
+          v68:NotString = RefineType v62, NotString
+          v69:String = AnyToString v52, str: v68
+          Jump bb21(v69)
+        bb21(v71:String):
+          v73:StringExact = StringConcat v29, v50, v71
           CheckInterrupts
-          Return v52
+          Return v73
         ");
     }
 
@@ -5443,10 +5488,19 @@ pub(crate) mod hir_build_tests {
           v20:BasicObject = Send v19, :to_s # SendFallbackReason: ObjToString: result is not a string
           Jump bb6(v20)
         bb6(v22:BasicObject):
-          v24:String = AnyToString v12, str: v22
-          v26:StringExact = StringConcat v10, v24
+          v24:CBool = HasType v22, String
+          CondBranch v24, bb7(), bb8()
+        bb7():
+          v26:String = RefineType v22, String
+          Jump bb9(v26)
+        bb8():
+          v28:NotString = RefineType v22, NotString
+          v29:String = AnyToString v12, str: v28
+          Jump bb9(v29)
+        bb9(v31:String):
+          v33:StringExact = StringConcat v10, v31
           CheckInterrupts
-          Return v26
+          Return v33
         ");
     }
 
@@ -5478,34 +5532,61 @@ pub(crate) mod hir_build_tests {
           v18:BasicObject = Send v17, :to_s # SendFallbackReason: ObjToString: result is not a string
           Jump bb6(v18)
         bb6(v20:BasicObject):
-          v22:String = AnyToString v10, str: v20
-          v24:Fixnum[2] = Const Value(2)
-          v27:CBool[false] = HasType v24, String
-          CondBranch v27, bb7(), bb8()
+          v22:CBool = HasType v20, String
+          CondBranch v22, bb7(), bb8()
         bb7():
-          v29 = RefineType v24, String
-          Jump bb9(v29)
+          v24:String = RefineType v20, String
+          Jump bb9(v24)
         bb8():
-          v31:Fixnum[2] = RefineType v24, NotString
-          v32:BasicObject = Send v31, :to_s # SendFallbackReason: ObjToString: result is not a string
-          Jump bb9(v32)
-        bb9(v34:BasicObject):
-          v36:String = AnyToString v24, str: v34
-          v38:Fixnum[3] = Const Value(3)
-          v41:CBool[false] = HasType v38, String
-          CondBranch v41, bb10(), bb11()
+          v26:NotString = RefineType v20, NotString
+          v27:String = AnyToString v10, str: v26
+          Jump bb9(v27)
+        bb9(v29:String):
+          v31:Fixnum[2] = Const Value(2)
+          v34:CBool[false] = HasType v31, String
+          CondBranch v34, bb10(), bb11()
         bb10():
-          v43 = RefineType v38, String
-          Jump bb12(v43)
+          v36 = RefineType v31, String
+          Jump bb12(v36)
         bb11():
-          v45:Fixnum[3] = RefineType v38, NotString
-          v46:BasicObject = Send v45, :to_s # SendFallbackReason: ObjToString: result is not a string
-          Jump bb12(v46)
-        bb12(v48:BasicObject):
-          v50:String = AnyToString v38, str: v48
-          v52:RegexpExact = ToRegexp v22, v36, v50
+          v38:Fixnum[2] = RefineType v31, NotString
+          v39:BasicObject = Send v38, :to_s # SendFallbackReason: ObjToString: result is not a string
+          Jump bb12(v39)
+        bb12(v41:BasicObject):
+          v43:CBool = HasType v41, String
+          CondBranch v43, bb13(), bb14()
+        bb13():
+          v45:String = RefineType v41, String
+          Jump bb15(v45)
+        bb14():
+          v47:NotString = RefineType v41, NotString
+          v48:String = AnyToString v31, str: v47
+          Jump bb15(v48)
+        bb15(v50:String):
+          v52:Fixnum[3] = Const Value(3)
+          v55:CBool[false] = HasType v52, String
+          CondBranch v55, bb16(), bb17()
+        bb16():
+          v57 = RefineType v52, String
+          Jump bb18(v57)
+        bb17():
+          v59:Fixnum[3] = RefineType v52, NotString
+          v60:BasicObject = Send v59, :to_s # SendFallbackReason: ObjToString: result is not a string
+          Jump bb18(v60)
+        bb18(v62:BasicObject):
+          v64:CBool = HasType v62, String
+          CondBranch v64, bb19(), bb20()
+        bb19():
+          v66:String = RefineType v62, String
+          Jump bb21(v66)
+        bb20():
+          v68:NotString = RefineType v62, NotString
+          v69:String = AnyToString v52, str: v68
+          Jump bb21(v69)
+        bb21(v71:String):
+          v73:RegexpExact = ToRegexp v29, v50, v71
           CheckInterrupts
-          Return v52
+          Return v73
         ");
     }
 
@@ -5537,22 +5618,40 @@ pub(crate) mod hir_build_tests {
           v18:BasicObject = Send v17, :to_s # SendFallbackReason: ObjToString: result is not a string
           Jump bb6(v18)
         bb6(v20:BasicObject):
-          v22:String = AnyToString v10, str: v20
-          v24:Fixnum[2] = Const Value(2)
-          v27:CBool[false] = HasType v24, String
-          CondBranch v27, bb7(), bb8()
+          v22:CBool = HasType v20, String
+          CondBranch v22, bb7(), bb8()
         bb7():
-          v29 = RefineType v24, String
-          Jump bb9(v29)
+          v24:String = RefineType v20, String
+          Jump bb9(v24)
         bb8():
-          v31:Fixnum[2] = RefineType v24, NotString
-          v32:BasicObject = Send v31, :to_s # SendFallbackReason: ObjToString: result is not a string
-          Jump bb9(v32)
-        bb9(v34:BasicObject):
-          v36:String = AnyToString v24, str: v34
-          v38:RegexpExact = ToRegexp v22, v36, MULTILINE|IGNORECASE|EXTENDED|NOENCODING
+          v26:NotString = RefineType v20, NotString
+          v27:String = AnyToString v10, str: v26
+          Jump bb9(v27)
+        bb9(v29:String):
+          v31:Fixnum[2] = Const Value(2)
+          v34:CBool[false] = HasType v31, String
+          CondBranch v34, bb10(), bb11()
+        bb10():
+          v36 = RefineType v31, String
+          Jump bb12(v36)
+        bb11():
+          v38:Fixnum[2] = RefineType v31, NotString
+          v39:BasicObject = Send v38, :to_s # SendFallbackReason: ObjToString: result is not a string
+          Jump bb12(v39)
+        bb12(v41:BasicObject):
+          v43:CBool = HasType v41, String
+          CondBranch v43, bb13(), bb14()
+        bb13():
+          v45:String = RefineType v41, String
+          Jump bb15(v45)
+        bb14():
+          v47:NotString = RefineType v41, NotString
+          v48:String = AnyToString v31, str: v47
+          Jump bb15(v48)
+        bb15(v50:String):
+          v52:RegexpExact = ToRegexp v29, v50, MULTILINE|IGNORECASE|EXTENDED|NOENCODING
           CheckInterrupts
-          Return v38
+          Return v52
         ");
     }
 


### PR DESCRIPTION
Instead of special-casing it in the optimizer, expand the run-time type
check into HIR and let the optimizer fold it if/when it can. Leave
the `AnyToString` opcode as the fallback.

This leaves us only optimizing the following in `type_specialize`:

* `Send`
* `IsMethodCfunc`
* `ObjectAlloc`
* `NewRange`
* `InvokeSuper`
