### PR TITLE
Fix method coverage silently dropping methods after GC [Bug #22179]

### DIFF
--- a/ext/coverage/coverage.c
+++ b/ext/coverage/coverage.c
@@ -239,6 +239,45 @@ branch_coverage(VALUE branches)
     return b.result;
 }
 
+/*
+ * Fold a single method entry's contribution into the method coverage result.
+ * `add` is the number of calls to attribute to it (0 is used to make sure a
+ * defined-but-uncalled method shows up). Entries that resolve elsewhere (e.g.
+ * aliases) are skipped: their calls are attributed to the original definition
+ * via the [owner, mid, location] key, exactly like the old heap-walk did.
+ */
+static void
+method_coverage_add(const rb_method_entry_t *me, long add, VALUE ncoverages)
+{
+    VALUE data[5];
+    const rb_method_entry_t *me2 = rb_resolve_me_location(me, data);
+    if (me != me2) return;
+
+    VALUE klass = me->owner;
+    if (RB_TYPE_P(klass, T_ICLASS)) return;
+
+    VALUE first_lineno = data[1];
+    if (FIX2LONG(first_lineno) <= 0) return;
+
+    VALUE path = data[0];
+    VALUE ncoverage = rb_hash_aref(ncoverages, path);
+    if (NIL_P(ncoverage)) return;
+
+    VALUE methods = rb_hash_aref(ncoverage, ID2SYM(rb_intern("methods")));
+    VALUE method_id = ID2SYM(me->def->original_id);
+    VALUE key = rb_ary_new_from_args(6, klass, method_id, data[1], data[2], data[3], data[4]);
+
+    VALUE rcount = rb_hash_aref(methods, key);
+    long count = NIL_P(rcount) ? 0 : FIX2LONG(rcount);
+    if (!POSFIXABLE(count + add)) {
+        count = FIXNUM_MAX;
+    }
+    else {
+        count += add;
+    }
+    rb_hash_aset(methods, key, LONG2FIX(count));
+}
+
 static int
 method_coverage_i(void *vstart, void *vend, size_t stride, void *data)
 {
@@ -259,43 +298,9 @@ method_coverage_i(void *vstart, void *vend, size_t stride, void *data)
         rb_asan_unpoison_object(v, false);
 
         if (RB_TYPE_P(v, T_IMEMO) && imemo_type(v) == imemo_ment) {
-            const rb_method_entry_t *me = (rb_method_entry_t *) v;
-            VALUE path, first_lineno, first_column, last_lineno, last_column;
-            VALUE data[5], ncoverage, methods;
-            VALUE methods_id = ID2SYM(rb_intern("methods"));
-            VALUE klass;
-            const rb_method_entry_t *me2 = rb_resolve_me_location(me, data);
-            if (me != me2) continue;
-            klass = me->owner;
-            if (RB_TYPE_P(klass, T_ICLASS)) {
-                rb_bug("T_ICLASS");
-            }
-            path = data[0];
-            first_lineno = data[1];
-            first_column = data[2];
-            last_lineno = data[3];
-            last_column = data[4];
-            if (FIX2LONG(first_lineno) <= 0) continue;
-            ncoverage = rb_hash_aref(ncoverages, path);
-            if (NIL_P(ncoverage)) continue;
-            methods = rb_hash_aref(ncoverage, methods_id);
-
-            {
-                VALUE method_id = ID2SYM(me->def->original_id);
-                VALUE rcount = rb_hash_aref(cme2counter, (VALUE) me);
-                VALUE key = rb_ary_new_from_args(6, klass, method_id, first_lineno, first_column, last_lineno, last_column);
-                VALUE rcount2 = rb_hash_aref(methods, key);
-
-                if (NIL_P(rcount)) rcount = LONG2FIX(0);
-                if (NIL_P(rcount2)) rcount2 = LONG2FIX(0);
-                if (!POSFIXABLE(FIX2LONG(rcount) + FIX2LONG(rcount2))) {
-                    rcount = LONG2FIX(FIXNUM_MAX);
-                }
-                else {
-                    rcount = LONG2FIX(FIX2LONG(rcount) + FIX2LONG(rcount2));
-                }
-                rb_hash_aset(methods, key, rcount);
-            }
+            const rb_method_entry_t *me = (const rb_method_entry_t *) v;
+            VALUE rcount = rb_hash_aref(cme2counter, (VALUE) me);
+            method_coverage_add(me, NIL_P(rcount) ? 0 : FIX2LONG(rcount), ncoverages);
         }
 
         if (poisoned) {

--- a/ext/coverage/coverage.c
+++ b/ext/coverage/coverage.c
@@ -21,7 +21,7 @@ static enum {
     RUNNING
 } current_state = IDLE;
 static int current_mode;
-static VALUE me2counter = Qnil;
+static VALUE cme2counter = Qnil;
 
 /*
  *  call-seq: Coverage.supported?(mode) -> true or false
@@ -115,10 +115,10 @@ rb_coverage_setup(int argc, VALUE *argv, VALUE klass)
     }
 
     if (mode & COVERAGE_TARGET_METHODS) {
-        me2counter = rb_ident_hash_new();
+        cme2counter = rb_ident_hash_new();
     }
     else {
-        me2counter = Qnil;
+        cme2counter = Qnil;
     }
 
     coverages = rb_get_coverages();
@@ -127,7 +127,7 @@ rb_coverage_setup(int argc, VALUE *argv, VALUE klass)
         rb_obj_hide(coverages);
         current_mode = mode;
         if (mode == 0) mode = COVERAGE_TARGET_LINES;
-        rb_set_coverages(coverages, mode, me2counter);
+        rb_set_coverages(coverages, mode, cme2counter);
         current_state = SUSPENDED;
     }
     else if (current_mode != mode) {
@@ -282,7 +282,7 @@ method_coverage_i(void *vstart, void *vend, size_t stride, void *data)
 
             {
                 VALUE method_id = ID2SYM(me->def->original_id);
-                VALUE rcount = rb_hash_aref(me2counter, (VALUE) me);
+                VALUE rcount = rb_hash_aref(cme2counter, (VALUE) me);
                 VALUE key = rb_ary_new_from_args(6, klass, method_id, first_lineno, first_column, last_lineno, last_column);
                 VALUE rcount2 = rb_hash_aref(methods, key);
 
@@ -377,9 +377,9 @@ rb_coverage_peek_result(VALUE klass)
 
 
 static int
-clear_me2counter_i(VALUE key, VALUE value, VALUE unused)
+clear_cme2counter_i(VALUE key, VALUE value, VALUE unused)
 {
-    rb_hash_aset(me2counter, key, INT2FIX(0));
+    rb_hash_aset(cme2counter, key, INT2FIX(0));
     return ST_CONTINUE;
 }
 
@@ -435,14 +435,14 @@ rb_coverage_result(int argc, VALUE *argv, VALUE klass)
     }
     if (clear) {
         rb_clear_coverages();
-        if (!NIL_P(me2counter)) rb_hash_foreach(me2counter, clear_me2counter_i, Qnil);
+        if (!NIL_P(cme2counter)) rb_hash_foreach(cme2counter, clear_cme2counter_i, Qnil);
     }
     if (stop) {
         if (current_state == RUNNING) {
             rb_coverage_suspend(klass);
         }
         rb_reset_coverages();
-        me2counter = Qnil;
+        cme2counter = Qnil;
         current_state = IDLE;
     }
     return ncoverages;
@@ -706,5 +706,5 @@ Init_coverage(void)
     rb_define_module_function(rb_mCoverage, "peek_result", rb_coverage_peek_result, 0);
     rb_define_module_function(rb_mCoverage, "state", rb_coverage_state, 0);
     rb_define_module_function(rb_mCoverage, "running?", rb_coverage_running, 0);
-    rb_global_variable(&me2counter);
+    rb_global_variable(&cme2counter);
 }

--- a/ext/coverage/coverage.c
+++ b/ext/coverage/coverage.c
@@ -22,6 +22,7 @@ static enum {
 } current_state = IDLE;
 static int current_mode;
 static VALUE cme2counter = Qnil;
+static VALUE me_set = Qnil;
 
 /*
  *  call-seq: Coverage.supported?(mode) -> true or false
@@ -116,9 +117,11 @@ rb_coverage_setup(int argc, VALUE *argv, VALUE klass)
 
     if (mode & COVERAGE_TARGET_METHODS) {
         cme2counter = rb_ident_hash_new();
+        me_set = rb_ident_hash_new();
     }
     else {
         cme2counter = Qnil;
+        me_set = Qnil;
     }
 
     coverages = rb_get_coverages();
@@ -127,7 +130,7 @@ rb_coverage_setup(int argc, VALUE *argv, VALUE klass)
         rb_obj_hide(coverages);
         current_mode = mode;
         if (mode == 0) mode = COVERAGE_TARGET_LINES;
-        rb_set_coverages(coverages, mode, cme2counter);
+        rb_set_coverages(coverages, mode, cme2counter, me_set);
         current_state = SUSPENDED;
     }
     else if (current_mode != mode) {
@@ -278,36 +281,21 @@ method_coverage_add(const rb_method_entry_t *me, long add, VALUE ncoverages)
     rb_hash_aset(methods, key, LONG2FIX(count));
 }
 
+/* me_set entries: every defined method, so uncalled ones appear with count 0. */
 static int
-method_coverage_i(void *vstart, void *vend, size_t stride, void *data)
+method_coverage_me_i(VALUE key, VALUE value, VALUE ncoverages)
 {
-    /*
-     * ObjectSpace.each_object(Module){|mod|
-     *   mod.instance_methods.each{|mid|
-     *     m = mod.instance_method(mid)
-     *     if loc = m.source_location
-     *       p [m.name, loc, $g_method_cov_counts[m]]
-     *     end
-     *   }
-     * }
-     */
-    VALUE ncoverages = *(VALUE*)data, v;
+    method_coverage_add((const rb_method_entry_t *)key, 0, ncoverages);
+    return ST_CONTINUE;
+}
 
-    for (v = (VALUE)vstart; v != (VALUE)vend; v += stride) {
-        void *poisoned = rb_asan_poisoned_object_p(v);
-        rb_asan_unpoison_object(v, false);
-
-        if (RB_TYPE_P(v, T_IMEMO) && imemo_type(v) == imemo_ment) {
-            const rb_method_entry_t *me = (const rb_method_entry_t *) v;
-            VALUE rcount = rb_hash_aref(cme2counter, (VALUE) me);
-            method_coverage_add(me, NIL_P(rcount) ? 0 : FIX2LONG(rcount), ncoverages);
-        }
-
-        if (poisoned) {
-            rb_asan_poison_object(v);
-        }
-    }
-    return 0;
+/* cme2counter entries: call counts, attributed to the definition's key. */
+static int
+method_coverage_count_i(VALUE key, VALUE value, VALUE ncoverages)
+{
+    long add = FIXNUM_P(value) ? FIX2LONG(value) : 0;
+    method_coverage_add((const rb_method_entry_t *)key, add, ncoverages);
+    return ST_CONTINUE;
 }
 
 static int
@@ -373,7 +361,8 @@ rb_coverage_peek_result(VALUE klass)
     rb_hash_foreach(coverages, coverage_peek_result_i, ncoverages);
 
     if (current_mode & COVERAGE_TARGET_METHODS) {
-        rb_objspace_each_objects(method_coverage_i, &ncoverages);
+        if (RTEST(me_set)) rb_hash_foreach(me_set, method_coverage_me_i, ncoverages);
+        if (RTEST(cme2counter)) rb_hash_foreach(cme2counter, method_coverage_count_i, ncoverages);
     }
 
     rb_hash_freeze(ncoverages);
@@ -440,6 +429,8 @@ rb_coverage_result(int argc, VALUE *argv, VALUE klass)
     }
     if (clear) {
         rb_clear_coverages();
+        /* Reset call counts, but keep me_set: the set of defined methods
+         * persists across clear so that uncalled methods keep showing up. */
         if (!NIL_P(cme2counter)) rb_hash_foreach(cme2counter, clear_cme2counter_i, Qnil);
     }
     if (stop) {
@@ -448,6 +439,7 @@ rb_coverage_result(int argc, VALUE *argv, VALUE klass)
         }
         rb_reset_coverages();
         cme2counter = Qnil;
+        me_set = Qnil;
         current_state = IDLE;
     }
     return ncoverages;
@@ -712,4 +704,5 @@ Init_coverage(void)
     rb_define_module_function(rb_mCoverage, "state", rb_coverage_state, 0);
     rb_define_module_function(rb_mCoverage, "running?", rb_coverage_running, 0);
     rb_global_variable(&cme2counter);
+    rb_global_variable(&me_set);
 }

--- a/method.h
+++ b/method.h
@@ -238,6 +238,8 @@ RUBY_SYMBOL_EXPORT_BEGIN
 const rb_method_entry_t *rb_resolve_me_location(const rb_method_entry_t *, VALUE[5]);
 RUBY_SYMBOL_EXPORT_END
 
+void rb_vm_coverage_record_me(const rb_method_entry_t *me);
+
 const rb_callable_method_entry_t *rb_callable_method_entry(VALUE klass, ID id);
 const rb_callable_method_entry_t *rb_callable_method_entry_or_negative(VALUE klass, ID id);
 const rb_callable_method_entry_t *rb_callable_method_entry_with_refinements(VALUE klass, ID id, VALUE *defined_class);

--- a/test/coverage/test_coverage.rb
+++ b/test/coverage/test_coverage.rb
@@ -583,6 +583,45 @@ class TestCoverage < Test::Unit::TestCase
     end;
   end
 
+  def test_method_coverage_for_redefinition
+    # [Bug #22179] A method shadowed by a redefinition (and never called) must
+    # not disappear from the result even when GC collects its method entry.
+    result = {
+      :methods => {
+        [Object, :foo, 1, 0, 2, 3] => 0,
+        [Object, :foo, 3, 0, 4, 3] => 1,
+      }
+    }
+    assert_coverage(<<~"end;", { methods: true }, result)
+      def foo
+      end
+      def foo
+      end
+      foo
+      GC.start
+      GC.start
+    end;
+  end
+
+  def test_method_coverage_for_removed_method
+    # [Bug #22179] A method removed by remove_method (and never called) must not
+    # disappear from the result even when GC collects its method entry.
+    result = {
+      :methods => {
+        [Object, :foo, 1, 0, 2, 3] => 0,
+      }
+    }
+    assert_coverage(<<~"end;", { methods: true }, result)
+      def foo
+      end
+      class Object
+        remove_method(:foo)
+      end
+      GC.start
+      GC.start
+    end;
+  end
+
   def test_method_coverage_for_define_method
     result = {
       :methods => {

--- a/thread.c
+++ b/thread.c
@@ -6118,6 +6118,26 @@ update_method_coverage(VALUE cme2counter, rb_trace_arg_t *trace_arg)
     }
 }
 
+/* [Bug #22179] Record every method entry as it is defined (via method_added)
+ * into me_set, so that method coverage no longer needs to reconstruct the set
+ * of defined methods by walking the heap. This keeps shadowed/removed method
+ * entries discoverable (me_set holds them as keys, so GC cannot reclaim them)
+ * and makes the result independent of GC timing. Only entries that carry a
+ * source location (Ruby / define_method methods) are recorded. */
+void
+rb_vm_coverage_record_me(const rb_method_entry_t *me)
+{
+    if (!RTEST(GET_VM()->coverages)) return;
+    if (!(GET_VM()->coverage_mode & COVERAGE_TARGET_METHODS)) return;
+
+    VALUE me_set = GET_VM()->me_set;
+    if (!RTEST(me_set)) return;
+
+    if (rb_resolve_me_location(me, 0)) {
+        rb_hash_aset(me_set, (VALUE)me, Qtrue);
+    }
+}
+
 VALUE
 rb_get_coverages(void)
 {
@@ -6131,10 +6151,11 @@ rb_get_coverage_mode(void)
 }
 
 void
-rb_set_coverages(VALUE coverages, int mode, VALUE cme2counter)
+rb_set_coverages(VALUE coverages, int mode, VALUE cme2counter, VALUE me_set)
 {
     GET_VM()->coverages = coverages;
     GET_VM()->cme2counter = cme2counter;
+    GET_VM()->me_set = me_set;
     GET_VM()->coverage_mode = mode;
 }
 
@@ -6172,6 +6193,7 @@ rb_reset_coverages(void)
     rb_iseq_remove_coverage_all();
     GET_VM()->coverages = Qfalse;
     GET_VM()->cme2counter = Qnil;
+    GET_VM()->me_set = Qnil;
 }
 
 VALUE

--- a/thread.c
+++ b/thread.c
@@ -6122,8 +6122,9 @@ update_method_coverage(VALUE cme2counter, rb_trace_arg_t *trace_arg)
  * into me_set, so that method coverage no longer needs to reconstruct the set
  * of defined methods by walking the heap. This keeps shadowed/removed method
  * entries discoverable (me_set holds them as keys, so GC cannot reclaim them)
- * and makes the result independent of GC timing. Only entries that carry a
- * source location (Ruby / define_method methods) are recorded. */
+ * and makes the result independent of GC timing. Only entries that resolve to
+ * themselves (i.e. methods defined by `def` or Module#define_method) are
+ * recorded. */
 void
 rb_vm_coverage_record_me(const rb_method_entry_t *me)
 {
@@ -6133,7 +6134,7 @@ rb_vm_coverage_record_me(const rb_method_entry_t *me)
     VALUE me_set = GET_VM()->me_set;
     if (!RTEST(me_set)) return;
 
-    if (rb_resolve_me_location(me, 0)) {
+    if (rb_resolve_me_location(me, 0) == me) {
         rb_hash_aset(me_set, (VALUE)me, Qtrue);
     }
 }

--- a/thread.c
+++ b/thread.c
@@ -6100,7 +6100,7 @@ rb_resolve_me_location(const rb_method_entry_t *me, VALUE resolved_location[5])
 }
 
 static void
-update_method_coverage(VALUE me2counter, rb_trace_arg_t *trace_arg)
+update_method_coverage(VALUE cme2counter, rb_trace_arg_t *trace_arg)
 {
     const rb_control_frame_t *cfp = GET_EC()->cfp;
     const rb_callable_method_entry_t *cme = rb_vm_frame_method_entry(cfp);
@@ -6111,10 +6111,10 @@ update_method_coverage(VALUE me2counter, rb_trace_arg_t *trace_arg)
     me = rb_resolve_me_location(me, 0);
     if (!me) return;
 
-    rcount = rb_hash_aref(me2counter, (VALUE) me);
+    rcount = rb_hash_aref(cme2counter, (VALUE) me);
     count = FIXNUM_P(rcount) ? FIX2LONG(rcount) + 1 : 1;
     if (POSFIXABLE(count)) {
-        rb_hash_aset(me2counter, (VALUE) me, LONG2FIX(count));
+        rb_hash_aset(cme2counter, (VALUE) me, LONG2FIX(count));
     }
 }
 
@@ -6131,10 +6131,10 @@ rb_get_coverage_mode(void)
 }
 
 void
-rb_set_coverages(VALUE coverages, int mode, VALUE me2counter)
+rb_set_coverages(VALUE coverages, int mode, VALUE cme2counter)
 {
     GET_VM()->coverages = coverages;
-    GET_VM()->me2counter = me2counter;
+    GET_VM()->cme2counter = cme2counter;
     GET_VM()->coverage_mode = mode;
 }
 
@@ -6142,13 +6142,13 @@ void
 rb_resume_coverages(void)
 {
     int mode = GET_VM()->coverage_mode;
-    VALUE me2counter = GET_VM()->me2counter;
+    VALUE cme2counter = GET_VM()->cme2counter;
     rb_add_event_hook2((rb_event_hook_func_t) update_line_coverage, RUBY_EVENT_COVERAGE_LINE, Qnil, RUBY_EVENT_HOOK_FLAG_SAFE | RUBY_EVENT_HOOK_FLAG_RAW_ARG);
     if (mode & COVERAGE_TARGET_BRANCHES) {
         rb_add_event_hook2((rb_event_hook_func_t) update_branch_coverage, RUBY_EVENT_COVERAGE_BRANCH, Qnil, RUBY_EVENT_HOOK_FLAG_SAFE | RUBY_EVENT_HOOK_FLAG_RAW_ARG);
     }
     if (mode & COVERAGE_TARGET_METHODS) {
-        rb_add_event_hook2((rb_event_hook_func_t) update_method_coverage, RUBY_EVENT_CALL, me2counter, RUBY_EVENT_HOOK_FLAG_SAFE | RUBY_EVENT_HOOK_FLAG_RAW_ARG);
+        rb_add_event_hook2((rb_event_hook_func_t) update_method_coverage, RUBY_EVENT_CALL, cme2counter, RUBY_EVENT_HOOK_FLAG_SAFE | RUBY_EVENT_HOOK_FLAG_RAW_ARG);
     }
 }
 
@@ -6171,7 +6171,7 @@ rb_reset_coverages(void)
     rb_clear_coverages();
     rb_iseq_remove_coverage_all();
     GET_VM()->coverages = Qfalse;
-    GET_VM()->me2counter = Qnil;
+    GET_VM()->cme2counter = Qnil;
 }
 
 VALUE

--- a/vm.c
+++ b/vm.c
@@ -3375,7 +3375,7 @@ rb_vm_update_references(void *ptr)
 
         if (vm->coverages) {
             vm->coverages = rb_gc_location(vm->coverages);
-            vm->me2counter = rb_gc_location(vm->me2counter);
+            vm->cme2counter = rb_gc_location(vm->cme2counter);
         }
     }
 }
@@ -3458,7 +3458,7 @@ rb_vm_mark(void *ptr)
 
         rb_gc_mark_movable(vm->orig_progname);
         rb_gc_mark_movable(vm->coverages);
-        rb_gc_mark_movable(vm->me2counter);
+        rb_gc_mark_movable(vm->cme2counter);
         rb_gc_mark_movable(vm->cc_refinement_set);
 
         rb_gc_mark_values(RUBY_NSIG, vm->trap_list.cmd);

--- a/vm.c
+++ b/vm.c
@@ -3376,6 +3376,7 @@ rb_vm_update_references(void *ptr)
         if (vm->coverages) {
             vm->coverages = rb_gc_location(vm->coverages);
             vm->cme2counter = rb_gc_location(vm->cme2counter);
+            vm->me_set = rb_gc_location(vm->me_set);
         }
     }
 }
@@ -3459,6 +3460,7 @@ rb_vm_mark(void *ptr)
         rb_gc_mark_movable(vm->orig_progname);
         rb_gc_mark_movable(vm->coverages);
         rb_gc_mark_movable(vm->cme2counter);
+        rb_gc_mark_movable(vm->me_set);
         rb_gc_mark_movable(vm->cc_refinement_set);
 
         rb_gc_mark_values(RUBY_NSIG, vm->trap_list.cmd);

--- a/vm_core.h
+++ b/vm_core.h
@@ -807,7 +807,7 @@ typedef struct rb_vm_struct {
     rb_nativethread_cond_t once_cond;
 
     VALUE orig_progname, progname;
-    VALUE coverages, me2counter;
+    VALUE coverages, cme2counter;
     int coverage_mode;
 
     struct {

--- a/vm_core.h
+++ b/vm_core.h
@@ -807,7 +807,7 @@ typedef struct rb_vm_struct {
     rb_nativethread_cond_t once_cond;
 
     VALUE orig_progname, progname;
-    VALUE coverages, cme2counter;
+    VALUE coverages, cme2counter, me_set;
     int coverage_mode;
 
     struct {
@@ -2438,7 +2438,7 @@ int rb_thread_check_trap_pending(void);
 #define RUBY_EVENT_COVERAGE_BRANCH              0x020000
 
 extern VALUE rb_get_coverages(void);
-extern void rb_set_coverages(VALUE, int, VALUE);
+extern void rb_set_coverages(VALUE, int, VALUE, VALUE);
 extern void rb_clear_coverages(void);
 extern void rb_reset_coverages(void);
 extern void rb_resume_coverages(void);

--- a/vm_method.c
+++ b/vm_method.c
@@ -1702,9 +1702,13 @@ rb_check_overloaded_cme(const rb_callable_method_entry_t *cme, const struct rb_c
     } while (0)
 
 static void
-method_added(VALUE klass, ID mid)
+method_added(VALUE klass, ID mid, const rb_method_entry_t *me)
 {
     if (ruby_running) {
+        /* [Bug #22179] Record the just-defined method entry for method coverage
+         * so the result no longer depends on walking the heap (and thus on GC
+         * timing). */
+        if (me) rb_vm_coverage_record_me(me);
         CALL_METHOD_HOOK(klass, added, mid);
     }
 }
@@ -1712,12 +1716,13 @@ method_added(VALUE klass, ID mid)
 void
 rb_add_method(VALUE klass, ID mid, rb_method_type_t type, void *opts, rb_method_visibility_t visi)
 {
+    const rb_method_entry_t *me;
     RB_VM_LOCKING() {
-        rb_method_entry_make(klass, mid, klass, visi, type, NULL, mid, opts);
+        me = rb_method_entry_make(klass, mid, klass, visi, type, NULL, mid, opts);
     }
 
     if (type != VM_METHOD_TYPE_UNDEF && type != VM_METHOD_TYPE_REFINED) {
-        method_added(klass, mid);
+        method_added(klass, mid, me);
     }
 }
 
@@ -1749,7 +1754,7 @@ method_entry_set(VALUE klass, ID mid, const rb_method_entry_t *me,
         }
     }
 
-    method_added(klass, mid);
+    method_added(klass, mid, newme);
     return newme;
 }
 
@@ -2881,10 +2886,11 @@ rb_alias(VALUE klass, ID alias_name, ID original_name)
     if (visi == METHOD_VISI_UNDEF) visi = METHOD_ENTRY_VISI(orig_me);
 
     if (orig_me->defined_class == 0) {
-        rb_method_entry_make(target_klass, alias_name, target_klass, visi,
-                             VM_METHOD_TYPE_ALIAS, NULL, orig_me->called_id,
-                             (void *)rb_method_entry_clone(orig_me));
-        method_added(target_klass, alias_name);
+        const rb_method_entry_t *alias_me =
+            rb_method_entry_make(target_klass, alias_name, target_klass, visi,
+                                 VM_METHOD_TYPE_ALIAS, NULL, orig_me->called_id,
+                                 (void *)rb_method_entry_clone(orig_me));
+        method_added(target_klass, alias_name, alias_me);
     }
     else {
         rb_method_entry_t *alias_me;


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/22179

Method coverage rebuilt its result by walking the heap for method entries, so a redefined or removed method that was never called could be reclaimed by GC and vanish from the result depending on GC timing.

Instead, record each defined method entry in `me_set` at `method_added`, and build the result from `me_set` and the counter (renamed to `cme2counter`) without walking the heap.

Discussed with @ko1. He plans Ractor-local GC soon which may interfere, so please hold off merging for ~1 month.