### PR TITLE
Fix out-of-bounds read in strrdirsep fast path for all-separator paths

### DIFF
--- a/file.c
+++ b/file.c
@@ -3985,7 +3985,7 @@ strrdirsep(const char *path, const char *end, bool mb_enc, rb_encoding *enc)
 
     const char *cursor = end - 1;
 
-    while (isdirsep(cursor[0])) {
+    while (cursor >= path && isdirsep(cursor[0])) {
         cursor--;
     }
 

--- a/file.c
+++ b/file.c
@@ -4196,7 +4196,7 @@ strrdirsep(const char *path, const char *end, bool mb_enc, rb_encoding *enc)
 
     const char *cursor = end - 1;
 
-    while (isdirsep(cursor[0])) {
+    while (cursor >= path && isdirsep(cursor[0])) {
         cursor--;
     }
 

--- a/test/pathname/test_pathname.rb
+++ b/test/pathname/test_pathname.rb
@@ -587,6 +587,15 @@ class TestPathname < Test::Unit::TestCase
   defassert(:pathsubext, 'd.e/aa.o', 'd.e/aa', '.o')
   defassert(:pathsubext, 'long_enough.bug-3664', 'long_enough.not_to_be_embedded[ruby-core:31640]', '.bug-3664')
 
+  def test_sub_ext_separator_only
+    # sub_ext skips the length check File.extname does first, so it can hand
+    # the backward scan in strrdirsep an empty range.  See test_extname in
+    # test/ruby/test_file_exhaustive.rb for what that scan must not do.
+    assert_equal(".txt", Pathname.new("").sub_ext(".txt").to_s)
+    assert_equal("/.txt", Pathname.new("/").sub_ext(".txt").to_s)
+    assert_equal("#{"/" * 4096}.txt", Pathname.new("/" * 4096).sub_ext(".txt").to_s)
+  end
+
   def test_sub_matchdata
     result = Pathname("abc.gif").sub(/\..*/) {
       assert_not_nil($~)

--- a/test/ruby/test_file_exhaustive.rb
+++ b/test/ruby/test_file_exhaustive.rb
@@ -1371,6 +1371,17 @@ class TestFileExhaustive < Test::Unit::TestCase
     bug3175 = '[ruby-core:29627]'
     assert_equal(".rb", File.extname("/tmp//bla.rb"), bug3175)
 
+    # A path consisting only of separators must not make the backward
+    # scan in strrdirsep read before the beginning of the string.
+    seps = NTFS ? ["/", "\\"] : ["/"]
+    seps.each do |sep|
+      [1, 2, 23, 24, 1000].each do |len|
+        path = sep * len
+        assert_equal("", File.extname(path), "File.extname(#{path.inspect})")
+      end
+    end
+    assert_equal("", File.extname(""))
+
     assert_incompatible_encoding {|d| File.extname(d)}
   end
 

--- a/test/ruby/test_file_exhaustive.rb
+++ b/test/ruby/test_file_exhaustive.rb
@@ -1371,6 +1371,20 @@ class TestFileExhaustive < Test::Unit::TestCase
     bug3175 = '[ruby-core:29627]'
     assert_equal(".rb", File.extname("/tmp//bla.rb"), bug3175)
 
+    assert_equal("", File.extname(""))
+
+    # A path consisting only of separators must not make the backward scan in
+    # strrdirsep read before the beginning of the string.  The return value is
+    # correct either way, so a regression shows up only on a sanitizer build,
+    # and only once the string is too long to be embedded in its RVALUE.
+    seps = [File::SEPARATOR, File::ALT_SEPARATOR].compact
+    seps.each do |sep|
+      [1, 2, 4096].each do |len|
+        path = sep * len
+        assert_equal("", File.extname(path), "File.extname(#{sep.inspect} * #{len})")
+      end
+    end
+
     assert_incompatible_encoding {|d| File.extname(d)}
   end
 

--- a/test/ruby/test_file_exhaustive.rb
+++ b/test/ruby/test_file_exhaustive.rb
@@ -868,6 +868,9 @@ class TestFileExhaustive < Test::Unit::TestCase
   def test_expand_path
     assert_equal(regular_file, File.expand_path(File.basename(regular_file), File.dirname(regular_file)))
     assert_equal(utf8_file, File.expand_path(File.basename(utf8_file), File.dirname(utf8_file)))
+    # On POSIX expand_path reaches the backward scan in strrdirsep too.  See
+    # test_extname for what that scan must not do.
+    assert_equal(File.expand_path("/" * 4096), File.expand_path("/" * 4096 + ".."))
   end
 
   if NTFS


### PR DESCRIPTION
The ASCII/UTF-8 fast path of `strrdirsep` introduced in 11d29d32d2 skips trailing directory separators by scanning backward from the end of the string, but the first loop has no lower bound. When the whole string consists of separators, the cursor walks past the beginning of the buffer and keeps reading until it happens to hit a byte that is not a separator. `File.extname` reaches this code with the unstripped path, so `File.extname("/")` and `File.extname("//")` trigger the underflow, and on Windows `File.extname("\\")` does as well. The multibyte slow path `enc_path_last_separator` already checks the bound.

The out-of-bounds read does not affect the returned value, so existing tests and specs pass over it. It is only observable under AddressSanitizer, and only when the receiver is a heap string, because for embedded strings the read lands inside the RVALUE slot. Reproduced with an ASAN build of miniruby on x86_64-linux:

```
$ ./miniruby -e 'File.extname("/" * 1000)'
==7969==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x519000072b7f at pc 0x5e5ec391a1ae bp 0x7ffc83371360 sp 0x7ffc83371358
READ of size 1 at 0x519000072b7f thread T0
    #0 0x5e5ec391a1ad in strrdirsep /src/file.c:3988
    #1 0x5e5ec391a1ad in enc_find_extname /src/file.c:5470
    #2 0x5e5ec391a1ad in rb_file_s_extname /src/file.c:5590
    ...
0x519000072b7f is located 1 bytes before 1001-byte region [0x519000072b80,0x519000072f69)
```

This adds a `cursor >= path` guard to the loop, and value assertions for all-separator inputs to `test/ruby/test_file_exhaustive.rb` so the inputs stay exercised where an ASAN build can catch a regression. Calling `File.basename("a/b/c.rb")` one million times on x64-mswin64 shows no measurable difference before and after. Run-to-run variance exceeds any effect of the added comparison.
