### PR TITLE
ZJIT: Port tests to the rust harness and rename to test_zjit_cli.rb

### DIFF
--- a/.github/workflows/zjit-macos.yml
+++ b/.github/workflows/zjit-macos.yml
@@ -47,7 +47,7 @@ jobs:
             specopts: '-T --zjit-disable-hir-opt -T --zjit-call-threshold=1'
             configure: '--enable-zjit=dev'
 
-          - test_task: 'zjit-check' # zjit-test + quick feedback of test_zjit.rb
+          - test_task: 'zjit-check' # zjit-test + quick feedback of test_zjit_cli.rb
             configure: '--enable-yjit=dev --enable-zjit'
             rust_version: "1.85.0"
 

--- a/.github/workflows/zjit-ubuntu.yml
+++ b/.github/workflows/zjit-ubuntu.yml
@@ -95,7 +95,7 @@ jobs:
             configure: '--enable-zjit=dev'
             run_opts: '--zjit-inline-threshold=0 --zjit-call-threshold=1'
 
-          - test_task: 'zjit-check' # zjit-test + quick feedback of test_zjit.rb
+          - test_task: 'zjit-check' # zjit-test + quick feedback of test_zjit_cli.rb
             configure: '--enable-yjit --enable-zjit=dev'
             rust_version: '1.85.0'
 

--- a/doc/jit/zjit.md
+++ b/doc/jit/zjit.md
@@ -287,27 +287,27 @@ cd zjit && cargo insta review
 
 Test changes will be reviewed alongside code changes.
 
-### Running integration tests
-
-This command runs Ruby execution tests.
-
-```bash
-make test-all TESTS="test/ruby/test_zjit_cli.rb"
-```
-
-You can also run a single test case by matching the method name:
-
-```bash
-make test-all TESTS="test/ruby/test_zjit_cli.rb -n TestZJITCLI#test_enabled"
-```
-
-### Running all tests
+### Running smoke tests
 
 Runs both `make zjit-test` and `test/ruby/test_zjit_cli.rb`:
 
 ```bash
 make zjit-check
 ```
+
+### Integration testing
+
+A thorough test run will want to enable ZJIT on Ruby workloads. Some
+test suites written in Ruby in this repository accepts the `RUN_OPTS`
+Make macro for passing ruby(1) command-line arguments:
+
+```bash
+make test-all RUN_OPTS='--zjit-call-threshold=2'
+make btest RUN_OPTS='--zjit-call-threshold=1'
+```
+
+See [Testing Ruby](rdoc-ref:contributing/testing_ruby.md) for a list of
+test suites.
 
 ## Statistics Collection
 

--- a/doc/jit/zjit.md
+++ b/doc/jit/zjit.md
@@ -292,18 +292,18 @@ Test changes will be reviewed alongside code changes.
 This command runs Ruby execution tests.
 
 ```bash
-make test-all TESTS="test/ruby/test_zjit.rb"
+make test-all TESTS="test/ruby/test_zjit_cli.rb"
 ```
 
 You can also run a single test case by matching the method name:
 
 ```bash
-make test-all TESTS="test/ruby/test_zjit.rb -n TestZJIT#test_putobject"
+make test-all TESTS="test/ruby/test_zjit_cli.rb -n TestZJITCLI#test_enabled"
 ```
 
 ### Running all tests
 
-Runs both `make zjit-test` and `test/ruby/test_zjit.rb`:
+Runs both `make zjit-test` and `test/ruby/test_zjit_cli.rb`:
 
 ```bash
 make zjit-check

--- a/test/ruby/test_zjit_cli.rb
+++ b/test/ruby/test_zjit_cli.rb
@@ -1,19 +1,22 @@
 # frozen_string_literal: true
 #
 # This set of tests can be run with:
-# make test-all TESTS=test/ruby/test_zjit.rb
 #
-# Instead of adding new tests here, you should probably
-# be adding tests that run under the Rust test harness,
-# say, in `codegen_tests.rs`. It parallelizes better and
-# allows for easy inspection of VM internal states.
+#     make test/ruby/test_zjit_cli.rb
+#
+# Test ZJIT through the command-line interface. This relatively heavy-weight
+# way to test is only necessary when exercising command-line options, stats,
+# environment variables, or process-level behavior. Tests that only exercise
+# codegen should be added to the Rust test harness (`codegen_tests.rs`)
+# instead: it parallelizes better and allows for easy inspection of VM internal
+# states.
 
 require 'test/unit'
 require 'envutil'
 require_relative '../lib/jit_support'
 return unless JITSupport.zjit_supported?
 
-class TestZJIT < Test::Unit::TestCase
+class TestZJITCLI < Test::Unit::TestCase
   def test_enabled
     assert_runs 'false', <<~RUBY, zjit: false
       RubyVM::ZJIT.enabled?
@@ -192,13 +195,6 @@ class TestZJIT < Test::Unit::TestCase
     }, insns: [:opt_new], call_threshold: 2
   end
 
-  def test_uncached_getconstant_path
-    assert_compiles RUBY_COPYRIGHT.dump, %q{
-      def test = RUBY_COPYRIGHT
-      test
-    }, call_threshold: 1, insns: [:opt_getconstant_path]
-  end
-
   def test_getconstant_path_autoload
     # A constant-referencing expression can run arbitrary code through Kernel#autoload.
     Dir.mktmpdir('autoload') do |tmpdir|
@@ -211,22 +207,6 @@ class TestZJIT < Test::Unit::TestCase
         test
       }, call_threshold: 1, insns: [:opt_getconstant_path]
     end
-  end
-
-  def test_send_backtrace
-    backtrace = [
-      "-e:2:in 'Object#jit_frame1'",
-      "-e:3:in 'Object#entry'",
-      "-e:5:in 'block in <main>'",
-      "-e:6:in '<main>'",
-    ]
-    assert_compiles backtrace.inspect, %q{
-      def jit_frame2 = caller     # 1
-      def jit_frame1 = jit_frame2 # 2
-      def entry = jit_frame1      # 3
-      entry # profile send        # 4
-      entry                       # 5
-    }, call_threshold: 2
   end
 
   # tool/ruby_vm/views/*.erb relies on the zjit instructions a) being contiguous and
@@ -305,105 +285,6 @@ class TestZJIT < Test::Unit::TestCase
     }, stats: true
   end
 
-  def test_zjit_option_uses_array_each_in_ruby
-    omit 'ZJIT wrongly compiles Array#each, so it is disabled for now'
-    assert_runs '"<internal:array>"', %q{
-      Array.instance_method(:each).source_location&.first
-    }
-  end
-
-  def test_line_tracepoint_on_c_method
-    assert_compiles '"[[:line, true]]"', %q{
-      events = []
-      events.instance_variable_set(
-        :@tp,
-        TracePoint.new(:line) { |tp| events << [tp.event, tp.lineno] if tp.path == __FILE__ }
-      )
-      def events.to_str
-        @tp.enable; ''
-      end
-
-      # Stay in generated code while enabling tracing
-      def events.compiled(obj)
-        String(obj)
-        @tp.disable; __LINE__
-      end
-
-      line = events.compiled(events)
-      events[0][-1] = (events[0][-1] == line)
-
-      events.to_s # can't dump events as it's a singleton object AND it has a TracePoint instance variable, which also can't be dumped
-    }
-  end
-
-  def test_targeted_line_tracepoint_in_c_method_call
-    assert_compiles '"[true]"', %q{
-      events = []
-      events.instance_variable_set(:@tp, TracePoint.new(:line) { |tp| events << tp.lineno })
-      def events.to_str
-        @tp.enable(target: method(:compiled))
-        ''
-      end
-
-      # Stay in generated code while enabling tracing
-      def events.compiled(obj)
-        String(obj)
-        __LINE__
-      end
-
-      line = events.compiled(events)
-      events[0] = (events[0] == line)
-
-      events.to_s # can't dump events as it's a singleton object AND it has a TracePoint instance variable, which also can't be dumped
-    }
-  end
-
-  def test_regression_cfp_sp_set_correctly_before_leaf_gc_call
-    assert_compiles ':ok', %q{
-      def check(l, r)
-        return 1 unless l
-        1 + check(*l) + check(*r)
-      end
-
-      def tree(depth)
-        # This duparray is our leaf-gc target.
-        return [nil, nil] unless depth > 0
-
-        # Modify the local and pass it to the following calls.
-        depth -= 1
-        [tree(depth), tree(depth)]
-      end
-
-      def test
-        GC.stress = true
-        2.times do
-          t = tree(11)
-          check(*t)
-        end
-        :ok
-      end
-
-      test
-    }, call_threshold: 14, num_profiles: 5
-  end
-
-  def test_regression_gc_stress_with_lazy_block_code
-    assert_compiles ':ok', %q{
-      def allocate_array
-        [1, 2, 3]
-      end
-
-      begin
-        GC.stress = true
-        allocate_array
-        allocate_array
-        :ok
-      ensure
-        GC.stress = false
-      end
-    }
-  end
-
   def test_exit_tracing
     # Smoke test: --zjit-trace-exits writes a Fuchsia trace (.fxt) file to /tmp
     assert_compiles('true', <<~RUBY, extra_args: ['--zjit-trace-exits'])
@@ -421,35 +302,6 @@ class TestZJIT < Test::Unit::TestCase
       File.unlink(*fxt_files)
       result
     RUBY
-  end
-
-  def test_send_no_profiles_with_disabled_specialized_instruction
-    # Regression test: when specialized_instruction is disabled (as power_assert does),
-    # eval'd code uses `send` instead of `opt_send_without_block`, producing SendNoProfiles.
-    # The `times` call with a literal block is the SendNoProfiles send whose exit profiling
-    # triggers recompilation of `run`. After recompilation, `make`'s eval("proc { }") crashes
-    # in vm_make_env_each because the caller frame's EP[-1] (specval) has a stale value.
-    assert_runs ':ok', <<~RUBY
-      RubyVM::InstructionSequence.compile_option = { specialized_instruction: false }
-      eval <<~'INNERRUBY'
-        def make = eval("proc { }")
-        def run(n) = n.times { make }
-      INNERRUBY
-      run(6)
-      :ok
-    RUBY
-  end
-
-  def test_float_arithmetic
-    assert_compiles '4.0', 'def test = 1.5 + 2.5; test'
-    assert_compiles '6.0', 'def test = 2.0 * 3.0; test'
-    assert_compiles '1.5', 'def test = 3.5 - 2.0; test'
-    assert_compiles '2.5', 'def test = 5.0 / 2.0; test'
-    assert_compiles '4.5', 'def test = 1.5 * 3; test' # Float * Fixnum
-    assert_compiles 'true', 'def test = (Float::NAN + 1.0).nan?; test'
-    assert_compiles 'Infinity', 'def test = Float::INFINITY * 2.0; test'
-    assert_compiles '3', 'def test = 3.7.to_i; test'
-    assert_compiles '-2', 'def test = (-2.9).to_i; test'
   end
 
   private

--- a/zjit/src/codegen_tests.rs
+++ b/zjit/src/codegen_tests.rs
@@ -6865,3 +6865,170 @@ fn test_getlocal_level_zero_after_setlocal_wc_0() {
         test
     "#), @"2");
 }
+
+#[test]
+fn test_uncached_getconstant_path() {
+    set_call_threshold(1);
+    eval("
+        def test = RUBY_COPYRIGHT
+        test
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_getconstant_path);
+    // RUBY_COPYRIGHT is version-dependent, so compare against its runtime value
+    // rather than a fixed snapshot.
+    assert_eq!(assert_compiles_allowing_exits("test"), inspect("RUBY_COPYRIGHT"));
+}
+
+#[test]
+fn test_line_tracepoint_on_c_method() {
+    set_call_threshold(1);
+    eval("nil"); // boot the VM before assert_compiles_allowing_exits touches ZJITState
+    assert_snapshot!(assert_compiles_allowing_exits(r#"
+        events = []
+        events.instance_variable_set(
+          :@tp,
+          TracePoint.new(:line) { |tp| events << [tp.event, tp.lineno] if tp.path == __FILE__ }
+        )
+        def events.to_str
+          @tp.enable; ''
+        end
+
+        # Stay in generated code while enabling tracing
+        def events.compiled(obj)
+          String(obj)
+          @tp.disable; __LINE__
+        end
+
+        line = events.compiled(events)
+        events[0][-1] = (events[0][-1] == line)
+
+        events.to_s # can't dump events as it's a singleton object AND it has a TracePoint instance variable, which also can't be dumped
+    "#), @r#""[[:line, true]]""#);
+}
+
+#[test]
+fn test_targeted_line_tracepoint_in_c_method_call() {
+    set_call_threshold(1);
+    eval("nil"); // boot the VM before assert_compiles_allowing_exits touches ZJITState
+    assert_snapshot!(assert_compiles_allowing_exits(r#"
+        events = []
+        events.instance_variable_set(:@tp, TracePoint.new(:line) { |tp| events << tp.lineno })
+        def events.to_str
+          @tp.enable(target: method(:compiled))
+          ''
+        end
+
+        # Stay in generated code while enabling tracing
+        def events.compiled(obj)
+          String(obj)
+          __LINE__
+        end
+
+        line = events.compiled(events)
+        events[0] = (events[0] == line)
+
+        events.to_s # can't dump events as it's a singleton object AND it has a TracePoint instance variable, which also can't be dumped
+    "#), @r#""[true]""#);
+}
+
+#[test]
+fn test_regression_cfp_sp_set_correctly_before_leaf_gc_call() {
+    set_call_threshold(14);
+    eval("nil"); // boot the VM before assert_compiles_allowing_exits touches ZJITState
+    assert_snapshot!(assert_compiles_allowing_exits(r#"
+        def check(l, r)
+          return 1 unless l
+          1 + check(*l) + check(*r)
+        end
+
+        def tree(depth)
+          # This duparray is our leaf-gc target.
+          return [nil, nil] unless depth > 0
+
+          # Modify the local and pass it to the following calls.
+          depth -= 1
+          [tree(depth), tree(depth)]
+        end
+
+        def test
+          GC.stress = true
+          2.times do
+            t = tree(11)
+            check(*t)
+          end
+          :ok
+        end
+
+        test
+    "#), @":ok");
+}
+
+#[test]
+fn test_regression_gc_stress_with_lazy_block_code() {
+    eval("nil"); // boot the VM before assert_compiles_allowing_exits touches ZJITState
+    assert_snapshot!(assert_compiles_allowing_exits(r#"
+        def allocate_array
+          [1, 2, 3]
+        end
+
+        begin
+          GC.stress = true
+          allocate_array
+          allocate_array
+          :ok
+        ensure
+          GC.stress = false
+        end
+    "#), @":ok");
+}
+
+#[test]
+fn test_float_arithmetic() {
+    set_call_threshold(1);
+    eval("nil"); // boot the VM before assert_compiles_allowing_exits touches ZJITState
+    assert_snapshot!(assert_compiles_allowing_exits("def test = 1.5 + 2.5; test"), @"4.0");
+    assert_snapshot!(assert_compiles_allowing_exits("def test = 2.0 * 3.0; test"), @"6.0");
+    assert_snapshot!(assert_compiles_allowing_exits("def test = 3.5 - 2.0; test"), @"1.5");
+    assert_snapshot!(assert_compiles_allowing_exits("def test = 5.0 / 2.0; test"), @"2.5");
+    assert_snapshot!(assert_compiles_allowing_exits("def test = 1.5 * 3; test"), @"4.5"); // Float * Fixnum
+    assert_snapshot!(assert_compiles_allowing_exits("def test = (Float::NAN + 1.0).nan?; test"), @"true");
+    assert_snapshot!(assert_compiles_allowing_exits("def test = Float::INFINITY * 2.0; test"), @"Infinity");
+    assert_snapshot!(assert_compiles_allowing_exits("def test = 3.7.to_i; test"), @"3");
+    assert_snapshot!(assert_compiles_allowing_exits("def test = (-2.9).to_i; test"), @"-2");
+}
+
+#[test]
+fn test_send_backtrace() {
+    eval("nil"); // boot the VM before assert_compiles_allowing_exits touches ZJITState
+    assert_snapshot!(assert_compiles_allowing_exits(r#"
+        def jit_frame2 = caller     # 1
+        def jit_frame1 = jit_frame2 # 2
+        def entry = jit_frame1      # 3
+        entry # profile send        # 4
+        entry                       # 5
+    "#), @r#"["<compiled>:3:in 'Object#jit_frame1'", "<compiled>:4:in 'Object#entry'", "<compiled>:6:in '<compiled>'", "-e:in 'RubyVM::InstructionSequence#eval'"]"#);
+}
+
+// Regression test: when specialized_instruction is disabled (as power_assert does),
+// eval'd code uses `send` instead of `opt_send_without_block`, producing SendNoProfiles.
+// The `times` call with a literal block is the SendNoProfiles send whose exit profiling
+// triggers recompilation of `run`. After recompilation, `make`'s eval("proc { }") crashes
+// in vm_make_env_each because the caller frame's EP[-1] (specval) has a stale value.
+#[test]
+fn test_send_no_profiles_with_disabled_specialized_instruction() {
+    set_call_threshold(1);
+    assert_snapshot!(inspect(r#"
+        RubyVM::InstructionSequence.compile_option = { specialized_instruction: false }
+        eval <<~'INNERRUBY'
+          def make = eval("proc { }")
+          def run(n) = n.times { make }
+        INNERRUBY
+        run(6)
+        :ok
+    "#), @":ok");
+}
+
+#[test]
+fn test_array_each_is_defined_in_ruby() {
+    assert_snapshot!(inspect("Array.instance_method(:each).source_location&.first"), @r#""<internal:array>""#);
+}

--- a/zjit/zjit.mk
+++ b/zjit/zjit.mk
@@ -51,7 +51,7 @@ update-zjit-bench:
 .PHONY: zjit-check
 zjit-check:
 	$(MAKE) zjit-test
-	$(MAKE) test-all TESTS='$(top_srcdir)/test/ruby/test_zjit.rb'
+	$(MAKE) test-all TESTS='$(top_srcdir)/test/ruby/test_zjit_cli.rb'
 
 ZJIT_BINDGEN_DIFF_OPTS =
 


### PR DESCRIPTION
New and returning contributors have been tripped up by adding tests to
test_zjit.rb instead of to zjit/src/codegen_tests.rs, where new tests
of the sort should go 99.9% of the time. Let's port and rename to make
this clear.

There are still some non command line interface stuff in test_zjit_cli.rb
that are just hard to port, but that's okay. It's clearer.