### PR TITLE
Split -I option with File::PATH_SEPARATOR in test runner

### DIFF
--- a/tool/lib/test/unit.rb
+++ b/tool/lib/test/unit.rb
@@ -1108,7 +1108,7 @@ module Test
         super
         parser.separator "load path options:"
         parser.on '-Idirectory', 'Add library load path' do |dirs|
-          dirs.split(':').each { |d| $LOAD_PATH.unshift d }
+          dirs.split(File::PATH_SEPARATOR).each { |d| $LOAD_PATH.unshift d }
         end
       end
     end

--- a/tool/test/testunit/test_load_path.rb
+++ b/tool/test/testunit/test_load_path.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: false
+require 'test/unit'
+require 'optparse'
+
+class TestLoadPathOption < Test::Unit::TestCase
+  # Representative absolute paths that never contain the platform's
+  # File::PATH_SEPARATOR, so joining them with it round-trips exactly.
+  # On Windows the separator is ";", so drive-letter paths (which embed
+  # a colon) are the case the old hardcoded split(":") used to break.
+  def sample_dirs
+    if File::PATH_SEPARATOR == ";"
+      ["V:/foo/lib", "C:/bar/lib"]
+    else
+      ["/foo/lib", "/bar/lib"]
+    end
+  end
+
+  def build_parser
+    base = Class.new do
+      def setup_options(parser, options); end
+    end
+    klass = Class.new(base) do
+      prepend Test::Unit::LoadPathOption
+    end
+    parser = OptionParser.new
+    klass.new.setup_options(parser, {})
+    parser
+  end
+
+  def parse_load_path(argv)
+    saved = $LOAD_PATH.dup
+    build_parser.parse(argv)
+    $LOAD_PATH - saved
+  ensure
+    $LOAD_PATH.replace(saved)
+  end
+
+  def test_single_directory_kept_intact
+    dir = sample_dirs.first
+    assert_equal([dir], parse_load_path(["-I#{dir}"]),
+                 "a single -I directory must be added verbatim")
+  end
+
+  def test_multiple_directories_split_on_path_separator
+    dirs = sample_dirs
+    joined = dirs.join(File::PATH_SEPARATOR)
+    # unshift reverses insertion order, so compare as a set.
+    assert_equal(dirs.sort, parse_load_path(["-I#{joined}"]).sort,
+                 "-I must split only on File::PATH_SEPARATOR")
+  end
+end


### PR DESCRIPTION
The `test/unit` runner splits its `-Idirectory` argument on a hardcoded `":"`, so on Windows an absolute path such as `-IV:/foo/lib` is broken into `"V"` and `"/foo/lib"`. Both fragments are pushed onto `$LOAD_PATH`, and the tail only resolves by accident when the current drive happens to be `V:`. `File::PATH_SEPARATOR` is the correct delimiter and matches how `ruby -I` itself parses the option.

This is the same class of bug as the test-syntax-suggest `-I` fix in commit 3c7a4c174f, which replaced `":"` with `$(PATH_SEPARATOR)` in `common.mk`. The Makefiles only ever pass relative paths to the runner, so the runner-side occurrence stayed latent.

The added test in `tool/test/testunit/test_load_path.rb` exercises the option parser directly. It uses drive-letter paths on Windows and colon-free absolute paths elsewhere, joins them with `File::PATH_SEPARATOR`, and asserts each directory is added to `$LOAD_PATH` verbatim, so the round-trip is meaningful on every platform.