### PR TITLE
Update DTRACE_DEPENDENT_OBJS

### DIFF
--- a/template/Makefile.in
+++ b/template/Makefile.in
@@ -215,7 +215,9 @@ DTRACE_DEPENDENT_OBJS = array.$(OBJEXT) \
 			parse.$(OBJEXT) \
 			string.$(OBJEXT) \
 			symbol.$(OBJEXT) \
+			thread.$(OBJEXT) \
 			vm.$(OBJEXT) \
+			vm_sync.$(OBJEXT) \
 			$(YJIT_OBJ) \
 			$(ZJIT_OBJ)
 


### PR DESCRIPTION
Commit 89e7b08 added thread.c and vm_sync.c to have DTrace probes, we need to update DTRACE_DEPENDENT_OBJS to fix FreeBSD.