### PR TITLE
ZJIT: Recompile on Float operand guard misses

### DIFF
--- a/zjit/src/cruby_methods.rs
+++ b/zjit/src/cruby_methods.rs
@@ -655,12 +655,20 @@ fn try_inline_float_op(fun: &mut hir::Function, block: hir::BlockId, f: &dyn Fn(
     if fun.likely_a(recv, types::Flonum, state)
         && (fun.likely_a(other, types::Flonum, state) || fun.likely_a(other, types::Fixnum, state))
     {
-        let recv = fun.coerce_to(block, recv, types::Flonum, state);
+        let recv = coerce_float_op_operand(fun, block, recv, types::Flonum, state);
         let other_type = if fun.likely_a(other, types::Flonum, state) { types::Flonum } else { types::Fixnum };
-        let other = fun.coerce_to(block, other, other_type, state);
+        let other = coerce_float_op_operand(fun, block, other, other_type, state);
         return Some(fun.push_insn(block, f(recv, other)));
     }
     None
+}
+
+fn coerce_float_op_operand(fun: &mut hir::Function, block: hir::BlockId, val: hir::InsnId, guard_type: Type, state: hir::InsnId) -> hir::InsnId {
+    if fun.is_a(val, guard_type) {
+        val
+    } else {
+        fun.guard_type_recompile(block, val, guard_type, state, hir::Recompile)
+    }
 }
 
 fn inline_float_plus(fun: &mut hir::Function, block: hir::BlockId, recv: hir::InsnId, args: &[hir::InsnId], state: hir::InsnId) -> Option<hir::InsnId> {

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -17717,6 +17717,87 @@ mod hir_opt_tests {
     }
 
     #[test]
+    fn test_float_mul_recompile_stops_inlining_heap_float_receiver() {
+        set_max_versions(2);
+        eval(r#"
+            def test_float_mul_recompile(a, b) = a * b
+
+            30.times { test_float_mul_recompile(1.5, 2.5) }
+        "#);
+
+        let intermediate_hir = hir_string("test_float_mul_recompile");
+        assert!(intermediate_hir.contains("FloatMul"), "{intermediate_hir}");
+
+        eval(r#"
+            30.times { test_float_mul_recompile(-0.0, 1.5) }
+        "#);
+
+        let final_hir = hir_string("test_float_mul_recompile");
+        assert!(final_hir.contains("CCallWithFrame"), "{final_hir}");
+        assert!(!final_hir.contains("FloatMul"), "{final_hir}");
+        assert_snapshot!(format!("{intermediate_hir}\n{final_hir}"), @"
+        fn test_float_mul_recompile@<compiled>:2:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          v2:CPtr = LoadSP
+          v3:BasicObject = LoadField v2, :a@0x1000
+          v4:BasicObject = LoadField v2, :b@0x1001
+          Jump bb3(v1, v3, v4)
+        bb2():
+          EntryPoint JIT(0)
+          v7:BasicObject = LoadArg :self@0
+          v8:BasicObject = LoadArg :a@1
+          v9:BasicObject = LoadArg :b@2
+          Jump bb3(v7, v8, v9)
+        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          PatchPoint MethodRedefined(Float@0x1008, *@0x1010, cme:0x1018)
+          v28:Flonum = GuardType v12, Flonum recompile
+          v29:Flonum = GuardType v13, Flonum recompile
+          v30:Float = FloatMul v28, v29
+          CheckInterrupts
+          Return v30
+
+        fn test_float_mul_recompile@<compiled>:2:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          v2:CPtr = LoadSP
+          v3:BasicObject = LoadField v2, :a@0x1000
+          v4:BasicObject = LoadField v2, :b@0x1001
+          Jump bb3(v1, v3, v4)
+        bb2():
+          EntryPoint JIT(0)
+          v7:BasicObject = LoadArg :self@0
+          v8:BasicObject = LoadArg :a@1
+          v9:BasicObject = LoadArg :b@2
+          Jump bb3(v7, v8, v9)
+        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          v21:CBool = HasType v12, HeapFloat
+          CondBranch v21, bb5(), bb6()
+        bb5():
+          v24:HeapFloat = RefineType v12, HeapFloat
+          PatchPoint MethodRedefined(Float@0x1008, *@0x1010, cme:0x1018)
+          v42:BasicObject = CCallWithFrame v24, :Float#*@0x1040, v13
+          Jump bb4(v42)
+        bb6():
+          v27:CBool = HasType v12, Flonum
+          CondBranch v27, bb7(), bb8()
+        bb7():
+          v30:Flonum = RefineType v12, Flonum
+          PatchPoint MethodRedefined(Float@0x1008, *@0x1010, cme:0x1018)
+          v45:BasicObject = CCallWithFrame v30, :Float#*@0x1040, v13
+          Jump bb4(v45)
+        bb8():
+          v33:BasicObject = Send v12, :*, v13 # SendFallbackReason: SendWithoutBlock: polymorphic fallback
+          Jump bb4(v33)
+        bb4(v20:BasicObject):
+          CheckInterrupts
+          Return v20
+        ");
+    }
+
+    #[test]
     fn test_elide_repeated_heap_object_guards() {
         eval(r#"
             C = Struct.new(:var)

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -17492,7 +17492,7 @@ mod hir_opt_tests {
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint MethodRedefined(Float@0x1008, +@0x1010, cme:0x1018)
           v28:Flonum = GuardType v12, Flonum recompile
-          v29:Flonum = GuardType v13, Flonum
+          v29:Flonum = GuardType v13, Flonum recompile
           v30:Float = FloatAdd v28, v29
           CheckInterrupts
           Return v30
@@ -17523,7 +17523,7 @@ mod hir_opt_tests {
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint MethodRedefined(Float@0x1008, *@0x1010, cme:0x1018)
           v28:Flonum = GuardType v12, Flonum recompile
-          v29:Flonum = GuardType v13, Flonum
+          v29:Flonum = GuardType v13, Flonum recompile
           v30:Float = FloatMul v28, v29
           CheckInterrupts
           Return v30
@@ -17554,7 +17554,7 @@ mod hir_opt_tests {
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint MethodRedefined(Float@0x1008, -@0x1010, cme:0x1018)
           v28:Flonum = GuardType v12, Flonum recompile
-          v29:Flonum = GuardType v13, Flonum
+          v29:Flonum = GuardType v13, Flonum recompile
           v30:Float = FloatSub v28, v29
           CheckInterrupts
           Return v30
@@ -17585,7 +17585,7 @@ mod hir_opt_tests {
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint MethodRedefined(Float@0x1008, /@0x1010, cme:0x1018)
           v28:Flonum = GuardType v12, Flonum recompile
-          v29:Flonum = GuardType v13, Flonum
+          v29:Flonum = GuardType v13, Flonum recompile
           v30:Float = FloatDiv v28, v29
           CheckInterrupts
           Return v30
@@ -17644,10 +17644,75 @@ mod hir_opt_tests {
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           PatchPoint MethodRedefined(Float@0x1008, *@0x1010, cme:0x1018)
           v28:Flonum = GuardType v12, Flonum recompile
-          v29:Fixnum = GuardType v13, Fixnum
+          v29:Fixnum = GuardType v13, Fixnum recompile
           v30:Float = FloatMul v28, v29
           CheckInterrupts
           Return v30
+        ");
+    }
+
+    #[test]
+    fn test_float_mul_recompile_stops_inlining_heap_float() {
+        set_max_versions(2);
+        eval(r#"
+            def test_float_mul_recompile(a, b) = a * b
+
+            30.times { test_float_mul_recompile(1.5, 2.5) }
+        "#);
+
+        let intermediate_hir = hir_string("test_float_mul_recompile");
+        assert!(intermediate_hir.contains("FloatMul"), "{intermediate_hir}");
+
+        eval(r#"
+            30.times { test_float_mul_recompile(1.5, -0.0) }
+        "#);
+
+        let final_hir = hir_string("test_float_mul_recompile");
+        assert!(final_hir.contains("CCallWithFrame"), "{final_hir}");
+        assert!(!final_hir.contains("FloatMul"), "{final_hir}");
+        assert_snapshot!(format!("{intermediate_hir}\n{final_hir}"), @"
+        fn test_float_mul_recompile@<compiled>:2:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          v2:CPtr = LoadSP
+          v3:BasicObject = LoadField v2, :a@0x1000
+          v4:BasicObject = LoadField v2, :b@0x1001
+          Jump bb3(v1, v3, v4)
+        bb2():
+          EntryPoint JIT(0)
+          v7:BasicObject = LoadArg :self@0
+          v8:BasicObject = LoadArg :a@1
+          v9:BasicObject = LoadArg :b@2
+          Jump bb3(v7, v8, v9)
+        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          PatchPoint MethodRedefined(Float@0x1008, *@0x1010, cme:0x1018)
+          v28:Flonum = GuardType v12, Flonum recompile
+          v29:Flonum = GuardType v13, Flonum recompile
+          v30:Float = FloatMul v28, v29
+          CheckInterrupts
+          Return v30
+
+        fn test_float_mul_recompile@<compiled>:2:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          v2:CPtr = LoadSP
+          v3:BasicObject = LoadField v2, :a@0x1000
+          v4:BasicObject = LoadField v2, :b@0x1001
+          Jump bb3(v1, v3, v4)
+        bb2():
+          EntryPoint JIT(0)
+          v7:BasicObject = LoadArg :self@0
+          v8:BasicObject = LoadArg :a@1
+          v9:BasicObject = LoadArg :b@2
+          Jump bb3(v7, v8, v9)
+        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          PatchPoint MethodRedefined(Float@0x1008, *@0x1010, cme:0x1018)
+          v28:Flonum = GuardType v12, Flonum recompile
+          v29:BasicObject = CCallWithFrame v28, :Float#*@0x1040, v13
+          CheckInterrupts
+          Return v29
         ");
     }
 


### PR DESCRIPTION
This PR fixes a `matmul` regression in https://github.com/ruby/ruby/pull/16735 differently from https://github.com/ruby/ruby/pull/16766.

## Summary
Make ZJIT’s inlined Float arithmetic operand guards use recompile exits.

This lets ZJIT reprofile and recompile when an operand is usually a Flonum/Fixnum but sometimes becomes a valid HeapFloat, such as `-0.0`. For `matmul`, this avoids repeatedly taking normal guard exits.

## Benchmark

```
before: ruby 4.1.0dev (2026-07-09T17:58:17Z master 9c3275a517) +ZJIT +PRISM [x86_64-linux]
after: ruby 4.1.0dev (2026-07-09T23:12:28Z zjit-float-guard-r.. 27dd70f55e) +ZJIT +PRISM [x86_64-linux]

------  ------------  ------------  -------------  ------------
bench    before (ms)    after (ms)  after 1st itr  before/after
matmul  215.4 ± 1.2%  126.7 ± 1.3%          1.152         1.699
------  ------------  ------------  -------------  ------------
```