### PR TITLE
[Backport #22183] parse.y interpolation inside lambda literal

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -6115,6 +6115,10 @@ string_content	: tSTRING_CONTENT
                         p->lex.brace_nest = 0;
                     }[brace]<num>
                     {
+                        $$ = p->lex.lpar_beg;
+                        p->lex.lpar_beg = -1;
+                    }[lpar]<num>
+                    {
                         $$ = p->heredoc_indent;
                         p->heredoc_indent = 0;
                     }[indent]<num>
@@ -6125,6 +6129,7 @@ string_content	: tSTRING_CONTENT
                         p->lex.strterm = $term;
                         SET_LEX_STATE($state);
                         p->lex.brace_nest = $brace;
+                        p->lex.lpar_beg = $lpar;
                         p->heredoc_indent = $indent;
                         p->heredoc_line_indent = -1;
                         if ($compstmt) nd_unset_fl_newline($compstmt);

--- a/test/ruby/test_parse.rb
+++ b/test/ruby/test_parse.rb
@@ -323,6 +323,12 @@ class TestParse < Test::Unit::TestCase
     end
     a.call
     assert_equal(42, b)
+
+    obj = BasicObject.new
+    assert_nothing_raised do
+      a = obj.instance_eval('-> a = "#{foo do end}" do end', __FILE__, __LINE__)
+    end
+    assert_raise_with_message(NoMethodError, /foo/) {a.call}
   end
 
   def test_block_call_colon2


### PR DESCRIPTION
Backport of https://bugs.ruby-lang.org/issues/22183 to ruby_4_0.

Cherry-picked from commit 3f7d4bc859f03f4c7ea131af910d1c4ae142586d.