### PR TITLE
[DOC] Fix man page markup for groff 1.24

### DIFF
--- a/man/erb.1
+++ b/man/erb.1
@@ -31,7 +31,7 @@ is a part of
 .Nm Ruby .
 .Pp
 .Sh OPTIONS
-.Bl -tag -width "1234567890123" -compact
+.Bl -tag -width "--encoding" -compact
 .Pp
 .It Fl -version
 Prints the version of

--- a/man/erb.1
+++ b/man/erb.1
@@ -1,5 +1,5 @@
 .\"Ruby is copyrighted by Yukihiro Matsumoto <matz@netlab.jp>.
-.Dd June 07, 2026
+.Dd July 10, 2026
 .Dt ERB 1 "Ruby Programmer's Reference Guide"
 .Os UNIX
 .Sh NAME

--- a/man/goruby.1
+++ b/man/goruby.1
@@ -1,5 +1,5 @@
 .\"Ruby is copyrighted by Yukihiro Matsumoto <matz@netlab.jp>.
-.Dd June 07, 2026
+.Dd May 24, 2026
 .Dt GORUBY 1 "Ruby Programmer's Reference Guide"
 .Os UNIX
 .Sh NAME

--- a/man/ruby.1
+++ b/man/ruby.1
@@ -1,5 +1,5 @@
 .\"Ruby is copyrighted by Yukihiro Matsumoto <matz@netlab.jp>.
-.Dd June 07, 2026
+.Dd July 10, 2026
 .Dt RUBY 1 "Ruby Programmer's Reference Guide"
 .Os UNIX
 .Sh NAME

--- a/man/ruby.1
+++ b/man/ruby.1
@@ -141,7 +141,7 @@ to see how they are being developed and used.
 The Ruby interpreter accepts the following command-line options (switches).
 They are quite similar to those of
 .Xr perl 1 .
-.Bl -tag -width "1234567890123" -compact
+.Bl -tag -width "--encoding" -compact
 .Pp
 .It Fl -copyright
 Prints the copyright notice, and quits immediately without running any
@@ -808,6 +808,7 @@ When set to
 .Li 0
 or left unset, the fast fallback feature is enabled.
 Introduced in Ruby 3.4, default: unset.
+.El
 .Sh SEE ALSO
 .Bl -hang -compact -width "https://www.ruby-toolbox.com/"
 .It Lk https://www.ruby-lang.org/


### PR DESCRIPTION
Two issues caused groff/lintian warnings on the mdoc pages:

1. man/ruby.1: the MISC ENVIRONMENT list for RUBY_TCP_NO_FAST_FALLBACK opened a .Bl that was never closed before .Sh SEE ALSO, producing "A .Bl directive has no matching .El".

2. man/erb.1 and man/ruby.1: .Bl -tag -width "1234567890123" uses a long all-digit width string. Under groff 1.24 that is mishandled and floods "cannot adjust line; overset by ~5e7n" warnings, and mangled OPTIONS rendering. Replace it with -width "--encoding" (a representative tag).

Verified with man --warnings: 0 warnings on erb.1/ruby.1/goruby.1 after this change (was 249 / 1399 / 0 on master).