### PR TITLE
[Backport #22112] Backport IO::Buffer UAF fixes

### DIFF
--- a/io_buffer.c
+++ b/io_buffer.c
@@ -3500,13 +3500,21 @@ io_buffer_xor(VALUE self, VALUE mask)
     struct rb_io_buffer *mask_buffer = NULL;
     TypedData_Get_Struct(mask, struct rb_io_buffer, &rb_io_buffer_type, mask_buffer);
 
-    io_buffer_check_mask_size(mask_buffer->size);
+    const void *base;
+    size_t size;
+    io_buffer_get_bytes_for_reading(buffer, &base, &size);
 
-    VALUE output = rb_io_buffer_new(NULL, buffer->size, io_flags_for_size(buffer->size));
+    const void *mask_base;
+    size_t mask_size;
+    io_buffer_get_bytes_for_reading(mask_buffer, &mask_base, &mask_size);
+
+    io_buffer_check_mask_size(mask_size);
+
+    VALUE output = rb_io_buffer_new(NULL, size, io_flags_for_size(size));
     struct rb_io_buffer *output_buffer = NULL;
     TypedData_Get_Struct(output, struct rb_io_buffer, &rb_io_buffer_type, output_buffer);
 
-    memory_xor(output_buffer->base, buffer->base, buffer->size, mask_buffer->base, mask_buffer->size);
+    memory_xor(output_buffer->base, base, size, mask_base, mask_size);
 
     return output;
 }

--- a/io_buffer.c
+++ b/io_buffer.c
@@ -894,8 +894,8 @@ rb_io_buffer_get_bytes(VALUE self, void **base, size_t *size)
 }
 
 // Internal function for accessing bytes for writing, wil
-static inline void
-io_buffer_get_bytes_for_writing(struct rb_io_buffer *buffer, void **base, size_t *size)
+static void
+io_buffer_validate_for_writing(struct rb_io_buffer *buffer)
 {
     if (buffer->flags & RB_IO_BUFFER_READONLY ||
         (!NIL_P(buffer->source) && OBJ_FROZEN(buffer->source))) {
@@ -905,6 +905,21 @@ io_buffer_get_bytes_for_writing(struct rb_io_buffer *buffer, void **base, size_t
     if (!io_buffer_validate(buffer)) {
         rb_raise(rb_eIOBufferInvalidatedError, "Buffer is invalid!");
     }
+}
+
+static struct rb_io_buffer *
+get_io_buffer_for_writing(VALUE self)
+{
+    struct rb_io_buffer *buffer = NULL;
+    TypedData_Get_Struct(self, struct rb_io_buffer, &rb_io_buffer_type, buffer);
+    io_buffer_validate_for_writing(buffer);
+    return buffer;
+}
+
+static inline void
+io_buffer_get_bytes_for_writing(struct rb_io_buffer *buffer, void **base, size_t *size)
+{
+    io_buffer_validate_for_writing(buffer);
 
     if (buffer->base) {
         *base = buffer->base;
@@ -1374,14 +1389,23 @@ io_buffer_readonly_p(VALUE self)
     return RBOOL(rb_io_buffer_readonly_p(self));
 }
 
-static void
-io_buffer_lock(struct rb_io_buffer *buffer)
+static int
+io_buffer_try_lock(struct rb_io_buffer *buffer)
 {
     if (buffer->flags & RB_IO_BUFFER_LOCKED) {
-        rb_raise(rb_eIOBufferLockedError, "Buffer already locked!");
+        return 0;
     }
 
     buffer->flags |= RB_IO_BUFFER_LOCKED;
+    return 1;
+}
+
+static void
+io_buffer_lock(struct rb_io_buffer *buffer)
+{
+    if (!io_buffer_try_lock(buffer)) {
+        rb_raise(rb_eIOBufferLockedError, "Buffer already locked!");
+    }
 }
 
 VALUE
@@ -1959,6 +1983,10 @@ ruby_swap128_int(rb_int128_t x)
     return conversion.int128;
 }
 
+#define IO_BUFFER_VALIDATE_TYPE_FOR_WRITING(buffer, base, size, offset, type) \
+    (io_buffer_get_bytes_for_writing(buffer, &(base), &(size)), \
+     io_buffer_validate_type(size, offset, sizeof(type)))
+
 #define IO_BUFFER_DECLARE_TYPE(name, type, endian, wrap, unwrap, swap) \
 static ID RB_IO_BUFFER_DATA_TYPE_##name; \
 \
@@ -1974,10 +2002,12 @@ io_buffer_read_##name(const void* base, size_t size, size_t *offset) \
 } \
 \
 static void \
-io_buffer_write_##name(const void* base, size_t size, size_t *offset, VALUE _value) \
+io_buffer_write_##name(struct rb_io_buffer* buffer, size_t *offset, VALUE _value) \
 { \
-    io_buffer_validate_type(size, *offset, sizeof(type)); \
+    void* base; size_t size; \
+    IO_BUFFER_VALIDATE_TYPE_FOR_WRITING(buffer, base, size, *offset, type); \
     type value = unwrap(_value); \
+    IO_BUFFER_VALIDATE_TYPE_FOR_WRITING(buffer, base, size, *offset, type); \
     if (endian != RB_IO_BUFFER_HOST_ENDIAN) value = swap(value); \
     memcpy((char*)base + *offset, &value, sizeof(type)); \
     *offset += sizeof(type); \
@@ -2348,9 +2378,10 @@ io_buffer_each_byte(int argc, VALUE *argv, VALUE self)
 }
 
 static inline void
-rb_io_buffer_set_value(const void* base, size_t size, ID buffer_type, size_t *offset, VALUE value)
+rb_io_buffer_set_value(struct rb_io_buffer *buffer, VALUE buffer_type, size_t *offset, VALUE value)
 {
-#define IO_BUFFER_SET_VALUE(name) if (buffer_type == RB_IO_BUFFER_DATA_TYPE_##name) {io_buffer_write_##name(base, size, offset, value); return;}
+    ID type = RB_SYM2ID(buffer_type);
+#define IO_BUFFER_SET_VALUE(name) if (type == RB_IO_BUFFER_DATA_TYPE_##name) {io_buffer_write_##name(buffer, offset, value); return;}
     IO_BUFFER_SET_VALUE(U8);
     IO_BUFFER_SET_VALUE(S8);
 
@@ -2381,6 +2412,21 @@ rb_io_buffer_set_value(const void* base, size_t size, ID buffer_type, size_t *of
 #undef IO_BUFFER_SET_VALUE
 
     rb_raise(rb_eArgError, "Invalid type name!");
+}
+
+struct io_buffer_set_value_arguments {
+    struct rb_io_buffer *buffer;
+    size_t offset;
+    VALUE type, value;
+};
+
+static VALUE
+io_buffer_set_value_try(VALUE arguments)
+{
+    struct io_buffer_set_value_arguments *args = (void *)arguments;
+    size_t offset = args->offset;
+    rb_io_buffer_set_value(args->buffer, args->type, &offset, args->value);
+    return SIZET2NUM(offset);
 }
 
 /*
@@ -2416,13 +2462,30 @@ rb_io_buffer_set_value(const void* base, size_t size, ID buffer_type, size_t *of
 static VALUE
 io_buffer_set_value(VALUE self, VALUE type, VALUE _offset, VALUE value)
 {
-    void *base;
-    size_t size;
-    size_t offset = io_buffer_extract_offset(_offset);
+    struct io_buffer_set_value_arguments arguments = {
+        .buffer = get_io_buffer_for_writing(self),
+        .offset = io_buffer_extract_offset(_offset),
+        .type = type,
+        .value = value,
+    };
 
-    rb_io_buffer_get_bytes_for_writing(self, &base, &size);
+    if (!io_buffer_try_lock(arguments.buffer)) {
+        return io_buffer_set_value_try((VALUE)&arguments);
+    }
+    return rb_ensure(io_buffer_set_value_try, (VALUE)&arguments, rb_io_buffer_locked_ensure, self);
+}
 
-    rb_io_buffer_set_value(base, size, RB_SYM2ID(type), &offset, value);
+static VALUE
+io_buffer_set_values_try(VALUE arguments)
+{
+    struct io_buffer_set_value_arguments *args = (void *)arguments;
+    size_t offset = args->offset;
+
+    for (long i = 0; i < RARRAY_LEN(args->type); i++) {
+        VALUE type = rb_ary_entry(args->type, i);
+        VALUE value = rb_ary_entry(args->value, i);
+        rb_io_buffer_set_value(args->buffer, type, &offset, value);
+    }
 
     return SIZET2NUM(offset);
 }
@@ -2444,31 +2507,31 @@ io_buffer_set_value(VALUE self, VALUE type, VALUE _offset, VALUE value)
 static VALUE
 io_buffer_set_values(VALUE self, VALUE buffer_types, VALUE _offset, VALUE values)
 {
+    struct io_buffer_set_value_arguments arguments = {
+        .buffer = get_io_buffer_for_writing(self),
+    };
+
     if (!RB_TYPE_P(buffer_types, T_ARRAY)) {
         rb_raise(rb_eArgError, "Argument buffer_types should be an array!");
     }
+    arguments.type = buffer_types;
+
+    arguments.offset = io_buffer_extract_offset(_offset);
 
     if (!RB_TYPE_P(values, T_ARRAY)) {
         rb_raise(rb_eArgError, "Argument values should be an array!");
     }
+    arguments.value = values;
 
     if (RARRAY_LEN(buffer_types) != RARRAY_LEN(values)) {
         rb_raise(rb_eArgError, "Argument buffer_types and values should have the same length!");
     }
 
-    size_t offset = io_buffer_extract_offset(_offset);
-
-    void *base;
-    size_t size;
-    rb_io_buffer_get_bytes_for_writing(self, &base, &size);
-
-    for (long i = 0; i < RARRAY_LEN(buffer_types); i++) {
-        VALUE type = rb_ary_entry(buffer_types, i);
-        VALUE value = rb_ary_entry(values, i);
-        rb_io_buffer_set_value(base, size, RB_SYM2ID(type), &offset, value);
+    if (!io_buffer_try_lock(arguments.buffer)) {
+        return io_buffer_set_values_try((VALUE)&arguments);
     }
+    return rb_ensure(io_buffer_set_values_try, (VALUE)&arguments, rb_io_buffer_locked_ensure, self);
 
-    return SIZET2NUM(offset);
 }
 
 static size_t IO_BUFFER_BLOCKING_SIZE = 1024*1024;

--- a/io_buffer.c
+++ b/io_buffer.c
@@ -3369,14 +3369,14 @@ io_buffer_pwrite(int argc, VALUE *argv, VALUE self)
 }
 
 static inline void
-io_buffer_check_mask(const struct rb_io_buffer *buffer)
+io_buffer_check_mask_size(size_t size)
 {
-    if (buffer->size == 0)
+    if (size == 0)
         rb_raise(rb_eIOBufferMaskError, "Zero-length mask given!");
 }
 
 static void
-memory_and(unsigned char * restrict output, unsigned char * restrict base, size_t size, unsigned char * restrict mask, size_t mask_size)
+memory_and(unsigned char * restrict output, const unsigned char * restrict base, size_t size, const unsigned char * restrict mask, size_t mask_size)
 {
     for (size_t offset = 0; offset < size; offset += 1) {
         output[offset] = base[offset] & mask[offset % mask_size];
@@ -3404,13 +3404,21 @@ io_buffer_and(VALUE self, VALUE mask)
     struct rb_io_buffer *mask_buffer = NULL;
     TypedData_Get_Struct(mask, struct rb_io_buffer, &rb_io_buffer_type, mask_buffer);
 
-    io_buffer_check_mask(mask_buffer);
+    const void *base;
+    size_t size;
+    io_buffer_get_bytes_for_reading(buffer, &base, &size);
 
-    VALUE output = rb_io_buffer_new(NULL, buffer->size, io_flags_for_size(buffer->size));
+    const void *mask_base;
+    size_t mask_size;
+    io_buffer_get_bytes_for_reading(mask_buffer, &mask_base, &mask_size);
+
+    io_buffer_check_mask_size(mask_size);
+
+    VALUE output = rb_io_buffer_new(NULL, size, io_flags_for_size(size));
     struct rb_io_buffer *output_buffer = NULL;
     TypedData_Get_Struct(output, struct rb_io_buffer, &rb_io_buffer_type, output_buffer);
 
-    memory_and(output_buffer->base, buffer->base, buffer->size, mask_buffer->base, mask_buffer->size);
+    memory_and(output_buffer->base, base, size, mask_base, mask_size);
 
     return output;
 }
@@ -3444,7 +3452,7 @@ io_buffer_or(VALUE self, VALUE mask)
     struct rb_io_buffer *mask_buffer = NULL;
     TypedData_Get_Struct(mask, struct rb_io_buffer, &rb_io_buffer_type, mask_buffer);
 
-    io_buffer_check_mask(mask_buffer);
+    io_buffer_check_mask_size(mask_buffer->size);
 
     VALUE output = rb_io_buffer_new(NULL, buffer->size, io_flags_for_size(buffer->size));
     struct rb_io_buffer *output_buffer = NULL;
@@ -3484,7 +3492,7 @@ io_buffer_xor(VALUE self, VALUE mask)
     struct rb_io_buffer *mask_buffer = NULL;
     TypedData_Get_Struct(mask, struct rb_io_buffer, &rb_io_buffer_type, mask_buffer);
 
-    io_buffer_check_mask(mask_buffer);
+    io_buffer_check_mask_size(mask_buffer->size);
 
     VALUE output = rb_io_buffer_new(NULL, buffer->size, io_flags_for_size(buffer->size));
     struct rb_io_buffer *output_buffer = NULL;
@@ -3581,7 +3589,7 @@ io_buffer_and_inplace(VALUE self, VALUE mask)
     struct rb_io_buffer *mask_buffer = NULL;
     TypedData_Get_Struct(mask, struct rb_io_buffer, &rb_io_buffer_type, mask_buffer);
 
-    io_buffer_check_mask(mask_buffer);
+    io_buffer_check_mask_size(mask_buffer->size);
     io_buffer_check_overlaps(buffer, mask_buffer);
 
     void *base;
@@ -3627,7 +3635,7 @@ io_buffer_or_inplace(VALUE self, VALUE mask)
     struct rb_io_buffer *mask_buffer = NULL;
     TypedData_Get_Struct(mask, struct rb_io_buffer, &rb_io_buffer_type, mask_buffer);
 
-    io_buffer_check_mask(mask_buffer);
+    io_buffer_check_mask_size(mask_buffer->size);
     io_buffer_check_overlaps(buffer, mask_buffer);
 
     void *base;
@@ -3673,7 +3681,7 @@ io_buffer_xor_inplace(VALUE self, VALUE mask)
     struct rb_io_buffer *mask_buffer = NULL;
     TypedData_Get_Struct(mask, struct rb_io_buffer, &rb_io_buffer_type, mask_buffer);
 
-    io_buffer_check_mask(mask_buffer);
+    io_buffer_check_mask_size(mask_buffer->size);
     io_buffer_check_overlaps(buffer, mask_buffer);
 
     void *base;

--- a/io_buffer.c
+++ b/io_buffer.c
@@ -3616,6 +3616,10 @@ io_buffer_and_inplace(VALUE self, VALUE mask)
     size_t size;
     io_buffer_get_bytes_for_writing(buffer, &base, &size);
 
+    const void *mask_base;
+    size_t mask_size;
+    io_buffer_get_bytes_for_reading(mask_buffer, &mask_base, &mask_size);
+
     memory_and_inplace(base, size, mask_buffer->base, mask_buffer->size);
 
     return self;
@@ -3662,6 +3666,10 @@ io_buffer_or_inplace(VALUE self, VALUE mask)
     size_t size;
     io_buffer_get_bytes_for_writing(buffer, &base, &size);
 
+    const void *mask_base;
+    size_t mask_size;
+    io_buffer_get_bytes_for_reading(mask_buffer, &mask_base, &mask_size);
+
     memory_or_inplace(base, size, mask_buffer->base, mask_buffer->size);
 
     return self;
@@ -3707,6 +3715,10 @@ io_buffer_xor_inplace(VALUE self, VALUE mask)
     void *base;
     size_t size;
     io_buffer_get_bytes_for_writing(buffer, &base, &size);
+
+    const void *mask_base;
+    size_t mask_size;
+    io_buffer_get_bytes_for_reading(mask_buffer, &mask_base, &mask_size);
 
     memory_xor_inplace(base, size, mask_buffer->base, mask_buffer->size);
 

--- a/io_buffer.c
+++ b/io_buffer.c
@@ -3472,7 +3472,7 @@ io_buffer_or(VALUE self, VALUE mask)
 }
 
 static void
-memory_xor(unsigned char * restrict output, unsigned char * restrict base, size_t size, unsigned char * restrict mask, size_t mask_size)
+memory_xor(unsigned char * restrict output, const unsigned char * restrict base, size_t size, const unsigned char * restrict mask, size_t mask_size)
 {
     for (size_t offset = 0; offset < size; offset += 1) {
         output[offset] = base[offset] ^ mask[offset % mask_size];
@@ -3512,7 +3512,7 @@ io_buffer_xor(VALUE self, VALUE mask)
 }
 
 static void
-memory_not(unsigned char * restrict output, unsigned char * restrict base, size_t size)
+memory_not(unsigned char * restrict output, const unsigned char * restrict base, size_t size)
 {
     for (size_t offset = 0; offset < size; offset += 1) {
         output[offset] = ~base[offset];

--- a/io_buffer.c
+++ b/io_buffer.c
@@ -925,11 +925,17 @@ rb_io_buffer_get_bytes_for_writing(VALUE self, void **base, size_t *size)
 }
 
 static void
-io_buffer_get_bytes_for_reading(struct rb_io_buffer *buffer, const void **base, size_t *size)
+io_buffer_validate_for_reading(struct rb_io_buffer *buffer)
 {
     if (!io_buffer_validate(buffer)) {
         rb_raise(rb_eIOBufferInvalidatedError, "Buffer has been invalidated!");
     }
+}
+
+static void
+io_buffer_get_bytes_for_reading(struct rb_io_buffer *buffer, const void **base, size_t *size)
+{
+    io_buffer_validate_for_reading(buffer);
 
     if (buffer->base) {
         *base = buffer->base;
@@ -1543,6 +1549,8 @@ size_sum_is_bigger_than(size_t a, size_t b, size_t x)
 static inline void
 io_buffer_validate_range(struct rb_io_buffer *buffer, size_t offset, size_t length)
 {
+    io_buffer_validate_for_reading(buffer);
+
     if (size_sum_is_bigger_than(offset, length, buffer->size)) {
         rb_raise(rb_eArgError, "Specified offset+length is bigger than the buffer size!");
     }
@@ -1746,6 +1754,8 @@ rb_io_buffer_resize(VALUE self, size_t size)
 {
     struct rb_io_buffer *buffer = NULL;
     TypedData_Get_Struct(self, struct rb_io_buffer, &rb_io_buffer_type, buffer);
+
+    io_buffer_validate_for_reading(buffer);
 
     if (buffer->flags & RB_IO_BUFFER_LOCKED) {
         rb_raise(rb_eIOBufferLockedError, "Cannot resize locked buffer!");

--- a/io_buffer.c
+++ b/io_buffer.c
@@ -3424,7 +3424,7 @@ io_buffer_and(VALUE self, VALUE mask)
 }
 
 static void
-memory_or(unsigned char * restrict output, unsigned char * restrict base, size_t size, unsigned char * restrict mask, size_t mask_size)
+memory_or(unsigned char * restrict output, const unsigned char * restrict base, size_t size, const unsigned char * restrict mask, size_t mask_size)
 {
     for (size_t offset = 0; offset < size; offset += 1) {
         output[offset] = base[offset] | mask[offset % mask_size];
@@ -3452,13 +3452,21 @@ io_buffer_or(VALUE self, VALUE mask)
     struct rb_io_buffer *mask_buffer = NULL;
     TypedData_Get_Struct(mask, struct rb_io_buffer, &rb_io_buffer_type, mask_buffer);
 
-    io_buffer_check_mask_size(mask_buffer->size);
+    const void *base;
+    size_t size;
+    io_buffer_get_bytes_for_reading(buffer, &base, &size);
 
-    VALUE output = rb_io_buffer_new(NULL, buffer->size, io_flags_for_size(buffer->size));
+    const void *mask_base;
+    size_t mask_size;
+    io_buffer_get_bytes_for_reading(mask_buffer, &mask_base, &mask_size);
+
+    io_buffer_check_mask_size(mask_size);
+
+    VALUE output = rb_io_buffer_new(NULL, size, io_flags_for_size(size));
     struct rb_io_buffer *output_buffer = NULL;
     TypedData_Get_Struct(output, struct rb_io_buffer, &rb_io_buffer_type, output_buffer);
 
-    memory_or(output_buffer->base, buffer->base, buffer->size, mask_buffer->base, mask_buffer->size);
+    memory_or(output_buffer->base, base, size, mask_base, mask_size);
 
     return output;
 }

--- a/io_buffer.c
+++ b/io_buffer.c
@@ -3545,11 +3545,15 @@ io_buffer_not(VALUE self)
     struct rb_io_buffer *buffer = NULL;
     TypedData_Get_Struct(self, struct rb_io_buffer, &rb_io_buffer_type, buffer);
 
-    VALUE output = rb_io_buffer_new(NULL, buffer->size, io_flags_for_size(buffer->size));
+    const void *base;
+    size_t size;
+    io_buffer_get_bytes_for_reading(buffer, &base, &size);
+
+    VALUE output = rb_io_buffer_new(NULL, size, io_flags_for_size(size));
     struct rb_io_buffer *output_buffer = NULL;
     TypedData_Get_Struct(output, struct rb_io_buffer, &rb_io_buffer_type, output_buffer);
 
-    memory_not(output_buffer->base, buffer->base, buffer->size);
+    memory_not(output_buffer->base, base, size);
 
     return output;
 }

--- a/test/ruby/test_io_buffer.rb
+++ b/test/ruby/test_io_buffer.rb
@@ -702,6 +702,7 @@ class TestIOBuffer < Test::Unit::TestCase
     mask = IO::Buffer.for("ABCDEFGH")
     assert_raise(IO::Buffer::InvalidatedError) { slice & mask }
     assert_raise(IO::Buffer::InvalidatedError) { slice | mask }
+    assert_raise(IO::Buffer::InvalidatedError) { slice ^ mask }
   end
 
   def test_operators_raise_on_freed_mask
@@ -712,6 +713,7 @@ class TestIOBuffer < Test::Unit::TestCase
     source = IO::Buffer.for("ABCDEFGH")
     assert_raise(IO::Buffer::InvalidatedError) { source & mask_slice }
     assert_raise(IO::Buffer::InvalidatedError) { source | mask_slice }
+    assert_raise(IO::Buffer::InvalidatedError) { source ^ mask_slice }
   end
 
   def test_shared

--- a/test/ruby/test_io_buffer.rb
+++ b/test/ruby/test_io_buffer.rb
@@ -704,6 +704,10 @@ class TestIOBuffer < Test::Unit::TestCase
     assert_raise(IO::Buffer::InvalidatedError) { slice | mask }
     assert_raise(IO::Buffer::InvalidatedError) { slice ^ mask }
     assert_raise(IO::Buffer::InvalidatedError) { ~slice }
+
+    assert_raise(IO::Buffer::InvalidatedError) { slice.and!(mask) }
+    assert_raise(IO::Buffer::InvalidatedError) { slice.or!(mask) }
+    assert_raise(IO::Buffer::InvalidatedError) { slice.xor!(mask) }
   end
 
   def test_operators_raise_on_freed_mask
@@ -715,6 +719,11 @@ class TestIOBuffer < Test::Unit::TestCase
     assert_raise(IO::Buffer::InvalidatedError) { source & mask_slice }
     assert_raise(IO::Buffer::InvalidatedError) { source | mask_slice }
     assert_raise(IO::Buffer::InvalidatedError) { source ^ mask_slice }
+
+    source = source.dup
+    assert_raise(IO::Buffer::InvalidatedError) { source.and!(mask_slice) }
+    assert_raise(IO::Buffer::InvalidatedError) { source.or!(mask_slice) }
+    assert_raise(IO::Buffer::InvalidatedError) { source.xor!(mask_slice) }
   end
 
   def test_shared

--- a/test/ruby/test_io_buffer.rb
+++ b/test/ruby/test_io_buffer.rb
@@ -242,6 +242,16 @@ class TestIOBuffer < Test::Unit::TestCase
     end
   end
 
+  def test_resize_invalidated_slice
+    inner = IO::Buffer.new(IO::Buffer::PAGE_SIZE)
+    slice = inner.slice(0, 8)
+    inner.free
+
+    assert_raise(IO::Buffer::InvalidatedError) do
+      slice.resize(16)
+    end
+  end
+
   def test_compare_same_size
     buffer1 = IO::Buffer.new(1)
     assert_equal buffer1, buffer1
@@ -375,6 +385,17 @@ class TestIOBuffer < Test::Unit::TestCase
 
     assert_raise_with_message(ArgumentError, /Offset can't be negative/) do
       buffer.get_string(-1)
+    end
+
+    encoding = Struct.new(:buffer) do
+      def to_str
+        buffer.free
+        "BINARY"
+      end
+    end.new(buffer.dup)
+    slice = encoding.buffer.slice(0, 8)
+    assert_raise(IO::Buffer::InvalidatedError) do
+      slice.get_string(0, 8, encoding)
     end
   end
 

--- a/test/ruby/test_io_buffer.rb
+++ b/test/ruby/test_io_buffer.rb
@@ -694,22 +694,24 @@ class TestIOBuffer < Test::Unit::TestCase
     assert_equal IO::Buffer.for("\xce\xcd\xcc\xcb\xce\xcd\xcc\xcb\xce\xcd"), source.dup.not!
   end
 
-  def test_and_raises_on_freed_self
+  def test_operators_raise_on_freed_self
     inner = IO::Buffer.new(IO::Buffer::PAGE_SIZE)
     slice = inner.slice(0, 8)
     inner.free
 
     mask = IO::Buffer.for("ABCDEFGH")
     assert_raise(IO::Buffer::InvalidatedError) { slice & mask }
+    assert_raise(IO::Buffer::InvalidatedError) { slice | mask }
   end
 
-  def test_and_raises_on_freed_mask
+  def test_operators_raise_on_freed_mask
     inner = IO::Buffer.new(IO::Buffer::PAGE_SIZE)
     mask_slice = inner.slice(0, 8)
     inner.free
 
     source = IO::Buffer.for("ABCDEFGH")
     assert_raise(IO::Buffer::InvalidatedError) { source & mask_slice }
+    assert_raise(IO::Buffer::InvalidatedError) { source | mask_slice }
   end
 
   def test_shared

--- a/test/ruby/test_io_buffer.rb
+++ b/test/ruby/test_io_buffer.rb
@@ -470,6 +470,26 @@ class TestIOBuffer < Test::Unit::TestCase
     end
   end
 
+  def test_set_values_invalidated_slice
+    to_int = Struct.new(:buffer) do
+      def to_int
+        buffer.free
+        0x41
+      end
+    end
+    buffer = IO::Buffer.new(128)
+    slice = buffer.slice(0, 8)
+    value = to_int.new(buffer)
+    assert_raise(IO::Buffer::InvalidatedError) {slice.set_value(:U8, 0, value)}
+
+    buffer = IO::Buffer.new(128)
+    slice = buffer.slice(0, 8)
+    value = to_int.new(buffer)
+    assert_raise(IO::Buffer::InvalidatedError) {
+      slice.set_values([:U8, :U8], 0, [0, value])
+    }
+  end
+
   def test_zero_length_get_set_values
     buffer = IO::Buffer.new(0)
 

--- a/test/ruby/test_io_buffer.rb
+++ b/test/ruby/test_io_buffer.rb
@@ -694,6 +694,24 @@ class TestIOBuffer < Test::Unit::TestCase
     assert_equal IO::Buffer.for("\xce\xcd\xcc\xcb\xce\xcd\xcc\xcb\xce\xcd"), source.dup.not!
   end
 
+  def test_and_raises_on_freed_self
+    inner = IO::Buffer.new(IO::Buffer::PAGE_SIZE)
+    slice = inner.slice(0, 8)
+    inner.free
+
+    mask = IO::Buffer.for("ABCDEFGH")
+    assert_raise(IO::Buffer::InvalidatedError) { slice & mask }
+  end
+
+  def test_and_raises_on_freed_mask
+    inner = IO::Buffer.new(IO::Buffer::PAGE_SIZE)
+    mask_slice = inner.slice(0, 8)
+    inner.free
+
+    source = IO::Buffer.for("ABCDEFGH")
+    assert_raise(IO::Buffer::InvalidatedError) { source & mask_slice }
+  end
+
   def test_shared
     message = "Hello World"
     buffer = IO::Buffer.new(64, IO::Buffer::MAPPED | IO::Buffer::SHARED)

--- a/test/ruby/test_io_buffer.rb
+++ b/test/ruby/test_io_buffer.rb
@@ -703,6 +703,7 @@ class TestIOBuffer < Test::Unit::TestCase
     assert_raise(IO::Buffer::InvalidatedError) { slice & mask }
     assert_raise(IO::Buffer::InvalidatedError) { slice | mask }
     assert_raise(IO::Buffer::InvalidatedError) { slice ^ mask }
+    assert_raise(IO::Buffer::InvalidatedError) { ~slice }
   end
 
   def test_operators_raise_on_freed_mask


### PR DESCRIPTION
Backport of https://bugs.ruby-lang.org/issues/22112 to ruby_4_0.

Commits:
- 2552db04ddc44349c7b0f5f93aeb0fb02eccb509 Fix UAF in IO::Buffer#& when self or mask is an invalidated slice
- 95626e3a9c59cd073221c08ed013ed0f2d655b6f Fix UAF in IO::Buffer#| when self or mask is an invalidated slice
- b38f133c70c44bac724c7085d59b4fca510855fb Constify `memory_xor` and `memory_not` (prerequisite for the following const read buffers)
- 90ed85f91ed8c9df26efcbdc5e6a1b428be3ef06 Fix UAF in IO::Buffer#^ when self or mask is an invalidated slice
- 3373fcc2dee7c4560d2c3e4280c549cdb1b5de63 Fix UAF in IO::Buffer#~ when self is an invalidated slice
- 4bd3e14fc2623414680008c7b1d38f1a3df2877e IO::Buffer: Validate the mask argument of bit operations
- 2c8002d58302e4fff51484826e1fd706cc2bfb19 IO::Buffer: Validate the buffer after argument conversion
- 773e0c3a0f2ab2bd235c8d44cad1f999bfe2514b IO::Buffer: Validate the buffer after type argument conversion