### PR TITLE
ZJIT: Optimize polymorphic setivar

### DIFF
--- a/zjit/src/codegen_tests.rs
+++ b/zjit/src/codegen_tests.rs
@@ -4170,6 +4170,29 @@ fn test_setinstancevariable() {
 }
 
 #[test]
+fn test_polymorphic_setinstancevariable_with_shape_transitions() {
+    set_call_threshold(3);
+    assert_snapshot!(inspect(r#"
+        class C
+          def set(value) = @a = value
+        end
+
+        normal = C.new
+        with_b = C.new
+        with_b.instance_variable_set(:@b, true)
+        normal.set(:profile_normal)
+        with_b.set(:profile_with_b)
+
+        normal = C.new
+        with_b = C.new
+        with_b.instance_variable_set(:@b, true)
+        results = [normal.set(:normal), with_b.set(:with_b)]
+        results << normal.instance_variable_get(:@a)
+        results << with_b.instance_variable_get(:@a)
+    "#), @"[:normal, :with_b, :normal, :with_b]");
+}
+
+#[test]
 fn test_getclassvariable() {
     assert_snapshot!(inspect("
         class Foo

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -573,6 +573,7 @@ pub enum SideExitReason {
     SendWhileTracing,
     NoProfileSend,
     NoProfileGetIvar,
+    NoProfileSetIvar,
     InvokeBlockNotIfunc,
 }
 
@@ -2609,6 +2610,13 @@ struct CompilePolicy {
     /// side-exit, and instead use fallback paths (e.g. C calls) on mismatch.
     /// Set when this is the final version of an ISEQ after recompilation.
     no_side_exits: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SetIvarSpec {
+    profiled_type: ProfiledType,
+    ivar_index: attr_index_t,
+    next_shape: ShapeId,
 }
 
 impl CompilePolicy {
@@ -5250,9 +5258,9 @@ impl Function {
         Ok(self.load_ivar(block, self_val, profiled_type, id))
     }
 
-    fn try_emit_optimized_setivar(&mut self, block: BlockId, self_val: InsnId, id: ID, val: InsnId, profiled_type: ProfiledType, state: InsnId, recompile: Option<Recompile>) -> Result<(), Counter> {
+    fn prepare_optimized_setivar(&mut self, id: ID, profiled_type: ProfiledType) -> Result<SetIvarSpec, Counter> {
         if profiled_type.flags().is_immediate() {
-            // Instance variable lookups on immediate values are always nil
+            // Instance variable writes on immediate values raise.
             return Err(Counter::setivar_fallback_immediate);
         }
         if !profiled_type.flags().is_t_object() {
@@ -5268,63 +5276,69 @@ impl Function {
             // too-complex shapes can't use index access
             return Err(Counter::setivar_fallback_complex);
         }
-        if self.policy.no_side_exits {
-            // On the final version, skip GetIvar shape specialization.
-            // iseq_to_hir already generates polymorphic branches with a
-            // GetIvar C call fallback for getinstancevariable, so we don't
-            // need to wrap it again here.
-            return Err(Counter::setivar_fallback_no_side_exits);
-        }
-
         let mut ivar_index: attr_index_t = 0;
-        let mut next_shape_id = profiled_type.shape();
+        let mut next_shape = profiled_type.shape();
         if !unsafe { rb_shape_get_iv_index(profiled_type.shape().0, id, &mut ivar_index) } {
             // Current shape does not contain this ivar; do a shape transition.
             let current_shape_id = profiled_type.shape();
             let class = profiled_type.class();
             // We're only looking at T_OBJECT so ignore all of the imemo stuff.
             assert!(profiled_type.flags().is_t_object());
-            next_shape_id = ShapeId(unsafe { rb_shape_transition_add_ivar_no_warnings(current_shape_id.0, id, class) });
+            next_shape = ShapeId(unsafe { rb_shape_transition_add_ivar_no_warnings(current_shape_id.0, id, class) });
             // If the VM ran out of shapes, or this class generated too many leaf,
             // it may be de-optimized into OBJ_COMPLEX_SHAPE (hash-table).
-            let new_shape_complex = unsafe { rb_jit_shape_complex_p(next_shape_id.0) };
+            let new_shape_complex = unsafe { rb_jit_shape_complex_p(next_shape.0) };
             // TODO(max): Is it OK to bail out here after making a shape transition?
             if new_shape_complex {
                 return Err(Counter::setivar_fallback_new_shape_complex);
             }
-            let ivar_result = unsafe { rb_shape_get_iv_index(next_shape_id.0, id, &mut ivar_index) };
+            let ivar_result = unsafe { rb_shape_get_iv_index(next_shape.0, id, &mut ivar_index) };
             assert!(ivar_result, "New shape must have the ivar index");
             let current_capacity = unsafe { rb_jit_shape_capacity(current_shape_id.0) };
-            let next_capacity = unsafe { rb_jit_shape_capacity(next_shape_id.0) };
+            let next_capacity = unsafe { rb_jit_shape_capacity(next_shape.0) };
             // If the new shape has a different capacity, or is COMPLEX, we'll have to
             // reallocate it.
             let needs_extension = next_capacity != current_capacity;
             if needs_extension {
                 return Err(Counter::setivar_fallback_new_shape_needs_extension);
             }
-            // Fall through to emitting the ivar write
+            // Fall through to preparing the ivar write.
         }
-        let self_val = self.guard_heap(block, self_val, state);
-        let shape = self.load_shape(block, self_val);
-        self.guard_shape(block, shape, profiled_type.shape(), state, recompile);
+
+        Ok(SetIvarSpec { profiled_type, ivar_index, next_shape })
+    }
+
+    fn emit_optimized_setivar(&mut self, block: BlockId, self_val: InsnId, id: ID, val: InsnId, spec: SetIvarSpec) {
         // Current shape contains this ivar
-        let (ivar_storage, offset) = if profiled_type.flags().is_embedded() {
+        let (ivar_storage, offset) = if spec.profiled_type.flags().is_embedded() {
             // See ROBJECT_FIELDS() from include/ruby/internal/core/robject.h
-            let offset = ROBJECT_OFFSET_AS_ARY + (SIZEOF_VALUE * ivar_index.to_usize()) as i32;
+            let offset = ROBJECT_OFFSET_AS_ARY + (SIZEOF_VALUE * spec.ivar_index.to_usize()) as i32;
             (self_val, offset)
         } else {
             let as_heap = self.load_field(block, self_val, FieldName::as_heap, ROBJECT_OFFSET_AS_HEAP_FIELDS, types::CPtr);
-            let offset = SIZEOF_VALUE_I32 * ivar_index as i32;
+            let offset = SIZEOF_VALUE_I32 * spec.ivar_index as i32;
             (as_heap, offset)
         };
         self.push_insn(block, Insn::StoreField { recv: ivar_storage, id: id.into(), offset, val, num_bits: types::BasicObject.num_bits() });
         self.push_insn(block, Insn::WriteBarrier { recv: self_val, val });
-        if next_shape_id != profiled_type.shape() {
+        if spec.next_shape != spec.profiled_type.shape() {
             // Write the new shape ID
-            let shape_id = self.push_insn(block, Insn::Const { val: Const::CShape(next_shape_id) });
+            let shape_id = self.push_insn(block, Insn::Const { val: Const::CShape(spec.next_shape) });
             let shape_id_offset = unsafe { rb_shape_id_offset() };
             self.push_insn(block, Insn::StoreField { recv: self_val, id: FieldName::shape_id, offset: shape_id_offset, val: shape_id, num_bits: types::CShape.num_bits() });
         }
+    }
+
+    fn try_emit_optimized_setivar(&mut self, block: BlockId, self_val: InsnId, id: ID, val: InsnId, profiled_type: ProfiledType, state: InsnId, recompile: Option<Recompile>) -> Result<(), Counter> {
+        if self.policy.no_side_exits {
+            // On the final version, don't add a shape guard without a fallback.
+            return Err(Counter::setivar_fallback_no_side_exits);
+        }
+        let spec = self.prepare_optimized_setivar(id, profiled_type)?;
+        let self_val = self.guard_heap(block, self_val, state);
+        let shape = self.load_shape(block, self_val);
+        self.guard_shape(block, shape, profiled_type.shape(), state, recompile);
+        self.emit_optimized_setivar(block, self_val, id, val, spec);
         Ok(())
     }
 
@@ -6932,6 +6946,82 @@ impl Function {
             self.push_insn(load_optimized_block, Insn::Jump(BranchEdge { target: join_block, args: vec![result] }));
         }
         Some((join_block, result))
+    }
+
+    /// Return Some(BlockId) if we generated a setivar or None if we only generated an
+    /// unconditional SideExit (in which case we should end the block).
+    fn dispatch_setivar(
+        &mut self,
+        specs: &[SetIvarSpec],
+        unoptimized_reason: Option<Counter>,
+        mut block: BlockId,
+        insn_idx: u32,
+        self_param: InsnId,
+        id: ID,
+        ic: *const iseq_inline_iv_cache_entry,
+        val: InsnId,
+        exit_id: InsnId,
+    ) -> Option<BlockId> {
+        // 0 specs: Generate a recompile exit or a fallback. No need for new HIR blocks.
+        if specs.is_empty() {
+            if let Some(counter) = unoptimized_reason {
+                self.count(block, counter);
+                self.push_insn(block, Insn::SetIvar { self_val: self_param, id, ic, val, state: exit_id });
+                return Some(block);
+            } else if self.policy.no_side_exits {
+                self.count(block, Counter::setivar_fallback_no_side_exits);
+                self.push_insn(block, Insn::SetIvar { self_val: self_param, id, ic, val, state: exit_id });
+                return Some(block);
+            } else {
+                self.push_insn(block, Insn::SideExit { state: exit_id, reason: Box::new(SideExitReason::NoProfileSetIvar), recompile: Some(Recompile) });
+                return None;
+            }
+        }
+        // 1 spec: Generate a monomorphic setivar with a guard if allowed by policy. No need for new HIR blocks.
+        if specs.len() == 1 && !self.policy.no_side_exits {
+            let actual = self.load_shape(block, self_param);
+            self.guard_shape(block, actual, specs[0].profiled_type.shape(), exit_id, Some(Recompile));
+            self.emit_optimized_setivar(block, self_param, id, val, specs[0]);
+            return Some(block);
+        }
+
+        // Otherwise, make HIR blocks to handle different shapes or a fallback, and let them jump to join_block.
+        let edge = |target: BlockId| BranchEdge { target, args: vec![] };
+        let branch = |cond: InsnId, if_true: BlockId, if_false: BlockId| Insn::CondBranch { val: cond, if_true: edge(if_true), if_false: edge(if_false) };
+        let actual = self.load_shape(block, self_param);
+        let last_shape_index = specs.len() - 1;
+        let join_block = self.new_block(insn_idx);
+        for (i, &spec) in specs.iter().enumerate() {
+            let store_optimized_block = self.new_block(insn_idx);
+            if i == last_shape_index {
+                if self.policy.no_side_exits {
+                    // If the policy doesn't allow exits, make a fallback block and jump to it if the shape doesn't match.
+                    let expected = self.push_insn(block, Insn::Const { val: Const::CShape(spec.profiled_type.shape()) });
+                    let matches = self.push_insn(block, Insn::IsBitEqual { left: actual, right: expected });
+                    let store_fallback_block = self.new_block(insn_idx);
+                    self.push_insn(block, branch(matches, store_optimized_block, store_fallback_block));
+                    self.count(store_fallback_block, Counter::setivar_fallback_no_side_exits);
+                    self.push_insn(store_fallback_block, Insn::SetIvar { self_val: self_param, id, ic, val, state: exit_id });
+                    self.push_insn(store_fallback_block, Insn::Jump(edge(join_block)));
+                } else {
+                    // If the policy allows exits, exit to the interpreter if the shape doesn't match.
+                    self.guard_shape(block, actual, spec.profiled_type.shape(), exit_id, Some(Recompile));
+                    // TODO(max): Don't make a new block in this case
+                    self.push_insn(block, Insn::Jump(edge(store_optimized_block)));
+                }
+            } else {
+                // If this is not the last profiled shape, let the guard jump to the next block.
+                let expected = self.push_insn(block, Insn::Const { val: Const::CShape(spec.profiled_type.shape()) });
+                let matches = self.push_insn(block, Insn::IsBitEqual { left: actual, right: expected });
+                let next_block = self.new_block(insn_idx);
+                self.push_insn(block, branch(matches, store_optimized_block, next_block));
+                block = next_block;
+            }
+            // Generate the optimized setivar for the profiled shape and jump to join_block.
+            self.emit_optimized_setivar(store_optimized_block, self_param, id, val, spec);
+            self.push_insn(store_optimized_block, Insn::Jump(edge(join_block)));
+        }
+        Some(join_block)
     }
 }
 
@@ -9161,19 +9251,53 @@ fn add_iseq_to_hir(
                         break;  // End the block
                     }
                     let val = state.stack_pop()?;
-                    if let Some(profiled_type) = fun.monomorphic_summary(&profiles, self_param, exit_id) {
-                        // TODO(max): Assert ic is never null
-                        let recompile = (!ic.is_null()).then_some(Recompile);
-                        fun.try_emit_optimized_setivar(block, self_param, id, val, profiled_type, exit_id, recompile).unwrap_or_else(|counter| {
-                            fun.count(block, counter);
-                            fun.push_insn(block, Insn::SetIvar { self_val: self_param, id, ic, val, state: exit_id });
-                        });
-                    } else {
-                        fun.push_insn(block, Insn::SetIvar { self_val: self_param, id, ic, val, state: exit_id });
+                    let unrefined_self_param = self_param;
+                    let summary = fun.profile_summary(&profiles, self_param, exit_id);
+                    // Filter out profiled types we don't know how to optimize and de-duplicate shapes.
+                    let mut seen_shapes = Vec::with_capacity(summary.buckets().len());
+                    let mut specs = Vec::with_capacity(summary.buckets().len());
+                    let mut unoptimized_reason = None;
+                    for &profiled_type in summary.buckets() {
+                        if profiled_type.is_empty() {
+                            continue;
+                        }
+                        let shape = if profiled_type.flags().is_immediate() {
+                            INVALID_SHAPE_ID
+                        } else {
+                            profiled_type.shape()
+                        };
+                        if seen_shapes.contains(&shape) {
+                            continue;
+                        }
+                        seen_shapes.push(shape);
+                        match fun.prepare_optimized_setivar(id, profiled_type) {
+                            Ok(spec) => specs.push(spec),
+                            Err(counter) => {
+                                unoptimized_reason.get_or_insert(counter);
+                            },
+                        }
                     }
+                    if !specs.is_empty() || unoptimized_reason.is_none() {
+                        self_param = fun.guard_heap(block, self_param, exit_id);
+                    }
+                    let Some(new_block) = fun.dispatch_setivar(
+                        &specs,
+                        unoptimized_reason,
+                        block,
+                        insn_idx,
+                        self_param,
+                        id,
+                        ic,
+                        val,
+                        exit_id,
+                    ) else {
+                        // Side-exiting unconditionally; end the block.
+                        break;
+                    };
+                    block = new_block;
                     // SetIvar will raise if self is an immediate. If it raises, we will have
                     // exited JIT code. So upgrade the type within JIT code to a heap object.
-                    self_param = fun.push_insn(block, Insn::RefineType { val: self_param, new_type: types::HeapBasicObject });
+                    self_param = fun.push_insn(block, Insn::RefineType { val: unrefined_self_param, new_type: types::HeapBasicObject });
                 }
                 YARVINSN_getclassvariable => {
                     let id = ID(get_arg(pc, 0).as_u64());

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -6876,76 +6876,112 @@ impl Function {
         Ok(())
     }
 
-    /// Return Some(InsnId) if we generated any code to load an ivar and None if we only generated
-    /// an unconditional SideExit (in which case we should end the block).
-    fn dispatch_getivar(
+    /// Dispatch an ivar access to profiled shapes. Callbacks generate the optimized access and
+    /// generic fallback, optionally returning a value to pass through the join block.
+    fn dispatch_ivar<T: Copy>(
         &mut self,
-        profiled_types: &Vec<ProfiledType>,
+        profiles: &[T],
         mut block: BlockId,
         insn_idx: u32,
         self_param: InsnId,
-        id: ID,
-        ic: *const iseq_inline_iv_cache_entry,
         exit_id: InsnId,
-    ) -> Option<(BlockId, InsnId)> {
-        // 0 profiled_types: Generate a recompile exit or a fallback. No need for new HIR blocks.
-        if profiled_types.is_empty() {
+        no_profile_reason: SideExitReason,
+        fallback_counter: Counter,
+        has_result: bool,
+        profile_shape: impl Fn(T) -> ShapeId,
+        mut emit_optimized: impl FnMut(&mut Function, BlockId, T) -> Option<InsnId>,
+        mut emit_fallback: impl FnMut(&mut Function, BlockId) -> Option<InsnId>,
+    ) -> Option<(BlockId, Option<InsnId>)> {
+        // 0 profiles: Generate a recompile exit or a fallback. No need for new HIR blocks.
+        if profiles.is_empty() {
             if self.policy.no_side_exits {
-                self.count(block, Counter::getivar_fallback_no_side_exits);
-                let result = self.push_insn(block, Insn::GetIvar { self_val: self_param, id, ic, state: exit_id });
+                self.count(block, fallback_counter);
+                let result = emit_fallback(self, block);
+                assert_eq!(has_result, result.is_some());
                 return Some((block, result));
             } else {
-                self.push_insn(block, Insn::SideExit { state: exit_id, reason: Box::new(SideExitReason::NoProfileGetIvar), recompile: Some(Recompile) });
+                self.push_insn(block, Insn::SideExit { state: exit_id, reason: Box::new(no_profile_reason), recompile: Some(Recompile) });
                 return None;
             }
         }
-        // 1 profiled_types: Generate a monomorphic getivar with a guard if allowed by policy. No need for new HIR blocks.
-        if profiled_types.len() == 1 && !self.policy.no_side_exits {
-            // 0 profiled_types: Generate a recompile exit or a fallback.
+        // 1 profile: Generate a monomorphic ivar access with a guard if allowed by policy. No need for new HIR blocks.
+        if profiles.len() == 1 && !self.policy.no_side_exits {
             let actual = self.load_shape(block, self_param);
-            self.guard_shape(block, actual, profiled_types[0].shape(), exit_id, Some(Recompile));
-            let result = self.load_ivar(block, self_param, profiled_types[0], id);
+            self.guard_shape(block, actual, profile_shape(profiles[0]), exit_id, Some(Recompile));
+            let result = emit_optimized(self, block, profiles[0]);
+            assert_eq!(has_result, result.is_some());
             return Some((block, result));
         }
 
         // Otherwise, make HIR blocks to handle different shapes or a fallback, and let them jump to join_block.
         let edge = |target: BlockId| BranchEdge { target, args: vec![] };
         let branch = |cond: InsnId, if_true: BlockId, if_false: BlockId| Insn::CondBranch { val: cond, if_true: edge(if_true), if_false: edge(if_false) };
+        let result_edge = |target: BlockId, result: Option<InsnId>| {
+            assert_eq!(has_result, result.is_some());
+            BranchEdge { target, args: result.into_iter().collect() }
+        };
         let actual = self.load_shape(block, self_param);
-        let last_shape_index = profiled_types.len() - 1;
+        let last_shape_index = profiles.len() - 1;
         let join_block = self.new_block(insn_idx);
-        let result = self.push_insn(join_block, Insn::Param);
-        for (i, &profiled_type) in profiled_types.iter().enumerate() {
-            let load_optimized_block = self.new_block(insn_idx);
+        let result = has_result.then(|| self.push_insn(join_block, Insn::Param));
+        for (i, &profile) in profiles.iter().enumerate() {
+            let optimized_block = self.new_block(insn_idx);
             if i == last_shape_index {
                 if self.policy.no_side_exits {
                     // If the policy doesn't allow exits, make a fallback block and jump to it if the shape doesn't match.
-                    let expected = self.push_insn(block, Insn::Const { val: Const::CShape(profiled_type.shape()) });
-                    let val = self.push_insn(block, Insn::IsBitEqual { left: actual, right: expected });
-                    let load_fallback_block = self.new_block(insn_idx);
-                    self.push_insn(block, branch(val, load_optimized_block, load_fallback_block));
-                    self.count(load_fallback_block, Counter::getivar_fallback_no_side_exits);
-                    let result = self.push_insn(load_fallback_block, Insn::GetIvar { self_val: self_param, id, ic, state: exit_id });
-                    self.push_insn(load_fallback_block, Insn::Jump(BranchEdge { target: join_block, args: vec![result] }));
+                    let expected = self.push_insn(block, Insn::Const { val: Const::CShape(profile_shape(profile)) });
+                    let matches = self.push_insn(block, Insn::IsBitEqual { left: actual, right: expected });
+                    let fallback_block = self.new_block(insn_idx);
+                    self.push_insn(block, branch(matches, optimized_block, fallback_block));
+                    self.count(fallback_block, fallback_counter);
+                    let fallback_result = emit_fallback(self, fallback_block);
+                    self.push_insn(fallback_block, Insn::Jump(result_edge(join_block, fallback_result)));
                 } else {
                     // If the policy allows exits, exit to the interpreter if the shape doesn't match.
-                    self.guard_shape(block, actual, profiled_type.shape(), exit_id, Some(Recompile));
+                    self.guard_shape(block, actual, profile_shape(profile), exit_id, Some(Recompile));
                     // TODO(max): Don't make a new block in this case
-                    self.push_insn(block, Insn::Jump(BranchEdge { target: load_optimized_block, args: vec![] }));
+                    self.push_insn(block, Insn::Jump(edge(optimized_block)));
                 }
             } else {
                 // If this is not the last profiled shape, let the guard jump to the next block.
-                let expected = self.push_insn(block, Insn::Const { val: Const::CShape(profiled_type.shape()) });
-                let val = self.push_insn(block, Insn::IsBitEqual { left: actual, right: expected});
+                let expected = self.push_insn(block, Insn::Const { val: Const::CShape(profile_shape(profile)) });
+                let matches = self.push_insn(block, Insn::IsBitEqual { left: actual, right: expected });
                 let next_block = self.new_block(insn_idx);
-                self.push_insn(block, branch(val, load_optimized_block, next_block));
+                self.push_insn(block, branch(matches, optimized_block, next_block));
                 block = next_block;
             }
-            // Generate the optimized getivar for the profiled_type and jump to join_block
-            let result = self.load_ivar(load_optimized_block, self_param, profiled_type, id);
-            self.push_insn(load_optimized_block, Insn::Jump(BranchEdge { target: join_block, args: vec![result] }));
+            let optimized_result = emit_optimized(self, optimized_block, profile);
+            self.push_insn(optimized_block, Insn::Jump(result_edge(join_block, optimized_result)));
         }
         Some((join_block, result))
+    }
+
+    /// Return Some(InsnId) if we generated any code to load an ivar and None if we only generated
+    /// an unconditional SideExit (in which case we should end the block).
+    fn dispatch_getivar(
+        &mut self,
+        profiled_types: &[ProfiledType],
+        block: BlockId,
+        insn_idx: u32,
+        self_param: InsnId,
+        id: ID,
+        ic: *const iseq_inline_iv_cache_entry,
+        exit_id: InsnId,
+    ) -> Option<(BlockId, InsnId)> {
+        let (block, result) = self.dispatch_ivar(
+            profiled_types,
+            block,
+            insn_idx,
+            self_param,
+            exit_id,
+            SideExitReason::NoProfileGetIvar,
+            Counter::getivar_fallback_no_side_exits,
+            true,
+            |profiled_type| profiled_type.shape(),
+            |fun, block, profiled_type| Some(fun.load_ivar(block, self_param, profiled_type, id)),
+            |fun, block| Some(fun.push_insn(block, Insn::GetIvar { self_val: self_param, id, ic, state: exit_id })),
+        )?;
+        Some((block, result.unwrap()))
     }
 
     /// Return Some(BlockId) if we generated a setivar or None if we only generated an
@@ -6954,7 +6990,7 @@ impl Function {
         &mut self,
         specs: &[SetIvarSpec],
         unoptimized_reason: Option<Counter>,
-        mut block: BlockId,
+        block: BlockId,
         insn_idx: u32,
         self_param: InsnId,
         id: ID,
@@ -6962,66 +6998,34 @@ impl Function {
         val: InsnId,
         exit_id: InsnId,
     ) -> Option<BlockId> {
-        // 0 specs: Generate a recompile exit or a fallback. No need for new HIR blocks.
         if specs.is_empty() {
             if let Some(counter) = unoptimized_reason {
                 self.count(block, counter);
                 self.push_insn(block, Insn::SetIvar { self_val: self_param, id, ic, val, state: exit_id });
                 return Some(block);
-            } else if self.policy.no_side_exits {
-                self.count(block, Counter::setivar_fallback_no_side_exits);
-                self.push_insn(block, Insn::SetIvar { self_val: self_param, id, ic, val, state: exit_id });
-                return Some(block);
-            } else {
-                self.push_insn(block, Insn::SideExit { state: exit_id, reason: Box::new(SideExitReason::NoProfileSetIvar), recompile: Some(Recompile) });
-                return None;
             }
         }
-        // 1 spec: Generate a monomorphic setivar with a guard if allowed by policy. No need for new HIR blocks.
-        if specs.len() == 1 && !self.policy.no_side_exits {
-            let actual = self.load_shape(block, self_param);
-            self.guard_shape(block, actual, specs[0].profiled_type.shape(), exit_id, Some(Recompile));
-            self.emit_optimized_setivar(block, self_param, id, val, specs[0]);
-            return Some(block);
-        }
-
-        // Otherwise, make HIR blocks to handle different shapes or a fallback, and let them jump to join_block.
-        let edge = |target: BlockId| BranchEdge { target, args: vec![] };
-        let branch = |cond: InsnId, if_true: BlockId, if_false: BlockId| Insn::CondBranch { val: cond, if_true: edge(if_true), if_false: edge(if_false) };
-        let actual = self.load_shape(block, self_param);
-        let last_shape_index = specs.len() - 1;
-        let join_block = self.new_block(insn_idx);
-        for (i, &spec) in specs.iter().enumerate() {
-            let store_optimized_block = self.new_block(insn_idx);
-            if i == last_shape_index {
-                if self.policy.no_side_exits {
-                    // If the policy doesn't allow exits, make a fallback block and jump to it if the shape doesn't match.
-                    let expected = self.push_insn(block, Insn::Const { val: Const::CShape(spec.profiled_type.shape()) });
-                    let matches = self.push_insn(block, Insn::IsBitEqual { left: actual, right: expected });
-                    let store_fallback_block = self.new_block(insn_idx);
-                    self.push_insn(block, branch(matches, store_optimized_block, store_fallback_block));
-                    self.count(store_fallback_block, Counter::setivar_fallback_no_side_exits);
-                    self.push_insn(store_fallback_block, Insn::SetIvar { self_val: self_param, id, ic, val, state: exit_id });
-                    self.push_insn(store_fallback_block, Insn::Jump(edge(join_block)));
-                } else {
-                    // If the policy allows exits, exit to the interpreter if the shape doesn't match.
-                    self.guard_shape(block, actual, spec.profiled_type.shape(), exit_id, Some(Recompile));
-                    // TODO(max): Don't make a new block in this case
-                    self.push_insn(block, Insn::Jump(edge(store_optimized_block)));
-                }
-            } else {
-                // If this is not the last profiled shape, let the guard jump to the next block.
-                let expected = self.push_insn(block, Insn::Const { val: Const::CShape(spec.profiled_type.shape()) });
-                let matches = self.push_insn(block, Insn::IsBitEqual { left: actual, right: expected });
-                let next_block = self.new_block(insn_idx);
-                self.push_insn(block, branch(matches, store_optimized_block, next_block));
-                block = next_block;
-            }
-            // Generate the optimized setivar for the profiled shape and jump to join_block.
-            self.emit_optimized_setivar(store_optimized_block, self_param, id, val, spec);
-            self.push_insn(store_optimized_block, Insn::Jump(edge(join_block)));
-        }
-        Some(join_block)
+        let (block, result) = self.dispatch_ivar(
+            specs,
+            block,
+            insn_idx,
+            self_param,
+            exit_id,
+            SideExitReason::NoProfileSetIvar,
+            Counter::setivar_fallback_no_side_exits,
+            false,
+            |spec| spec.profiled_type.shape(),
+            |fun, block, spec| {
+                fun.emit_optimized_setivar(block, self_param, id, val, spec);
+                None
+            },
+            |fun, block| {
+                fun.push_insn(block, Insn::SetIvar { self_val: self_param, id, ic, val, state: exit_id });
+                None
+            },
+        )?;
+        assert!(result.is_none());
+        Some(block)
     }
 }
 

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -5752,9 +5752,8 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           v10:Fixnum[1] = Const Value(1)
           PatchPoint SingleRactorMode
-          SetIvar v6, :@foo, v10
-          CheckInterrupts
-          Return v10
+          v14:HeapBasicObject = GuardType v6, HeapBasicObject
+          SideExit NoProfileSetIvar recompile
         ");
     }
 
@@ -6456,6 +6455,30 @@ mod hir_opt_tests {
     }
 
     #[test]
+    fn test_specialize_monomorphic_setivar_on_final_version() {
+        set_max_versions(2);
+        set_inline_threshold(0);
+        eval("
+            class FinalSetIvar
+              def test(x)
+                @foo = 5
+                x + 1
+              end
+            end
+
+            obj = FinalSetIvar.new
+            30.times { obj.test(1) }
+            30.times { obj.test(1.5) }
+        ");
+
+        let hir = hir_string_proc("FinalSetIvar.new.method(:test)");
+        assert!(hir.contains("CondBranch"), "{hir}");
+        assert!(hir.contains("StoreField"), "{hir}");
+        assert!(hir.contains("SetIvar"), "{hir}");
+        assert!(!hir.contains("GuardBitEquals"), "{hir}");
+    }
+
+    #[test]
     fn test_specialize_multiple_monomorphic_setivar_with_shape_transition() {
         eval(r#"
             klass = Class.new do
@@ -6537,7 +6560,7 @@ mod hir_opt_tests {
     }
 
     #[test]
-    fn test_dont_specialize_polymorphic_setivar() {
+    fn test_specialize_polymorphic_setivar() {
         set_call_threshold(3);
         eval("
             class C
@@ -6564,7 +6587,23 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           v10:Fixnum[5] = Const Value(5)
           PatchPoint SingleRactorMode
-          SetIvar v6, :@a, v10
+          v14:HeapBasicObject = GuardType v6, HeapBasicObject
+          v15:CShape = LoadField v14, :shape_id@0x1000
+          v16:CShape[0x1001] = Const CShape(0x1001)
+          v17:CBool = IsBitEqual v15, v16
+          CondBranch v17, bb5(), bb6()
+        bb5():
+          StoreField v14, :@a@0x1002, v10
+          WriteBarrier v14, v10
+          v21:CShape[0x1003] = Const CShape(0x1003)
+          StoreField v14, :shape_id@0x1000, v21
+          Jump bb4()
+        bb6():
+          v24:CShape[0x1004] = GuardBitEquals v15, CShape(0x1004) recompile
+          StoreField v14, :@a@0x1005, v10
+          WriteBarrier v14, v10
+          Jump bb4()
+        bb4():
           CheckInterrupts
           Return v10
         ");
@@ -8735,9 +8774,10 @@ mod hir_opt_tests {
 
     #[test]
     fn test_setivar_shape_guard_recompile() {
+        set_max_versions(2);
         // Call with one shape to compile, then call with a different shape to
-        // trigger shape guard exits and recompilation. On the recompiled version,
-        // SetIvar stays as a C call fallback to avoid more shape guard exits.
+        // trigger shape guard exits and recompilation. The recompiled version
+        // specializes both profiled shapes.
         eval("
             class C
               def initialize(extra = false)
@@ -8767,7 +8807,20 @@ mod hir_opt_tests {
         bb3(v6:HeapBasicObject):
           v10:Fixnum[5] = Const Value(5)
           PatchPoint SingleRactorMode
-          SetIvar v6, :@foo, v10
+          v15:CShape = LoadField v6, :shape_id@0x1000
+          v16:CShape[0x1001] = Const CShape(0x1001)
+          v17:CBool = IsBitEqual v15, v16
+          CondBranch v17, bb5(), bb6()
+        bb5():
+          StoreField v6, :@foo@0x1002, v10
+          WriteBarrier v6, v10
+          Jump bb4()
+        bb6():
+          v22:CShape[0x1003] = GuardBitEquals v15, CShape(0x1003) recompile
+          StoreField v6, :@foo@0x1004, v10
+          WriteBarrier v6, v10
+          Jump bb4()
+        bb4():
           CheckInterrupts
           Return v10
         ");
@@ -14777,17 +14830,33 @@ mod hir_opt_tests {
          CheckInterrupts
          SetLocal :formatted, l0, EP@3, v21
          PatchPoint SingleRactorMode
-         SetIvar v20, :@formatted, v21
-         v52:ClassSubclass[VMFrozenCore] = Const Value(VALUE(0x1008))
-         PatchPoint MethodRedefined(Class@0x1010, lambda@0x1018, cme:0x1020)
-         v68:BasicObject = CCallWithFrame v52, :RubyVM::FrozenCore.lambda@0x1048, block=0x1050
-         v55:CPtr = GetEP 0
-         v56:BasicObject = LoadField v55, :a@0x1001
-         v57:BasicObject = LoadField v55, :_b@0x1002
-         v58:BasicObject = LoadField v55, :_c@0x1003
-         v59:BasicObject = LoadField v55, :formatted@0x1004
+         v48:HeapBasicObject = GuardType v20, HeapBasicObject
+         v49:CShape = LoadField v48, :shape_id@0x1005
+         v50:CShape[0x1006] = Const CShape(0x1006)
+         v51:CBool = IsBitEqual v49, v50
+         CondBranch v51, bb7(), bb8()
+       bb7():
+         StoreField v48, :@formatted@0x1007, v21
+         WriteBarrier v48, v21
+         Jump bb6()
+       bb8():
+         v56:CShape[0x1008] = GuardBitEquals v49, CShape(0x1008) recompile
+         StoreField v48, :@formatted@0x1007, v21
+         WriteBarrier v48, v21
+         v60:CShape[0x1006] = Const CShape(0x1006)
+         StoreField v48, :shape_id@0x1005, v60
+         Jump bb6()
+       bb6():
+         v66:ClassSubclass[VMFrozenCore] = Const Value(VALUE(0x1010))
+         PatchPoint MethodRedefined(Class@0x1018, lambda@0x1020, cme:0x1028)
+         v82:BasicObject = CCallWithFrame v66, :RubyVM::FrozenCore.lambda@0x1050, block=0x1058
+         v69:CPtr = GetEP 0
+         v70:BasicObject = LoadField v69, :a@0x1001
+         v71:BasicObject = LoadField v69, :_b@0x1002
+         v72:BasicObject = LoadField v69, :_c@0x1003
+         v73:BasicObject = LoadField v69, :formatted@0x1004
          CheckInterrupts
-         Return v68
+         Return v82
        ");
     }
 
@@ -18141,16 +18210,48 @@ mod hir_opt_tests {
         bb3(v11:HeapBasicObject, v12:BasicObject, v13:NilClass):
           v17:Fixnum[1] = Const Value(1)
           PatchPoint SingleRactorMode
+          v21:CShape = LoadField v11, :shape_id@0x1001
+          v22:CShape[0x1002] = Const CShape(0x1002)
+          v23:CBool = IsBitEqual v21, v22
+          CondBranch v23, bb5(), bb6()
+        bb5():
+          StoreField v11, :@a@0x1003, v17
+          WriteBarrier v11, v17
+          Jump bb4()
+        bb6():
+          v28:CShape[0x1004] = Const CShape(0x1004)
+          v29:CBool = IsBitEqual v21, v28
+          CondBranch v29, bb7(), bb8()
+        bb7():
+          StoreField v11, :@a@0x1003, v17
+          WriteBarrier v11, v17
+          v35:CShape[0x1002] = Const CShape(0x1002)
+          StoreField v11, :shape_id@0x1001, v35
+          Jump bb4()
+        bb8():
           SetIvar v11, :@a, v17
+          Jump bb4()
+        bb4():
           PatchPoint NoEPEscape(f)
-          v27:Fixnum[1] = Const Value(1)
+          v44:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Integer@0x1008, +@0x1010, cme:0x1018)
-          v46:Fixnum = GuardType v12, Fixnum recompile
-          v47:Fixnum = FixnumAdd v46, v27
+          v72:Fixnum = GuardType v12, Fixnum recompile
+          v73:Fixnum = FixnumAdd v72, v44
           PatchPoint SingleRactorMode
-          SetIvar v11, :@a, v47
+          v55:CShape = LoadField v11, :shape_id@0x1001
+          v56:CShape[0x1002] = Const CShape(0x1002)
+          v57:CBool = IsBitEqual v55, v56
+          CondBranch v57, bb10(), bb11()
+        bb10():
+          StoreField v11, :@a@0x1003, v73
+          WriteBarrier v11, v73
+          Jump bb9()
+        bb11():
+          SetIvar v11, :@a, v73
+          Jump bb9()
+        bb9():
           CheckInterrupts
-          Return v47
+          Return v73
 
         fn f@<compiled>:4:
         bb1():
@@ -18169,34 +18270,66 @@ mod hir_opt_tests {
         bb3(v11:HeapBasicObject, v12:BasicObject, v13:NilClass):
           v17:Fixnum[1] = Const Value(1)
           PatchPoint SingleRactorMode
-          SetIvar v11, :@a, v17
-          PatchPoint NoEPEscape(f)
-          v27:Fixnum[1] = Const Value(1)
-          v31:CBool = HasType v12, Flonum
-          CondBranch v31, bb5(), bb6()
+          v21:CShape = LoadField v11, :shape_id@0x1001
+          v22:CShape[0x1002] = Const CShape(0x1002)
+          v23:CBool = IsBitEqual v21, v22
+          CondBranch v23, bb5(), bb6()
         bb5():
-          v34:Flonum = RefineType v12, Flonum
-          PatchPoint MethodRedefined(Float@0x1008, +@0x1010, cme:0x1018)
-          v60:Float = FloatAdd v34, v27
-          Jump bb4(v60)
+          StoreField v11, :@a@0x1003, v17
+          WriteBarrier v11, v17
+          Jump bb4()
         bb6():
-          v37:CBool = HasType v12, Fixnum
-          CondBranch v37, bb7(), bb8()
+          v28:CShape[0x1004] = Const CShape(0x1004)
+          v29:CBool = IsBitEqual v21, v28
+          CondBranch v29, bb7(), bb8()
         bb7():
-          v40:Fixnum = RefineType v12, Fixnum
-          PatchPoint MethodRedefined(Integer@0x1040, +@0x1010, cme:0x1048)
-          v63:Fixnum = FixnumAdd v40, v27
-          Jump bb4(v63)
+          StoreField v11, :@a@0x1003, v17
+          WriteBarrier v11, v17
+          v35:CShape[0x1002] = Const CShape(0x1002)
+          StoreField v11, :shape_id@0x1001, v35
+          Jump bb4()
         bb8():
+          SetIvar v11, :@a, v17
+          Jump bb4()
+        bb4():
+          PatchPoint NoEPEscape(f)
+          v44:Fixnum[1] = Const Value(1)
+          v48:CBool = HasType v12, Flonum
+          CondBranch v48, bb10(), bb11()
+        bb10():
+          v51:Flonum = RefineType v12, Flonum
           PatchPoint MethodRedefined(Float@0x1008, +@0x1010, cme:0x1018)
-          v66:Flonum = GuardType v12, Flonum recompile
-          v67:Float = FloatAdd v66, v27
-          Jump bb4(v67)
-        bb4(v30:Float|Fixnum):
+          v86:Float = FloatAdd v51, v44
+          Jump bb9(v86)
+        bb11():
+          v54:CBool = HasType v12, Fixnum
+          CondBranch v54, bb12(), bb13()
+        bb12():
+          v57:Fixnum = RefineType v12, Fixnum
+          PatchPoint MethodRedefined(Integer@0x1040, +@0x1010, cme:0x1048)
+          v89:Fixnum = FixnumAdd v57, v44
+          Jump bb9(v89)
+        bb13():
+          PatchPoint MethodRedefined(Float@0x1008, +@0x1010, cme:0x1018)
+          v92:Flonum = GuardType v12, Flonum recompile
+          v93:Float = FloatAdd v92, v44
+          Jump bb9(v93)
+        bb9(v47:Float|Fixnum):
           PatchPoint SingleRactorMode
-          SetIvar v11, :@a, v30
+          v69:CShape = LoadField v11, :shape_id@0x1001
+          v70:CShape[0x1002] = Const CShape(0x1002)
+          v71:CBool = IsBitEqual v69, v70
+          CondBranch v71, bb15(), bb16()
+        bb15():
+          StoreField v11, :@a@0x1003, v47
+          WriteBarrier v11, v47
+          Jump bb14()
+        bb16():
+          SetIvar v11, :@a, v47
+          Jump bb14()
+        bb14():
           CheckInterrupts
-          Return v30
+          Return v47
         ");
     }
 

--- a/zjit/src/stats.rs
+++ b/zjit/src/stats.rs
@@ -238,6 +238,7 @@ make_counters! {
         exit_too_many_args_for_lir,
         exit_no_profile_send,
         exit_no_profile_getivar,
+        exit_no_profile_setivar,
         exit_splatkw_not_nil_or_hash,
         exit_splatkw_polymorphic,
         exit_splatkw_not_profiled,
@@ -666,6 +667,7 @@ pub fn side_exit_counter(reason: crate::hir::SideExitReason) -> Counter {
         SendWhileTracing              => exit_send_while_tracing,
         NoProfileSend                 => exit_no_profile_send,
         NoProfileGetIvar              => exit_no_profile_getivar,
+        NoProfileSetIvar              => exit_no_profile_setivar,
         InvokeBlockNotIfunc           => exit_invokeblock_not_ifunc,
     }
 }


### PR DESCRIPTION
This PR adds support for specializing polymorphic setivar.

Best reviewed as individual commits. I'm open to dropping the second commit if we don't like the unification.

## Benchmark

I didn't see a significant impact on lobsters, but this sped up optcarrot:

```
before: ruby 4.1.0dev (2026-07-10T22:31:11Z master c0a2282bb8) +ZJIT +PRISM [x86_64-linux]
after: ruby 4.1.0dev (2026-07-11T00:24:18Z zjit-unified-ivar-.. ef4f809fa6) +ZJIT +PRISM [x86_64-linux]

---------  ------------  ------------  -------------  ------------
bench       before (ms)    after (ms)  after 1st itr  before/after
optcarrot  868.9 ± 3.6%  834.0 ± 3.8%          1.036         1.042
---------  ------------  ------------  -------------  ------------
```

## ZJIT stats

```diff
 Top-20 calls to C functions from JIT code (99.9% of total 61,226,933):
                   rb_ary_push: 12,448,107 (20.3%)
                rb_fix_mod_fix: 12,226,463 (20.0%)
-    rb_vm_setinstancevariable: 11,611,460 (16.4%)
  rb_vm_opt_send_without_block:  7,852,881 (12.8%)
                   rb_fix_aref:  7,157,466 (11.7%)
     rb_vm_getinstancevariable:  4,490,163 ( 7.3%)
                            []:  3,969,300 ( 6.5%)
            rb_gc_writebarrier:  3,943,383 ( 6.4%)
+    rb_vm_setinstancevariable:  2,183,242 ( 3.6%)
             rb_vm_splat_array:  1,677,153 ( 2.7%)

 Top-1 setivar fallback reasons (100.0% of total 5,691,054):
-  no_side_exits: 5,691,054 (100.0%)
+  no_side_exits: 2,183,242 (100.0%)

-dynamic_setivar_count:                                           5,691,054
+dynamic_setivar_count:                                           2,183,242
```