### PR TITLE
Remove `String#to_f` and `Kernel#Float` out of range warning

### DIFF
--- a/object.c
+++ b/object.c
@@ -3571,7 +3571,6 @@ rb_cstr_to_dbl_raise(const char *p, rb_encoding *enc, int badcheck, int raise, i
     d = strtod(p, &end);
     if (errno == ERANGE) {
         OutOfRange();
-        rb_warning("Float %.*s%s out of range", w, p, ellipsis);
         errno = 0;
     }
     if (p == end) {
@@ -3654,7 +3653,6 @@ rb_cstr_to_dbl_raise(const char *p, rb_encoding *enc, int badcheck, int raise, i
         d = strtod(p, &end);
         if (errno == ERANGE) {
             OutOfRange();
-            rb_warning("Float %.*s%s out of range", w, p, ellipsis);
             errno = 0;
         }
         if (badcheck) {


### PR DESCRIPTION
[Feature #22085]

This warning is only actionable for float literals in source code. When parsing user input into a float, most of the time this warning isn't actionable and is pure noise.