### PR TITLE
Remove stale rb_class_descendants() declaration

### DIFF
--- a/include/ruby/internal/intern/class.h
+++ b/include/ruby/internal/intern/class.h
@@ -175,19 +175,6 @@ VALUE rb_mod_include_p(VALUE child, VALUE parent);
 VALUE rb_mod_ancestors(VALUE mod);
 
 /**
- * Queries the class's descendants. This  routine gathers classes that are
- * subclasses of the given class (or subclasses of those subclasses, etc.),
- * returning an array of classes that have the given class as an ancestor.
- * The returned array does not include the given class or singleton classes.
- *
- * @param[in]  klass A class.
- * @return     An array of classes where `klass` is an ancestor.
- *
- * @internal
- */
-VALUE rb_class_descendants(VALUE klass);
-
-/**
  * Queries the class's direct descendants. This  routine gathers classes that are
  * direct subclasses of the given class,
  * returning an array of classes that have the given class as a superclass.


### PR DESCRIPTION
The implementation was removed together with Class#descendants in 3bd5f27f737c7d365b7d01c43d77a958c224ab16 ([Feature #14394]), but the declaration was left behind.