### PR TITLE
[Feature #22186] Copy sharable substrings up to a 256 byte slot

### DIFF
--- a/string.c
+++ b/string.c
@@ -3174,6 +3174,11 @@ rb_str_sublen(VALUE str, long pos)
     }
 }
 
+/* Substrings that need a slot larger than this are shared instead of copied.
+ * Larger slots hold fewer objects per page and trigger GC more often, which
+ * outweighs the copy they save; see [Feature #22186] for the benchmarks. */
+#define STR_SUBSEQ_MAX_EMBED_SIZE 256
+
 static VALUE
 str_subseq(VALUE str, long beg, long len)
 {
@@ -3193,12 +3198,19 @@ str_subseq(VALUE str, long beg, long len)
         return str2;
     }
 
-    str2 = str_alloc_heap(rb_cString);
-    if (str_embed_capa(str2) >= len + termlen) {
+    /* Sharing allocates a shared root as well unless str can be one itself, so
+     * a copy is worth a larger slot only when it saves that second object. */
+    const bool root_available = STR_SHARED_P(str) ||
+        RB_FL_TEST_RAW(str, FL_FREEZE | STR_CHILLED) == FL_FREEZE;
+    const size_t max_embed_size = root_available ?
+        rb_gc_size_slot_size(sizeof(struct RString)) : STR_SUBSEQ_MAX_EMBED_SIZE;
+    const size_t embed_size = rb_str_embed_size(len, termlen);
+
+    if (embed_size <= max_embed_size && rb_gc_size_allocatable_p(embed_size)) {
+        str2 = str_alloc_embed(rb_cString, len + termlen);
         char *ptr2 = RSTRING(str2)->as.embed.ary;
-        STR_SET_EMBED(str2);
         memcpy(ptr2, RSTRING_PTR(str) + beg, len);
-        TERM_FILL(ptr2+len, termlen);
+        TERM_FILL(ptr2 + len, termlen);
 
         STR_SET_LEN(str2, len);
         if (ENC_CODERANGE(str) == ENC_CODERANGE_7BIT) {
@@ -3208,6 +3220,7 @@ str_subseq(VALUE str, long beg, long len)
         RB_GC_GUARD(str);
     }
     else {
+        str2 = str_alloc_heap(rb_cString);
         str_replace_shared(str2, str);
         RUBY_ASSERT(!STR_EMBED_P(str2));
         if (ENC_CODERANGE(str) != ENC_CODERANGE_7BIT) {

--- a/test/ruby/test_string.rb
+++ b/test/ruby/test_string.rb
@@ -3639,6 +3639,27 @@ CODE
     refute_includes ObjectSpace.dump(substr), ' "shared":true,'
   end
 
+  def test_substring_embed
+    str = "a" * 448
+
+    require 'objspace'
+
+    # 128 and 320 sit either side of STR_SUBSEQ_MAX_EMBED_SIZE in string.c, which
+    # the copy has to fit in along with the header and the terminator
+    substr = str.byteslice(320, 128)
+    assert_equal "a" * 128, substr
+    assert_includes ObjectSpace.dump(substr), ' "embedded":true,'
+
+    substr = str.byteslice(128, 320)
+    assert_equal "a" * 320, substr
+    assert_includes ObjectSpace.dump(substr), ' "shared":true,'
+
+    # A frozen source is a shared root itself, so the same substring is shared
+    substr = str.freeze.byteslice(320, 128)
+    assert_equal "a" * 128, substr
+    assert_includes ObjectSpace.dump(substr), ' "shared":true,'
+  end
+
   def test_unknown_string_option
     str = nil
     assert_nothing_raised(SyntaxError) do


### PR DESCRIPTION
`str_subseq()` allocates the new string with `str_alloc_heap()`, which always takes the default `sizeof(struct RString)` slot, so a sharable substring is copied only while it fits in that slot's embed capacity and is shared otherwise.

This allocates with `str_alloc_embed()` sized to the substring instead, and copies while the allocation fits in a slot of 256 bytes. When the source is frozen or already shared it can be the shared root itself, so sharing allocates only the substring there and the cap stays at the slot `str_alloc_heap()` gives.

Benchmark results and discussion are on the Redmine ticket.