### PR TITLE
ZJIT: Fix CFP publication for direct calls

### DIFF
--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -3378,7 +3378,7 @@ c_callable! {
             unsafe { rb_set_cfp_pc(cfp, pc) };
             unsafe { (*cfp)._iseq = iseq };
             unsafe { (*cfp).jit_return = std::ptr::null_mut() };
-            let ec_cfp = unsafe { (ec as *mut u8).add(RUBY_OFFSET_EC_CFP as usize) as *mut CfpPtr };
+            let ec_cfp = unsafe { ec.byte_add(RUBY_OFFSET_EC_CFP as usize) as *mut CfpPtr };
             unsafe { *ec_cfp = cfp };
         }
 

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -1758,7 +1758,6 @@ fn gen_send_iseq_direct(
     asm_comment!(asm, "switch to new CFP");
     let new_cfp = asm.sub(CFP, RUBY_SIZEOF_CONTROL_FRAME.into());
     asm.mov(CFP, new_cfp);
-    asm.store(Opnd::mem(64, EC, RUBY_OFFSET_EC_CFP), CFP);
 
     let params = unsafe { iseq.params() };
 
@@ -2391,6 +2390,11 @@ fn gen_entry_point(jit: &mut JITState, asm: &mut Assembler, jit_entry_idx: Optio
     let jit_frame = JITFrame::new_iseq(entry_pc(jit.iseq(), jit_entry_idx), jit.iseq(), 0);
     asm.mov(Opnd::mem(64, NATIVE_BASE_PTR, -SIZEOF_VALUE_I32), Opnd::const_ptr(jit_frame));
     asm.mov(Opnd::mem(64, CFP, RUBY_OFFSET_CFP_JIT_RETURN), NATIVE_BASE_PTR);
+
+    // Direct JIT-to-JIT callers switch the CFP register before calling this entry
+    // point, but they leave ec->cfp pointing at the caller until cfp->jit_return
+    // is valid so signal-based frame walkers never observe a half-published callee.
+    asm.mov(Opnd::mem(64, EC, RUBY_OFFSET_EC_CFP), CFP);
 }
 
 /// Compile code that exits from JIT code with a return value
@@ -3374,6 +3378,8 @@ c_callable! {
             unsafe { rb_set_cfp_pc(cfp, pc) };
             unsafe { (*cfp)._iseq = iseq };
             unsafe { (*cfp).jit_return = std::ptr::null_mut() };
+            let ec_cfp = unsafe { (ec as *mut u8).add(RUBY_OFFSET_EC_CFP as usize) as *mut CfpPtr };
+            unsafe { *ec_cfp = cfp };
         }
 
         with_vm_lock(src_loc!(), || {

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -1757,7 +1757,7 @@ fn gen_send_iseq_direct(
 
     asm_comment!(asm, "switch to new CFP");
     let new_cfp = asm.sub(CFP, RUBY_SIZEOF_CONTROL_FRAME.into());
-    asm.mov(CFP, new_cfp);
+    asm.mov(CFP, new_cfp); // will be published at `ec->cfp` after callee's entrypoint
 
     let params = unsafe { iseq.params() };
 

--- a/zjit/src/codegen_tests.rs
+++ b/zjit/src/codegen_tests.rs
@@ -4729,6 +4729,46 @@ fn test_profile_frames_from_signal_handler() {
     assert!(profiler.samples() > 0, "rb_profile_frames was not called from SIGPROF handler");
 }
 
+// A direct JIT-to-JIT call switches the CFP register before entering the callee.
+// Signal profilers must not observe the callee through ec->cfp until the callee's
+// cfp->jit_return points at a valid JITFrame.
+#[cfg(all(
+    any(target_os = "linux", target_os = "macos"),
+    any(target_arch = "x86_64", target_arch = "aarch64"),
+))]
+#[test]
+fn test_profile_frames_during_direct_jit_to_jit_entry() {
+    with_inlining_threshold(0, || {
+        eval(r#"
+            def profiled_direct_callee(value)
+              value + 1
+            end
+
+            def profiled_direct_loop(n)
+              i = 0
+              value = 0
+              while i < n
+                value = profiled_direct_callee(value)
+                i += 1
+              end
+              value
+            end
+
+            # Compile both methods and patch the caller's SendDirect site before
+            # arming the sampler.
+            profiled_direct_callee(0)
+            profiled_direct_callee(0)
+            profiled_direct_loop(1)
+            profiled_direct_loop(1)
+            profiled_direct_loop(1)
+        "#);
+
+        let profiler = signal_profiler::Profiler::start(10);
+        assert_snapshot!(assert_compiles("profiled_direct_loop(1_000_000)"), @"1000000");
+        assert!(profiler.samples() > 0, "rb_profile_frames was not called from SIGPROF handler");
+    });
+}
+
 #[test]
 fn test_profile_under_nested_jit_call() {
     assert_snapshot!(inspect("


### PR DESCRIPTION
Publish ec->cfp for direct JIT-to-JIT calls only after the callee entry point has installed a valid JITFrame. This keeps signal-based profilers from observing a half-published callee frame.

Update the cold function-stub path to publish ec->cfp after preparing fallback-safe frame metadata, and cover the race with a SIGPROF rb_profile_frames regression test.