### PR TITLE
[Backport #22086] Backport Marshal overflow fix

### DIFF
--- a/marshal.c
+++ b/marshal.c
@@ -1429,6 +1429,18 @@ ruby_marshal_read_long(const char **buf, long len)
     return x;
 }
 
+static long
+r_keep_readable(struct load_arg *arg, long len, size_t size)
+{
+    if (UNLIKELY(len < 0)) {
+        rb_raise(rb_eArgError, "negative length");
+    }
+    if (UNLIKELY((unsigned long)len > SIZE_MAX / size || arg->readable >= LONG_MAX - len)) {
+        rb_raise(rb_eArgError, "marshaled data too big");
+    }
+    return len;
+}
+
 static VALUE
 r_bytes1(long len, struct load_arg *arg)
 {
@@ -2009,7 +2021,7 @@ r_object_for(struct load_arg *arg, bool partial, int *ivp, VALUE extmod, int typ
             int sign;
 
             sign = r_byte(arg);
-            len = r_long(arg);
+            len = r_keep_readable(arg, r_long(arg), 2);
 
             if (SIZEOF_VALUE >= 8 && len <= 4) {
                 // Representable within uintptr, likely FIXNUM
@@ -2084,7 +2096,7 @@ r_object_for(struct load_arg *arg, bool partial, int *ivp, VALUE extmod, int typ
 
       case TYPE_ARRAY:
         {
-            long len = r_long(arg);
+            long len = r_keep_readable(arg, r_long(arg), 1);
 
             v = rb_ary_new2(len);
             v = r_entry(v, arg);
@@ -2102,7 +2114,7 @@ r_object_for(struct load_arg *arg, bool partial, int *ivp, VALUE extmod, int typ
       case TYPE_HASH_DEF:
       type_hash:
         {
-            long len = r_long(arg);
+            long len = r_keep_readable(arg, r_long(arg), 2);
 
             v = hash_new_with_size(len);
             v = r_entry(v, arg);
@@ -2128,7 +2140,7 @@ r_object_for(struct load_arg *arg, bool partial, int *ivp, VALUE extmod, int typ
             VALUE slot;
             st_index_t idx = r_prepare(arg);
             VALUE klass = path2class(r_unique(arg));
-            long len = r_long(arg);
+            long len = r_keep_readable(arg, r_long(arg), 2);
 
             v = rb_obj_alloc(klass);
             if (!RB_TYPE_P(v, T_STRUCT)) {

--- a/marshal.c
+++ b/marshal.c
@@ -2021,6 +2021,9 @@ r_object_for(struct load_arg *arg, bool partial, int *ivp, VALUE extmod, int typ
             int sign;
 
             sign = r_byte(arg);
+            if (sign != '+' && sign != '-') {
+                rb_raise(rb_eArgError, "invalid Bignum sign");
+            }
             len = r_keep_readable(arg, r_long(arg), 2);
 
             if (SIZEOF_VALUE >= 8 && len <= 4) {

--- a/marshal.c
+++ b/marshal.c
@@ -1240,6 +1240,7 @@ rb_marshal_dump_limited(VALUE obj, VALUE port, int limit)
 struct load_arg {
     VALUE src;
     char *buf;
+    long bufsize;
     long buflen;
     long readable;
     long offset;
@@ -1325,15 +1326,22 @@ static unsigned char
 r_byte1_buffered(struct load_arg *arg)
 {
     if (arg->buflen == 0) {
-        long readable = arg->readable < BUFSIZ ? arg->readable : BUFSIZ;
+        long readable = arg->readable < arg->bufsize ? arg->readable : arg->bufsize;
+        long read_len;
         VALUE str, n = LONG2NUM(readable);
 
         str = load_funcall(arg, arg->src, s_read, 1, &n);
         if (NIL_P(str)) too_short();
         StringValue(str);
-        memcpy(arg->buf, RSTRING_PTR(str), RSTRING_LEN(str));
+        read_len = RSTRING_LEN(str);
+        if (UNLIKELY(read_len < readable)) too_short();
+        if (UNLIKELY(read_len > arg->bufsize)) {
+            arg->buf = ruby_sized_realloc_n(arg->buf, read_len, 1, arg->bufsize);
+            arg->bufsize = read_len;
+        }
+        memcpy(arg->buf, RSTRING_PTR(str), read_len);
         arg->offset = 0;
-        arg->buflen = RSTRING_LEN(str);
+        arg->buflen = read_len;
         RB_GC_GUARD(str);
     }
     arg->buflen--;
@@ -1450,7 +1458,7 @@ r_bytes1_buffered(long len, struct load_arg *arg)
         long tmp_len, read_len, need_len = len - buflen;
         VALUE tmp, n;
 
-        readable = readable < BUFSIZ ? readable : BUFSIZ;
+        readable = readable < arg->bufsize ? readable : arg->bufsize;
         read_len = need_len > readable ? need_len : readable;
         n = LONG2NUM(read_len);
         tmp = load_funcall(arg, arg->src, s_read, 1, &n);
@@ -2339,6 +2347,7 @@ clear_load_arg(struct load_arg *arg)
 {
     xfree(arg->buf);
     arg->buf = NULL;
+    arg->bufsize = 0;
     arg->buflen = 0;
     arg->offset = 0;
     arg->readable = 0;
@@ -2384,10 +2393,14 @@ rb_marshal_load_with_proc(VALUE port, VALUE proc, bool freeze)
     arg->readable = 0;
     arg->freeze = freeze;
 
-    if (NIL_P(v))
+    if (NIL_P(v)) {
+        arg->bufsize = BUFSIZ;
         arg->buf = xmalloc(BUFSIZ);
-    else
+    }
+    else {
+        arg->bufsize = 0;
         arg->buf = 0;
+    }
 
     major = r_byte(arg);
     minor = r_byte(arg);

--- a/test/ruby/test_marshal.rb
+++ b/test/ruby/test_marshal.rb
@@ -933,6 +933,26 @@ class TestMarshal < Test::Unit::TestCase
     end
   end
 
+  def test_load_overread
+    input = Struct.new(:bytes, :used) do
+      def initialize
+        super("\x04\x08[\x07".bytes, false)
+      end
+
+      def getbyte
+        bytes.shift
+      end
+
+      def read(_len, _outbuf = nil)
+        return nil if used
+        self.used = true
+        "0" * (1024 * 128)
+      end
+    end.new
+
+    assert_equal([nil, nil], Marshal.load(input))
+  end
+
   class TestMarshalFreezeProc < Test::Unit::TestCase
     include MarshalTestLib
 

--- a/test/ruby/test_marshal.rb
+++ b/test/ruby/test_marshal.rb
@@ -953,6 +953,15 @@ class TestMarshal < Test::Unit::TestCase
     assert_equal([nil, nil], Marshal.load(input))
   end
 
+  def test_bignum_len_overflow
+    assert_raise(ArgumentError) do
+      Marshal.load("\x04\x08l+\x04\x00\x00\x00\x40")
+    end
+    assert_raise(ArgumentError) do
+      Marshal.load("\x04\x08l+\xfc\x00\x00\x00\x80")
+    end
+  end
+
   class TestMarshalFreezeProc < Test::Unit::TestCase
     include MarshalTestLib
 

--- a/test/ruby/test_marshal.rb
+++ b/test/ruby/test_marshal.rb
@@ -962,6 +962,12 @@ class TestMarshal < Test::Unit::TestCase
     end
   end
 
+  def test_bignum_invalid_sign
+    assert_raise(ArgumentError) do
+      Marshal.load("\x04\bl?")
+    end
+  end
+
   class TestMarshalFreezeProc < Test::Unit::TestCase
     include MarshalTestLib
 


### PR DESCRIPTION
Backport of https://bugs.ruby-lang.org/issues/22086 to ruby_4_0.

Commits:
- 8ed456afc95ccb23256fe10036cd0d9678ceb245 Marshal.load: Fix buffer overflow at overread
- 2510dfee2a6aba9e99664b453e2be69e00eb21a6 Marshal.load: Fix integer overflow of length
- 3f6d6c0373d2cb005f7cf164414cbb531f42d525 Marshal.load: Check bignum sign