### PR TITLE
Make two VM-global GC roots per-Ractor (mark_object_ary, traversal mark redirect)

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -2662,11 +2662,22 @@ ruby_stack_check(void)
 
 /* ==================== Marking ==================== */
 
+/* The traversal mark redirect is per-Ractor, except on a modular GC where
+ * marking can run on worker threads with no current EC and it lives in the VM.
+ * GC_MARK_FUNC_DATA_SLOTP() points at the active slot; a non-modular build pays
+ * nothing extra over a plain GET_VM() (one GET_RACTOR(), no NULL check). */
+#if USE_MODULAR_GC
+#  define GC_MARK_FUNC_DATA_SLOTP()  (&GET_VM()->gc.mark_func_data)
+#else
+#  define GC_MARK_FUNC_DATA_SLOTP()  (&GET_RACTOR()->mark_func_data)
+#endif
+
 #define RB_GC_MARK_OR_TRAVERSE(func, obj_or_ptr, obj, check_obj) do { \
     if (!RB_SPECIAL_CONST_P(obj)) { \
-        rb_vm_t *vm = GET_VM(); \
-        void *objspace = vm->gc.objspace; \
-        if (LIKELY(vm->gc.mark_func_data == NULL)) { \
+        struct gc_mark_func_data_struct **mfdp = GC_MARK_FUNC_DATA_SLOTP(); \
+        struct gc_mark_func_data_struct *mark_func_data = *mfdp; \
+        void *objspace = GET_VM()->gc.objspace; \
+        if (LIKELY(mark_func_data == NULL)) { \
             GC_ASSERT(rb_gc_impl_during_gc_p(objspace)); \
             (func)(objspace, (obj_or_ptr)); \
         } \
@@ -2675,10 +2686,9 @@ ruby_stack_check(void)
                     !rb_gc_impl_garbage_object_p(objspace, obj) : \
                 true) { \
             GC_ASSERT(!rb_gc_impl_during_gc_p(objspace)); \
-            struct gc_mark_func_data_struct *mark_func_data = vm->gc.mark_func_data; \
-            vm->gc.mark_func_data = NULL; \
+            *mfdp = NULL; \
             mark_func_data->mark_func((obj), mark_func_data->data); \
-            vm->gc.mark_func_data = mark_func_data; \
+            *mfdp = mark_func_data; \
         } \
     } \
 } while (0)
@@ -4545,16 +4555,16 @@ rb_objspace_reachable_objects_from(VALUE obj, void (func)(VALUE, void *), void *
         if (rb_gc_impl_during_gc_p(rb_gc_get_objspace())) rb_bug("rb_objspace_reachable_objects_from() is not supported while during GC");
 
         if (!RB_SPECIAL_CONST_P(obj)) {
-            rb_vm_t *vm = GET_VM();
-            struct gc_mark_func_data_struct *prev_mfd = vm->gc.mark_func_data;
+            struct gc_mark_func_data_struct **mfdp = GC_MARK_FUNC_DATA_SLOTP();
+            struct gc_mark_func_data_struct *prev_mfd = *mfdp;
             struct gc_mark_func_data_struct mfd = {
                 .mark_func = func,
                 .data = data,
             };
 
-            vm->gc.mark_func_data = &mfd;
+            *mfdp = &mfd;
             rb_gc_mark_children(rb_gc_get_objspace(), obj);
-            vm->gc.mark_func_data = prev_mfd;
+            *mfdp = prev_mfd;
         }
     }
 }
@@ -4584,16 +4594,17 @@ rb_objspace_reachable_objects_from_root(void (func)(const char *category, VALUE,
         .data = passing_data,
     };
 
-    struct gc_mark_func_data_struct *prev_mfd = vm->gc.mark_func_data;
+    struct gc_mark_func_data_struct **mfdp = GC_MARK_FUNC_DATA_SLOTP();
+    struct gc_mark_func_data_struct *prev_mfd = *mfdp;
     struct gc_mark_func_data_struct mfd = {
         .mark_func = root_objects_from,
         .data = &data,
     };
 
-    vm->gc.mark_func_data = &mfd;
+    *mfdp = &mfd;
     rb_gc_save_machine_context();
     rb_gc_mark_roots(vm->gc.objspace, &data.category);
-    vm->gc.mark_func_data = prev_mfd;
+    *mfdp = prev_mfd;
 }
 
 /*

--- a/ractor.c
+++ b/ractor.c
@@ -237,6 +237,12 @@ ractor_mark(void *ptr)
 
     if (!checking_shareable) {
         // may unshareable objects
+
+        /* objects this Ractor pinned via rb_gc_register_mark_object (the
+         * pin_array_list wrapper itself is an unshareable internal object;
+         * updated in ractor_update_references) */
+        if (r->mark_object_ary) rb_gc_mark_movable(r->mark_object_ary);
+
         rb_gc_mark(r->r_stdin);
         rb_gc_mark(r->r_stdout);
         rb_gc_mark(r->r_stderr);
@@ -313,13 +319,23 @@ ractor_memsize(const void *ptr)
     return sizeof(rb_ractor_t) + ractor_sync_memsize(r);
 }
 
+static void
+ractor_update_references(void *ptr)
+{
+    rb_ractor_t *r = (rb_ractor_t *)ptr;
+    /* the registered mark objects list is marked movable in ractor_mark */
+    if (r->mark_object_ary) {
+        r->mark_object_ary = rb_gc_location(r->mark_object_ary);
+    }
+}
+
 static const rb_data_type_t ractor_data_type = {
     "ractor",
     {
         ractor_mark,
         ractor_free,
         ractor_memsize,
-        NULL, // update
+        ractor_update_references,
     },
     0, 0, RUBY_TYPED_FREE_IMMEDIATELY /* | RUBY_TYPED_WB_PROTECTED */
 };
@@ -437,6 +453,9 @@ vm_remove_ractor(rb_vm_t *vm, rb_ractor_t *cr)
 
     RB_VM_LOCK();
     {
+        /* keep this Ractor's registered mark objects alive under the main Ractor */
+        if (cr->mark_object_ary) rb_vm_ractor_migrate_mark_objects(vm->ractor.main_ractor, cr);
+
         RUBY_DEBUG_LOG("ractor.cnt:%u-- terminate_waiting:%d",
                        vm->ractor.cnt,  vm->ractor.sync.terminate_waiting);
 

--- a/ractor_core.h
+++ b/ractor_core.h
@@ -69,6 +69,13 @@ struct rb_ractor_struct {
     struct rb_ractor_pub pub;
     struct rb_ractor_sync sync;
 
+#if !USE_MODULAR_GC
+    /* traversal-API mark redirect (NULL outside a traversal).  Per Ractor so a
+     * concurrent traversal on another Ractor is never observed.  A modular GC
+     * keeps this in the VM instead (vm->gc.mark_func_data). */
+    struct gc_mark_func_data_struct *mark_func_data;
+#endif
+
     // thread management
     struct {
         struct ccan_list_head set;

--- a/ractor_core.h
+++ b/ractor_core.h
@@ -69,6 +69,10 @@ struct rb_ractor_struct {
     struct rb_ractor_pub pub;
     struct rb_ractor_sync sync;
 
+    /* objects pinned via rb_gc_register_mark_object; this Ractor owns them and
+     * marks them, and hands them to the main Ractor when it terminates. */
+    VALUE mark_object_ary;
+
 #if !USE_MODULAR_GC
     /* traversal-API mark redirect (NULL outside a traversal).  Per Ractor so a
      * concurrent traversal on another Ractor is never observed.  A modular GC
@@ -143,6 +147,7 @@ rb_ractor_self(const rb_ractor_t *r)
 
 rb_ractor_t *rb_ractor_main_alloc(void);
 void rb_ractor_main_setup(rb_vm_t *vm, rb_ractor_t *main_ractor, rb_thread_t *main_thread);
+void rb_vm_ractor_migrate_mark_objects(rb_ractor_t *dst, rb_ractor_t *src);
 void rb_ractor_atexit(rb_execution_context_t *ec, VALUE result);
 void rb_ractor_atexit_exception(rb_execution_context_t *ec);
 void rb_ractor_teardown(rb_execution_context_t *ec);

--- a/vm.c
+++ b/vm.c
@@ -3290,7 +3290,6 @@ rb_vm_update_references(void *ptr)
         rb_vm_t *vm = ptr;
 
         vm->self = rb_gc_location(vm->self);
-        vm->mark_object_ary = rb_gc_location(vm->mark_object_ary);
         vm->orig_progname = rb_gc_location(vm->orig_progname);
         vm->cc_refinement_set = rb_gc_location(vm->cc_refinement_set);
 
@@ -3376,7 +3375,14 @@ rb_vm_mark(void *ptr)
             rb_box_entry_mark(vm->main_box);
         }
 
-        rb_gc_mark_movable(vm->mark_object_ary);
+        /* The main Ractor's registered mark objects (rb_gc_register_mark_object)
+         * are process-lifetime pins.  Mark them here as well as from ractor_mark
+         * so they stay live before the main Ractor joins vm->ractor.set, e.g.
+         * during early boot under GC.stress. */
+        if (vm->ractor.main_ractor && vm->ractor.main_ractor->mark_object_ary) {
+            rb_gc_mark_movable(vm->ractor.main_ractor->mark_object_ary);
+        }
+
         rb_gc_mark_movable(vm->orig_progname);
         rb_gc_mark_movable(vm->coverages);
         rb_gc_mark_movable(vm->me2counter);
@@ -4824,13 +4830,35 @@ rb_vm_register_global_object(VALUE obj)
         break;
     }
     RB_VM_LOCKING() {
-        VALUE list = GET_VM()->mark_object_ary;
+        rb_ractor_t *cr = GET_RACTOR();
+        if (!cr->mark_object_ary) cr->mark_object_ary = pin_array_list_new(Qnil);
+        VALUE list = cr->mark_object_ary;
         VALUE head = pin_array_list_append(list, obj);
         if (head != list) {
-            GET_VM()->mark_object_ary = head;
+            cr->mark_object_ary = head;
         }
         RB_GC_GUARD(obj);
     }
+}
+
+/* Hand src's registered mark objects to dst (used when a Ractor terminates:
+ * these are process-lifetime pins, so the main Ractor keeps them alive). */
+void
+rb_vm_ractor_migrate_mark_objects(rb_ractor_t *dst, rb_ractor_t *src)
+{
+    ASSERT_vm_locking();
+    VALUE list = src->mark_object_ary;
+    while (!NIL_P(list) && list) {
+        struct pin_array_list *array_list;
+        TypedData_Get_Struct(list, struct pin_array_list, &pin_array_list_type, array_list);
+        for (long i = 0; i < array_list->len; i++) {
+            if (!dst->mark_object_ary) dst->mark_object_ary = pin_array_list_new(Qnil);
+            VALUE head = pin_array_list_append(dst->mark_object_ary, array_list->array[i]);
+            if (head != dst->mark_object_ary) dst->mark_object_ary = head;
+        }
+        list = array_list->next;
+    }
+    src->mark_object_ary = 0;
 }
 
 VALUE rb_cc_refinement_set_create(void);
@@ -4840,8 +4868,8 @@ Init_vm_objects(void)
 {
     rb_vm_t *vm = GET_VM();
 
-    /* initialize mark object array, hash */
-    vm->mark_object_ary = pin_array_list_new(Qnil);
+    /* mark object arrays are per-Ractor (rb_ractor_t.mark_object_ary),
+     * lazily created on first rb_gc_register_mark_object */
     st_init_existing_table_with_size(&vm->ci_table, &vm_ci_hashtype, 0);
     vm->cc_refinement_set = rb_cc_refinement_set_create();
 }

--- a/vm_core.h
+++ b/vm_core.h
@@ -773,7 +773,6 @@ typedef struct rb_vm_struct {
     unsigned int thread_ignore_deadlock: 1;
 
     /* object management */
-    VALUE mark_object_ary;
     VALUE **global_object_list;
     size_t global_object_list_size;
     size_t global_object_list_capa;

--- a/vm_core.h
+++ b/vm_core.h
@@ -679,6 +679,16 @@ typedef struct rb_hook_list_struct {
 // see builtin.h for definition
 typedef const struct rb_builtin_function *RB_BUILTIN;
 
+/* The mark redirect used by the object-traversal APIs
+ * (rb_objspace_reachable_objects_from etc.).  It is installed while a traversal
+ * runs and is NULL during a real GC.  Storage is per-Ractor
+ * (rb_ractor_t.mark_func_data), except on a modular GC where it lives in the VM
+ * (rb_vm_struct's gc sub-struct; see gc.c). */
+struct gc_mark_func_data_struct {
+    void *data;
+    void (*mark_func)(VALUE v, void *data);
+};
+
 typedef struct rb_vm_struct {
     VALUE self;
 
@@ -799,10 +809,13 @@ typedef struct rb_vm_struct {
 
     struct {
         struct rb_objspace *objspace;
-        struct gc_mark_func_data_struct {
-            void *data;
-            void (*mark_func)(VALUE v, void *data);
-        } *mark_func_data;
+#if USE_MODULAR_GC
+        /* A modular GC (e.g. MMTk) may mark on worker threads that have no
+         * current EC, so the traversal mark redirect must be reachable without
+         * a Ractor and lives here.  Otherwise it is per-Ractor
+         * (rb_ractor_t.mark_func_data). */
+        struct gc_mark_func_data_struct *mark_func_data;
+#endif
     } gc;
 
     rb_at_exit_list *at_exit;


### PR DESCRIPTION
## What

Move two GC roots that currently live on `rb_vm_t` to `rb_ractor_t`:

1. **The object-traversal mark redirect** (`vm->gc.mark_func_data`).
   `rb_objspace_reachable_objects_from` / `_from_root` install a redirect so
   that marking a child hands it to a callback instead of the real mark
   routine. An installed redirect belongs to the Ractor performing the
   traversal, so it now lives on that Ractor (`rb_ractor_t.mark_func_data`).

2. **`mark_object_ary`** — the pin list behind `rb_gc_register_mark_object`.
   Each Ractor now owns the objects it registers
   (`rb_ractor_t.mark_object_ary`, created lazily) and marks them from
   `ractor_mark`. When a Ractor terminates, its registered objects are handed
   to the main Ractor so these process-lifetime pins stay alive.

`global_object_list` (`rb_gc_register_address`) intentionally stays VM-global:
a registered *address* is a slot whose value changes over time, so it has no
single owning Ractor and every root scan must keep scanning all of them.

## Why

Groundwork for per-Ractor (Ractor-local) GC, where each Ractor marks its own
roots. These two roots are the ones with a natural per-Ractor owner: a
traversal redirect belongs to the traversing Ractor, and a registered
mark-object belongs to the Ractor that created and registered it. Splitting
them out now is behaviour-neutral with a single Ractor and removes VM-global
mutable state that would otherwise be shared across Ractors.

## Notes

- Behaviour is unchanged for a single Ractor; `mark_object` registration from
  a non-main Ractor is rare (nearly all callers run at boot / extension init
  on the main Ractor), but the terminate-time hand-off keeps it correct.
- The `RB_GC_MARK_OR_TRAVERSE` fast path now checks the current Ractor's
  redirect (`GET_RACTOR()->mark_func_data`) instead of the VM's; the cost is
  the same order as the previous `GET_VM()` lookup.
- Each commit builds and is self-contained, so they can be reviewed (or
  landed) independently.

## Testing

`RUBY_DEBUG=1` build:
- `make btest` — all 2045 pass
- `make test-all` — 35867 tests, 0 failures, 0 errors, 181 skips
- Exercised the terminate hand-off directly (register a mark-object from a
  child Ractor, then terminate it) and confirmed the object migrates to the
  main Ractor and survives `GC.compact` + a full GC.
