### PR TITLE
Park the calling thread in rb_ractor_sched_barrier_join

### DIFF
--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -2620,3 +2620,24 @@ assert_equal 'ok', %q{
 
   :ok
 }
+
+# A terminating/blocking thread that joins the Ractor barrier must not save
+# its machine context into cr->threads.sched.running's ec: that corrupts the
+# blocked thread's stack bounds, the barrier GC then scans nothing of its
+# machine stack, and its IO buffer gets swept (use-after-free on read).
+assert_equal 'ok', %q{
+  Warning[:experimental] = false
+  b = Ractor.new do
+    60.times do
+      r, w = IO.pipe
+      t = Thread.new { sleep(0.0004); w.write("x" * 40); w.close }
+      r.read
+      r.close
+      t.join
+    end
+    :ok
+  end
+  a = Ractor.new { 300.times { GC.compact }; :ok }
+  [a, b].each(&:value)
+  :ok
+}

--- a/ractor.c
+++ b/ractor.c
@@ -753,7 +753,7 @@ rb_vm_ractor_blocking_cnt_dec(rb_vm_t *vm, rb_ractor_t *cr, const char *file, in
 }
 
 static void
-ractor_check_blocking(rb_ractor_t *cr, unsigned int remained_thread_cnt, const char *file, int line)
+ractor_check_blocking(rb_ractor_t *cr, unsigned int remained_thread_cnt, bool sched_detached, const char *file, int line)
 {
     VM_ASSERT(cr == GET_RACTOR());
 
@@ -771,18 +771,23 @@ ractor_check_blocking(rb_ractor_t *cr, unsigned int remained_thread_cnt, const c
         rb_vm_t *vm = GET_VM();
 
         RB_VM_LOCKING() {
-            rb_vm_ractor_blocking_cnt_inc(vm, cr, file, line);
+            /* Re-check: acquiring the VM lock can join a barrier, and the world
+             * may have changed meanwhile (a sibling resumed, a successor ran). */
+            if (cr->threads.cnt == cr->threads.blocking_cnt + 1 &&
+                (!sched_detached || !rb_ractor_sched_running_thread_p(cr))) {
+                rb_vm_ractor_blocking_cnt_inc(vm, cr, file, line);
+            }
         }
     }
 }
 
 
 void
-rb_ractor_living_threads_remove(rb_ractor_t *cr, rb_thread_t *th)
+rb_ractor_living_threads_remove(rb_ractor_t *cr, rb_thread_t *th, bool sched_detached)
 {
     VM_ASSERT(cr == GET_RACTOR());
     RUBY_DEBUG_LOG("r->threads.cnt:%d--", cr->threads.cnt);
-    ractor_check_blocking(cr, cr->threads.cnt - 1, __FILE__, __LINE__);
+    ractor_check_blocking(cr, cr->threads.cnt - 1, sched_detached, __FILE__, __LINE__);
 
 
     if (cr->threads.cnt == 1) {
@@ -806,7 +811,7 @@ rb_ractor_blocking_threads_inc(rb_ractor_t *cr, const char *file, int line)
     VM_ASSERT(cr->threads.cnt > 0);
     VM_ASSERT(cr == GET_RACTOR());
 
-    ractor_check_blocking(cr, cr->threads.cnt, __FILE__, __LINE__);
+    ractor_check_blocking(cr, cr->threads.cnt, false, __FILE__, __LINE__);
     cr->threads.blocking_cnt++;
 }
 
@@ -819,11 +824,15 @@ rb_ractor_blocking_threads_dec(rb_ractor_t *cr, const char *file, int line)
 
     VM_ASSERT(cr == GET_RACTOR());
 
-    if (cr->threads.cnt == cr->threads.blocking_cnt) {
+    /* Keyed on the status, not on cnt arithmetic, to stay paired with the
+     * inc side (which can skip the transition for a detached caller). */
+    if (rb_ractor_status_p(cr, ractor_blocking)) {
         rb_vm_t *vm = GET_VM();
 
         RB_VM_LOCKING() {
-            rb_vm_ractor_blocking_cnt_dec(vm, cr, __FILE__, __LINE__);
+            if (rb_ractor_status_p(cr, ractor_blocking)) {
+                rb_vm_ractor_blocking_cnt_dec(vm, cr, __FILE__, __LINE__);
+            }
         }
     }
 

--- a/ractor_core.h
+++ b/ractor_core.h
@@ -162,7 +162,8 @@ bool rb_ractor_p(VALUE rv);
 
 void rb_ractor_living_threads_init(rb_ractor_t *r);
 void rb_ractor_living_threads_insert(rb_ractor_t *r, rb_thread_t *th);
-void rb_ractor_living_threads_remove(rb_ractor_t *r, rb_thread_t *th);
+void rb_ractor_living_threads_remove(rb_ractor_t *r, rb_thread_t *th, bool sched_detached);
+bool rb_ractor_sched_running_thread_p(rb_ractor_t *cr);
 void rb_ractor_blocking_threads_inc(rb_ractor_t *r, const char *file, int line); // TODO: file, line only for RUBY_DEBUG_LOG
 void rb_ractor_blocking_threads_dec(rb_ractor_t *r, const char *file, int line); // TODO: file, line only for RUBY_DEBUG_LOG
 

--- a/thread.c
+++ b/thread.c
@@ -837,10 +837,10 @@ thread_start_func_2(rb_thread_t *th, VALUE *stack_start)
         // GC will happen anytime and this ractor can be collected (and destroy GVL).
         // So gvl_release() should be before it.
         thread_sched_to_dead(TH_SCHED(th), th);
-        rb_ractor_living_threads_remove(th->ractor, th);
+        rb_ractor_living_threads_remove(th->ractor, th, true);
     }
     else {
-        rb_ractor_living_threads_remove(th->ractor, th);
+        rb_ractor_living_threads_remove(th->ractor, th, false);
         thread_sched_to_dead(TH_SCHED(th), th);
     }
 
@@ -941,7 +941,7 @@ thread_create_core(VALUE thval, struct thread_create_params *params)
     err = native_thread_create(th);
     if (err) {
         th->status = THREAD_KILLED;
-        rb_ractor_living_threads_remove(th->ractor, th);
+        rb_ractor_living_threads_remove(th->ractor, th, false);
         rb_raise(rb_eThreadError, "can't create Thread: %s", strerror(err));
     }
     return thval;

--- a/thread_none.c
+++ b/thread_none.c
@@ -156,7 +156,7 @@ static int
 native_thread_create(rb_thread_t *th)
 {
     th->status = THREAD_KILLED;
-    rb_ractor_living_threads_remove(th->ractor, th);
+    rb_ractor_living_threads_remove(th->ractor, th, false);
     rb_notimplement();
 }
 
@@ -339,4 +339,10 @@ rb_thread_sched_wait_winding(rb_vm_t *vm)
     // no coroutine (M:N) threads on this implementation: nothing winds down
     // after leaving the living set (see thread_pthread.c)
     (void)vm;
+}
+
+bool
+rb_ractor_sched_running_thread_p(rb_ractor_t *cr)
+{
+    return false;
 }

--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -1674,7 +1674,9 @@ rb_ractor_sched_barrier_join(rb_vm_t *vm, rb_ractor_t *cr)
             else {
                 RUBY_DEBUG_LOG("join without counting (not running) serial:%u", barrier_serial);
             }
-            ractor_sched_barrier_join_wait_locked(vm, cr->threads.sched.running);
+            /* Park the CALLING thread: cr->threads.sched.running can be another
+             * thread (e.g. blocked in IO); saving into its ec corrupts its bounds. */
+            ractor_sched_barrier_join_wait_locked(vm, GET_THREAD());
         }
         ractor_sched_unlock(vm, cr);
     }

--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -545,6 +545,18 @@ ractor_sched_running_threads_contain_p(rb_vm_t *vm, rb_thread_t *th)
     return false;
 }
 
+// Whether this Ractor's scheduler has a running (or designated successor) thread.
+bool
+rb_ractor_sched_running_thread_p(rb_ractor_t *cr)
+{
+    struct rb_thread_sched *sched = &cr->threads.sched;
+    bool ret;
+    thread_sched_lock(sched, NULL);
+    ret = (sched->running != NULL);
+    thread_sched_unlock(sched, NULL);
+    return ret;
+}
+
 RBIMPL_ATTR_MAYBE_UNUSED()
 static unsigned int
 ractor_sched_running_threads_size(rb_vm_t *vm)

--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -525,6 +525,15 @@ ASSERT_ractor_sched_locked(rb_vm_t *vm, rb_ractor_t *cr)
     VM_ASSERT(cr == NULL || vm->ractor.sched.lock_owner == cr);
 }
 
+/* O(1) membership in vm->ractor.sched.running_threads: the node is
+ * NULL-initialized before the first add and self-linked after del_init. */
+static bool
+ractor_sched_running_threads_member_p(const rb_thread_t *th)
+{
+    const struct ccan_list_node *node = &th->sched.node.running_threads;
+    return node->next != NULL && node->next != node;
+}
+
 RBIMPL_ATTR_MAYBE_UNUSED()
 static bool
 ractor_sched_running_threads_contain_p(rb_vm_t *vm, rb_thread_t *th)
@@ -1650,33 +1659,33 @@ rb_ractor_sched_barrier_join(rb_vm_t *vm, rb_ractor_t *cr)
     VM_ASSERT(vm->ractor.sync.lock_owner == NULL); // VM is locked, but owner == NULL
     VM_ASSERT(vm->ractor.sched.barrier_waiting);  // VM needs barrier sync
 
-#if USE_RUBY_DEBUG_LOG || VM_CHECK_MODE > 0
-    unsigned int barrier_serial = vm->ractor.sched.barrier_serial;
-#endif
+    const unsigned int barrier_serial = vm->ractor.sched.barrier_serial;
 
     RUBY_DEBUG_LOG("join");
 
     rb_native_mutex_unlock(&vm->ractor.sync.lock);
     {
-        VM_ASSERT(vm->ractor.sched.barrier_waiting);  // VM needs barrier sync
-        VM_ASSERT(vm->ractor.sched.barrier_serial == barrier_serial);
-
         ractor_sched_lock(vm, cr);
-        {
-            // running_cnt
-            /* A not-yet-running thread (blocking/terminating, joined only to
-             * sync) must not be counted, or barrier_waiting_cnt > running_cnt-1. */
-            if (cr->threads.sched.is_running) {
+        /* The barrier seen under the VM lock can complete before we get here;
+         * waiting then would sleep until the NEXT barrier completes. Skip
+         * instead and let the caller re-evaluate. */
+        if (vm->ractor.sched.barrier_waiting && vm->ractor.sched.barrier_serial == barrier_serial) {
+            rb_thread_t *th = GET_THREAD();
+
+            /* Count only a member of the running set, checked per-thread:
+             * sched.is_running can already be true for a designated successor
+             * while this (terminating) caller has left the set. */
+            if (ractor_sched_running_threads_member_p(th)) {
                 vm->ractor.sched.barrier_waiting_cnt++;
                 RUBY_DEBUG_LOG("waiting_cnt:%u serial:%u", vm->ractor.sched.barrier_waiting_cnt, barrier_serial);
                 ractor_sched_barrier_join_signal_locked(vm);
             }
             else {
-                RUBY_DEBUG_LOG("join without counting (not running) serial:%u", barrier_serial);
+                RUBY_DEBUG_LOG("join without counting (not in running set) serial:%u", barrier_serial);
             }
             /* Park the CALLING thread: cr->threads.sched.running can be another
              * thread (e.g. blocked in IO); saving into its ec corrupts its bounds. */
-            ractor_sched_barrier_join_wait_locked(vm, GET_THREAD());
+            ractor_sched_barrier_join_wait_locked(vm, th);
         }
         ractor_sched_unlock(vm, cr);
     }

--- a/thread_pthread_mn.c
+++ b/thread_pthread_mn.c
@@ -496,7 +496,7 @@ coroutine_thread_terminated(rb_thread_t *th)
     // collect th (and, for a Ractor's main thread, the Ractor).
     // (interrupt_lock stays valid up to here -- a concurrent terminate_all
     // may interrupt any still-listed thread; it is destroyed in thread_free.)
-    rb_ractor_living_threads_remove(r, th);
+    rb_ractor_living_threads_remove(r, th, true);
 
     if (last) {
         rb_current_ec_set(NULL); // TLS only; r may be collectable already


### PR DESCRIPTION
ractor_sched_barrier_join_wait_locked was passed cr->threads.sched.running, but the joining (calling) thread is not always sched.running: a terminating or blocking thread can join the barrier while another thread of the same Ractor -- e.g. one blocked in IO with live frames on its coroutine stack -- is sched.running.  RB_VM_SAVE_MACHINE_CONTEXT(th) then runs on the caller's stack but writes into the other thread's ec, so machine.stack_end ends up pointing into a foreign stack.  The barrier GC then scans an invalid range for the blocked thread and misses every reference living only on its machine stack; e.g. the STR_TMPLOCK'd buffer of a blocked IO#read gets swept and is used after free when the read completes (ASAN use-after-poison in rb_str_unlocktmp, 14/20 -> 0/20 with this fix).

Pass GET_THREAD() so the join saves and parks the calling thread itself.