### PR TITLE
Fix unused variable warning in thread_sched_set_running on non-DTrace platforms

### DIFF
--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -709,8 +709,7 @@ thread_sched_set_running(struct rb_thread_sched *sched, rb_thread_t *th)
     VM_ASSERT(sched->running != th);
 
     if (RUBY_DTRACE_RTS_SET_RUNNING_ENABLED()) {
-        rb_thread_t *old = sched->running;
-        RUBY_DTRACE_RTS_SET_RUNNING(sched, old, th);
+        RUBY_DTRACE_RTS_SET_RUNNING(sched, sched->running, th);
     }
 
     sched->running = th;


### PR DESCRIPTION
On platforms without DTrace (e.g. riscv64), `gen_dummy_probes.rb` generates stub macros where `RUBY_DTRACE_RTS_SET_RUNNING_ENABLED()` expands to `0` and `RUBY_DTRACE_RTS_SET_RUNNING(...)` expands to `do {} while (0)`. This left the temporary `old` variable inside a dead `if (0)` block, producing a `-Wunused-variable` warning.

## Changes

- Remove the `rb_thread_t *old` temporary variable; pass `sched->running` directly to the probe macro (it is still the old value at that point, before `sched->running = th`)
- Restore the `if (RUBY_DTRACE_RTS_SET_RUNNING_ENABLED())` guard to preserve the original intent of skipping the probe call when DTrace is inactive

```c
// Before
if (RUBY_DTRACE_RTS_SET_RUNNING_ENABLED()) {
    rb_thread_t *old = sched->running;  // unused on non-DTrace builds
    RUBY_DTRACE_RTS_SET_RUNNING(sched, old, th);
}
sched->running = th;

// After
if (RUBY_DTRACE_RTS_SET_RUNNING_ENABLED()) {
    RUBY_DTRACE_RTS_SET_RUNNING(sched, sched->running, th);
}
sched->running = th;
```