### PR TITLE
ZJIT: duparray allocation fastpath for arrays we embed

### DIFF
--- a/array.c
+++ b/array.c
@@ -34,6 +34,7 @@
 #include "shape.h"
 #include "vm_core.h"
 #include "builtin.h"
+#include "zjit.h"
 
 #if !ARRAY_DEBUG
 # undef NDEBUG
@@ -2924,6 +2925,25 @@ rb_ary_resurrect(VALUE ary)
 {
     return ary_make_partial(ary, rb_cArray, 0, RARRAY_LEN(ary));
 }
+
+#if USE_ZJIT
+bool
+rb_zjit_array_dup_can_fastpath(VALUE ary, size_t *alloc_size_out, VALUE *flags_out, long *len_out)
+{
+    long len = RARRAY_LEN(ary);
+    long embed_capa = (sizeof(struct RArray) - offsetof(struct RArray, as.ary)) / sizeof(VALUE);
+
+    if (len > embed_capa) return false;
+
+    size_t size = sizeof(struct RArray);
+    shape_id_t shape_id = rb_shape_transition_slot_size(ROOT_SHAPE_ID | SHAPE_ID_LAYOUT_OTHER,
+                                                        rb_gc_size_slot_size(size));
+    *alloc_size_out = size;
+    *flags_out = T_ARRAY | RARRAY_EMBED_FLAG | ((VALUE)len << RARRAY_EMBED_LEN_SHIFT) | ((VALUE)shape_id << SHAPE_FLAG_SHIFT);
+    *len_out = len;
+    return true;
+}
+#endif
 
 extern VALUE rb_output_fs;
 

--- a/depend
+++ b/depend
@@ -279,6 +279,7 @@ array.$(OBJEXT): {$(VPATH)}thread_native.h
 array.$(OBJEXT): {$(VPATH)}util.h
 array.$(OBJEXT): {$(VPATH)}vm_core.h
 array.$(OBJEXT): {$(VPATH)}vm_opts.h
+array.$(OBJEXT): {$(VPATH)}zjit.h
 ast.$(OBJEXT): $(CCAN_DIR)/check_type/check_type.h
 ast.$(OBJEXT): $(CCAN_DIR)/container_of/container_of.h
 ast.$(OBJEXT): $(CCAN_DIR)/list/list.h

--- a/zjit.h
+++ b/zjit.h
@@ -95,6 +95,7 @@ void rb_zjit_materialize_frames(const rb_execution_context_t *ec, rb_control_fra
 size_t rb_zjit_hash_new_size(void);
 bool rb_zjit_class_allocate_instance_fastpath(VALUE klass, size_t *size_out, shape_id_t *shape_id_out);
 bool rb_zjit_str_resurrect_fastpath(VALUE str, bool chilled, size_t *size_out, VALUE *flags_out, long *len_out, size_t *byte_size_out);
+bool rb_zjit_array_dup_can_fastpath(VALUE ary, size_t *alloc_size_out, VALUE *flags_out, long *len_out);
 
 // Special value for cfp->jit_return that means "this is a C method frame, use
 // rb_zjit_c_frame as the JITFrame". We don't control the native stack layout

--- a/zjit/bindgen/src/main.rs
+++ b/zjit/bindgen/src/main.rs
@@ -115,6 +115,7 @@ fn main() {
         .allowlist_function("rb_zjit_hash_new_size")
         .allowlist_function("rb_zjit_class_allocate_instance_fastpath")
         .allowlist_function("rb_zjit_str_resurrect_fastpath")
+        .allowlist_function("rb_zjit_array_dup_can_fastpath")
 
         // For crashing
         .allowlist_function("rb_bug")

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -622,7 +622,7 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
         }
         Insn::NewRange { low, high, flag, state } => gen_new_range(jit, asm, function, opnd!(low), opnd!(high), *flag, &function.frame_state(*state)),
         Insn::NewRangeFixnum { low, high, flag, state } => gen_new_range_fixnum(asm, opnd!(low), opnd!(high), *flag, &function.frame_state(*state)),
-        Insn::ArrayDup { val, state } => gen_array_dup(asm, opnd!(val), &function.frame_state(*state)),
+        Insn::ArrayDup { val, state } => gen_array_dup(jit, asm, function, *val, opnd!(val), &function.frame_state(*state)),
         Insn::AdjustBounds { index, length } => gen_adjust_bounds(asm, opnd!(index), opnd!(length)),
         Insn::ArrayAref { array, index, .. } => gen_array_aref(asm, opnd!(array), opnd!(index)),
         Insn::ArrayAset { array, index, val } => {
@@ -2127,12 +2127,38 @@ fn gen_string_equal(asm: &mut Assembler, left: Opnd, right: Opnd) -> lir::Opnd {
 
 /// Compile an array duplication instruction
 fn gen_array_dup(
+    jit: &mut JITState,
     asm: &mut Assembler,
+    function: &Function,
+    val_id: InsnId,
     val: lir::Opnd,
     state: &FrameState,
 ) -> lir::Opnd {
-    gen_prepare_leaf_call_with_gc(asm, state);
+    // duparray resurrects a frozen literal array baked into the ISEQ, so its elements are known
+    // here. When the resurrected copy would be embedded, bump-allocate it inline and store the
+    // elements directly; the fresh object is young and white, so those writes need no write
+    // barrier (elements may be heap objects).
+    if let Some(src) = function.type_of(val_id).ruby_object() {
+        let mut alloc_size: usize = 0;
+        let mut flags = VALUE(0);
+        let mut len: std::os::raw::c_long = 0;
+        if unsafe { rb_zjit_array_dup_can_fastpath(src, &mut alloc_size, &mut flags, &mut len) } {
+            let klass = unsafe { rb_cArray };
+            return gc_fastpath::gc_fastpath_new_obj(jit, asm, alloc_size, flags.as_u64(), klass, &|asm, obj| {
+                for i in 0..len {
+                    let elem = unsafe { rb_ary_entry(src, i) };
+                    let offset = RUBY_OFFSET_RARRAY_AS_ARY + (i as i32) * SIZEOF_VALUE_I32;
+                    asm.store(Opnd::mem(VALUE_BITS, obj, offset), Opnd::Value(elem));
+                }
+            },
+            |asm| {
+                gen_prepare_leaf_call_with_gc(asm, state);
+                asm_ccall!(asm, rb_ary_resurrect, val)
+            });
+        }
+    }
 
+    gen_prepare_leaf_call_with_gc(asm, state);
     asm_ccall!(asm, rb_ary_resurrect, val)
 }
 

--- a/zjit/src/codegen_tests.rs
+++ b/zjit/src/codegen_tests.rs
@@ -3714,6 +3714,43 @@ fn test_array_dup() {
 }
 
 #[test]
+fn test_array_dup_embedded_gc_stress() {
+    eval(r#"
+        def make = [1, 100000000000000000000, :sym]
+    "#);
+    assert_contains_opcode("make", YARVINSN_duparray);
+    assert_snapshot!(assert_compiles(r#"
+        begin
+          GC.stress = true
+          make
+          a = make
+          a << :extra
+          [a.frozen?, a.class, a]
+        ensure
+          GC.stress = false
+        end
+    "#), @r#"[false, Array, [1, 100000000000000000000, :sym, :extra]]"#);
+}
+
+#[test]
+fn test_array_dup_non_embedded_gc_stress() {
+    eval("
+        def make = [10, 20, 30, 40, 50]
+    ");
+    assert_contains_opcode("make", YARVINSN_duparray);
+    assert_snapshot!(assert_compiles(r#"
+        begin
+          GC.stress = true
+          make
+          m = make
+          [m.frozen?, m]
+        ensure
+          GC.stress = false
+        end
+    "#), @"[false, [10, 20, 30, 40, 50]]");
+}
+
+#[test]
 fn test_array_fixnum_aref() {
     eval("
         def test(x) = [1,2,3][x]

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -2286,6 +2286,12 @@ unsafe extern "C" {
         len_out: *mut ::std::os::raw::c_long,
         byte_size_out: *mut usize,
     ) -> bool;
+    pub fn rb_zjit_array_dup_can_fastpath(
+        ary: VALUE,
+        alloc_size_out: *mut usize,
+        flags_out: *mut VALUE,
+        len_out: *mut ::std::os::raw::c_long,
+    ) -> bool;
     pub fn rb_profile_frames(
         start: ::std::os::raw::c_int,
         limit: ::std::os::raw::c_int,


### PR DESCRIPTION
We can reuse some of this work for gen_new_array fastpath for embedded arrays.