### PR TITLE
coverage: Release me2counter when method measurement stops

### DIFF
--- a/thread.c
+++ b/thread.c
@@ -6106,6 +6106,7 @@ rb_reset_coverages(void)
     rb_clear_coverages();
     rb_iseq_remove_coverage_all();
     GET_VM()->coverages = Qfalse;
+    GET_VM()->me2counter = Qnil;
 }
 
 VALUE


### PR DESCRIPTION
rb_reset_coverages left GET_VM()->me2counter pointing at the counter hash, which is marked unconditionally, so after Coverage stops (methods mode) the method entries it holds -- and the classes that own them -- were kept alive until the next Coverage.start or process exit.