### PR TITLE
ZJIT: Merge send and send_without_block counters

### DIFF
--- a/zjit.rb
+++ b/zjit.rb
@@ -102,7 +102,6 @@ class << RubyVM::ZJIT
 
     # Show fallback counters, ordered by the typical amount of fallbacks for the prefix at the time
     print_counters_with_prefix(prefix: 'unspecialized_send_def_type_', prompt: 'not optimized method types for send', buf:, stats:, limit: 20)
-    print_counters_with_prefix(prefix: 'unspecialized_send_without_block_def_type_', prompt: 'not optimized method types for send_without_block', buf:, stats:, limit: 20)
     print_counters_with_prefix(prefix: 'unspecialized_super_def_type_', prompt: 'not optimized method types for super', buf:, stats:, limit: 20)
     print_counters_with_prefix(prefix: 'uncategorized_fallback_yarv_insn_', prompt: 'instructions with uncategorized fallback reason', buf:, stats:, limit: 20)
     print_counters_with_prefix(prefix: 'send_fallback_', prompt: 'send fallback reasons', buf:, stats:, limit: 20)

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -18,7 +18,7 @@ use crate::invariants::{
 use crate::gc::append_gc_offsets;
 use crate::payload::{IseqCodePtrs, IseqStatus, IseqVersion, IseqVersionRef, JITFrame, get_or_create_iseq_payload};
 use crate::state::ZJITState;
-use crate::stats::{CompileError, exit_counter_for_compile_error, exit_counter_for_unhandled_hir_insn, incr_counter, incr_counter_by, send_fallback_counter, send_fallback_counter_for_method_type, send_fallback_counter_for_super_method_type, send_fallback_counter_ptr_for_opcode, send_without_block_fallback_counter_for_method_type, send_without_block_fallback_counter_for_optimized_method_type};
+use crate::stats::{CompileError, exit_counter_for_compile_error, exit_counter_for_unhandled_hir_insn, incr_counter, incr_counter_by, send_fallback_counter, send_fallback_counter_for_method_type, send_fallback_counter_for_super_method_type, send_fallback_counter_ptr_for_opcode, send_fallback_counter_for_optimized_method_type};
 use crate::stats::{counter_ptr, with_time_stat, trace_compile_phase, Counter, Counter::{compile_time_ns, exit_compile_error}};
 use crate::{asm::CodeBlock, cruby::*, options::debug, virtualmem::CodePtr};
 use crate::backend::lir::{self, Assembler, C_ARG_OPNDS, C_RET_OPND, CFP, EC, NATIVE_BASE_PTR, Opnd, SP, SideExit, SideExitRecompile, SideExitTarget, StackMap, StackMapEntry, Target, asm_ccall, asm_comment};
@@ -2996,11 +2996,8 @@ fn gen_incr_send_fallback_counter(asm: &mut Assembler, reason: SendFallbackReaso
         Uncategorized(opcode) => {
             gen_incr_counter_ptr(asm, send_fallback_counter_ptr_for_opcode(opcode));
         }
-        SendWithoutBlockNotOptimizedMethodType(method_type) => {
-            gen_incr_counter(asm, send_without_block_fallback_counter_for_method_type(method_type));
-        }
-        SendWithoutBlockNotOptimizedMethodTypeOptimized(method_type) => {
-            gen_incr_counter(asm, send_without_block_fallback_counter_for_optimized_method_type(method_type));
+        SendNotOptimizedMethodTypeOptimized(method_type) => {
+            gen_incr_counter(asm, send_fallback_counter_for_optimized_method_type(method_type));
         }
         SendNotOptimizedMethodType(method_type) => {
             gen_incr_counter(asm, send_fallback_counter_for_method_type(method_type));

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -683,17 +683,11 @@ pub enum ReceiverTypeResolution {
 /// Reason why a send-ish instruction cannot be optimized from a fallback instruction
 #[derive(Debug, Clone, Copy)]
 pub enum SendFallbackReason {
-    SendWithoutBlockPolymorphic,
-    SendWithoutBlockMegamorphic,
-    SendWithoutBlockNoProfiles,
-    SendWithoutBlockCfuncNotVariadic,
-    SendWithoutBlockCfuncArrayVariadic,
-    SendWithoutBlockNotOptimizedMethodType(MethodType),
-    SendWithoutBlockNotOptimizedMethodTypeOptimized(OptimizedMethodType),
-    SendWithoutBlockNotOptimizedNeedPermission,
-    SendWithoutBlockBopRedefined,
-    SendWithoutBlockOperandsNotFixnum,
-    SendWithoutBlockPolymorphicFallback,
+    SendCfuncNotVariadic,
+    SendNotOptimizedMethodTypeOptimized(OptimizedMethodType),
+    SendBopRedefined,
+    SendOperandsNotFixnum,
+    SendPolymorphicFallback,
     SendDirectKeywordMismatch,
     SendDirectKeywordCountMismatch,
     SendDirectMissingKeyword,
@@ -759,18 +753,12 @@ pub enum SendFallbackReason {
 impl Display for SendFallbackReason {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            SendWithoutBlockPolymorphic => write!(f, "SendWithoutBlock: polymorphic call site"),
-            SendWithoutBlockMegamorphic => write!(f, "SendWithoutBlock: megamorphic call site"),
-            SendWithoutBlockNoProfiles => write!(f, "SendWithoutBlock: no profile data available"),
-            SendWithoutBlockCfuncNotVariadic => write!(f, "SendWithoutBlock: C function is not variadic"),
-            SendWithoutBlockCfuncArrayVariadic => write!(f, "SendWithoutBlock: C function expects array variadic"),
-            SendWithoutBlockNotOptimizedMethodType(method_type) => write!(f, "SendWithoutBlock: unsupported method type {:?}", method_type),
-            SendWithoutBlockNotOptimizedMethodTypeOptimized(opt_type) => write!(f, "SendWithoutBlock: unsupported optimized method type {:?}", opt_type),
-            SendWithoutBlockNotOptimizedNeedPermission => write!(f, "SendWithoutBlock: method private or protected and no FCALL"),
+            SendCfuncNotVariadic => write!(f, "Send: C function is not variadic"),
+            SendNotOptimizedMethodTypeOptimized(opt_type) => write!(f, "Send: unsupported optimized method type {:?}", opt_type),
             SendNotOptimizedNeedPermission => write!(f, "Send: method private or protected and no FCALL"),
-            SendWithoutBlockBopRedefined => write!(f, "SendWithoutBlock: basic operation was redefined"),
-            SendWithoutBlockOperandsNotFixnum => write!(f, "SendWithoutBlock: operands are not fixnums"),
-            SendWithoutBlockPolymorphicFallback => write!(f, "SendWithoutBlock: polymorphic fallback"),
+            SendBopRedefined => write!(f, "Send: basic operation was redefined"),
+            SendOperandsNotFixnum => write!(f, "Send: operands are not fixnums"),
+            SendPolymorphicFallback => write!(f, "Send: polymorphic fallback"),
             SendDirectKeywordMismatch => write!(f, "SendDirect: keyword mismatch"),
             SendDirectKeywordCountMismatch => write!(f, "SendDirect: keyword count mismatch"),
             SendDirectMissingKeyword => write!(f, "SendDirect: missing keyword"),
@@ -3872,7 +3860,7 @@ impl Function {
     fn rewrite_if_frozen(&mut self, block: BlockId, orig_insn_id: InsnId, self_val: InsnId, klass: u32, bop: u32, state: InsnId) {
         if !unsafe { rb_BASIC_OP_UNREDEFINED_P(bop, klass) } {
             // If the basic operation is already redefined, we cannot optimize it.
-            self.set_dynamic_send_reason(orig_insn_id, SendWithoutBlockBopRedefined);
+            self.set_dynamic_send_reason(orig_insn_id, SendBopRedefined);
             self.push_insn_id(block, orig_insn_id);
             return;
         }
@@ -4086,23 +4074,20 @@ impl Function {
                             ReceiverTypeResolution::SkewedMegamorphic { .. }
                             | ReceiverTypeResolution::Megamorphic => {
                                 if get_option!(stats) {
-                                    let reason = if has_block { SendMegamorphic } else { SendWithoutBlockMegamorphic };
-                                    self.set_dynamic_send_reason(insn_id, reason);
+                                    self.set_dynamic_send_reason(insn_id, SendMegamorphic);
                                 }
                                 self.push_insn_id(block, insn_id);
                                 continue;
                             }
                             ReceiverTypeResolution::Polymorphic => {
                                 if get_option!(stats) {
-                                    let reason = if has_block { SendPolymorphic } else { SendWithoutBlockPolymorphic };
-                                    self.set_dynamic_send_reason(insn_id, reason);
+                                    self.set_dynamic_send_reason(insn_id, SendPolymorphic);
                                 }
                                 self.push_insn_id(block, insn_id);
                                 continue;
                             }
                             ReceiverTypeResolution::NoProfile => {
-                                let reason = if has_block { SendNoProfiles } else { SendWithoutBlockNoProfiles };
-                                self.set_dynamic_send_reason(insn_id, reason);
+                                self.set_dynamic_send_reason(insn_id, SendNoProfiles);
                                 self.push_insn_id(block, insn_id);
                                 continue;
                             }
@@ -4115,8 +4100,7 @@ impl Function {
                         // Do method lookup
                         let mut cme = unsafe { rb_callable_method_entry(klass, mid) };
                         if cme.is_null() {
-                            let reason = if has_block { SendNotOptimizedMethodType(MethodType::Null) } else { SendWithoutBlockNotOptimizedMethodType(MethodType::Null) };
-                            self.set_dynamic_send_reason(insn_id, reason);
+                            self.set_dynamic_send_reason(insn_id, SendNotOptimizedMethodType(MethodType::Null));
                             self.push_insn_id(block, insn_id); continue;
                         }
                         // Load an overloaded cme if applicable. See vm_search_cc().
@@ -4128,8 +4112,7 @@ impl Function {
                             (METHOD_VISI_PRIVATE, true) => {}
                             (METHOD_VISI_PROTECTED, true) => {}
                             _ => {
-                                let reason = if has_block { SendNotOptimizedNeedPermission } else { SendWithoutBlockNotOptimizedNeedPermission };
-                                self.set_dynamic_send_reason(insn_id, reason);
+                                self.set_dynamic_send_reason(insn_id, SendNotOptimizedNeedPermission);
                                 self.push_insn_id(block, insn_id); continue;
                             }
                         }
@@ -4376,8 +4359,7 @@ impl Function {
                                     // Get the profiled type to check if the fields is embedded or heap allocated.
                                     let Some(is_embedded) = self.profiled_type_of_at(recv, state).map(|t| t.flags().is_struct_embedded()) else {
                                         // No (monomorphic/skewed polymorphic) profile info
-                                        let reason = if has_block { SendNoProfiles } else { SendWithoutBlockNoProfiles };
-                                        self.set_dynamic_send_reason(insn_id, reason);
+                                        self.set_dynamic_send_reason(insn_id, SendNoProfiles);
                                         self.push_insn_id(block, insn_id); continue;
                                     };
                                     // Check singleton class assumption first, before emitting other patchpoints
@@ -4418,7 +4400,7 @@ impl Function {
                                     self.make_equal_to(insn_id, replacement);
                                 },
                                 _ => {
-                                    self.set_dynamic_send_reason(insn_id, SendWithoutBlockNotOptimizedMethodTypeOptimized(OptimizedMethodType::from(opt_type)));
+                                    self.set_dynamic_send_reason(insn_id, SendNotOptimizedMethodTypeOptimized(OptimizedMethodType::from(opt_type)));
                                     self.push_insn_id(block, insn_id); continue;
                                 },
                             };
@@ -4639,8 +4621,7 @@ impl Function {
 
                             self.push_insn_id(block, insn_id);
                         } else {
-                            let reason = if has_block { SendNotOptimizedMethodType(MethodType::from(def_type)) } else { SendWithoutBlockNotOptimizedMethodType(MethodType::from(def_type)) };
-                            self.set_dynamic_send_reason(insn_id, reason);
+                            self.set_dynamic_send_reason(insn_id, SendNotOptimizedMethodType(MethodType::from(def_type)));
                             self.push_insn_id(block, insn_id); continue;
                         }
                     }
@@ -5682,7 +5663,7 @@ impl Function {
             assert!(self.blocks[block.0].insns.is_empty());
             for insn_id in old_insns {
                 match self.find(insn_id) {
-                    Insn::Send { state, reason: SendFallbackReason::SendWithoutBlockNoProfiles | SendFallbackReason::SendNoProfiles, .. } => {
+                    Insn::Send { state, reason: SendFallbackReason::SendNoProfiles, .. } => {
                         self.push_insn(block, Insn::SideExit { state, reason: Box::new(SideExitReason::NoProfileSend), recompile: Some(Recompile) });
                         // SideExit is a terminator; don't add remaining instructions
                         break;
@@ -9170,7 +9151,7 @@ fn add_iseq_to_hir(
                             fun.push_insn(iftrue_block, Insn::Jump(BranchEdge { target: join_block, args: vec![send] }));
                         }
                         // In the fallthrough case, do a generic interpreter send and then join.
-                        let reason = SendWithoutBlockPolymorphicFallback;
+                        let reason = SendPolymorphicFallback;
                         let send = fun.push_insn(block, Insn::Send { recv, cd, block: None, args, state: exit_id, reason });
                         fun.push_insn(block, Insn::Jump(BranchEdge { target: join_block, args: vec![send] }));
                         state.stack_push(join_param);

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -1671,7 +1671,7 @@ mod hir_opt_tests {
           v4:BasicObject = LoadArg :self@0
           Jump bb3(v4)
         bb3(v6:BasicObject):
-          v11:BasicObject = Send v6, :foo # SendFallbackReason: SendWithoutBlock: unsupported method type Null
+          v11:BasicObject = Send v6, :foo # SendFallbackReason: Send: unsupported method type Null
           CheckInterrupts
           Return v11
         ");
@@ -3801,7 +3801,7 @@ mod hir_opt_tests {
           v42:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1048))
           Jump bb8(v42, v52)
         bb8(v32:BasicObject, v33:BasicObject):
-          v47:BasicObject = Send v32, :call, v11, v13 # SendFallbackReason: SendWithoutBlock: unsupported optimized method type BlockCall
+          v47:BasicObject = Send v32, :call, v11, v13 # SendFallbackReason: Send: unsupported optimized method type BlockCall
           CheckInterrupts
           PopInlineFrame
           Return v47
@@ -8442,7 +8442,7 @@ mod hir_opt_tests {
           v60:TrueClass = Const Value(true)
           Jump bb7(v60)
         bb11():
-          v48:BasicObject = Send v31, :! # SendFallbackReason: SendWithoutBlock: polymorphic fallback
+          v48:BasicObject = Send v31, :! # SendFallbackReason: Send: polymorphic fallback
           Jump bb7(v48)
         bb7(v35:BasicObject):
           CheckInterrupts
@@ -9761,7 +9761,7 @@ mod hir_opt_tests {
           v31:BasicObject = GetIvar v19, :@foo
           Jump bb4(v31)
         bb6():
-          v22:BasicObject = Send v10, :foo # SendFallbackReason: SendWithoutBlock: polymorphic fallback
+          v22:BasicObject = Send v10, :foo # SendFallbackReason: Send: polymorphic fallback
           Jump bb4(v22)
         bb4(v15:BasicObject):
           CheckInterrupts
@@ -10094,7 +10094,7 @@ mod hir_opt_tests {
           v54:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1048))
           Jump bb13(v54, v27)
         bb13(v44:BasicObject, v45:BasicObject):
-          v57:BasicObject = Send v44, :call # SendFallbackReason: SendWithoutBlock: no profile data available
+          v57:BasicObject = Send v44, :call # SendFallbackReason: Send: no profile data available
           CheckInterrupts
           Jump bb4(v57)
         bb6(v62:ObjectSubclass[class_exact*:Object@VALUE(0x1000)], v63:BasicObject):
@@ -15764,7 +15764,7 @@ mod hir_opt_tests {
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1000, Obj)
           v12:ObjectSubclass[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-          v14:BasicObject = Send v12, :secret # SendFallbackReason: SendWithoutBlock: method private or protected and no FCALL
+          v14:BasicObject = Send v12, :secret # SendFallbackReason: Send: method private or protected and no FCALL
           CheckInterrupts
           Return v14
         ");
@@ -15819,7 +15819,7 @@ mod hir_opt_tests {
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1000, Obj)
           v12:BasicObjectExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-          v14:BasicObject = Send v12, :initialize # SendFallbackReason: SendWithoutBlock: method private or protected and no FCALL
+          v14:BasicObject = Send v12, :initialize # SendFallbackReason: Send: method private or protected and no FCALL
           CheckInterrupts
           Return v14
         ");
@@ -15847,7 +15847,7 @@ mod hir_opt_tests {
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1000, Obj)
           v12:ObjectExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-          v14:BasicObject = Send v12, :toplevel_method # SendFallbackReason: SendWithoutBlock: method private or protected and no FCALL
+          v14:BasicObject = Send v12, :toplevel_method # SendFallbackReason: Send: method private or protected and no FCALL
           CheckInterrupts
           Return v14
         ");
@@ -15906,7 +15906,7 @@ mod hir_opt_tests {
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1000, Obj)
           v12:ObjectSubclass[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-          v14:BasicObject = Send v12, :secret # SendFallbackReason: SendWithoutBlock: method private or protected and no FCALL
+          v14:BasicObject = Send v12, :secret # SendFallbackReason: Send: method private or protected and no FCALL
           CheckInterrupts
           Return v14
         ");
@@ -16719,7 +16719,7 @@ mod hir_opt_tests {
           v45:Fixnum[4] = Const Value(4)
           Jump bb4(v45)
         bb8():
-          v28:BasicObject = Send v10, :foo # SendFallbackReason: SendWithoutBlock: polymorphic fallback
+          v28:BasicObject = Send v10, :foo # SendFallbackReason: Send: polymorphic fallback
           Jump bb4(v28)
         bb4(v15:BasicObject):
           v31:Fixnum[2] = Const Value(2)
@@ -16772,7 +16772,7 @@ mod hir_opt_tests {
           PatchPoint MethodRedefined(Integer@0x1040, itself@0x1010, cme:0x1018)
           Jump bb4(v25)
         bb8():
-          v28:BasicObject = Send v10, :itself # SendFallbackReason: SendWithoutBlock: polymorphic fallback
+          v28:BasicObject = Send v10, :itself # SendFallbackReason: Send: polymorphic fallback
           Jump bb4(v28)
         bb4(v15:BasicObject):
           CheckInterrupts
@@ -16828,7 +16828,7 @@ mod hir_opt_tests {
           v40:StringExact = CCallVariadic v25, :Integer#to_s@0x1040
           Jump bb4(v40)
         bb8():
-          v28:BasicObject = Send v10, :to_s # SendFallbackReason: SendWithoutBlock: polymorphic fallback
+          v28:BasicObject = Send v10, :to_s # SendFallbackReason: Send: polymorphic fallback
           Jump bb4(v28)
         bb4(v15:BasicObject):
           CheckInterrupts
@@ -16881,7 +16881,7 @@ mod hir_opt_tests {
           v40:BasicObject = CCallWithFrame v25, :Float#to_s@0x1040
           Jump bb4(v40)
         bb8():
-          v28:BasicObject = Send v10, :to_s # SendFallbackReason: SendWithoutBlock: polymorphic fallback
+          v28:BasicObject = Send v10, :to_s # SendFallbackReason: Send: polymorphic fallback
           Jump bb4(v28)
         bb4(v15:BasicObject):
           CheckInterrupts
@@ -16934,7 +16934,7 @@ mod hir_opt_tests {
           v38:StringExact = InvokeBuiltin leaf <inline_expr>, v25
           Jump bb4(v38)
         bb8():
-          v28:BasicObject = Send v10, :to_s # SendFallbackReason: SendWithoutBlock: polymorphic fallback
+          v28:BasicObject = Send v10, :to_s # SendFallbackReason: Send: polymorphic fallback
           Jump bb4(v28)
         bb4(v15:BasicObject):
           CheckInterrupts
@@ -16983,7 +16983,7 @@ mod hir_opt_tests {
           v31:Fixnum[3] = Const Value(3)
           Jump bb4(v31)
         bb6():
-          v22:BasicObject = Send v10, :foo # SendFallbackReason: SendWithoutBlock: polymorphic fallback
+          v22:BasicObject = Send v10, :foo # SendFallbackReason: Send: polymorphic fallback
           Jump bb4(v22)
         bb4(v15:BasicObject):
           CheckInterrupts
@@ -17708,7 +17708,7 @@ mod hir_opt_tests {
         bb5():
           v18:Truthy = RefineType v10, Truthy
           v22:Fixnum[42] = Const Value(42)
-          v24:BasicObject = Send v9, :greet_final, v22 # SendFallbackReason: SendWithoutBlock: no profile data available
+          v24:BasicObject = Send v9, :greet_final, v22 # SendFallbackReason: Send: no profile data available
           CheckInterrupts
           Return v24
         bb4(v29:BasicObject, v30:Falsy):
@@ -18501,7 +18501,7 @@ mod hir_opt_tests {
           v45:BasicObject = CCallWithFrame v30, :Float#*@0x1040, v13
           Jump bb4(v45)
         bb8():
-          v33:BasicObject = Send v12, :*, v13 # SendFallbackReason: SendWithoutBlock: polymorphic fallback
+          v33:BasicObject = Send v12, :*, v13 # SendFallbackReason: Send: polymorphic fallback
           Jump bb4(v33)
         bb4(v20:BasicObject):
           CheckInterrupts
@@ -19995,7 +19995,7 @@ mod hir_opt_tests {
           v44:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1050))
           Jump bb8(v44, v53)
         bb8(v34:BasicObject, v35:BasicObject):
-          v48:BasicObject = Send v34, :call, v10 # SendFallbackReason: SendWithoutBlock: unsupported optimized method type BlockCall
+          v48:BasicObject = Send v34, :call, v10 # SendFallbackReason: Send: unsupported optimized method type BlockCall
           CheckInterrupts
           PopInlineFrame
           PatchPoint NoEPEscape(test)

--- a/zjit/src/stats.rs
+++ b/zjit/src/stats.rs
@@ -251,22 +251,16 @@ make_counters! {
     // Send fallback counters that are summed as dynamic_send_count
     dynamic_send {
         // send_fallback_: Fallback reasons for send-ish instructions
-        send_fallback_send_without_block_polymorphic,
-        send_fallback_send_without_block_megamorphic,
-        send_fallback_send_without_block_no_profiles,
-        send_fallback_send_without_block_cfunc_not_variadic,
-        send_fallback_send_without_block_cfunc_array_variadic,
-        send_fallback_send_without_block_not_optimized_method_type,
-        send_fallback_send_without_block_not_optimized_method_type_optimized,
-        send_fallback_send_without_block_not_optimized_need_permission,
+        send_fallback_send_cfunc_not_variadic,
+        send_fallback_send_not_optimized_method_type_optimized,
         send_fallback_too_many_args_for_lir,
-        send_fallback_send_without_block_bop_redefined,
-        send_fallback_send_without_block_operands_not_fixnum,
-        send_fallback_send_without_block_polymorphic_fallback,
-        send_fallback_send_without_block_direct_keyword_mismatch,
-        send_fallback_send_without_block_direct_keyword_count_mismatch,
-        send_fallback_send_without_block_direct_missing_keyword,
-        send_fallback_send_without_block_direct_too_many_keywords,
+        send_fallback_send_bop_redefined,
+        send_fallback_send_operands_not_fixnum,
+        send_fallback_send_polymorphic_fallback,
+        send_fallback_send_direct_keyword_mismatch,
+        send_fallback_send_direct_keyword_count_mismatch,
+        send_fallback_send_direct_missing_keyword,
+        send_fallback_send_direct_too_many_keywords,
         send_fallback_send_polymorphic,
         send_fallback_send_megamorphic,
         send_fallback_send_no_profiles,
@@ -384,27 +378,12 @@ make_counters! {
     // The number of times YARV instructions are executed on JIT code
     zjit_insn_count,
 
-    // Method call def_type related to send without block fallback to dynamic dispatch
-    unspecialized_send_without_block_def_type_iseq,
-    unspecialized_send_without_block_def_type_cfunc,
-    unspecialized_send_without_block_def_type_attrset,
-    unspecialized_send_without_block_def_type_ivar,
-    unspecialized_send_without_block_def_type_bmethod,
-    unspecialized_send_without_block_def_type_zsuper,
-    unspecialized_send_without_block_def_type_alias,
-    unspecialized_send_without_block_def_type_undef,
-    unspecialized_send_without_block_def_type_not_implemented,
-    unspecialized_send_without_block_def_type_optimized,
-    unspecialized_send_without_block_def_type_missing,
-    unspecialized_send_without_block_def_type_refined,
-    unspecialized_send_without_block_def_type_null,
-
     // Method call optimized_type related to send without block fallback to dynamic dispatch
-    unspecialized_send_without_block_def_type_optimized_send,
-    unspecialized_send_without_block_def_type_optimized_call,
-    unspecialized_send_without_block_def_type_optimized_block_call,
-    unspecialized_send_without_block_def_type_optimized_struct_aref,
-    unspecialized_send_without_block_def_type_optimized_struct_aset,
+    unspecialized_send_def_type_optimized_send,
+    unspecialized_send_def_type_optimized_call,
+    unspecialized_send_def_type_optimized_block_call,
+    unspecialized_send_def_type_optimized_struct_aref,
+    unspecialized_send_def_type_optimized_struct_aset,
 
     // Method call def_type related to send fallback to dynamic dispatch
     unspecialized_send_def_type_iseq,
@@ -686,24 +665,17 @@ pub fn send_fallback_counter(reason: crate::hir::SendFallbackReason) -> Counter 
     use crate::hir::SendFallbackReason::*;
     use crate::stats::Counter::*;
     match reason {
-        SendWithoutBlockPolymorphic               => send_fallback_send_without_block_polymorphic,
-        SendWithoutBlockMegamorphic               => send_fallback_send_without_block_megamorphic,
-        SendWithoutBlockNoProfiles                => send_fallback_send_without_block_no_profiles,
-        SendWithoutBlockCfuncNotVariadic          => send_fallback_send_without_block_cfunc_not_variadic,
-        SendWithoutBlockCfuncArrayVariadic        => send_fallback_send_without_block_cfunc_array_variadic,
-        SendWithoutBlockNotOptimizedMethodType(_) => send_fallback_send_without_block_not_optimized_method_type,
-        SendWithoutBlockNotOptimizedMethodTypeOptimized(_)
-                                                  => send_fallback_send_without_block_not_optimized_method_type_optimized,
-        SendWithoutBlockNotOptimizedNeedPermission
-                                                  => send_fallback_send_without_block_not_optimized_need_permission,
+        SendCfuncNotVariadic          => send_fallback_send_cfunc_not_variadic,
+        SendNotOptimizedMethodTypeOptimized(_)
+                                                  => send_fallback_send_not_optimized_method_type_optimized,
         TooManyArgsForLir                         => send_fallback_too_many_args_for_lir,
-        SendWithoutBlockBopRedefined              => send_fallback_send_without_block_bop_redefined,
-        SendWithoutBlockOperandsNotFixnum         => send_fallback_send_without_block_operands_not_fixnum,
-        SendWithoutBlockPolymorphicFallback       => send_fallback_send_without_block_polymorphic_fallback,
-        SendDirectKeywordMismatch                 => send_fallback_send_without_block_direct_keyword_mismatch,
-        SendDirectKeywordCountMismatch            => send_fallback_send_without_block_direct_keyword_count_mismatch,
-        SendDirectMissingKeyword                  => send_fallback_send_without_block_direct_missing_keyword,
-        SendDirectTooManyKeywords                 => send_fallback_send_without_block_direct_too_many_keywords,
+        SendBopRedefined              => send_fallback_send_bop_redefined,
+        SendOperandsNotFixnum         => send_fallback_send_operands_not_fixnum,
+        SendPolymorphicFallback       => send_fallback_send_polymorphic_fallback,
+        SendDirectKeywordMismatch                 => send_fallback_send_direct_keyword_mismatch,
+        SendDirectKeywordCountMismatch            => send_fallback_send_direct_keyword_count_mismatch,
+        SendDirectMissingKeyword                  => send_fallback_send_direct_missing_keyword,
+        SendDirectTooManyKeywords                 => send_fallback_send_direct_too_many_keywords,
         SendPolymorphic                           => send_fallback_send_polymorphic,
         SendMegamorphic                           => send_fallback_send_megamorphic,
         SendNoProfiles                            => send_fallback_send_no_profiles,
@@ -736,37 +708,16 @@ pub fn send_fallback_counter(reason: crate::hir::SendFallbackReason) -> Counter 
     }
 }
 
-pub fn send_without_block_fallback_counter_for_method_type(method_type: crate::hir::MethodType) -> Counter {
-    use crate::hir::MethodType::*;
-    use crate::stats::Counter::*;
-
-    match method_type {
-        Iseq => unspecialized_send_without_block_def_type_iseq,
-        Cfunc => unspecialized_send_without_block_def_type_cfunc,
-        Attrset => unspecialized_send_without_block_def_type_attrset,
-        Ivar => unspecialized_send_without_block_def_type_ivar,
-        Bmethod => unspecialized_send_without_block_def_type_bmethod,
-        Zsuper => unspecialized_send_without_block_def_type_zsuper,
-        Alias => unspecialized_send_without_block_def_type_alias,
-        Undefined => unspecialized_send_without_block_def_type_undef,
-        NotImplemented => unspecialized_send_without_block_def_type_not_implemented,
-        Optimized => unspecialized_send_without_block_def_type_optimized,
-        Missing => unspecialized_send_without_block_def_type_missing,
-        Refined => unspecialized_send_without_block_def_type_refined,
-        Null => unspecialized_send_without_block_def_type_null,
-    }
-}
-
-pub fn send_without_block_fallback_counter_for_optimized_method_type(method_type: crate::hir::OptimizedMethodType) -> Counter {
+pub fn send_fallback_counter_for_optimized_method_type(method_type: crate::hir::OptimizedMethodType) -> Counter {
     use crate::hir::OptimizedMethodType::*;
     use crate::stats::Counter::*;
 
     match method_type {
-        Send => unspecialized_send_without_block_def_type_optimized_send,
-        Call => unspecialized_send_without_block_def_type_optimized_call,
-        BlockCall => unspecialized_send_without_block_def_type_optimized_block_call,
-        StructAref => unspecialized_send_without_block_def_type_optimized_struct_aref,
-        StructAset => unspecialized_send_without_block_def_type_optimized_struct_aset,
+        Send => unspecialized_send_def_type_optimized_send,
+        Call => unspecialized_send_def_type_optimized_call,
+        BlockCall => unspecialized_send_def_type_optimized_block_call,
+        StructAref => unspecialized_send_def_type_optimized_struct_aref,
+        StructAset => unspecialized_send_def_type_optimized_struct_aset,
     }
 }
 

--- a/zjit/src/stats.rs
+++ b/zjit/src/stats.rs
@@ -665,13 +665,13 @@ pub fn send_fallback_counter(reason: crate::hir::SendFallbackReason) -> Counter 
     use crate::hir::SendFallbackReason::*;
     use crate::stats::Counter::*;
     match reason {
-        SendCfuncNotVariadic          => send_fallback_send_cfunc_not_variadic,
+        SendCfuncNotVariadic                      => send_fallback_send_cfunc_not_variadic,
         SendNotOptimizedMethodTypeOptimized(_)
                                                   => send_fallback_send_not_optimized_method_type_optimized,
         TooManyArgsForLir                         => send_fallback_too_many_args_for_lir,
-        SendBopRedefined              => send_fallback_send_bop_redefined,
-        SendOperandsNotFixnum         => send_fallback_send_operands_not_fixnum,
-        SendPolymorphicFallback       => send_fallback_send_polymorphic_fallback,
+        SendBopRedefined                          => send_fallback_send_bop_redefined,
+        SendOperandsNotFixnum                     => send_fallback_send_operands_not_fixnum,
+        SendPolymorphicFallback                   => send_fallback_send_polymorphic_fallback,
         SendDirectKeywordMismatch                 => send_fallback_send_direct_keyword_mismatch,
         SendDirectKeywordCountMismatch            => send_fallback_send_direct_keyword_count_mismatch,
         SendDirectMissingKeyword                  => send_fallback_send_direct_missing_keyword,


### PR DESCRIPTION
We only have one `Send` HIR opcode now. Let's not count everything separately.