### PR TITLE
ZJIT: Profile distinct shapes for getivar

### DIFF
--- a/zjit/src/distribution.rs
+++ b/zjit/src/distribution.rs
@@ -22,8 +22,13 @@ impl<T: Copy + PartialEq + Default, const N: usize> Distribution<T, N> {
     }
 
     pub fn observe(&mut self, item: T) {
+        self.observe_with(item, |left, right| left == right);
+    }
+
+    /// Observe an item using a caller-defined notion of bucket equivalence.
+    pub fn observe_with(&mut self, item: T, equivalent: impl Fn(T, T) -> bool) {
         for (bucket, count) in self.buckets.iter_mut().zip(self.counts.iter_mut()) {
-            if *bucket == item || *count == 0 {
+            if *count == 0 || equivalent(*bucket, item) {
                 *bucket = item;
                 *count = count.saturating_add(1);
                 // Keep the most frequent item at the front
@@ -198,6 +203,18 @@ mod distribution_tests {
         assert!(dist.buckets.is_empty());
         assert!(dist.counts.is_empty());
         assert_eq!(dist.other, 1);
+    }
+
+    #[test]
+    fn observe_with_uses_custom_equivalence() {
+        let mut dist = Distribution::<(usize, usize), 2>::new();
+        dist.observe_with((1, 10), |left, right| left.1 == right.1);
+        dist.observe_with((2, 10), |left, right| left.1 == right.1);
+        dist.observe_with((3, 20), |left, right| left.1 == right.1);
+
+        assert_eq!(dist.buckets, [(2, 10), (3, 20)]);
+        assert_eq!(dist.counts, [2, 1]);
+        assert_eq!(dist.other, 0);
     }
 
     #[test]

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -9116,7 +9116,7 @@ fn add_iseq_to_hir(
                     let summary = fun.profile_summary(&profiles, self_param, exit_id);
                     let self_param = fun.guard_heap(block, self_param, exit_id);
                     // Filter out profiled types we don't care to optimize
-                    let profiled_types = summary.buckets().iter().filter(|profiled_type| {
+                    let profiled_types = summary.buckets().iter().copied().filter(|profiled_type| {
                         // Don't read past the end of the profiled types
                         !profiled_type.is_empty()
                         // Instance variable lookups on immediate values are always nil; don't bother
@@ -9126,17 +9126,8 @@ fn add_iseq_to_hir(
                         // Let the fallthrough GetIvar handle these.
                         && !profiled_type.shape().is_complex()
                     }).collect::<Vec<_>>();
-                    // We might have two objects of class A and B with the same shape; de-duplicate
-                    // profiled types by shape. This is just an optimization to reduce code size.
-                    let mut profiled_types_unique_shapes = Vec::with_capacity(profiled_types.len());
-                    for &profiled_type in profiled_types {
-                        if profiled_types_unique_shapes.iter().any(|t: &ProfiledType| t.shape() == profiled_type.shape()) {
-                            continue;
-                        }
-                        profiled_types_unique_shapes.push(profiled_type);
-                    }
                     let Some((new_block, result)) = fun.dispatch_getivar(
-                        &profiled_types_unique_shapes,
+                        &profiled_types,
                         block,
                         insn_idx,
                         self_param,

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -9240,6 +9240,44 @@ mod hir_opt_tests {
     }
 
     #[test]
+    fn test_getivar_recompile_profiles_distinct_shapes_across_classes() {
+        // Fill the initial profiles with different classes that have the same
+        // shape, compile, then trigger recompile exits with a distinct shape.
+        set_call_threshold(6);
+        eval(r#"
+            module DistinctShapeReader
+              def foo = @foo
+            end
+
+            SAME_SHAPE_OBJECTS = 4.times.map do
+              Class.new do
+                include DistinctShapeReader
+                def initialize
+                  @foo = 1
+                end
+              end.new
+            end
+
+            different_shape_class = Class.new do
+              include DistinctShapeReader
+              def initialize
+                @bar = 2
+                @foo = 1
+              end
+            end
+            DIFFERENT_SHAPE_OBJECT = different_shape_class.new
+
+            SAME_SHAPE_OBJECTS.each(&:foo) # four profiles with one shape
+            SAME_SHAPE_OBJECTS[0].foo      # fifth profile
+            SAME_SHAPE_OBJECTS[0].foo      # compile
+            100.times { DIFFERENT_SHAPE_OBJECT.foo } # profile recompile exits
+        "#);
+
+        let hir = hir_string_proc("DistinctShapeReader.instance_method(:foo)");
+        assert!(hir.contains("CondBranch"), "expected getivar branches for two distinct shapes:\n{hir}");
+    }
+
+    #[test]
     fn test_optimize_getivar_polymorphic_with_subclass() {
         set_call_threshold(3);
         eval(r#"

--- a/zjit/src/profile.rs
+++ b/zjit/src/profile.rs
@@ -84,7 +84,7 @@ fn profile_insn_sample(
         YARVINSN_opt_ltlt  => profile_operands(profiler, profile, 2),
         YARVINSN_opt_aset  => profile_operands(profiler, profile, 3),
         YARVINSN_opt_not   => profile_operands(profiler, profile, 1),
-        YARVINSN_getinstancevariable => profile_self(profiler, profile),
+        YARVINSN_getinstancevariable => profile_getivar(profiler, profile),
         YARVINSN_setinstancevariable => profile_self(profiler, profile),
         YARVINSN_definedivar   => profile_self(profiler, profile),
         YARVINSN_opt_regexpmatch2    => profile_operands(profiler, profile, 2),
@@ -187,6 +187,23 @@ fn profile_operands(profiler: &mut Profiler, profile: &mut IseqProfile, n: usize
 }
 
 fn profile_self(profiler: &mut Profiler, profile: &mut IseqProfile) {
+    profile_self_with(profiler, profile, |distribution, ty| distribution.observe(ty));
+}
+
+fn profile_getivar(profiler: &mut Profiler, profile: &mut IseqProfile) {
+    profile_self_with(profiler, profile, observe_getivar_type);
+}
+
+fn observe_getivar_type(distribution: &mut TypeDistribution, ty: ProfiledType) {
+    // getivar specializes on shapes, so class variations should not consume buckets.
+    distribution.observe_with(ty, |left, right| left.shape() == right.shape());
+}
+
+fn profile_self_with(
+    profiler: &mut Profiler,
+    profile: &mut IseqProfile,
+    observe: impl FnOnce(&mut TypeDistribution, ProfiledType),
+) {
     let entry = profile.entry_mut(profiler.insn_idx);
     if entry.opnd_types.is_empty() {
         entry.opnd_types.resize(1, TypeDistribution::new());
@@ -196,7 +213,7 @@ fn profile_self(profiler: &mut Profiler, profile: &mut IseqProfile) {
     // drop them or something
     let ty = ProfiledType::new(obj);
     VALUE::from(profiler.iseq).write_barrier(ty.class());
-    entry.opnd_types[0].observe(ty);
+    observe(&mut entry.opnd_types[0], ty);
 }
 
 fn profile_block_handler(profiler: &mut Profiler, profile: &mut IseqProfile) {
@@ -525,7 +542,28 @@ impl IseqProfile {
 
 #[cfg(test)]
 mod tests {
-    use crate::cruby::*;
+    use super::*;
+
+    #[test]
+    fn getivar_profiles_distinct_shapes() {
+        let mut distribution = TypeDistribution::new();
+        let shape = ShapeId(1);
+
+        // Different classes with the same shape should share one bucket.
+        for class in 1..=DISTRIBUTION_SIZE {
+            let ty = ProfiledType { class: VALUE(class), shape, flags: Flags::none() };
+            observe_getivar_type(&mut distribution, ty);
+        }
+
+        // The remaining buckets should be available for distinct shapes.
+        for shape_id in 2..=DISTRIBUTION_SIZE {
+            let ty = ProfiledType { class: VALUE(shape_id + DISTRIBUTION_SIZE), shape: ShapeId(shape_id as u32), flags: Flags::none() };
+            observe_getivar_type(&mut distribution, ty);
+        }
+
+        let shapes = distribution.each_item().map(|ty| ty.shape()).collect::<Vec<_>>();
+        assert_eq!(shapes, vec![ShapeId(1), ShapeId(2), ShapeId(3), ShapeId(4)]);
+    }
 
     #[test]
     fn can_profile_block_handler() {


### PR DESCRIPTION
This PR lets the profiler profile only distinct shapes for getivar.

The getivar HIR builder https://github.com/ruby/ruby/pull/17582 filters out profiles that have duplicated shape information, so we don't need to profile them. Currently, if there are N types that share the same shape, it consumes N buckets. With this PR, they will consume only 1 bucket so that we can accommodate more shapes.