### PR TITLE
[DOC] Doc for Pathname#readlines

### DIFF
--- a/io.c
+++ b/io.c
@@ -12141,7 +12141,7 @@ io_s_foreach(VALUE v)
  *
  *  - {Open Options}[rdoc-ref:IO@Open+Options].
  *  - {Encoding options}[rdoc-ref:encodings.rdoc@Encoding+Options].
- *  - {Line Options}[rdoc-ref:IO@Line+IO].
+ *  - {Line Input Options}[rdoc-ref:IO@Line+Input+Options].
  *
  *  Returns an Enumerator if no block is given.
  *
@@ -12217,7 +12217,7 @@ io_s_readlines(VALUE v)
  *
  *  - {Open Options}[rdoc-ref:IO@Open+Options].
  *  - {Encoding options}[rdoc-ref:encodings.rdoc@Encoding+Options].
- *  - {Line Options}[rdoc-ref:IO@Line+IO].
+ *  - {Line Input Options}[rdoc-ref:IO@Line+Input+Options].
  *
  */
 
@@ -15253,7 +15253,12 @@ set_LAST_READ_LINE(VALUE val, ID _x, VALUE *_y)
  *  === Line Input
  *
  *  Class \IO supports line-oriented input for
- *  {files}[rdoc-ref:IO@File+Line+Input] and {IO streams}[rdoc-ref:IO@Stream+Line+Input]
+ *  {files}[rdoc-ref:IO@File+Line+Input] and {IO streams}[rdoc-ref:IO@Stream+Line+Input].
+ *
+ *  ==== Line Input Options
+ *
+ *  Optional keyword argument +chomp+ (default: +false+)
+ *  specifies whether line separators are to be excluded from the result of a read.
  *
  *  ==== \File Line Input
  *

--- a/pathname_builtin.rb
+++ b/pathname_builtin.rb
@@ -952,10 +952,10 @@ class Pathname    # * File *
   # :markup: markdown
   #
   # call-seq:
-  #   each_line(sep = $/, **opts) {|line| ... } → nil
-  #   each_line(limit, **opts) {|line| ... } → nil
-  #   each_line(sep, limit, **opts) {|line| ... } → nil
-  #   each_line(...) → new_enumerator
+  #   each_line(sep = $/, **opts) {|line| ... } -> nil
+  #   each_line(limit, **opts) {|line| ... } -> nil
+  #   each_line(sep, limit, **opts) {|line| ... } -> nil
+  #   each_line(...) -> new_enumerator
   #
   # With a block given, calls the block with each line
   # from the file represented by `self`;
@@ -1050,9 +1050,9 @@ class Pathname    # * File *
   # :markup: markdown
   #
   # call-seq:
-  #   readlines(sep = $/, **options) → array
-  #   readlines(limit, **options) → array
-  #   readlines(sep, limit, **options) → array
+  #   readlines(sep = $/, **options) -> array
+  #   readlines(limit, **options) -> array
+  #   readlines(sep, limit, **options) -> array
   #
   # Returns an array of all lines read from the source at the path in `self`,
   # which must be the path to a file.
@@ -2030,8 +2030,8 @@ end
 
 class Pathname
   # call-seq:
-  #   glob(patterns, base: '.', flags: 0, sort: true) → array_of_pathnames
-  #   glob(patterns, base: '.', flags: 0, sort: true) {|pathname| ... } → nil
+  #   glob(patterns, base: '.', flags: 0, sort: true) -> array_of_pathnames
+  #   glob(patterns, base: '.', flags: 0, sort: true) {|pathname| ... } -> nil
   #
   # Selects filesystem entries
   # based on the given keyword arguments +base+, +flags+, and +sort+;

--- a/pathname_builtin.rb
+++ b/pathname_builtin.rb
@@ -1047,7 +1047,60 @@ class Pathname    # * File *
   #
   def binread(...) File.binread(@path, ...) end
 
-  # See <tt>File.readlines</tt>.  Returns all the lines from the file.
+  # :markup: markdown
+  #
+  # call-seq:
+  #   readlines(sep = $/, **options) → array
+  #   readlines(limit, **options) → array
+  #   readlines(sep, limit, **options) → array
+  #
+  # Returns an array of all lines read from the source at the path in `self`,
+  # which must be the path to a file.
+  #
+  # Examples here use a file defined
+  # at [IO Example Files](rdoc-ref:IO@Example+Files).
+  #
+  # With no arguments given, parses lines from the file at the given path,
+  # as determined by the default line separator, and returns those lines in an array:
+  #
+  # ```ruby
+  # pn = Pathname('t.txt')
+  # ppn.readlines
+  # # => ["First line\n", "Second line\n", "\n", "Fourth line\n", "Fifth line\n"]
+  # ```
+  #
+  # With argument `sep` given,
+  # parses lines as determined by that line separator
+  # (see [IO Line Separator](rdoc-ref:IO@Line+Separator)):
+  #
+  # ```ruby
+  # pn.readlines('li')
+  # # => ["First li", "ne\nSecond li", "ne\n\nFourth li", "ne\nFifth li", "ne\n"]
+  # pn.readlines('')  # Special "paragraphs" separator value.
+  # # => ["First line\nSecond line\n\n", "Fourth line\nFifth line\n"]
+  # pn.readlines(nil) # Special "slurp" separator value.
+  # # => ["First line\nSecond line\n\nFourth line\nFifth line\n"]
+  # ```
+  #
+  # With argument `limit` given, parses lines as determined by the default line separator
+  # and the given line-length `limit`
+  # (see [IO Line Separator](rdoc-ref:IO@Line+Separator)
+  # and [IO Line Limit](rdoc-ref:IO@Line+Limit)):
+  #
+  # ```ruby
+  # pn.readlines(7)
+  # # => ["First l", "ine\n", "Second ", "line\n", "\n", "Fourth ", "line\n", "Fifth l", "ine\n"]
+  # ```
+  #
+  # With arguments `sep` and `limit` given, combines the two behaviors
+  # (see [IO Line Separator and Line Limit](rdoc-ref:IO@Line+Separator+and+Line+Limit)).
+  #
+  # Optional keyword arguments `options` specify:
+  #
+  # - {IO Open Options}[rdoc-ref:IO@Open+Options].
+  # - {Encoding options}[rdoc-ref:encodings.rdoc@Encoding+Options].
+  # - {IO Line Input Options}[rdoc-ref:IO@Line+Input+Options].
+  #
   def readlines(...) File.readlines(@path, ...) end
 
   # See <tt>File.sysopen</tt>.


### PR DESCRIPTION
Also creates section "Line Input Options" in the `IO` class documentation;  that documentation referred to the section, but didn't actually have it (linking instead to a more general section).