### PR TITLE
gc: call rb_gc_obj_changed_slot_size for all types

### DIFF
--- a/array.c
+++ b/array.c
@@ -192,7 +192,7 @@ ARY_SET(VALUE a, long i, VALUE v)
 static long
 ary_embed_capa(VALUE ary)
 {
-    size_t size = rb_gc_obj_slot_size(ary) - offsetof(struct RArray, as.ary);
+    size_t size = rb_obj_shape_slot_size(ary) - offsetof(struct RArray, as.ary);
     RUBY_ASSERT(size % sizeof(VALUE) == 0);
     return size / sizeof(VALUE);
 }

--- a/array.c
+++ b/array.c
@@ -66,6 +66,10 @@ VALUE rb_cArray_empty_frozen;
  * 14:  RARRAY_PTR_IN_USE_FLAG
  *          The buffer of the array is in use. This is only used during
  *          debugging.
+ * 19:  RARRAY_FAKEARY
+ *            The array is not allocated or managed by the garbage collector.
+ *            Typically, the array object header (struct RString) is temporarily
+ *            allocated on C stack.
  */
 
 /* for OPTIMIZED_CMP: */
@@ -900,7 +904,7 @@ static VALUE
 init_fake_ary_flags(void)
 {
     struct RArray fake_ary = {0};
-    fake_ary.basic.flags = T_ARRAY;
+    fake_ary.basic.flags = T_ARRAY | RARRAY_FAKEARY;
     VALUE ary = (VALUE)&fake_ary;
     RBASIC_SET_FULL_SHAPE_ID(ary, ROOT_SHAPE_ID | SHAPE_ID_LAYOUT_OTHER);
     rb_ary_freeze(ary);

--- a/benchmark/string_concat.yml
+++ b/benchmark/string_concat.yml
@@ -1,10 +1,18 @@
 prelude: |
+  # frozen_string_literal: true
   CHUNK = "a" * 64
   UCHUNK = "é" * 32
   SHORT = "a" * (GC.stat_heap(0, :slot_size) / 2)
   LONG = "a" * (GC.stat_heap(0, :slot_size) * 2)
   GC.disable # GC causes a lot of variance
 benchmark:
+  binary_concat_embedded: |
+    # Concat 20 times in a String with 23 capacity
+    # Excercise `str_embed_capa`
+    buffer = +""
+    buffer << "1" << "2" << "3" << "4" << "5" << "6" << "7" << "8" << "9" << "0"
+    buffer << "1" << "2" << "3" << "4" << "5" << "6" << "7" << "8" << "9" << "0"
+
   binary_concat_7bit: |
     buffer = String.new(capacity: 4096, encoding: Encoding::BINARY)
     buffer << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK

--- a/bignum.c
+++ b/bignum.c
@@ -3002,7 +3002,7 @@ rb_cmpint(VALUE val, VALUE a, VALUE b)
 static size_t
 big_embed_capa(VALUE big)
 {
-    size_t size = rb_gc_obj_slot_size(big) - offsetof(struct RBignum, as.ary);
+    size_t size = rb_obj_shape_slot_size(big) - offsetof(struct RBignum, as.ary);
     RUBY_ASSERT(size % sizeof(BDIGIT) == 0);
     size_t capa = size / sizeof(BDIGIT);
     RUBY_ASSERT(capa <= BIGNUM_EMBED_LEN_MAX);

--- a/gc.c
+++ b/gc.c
@@ -376,8 +376,6 @@ rb_gc_shutdown_call_finalizer_p(VALUE obj)
 void
 rb_gc_obj_changed_slot_size(VALUE obj, size_t slot_size)
 {
-    RUBY_ASSERT(RB_TYPE_P(obj, T_OBJECT));
-
     RBASIC_SET_FULL_SHAPE_ID(obj, rb_obj_shape_transition_slot_size(obj, slot_size));
 }
 

--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -7616,7 +7616,7 @@ gc_move(rb_objspace_t *objspace, VALUE src, VALUE dest, struct heap_page *src_pa
     /* Move the object */
     memcpy((void *)dest, (void *)src, MIN(src_slot_size, slot_size));
 
-    if (src_slot_size != slot_size && RB_TYPE_P(src, T_OBJECT)) {
+    if (src_slot_size != slot_size) {
         rb_gc_obj_changed_slot_size(dest, slot_size - RVALUE_OVERHEAD);
     }
 

--- a/internal/array.h
+++ b/internal/array.h
@@ -21,6 +21,7 @@
 #define RARRAY_SHARED_FLAG      ELTS_SHARED
 #define RARRAY_SHARED_ROOT_FLAG FL_USER12
 #define RARRAY_PTR_IN_USE_FLAG  FL_USER14
+#define RARRAY_FAKEARY          FL_USER19
 
 /* array.c */
 VALUE rb_ary_hash_values(long len, const VALUE *elements);

--- a/internal/string.h
+++ b/internal/string.h
@@ -21,6 +21,7 @@
 #define STR_CHILLED                 (FL_USER2 | FL_USER3)
 #define STR_CHILLED_LITERAL         FL_USER2
 #define STR_CHILLED_SYMBOL_TO_S     FL_USER3
+#define STR_FAKESTR                 FL_USER19
 
 enum ruby_rstring_private_flags {
     RSTRING_CHILLED = STR_CHILLED,

--- a/ractor.c
+++ b/ractor.c
@@ -2032,7 +2032,7 @@ move_enter(VALUE obj, struct obj_traverse_replace_data *data)
     }
     else {
         VALUE type = RB_BUILTIN_TYPE(obj);
-        size_t slot_size = rb_gc_obj_slot_size(obj);
+        size_t slot_size = rb_obj_shape_slot_size(obj);
         VALUE moved = rb_newobj(GET_EC(), 0, type, RBASIC_SHAPE_ID(obj), wb_protected_types[type], slot_size);
         MEMZERO(((struct RBasic *)moved) + 1, char, slot_size - sizeof(struct RBasic));
         data->replacement = (VALUE)moved;
@@ -2050,7 +2050,7 @@ move_leave(VALUE obj, struct obj_traverse_replace_data *data)
     memcpy(
         (char *)data->replacement + sizeof(VALUE),
         (char *)obj + sizeof(VALUE),
-        rb_gc_obj_slot_size(obj) - sizeof(VALUE)
+        rb_obj_shape_slot_size(obj) - sizeof(VALUE)
     );
 
     // We've copied obj's references to the replacement

--- a/shape.c
+++ b/shape.c
@@ -1244,6 +1244,21 @@ rb_shape_expected_layout(VALUE obj)
 }
 
 bool
+rb_shape_verify_capacity_consistency_p(VALUE obj)
+{
+    switch (BUILTIN_TYPE(obj)) {
+      case T_IMEMO:
+        return IMEMO_TYPE_P(obj, imemo_fields);
+      case T_STRING:
+        return !FL_TEST_RAW(obj, FL_USER19); // STR_FAKESTR
+      case T_ARRAY:
+        return !FL_TEST_RAW(obj, RARRAY_FAKEARY);
+      default:
+        return true;
+    }
+}
+
+bool
 rb_shape_verify_consistency(VALUE obj, shape_id_t shape_id)
 {
     if (shape_id == INVALID_SHAPE_ID) {
@@ -1305,8 +1320,8 @@ rb_shape_verify_consistency(VALUE obj, shape_id_t shape_id)
         }
     }
 
-    attr_index_t shape_id_capacity = rb_shape_embedded_capacity(shape_id);
-    if (RB_TYPE_P(obj, T_OBJECT) || IMEMO_TYPE_P(obj, imemo_fields)) {
+    if (rb_shape_verify_capacity_consistency_p(obj)) {
+        attr_index_t shape_id_capacity = rb_shape_embedded_capacity(shape_id);
         RUBY_ASSERT(shape_id_capacity > 0);
 
         size_t shape_id_slot_size = shape_id_capacity * sizeof(VALUE) + sizeof(struct RBasic);

--- a/shape.h
+++ b/shape.h
@@ -286,6 +286,19 @@ rb_shape_embedded_capacity(shape_id_t shape_id)
     return (attr_index_t)((shape_id & SHAPE_ID_CAPACITY_MASK) >> SHAPE_ID_CAPACITY_OFFSET);
 }
 
+static inline size_t
+rb_shape_slot_size(shape_id_t shape_id)
+{
+    return sizeof(struct RBasic) + (rb_shape_embedded_capacity(shape_id) * sizeof(VALUE));
+}
+
+static inline size_t
+rb_obj_shape_slot_size(VALUE obj)
+{
+    RUBY_ASSERT(!RB_TYPE_P(obj, T_IMEMO) || IMEMO_TYPE_P(obj, imemo_fields));
+    return rb_shape_slot_size(RBASIC_SHAPE_ID(obj));
+}
+
 static inline attr_index_t
 rb_shape_capacity_for_slot_size(size_t slot_size)
 {

--- a/string.c
+++ b/string.c
@@ -222,7 +222,7 @@ SHARABLE_SUBSTRING_P(VALUE str, long beg, long len)
 static inline long
 str_embed_capa(VALUE str)
 {
-    return rb_gc_obj_slot_size(str) - offsetof(struct RString, as.embed.ary);
+    return rb_obj_shape_slot_size(str) - offsetof(struct RString, as.embed.ary);
 }
 
 bool

--- a/string.c
+++ b/string.c
@@ -131,7 +131,6 @@ VALUE rb_cSymbol;
 #define STR_BORROWED FL_USER6
 #define STR_TMPLOCK FL_USER7
 #define STR_NOFREE FL_USER18
-#define STR_FAKESTR FL_USER19
 
 #define STR_SET_NOEMBED(str) do {\
     FL_SET((str), STR_NOEMBED);\

--- a/struct.c
+++ b/struct.c
@@ -840,7 +840,7 @@ struct_alloc(VALUE klass)
         NEWOBJ_OF(st, struct RStruct, klass, flags, embedded_size);
         if (RCLASS_MAX_IV_COUNT(klass) == 0) {
             if (!rb_obj_shape_has_fields((VALUE)st)
-                    && embedded_size < rb_gc_obj_slot_size((VALUE)st)) {
+                    && embedded_size < rb_obj_shape_slot_size((VALUE)st)) {
                 FL_UNSET_RAW((VALUE)st, RSTRUCT_GEN_FIELDS);
                 RSTRUCT_SET_FIELDS_OBJ((VALUE)st, 0);
             }


### PR DESCRIPTION
Followup: https://github.com/ruby/ruby/pull/17572

Now that the shape contains the slot capacity, we should update the shape for all objects when moving them, not just T_OBJECT.

This allows replacing calls to `rb_gc_obj_slot_size` for `rb_obj_shape_slot_size`.

`rb_gc_obj_slot_size` has to check the page metadata to get the slot size, which likely cause cache misses.

`rb_obj_shape_slot_size` does simple arithmetic using only a few shape bits.

```
compare-ruby: ruby 4.1.0dev (2026-07-08T03:48:16Z master 01c5b2e890) +PRISM [arm64-darwin25]
built-ruby: ruby 4.1.0dev (2026-07-08T10:17:41Z gc-changed-slot-size 08029b0f7c) +PRISM [arm64-darwin25]
warming up.
```

|                        |compare-ruby|built-ruby|
|:-----------------------|-----------:|---------:|
|binary_concat_embedded  |      5.262M|    5.707M|
|                        |           -|     1.08x|