### PR TITLE
Fix option parsing bugs in win32/configure.bat

### DIFF
--- a/win32/configure.bat
+++ b/win32/configure.bat
@@ -188,7 +188,7 @@ goto :loop ;
 :ntver
   ::- For version constants, see
   ::- https://learn.microsoft.com/en-us/cpp/porting/modifying-winver-and-win32-winnt#remarks
-  if "%eq%" == "" (set "NTVER=%~1" & call :shift) else (set "NTVER=%arg%")
+  set "NTVER=%arg%"
   if /i not "%NTVER:~0,2%" == "0x" if /i not "%NTVER:~0,13%" == "_WIN32_WINNT_" (
     for %%i in (A B C D E F G H I J K L M N O P Q R S T U V W X Y Z) do (
       call :set NTVER=%%NTVER:%%i=%%i%%

--- a/win32/configure.bat
+++ b/win32/configure.bat
@@ -118,7 +118,7 @@ goto :loop ;
   echo>>%confargs%  "--target=%arg:$=$$%" \
 goto :loop ;
 :program_name
-  for /f "delims=- tokens=1,*" %I in ("%opt%") do set "var=%%J"
+  for /f "delims=- tokens=1,*" %%I in ("%opt%") do set "var=%%J"
   if "%var%" == "prefix" (set "var=PROGRAM_PREFIX" & goto :name)
   if "%var%" == "suffix" (set "var=PROGRAM_SUFFIX" & goto :name)
   if "%var%" == "name" (set "var=RUBY_INSTALL_NAME" & goto :name)


### PR DESCRIPTION
`configure.bat --program-prefix=x` (likewise `--program-suffix` and `--program-name`) aborts immediately with a cmd parse error, because the `for /f` at the `:program_name` label uses `%I` where a batch file requires `%%I`:

```
> configure.bat --program-prefix=x
optJ" was unexpected at this time.
```

With the fix, the options reach the generated `Makefile` as expected:

```
PROGRAM_PREFIX = my-
PROGRAM_SUFFIX = -32
RUBY_INSTALL_NAME = foo
```

The second commit fixes the space-separated form of `--with-ntver` in the same file. `--with-ntver XXXX` set `NTVER` from `%~1`, which is the first argument of the whole command line rather than the option value, and then shifted the argument list once more even though `:witharg` had already consumed the value via `:take_arg`, so the option following the value was silently dropped. For example `configure.bat --debug-configure --with-ntver 0x0602 --without-baseruby` wrote `NTVER = _WIN32_WINNT_--DEBUG-CONFIGURE` and ignored `--without-baseruby` entirely. Since `:take_arg` populates `%arg%` for both the `=` form and the space form, `:ntver` can simply use `%arg%`. After the fix both forms write `NTVER = 0x0602`, `--without-baseruby` is honored, and the bare-name form still expands (`--with-ntver WIN10` gives `NTVER = _WIN32_WINNT_WIN10`).

There is no automated test for `configure.bat`, so I verified manually with the runs above in a scratch directory. CI does not cover these options, which is why both bugs went unnoticed.

Generated with [Claude Code](https://claude.com/claude-code)
