### PR TITLE
Optimize Symbol#empty? with an interned empty symbol

### DIFF
--- a/symbol.rb
+++ b/symbol.rb
@@ -34,7 +34,7 @@ class Symbol
   # Returns +true+ if +self+ is <tt>:''</tt>, +false+ otherwise.
   def empty?
     Primitive.attr! :leaf
-    Primitive.cexpr! 'RBOOL(RSTRING_LEN(rb_sym2str(self)) == 0)'
+    Primitive.cexpr! 'RBOOL(self == STATIC_ID2SYM(idNULL))'
   end
 
   # call-seq:


### PR DESCRIPTION
Compare self against STATIC_ID2SYM(idNULL), the constant symbol for :"", instead of calling rb_sym2str and checking RSTRING_LEN. 

The idea for this is from @XrXr on https://github.com/ruby/ruby/pull/17464. 

## Benchmark

`benchmark/symbol_empty.yml`, identity vs master (5 runs each), same base commit built with identical config.

**M1 Pro (arm64-darwin):**

| bench | master | identity | result |
|---|---|---|---|
| `symbol_empty-0` (`:"".empty?`) | 74.0M i/s | 93.4M i/s | **1.26x faster** |
| `symbol_empty-8` (`:abcdefgh.empty?`) | 73.1M i/s | 94.5M i/s | **1.29x faster** |

**Apple container (aarch64-linux):**

| bench | master | identity | result |
|---|---|---|---|
| `symbol_empty-0` (`:"".empty?`) | 86.3M i/s | 96.7M i/s | **1.12x faster** |
| `symbol_empty-8` (`:abcdefgh.empty?`) | 86.6M i/s | 97.3M i/s | **1.12x faster** |