### PR TITLE
Remove unused rb_vm_using_module

### DIFF
--- a/eval.c
+++ b/eval.c
@@ -1492,12 +1492,6 @@ rb_using_module(const rb_cref_t *cref, VALUE module)
     rb_clear_all_refinement_method_cache();
 }
 
-void
-rb_vm_using_module(VALUE module)
-{
-    rb_using_module(rb_vm_cref_replace_with_duplicated_cref(), module);
-}
-
 /*
  *  call-seq:
  *     target    -> class_or_module

--- a/internal/eval.h
+++ b/internal/eval.h
@@ -29,7 +29,6 @@ void rb_class_modify_check(VALUE);
 NORETURN(VALUE rb_f_raise(int argc, VALUE *argv));
 VALUE rb_exception_setup(int argc, VALUE *argv);
 void rb_refinement_setup(struct rb_refinements_data *data, VALUE module, VALUE klass);
-void rb_vm_using_module(VALUE module);
 VALUE rb_top_main_class(const char *method);
 VALUE rb_ec_ensure(rb_execution_context_t *ec, VALUE (*b_proc)(VALUE), VALUE data1, VALUE (*e_proc)(VALUE), VALUE data2);
 


### PR DESCRIPTION
382645d440 added rb_vm_using_module together with its only caller (the namespace loader), and 4f47327287 removed that caller when the current namespace management was reworked, leaving the function unused.