### PR TITLE
ZJIT: gen_new_hash for nonempty hashes with symbol keys

### DIFF
--- a/jit.c
+++ b/jit.c
@@ -41,6 +41,9 @@ enum jit_bindgen_constants {
     // Field offset for the RHash struct
     RUBY_OFFSET_RHASH_IFNONE = offsetof(struct RHash, ifnone),
 
+    // Max pairs an embedded ar_table hash holds before it converts to an st_table
+    RUBY_RHASH_AR_TABLE_MAX_SIZE = RHASH_AR_TABLE_MAX_SIZE,
+
     // Field offsets for the RString struct
     RUBY_OFFSET_RSTRING_LEN = offsetof(struct RString, len),
 

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -989,6 +989,7 @@ pub const ROBJECT_OFFSET_AS_ARY: jit_bindgen_constants = 16;
 pub const RCLASS_OFFSET_PRIME_FIELDS_OBJ: jit_bindgen_constants = 40;
 pub const TDATA_OFFSET_FIELDS_OBJ: jit_bindgen_constants = 16;
 pub const RUBY_OFFSET_RHASH_IFNONE: jit_bindgen_constants = 16;
+pub const RUBY_RHASH_AR_TABLE_MAX_SIZE: jit_bindgen_constants = 8;
 pub const RUBY_OFFSET_RSTRING_LEN: jit_bindgen_constants = 16;
 pub const RB_SHAPE_FLAG_SHIFT: jit_bindgen_constants = 32;
 pub const RUBY_OFFSET_EC_CFP: jit_bindgen_constants = 16;

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -615,7 +615,10 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
         }
         Insn::Const { .. } => panic!("Unexpected Const in gen_insn: {insn}"),
         Insn::NewArray { elements, state } => gen_new_array(jit, asm, opnds!(elements), &function.frame_state(*state)),
-        Insn::NewHash { elements, state } => gen_new_hash(jit, asm, function, opnds!(elements), &function.frame_state(*state)),
+        Insn::NewHash { elements, state } => {
+            let sym_keys = elements.iter().step_by(2).all(|&key| function.type_of(key).is_subtype(types::Symbol));
+            gen_new_hash(jit, asm, function, opnds!(elements), sym_keys, &function.frame_state(*state))
+        }
         Insn::NewRange { low, high, flag, state } => gen_new_range(jit, asm, function, opnd!(low), opnd!(high), *flag, &function.frame_state(*state)),
         Insn::NewRangeFixnum { low, high, flag, state } => gen_new_range_fixnum(asm, opnd!(low), opnd!(high), *flag, &function.frame_state(*state)),
         Insn::ArrayDup { val, state } => gen_array_dup(asm, opnd!(val), &function.frame_state(*state)),
@@ -2285,6 +2288,7 @@ fn gen_new_hash(
     asm: &mut Assembler,
     function: &Function,
     elements: Vec<Opnd>,
+    sym_keys: bool,
     state: &FrameState,
 ) -> lir::Opnd {
     if elements.is_empty() {
@@ -2301,6 +2305,33 @@ fn gen_new_hash(
         // ifnone. A fast-path-only init hook in gc_fast_path_new_obj would avoid
         // the redundant store and be reusable for other types.
         asm.store(Opnd::mem(VALUE_BITS, hash, RUBY_OFFSET_RHASH_IFNONE), Qnil.into());
+        hash
+    // TODO: we should use effects_of for this (we would need to add it).
+    } else if sym_keys {
+        // Symbols hash and compare without running Ruby and those operations never raise so
+        // the bulk insert is leaf.
+        gen_prepare_leaf_call_with_gc(asm, state);
+
+        let num_pairs = elements.len() / 2;
+        let hash = if num_pairs <= RUBY_RHASH_AR_TABLE_MAX_SIZE as usize {
+            let alloc_size = unsafe { rb_zjit_hash_new_size() };
+            let flags = RUBY_T_HASH as u64;
+            let klass = unsafe { rb_cHash };
+
+            let hash = gc_fastpath::gc_fast_path_new_obj(jit, asm, alloc_size, flags, klass, |asm| {
+                asm_ccall!(asm, rb_hash_new_with_size, num_pairs.into())
+            });
+            // TODO: this runs on the slow path too, where rb_hash_new already set
+            // ifnone. A fast-path-only init hook in gc_fast_path_new_obj would avoid
+            // the redundant store and be reusable for other types.
+            asm.store(Opnd::mem(VALUE_BITS, hash, RUBY_OFFSET_RHASH_IFNONE), Qnil.into());
+            hash
+        } else {
+            asm_ccall!(asm, rb_hash_new_with_size, num_pairs.into())
+        };
+
+        let argv = gen_push_opnds(jit, asm, &elements);
+        asm_ccall!(asm, rb_hash_bulk_insert, elements.len().into(), argv, hash);
         hash
     } else {
         gen_prepare_non_leaf_call(jit, asm, function, state);

--- a/zjit/src/codegen_tests.rs
+++ b/zjit/src/codegen_tests.rs
@@ -2920,6 +2920,70 @@ fn test_new_hash_empty_gc_stress() {
     "#), @"[Hash, 1, nil, {a: 1}]");
 }
 
+// Static-symbol keys hash and compare without running Ruby, so NewHash takes the
+// leaf bulk-insert fast path into an inline-allocated ar_table. Runs under GC
+// stress to guard the leaf-call preparation.
+#[test]
+fn test_new_hash_static_sym_keys_gc_stress() {
+    eval("
+        def make(a, b) = {x: a, y: b}
+    ");
+    assert_contains_opcode("make", YARVINSN_newhash);
+    assert_snapshot!(assert_compiles(r#"
+        begin
+          GC.stress = true
+          make(1, 2)
+          h = make(:foo, [3])
+          [h.class, h.size, h[:x], h[:y], h[:z], h.default, h]
+        ensure
+          GC.stress = false
+        end
+    "#), @"[Hash, 2, :foo, [3], nil, nil, {x: :foo, y: [3]}]");
+}
+
+// Eight pairs fills an inline embedded ar_table (the fast path); nine crosses
+// RHASH_AR_TABLE_MAX_SIZE, so it's built as a pre-sized st_table instead. Both stay
+// on the static-symbol leaf path, so this guards the ar_table and st_table routes.
+#[test]
+fn test_new_hash_static_sym_ar_table_boundary() {
+    eval("
+        def eight(v) = {a:v,b:v,c:v,d:v,e:v,f:v,g:v,h:v}
+        def nine(v)  = {a:v,b:v,c:v,d:v,e:v,f:v,g:v,h:v,i:v}
+    ");
+    assert_contains_opcode("eight", YARVINSN_newhash);
+    assert_contains_opcode("nine", YARVINSN_newhash);
+    assert_snapshot!(assert_compiles(r#"
+        begin
+          GC.stress = true
+          [eight(7).size, eight(7)[:h], nine([9]).size, nine([9])[:i]]
+        ensure
+          GC.stress = false
+        end
+    "#), @"[8, 7, 9, [9]]");
+}
+
+// Dynamic symbol keys hash and compare without running Ruby, so NewHash takes the
+// leaf bulk-insert fast path into an inline-allocated ar_table. Runs under GC
+// stress to guard the leaf-call preparation.
+#[test]
+fn test_new_hash_dynamic_sym_keys_gc_stress() {
+    eval(r#"
+        def make(k, v) = { :"x_#{k}" => v, :"y_#{k}" => v }
+    "#);
+    assert_contains_opcode("make", YARVINSN_newhash);
+    assert_contains_opcode("make", YARVINSN_intern);
+    assert_snapshot!(assert_compiles(r#"
+        begin
+          GC.stress = true
+          make("warm", 0)
+          h = make("k", [3])
+          [h.class, h.size, h[:"x_k"], h[:"y_k"]]
+        ensure
+          GC.stress = false
+        end
+    "#), @r#"[Hash, 2, [3], [3]]"#);
+}
+
 #[test]
 fn test_new_hash_nonempty() {
     eval(r#"

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -1958,6 +1958,7 @@ pub const ROBJECT_OFFSET_AS_ARY: jit_bindgen_constants = 16;
 pub const RCLASS_OFFSET_PRIME_FIELDS_OBJ: jit_bindgen_constants = 40;
 pub const TDATA_OFFSET_FIELDS_OBJ: jit_bindgen_constants = 16;
 pub const RUBY_OFFSET_RHASH_IFNONE: jit_bindgen_constants = 16;
+pub const RUBY_RHASH_AR_TABLE_MAX_SIZE: jit_bindgen_constants = 8;
 pub const RUBY_OFFSET_RSTRING_LEN: jit_bindgen_constants = 16;
 pub const RB_SHAPE_FLAG_SHIFT: jit_bindgen_constants = 32;
 pub const RUBY_OFFSET_EC_CFP: jit_bindgen_constants = 16;


### PR DESCRIPTION
When ZJIT can prove that we'll always receive static symbols as keys for NewHash, we can spill less because `rb_hash_bulk_insert` is now leaf (cmp and hash are leaf).

```
HashNew with static symbol keys (unit: millions of IPS)
┌───────────────────┬────────┬───────┬───────┬──────────────────────┐
│        op         │ before │ after │ raw Δ │ control-normalized Δ │
├───────────────────┼────────┼───────┼───────┼──────────────────────┤
│ hash 2 (ar_table) │ 27.95  │ 29.96 │ +7.2% │ +10.3%               │
├───────────────────┼────────┼───────┼───────┼──────────────────────┤
│ hash 6 (ar_table) │ 15.64  │ 16.84 │ +7.7% │ +10.9%               │
├───────────────────┼────────┼───────┼───────┼──────────────────────┤
│ hash 9 (st_table) │ 7.15   │ 7.25  │ +1.5% │ +4.5%                │
├───────────────────┼────────┼───────┼───────┼──────────────────────┤
│ array 4 (control) │ 33.90  │ 32.93 │ −2.9% │ — (reference)        │
└───────────────────┴────────┴───────┴───────┴──────────────────────┘
```