### PR TITLE
Remove a dying coroutine thread from the living set before its scheduler handoff

### DIFF
--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -2620,3 +2620,31 @@ assert_equal 'ok', %q{
 
   :ok
 }
+
+# A terminating thread joining an in-progress Ractor barrier must not corrupt
+# the designated successor's machine context, hang on a completed barrier, or
+# leave the Ractor's blocking status inconsistent.
+assert_equal 'ok', %q{
+  Warning[:experimental] = false
+  can_compact = begin
+    GC.compact
+    true
+  rescue NotImplementedError
+    false
+  end
+  if can_compact
+    b = Ractor.new do
+      30.times do
+        r, w = IO.pipe
+        t = Thread.new { sleep(0.0004); w.write("x" * 40); w.close }
+        r.read
+        r.close
+        t.join
+      end
+      :ok
+    end
+    a = Ractor.new { 100.times { GC.compact }; :ok }
+    [a, b].each(&:value)
+  end
+  :ok
+}

--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -1664,16 +1664,13 @@ rb_ractor_sched_barrier_join(rb_vm_t *vm, rb_ractor_t *cr)
         ractor_sched_lock(vm, cr);
         {
             // running_cnt
-            /* A not-yet-running thread (blocking/terminating, joined only to
-             * sync) must not be counted, or barrier_waiting_cnt > running_cnt-1. */
-            if (cr->threads.sched.is_running) {
-                vm->ractor.sched.barrier_waiting_cnt++;
-                RUBY_DEBUG_LOG("waiting_cnt:%u serial:%u", vm->ractor.sched.barrier_waiting_cnt, barrier_serial);
-                ractor_sched_barrier_join_signal_locked(vm);
-            }
-            else {
-                RUBY_DEBUG_LOG("join without counting (not running) serial:%u", barrier_serial);
-            }
+            /* Every joiner is a member of the running set: a dying thread now
+             * leaves the living set before handing over its scheduler slot. */
+            VM_ASSERT(ractor_sched_running_threads_contain_p(vm, GET_THREAD()));
+            vm->ractor.sched.barrier_waiting_cnt++;
+            RUBY_DEBUG_LOG("waiting_cnt:%u serial:%u", vm->ractor.sched.barrier_waiting_cnt, barrier_serial);
+
+            ractor_sched_barrier_join_signal_locked(vm);
             ractor_sched_barrier_join_wait_locked(vm, cr->threads.sched.running);
         }
         ractor_sched_unlock(vm, cr);

--- a/thread_pthread_mn.c
+++ b/thread_pthread_mn.c
@@ -448,9 +448,8 @@ native_thread_check_and_create_shared(rb_vm_t *vm)
 }
 
 // A coroutine thread's epilogue, run from thread_start_func_2 while th is
-// still valid (and, until the living-set removal, still GC-reachable).
-// Everything that touches th happens here; co_start then only makes the
-// final transfer, touching the execution-owned tctx alone.
+// still valid. Everything that touches th happens here; co_start then only
+// makes the final transfer, touching the execution-owned tctx alone.
 static void
 coroutine_thread_terminated(rb_thread_t *th)
 {
@@ -470,6 +469,20 @@ coroutine_thread_terminated(rb_thread_t *th)
 
     rb_thread_t *wake_th;
 
+    // Leave the living set BEFORE handing over the scheduler slot: the
+    // removal's VM-lock work (ractor_check_blocking, a barrier join) then
+    // runs as an ordinary counted running thread. Afterwards th may be
+    // unreachable, but no GC can complete while th still owns the slot
+    // (a barrier waits for it to join), so the handoff below may keep
+    // touching th/sched.
+    //
+    // The Ractor's last thread is the exception and keeps the reverse
+    // order (below): its removal unlinks the Ractor itself, after which
+    // r/sched must not be touched. That order is safe only for it: with
+    // no successor, sched->running stays NULL, so the removal's VM lock
+    // never joins a barrier (vm_need_barrier requires a running thread).
+    if (!last) rb_ractor_living_threads_remove(r, th);
+
     thread_sched_lock(sched, th);
     {
         // designate the successor (running = next from readyq, or NULL); for
@@ -477,12 +490,12 @@ coroutine_thread_terminated(rb_thread_t *th)
         thread_sched_to_dead_common(sched, th);
 
         // Only the successor WE designated here may be enqueued by this
-        // epilogue (below, after the living-set removal). If readyq was
-        // empty, running is now NULL and a waker (e.g. the timer thread)
-        // that later installs a runnable thread enqueues the Ractor itself
-        // -- enqueuing "whatever is running" at that point would duplicate
-        // its entry. While running is non-NULL, nobody else re-assigns it,
-        // so wake_th stays valid until we enqueue.
+        // epilogue (below). If readyq was empty, running is now NULL and a
+        // waker (e.g. the timer thread) that later installs a runnable
+        // thread enqueues the Ractor itself -- enqueuing "whatever is
+        // running" at that point would duplicate its entry. While running
+        // is non-NULL, nobody else re-assigns it, so wake_th stays valid
+        // until we enqueue.
         wake_th = is_dnt ? NULL : sched->running;
 
         tctx->nt = th->nt;        // stash the final transfer target for co_start
@@ -491,14 +504,10 @@ coroutine_thread_terminated(rb_thread_t *th)
     }
     thread_sched_unlock(sched, th);
 
-    // Leave the living set. This is the dying thread's last access to th --
-    // the removal needs the current ec (VM lock), and after it the GC may
-    // collect th (and, for a Ractor's main thread, the Ractor).
-    // (interrupt_lock stays valid up to here -- a concurrent terminate_all
-    // may interrupt any still-listed thread; it is destroyed in thread_free.)
-    rb_ractor_living_threads_remove(r, th);
-
     if (last) {
+        // Last access to th/r: the removal may unlink the Ractor, after
+        // which the GC may collect th and r.
+        rb_ractor_living_threads_remove(r, th);
         rb_current_ec_set(NULL); // TLS only; r may be collectable already
     }
     else {


### PR DESCRIPTION
Fixes a family of races between terminating MN threads and the Ractor barrier, found while investigating a use-after-free of a blocked `IO#read` buffer under concurrent `GC.compact` (supersedes #17804 with a root-cause reorder instead of point fixes).

## Problem

`coroutine_thread_terminated` designated the successor first (`thread_sched_to_dead_common`) and only then removed the dying thread from the living set. The removal's VM-lock work (`ractor_check_blocking`, a possible barrier join) therefore ran *detached*: the thread had already left the running set while `sched.running` pointed to the successor. This one window produced four distinct failures:

- the barrier join parked `cr->threads.sched.running` (the successor) instead of the caller, and `RB_VM_SAVE_MACHINE_CONTEXT` — which can only capture the executing thread's state — overwrote the parked successor's `machine.stack_end`/registers with the dying thread's. The barrier GC then scanned an invalid machine-stack range for the successor and missed references living only there: the `STR_TMPLOCK`ed buffer of a blocked `IO#read` got swept and used after free (also visible as `[BUG] system stack overflow during GC` on release builds);
- a detached joiner arriving after its barrier already completed slept until the *next* barrier completes — forever if none follows (a hang at process exit);
- it was mis-counted in `barrier_waiting_cnt` (the per-Ractor `sched.is_running` can already be true for the successor);
- `ractor_check_blocking`'s will-block decision, evaluated before `RB_VM_LOCKING()` whose acquisition can join a barrier and take arbitrarily long, became stale and marked a Ractor with running threads as blocking.

## Fix

Do the removal first, while the thread still owns the Ractor's scheduler slot: the VM-lock work then runs as an ordinary counted running thread and the whole class of detached races disappears. After the removal `th` may be unreachable, but no GC can complete while `th` still owns the slot (a barrier waits for it to join), so the short handoff tail may keep touching `th`/`sched`.

The Ractor's last thread keeps the original reverse order: its removal unlinks the Ractor itself, so `r`/`sched` must not be touched afterwards. That order is safe only for it: with no successor, `sched->running` stays NULL and `vm_need_barrier` requires a running thread, so its removal's VM lock never joins a barrier in the first place.

The second commit removes the now-unreachable `is_running` guard from 3fa1c8708 (every joiner is a running-set member again) and asserts that invariant instead.

## Test / verification

- New bootstraptest: short-lived threads terminate while another Ractor drives compaction barriers. Skipped when the GC does not implement compaction (e.g. MMTk).
- x86_64-linux release build: an 8-Ractor pipe-read × GC.compact stress crashes 15/15 on master (`[BUG] system stack overflow during GC`, SEGV) vs 0/30 with this change; 2-Ractor, Ractor-termination-churn, Ractor-receive and `RUBY_MN_THREADS=1` variants are also clean.
- ASAN + `RUBY_DEBUG` build: 0/20 use-after-poison (previously 14/20 in `rb_str_unlocktmp`), 0/20 barrier assertion failures (previously ~40%), and the new joiner-membership assertion holds across the whole stress battery (0/48).
- `make btest`: all 2047 tests pass; `make test-all`: 35797 tests, 0 failures, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
