### PR TITLE
win32/ifchange.bat: normalize temporary file path and fail on copy error

### DIFF
--- a/win32/ifchange.bat
+++ b/win32/ifchange.bat
@@ -113,7 +113,11 @@ if exist %dest% (
 )
 for %%I in (%1) do echo %%~I updated
 del /f %dest% 2> nul
-copy %src% %dest% > nul
+copy %src% %dest% > nul || (
+    echo %progname%: failed to copy %src% to %dest% 1>&2
+    del %src%
+    exit /b 1
+)
 del %src%
 
 :nt_end

--- a/win32/ifchange.bat
+++ b/win32/ifchange.bat
@@ -96,6 +96,7 @@ if not "%src%" == "-" goto :srcfile
     ) else (
         set src=.\ifchange%RANDOM%.tmp
     )
+    set src=%src:/=\%
     findstr -r -c:"^" > "%src%"
 :srcfile
 


### PR DESCRIPTION
When `TMPDIR` (or `TEMP`/`TMP`) contains forward slashes such as `V:/tmp`, invocations reading from stdin like `win32\ifchange.bat --timestamp=.rbconfig.time rbconfig.rb -` build the temporary file path after the slash normalization of `dest` and `src`. The unnormalized path is passed to `copy` and `del` and the part after the slash is interpreted as a switch.

```
Invalid switch - "tmp\ifchange12345.tmp"
```

Because the script did not check the result of `copy`, it still touched the timestamp file, leaving the target missing while the timestamp claimed it was up to date. Subsequent `nmake` runs then stopped during `enc.mk` generation with a `LoadError` for `rbconfig` until the timestamp file was removed manually.

This PR normalizes the slashes in the temporary file path and makes the script exit with a non-zero status without touching the timestamp file when `copy` fails. Verified with an existing mswin build by removing `.rbconfig.time` and `rbconfig.rb` and running `nmake` with `TMPDIR=V:/tmp`, which reproduced the failure before the fix and regenerates `rbconfig.rb` correctly after it. The non-zero exit propagates through the pipe invocations in `common.mk` and `win32/Makefile.sub` so a failed update now stops the build instead of leaving an inconsistent state.
