### PR TITLE
ZJIT: Refine inline budget estimates

### DIFF
--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -2712,6 +2712,7 @@ pub struct Function {
     profiles: Option<ProfileOracle>,
     /// Rough estimate for the number of (actually executable) instructions in the function. Does
     /// not count Snapshot, PatchPoint, etc.
+    /// Currently updated by `infer_types` as a heuristic but that is not a guarantee.
     num_instructions: usize,
 }
 

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -2710,6 +2710,9 @@ pub struct Function {
     /// fulfilling `(0..=opt_num)` optional parameters.
     jit_entry_blocks: Vec<BlockId>,
     profiles: Option<ProfileOracle>,
+    /// Rough estimate for the number of (actually executable) instructions in the function. Does
+    /// not count Snapshot, PatchPoint, etc.
+    num_instructions: usize,
 }
 
 /// The kind of a value an ISEQ returns
@@ -2842,6 +2845,7 @@ impl Function {
             jit_entry_blocks: vec![],
             param_types: vec![],
             profiles: None,
+            num_instructions: 0,
         }
     }
 
@@ -3386,6 +3390,7 @@ impl Function {
         let rpo = self.reverse_post_order();
         loop {
             let mut changed = false;
+            let mut num_instructions = 0;
             for &block in &rpo {
                 if !reachable.get(block) { continue; }
                 for i in 0..self.blocks[block.0].insns.len() {
@@ -3394,6 +3399,7 @@ impl Function {
                     // of make_equal_to, so we don't need find() here.
                     let insn_type = match &self.insns[insn_id.0] {
                         Insn::CondBranch { val, if_true, if_false } => {
+                            num_instructions += 1;
                             assert!(!self.type_of(*val).bit_equal(types::Empty));
                             if self.type_of(*val).could_be(Type::from_cbool(true)) {
                                 reachable.insert(if_true.target);
@@ -3417,6 +3423,7 @@ impl Function {
                             continue;
                         }
                         &Insn::Jump(BranchEdge { target, ref args }) => {
+                            num_instructions += 1;
                             reachable.insert(target);
                             let arg_types: Vec<Type> = args.iter().map(|a| self.type_of(*a)).collect();
                             for (idx, arg_type) in arg_types.into_iter().enumerate() {
@@ -3432,12 +3439,23 @@ impl Function {
                             continue;
                         }
                         insn if insn.has_output() => self.infer_type(insn_id),
-                        _ => continue,
+                        Insn::Comment { .. }
+                        | Insn::IncrCounter { .. }
+                        | Insn::IncrCounterPtr { .. }
+                        | Insn::Snapshot { .. }
+                        | Insn::PatchPoint { .. }
+                        // Don't count metadata-only instructions.
+                        => continue,
+                        _ => {
+                            num_instructions += 1;
+                            continue
+                        }
                     };
                     changed |= set_type!(insn_id, insn_type);
                 }
             }
             if !changed {
+                self.num_instructions = num_instructions;
                 break;
             }
         }
@@ -4982,14 +5000,11 @@ impl Function {
             return false;
         }
 
-        // Per-caller cumulative budget. self.insns is append-only (InsnIds are stable
-        // indices), so its len() is a high-water mark of total HIR instructions ever
-        // allocated for this function — not the final compiled size. Once that count
-        // crosses the budget, every further callee is rejected and the optimization
-        // fixed-point loop reaches its terminal iteration. See `Options::inline_budget`
-        // for the full unit/semantics caveat.
+        // Per-caller cumulative budget. Once that count crosses the budget, every further callee
+        // is rejected and the optimization fixed-point loop reaches its terminal iteration. See
+        // `Options::inline_budget` for the full unit/semantics caveat.
         let budget = get_option!(inline_budget);
-        if budget != INLINE_BUDGET_UNLIMITED && self.insns.len() > budget {
+        if budget != INLINE_BUDGET_UNLIMITED && self.num_instructions > budget {
             incr_counter!(inline_reject_budget_exceeded);
             return false;
         }
@@ -5163,6 +5178,9 @@ impl Function {
                         continue;
                     }
                 };
+
+                // Bump the rough estimate of new instructions added by inlining this function
+                self.num_instructions += self.insns.len() - pre_insns_len;
 
                 // Past the point of no return: commit the inlining.
                 incr_counter!(inline_method_count);

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -1868,6 +1868,19 @@ impl Insn {
 
         abstract_heaps::Allocator.includes(self.effects_of().write_bits())
     }
+
+    fn counts_against_inlining_budget(&self) -> bool {
+        match self {
+            // Don't count metadata-only instructions.
+            Insn::Comment { .. }
+            | Insn::IncrCounter { .. }
+            | Insn::IncrCounterPtr { .. }
+            | Insn::Snapshot { .. }
+            | Insn::PatchPoint { .. }
+            => false,
+            _ => true,
+        }
+    }
 }
 
 /// Print adaptor for [`Insn`]. See [`PtrPrintMap`].
@@ -3396,11 +3409,13 @@ impl Function {
                 if !reachable.get(block) { continue; }
                 for i in 0..self.blocks[block.0].insns.len() {
                     let insn_id = self.blocks[block.0].insns[i];
+                    if self.insns[insn_id.0].counts_against_inlining_budget() {
+                        num_instructions += 1;
+                    }
                     // Instructions without output, including branch instructions, can't be targets
                     // of make_equal_to, so we don't need find() here.
                     let insn_type = match &self.insns[insn_id.0] {
                         Insn::CondBranch { val, if_true, if_false } => {
-                            num_instructions += 1;
                             assert!(!self.type_of(*val).bit_equal(types::Empty));
                             if self.type_of(*val).could_be(Type::from_cbool(true)) {
                                 reachable.insert(if_true.target);
@@ -3424,7 +3439,6 @@ impl Function {
                             continue;
                         }
                         &Insn::Jump(BranchEdge { target, ref args }) => {
-                            num_instructions += 1;
                             reachable.insert(target);
                             let arg_types: Vec<Type> = args.iter().map(|a| self.type_of(*a)).collect();
                             for (idx, arg_type) in arg_types.into_iter().enumerate() {
@@ -3440,17 +3454,7 @@ impl Function {
                             continue;
                         }
                         insn if insn.has_output() => self.infer_type(insn_id),
-                        Insn::Comment { .. }
-                        | Insn::IncrCounter { .. }
-                        | Insn::IncrCounterPtr { .. }
-                        | Insn::Snapshot { .. }
-                        | Insn::PatchPoint { .. }
-                        // Don't count metadata-only instructions.
-                        => continue,
-                        _ => {
-                            num_instructions += 1;
-                            continue
-                        }
+                        _ => continue,
                     };
                     changed |= set_type!(insn_id, insn_type);
                 }

--- a/zjit/src/options.rs
+++ b/zjit/src/options.rs
@@ -149,27 +149,16 @@ pub struct Options {
     pub inline_threshold: InlineThreshold,
 
     /// Per-caller cumulative size budget for inlining, measured as the caller
-    /// `Function`'s `insns.len()` at the moment `should_inline` is consulted (during
+    /// `Function::num_instructions` at the moment `should_inline` is consulted (during
     /// `inline_methods` inside the `optimize()` fixed-point loop). Once a caller has
     /// grown past this many HIR instructions, `should_inline` rejects further callees,
     /// bounding runaway code-size growth from depth-N inlining (and providing the
     /// optimization fixed-point loop's effective terminating condition).
     /// `INLINE_BUDGET_UNLIMITED` disables the budget.
     ///
-    /// Caveat on the unit: `self.insns` is append-only across the whole pipeline —
-    /// `InsnId`s are stable indices into it, so passes never shrink it. `len()` is
-    /// therefore a high-water mark of total HIR instructions ever allocated for the
-    /// function, including ones that later optimization passes mark dead via
-    /// `eliminate_dead_code` or alias away via `union_find`. By the time
-    /// `should_inline` runs in a given fixed-point iteration, `self.insns.len()` has
-    /// already been bumped by `iseq_to_hir`'s initial build, then by `type_specialize`
-    /// and the trivial `inline` pass, and (in iterations 2+) by every prior pass in
-    /// the loop including the previous round's `inline_methods`. It is a useful proxy
-    /// for "compile work done" but not for "size of the compiled output".
-    ///
     /// Note: this is a different unit than `inline_threshold` — that field is callee
-    /// YARV bytecode words; this one is caller HIR instructions, allocation high-water
-    /// mark. They aren't directly comparable; YARV → HIR typically expands roughly 1-3x.
+    /// YARV bytecode words; this one is caller HIR instructions. They aren't directly comparable;
+    /// YARV → HIR typically expands roughly 1-3x.
     pub inline_budget: InlineBudget,
 
     /// Set of qualified method names (e.g. `Class#method`, `Module::Class.method`) that


### PR DESCRIPTION
The first version of the inliner used the "high water mark" of HIR
instructions ever allocated. This PR estimates the number of live
instructions that we care about in `infer_types`. When inlining, it
also bumps the estimate by the delta of new HIR instructions from
inlining the callee.

`infer_types` is somewhat arbitrarily chosen because it runs
frequently between other passes and I don't want a whole other
pass.

Result: slightly different inlining behavior. On Lobste.rs, we go from
~5400 inlining rejected due to budget down to ~3900.