### PR TITLE
Use GitHub Packages NuGet feed for vcpkg binary caching (ruby_4_0 backport)

### DIFF
--- a/.github/workflows/tarball-test.yml
+++ b/.github/workflows/tarball-test.yml
@@ -91,6 +91,8 @@ jobs:
   windows:
     needs: tarball
     if: ${{ ! needs.tarball.outputs.skip }}
+    # For fork pull requests the GITHUB_TOKEN is capped to read-only, so
+    # they can only download vcpkg packages; uploads happen on push.
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/tarball-test.yml
+++ b/.github/workflows/tarball-test.yml
@@ -91,6 +91,9 @@ jobs:
   windows:
     needs: tarball
     if: ${{ ! needs.tarball.outputs.skip }}
+    permissions:
+      contents: read
+      packages: write
     uses: ./.github/workflows/tarball-windows.yml
     with:
       archname: snapshot-${{ needs.tarball.outputs.branch }}

--- a/.github/workflows/tarball-windows.yml
+++ b/.github/workflows/tarball-windows.yml
@@ -44,8 +44,6 @@ jobs:
       OS_VER: windows-${{ matrix.os }}
       VCPKG_DEFAULT_TRIPLET: x64-windows
       FEED_URL: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
-      # see https://github.com/ruby/ruby/commit/9ff4399decef0036897d3cfb9ac2c710dea913ca
-      OPENSSL_MODULES: ${{ github.workspace }}\${{ inputs.archname }}\vcpkg_installed\x64-windows\bin
     steps:
       - run: md build
         working-directory:
@@ -105,6 +103,7 @@ jobs:
       - name: setup env
         # %TEMP% is inconsistent with %TMP% and test-all expects they are consistent.
         # https://github.com/actions/virtual-environments/issues/712#issuecomment-613004302
+        # OPENSSL_MODULES: see https://github.com/ruby/ruby/commit/9ff4399decef0036897d3cfb9ac2c710dea913ca
         env:
           ARCHNAME: ${{ inputs.archname }}
         run: |
@@ -113,7 +112,8 @@ jobs:
           set TMP=%USERPROFILE%\AppData\Local\Temp
           set TEMP=%USERPROFILE%\AppData\Local\Temp
           set /a TEST_JOBS=(15 * %NUMBER_OF_PROCESSORS% / 10) > nul
-          set RUBY_OPT_DIR=%GITHUB_WORKSPACE:\=/%/%ARCHNAME%/vcpkg_installed/x64-windows
+          set RUBY_OPT_DIR=%GITHUB_WORKSPACE:\=/%/%ARCHNAME%/vcpkg_installed/%VCPKG_DEFAULT_TRIPLET%
+          set OPENSSL_MODULES=%GITHUB_WORKSPACE%\%ARCHNAME%\vcpkg_installed\%VCPKG_DEFAULT_TRIPLET%\bin
           set > new.env
 
       - name: update env

--- a/.github/workflows/tarball-windows.yml
+++ b/.github/workflows/tarball-windows.yml
@@ -18,9 +18,9 @@ on:
       SNAPSHOT_SLACK_WEBHOOK_URL:
         required: false
 
-permissions:
-  contents: read
-  packages: write
+# GITHUB_TOKEN permissions are inherited from the caller job. Declaring
+# permissions here would be an elevation request and fail at startup when
+# the caller's token is capped to read-only (fork pull requests).
 
 jobs:
   windows:

--- a/.github/workflows/tarball-windows.yml
+++ b/.github/workflows/tarball-windows.yml
@@ -43,10 +43,7 @@ jobs:
       PATCH: C:\msys64\usr\bin\patch.exe
       OS_VER: windows-${{ matrix.os }}
       VCPKG_DEFAULT_TRIPLET: x64-windows
-      FEED_URL: https://nuget.pkg.github.com/ruby/index.json
-      # The GITHUB_TOKEN of pull_request events (forks, dependabot) is
-      # read-only; built packages are uploaded on push and merge_group only.
-      VCPKG_BINARY_SOURCES: clear;nuget,https://nuget.pkg.github.com/ruby/index.json,${{ github.event_name != 'pull_request' && 'readwrite' || 'read' }}
+      FEED_URL: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
       # see https://github.com/ruby/ruby/commit/9ff4399decef0036897d3cfb9ac2c710dea913ca
       OPENSSL_MODULES: ${{ github.workspace }}\${{ inputs.archname }}\vcpkg_installed\x64-windows\bin
     steps:
@@ -82,11 +79,17 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FEED_OWNER: ${{ github.repository_owner }}
+          # The github context of a reusable workflow belongs to the caller;
+          # the GITHUB_TOKEN of pull_request events (forks, dependabot) is
+          # read-only. Packages are uploaded on push, merge_group, and
+          # workflow_dispatch.
+          FEED_MODE: ${{ github.event_name != 'pull_request' && 'readwrite' || 'read' }}
         run: |
           $nuget = (vcpkg fetch nuget) | Select-Object -Last 1
           & $nuget sources add -Source $Env:FEED_URL -StorePasswordInClearText `
             -Name GitHubPackages -UserName $Env:FEED_OWNER -Password $Env:GH_TOKEN
           & $nuget setapikey $Env:GH_TOKEN -Source $Env:FEED_URL
+          "VCPKG_BINARY_SOURCES=clear;nuget,$Env:FEED_URL,$Env:FEED_MODE" >> $Env:GITHUB_ENV
 
       - name: Install libraries with vcpkg
         run: |

--- a/.github/workflows/tarball-windows.yml
+++ b/.github/workflows/tarball-windows.yml
@@ -20,6 +20,7 @@ on:
 
 permissions:
   contents: read
+  packages: write
 
 jobs:
   windows:
@@ -41,8 +42,13 @@ jobs:
       GITPULLOPTIONS: --no-tags origin ${{github.ref}}
       PATCH: C:\msys64\usr\bin\patch.exe
       OS_VER: windows-${{ matrix.os }}
+      VCPKG_DEFAULT_TRIPLET: x64-windows
+      FEED_URL: https://nuget.pkg.github.com/ruby/index.json
+      # The GITHUB_TOKEN of pull_request events (forks, dependabot) is
+      # read-only; built packages are uploaded on push and merge_group only.
+      VCPKG_BINARY_SOURCES: clear;nuget,https://nuget.pkg.github.com/ruby/index.json,${{ github.event_name != 'pull_request' && 'readwrite' || 'read' }}
       # see https://github.com/ruby/ruby/commit/9ff4399decef0036897d3cfb9ac2c710dea913ca
-      OPENSSL_MODULES: C:\vcpkg\installed\x64-windows\bin
+      OPENSSL_MODULES: ${{ github.workspace }}\${{ inputs.archname }}\vcpkg_installed\x64-windows\bin
     steps:
       - run: md build
         working-directory:
@@ -63,17 +69,6 @@ jobs:
         shell: msys2 {0}
         run: echo PATCH=$(cygpath -wa $(command -v patch)) >> $GITHUB_ENV
         if: ${{ steps.setup-msys2.outcome == 'success' }}
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: C:\vcpkg\installed
-          key: ${{ runner.os }}-vcpkg-installed-${{ env.OS_VER }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-vcpkg-installed-${{ env.OS_VER }}-
-            ${{ runner.os }}-vcpkg-installed-
-      - name: Install libraries with vcpkg
-        run: |
-          vcpkg --triplet x64-windows install gmp libffi libyaml openssl zlib
-
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: Packages
@@ -81,6 +76,23 @@ jobs:
       - name: Extract
         run: 7z x pkg/*.zip
         working-directory:
+
+      - name: Set up vcpkg binary cache
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FEED_OWNER: ${{ github.repository_owner }}
+        run: |
+          $nuget = (vcpkg fetch nuget) | Select-Object -Last 1
+          & $nuget sources add -Source $Env:FEED_URL -StorePasswordInClearText `
+            -Name GitHubPackages -UserName $Env:FEED_OWNER -Password $Env:GH_TOKEN
+          & $nuget setapikey $Env:GH_TOKEN -Source $Env:FEED_URL
+
+      - name: Install libraries with vcpkg
+        run: |
+          git -C "%VCPKG_INSTALLATION_ROOT%" pull --quiet
+          vcpkg install
+        working-directory: ${{ inputs.archname }}
 
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
@@ -98,6 +110,7 @@ jobs:
           set TMP=%USERPROFILE%\AppData\Local\Temp
           set TEMP=%USERPROFILE%\AppData\Local\Temp
           set /a TEST_JOBS=(15 * %NUMBER_OF_PROCESSORS% / 10) > nul
+          set RUBY_OPT_DIR=%GITHUB_WORKSPACE:\=/%/%ARCHNAME%/vcpkg_installed/x64-windows
           set > new.env
 
       - name: update env
@@ -109,17 +122,13 @@ jobs:
             Where-Object { $_.SideIndicator -eq '=>' } |
             Select-Object -ExpandProperty InputObject |
             Add-Content -Path $env:GITHUB_ENV
-      - name: link libraries
-        run: |
-          for %%I in (C:\vcpkg\installed\x64-windows\bin\*.dll) do (
-            mklink %%~nxI %%I
-          )
       - name: Configure
         env:
           ARCHNAME: ${{ inputs.archname }}
         run: >-
           ../%ARCHNAME%/win32/configure.bat --disable-install-doc
-          --with-opt-dir=C:/vcpkg/installed/x64-windows
+          --with-opt-dir=%RUBY_OPT_DIR%
+      - run: nmake prepare-vcpkg
       - run: nmake incs
       - run: nmake extract-extlibs
       - run: nmake

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -109,6 +109,7 @@ jobs:
 
       - name: Install libraries with vcpkg
         run: |
+          git -C "%VCPKG_INSTALLATION_ROOT%" pull --quiet
           vcpkg install
         working-directory: src
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -51,9 +51,17 @@ jobs:
 
     name: Windows ${{ matrix.os }}/Visual C++ ${{ matrix.vc }} (${{ matrix.test_task }})
 
+    permissions:
+      contents: read
+      packages: write
+
     env:
       GITPULLOPTIONS: --no-tags origin ${{ github.ref }}
       VCPKG_DEFAULT_TRIPLET: ${{ matrix.target || 'x64' }}-windows
+      FEED_URL: https://nuget.pkg.github.com/ruby/index.json
+      # The GITHUB_TOKEN of pull_request events (forks, dependabot) is
+      # read-only; built packages are uploaded on push and merge_group only.
+      VCPKG_BINARY_SOURCES: clear;nuget,https://nuget.pkg.github.com/ruby/index.json,${{ github.event_name != 'pull_request' && 'readwrite' || 'read' }}
 
     steps:
       - run: md build
@@ -87,25 +95,21 @@ jobs:
           scoop install vcpkg
         shell: pwsh
 
-      - name: Restore vcpkg artifact
-        id: restore-vcpkg
-        uses: actions/cache/restore@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
-        with:
-          path: src\vcpkg_installed
-          key: windows-${{ matrix.os }}-vcpkg-${{ hashFiles('src/vcpkg.json') }}
+      - name: Set up vcpkg binary cache
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FEED_OWNER: ${{ github.repository_owner }}
+        run: |
+          $nuget = (vcpkg fetch nuget) | Select-Object -Last 1
+          & $nuget sources add -Source $Env:FEED_URL -StorePasswordInClearText `
+            -Name GitHubPackages -UserName $Env:FEED_OWNER -Password $Env:GH_TOKEN
+          & $nuget setapikey $Env:GH_TOKEN -Source $Env:FEED_URL
 
       - name: Install libraries with vcpkg
         run: |
           vcpkg install
         working-directory: src
-        if: ${{ ! steps.restore-vcpkg.outputs.cache-hit }}
-
-      - name: Save vcpkg artifact
-        uses: actions/cache/save@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
-        with:
-          path: src\vcpkg_installed
-          key: windows-${{ matrix.os }}-vcpkg-${{ hashFiles('src/vcpkg.json') }}
-        if: ${{ ! steps.restore-vcpkg.outputs.cache-hit && (github.ref_name == 'master' || startsWith(github.ref_name, 'ruby_')) }}
 
       - name: setup env
         # Available Ruby versions: https://github.com/actions/runner-images/blob/main/images/windows/Windows2019-Readme.md#ruby

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -58,10 +58,7 @@ jobs:
     env:
       GITPULLOPTIONS: --no-tags origin ${{ github.ref }}
       VCPKG_DEFAULT_TRIPLET: ${{ matrix.target || 'x64' }}-windows
-      FEED_URL: https://nuget.pkg.github.com/ruby/index.json
-      # The GITHUB_TOKEN of pull_request events (forks, dependabot) is
-      # read-only; built packages are uploaded on push and merge_group only.
-      VCPKG_BINARY_SOURCES: clear;nuget,https://nuget.pkg.github.com/ruby/index.json,${{ github.event_name != 'pull_request' && 'readwrite' || 'read' }}
+      FEED_URL: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
 
     steps:
       - run: md build
@@ -100,11 +97,15 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FEED_OWNER: ${{ github.repository_owner }}
+          # The GITHUB_TOKEN of pull_request events (forks, dependabot) is
+          # read-only; packages are uploaded on push and merge_group only.
+          FEED_MODE: ${{ github.event_name != 'pull_request' && 'readwrite' || 'read' }}
         run: |
           $nuget = (vcpkg fetch nuget) | Select-Object -Last 1
           & $nuget sources add -Source $Env:FEED_URL -StorePasswordInClearText `
             -Name GitHubPackages -UserName $Env:FEED_OWNER -Password $Env:GH_TOKEN
           & $nuget setapikey $Env:GH_TOKEN -Source $Env:FEED_URL
+          "VCPKG_BINARY_SOURCES=clear;nuget,$Env:FEED_URL,$Env:FEED_MODE" >> $Env:GITHUB_ENV
 
       - name: Install libraries with vcpkg
         run: |

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -7,5 +7,5 @@
     "openssl",
     "zlib"
   ],
-  "builtin-baseline": "84bab45d415d22042bd0b9081aea57f362da3f35"
+  "builtin-baseline": "cd61e1e26a038e82d6550a3ebbe0fbbfe7da78e3"
 }


### PR DESCRIPTION
This is a backport of https://github.com/ruby/ruby/pull/17820 to `ruby_4_0`.

It moves vcpkg binary caching in `windows.yml` and `tarball-windows.yml` from `actions/cache` to the NuGet feed on GitHub Packages, which is shared across branches and workflows and keyed by vcpkg's ABI hash. `tarball-windows.yml` now installs from the manifest included in the snapshot instead of the classic `vcpkg install` with a `github.sha`-keyed cache, so snapshot builds reuse the packages built by `windows.yml`.

In addition, `vcpkg.json` now uses the same `builtin-baseline` as master, so this branch downloads the binary packages master has already uploaded to the feed (identical runner image and baseline produce identical ABI hashes) instead of seeding its own set with a full build. This also pulls in 10f302f5877c53b878ded5698ae18dec8d5d52c4 so the runner's vcpkg checkout is fetched before install, which the newer baseline requires.
