### PR TITLE
Remove obj_free_object_id

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -2159,16 +2159,10 @@ object_id(VALUE obj)
     return object_id0(obj);
 }
 
-static inline void
-obj_free_object_id(VALUE obj)
-{
-}
-
 void
 rb_gc_obj_free_vm_weak_references(VALUE obj)
 {
     ASSUME(!RB_SPECIAL_CONST_P(obj));
-    obj_free_object_id(obj);
 
     if (rb_obj_gen_fields_p(obj)) {
         rb_free_generic_ivar(obj);


### PR DESCRIPTION
This empty function is no longer needed now that _id2ref is gone.