### PR TITLE
Optimize `Integer#to_s` string construction for Fixnums

### DIFF
--- a/benchmark/int_to_s.yml
+++ b/benchmark/int_to_s.yml
@@ -4,7 +4,10 @@ prelude: |
   N2   = 42
   N3   = 400
   N5   = 12345
+  N6   = 123_456
   N10  = 1_234_567_890
+  N13  = 1_234_567_890_123
+  N16  = 1_234_567_890_123_456
   N19  = 4_611_686_018_427_387_903
   NEG  = -1_234_567_890
   BIG20  = 10 ** 19 + 12_345_678_901_234_567
@@ -15,7 +18,10 @@ benchmark:
   fix_2digit:   "N2.to_s"
   fix_3digit:   "N3.to_s"
   fix_5digit:   "N5.to_s"
+  fix_6digit:   "N6.to_s"
   fix_10digit:  "N10.to_s"
+  fix_13digit:  "N13.to_s"
+  fix_16digit:  "N16.to_s"
   fix_19digit:  "N19.to_s"
   fix_negative: "NEG.to_s"
   big_20digit:  "BIG20.to_s"

--- a/numeric.c
+++ b/numeric.c
@@ -27,6 +27,7 @@
 #include "id.h"
 #include "internal.h"
 #include "internal/array.h"
+#include "internal/bits.h"
 #include "internal/compilers.h"
 #include "internal/complex.h"
 #include "internal/enumerator.h"
@@ -4052,6 +4053,48 @@ rb_int_uminus(VALUE num)
  * lookup-table itoa optimisation; both rb_fix2str here and big2str_2bdigits
  * in bignum.c consume it. */
 
+STATIC_ASSERT(fix_decimal_unsigned_long_fits_uint64, SIZEOF_LONG <= sizeof(uint64_t));
+
+static const uint64_t fix_decimal_powers[] = {
+    UINT64_C(1),
+    UINT64_C(10),
+    UINT64_C(100),
+    UINT64_C(1000),
+    UINT64_C(10000),
+    UINT64_C(100000),
+    UINT64_C(1000000),
+    UINT64_C(10000000),
+    UINT64_C(100000000),
+    UINT64_C(1000000000),
+    UINT64_C(10000000000),
+    UINT64_C(100000000000),
+    UINT64_C(1000000000000),
+    UINT64_C(10000000000000),
+    UINT64_C(100000000000000),
+    UINT64_C(1000000000000000),
+    UINT64_C(10000000000000000),
+    UINT64_C(100000000000000000),
+    UINT64_C(1000000000000000000),
+    UINT64_C(10000000000000000000),
+};
+
+static inline int
+fix_decimal_numdigits(unsigned long value)
+{
+    RUBY_ASSERT(value > 0);
+    uint64_t u = value;
+    unsigned int bit_length = 64 - nlz_int64(u);
+    /* Integer log10 via the well-known bit-twiddling trick: 1233 / 4096
+     * approximates log10(2), so bit_length * 1233 >> 12 is floor(log10) + 1
+     * for a 1..64 bit input, then the power-of-ten table corrects the
+     * off-by-one at each boundary.  See Sean Anderson's Bit Twiddling Hacks,
+     * "Find integer log base 10 of an integer"
+     * (https://graphics.stanford.edu/~seander/bithacks.html#IntegerLog10). */
+    unsigned int guess = bit_length * 1233 >> 12;
+    RUBY_ASSERT(guess < numberof(fix_decimal_powers));
+    return (int)(guess - (u < fix_decimal_powers[guess]) + 1);
+}
+
 VALUE
 rb_fix2str(VALUE x, int base)
 {
@@ -4085,27 +4128,40 @@ rb_fix2str(VALUE x, int base)
         u = val;
     }
     if (base == 10) {
-        /* Emit two digits per iteration from a precomputed table.  The
-         * compiler lowers `u % 100` and `u / 100` to a single multiply +
-         * shift, so each iteration costs roughly one multiply, one shift,
-         * and two stores.  About 2x fewer iterations than the classic
-         * per-digit loop for multi-digit inputs. */
+        /* Construct the decimal string directly in its result buffer, sized
+         * up front, instead of formatting into `buf` and copying.  The length
+         * stays zero until every byte is written, so the partially filled
+         * buffer is never observable and nothing below allocates. */
+        long len = fix_decimal_numdigits(u) + neg;
+        VALUE str = rb_str_buf_new(len);
+        char *p = RSTRING_PTR(str) + len;
+
         while (u >= 100) {
             unsigned long idx = (u % 100) * 2;
             u /= 100;
-            b -= 2;
-            b[0] = ruby_decimal_digit_pairs[idx];
-            b[1] = ruby_decimal_digit_pairs[idx + 1];
+            p -= 2;
+            p[0] = ruby_decimal_digit_pairs[idx];
+            p[1] = ruby_decimal_digit_pairs[idx + 1];
         }
         if (u >= 10) {
             unsigned long idx = u * 2;
-            b -= 2;
-            b[0] = ruby_decimal_digit_pairs[idx];
-            b[1] = ruby_decimal_digit_pairs[idx + 1];
+            p -= 2;
+            p[0] = ruby_decimal_digit_pairs[idx];
+            p[1] = ruby_decimal_digit_pairs[idx + 1];
         }
         else {
-            *--b = (char)('0' + u);
+            *--p = (char)('0' + u);
         }
+        if (neg) {
+            *--p = '-';
+        }
+
+        RUBY_ASSERT(p == RSTRING_PTR(str));
+        RSTRING(str)->len = len;
+        RSTRING_PTR(str)[len] = '\0';
+        ENCODING_SET_INLINED(str, ENCINDEX_US_ASCII);
+        ENC_CODERANGE_SET(str, ENC_CODERANGE_7BIT);
+        return str;
     }
     else {
         do {

--- a/spec/ruby/core/integer/to_s_spec.rb
+++ b/spec/ruby/core/integer/to_s_spec.rb
@@ -27,6 +27,29 @@ describe "Integer#to_s" do
         0.to_s.should == '0'
         -9002.to_s.should == '-9002'
       end
+
+      it "handles powers-of-ten boundaries across the fixnum range" do
+        1.upto(18) do |digits|
+          power = 10 ** digits
+          break if power > fixnum_max
+
+          (power - 1).to_s.should == "9" * digits
+          power.to_s.should == "1" + "0" * digits
+          (-power).to_s.should == "-1" + "0" * digits
+        end
+
+        fixnum_max.to_s.to_i.should == fixnum_max
+        fixnum_min.to_s.to_i.should == fixnum_min
+      end
+
+      it "returns a fresh mutable String" do
+        first = 12345.to_s
+        second = 12345.to_s
+        first << "6"
+
+        first.should == "123456"
+        second.should == "12345"
+      end
     end
 
     before :each do
@@ -45,6 +68,11 @@ describe "Integer#to_s" do
     it "returns a String in US-ASCII encoding when Encoding.default_internal is not nil" do
       Encoding.default_internal = Encoding::IBM437
       1.to_s.encoding.should.equal?(Encoding::US_ASCII)
+    end
+
+    it "returns an ASCII-only String" do
+      1_234_567_890.to_s.ascii_only?.should == true
+      (-1_234_567_890).to_s.ascii_only?.should == true
     end
   end
 


### PR DESCRIPTION
Previous, base-10 `Integer#to_s` formatted the digits into a stack buffer, only to be copied later into a `RString`. Instead, this PR write directly into a pre-allocated result buffer instead using a [neat trick](https://graphics.stanford.edu/~seander/bithacks.html#IntegerLog10)

## Benchmarks

arm64 (M4 Pro), paired alternating medians, candidate vs master:

```
5                    -2.3%
400                  -5.0%
12345                -6.4%
123456               -5.3%
1234567890           -3.1%
-1234567890          -2.6%
1234567890123        -9.5%
1234567890123456     -1.8%
4611686018427387903  -7.4%
```

Every case faster, database-ID sizes land around 2 to 9%. Correctness covered by a 500k decimal fuzz, a `GC.stress` round-trip loop, and the existing integer/fixnum/bignum specs and tests.