### PR TITLE
Invalidate iterator blocks whose data is on the C stack after iteration

### DIFF
--- a/array.c
+++ b/array.c
@@ -4659,7 +4659,7 @@ take_items(VALUE obj, long n)
     if (!NIL_P(result)) return rb_ary_subseq(result, 0, n);
     result = rb_ary_new2(n);
     args[0] = result; args[1] = (VALUE)n;
-    if (UNDEF_P(rb_check_block_call(obj, idEach, 0, 0, take_i, (VALUE)args)))
+    if (UNDEF_P(rb_check_block_call_noescape(obj, idEach, 0, 0, take_i, (VALUE)args)))
         rb_raise(rb_eTypeError, "wrong argument type %"PRIsVALUE" (must respond to :each)",
                  rb_obj_class(obj));
     return result;

--- a/enum.c
+++ b/enum.c
@@ -20,6 +20,7 @@
 #include "internal/proc.h"
 #include "internal/rational.h"
 #include "internal/re.h"
+#include "internal/vm.h"
 #include "ruby/util.h"
 #include "ruby_assert.h"
 #include "symbol.h"
@@ -2134,7 +2135,7 @@ rb_nmin_run(VALUE obj, VALUE num, int by, int rev, int ary)
         }
     }
     else {
-        rb_block_call(obj, id_each, 0, 0, nmin_i, (VALUE)&data);
+        rb_block_call_noescape(obj, id_each, 0, 0, nmin_i, (VALUE)&data);
     }
     nmin_filter(&data);
     result = data.buf;
@@ -4854,7 +4855,7 @@ enum_sum(int argc, VALUE* argv, VALUE obj)
             rb_method_basic_definition_p(CLASS_OF(obj), id_each))
         hash_sum(obj, &memo);
     else
-        rb_block_call(obj, id_each, 0, 0, enum_sum_i, (VALUE)&memo);
+        rb_block_call_noescape(obj, id_each, 0, 0, enum_sum_i, (VALUE)&memo);
 
     if (memo.float_value) {
         return DBL2NUM(memo.f + memo.c);

--- a/enumerator.c
+++ b/enumerator.c
@@ -29,6 +29,7 @@
 #include "internal/numeric.h"
 #include "internal/range.h"
 #include "internal/rational.h"
+#include "internal/vm.h"
 #include "ruby/ruby.h"
 
 /*
@@ -2122,7 +2123,7 @@ lazy_flat_map_proc(VALUE proc_entry, struct MEMO *result, VALUE memos, long memo
     else if (rb_respond_to(value, id_force) && rb_respond_to(value, id_each)) {
         struct flat_map_i_arg arg = {.result = result, .index = proc_index};
         LAZY_MEMO_RESET_BREAK(result);
-        rb_block_call(value, id_each, 0, 0, lazy_flat_map_i, (VALUE)&arg);
+        rb_block_call_noescape(value, id_each, 0, 0, lazy_flat_map_i, (VALUE)&arg);
         if (break_p) LAZY_MEMO_SET_BREAK(result);
         return 0;
     }
@@ -3681,7 +3682,7 @@ product_each(VALUE obj, struct product_state *pstate)
     if (pstate->index < pstate->argc) {
         VALUE eobj = RARRAY_AREF(enums, pstate->index);
 
-        rb_block_call(eobj, id_each_entry, 0, NULL, product_each_i, (VALUE)pstate);
+        rb_block_call_noescape(eobj, id_each_entry, 0, NULL, product_each_i, (VALUE)pstate);
     }
     else {
         rb_funcall(pstate->block, id_call, 1, rb_ary_new_from_values(pstate->argc, pstate->argv));

--- a/internal/vm.h
+++ b/internal/vm.h
@@ -62,6 +62,7 @@ void rb_lastline_set_up(VALUE val, unsigned int up);
 /* vm_eval.c */
 VALUE rb_current_realfilepath(void);
 VALUE rb_check_block_call(VALUE, ID, int, const VALUE *, rb_block_call_func_t, VALUE);
+VALUE rb_block_call_retaining(VALUE obj, ID mid, int argc, const VALUE *argv, rb_block_call_func_t bl_proc, VALUE data2);
 typedef void rb_check_funcall_hook(int, VALUE, ID, int, const VALUE *, VALUE);
 VALUE rb_check_funcall_with_hook_kw(VALUE recv, ID mid, int argc, const VALUE *argv,
                                  rb_check_funcall_hook *hook, VALUE arg, int kw_splat);

--- a/internal/vm.h
+++ b/internal/vm.h
@@ -62,7 +62,8 @@ void rb_lastline_set_up(VALUE val, unsigned int up);
 /* vm_eval.c */
 VALUE rb_current_realfilepath(void);
 VALUE rb_check_block_call(VALUE, ID, int, const VALUE *, rb_block_call_func_t, VALUE);
-VALUE rb_block_call_retaining(VALUE obj, ID mid, int argc, const VALUE *argv, rb_block_call_func_t bl_proc, VALUE data2);
+VALUE rb_block_call_noescape(VALUE obj, ID mid, int argc, const VALUE *argv, rb_block_call_func_t bl_proc, VALUE data2);
+VALUE rb_check_block_call_noescape(VALUE obj, ID mid, int argc, const VALUE *argv, rb_block_call_func_t bl_proc, VALUE data2);
 typedef void rb_check_funcall_hook(int, VALUE, ID, int, const VALUE *, VALUE);
 VALUE rb_check_funcall_with_hook_kw(VALUE recv, ID mid, int argc, const VALUE *argv,
                                  rb_check_funcall_hook *hook, VALUE arg, int kw_splat);

--- a/proc.c
+++ b/proc.c
@@ -19,6 +19,7 @@
 #include "internal/object.h"
 #include "internal/proc.h"
 #include "internal/symbol.h"
+#include "internal/vm.h"
 #include "method.h"
 #include "iseq.h"
 #include "vm_core.h"
@@ -3796,7 +3797,7 @@ rb_proc_new(
     rb_block_call_func_t func,
     VALUE val)
 {
-    VALUE procval = rb_block_call(rb_mRubyVMFrozenCore, idProc, 0, 0, func, val);
+    VALUE procval = rb_block_call_retaining(rb_mRubyVMFrozenCore, idProc, 0, 0, func, val);
     return procval;
 }
 
@@ -3822,7 +3823,7 @@ method_to_proc(VALUE method)
      *   end
      * end
      */
-    procval = rb_block_call(rb_mRubyVMFrozenCore, idLambda, 0, 0, bmcall, method);
+    procval = rb_block_call_retaining(rb_mRubyVMFrozenCore, idLambda, 0, 0, bmcall, method);
     GetProcPtr(procval, proc);
     proc->is_from_method = 1;
     return procval;

--- a/proc.c
+++ b/proc.c
@@ -19,7 +19,6 @@
 #include "internal/object.h"
 #include "internal/proc.h"
 #include "internal/symbol.h"
-#include "internal/vm.h"
 #include "method.h"
 #include "iseq.h"
 #include "vm_core.h"
@@ -3797,7 +3796,7 @@ rb_proc_new(
     rb_block_call_func_t func,
     VALUE val)
 {
-    VALUE procval = rb_block_call_retaining(rb_mRubyVMFrozenCore, idProc, 0, 0, func, val);
+    VALUE procval = rb_block_call(rb_mRubyVMFrozenCore, idProc, 0, 0, func, val);
     return procval;
 }
 
@@ -3823,7 +3822,7 @@ method_to_proc(VALUE method)
      *   end
      * end
      */
-    procval = rb_block_call_retaining(rb_mRubyVMFrozenCore, idLambda, 0, 0, bmcall, method);
+    procval = rb_block_call(rb_mRubyVMFrozenCore, idLambda, 0, 0, bmcall, method);
     GetProcPtr(procval, proc);
     proc->is_from_method = 1;
     return procval;

--- a/range.c
+++ b/range.c
@@ -27,6 +27,7 @@
 #include "internal/error.h"
 #include "internal/numeric.h"
 #include "internal/range.h"
+#include "internal/vm.h"
 
 VALUE rb_cRange;
 static ID id_beg, id_end, id_excl;
@@ -1423,7 +1424,7 @@ range_first(int argc, VALUE *argv, VALUE range)
     rb_scan_args(argc, argv, "1", &n);
     ary[0] = n;
     ary[1] = rb_ary_new2(NUM2LONG(n));
-    rb_block_call(range, idEach, 0, 0, first_i, (VALUE)ary);
+    rb_block_call_noescape(range, idEach, 0, 0, first_i, (VALUE)ary);
 
     return ary[1];
 }
@@ -1768,7 +1769,7 @@ range_max(int argc, VALUE *argv, VALUE range)
         CONST_ID(reverse_each, "reverse_each");
         rb_scan_args(argc, argv, "1", &ary[0]);
         ary[1] = rb_ary_new2(NUM2LONG(ary[0]));
-        rb_block_call(range, reverse_each, 0, 0, first_i, (VALUE)ary);
+        rb_block_call_noescape(range, reverse_each, 0, 0, first_i, (VALUE)ary);
         return ary[1];
 #if 0
         if (integer_end_optimizable(range)) {

--- a/set.c
+++ b/set.c
@@ -14,6 +14,7 @@
 #include "internal/set_table.h"
 #include "internal/symbol.h"
 #include "internal/variable.h"
+#include "internal/vm.h"
 #include "ruby_assert.h"
 
 #include <stdio.h>
@@ -1186,7 +1187,7 @@ set_i_intersection(VALUE set, VALUE other)
             .into = ntable,
             .other = stable
         };
-        rb_block_call(other, enum_method_id(other), 0, 0, set_intersection_block, (VALUE)&data);
+        rb_block_call_noescape(other, enum_method_id(other), 0, 0, set_intersection_block, (VALUE)&data);
     }
 
     return new_set;

--- a/test/ruby/test_enum.rb
+++ b/test/ruby/test_enum.rb
@@ -1171,6 +1171,44 @@ class TestEnumerable < Test::Unit::TestCase
     assert_typed_equal(e, v, Complex, msg)
   end
 
+  def test_block_called_after_iteration_ended
+    bug22019 = '[Bug #22019]'
+    c = Class.new do
+      include Enumerable
+      attr_reader :block
+      def initialize(*values)
+        @values = values
+      end
+      def each(&b)
+        @block = b
+        @values.each {|v| yield v }
+        self
+      end
+    end
+
+    obj = c.new(1, 2)
+    assert_equal(3, obj.sum, bug22019)
+    assert_raise_with_message(RuntimeError, /after iteration ended/, bug22019) {obj.block.call(1)}
+
+    obj = c.new(3, 1, 2)
+    assert_equal([1], obj.min(1), bug22019)
+    assert_raise_with_message(RuntimeError, /after iteration ended/, bug22019) {obj.block.call(1)}
+
+    obj = c.new(1, 2)
+    assert_equal([[10, 1], [20, 2]], [10, 20].zip(obj), bug22019)
+    assert_raise_with_message(RuntimeError, /after iteration ended/, bug22019) {obj.block.call(1)}
+
+    # calling the block during the iteration is still fine
+    class << (reentrant = Object.new)
+      include Enumerable
+      def each(&b)
+        b.call(1)
+        b.call(2)
+      end
+    end
+    assert_equal(3, reentrant.sum, bug22019)
+  end
+
   def test_sum
     class << (enum = Object.new)
       include Enumerable

--- a/test/ruby/test_enumerator.rb
+++ b/test/ruby/test_enumerator.rb
@@ -965,6 +965,24 @@ class TestEnumerator < Test::Unit::TestCase
     assert_equal(true, e.is_lambda)
   end
 
+  def test_product_block_called_after_iteration_ended
+    bug22019 = '[Bug #22019]'
+    o = Object.new
+    def o.each_entry(&b)
+      @block = b
+      b.call(1)
+    end
+    def o.block
+      @block
+    end
+    acc = []
+    Enumerator::Product.new(o, [2]).each { |x, y| acc << [x, y] }
+    assert_equal([[1, 2]], acc, bug22019)
+    assert_raise_with_message(RuntimeError, /after iteration ended/, bug22019) {
+      o.block.call(1)
+    }
+  end
+
   def test_product_new
     # 0-dimensional
     e = Enumerator::Product.new

--- a/test/ruby/test_lazy_enumerator.rb
+++ b/test/ruby/test_lazy_enumerator.rb
@@ -124,6 +124,26 @@ class TestLazyEnumerator < Test::Unit::TestCase
     assert_equal(1, a.current)
   end
 
+  def test_flat_map_block_called_after_iteration_ended
+    bug22019 = '[Bug #22019]'
+    c = Class.new do
+      include Enumerable
+      attr_reader :block
+      def each(&b)
+        @block = b
+        yield 1
+      end
+      def force
+        to_a
+      end
+    end
+    obj = c.new
+    assert_equal([1], [obj].lazy.flat_map {|x| x}.force, bug22019)
+    assert_raise_with_message(RuntimeError, /after iteration ended/, bug22019) {
+      obj.block.call(1)
+    }
+  end
+
   def test_flat_map_nested
     a = Step.new(1..3)
     assert_equal([1, "a"],

--- a/test/ruby/test_range.rb
+++ b/test/ruby/test_range.rb
@@ -870,6 +870,22 @@ class TestRange < Test::Unit::TestCase
     assert_equal(nil, (0...nil).end)
   end
 
+  def test_first_block_called_after_iteration_ended
+    bug22019 = '[Bug #22019]'
+    c = Class.new(Range) do
+      attr_reader :block
+      def each(&b)
+        @block = b
+        super
+      end
+    end
+    r = c.new(1, 5)
+    assert_equal([1, 2], r.first(2), bug22019)
+    assert_raise_with_message(RuntimeError, /after iteration ended/, bug22019) {
+      r.block.call(9)
+    }
+  end
+
   def test_first_last
     assert_equal([0, 1, 2], (0..10).first(3))
     assert_equal([8, 9, 10], (0..10).last(3))

--- a/test/ruby/test_set.rb
+++ b/test/ruby/test_set.rb
@@ -689,6 +689,23 @@ class TC_Set < Test::Unit::TestCase
     assert_equal(Set[2,4], ret)
   end
 
+  def test_and_block_called_after_iteration_ended
+    bug22019 = '[Bug #22019]'
+    c = Class.new do
+      include Enumerable
+      attr_reader :block
+      def each(&b)
+        @block = b
+        yield 1
+      end
+    end
+    obj = c.new
+    assert_equal(Set[1], Set[1, 2, 3] & obj, bug22019)
+    assert_raise_with_message(RuntimeError, /after iteration ended/, bug22019) {
+      obj.block.call(1)
+    }
+  end
+
   def test_xor
     ALL_SET_CLASSES.each { |klass|
       set = klass[1,2,3,4]

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -1500,7 +1500,7 @@ iterator_data_on_machine_stack(const rb_execution_context_t *ec, const void *dat
 
 static VALUE
 rb_iterate0(VALUE (* it_proc) (VALUE), VALUE data1,
-            struct vm_ifunc *const ifunc,
+            struct vm_ifunc *const ifunc, bool invalidate_block,
             rb_execution_context_t *ec)
 {
     enum ruby_tag_type state;
@@ -1546,11 +1546,13 @@ rb_iterate0(VALUE (* it_proc) (VALUE), VALUE data1,
     }
     EC_POP_TAG();
 
-    if (ifunc && iterator_data_on_machine_stack(ec, ifunc->data)) {
+    if (invalidate_block && ifunc && iterator_data_on_machine_stack(ec, ifunc->data)) {
         /* The data points into a C stack frame that dies with this return,
          * so the block must not outlive this iteration.  Blocks whose data
          * is a heap object (e.g. the ones rb_proc_new or Enumerator pass to
-         * a method that retains them) stay callable. */
+         * a method that retains them) stay callable.  Constructors such as
+         * rb_proc_new()/rb_fiber_new() pass invalidate_block=false because
+         * their block deliberately outlives this call. */
         ifunc->func = iterator_block_expired;
         ifunc->data = NULL;
     }
@@ -1563,11 +1565,11 @@ rb_iterate0(VALUE (* it_proc) (VALUE), VALUE data1,
 
 static VALUE
 rb_iterate_internal(VALUE (* it_proc)(VALUE), VALUE data1,
-                    rb_block_call_func_t bl_proc, VALUE data2)
+                    rb_block_call_func_t bl_proc, VALUE data2, bool invalidate_block)
 {
     return rb_iterate0(it_proc, data1,
                        bl_proc ? rb_vm_ifunc_proc_new(bl_proc, (void *)data2) : 0,
-                       GET_EC());
+                       invalidate_block, GET_EC());
 }
 
 struct iter_method_arg {
@@ -1607,7 +1609,27 @@ rb_block_call_kw(VALUE obj, ID mid, int argc, const VALUE * argv,
     arg.argc = argc;
     arg.argv = argv;
     arg.kw_splat = kw_splat;
-    return rb_iterate_internal(iterate_method, (VALUE)&arg, bl_proc, data2);
+    return rb_iterate_internal(iterate_method, (VALUE)&arg, bl_proc, data2, true);
+}
+
+/*
+ * Like rb_block_call, but the block created for bl_proc is expected to
+ * outlive this call (it is captured into a Proc or Fiber that is
+ * returned).  Its ifunc is therefore not invalidated on return; the
+ * caller owns the lifetime of data2.
+ */
+VALUE
+rb_block_call_retaining(VALUE obj, ID mid, int argc, const VALUE *argv,
+                        rb_block_call_func_t bl_proc, VALUE data2)
+{
+    struct iter_method_arg arg;
+
+    arg.obj = obj;
+    arg.mid = mid;
+    arg.argc = argc;
+    arg.argv = argv;
+    arg.kw_splat = RB_NO_KEYWORDS;
+    return rb_iterate_internal(iterate_method, (VALUE)&arg, bl_proc, data2, false);
 }
 
 /*
@@ -1638,7 +1660,7 @@ rb_block_call2(VALUE obj, ID mid, int argc, const VALUE *argv,
     if (flags & RB_BLOCK_NO_USE_PACKED_ARGS)
         ifunc->flags |= IFUNC_YIELD_OPTIMIZABLE;
 
-    return rb_iterate0(iterate_method, (VALUE)&arg, ifunc, GET_EC());
+    return rb_iterate0(iterate_method, (VALUE)&arg, ifunc, true, GET_EC());
 }
 
 VALUE
@@ -1656,7 +1678,7 @@ rb_lambda_call(VALUE obj, ID mid, int argc, const VALUE *argv,
     arg.argv = argv;
     arg.kw_splat = 0;
     block = rb_vm_ifunc_new(bl_proc, (void *)data2, min_argc, max_argc);
-    return rb_iterate0(iterate_method, (VALUE)&arg, block, GET_EC());
+    return rb_iterate0(iterate_method, (VALUE)&arg, block, true, GET_EC());
 }
 
 static VALUE
@@ -1679,7 +1701,7 @@ rb_check_block_call(VALUE obj, ID mid, int argc, const VALUE *argv,
     arg.argc = argc;
     arg.argv = argv;
     arg.kw_splat = 0;
-    return rb_iterate_internal(iterate_check_method, (VALUE)&arg, bl_proc, data2);
+    return rb_iterate_internal(iterate_check_method, (VALUE)&arg, bl_proc, data2, true);
 }
 
 VALUE

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -1488,7 +1488,8 @@ rb_iterate0(VALUE (* it_proc) (VALUE), VALUE data1,
 {
     enum ruby_tag_type state;
     volatile VALUE retval = Qnil;
-    rb_control_frame_t *const cfp = ec->cfp;
+    rb_control_frame_t *volatile const cfp = ec->cfp;
+    struct vm_ifunc *volatile const invalidate_ifunc = block_noescape ? ifunc : NULL;
 
     EC_PUSH_TAG(ec);
     state = EC_EXEC_TAG();
@@ -1529,13 +1530,9 @@ rb_iterate0(VALUE (* it_proc) (VALUE), VALUE data1,
     }
     EC_POP_TAG();
 
-    if (block_noescape && ifunc) {
-        /* The block must not outlive this call: its data may point into
-         * this (now dead) C stack frame.  Invalidate it so that a block
-         * captured by the called method raises instead of causing a
-         * use-after-return. */
-        ifunc->func = iterator_block_expired;
-        ifunc->data = NULL;
+    if (invalidate_ifunc) {
+        invalidate_ifunc->func = iterator_block_expired;
+        invalidate_ifunc->data = NULL;
     }
 
     if (state) {

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -1475,8 +1475,32 @@ vm_frametype_name(const rb_control_frame_t *cfp);
 #endif
 
 static VALUE
+iterator_block_expired(RB_BLOCK_CALL_FUNC_ARGLIST(yielded_arg, callback_arg))
+{
+    rb_raise(rb_eRuntimeError, "iterator block was called after iteration ended");
+    UNREACHABLE_RETURN(Qnil);
+}
+
+/* Whether `data` points into the machine stack of the current execution
+ * context, i.e. into a local of one of the C frames above rb_iterate0. */
+static bool
+iterator_data_on_machine_stack(const rb_execution_context_t *ec, const void *data)
+{
+    /* A large Fixnum or a flonum passed as data could alias a stack
+     * address; a real pointer into the stack is at least VALUE-aligned
+     * and never a special constant. */
+    if (RB_SPECIAL_CONST_P((VALUE)data)) return false;
+
+    const uintptr_t p = (uintptr_t)data;
+    const uintptr_t start = (uintptr_t)ec->machine.stack_start;
+    const uintptr_t here = (uintptr_t)&p;
+
+    return start < here ? (start <= p && p <= here) : (here <= p && p <= start);
+}
+
+static VALUE
 rb_iterate0(VALUE (* it_proc) (VALUE), VALUE data1,
-            const struct vm_ifunc *const ifunc,
+            struct vm_ifunc *const ifunc,
             rb_execution_context_t *ec)
 {
     enum ruby_tag_type state;
@@ -1521,6 +1545,15 @@ rb_iterate0(VALUE (* it_proc) (VALUE), VALUE data1,
         }
     }
     EC_POP_TAG();
+
+    if (ifunc && iterator_data_on_machine_stack(ec, ifunc->data)) {
+        /* The data points into a C stack frame that dies with this return,
+         * so the block must not outlive this iteration.  Blocks whose data
+         * is a heap object (e.g. the ones rb_proc_new or Enumerator pass to
+         * a method that retains them) stay callable. */
+        ifunc->func = iterator_block_expired;
+        ifunc->data = NULL;
+    }
 
     if (state) {
         EC_JUMP_TAG(ec, state);

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -1481,26 +1481,9 @@ iterator_block_expired(RB_BLOCK_CALL_FUNC_ARGLIST(yielded_arg, callback_arg))
     UNREACHABLE_RETURN(Qnil);
 }
 
-/* Whether `data` points into the machine stack of the current execution
- * context, i.e. into a local of one of the C frames above rb_iterate0. */
-static bool
-iterator_data_on_machine_stack(const rb_execution_context_t *ec, const void *data)
-{
-    /* A large Fixnum or a flonum passed as data could alias a stack
-     * address; a real pointer into the stack is at least VALUE-aligned
-     * and never a special constant. */
-    if (RB_SPECIAL_CONST_P((VALUE)data)) return false;
-
-    const uintptr_t p = (uintptr_t)data;
-    const uintptr_t start = (uintptr_t)ec->machine.stack_start;
-    const uintptr_t here = (uintptr_t)&p;
-
-    return start < here ? (start <= p && p <= here) : (here <= p && p <= start);
-}
-
 static VALUE
 rb_iterate0(VALUE (* it_proc) (VALUE), VALUE data1,
-            struct vm_ifunc *const ifunc, bool invalidate_block,
+            struct vm_ifunc *const ifunc, bool block_noescape,
             rb_execution_context_t *ec)
 {
     enum ruby_tag_type state;
@@ -1546,13 +1529,11 @@ rb_iterate0(VALUE (* it_proc) (VALUE), VALUE data1,
     }
     EC_POP_TAG();
 
-    if (invalidate_block && ifunc && iterator_data_on_machine_stack(ec, ifunc->data)) {
-        /* The data points into a C stack frame that dies with this return,
-         * so the block must not outlive this iteration.  Blocks whose data
-         * is a heap object (e.g. the ones rb_proc_new or Enumerator pass to
-         * a method that retains them) stay callable.  Constructors such as
-         * rb_proc_new()/rb_fiber_new() pass invalidate_block=false because
-         * their block deliberately outlives this call. */
+    if (block_noescape && ifunc) {
+        /* The block must not outlive this call: its data may point into
+         * this (now dead) C stack frame.  Invalidate it so that a block
+         * captured by the called method raises instead of causing a
+         * use-after-return. */
         ifunc->func = iterator_block_expired;
         ifunc->data = NULL;
     }
@@ -1565,11 +1546,11 @@ rb_iterate0(VALUE (* it_proc) (VALUE), VALUE data1,
 
 static VALUE
 rb_iterate_internal(VALUE (* it_proc)(VALUE), VALUE data1,
-                    rb_block_call_func_t bl_proc, VALUE data2, bool invalidate_block)
+                    rb_block_call_func_t bl_proc, VALUE data2, bool block_noescape)
 {
     return rb_iterate0(it_proc, data1,
                        bl_proc ? rb_vm_ifunc_proc_new(bl_proc, (void *)data2) : 0,
-                       invalidate_block, GET_EC());
+                       block_noescape, GET_EC());
 }
 
 struct iter_method_arg {
@@ -1609,18 +1590,20 @@ rb_block_call_kw(VALUE obj, ID mid, int argc, const VALUE * argv,
     arg.argc = argc;
     arg.argv = argv;
     arg.kw_splat = kw_splat;
-    return rb_iterate_internal(iterate_method, (VALUE)&arg, bl_proc, data2, true);
+    return rb_iterate_internal(iterate_method, (VALUE)&arg, bl_proc, data2, false);
 }
 
 /*
- * Like rb_block_call, but the block created for bl_proc is expected to
- * outlive this call (it is captured into a Proc or Fiber that is
- * returned).  Its ifunc is therefore not invalidated on return; the
- * caller owns the lifetime of data2.
+ * Identical to rb_block_call(), except that the block created for
+ * `bl_proc` must not escape this call: it is invalidated when this
+ * function returns, and calling it afterwards raises RuntimeError.
+ * Use this variant whenever `data2` points to storage that dies with
+ * this call (e.g. a buffer on the caller's stack), so that a block
+ * captured by the called method cannot cause a use-after-return.
  */
 VALUE
-rb_block_call_retaining(VALUE obj, ID mid, int argc, const VALUE *argv,
-                        rb_block_call_func_t bl_proc, VALUE data2)
+rb_block_call_noescape(VALUE obj, ID mid, int argc, const VALUE *argv,
+                       rb_block_call_func_t bl_proc, VALUE data2)
 {
     struct iter_method_arg arg;
 
@@ -1629,7 +1612,7 @@ rb_block_call_retaining(VALUE obj, ID mid, int argc, const VALUE *argv,
     arg.argc = argc;
     arg.argv = argv;
     arg.kw_splat = RB_NO_KEYWORDS;
-    return rb_iterate_internal(iterate_method, (VALUE)&arg, bl_proc, data2, false);
+    return rb_iterate_internal(iterate_method, (VALUE)&arg, bl_proc, data2, true);
 }
 
 /*
@@ -1660,7 +1643,7 @@ rb_block_call2(VALUE obj, ID mid, int argc, const VALUE *argv,
     if (flags & RB_BLOCK_NO_USE_PACKED_ARGS)
         ifunc->flags |= IFUNC_YIELD_OPTIMIZABLE;
 
-    return rb_iterate0(iterate_method, (VALUE)&arg, ifunc, true, GET_EC());
+    return rb_iterate0(iterate_method, (VALUE)&arg, ifunc, false, GET_EC());
 }
 
 VALUE
@@ -1678,7 +1661,7 @@ rb_lambda_call(VALUE obj, ID mid, int argc, const VALUE *argv,
     arg.argv = argv;
     arg.kw_splat = 0;
     block = rb_vm_ifunc_new(bl_proc, (void *)data2, min_argc, max_argc);
-    return rb_iterate0(iterate_method, (VALUE)&arg, block, true, GET_EC());
+    return rb_iterate0(iterate_method, (VALUE)&arg, block, false, GET_EC());
 }
 
 static VALUE
@@ -1693,6 +1676,21 @@ iterate_check_method(VALUE obj)
 VALUE
 rb_check_block_call(VALUE obj, ID mid, int argc, const VALUE *argv,
                     rb_block_call_func_t bl_proc, VALUE data2)
+{
+    struct iter_method_arg arg;
+
+    arg.obj = obj;
+    arg.mid = mid;
+    arg.argc = argc;
+    arg.argv = argv;
+    arg.kw_splat = 0;
+    return rb_iterate_internal(iterate_check_method, (VALUE)&arg, bl_proc, data2, false);
+}
+
+/* The rb_block_call_noescape() counterpart of rb_check_block_call(). */
+VALUE
+rb_check_block_call_noescape(VALUE obj, ID mid, int argc, const VALUE *argv,
+                             rb_block_call_func_t bl_proc, VALUE data2)
 {
     struct iter_method_arg arg;
 


### PR DESCRIPTION
rb_block_call() and its variants create an imemo_ifunc whose data field may point to a struct on the C stack of the calling function. If the iterated method captures the passed block as a Proc and calls it after the iterating function has returned, the callback dereferences the dead C stack frame and crashes.

This fix prevents the block from being called after the iterating function returns.

New internal functions are added:

* `rb_block_call_noescape()`
* `rb_check_block_call_noescape()`

They are identical to `rb_block_call()`/`rb_check_block_call()`, except that the block created for `bl_proc` must not escape the call: when the function returns, the ifunc's `func` is replaced with a stub that raises a `RuntimeError` ("iterator block was called after iteration ended") and its `data` is cleared.

The vulnerable call sites in set.c, enum.c, enumerator.c, range.c, and array.c are converted to these variants, so a captured block now raises instead of causing a use-after-return:

```
$ ./ruby t.rb
t.rb:10:in '<main>': iterator block was called after iteration ended (RuntimeError)
```

[Bug #22019]
