### PR TITLE
[Bug #22189] Lazy `to_enum` should accept `String` method names too

### DIFF
--- a/enumerator.c
+++ b/enumerator.c
@@ -2003,7 +2003,7 @@ lazy_to_enum(int argc, VALUE *argv, VALUE self)
 
     if (argc > 0) {
         --argc;
-        meth = *argv++;
+        meth = rb_to_symbol(*argv++);
     }
     if (RTEST((super_meth = rb_hash_aref(lazy_use_super_method, meth)))) {
         meth = super_meth;

--- a/test/ruby/test_lazy_enumerator.rb
+++ b/test/ruby/test_lazy_enumerator.rb
@@ -542,15 +542,20 @@ EOS
       [:drop_while, selector],
       [:uniq, nil],
       [:uniq, proc{|x| x.odd?}],
-    ].each do |args|
-      block = args.pop
+    ].each do |*args, block|
       assert_equal [1, 2, 3].to_enum.to_enum(*args).first(2).to_a, [1, 2, 3].to_enum.lazy.to_enum(*args).first(2).to_a
       assert_equal (0..50).to_enum.to_enum(*args).first(2).to_a, (0..50000).to_enum.lazy.to_enum(*args).first(2).to_a
       if block
         assert_equal [1, 2, 3, 4].to_enum.to_enum(*args).map(&block).first(2).to_a, [1, 2, 3, 4].to_enum.lazy.to_enum(*args).map(&block).first(2).to_a
-        unless args.first == :take_while || args.first == :drop_while
+        case args.first
+        when :take_while, :drop_while, "take_while", "drop_while"
+        else
           assert_equal (0..50).to_enum.to_enum(*args).map(&block).first(2).to_a, (0..50000).to_enum.lazy.to_enum(*args).map(&block).first(2).to_a
         end
+      end
+      if Symbol === args.first
+        args.unshift(args.shift.name)
+        redo
       end
     end
   end


### PR DESCRIPTION
Since `lazy_use_super_method` is the `Symbol`-to-`Symbol` mapping, convert the given method name to a `Symbol` before consulting that table.