### PR TITLE
 M:N threads: decouple a dying coroutine thread's teardown from the GC (+ two ready-queue fixes)

### DIFF
--- a/ractor.c
+++ b/ractor.c
@@ -757,7 +757,6 @@ ractor_check_blocking(rb_ractor_t *cr, unsigned int remained_thread_cnt, const c
     }
 }
 
-void rb_threadptr_remove(rb_thread_t *th);
 
 void
 rb_ractor_living_threads_remove(rb_ractor_t *cr, rb_thread_t *th)
@@ -766,7 +765,6 @@ rb_ractor_living_threads_remove(rb_ractor_t *cr, rb_thread_t *th)
     RUBY_DEBUG_LOG("r->threads.cnt:%d--", cr->threads.cnt);
     ractor_check_blocking(cr, cr->threads.cnt - 1, __FILE__, __LINE__);
 
-    rb_threadptr_remove(th);
 
     if (cr->threads.cnt == 1) {
         vm_remove_ractor(th->vm, cr);

--- a/thread.c
+++ b/thread.c
@@ -535,10 +535,19 @@ thread_cleanup_func(void *th_ptr, int atfork)
     if (atfork) {
         native_thread_destroy_atfork(th->nt);
         th->nt = NULL;
+        // The copied interrupt_lock may have been held at the moment of
+        // fork (interrupters run concurrently); reinitialize it so that
+        // thread_free's destroy is well-defined in the child.
+        rb_native_mutex_initialize(&th->interrupt_lock);
         return;
     }
 
-    rb_native_mutex_destroy(&th->interrupt_lock);
+    // interrupt_lock is destroyed in thread_free: while th is in its
+    // Ractor's living set, anyone (terminate_all on the Ractor's main
+    // thread, Thread#kill/#raise) may lock it -- and the living set keeps
+    // the Thread object marked, so it cannot reach thread_free while
+    // listed. Destroying it anywhere during teardown leaves a window where
+    // a concurrent interrupter locks a destroyed mutex (EINVAL).
 }
 
 void
@@ -807,6 +816,16 @@ thread_start_func_2(rb_thread_t *th, VALUE *stack_start)
     thread_cleanup_func(th, FALSE);
     VM_ASSERT(th->ec->vm_stack == NULL);
 
+#if defined(USE_MN_THREADS) && USE_MN_THREADS
+    if (th_has_coroutine(th)) {
+        // Run the coroutine thread's epilogue here, while th is still valid;
+        // co_start then only makes the final transfer (see
+        // coroutine_thread_terminated in thread_pthread_mn.c).
+        coroutine_thread_terminated(th);
+        return 0;
+    }
+#endif
+
     if (th->invoke_type == thread_invoke_type_ractor_proc) {
         // after rb_ractor_living_threads_remove()
         // GC will happen anytime and this ractor can be collected (and destroy GVL).
@@ -907,8 +926,6 @@ thread_create_core(VALUE thval, struct thread_create_params *params)
         th->pending_interrupt_mask_stack = rb_ary_dup(current_th->pending_interrupt_mask_stack);
         RBASIC_CLEAR_CLASS(th->pending_interrupt_mask_stack);
     }
-
-    rb_native_mutex_initialize(&th->interrupt_lock);
 
     RUBY_DEBUG_LOG("r:%u th:%u", rb_ractor_id(th->ractor), rb_th_serial(th));
 

--- a/thread_none.c
+++ b/thread_none.c
@@ -311,17 +311,7 @@ rb_ractor_sched_barrier_join(rb_vm_t *vm, rb_ractor_t *cr)
     // do nothing
 }
 
-void
-rb_threadptr_remove(rb_thread_t *th)
-{
-    // do nothing
-}
 
-void
-rb_thread_sched_mark_zombies(rb_vm_t *vm)
-{
-    // do nothing
-}
 
 bool
 rb_thread_lock_native_thread(void)
@@ -342,3 +332,11 @@ rb_thread_malloc_stack_set(rb_thread_t *th, void *stack, size_t stack_size)
 }
 
 #endif /* THREAD_SYSTEM_DEPENDENT_IMPLEMENTATION */
+
+void
+rb_thread_sched_wait_winding(rb_vm_t *vm)
+{
+    // no coroutine (M:N) threads on this implementation: nothing winds down
+    // after leaving the living set (see thread_pthread.c)
+    (void)vm;
+}

--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -1742,6 +1742,11 @@ thread_sched_atfork(struct rb_thread_sched *sched)
     rb_native_cond_initialize(&vm->ractor.sched.barrier_release_cond);
 
     ccan_list_head_init(&vm->ractor.sched.grq);
+    vm->ractor.sched.grq_cnt = 0; // the list was just emptied; reset the count with it
+    // Threads that were winding down in the parent do not exist in the child;
+    // without this reset the child's ruby_vm_destruct would wait for their
+    // reclaim (which never comes) forever.
+    vm->ractor.sched.winding_cnt = 0;
     ccan_list_head_init(&vm->ractor.sched.timeslice_threads);
     ccan_list_head_init(&vm->ractor.sched.running_threads);
 

--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -332,7 +332,23 @@ static void timer_thread_wakeup_locked(rb_vm_t *vm);
 static void timer_thread_wakeup_force(void);
 static void thread_sched_switch(rb_thread_t *cth, rb_thread_t *next_th);
 static void ractor_sched_cancel_enq(rb_vm_t *vm, struct rb_thread_sched *sched);
-static void coroutine_transfer0(struct coroutine_context *transfer_from,
+#if USE_MN_THREADS
+// A coroutine thread's execution context: the coroutine_context (first, so
+// th->sched.context points at the whole block) plus what is needed to free
+// it without the rb_thread_t. Owned by the execution: the dying thread marks
+// it dead before its final transfer, and whichever context RESUMES from that
+// transfer frees it -- the resume itself proves the transfer's register save
+// into this block has completed, so no further synchronization is needed.
+struct rb_thread_context {
+    struct coroutine_context co; // must be first
+    void *stack;                 // the coroutine machine stack (pool stack)
+    struct rb_native_thread *nt; // final transfer target, stashed at termination
+    bool dead;
+};
+
+static bool thread_sched_reclaim_from(struct coroutine_context *returning_from);
+#endif
+static struct coroutine_context *coroutine_transfer0(struct coroutine_context *transfer_from,
                                 struct coroutine_context *transfer_to, bool to_dead);
 
 #define thread_sched_dump(s) thread_sched_dump_(__FILE__, __LINE__, s)
@@ -1053,6 +1069,10 @@ thread_sched_to_dead_common(struct rb_thread_sched *sched, rb_thread_t *th)
 
     RB_INTERNAL_THREAD_HOOK(RUBY_INTERNAL_THREAD_EVENT_SUSPENDED, th);
 
+    // A dying coroutine thread (will_switch=true here) does NOT wake the
+    // next thread now: it is still winding down (co_start's epilogue), and
+    // the same Ractor must not have two threads executing at once. The
+    // epilogue enqueues the Ractor after its last rb_ractor_t access.
     thread_sched_wakeup_next_thread(sched, th, !th_has_dedicated_nt(th));
 
     RB_INTERNAL_THREAD_HOOK(RUBY_INTERNAL_THREAD_EVENT_EXITED, th);
@@ -1244,7 +1264,7 @@ rb_thread_sched_init(struct rb_thread_sched *sched, bool atfork)
 #endif
 }
 
-static void
+static struct coroutine_context *
 coroutine_transfer0(struct coroutine_context *transfer_from, struct coroutine_context *transfer_to, bool to_dead)
 {
 #ifdef RUBY_ASAN_ENABLED
@@ -1259,7 +1279,6 @@ coroutine_transfer0(struct coroutine_context *transfer_from, struct coroutine_co
     __tsan_switch_to_fiber(transfer_to->tsan_fiber, 0);
 #endif
 
-    RBIMPL_ATTR_MAYBE_UNUSED()
     struct coroutine_context *returning_from = coroutine_transfer(transfer_from, transfer_to);
 
     /* if to_dead was passed, the caller is promising that this coroutine is finished and it should
@@ -1270,9 +1289,10 @@ coroutine_transfer0(struct coroutine_context *transfer_from, struct coroutine_co
                                    (const void**)&returning_from->stack_base, &returning_from->stack_size);
 #endif
 
+    return returning_from;
 }
 
-static void
+static struct coroutine_context *
 thread_sched_switch0(struct coroutine_context *current_cont, rb_thread_t *next_th, struct rb_native_thread *nt, bool to_dead)
 {
     VM_ASSERT(!nt->dedicated);
@@ -1287,7 +1307,7 @@ thread_sched_switch0(struct coroutine_context *current_cont, rb_thread_t *next_t
     ruby_thread_set_native(next_th);
     native_thread_assign(nt, next_th);
 
-    coroutine_transfer0(current_cont, next_th->sched.context, to_dead);
+    return coroutine_transfer0(current_cont, next_th->sched.context, to_dead);
 }
 
 static void
@@ -1318,6 +1338,18 @@ grq_size(rb_vm_t *vm, rb_ractor_t *cr)
     return i;
 }
 #endif
+
+// ruby_vm_destruct: wait until no native thread is between a coroutine
+// epilogue and its reclaim -- past that point the reclaim frees through the
+// (about to be destroyed) objspace and reads the (about to be unset) VM.
+// Runs without the VM lock, which the epilogue needs to progress.
+void
+rb_thread_sched_wait_winding(rb_vm_t *vm)
+{
+    while (RUBY_ATOMIC_LOAD(vm->ractor.sched.winding_cnt) > 0) {
+        native_thread_yield();
+    }
+}
 
 // A direct service of a runnable thread (direct transfer or the hot-thread
 // steal) bypasses the grq; cancel the Ractor's outstanding entry so that
@@ -2390,19 +2422,34 @@ nt_start(void *ptr)
             if (r) {
                 struct rb_thread_sched *sched = &r->threads.sched;
 
+                bool locked = true;
+
                 thread_sched_lock(sched, NULL);
                 {
                     rb_thread_t *next_th = sched->running;
 
                     if (next_th && next_th->nt == NULL) {
                         RUBY_DEBUG_LOG("nt:%d next_th:%d", (int)nt->serial, (int)next_th->serial);
+#if USE_MN_THREADS
+                        struct coroutine_context *from = thread_sched_switch0(nt->nt_context, next_th, nt, false);
+                        if (thread_sched_reclaim_from(from)) {
+                            // A terminal transfer: the dying thread released
+                            // the sched lock before transferring (its Ractor
+                            // may be gone by now); we resumed with NO lock
+                            // held and must not touch the sched again.
+                            locked = false;
+                        }
+#else
                         thread_sched_switch0(nt->nt_context, next_th, nt, false);
+#endif
                     }
                     else {
                         RUBY_DEBUG_LOG("no schedulable threads -- next_th:%p", next_th);
                     }
                 }
-                thread_sched_unlock(sched, NULL);
+                if (locked) {
+                    thread_sched_unlock(sched, NULL);
+                }
             }
             else {
                 // timeout -> deleted.
@@ -2423,26 +2470,30 @@ static int native_thread_create_shared(rb_thread_t *th);
 
 #if USE_MN_THREADS
 static void nt_free_stack(void *mstack);
-#endif
 
-void
-rb_threadptr_remove(rb_thread_t *th)
+
+// Reclaim the coroutine context the nt scheduling loop just resumed from,
+// if its thread terminated. A dying thread always returns to its native
+// thread's own context (co_start's epilogue), so this is the only place
+// terminal transfers arrive -- and our running here proves the transfer's
+// register save into the block has completed. Returns true for a terminal
+// transfer, whose dying thread RELEASED the sched lock before transferring.
+static bool
+thread_sched_reclaim_from(struct coroutine_context *returning_from)
 {
-#if USE_MN_THREADS
-    if (th->sched.malloc_stack) {
-        // dedicated
-        return;
-    }
-    else {
-        rb_vm_t *vm = th->vm;
-        th->sched.finished = false;
+    struct rb_thread_context *tctx = (struct rb_thread_context *)returning_from;
 
-        RB_VM_LOCKING() {
-            ccan_list_add(&vm->ractor.sched.zombie_threads, &th->sched.node.zombie_threads);
-        }
+    if (tctx != NULL && tctx->dead) {
+        nt_free_stack(tctx->stack);
+        SIZED_FREE(tctx);
+        // pairs with the increment at the top of coroutine_thread_terminated:
+        // a waiting VM destruct may proceed once this reclaim is done
+        RUBY_ATOMIC_DEC(GET_VM()->ractor.sched.winding_cnt);
+        return true;
     }
-#endif
+    return false;
 }
+#endif
 
 void
 rb_threadptr_sched_free(rb_thread_t *th)
@@ -2453,14 +2504,16 @@ rb_threadptr_sched_free(rb_thread_t *th)
         SIZED_FREE_N((VALUE *)th->sched.context_stack, th->sched.context_stack_size);
         native_thread_destroy(th->nt);
     }
-    else {
-        nt_free_stack(th->sched.context_stack);
+    else if (th->sched.context != NULL) {
+        // a coroutine thread that never reached its epilogue (never started);
+        // a terminated one is reclaimed by whoever resumed from its final
+        // transfer (thread_sched_reclaim_from), and cleared this pointer.
+        struct rb_thread_context *tctx = (struct rb_thread_context *)th->sched.context;
+        nt_free_stack(tctx->stack);
+        SIZED_FREE(tctx);
+        th->sched.context = NULL;
         // TODO: how to free nt and nt->altstack?
     }
-
-    SIZED_FREE(th->sched.context);
-    th->sched.context = NULL;
-    // VM_ASSERT(th->sched.context == NULL);
 #else
     SIZED_FREE_N((VALUE *)th->sched.context_stack, th->sched.context_stack_size);
     native_thread_destroy(th->nt);
@@ -2469,21 +2522,6 @@ rb_threadptr_sched_free(rb_thread_t *th)
     th->nt = NULL;
 }
 
-void
-rb_thread_sched_mark_zombies(rb_vm_t *vm)
-{
-    if (!ccan_list_empty(&vm->ractor.sched.zombie_threads)) {
-        rb_thread_t *zombie_th, *next_zombie_th;
-        ccan_list_for_each_safe(&vm->ractor.sched.zombie_threads, zombie_th, next_zombie_th, sched.node.zombie_threads) {
-            if (zombie_th->sched.finished) {
-                ccan_list_del_init(&zombie_th->sched.node.zombie_threads);
-            }
-            else {
-                rb_gc_mark(zombie_th->self);
-            }
-        }
-    }
-}
 
 static int
 native_thread_create(rb_thread_t *th)

--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -331,6 +331,7 @@ static void timer_thread_wakeup(void);
 static void timer_thread_wakeup_locked(rb_vm_t *vm);
 static void timer_thread_wakeup_force(void);
 static void thread_sched_switch(rb_thread_t *cth, rb_thread_t *next_th);
+static void ractor_sched_cancel_enq(rb_vm_t *vm, struct rb_thread_sched *sched);
 static void coroutine_transfer0(struct coroutine_context *transfer_from,
                                 struct coroutine_context *transfer_to, bool to_dead);
 
@@ -854,6 +855,12 @@ thread_sched_wait_running_turn(struct rb_thread_sched *sched, rb_thread_t *th, b
         if (th->has_dedicated_nt && th == sched->runnable_hot_th && (sched->running == NULL || sched->running->has_dedicated_nt)) {
             RUBY_DEBUG_LOG("(nt) stealing: hot-th:%u.  running:%u", rb_th_serial(th), rb_th_serial(sched->running));
 
+            // th serves itself on its own nt, displacing the enqueued
+            // running thread back to the readyq: cancel the entry that was
+            // posted for it (a later dequeue would find this Ractor served
+            // and its next enqueue would double-list the node)
+            ractor_sched_cancel_enq(th->vm, sched);
+
             // If there is a thread set to run, move it back to the front of the readyq
             if (sched->running != NULL) {
                 rb_thread_t *running = sched->running;
@@ -1230,6 +1237,7 @@ rb_thread_sched_init(struct rb_thread_sched *sched, bool atfork)
 
     ccan_list_head_init(&sched->readyq);
     sched->readyq_cnt = 0;
+    ccan_list_node_init(&sched->grq_node); // self-linked = not enqueued
 
 #if USE_MN_THREADS
     if (!atfork) sched->enable_mn_threads = true; // MN is enabled on Ractors
@@ -1272,6 +1280,10 @@ thread_sched_switch0(struct coroutine_context *current_cont, rb_thread_t *next_t
 
     RUBY_DEBUG_LOG("next_th:%u", rb_th_serial(next_th));
 
+    // this direct transfer serves next_th without a dequeue; cancel its
+    // Ractor's outstanding grq entry (no-op when nothing is enqueued)
+    ractor_sched_cancel_enq(next_th->vm, TH_SCHED(next_th));
+
     ruby_thread_set_native(next_th);
     native_thread_assign(nt, next_th);
 
@@ -1307,6 +1319,29 @@ grq_size(rb_vm_t *vm, rb_ractor_t *cr)
 }
 #endif
 
+// A direct service of a runnable thread (direct transfer or the hot-thread
+// steal) bypasses the grq; cancel the Ractor's outstanding entry so that
+// "enqueued <=> runnable and unserved" keeps holding. The caller holds the
+// per-Ractor sched lock, so no concurrent enqueue can relink the node: a
+// self-linked read needs no lock (the common case -- direct switches whose
+// transition never enqueued). A linked read can race only with a dequeue,
+// hence the recheck under the grq lock.
+static void
+ractor_sched_cancel_enq(rb_vm_t *vm, struct rb_thread_sched *sched)
+{
+    if (sched->grq_node.next != &sched->grq_node) {
+        ractor_sched_lock(vm, NULL);
+        {
+            if (sched->grq_node.next != &sched->grq_node) {
+                ccan_list_del_init(&sched->grq_node);
+                VM_ASSERT(vm->ractor.sched.grq_cnt > 0);
+                vm->ractor.sched.grq_cnt--;
+            }
+        }
+        ractor_sched_unlock(vm, NULL);
+    }
+}
+
 static void
 ractor_sched_enq(rb_vm_t *vm, rb_ractor_t *r)
 {
@@ -1318,14 +1353,16 @@ ractor_sched_enq(rb_vm_t *vm, rb_ractor_t *r)
 
     ractor_sched_lock(vm, cr);
     {
-#if VM_CHECK_MODE > 0
-        // check if grq contains r
-        rb_ractor_t *tr;
-        ccan_list_for_each(&vm->ractor.sched.grq, tr, threads.sched.grq_node) {
-            VM_ASSERT(r != tr);
+        // Precondition: not already enqueued (the grq_node is self-linked).
+        // This holds because every service of a runnable-but-unserved thread
+        // either dequeues the entry (the nt scheduling loop) or cancels it
+        // (direct transfers / the hot-thread steal; see
+        // ractor_sched_cancel_enq) -- re-adding a linked node would corrupt
+        // the queue, so check unconditionally (a CHECK-mode-only assert
+        // would miss it: the race needs timing that CHECK builds perturb).
+        if (sched->grq_node.next != &sched->grq_node) {
+            rb_bug("ractor_sched_enq: already enqueued");
         }
-#endif
-
         ccan_list_add_tail(&vm->ractor.sched.grq, &sched->grq_node);
         vm->ractor.sched.grq_cnt++;
         VM_ASSERT(grq_size(vm, cr) == vm->ractor.sched.grq_cnt);
@@ -1389,6 +1426,7 @@ ractor_sched_deq(rb_vm_t *vm, rb_ractor_t *cr)
         VM_ASSERT(rb_current_execution_context(false) == NULL);
 
         if (r) {
+            ccan_list_node_init(&r->threads.sched.grq_node); // back to self-linked
             VM_ASSERT(vm->ractor.sched.grq_cnt > 0);
             vm->ractor.sched.grq_cnt--;
             RUBY_DEBUG_LOG("r:%d grq_cnt:%u", (int)rb_ractor_id(r), vm->ractor.sched.grq_cnt);

--- a/thread_pthread.h
+++ b/thread_pthread.h
@@ -68,14 +68,11 @@ struct rb_thread_sched_item {
         // locked by vm->ractor.sched.lock
         struct ccan_list_node running_threads;
 
-        // connected to vm->ractor.sched.zombie_threads
-        struct ccan_list_node zombie_threads;
     } node;
 
     struct rb_thread_sched_waiting waiting_reason;
     uint32_t event_serial;
 
-    bool finished;
     bool malloc_stack;
     void *context_stack;
     size_t context_stack_size;
@@ -147,6 +144,16 @@ struct rb_thread_sched {
     // outstanding entry (see ractor_sched_cancel_enq).
     struct ccan_list_node grq_node;
 };
+
+struct rb_thread_context;
+
+// A coroutine (M:N) thread's teardown runs coroutine_thread_terminated
+// instead of the dedicated-thread path in thread_start_func_2; see the
+// comments there and in thread_pthread_mn.c. th->sched.context is cleared in
+// that epilogue, so this also reads as "did not tear down yet".
+// (Only meaningful when USE_MN_THREADS -- gate uses accordingly; the macro
+// itself is a plain pointer test and always compiles.)
+#define th_has_coroutine(th) ((th)->sched.context != NULL)
 
 #ifdef RB_THREAD_LOCAL_SPECIFIER
   NOINLINE(void rb_current_ec_set(struct rb_execution_context_struct *));

--- a/thread_pthread.h
+++ b/thread_pthread.h
@@ -141,6 +141,10 @@ struct rb_thread_sched {
     struct ccan_list_head readyq;
     int readyq_cnt;
     // ractor scheduling
+    // When not linked in vm->ractor.sched.grq, this node is kept
+    // self-linked (ccan_list_node_init), so "linked?" can be read off the
+    // node itself: enqueuers assert it, and direct transfers cancel an
+    // outstanding entry (see ractor_sched_cancel_enq).
     struct ccan_list_node grq_node;
 };
 

--- a/thread_pthread_mn.c
+++ b/thread_pthread_mn.c
@@ -447,6 +447,73 @@ native_thread_check_and_create_shared(rb_vm_t *vm)
     }
 }
 
+// A coroutine thread's epilogue, run from thread_start_func_2 while th is
+// still valid (and, until the living-set removal, still GC-reachable).
+// Everything that touches th happens here; co_start then only makes the
+// final transfer, touching the execution-owned tctx alone.
+static void
+coroutine_thread_terminated(rb_thread_t *th)
+{
+    struct rb_thread_context *tctx = (struct rb_thread_context *)th->sched.context;
+    struct rb_thread_sched *sched = TH_SCHED(th);
+    rb_ractor_t *r = th->ractor;
+    bool last = (th->invoke_type == thread_invoke_type_ractor_proc);
+    bool is_dnt = th_has_dedicated_nt(th);
+
+    // VM destruct tears down the heap and then unsets ruby_current_vm_ptr;
+    // this native thread still frees the dead context afterwards (the nt
+    // loop's reclaim uses ruby_xfree and the stack-pool geometry via
+    // GET_VM()). Make destruct wait until the reclaim finished. (Observed:
+    // an assert_separately child exiting right after a Ractor finished
+    // crashed at GET_VM()->default_params, offset 0x2600, on two arches.)
+    RUBY_ATOMIC_INC(th->vm->ractor.sched.winding_cnt);
+
+    rb_thread_t *wake_th;
+
+    thread_sched_lock(sched, th);
+    {
+        // designate the successor (running = next from readyq, or NULL); for
+        // a dedicated nt (will_switch false) this also enqueues the Ractor.
+        thread_sched_to_dead_common(sched, th);
+
+        // Only the successor WE designated here may be enqueued by this
+        // epilogue (below, after the living-set removal). If readyq was
+        // empty, running is now NULL and a waker (e.g. the timer thread)
+        // that later installs a runnable thread enqueues the Ractor itself
+        // -- enqueuing "whatever is running" at that point would duplicate
+        // its entry. While running is non-NULL, nobody else re-assigns it,
+        // so wake_th stays valid until we enqueue.
+        wake_th = is_dnt ? NULL : sched->running;
+
+        tctx->nt = th->nt;        // stash the final transfer target for co_start
+        native_thread_assign(NULL, th);
+        th->sched.context = NULL; // the wrapper's dfree must not reclaim tctx
+    }
+    thread_sched_unlock(sched, th);
+
+    // Leave the living set. This is the dying thread's last access to th --
+    // the removal needs the current ec (VM lock), and after it the GC may
+    // collect th (and, for a Ractor's main thread, the Ractor).
+    // (interrupt_lock stays valid up to here -- a concurrent terminate_all
+    // may interrupt any still-listed thread; it is destroyed in thread_free.)
+    rb_ractor_living_threads_remove(r, th);
+
+    if (last) {
+        rb_current_ec_set(NULL); // TLS only; r may be collectable already
+    }
+    else {
+        rb_ractor_set_current_ec(r, NULL); // r alive: it has other threads
+
+        if (wake_th && wake_th->nt == NULL) {
+            // enqueue the successor designated above -- exactly once per
+            // "runnable but unserved" period, by its designator.
+            thread_sched_lock(sched, NULL);
+            ractor_sched_enq(wake_th->vm, r);
+            thread_sched_unlock(sched, NULL);
+        }
+    }
+}
+
 #ifdef __APPLE__
 # define co_start ruby_coroutine_start
 #else
@@ -475,38 +542,14 @@ co_start(struct coroutine_context *from, struct coroutine_context *self)
         RB_INTERNAL_THREAD_HOOK(RUBY_INTERNAL_THREAD_EVENT_RESUMED, th);
         call_thread_start_func_2(th);
     }
-    thread_sched_lock(sched, NULL);
-
-    RUBY_DEBUG_LOG("terminated th:%d", (int)th->serial);
-
-    // Thread is terminated
-
-    struct rb_native_thread *nt = th->nt;
-    bool is_dnt = th_has_dedicated_nt(th);
-    native_thread_assign(NULL, th);
-    rb_ractor_set_current_ec(th->ractor, NULL);
-
-    if (is_dnt) {
-        // SNT became DNT while running. Just return to the nt_context
-
-        th->sched.finished = true;
-        coroutine_transfer0(self, nt->nt_context, true);
-    }
-    else {
-        rb_thread_t *next_th = sched->running;
-
-        if (next_th && !next_th->nt) {
-            // switch to the next thread
-            thread_sched_set_unlocked(sched, NULL);
-            th->sched.finished = true;
-            thread_sched_switch0(th->sched.context, next_th, nt, true);
-        }
-        else {
-            // switch to the next Ractor
-            th->sched.finished = true;
-            coroutine_transfer0(self, nt->nt_context, true);
-        }
-    }
+    // Thread is terminated. coroutine_thread_terminated (run from
+    // thread_start_func_2 while th was still valid) already left the living
+    // set and stashed the transfer target, so th / its Ractor may already be
+    // collected. Only tctx is touched here: mark it dead and transfer back to
+    // this native thread's own context, where the nt loop reclaims tctx.
+    struct rb_thread_context *tctx = (struct rb_thread_context *)self;
+    tctx->dead = true;
+    coroutine_transfer0(&tctx->co, tctx->nt->nt_context, true);
 
     rb_bug("unreachable");
 }
@@ -533,9 +576,12 @@ native_thread_create_shared(rb_thread_t *th)
     th->sched.context_stack = machine_stack;
     th->sched.context_stack_size = machine_stack_size;
 
-    th->sched.context = ruby_xmalloc(sizeof(struct coroutine_context));
-    coroutine_initialize(th->sched.context, co_start, machine_stack, machine_stack_size);
-    th->sched.context->argument = th;
+    struct rb_thread_context *tctx = ruby_xmalloc(sizeof(struct rb_thread_context));
+    tctx->stack = machine_stack;
+    tctx->dead = false;
+    th->sched.context = &tctx->co;
+    coroutine_initialize(&tctx->co, co_start, machine_stack, machine_stack_size);
+    tctx->co.argument = th;
 
     RUBY_DEBUG_LOG("th:%u vm_stack:%p machine_stack:%p", rb_th_serial(th), vm_stack, machine_stack);
     thread_sched_to_ready(TH_SCHED(th), th);

--- a/thread_win32.c
+++ b/thread_win32.c
@@ -910,17 +910,7 @@ rb_threadptr_sched_free(rb_thread_t *th)
     ruby_xfree(th->sched.vm_stack);
 }
 
-void
-rb_threadptr_remove(rb_thread_t *th)
-{
-    // do nothing
-}
 
-void
-rb_thread_sched_mark_zombies(rb_vm_t *vm)
-{
-    // do nothing
-}
 
 static bool
 vm_barrier_finish_p(rb_vm_t *vm)
@@ -1031,3 +1021,11 @@ rb_thread_malloc_stack_set(rb_thread_t *th, void *stack, size_t stack_size)
 }
 
 #endif /* THREAD_SYSTEM_DEPENDENT_IMPLEMENTATION */
+
+void
+rb_thread_sched_wait_winding(rb_vm_t *vm)
+{
+    // no coroutine (M:N) threads on this implementation: nothing winds down
+    // after leaving the living set (see thread_pthread.c)
+    (void)vm;
+}

--- a/vm.c
+++ b/vm.c
@@ -3337,7 +3337,6 @@ vm_mark_negative_cme(VALUE val, void *dmy)
     return ID_TABLE_CONTINUE;
 }
 
-void rb_thread_sched_mark_zombies(rb_vm_t *vm);
 
 void
 rb_vm_mark(void *ptr)
@@ -3393,8 +3392,6 @@ rb_vm_mark(void *ptr)
                 }
             }
         }
-
-        rb_thread_sched_mark_zombies(vm);
     }
 
     RUBY_MARK_LEAVE("vm");
@@ -3416,6 +3413,14 @@ void rb_objspace_free_objects(void *objspace);
 int
 ruby_vm_destruct(rb_vm_t *vm)
 {
+    {
+        // wait for native threads still winding down a dead coroutine: their
+        // reclaim frees through the objspace this function is about to
+        // destroy (see coroutine_thread_terminated)
+        void rb_thread_sched_wait_winding(rb_vm_t *vm);
+        rb_thread_sched_wait_winding(vm);
+    }
+
     RUBY_FREE_ENTER("vm");
     ruby_vm_during_cleanup = true;
 
@@ -3876,6 +3881,9 @@ thread_free(void *ptr)
     RUBY_FREE_ENTER("thread");
 
     rb_threadptr_sched_free(th);
+    // destroyed here rather than during teardown: nothing can interrupt a
+    // thread that is unreachable and off its Ractor's living set
+    rb_native_mutex_destroy(&th->interrupt_lock);
 
     if (th->locking_mutex != Qfalse) {
         rb_bug("thread_free: locking_mutex must be NULL (%p:%p)", (void *)th, (void *)th->locking_mutex);
@@ -3991,6 +3999,10 @@ th_init(rb_thread_t *th, VALUE self, rb_vm_t *vm)
     th->self = self;
 
     ccan_list_head_init(&th->interrupt_exec_tasks);
+    // initialized here (not at thread creation) so that every Thread object
+    // -- including allocated-but-never-started ones -- owns a valid mutex:
+    // thread_free destroys it unconditionally
+    rb_native_mutex_initialize(&th->interrupt_lock);
 
     rb_threadptr_root_fiber_setup(th);
 

--- a/vm_core.h
+++ b/vm_core.h
@@ -724,6 +724,7 @@ typedef struct rb_vm_struct {
 
             unsigned int max_cpu;
             struct ccan_list_head grq; // // Global Ready Queue
+            rb_atomic_t winding_cnt; // native threads between a coroutine epilogue and its reclaim; ruby_vm_destruct waits for 0
             unsigned int grq_cnt;
 
             // running threads
@@ -731,8 +732,6 @@ typedef struct rb_vm_struct {
 
             // threads which switch context by timeslice
             struct ccan_list_head timeslice_threads;
-
-            struct ccan_list_head zombie_threads;
 
             // true if timeslice timer is not enable
             bool timeslice_wait_inf;
@@ -2006,9 +2005,6 @@ rb_vm_living_threads_init(rb_vm_t *vm)
 {
     ccan_list_head_init(&vm->workqueue);
     ccan_list_head_init(&vm->ractor.set);
-#ifdef RUBY_THREAD_PTHREAD_H
-    ccan_list_head_init(&vm->ractor.sched.zombie_threads);
-#endif
 }
 
 typedef int rb_backtrace_iter_func(void *, VALUE, int, VALUE);


### PR DESCRIPTION
Summary

This PR redesigns the teardown of M:N (coroutine) threads so that the resources a winding-down native thread still touches are owned by the execution itself and
reclaimed at a well-defined point, instead of being kept alive by the zombie-threads machinery. It deletes vm->ractor.sched.zombie_threads, the sched.finished
publish and the GC mark/reap pass, and closes their UAF window: finished was published before the terminal coroutine transfer, so the GC could free the Thread
object -- whose coroutine context the transfer still saves registers into -- mid-teardown. (This is observable in released builds: e.g. ruby 4.0.2 with
RUBY_MN_THREADS=1 can crash at process exit.)

While stress-testing the change, two pre-existing ready-queue (grq) bugs were found and are fixed by the first and last commits; both reproduce on master and
are independent of the redesign.

Design (2nd commit)

The teardown follows the natural call structure nt_start → co_start → thread_start_func_2:

- struct rb_thread_context bundles what the execution owns: the coroutine_context (kept first, so th->sched.context points at the block), the machine stack, the
stashed final-transfer target, and a dead flag.
- When the thread body returns, coroutine_thread_terminated (run from thread_start_func_2, while th is still valid and listed) finishes every rb_thread_t /
rb_ractor_t access: wake the successor, stash th->nt, detach th->sched.context, leave the living set, clear the current ec, and enqueue the successor it
designated (not earlier -- waking it from to_dead would let another thread of the same Ractor run while this teardown is still in progress).
- co_start then makes exactly one final transfer back to the native thread's own context, touching only the execution-owned block -- th, and for a Ractor's main
thread the Ractor itself, may already be collected at this point.
- The nt loop, resuming there, reclaims dead contexts: the resume itself proves the transfer's register save has completed, so no list, no handshake and no
extra locking are needed.
- interrupt_lock is now destroyed in thread_free rather than during teardown: while a thread is in its Ractor's living set, terminate_all / Thread#kill may lock
it, and a listed thread is marked, so it cannot reach thread_free -- no interrupter can exist there.

Ready-queue fixes (1st and 3rd commits)

Double-list on re-enqueue. A runnable thread whose Ractor is enqueued in the grq can be served without a dequeue: a thread waking in wait_running_turn hands its
native thread over by direct transfer, and the hot-thread path steals running back. Both orphan the grq entry, and the next legitimate enqueue double-lists the
single grq_node, corrupting the queue:

```
t1  thread W blocks     -> running = X (no nt), Ractor enqueued   [entry]
t2  thread V wakes up   -> direct-transfers its nt to X           [entry orphaned]
t3  X blocks/dies       -> running = Y (no nt), enqueued again    [double-list]
```

Fixed by cancelling the entry at both direct-service points; membership is read off the self-linked grq_node (no lock for the common case, double-checked under
the grq lock for the cancel). ractor_sched_enq now rb_bugs unconditionally on a linked node -- the previous VM_CHECK_MODE-only assert never fired because CHECK
builds perturb the timing (reproduced ~1/20 runs of a Ractor×Thread×IO churn on plain builds, 0/12 on CHECK).

Stale grq_cnt after fork. thread_sched_atfork empties the grq list but leaves the counter, so a child forked while any Ractor was enqueued fails grq_size ==
grq_cnt assertions (reproducible with RUBY_MN_THREADS=1 + fork in a Ractor loop).

Verification

bootstraptest 2050 PASS and thread/ractor/fiber/gc test-all + ruby/spec, each under RUBY_MN_THREADS=0/1; ASAN (including collection of unreferenced
Thread/Ractor objects -- the old zombie window -- with zero reports, full btest); RGENGC_CHECK_MODE=2; TSan (warning profile identical to master);
Ractor×Thread×IO teardown churn 150/150 with the enqueue precondition armed; fork with live Ractors; kill/join races; GC.stress; RUBY_FREE_AT_EXIT; multi-hour
soak (thousands of iterations, MN=0 and MN=1) with no failures. Thread-churn microbenchmark shows no regression.
