### PR TITLE
Fix line events for optimized loop edges

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -97,6 +97,10 @@ typedef struct iseq_insn_data {
         int node_id;
         rb_event_flag_t events;
     } insn_info;
+    struct {
+        int line_no;
+        rb_event_flag_t events;
+    } trace_edge;
 } INSN;
 
 typedef struct iseq_adjust_data {
@@ -1390,6 +1394,8 @@ new_insn_core(rb_iseq_t *iseq, int line_no, int node_id, int insn_id, int argc, 
     iobj->insn_info.line_no = line_no;
     iobj->insn_info.node_id = node_id;
     iobj->insn_info.events = 0;
+    iobj->trace_edge.line_no = 0;
+    iobj->trace_edge.events = 0;
     iobj->operands = argv;
     iobj->operand_size = argc;
     iobj->sc_state = 0;
@@ -2605,6 +2611,7 @@ iseq_set_sequence(rb_iseq_t *iseq, LINK_ANCHOR *const anchor)
     long data = 0;
 
     int insn_num, code_index, insns_info_index, sp = 0;
+    int trace_edge_events_size = 0;
     int stack_max = fix_sp_depth(iseq, anchor);
 
     if (stack_max < 0) return COMPILE_NG;
@@ -2619,6 +2626,9 @@ iseq_set_sequence(rb_iseq_t *iseq, LINK_ANCHOR *const anchor)
                 /* update sp */
                 sp = calc_sp_depth(sp, iobj);
                 insn_num++;
+                if (iobj->trace_edge.events) {
+                    trace_edge_events_size++;
+                }
                 events = iobj->insn_info.events |= events;
                 if (ISEQ_COVERAGE(iseq)) {
                     if (ISEQ_LINE_COVERAGE(iseq) && (events & RUBY_EVENT_COVERAGE_LINE) &&
@@ -2633,6 +2643,13 @@ iseq_set_sequence(rb_iseq_t *iseq, LINK_ANCHOR *const anchor)
                             rb_ary_push(ISEQ_PC2BRANCHINDEX(iseq), Qnil);
                         }
                         RARRAY_ASET(ISEQ_PC2BRANCHINDEX(iseq), code_index, INT2FIX(data));
+                    }
+                    if (ISEQ_LINE_COVERAGE(iseq) && (iobj->trace_edge.events & RUBY_EVENT_COVERAGE_LINE) &&
+                        !(rb_get_coverage_mode() & COVERAGE_TARGET_ONESHOT_LINES)) {
+                        int line = iobj->trace_edge.line_no - 1;
+                        if (line >= 0 && line < RARRAY_LEN(ISEQ_LINE_COVERAGE(iseq))) {
+                            RARRAY_ASET(ISEQ_LINE_COVERAGE(iseq), line, INT2FIX(0));
+                        }
                     }
                 }
                 code_index += insn_data_length(iobj);
@@ -2701,6 +2718,14 @@ iseq_set_sequence(rb_iseq_t *iseq, LINK_ANCHOR *const anchor)
     }
     ISEQ_COMPILE_DATA(iseq)->ci_index = 0;
 
+    if (trace_edge_events_size) {
+        body->trace_edge_events = ZALLOC_N(struct iseq_trace_edge_event, trace_edge_events_size);
+    }
+    else {
+        body->trace_edge_events = NULL;
+    }
+    body->trace_edge_events_size = trace_edge_events_size;
+
     // Calculate the bitmask buffer size.
     // Round the generated_iseq size up to the nearest multiple
     // of the number of bits in an unsigned long.
@@ -2727,6 +2752,7 @@ iseq_set_sequence(rb_iseq_t *iseq, LINK_ANCHOR *const anchor)
 
     list = FIRST_ELEMENT(anchor);
     insns_info_index = code_index = sp = 0;
+    int trace_edge_events_index = 0;
 
     while (list) {
         switch (list->type) {
@@ -2863,6 +2889,13 @@ iseq_set_sequence(rb_iseq_t *iseq, LINK_ANCHOR *const anchor)
                     }
                 }
                 if (add_insn_info(insns_info, positions, insns_info_index, code_index, iobj)) insns_info_index++;
+                if (iobj->trace_edge.events) {
+                    VM_ASSERT(trace_edge_events_index < trace_edge_events_size);
+                    body->trace_edge_events[trace_edge_events_index].pc = code_index;
+                    body->trace_edge_events[trace_edge_events_index].events = iobj->trace_edge.events;
+                    body->trace_edge_events[trace_edge_events_index].line_no = iobj->trace_edge.line_no;
+                    trace_edge_events_index++;
+                }
                 code_index += len;
                 break;
             }
@@ -3664,31 +3697,7 @@ iseq_peephole_optimize(rb_iseq_t *iseq, LINK_ELEMENT *list, const int do_tailcal
          */
         INSN *nobj = (INSN *)get_destination_insn(iobj);
 
-        /* This is super nasty hack!!!
-         *
-         * This jump-jump optimization may ignore event flags of the jump
-         * instruction being skipped.  Actually, Line 2 TracePoint event
-         * is never fired in the following code:
-         *
-         *   1: raise if 1 == 2
-         *   2: while true
-         *   3:   break
-         *   4: end
-         *
-         * This is critical for coverage measurement.  [Bug #15980]
-         *
-         * This is a stopgap measure: stop the jump-jump optimization if
-         * coverage measurement is enabled and if the skipped instruction
-         * has any event flag.
-         *
-         * Note that, still, TracePoint Line event does not occur on Line 2.
-         * This should be fixed in future.
-         */
-        int stop_optimization =
-            ISEQ_COVERAGE(iseq) && ISEQ_LINE_COVERAGE(iseq) &&
-            nobj->link.type == ISEQ_ELEMENT_INSN &&
-            nobj->insn_info.events;
-        if (!stop_optimization) {
+        {
             INSN *pobj = (INSN *)iobj->link.prev;
             int prev_dup = 0;
             if (pobj) {
@@ -3700,7 +3709,13 @@ iseq_peephole_optimize(rb_iseq_t *iseq, LINK_ELEMENT *list, const int do_tailcal
 
             for (;;) {
                 if (IS_INSN(&nobj->link) && IS_INSN_ID(nobj, jump)) {
+                    rb_event_flag_t edge_events = nobj->insn_info.events & (RUBY_EVENT_LINE | RUBY_EVENT_COVERAGE_LINE);
                     if (!replace_destination(iobj, nobj)) break;
+                    if (edge_events) {
+                        /* Preserve line events from the skipped jump as taken-edge trace metadata. */
+                        iobj->trace_edge.events |= edge_events;
+                        iobj->trace_edge.line_no = nobj->insn_info.line_no;
+                    }
                 }
                 else if (prev_dup && IS_INSN(&nobj->link) && IS_INSN_ID(nobj, dup) &&
                          !!(nobj = (INSN *)nobj->link.next) &&

--- a/iseq.c
+++ b/iseq.c
@@ -205,6 +205,7 @@ rb_iseq_free(const rb_iseq_t *iseq)
 #if VM_INSN_INFO_TABLE_IMPL == 2
         ruby_xfree(body->insns_info.succ_index_table);
 #endif
+        SIZED_FREE_N(body->trace_edge_events, body->trace_edge_events_size);
         SIZED_FREE_N(body->is_entries, ISEQ_IS_SIZE(body));
         SIZED_FREE_N(body->call_data, body->ci_size);
         if (body->catch_table) {
@@ -496,6 +497,7 @@ rb_iseq_memsize(const rb_iseq_t *iseq)
         size += sizeof(struct rb_iseq_constant_body);
         size += body->iseq_size * sizeof(VALUE);
         size += body->insns_info.size * (sizeof(struct iseq_insn_info_entry) + sizeof(unsigned int));
+        size += body->trace_edge_events_size * sizeof(*body->trace_edge_events);
         size += body->local_table_size * sizeof(ID);
         size += ISEQ_MBITS_BUFLEN(body->iseq_size) * ISEQ_MBITS_SIZE;
         if (body->catch_table) {
@@ -2496,6 +2498,29 @@ rb_iseq_event_flags(const rb_iseq_t *iseq, size_t pos)
     }
 }
 
+rb_event_flag_t
+rb_iseq_trace_edge_event_flags(const rb_iseq_t *iseq, size_t pos, int *line_no)
+{
+    const struct rb_iseq_constant_body *const body = ISEQ_BODY(iseq);
+
+    for (unsigned int i = 0; i < body->trace_edge_events_size; i++) {
+        const struct iseq_trace_edge_event *event = &body->trace_edge_events[i];
+        if (event->pc == pos) {
+            if (line_no) *line_no = event->line_no;
+            return event->events;
+        }
+    }
+
+    if (line_no) *line_no = 0;
+    return 0;
+}
+
+static rb_event_flag_t
+iseq_trace_events_at_pc(const rb_iseq_t *iseq, size_t pos)
+{
+    return rb_iseq_event_flags(iseq, pos) | rb_iseq_trace_edge_event_flags(iseq, pos, NULL);
+}
+
 static void rb_iseq_trace_flag_cleared(const rb_iseq_t *iseq, size_t pos);
 
 // Clear tracing event flags and turn off tracing for a given instruction as needed.
@@ -2507,11 +2532,25 @@ rb_iseq_clear_event_flags(const rb_iseq_t *iseq, size_t pos, rb_event_flag_t res
         rb_vm_barrier();
 
         struct iseq_insn_info_entry *entry = (struct iseq_insn_info_entry *)get_insn_info(iseq, pos);
+        rb_event_flag_t events = 0;
+
         if (entry) {
             entry->events &= ~reset;
-            if (!(entry->events & iseq->aux.exec.global_trace_events)) {
-                rb_iseq_trace_flag_cleared(iseq, pos);
+            events |= entry->events;
+        }
+
+        struct rb_iseq_constant_body *body = (struct rb_iseq_constant_body *)ISEQ_BODY(iseq);
+        for (unsigned int i = 0; i < body->trace_edge_events_size; i++) {
+            struct iseq_trace_edge_event *event = &body->trace_edge_events[i];
+            if (event->pc == pos) {
+                event->events &= ~reset;
+                events |= event->events;
+                break;
             }
+        }
+
+        if (!(events & iseq->aux.exec.global_trace_events)) {
+            rb_iseq_trace_flag_cleared(iseq, pos);
         }
     }
 }
@@ -4056,6 +4095,8 @@ iseq_add_local_tracepoint(const rb_iseq_t *iseq, rb_event_flag_t turnon_events, 
     for (pc=0; pc<body->iseq_size;) {
         const struct iseq_insn_info_entry *entry = get_insn_info(iseq, pc);
         rb_event_flag_t pc_events = entry->events;
+        int edge_line = 0;
+        rb_event_flag_t edge_events = rb_iseq_trace_edge_event_flags(iseq, pc, &edge_line);
         rb_event_flag_t target_events = turnon_events;
         unsigned int line = (int)entry->line_no;
 
@@ -4066,10 +4107,17 @@ iseq_add_local_tracepoint(const rb_iseq_t *iseq, rb_event_flag_t turnon_events, 
             target_events &= ~RUBY_EVENT_LINE;
         }
 
-        if (pc_events & target_events) {
+        rb_event_flag_t local_pc_events = pc_events & target_events;
+        rb_event_flag_t local_edge_events = 0;
+
+        if (local_pc_events) {
             n++;
         }
-        pc += encoded_iseq_trace_instrument(&iseq_encoded[pc], pc_events & (target_events | iseq->aux.exec.global_trace_events), true);
+        if ((edge_events & turnon_events) && (target_line == 0 || target_line == (unsigned int)edge_line)) {
+            local_edge_events = edge_events & turnon_events;
+            n++;
+        }
+        pc += encoded_iseq_trace_instrument(&iseq_encoded[pc], (local_pc_events | local_edge_events) | (iseq_trace_events_at_pc(iseq, pc) & iseq->aux.exec.global_trace_events), true);
     }
 
     if (n > 0) {
@@ -4149,7 +4197,7 @@ iseq_remove_local_tracepoint(const rb_iseq_t *iseq, VALUE tpval, rb_ractor_t *r)
                 iseq_encoded = (VALUE *)body->iseq_encoded;
                 local_events = add_bmethod_events(local_events);
                 for (pc = 0; pc<body->iseq_size;) {
-                    rb_event_flag_t pc_events = rb_iseq_event_flags(iseq, pc);
+                    rb_event_flag_t pc_events = iseq_trace_events_at_pc(iseq, pc);
                     pc += encoded_iseq_trace_instrument(&iseq_encoded[pc], pc_events & (local_events | iseq->aux.exec.global_trace_events), false);
                 }
             }
@@ -4211,7 +4259,7 @@ rb_iseq_trace_set(const rb_iseq_t *iseq, rb_event_flag_t turnon_events)
         enabled_events = add_bmethod_events(turnon_events | local_events);
 
         for (pc=0; pc<body->iseq_size;) {
-            rb_event_flag_t pc_events = rb_iseq_event_flags(iseq, pc);
+            rb_event_flag_t pc_events = iseq_trace_events_at_pc(iseq, pc);
             pc += encoded_iseq_trace_instrument(&iseq_encoded[pc], pc_events & enabled_events, true);
         }
     }

--- a/test/ruby/test_settracefunc.rb
+++ b/test/ruby/test_settracefunc.rb
@@ -2808,6 +2808,62 @@ CODE
     assert_equal [__LINE__ - 5, __LINE__ - 4, __LINE__ - 3], lines, 'Bug #17868'
   end
 
+  def test_line_event_after_guard_before_while_true
+    lines = []
+    while_line = body_line = nil
+
+    TracePoint.new(:line) {|tp|
+      next unless target_thread?
+      lines << tp.lineno
+    }.enable {
+      raise if 1 == 2
+      while_line = __LINE__ + 1
+      while true
+        body_line = __LINE__ + 1
+        break
+      end
+    }
+
+    assert_includes lines, while_line
+    assert_includes lines, body_line
+    assert_operator lines.index(while_line), :<, lines.index(body_line)
+  end
+
+  def test_line_event_after_guard_before_while_predicate
+    parent = Class.new do
+      def read
+        @values.shift
+      end
+    end
+
+    child = Class.new(parent) do
+      def initialize
+        @values = ["chunk", nil]
+      end
+    end
+
+    start_line = __LINE__ + 2
+    while_line = start_line + 2
+    child.class_eval <<~RUBY, __FILE__, start_line
+      def read
+        return if @finished
+        while chunk = super
+          chunk.upcase
+        end
+      end
+    RUBY
+
+    lines = []
+    TracePoint.new(:line) {|tp|
+      next unless target_thread?
+      lines << tp.lineno
+    }.enable {
+      child.new.read
+    }
+
+    assert_includes lines, while_line
+  end
+
   def test_allow_reentry
     event_lines = []
     _l1 = _l2 = _l3 = _l4 = nil

--- a/thread.c
+++ b/thread.c
@@ -5988,7 +5988,7 @@ update_line_coverage(VALUE data, const rb_trace_arg_t *trace_arg)
     if (RB_TYPE_P(coverage, T_ARRAY) && !RBASIC_CLASS(coverage)) {
         VALUE lines = RARRAY_AREF(coverage, COVERAGE_INDEX_LINES);
         if (lines) {
-            long line = rb_sourceline() - 1;
+            long line = FIX2LONG(rb_tracearg_lineno((rb_trace_arg_t *)trace_arg)) - 1;
             VM_ASSERT(line >= 0);
             long count;
             VALUE num;

--- a/tool/ruby_vm/views/_trace_instruction.erb
+++ b/tool/ruby_vm/views/_trace_instruction.erb
@@ -11,6 +11,16 @@
 INSN_ENTRY(<%= insn.name %>)
 {
     vm_trace(ec, GET_CFP());
+%   case insn.name
+%   when 'trace_jump', 'trace_jump_without_ints'
+    vm_trace_branch_edge(ec, GET_CFP(), true);
+%   when 'trace_branchif', 'trace_branchif_without_ints'
+    vm_trace_branch_edge(ec, GET_CFP(), RTEST(TOPN(0)));
+%   when 'trace_branchunless', 'trace_branchunless_without_ints'
+    vm_trace_branch_edge(ec, GET_CFP(), !RTEST(TOPN(0)));
+%   when 'trace_branchnil', 'trace_branchnil_without_ints'
+    vm_trace_branch_edge(ec, GET_CFP(), NIL_P(TOPN(0)));
+%   end
 %   if insn.name =~
 %   /\Atrace_opt_(plus|minus|mult|div|mod|eq|neq|lt|le|gt|ge|ltlt|and|or|aref|aset|length|size|empty_p|nil_p|succ|not|regexpmatch2)\z/
 %     jump_dest = "opt_send_without_block"

--- a/vm_core.h
+++ b/vm_core.h
@@ -574,6 +574,13 @@ struct rb_iseq_constant_body {
     // ZJIT stores some data on each iseq.
     void *zjit_payload;
 #endif
+
+    struct iseq_trace_edge_event {
+        unsigned int pc;
+        rb_event_flag_t events;
+        int line_no;
+    } *trace_edge_events;
+    unsigned int trace_edge_events_size;
 };
 
 /* T_IMEMO/iseq */

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -7132,6 +7132,7 @@ vm_opt_regexpmatch2(VALUE recv, VALUE obj)
 }
 
 rb_event_flag_t rb_iseq_event_flags(const rb_iseq_t *iseq, size_t pos);
+rb_event_flag_t rb_iseq_trace_edge_event_flags(const rb_iseq_t *iseq, size_t pos, int *line_no);
 
 NOINLINE(static void vm_trace(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp));
 
@@ -7164,6 +7165,81 @@ vm_trace_hook(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, const VAL
             reg_cfp->pc--;
         }
     }
+}
+
+static void
+vm_trace_edge_hook(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, rb_hook_list_t *hooks,
+                   rb_event_flag_t event, unsigned int edge_pos, int line_no)
+{
+    struct rb_trace_arg_struct trace_arg;
+    const VALUE *pc = reg_cfp->pc;
+
+    if ((hooks->events & event) == 0) return;
+
+    trace_arg.event = event;
+    trace_arg.ec = ec;
+    trace_arg.cfp = ec->cfp;
+    trace_arg.self = GET_SELF();
+    trace_arg.id = 0;
+    trace_arg.called_id = 0;
+    trace_arg.klass = 0;
+    trace_arg.data = Qundef;
+    trace_arg.klass_solved = 0;
+    trace_arg.lineno = line_no;
+    trace_arg.path = rb_iseq_path(CFP_ISEQ(reg_cfp));
+
+    /* Coverage one-shot clearing expects CFP_PC - 1 to be the event PC. */
+    reg_cfp->pc = ISEQ_BODY(CFP_ISEQ(reg_cfp))->iseq_encoded + edge_pos + 1;
+    rb_exec_event_hooks(&trace_arg, hooks, 0);
+    reg_cfp->pc = pc;
+}
+
+static inline void
+vm_trace_branch_edge(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, bool taken)
+{
+    if (!taken) return;
+
+    const rb_iseq_t *iseq = CFP_ISEQ(reg_cfp);
+    unsigned int pos = (unsigned int)(reg_cfp->pc - ISEQ_BODY(iseq)->iseq_encoded);
+    unsigned int edge_pos = pos;
+    int line_no = 0;
+    rb_event_flag_t edge_events = rb_iseq_trace_edge_event_flags(iseq, edge_pos, &line_no);
+
+    if (!edge_events && pos > 0) {
+        edge_pos = pos - 1;
+        edge_events = rb_iseq_trace_edge_event_flags(iseq, edge_pos, &line_no);
+    }
+
+    if (!edge_events || ec->trace_arg != NULL) return;
+
+    rb_ractor_t *r = rb_ec_ractor_ptr(ec);
+    rb_event_flag_t enabled_flags = r->pub.hooks.events & edge_events;
+    rb_hook_list_t *local_hooks = NULL;
+
+    if (iseq->aux.exec.local_hooks_cnt > 0) {
+        st_data_t val;
+        if (st_lookup(rb_ractor_targeted_hooks(r), (st_data_t)iseq, &val)) {
+            local_hooks = (rb_hook_list_t *)val;
+            enabled_flags |= local_hooks->events & edge_events;
+        }
+    }
+
+    if (!enabled_flags) return;
+
+    rb_hook_list_t *global_hooks = rb_ec_ractor_hooks(ec);
+
+    if (local_hooks) local_hooks->running++;
+
+    if (edge_events & RUBY_EVENT_LINE) {
+        vm_trace_edge_hook(ec, reg_cfp, global_hooks, RUBY_EVENT_LINE, edge_pos, line_no);
+        if (local_hooks) vm_trace_edge_hook(ec, reg_cfp, local_hooks, RUBY_EVENT_LINE, edge_pos, line_no);
+    }
+    if (edge_events & RUBY_EVENT_COVERAGE_LINE) {
+        vm_trace_edge_hook(ec, reg_cfp, global_hooks, RUBY_EVENT_COVERAGE_LINE, edge_pos, line_no);
+        if (local_hooks) vm_trace_edge_hook(ec, reg_cfp, local_hooks, RUBY_EVENT_COVERAGE_LINE, edge_pos, line_no);
+    }
+
+    if (local_hooks) local_hooks->running--;
 }
 
 #define VM_TRACE_HOOK(target_event, val) do { \

--- a/vm_trace.c
+++ b/vm_trace.c
@@ -61,6 +61,17 @@ typedef void (*rb_event_hook_raw_arg_func_t)(VALUE data, const rb_trace_arg_t *a
 
 #define MAX_EVENT_NUM 32
 
+static unsigned int
+trace_arg_line_no(const rb_execution_context_t *ec, const rb_trace_arg_t *trace_arg)
+{
+    if (!UNDEF_P(trace_arg->path)) {
+        return (unsigned int)trace_arg->lineno;
+    }
+    else {
+        return (unsigned int)rb_vm_get_sourceline(ec->cfp);
+    }
+}
+
 void
 rb_hook_list_mark(rb_hook_list_t *hooks)
 {
@@ -458,7 +469,7 @@ exec_hooks_body(const rb_execution_context_t *ec, rb_hook_list_t *list, const rb
         if (!(hook->hook_flags & RUBY_EVENT_HOOK_FLAG_DELETED) &&
             (trace_arg->event & hook->events) &&
             (LIKELY(hook->filter.th == 0) || hook->filter.th == rb_ec_thread_ptr(ec)) &&
-            (LIKELY(hook->filter.target_line == 0) || (hook->filter.target_line == (unsigned int)rb_vm_get_sourceline(ec->cfp)))) {
+            (LIKELY(hook->filter.target_line == 0) || (hook->filter.target_line == trace_arg_line_no(ec, trace_arg)))) {
             if (!(hook->hook_flags & RUBY_EVENT_HOOK_FLAG_RAW_ARG)) {
                 (*hook->func)(trace_arg->event, hook->data, trace_arg->self, trace_arg->id, trace_arg->klass);
             }

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -1270,6 +1270,13 @@ pub union rb_iseq_constant_body__bindgen_ty_2 {
     pub single: iseq_bits_t,
 }
 #[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct rb_iseq_constant_body_iseq_trace_edge_event {
+    pub pc: ::std::os::raw::c_uint,
+    pub events: rb_event_flag_t,
+    pub line_no: ::std::os::raw::c_int,
+}
+#[repr(C)]
 pub struct rb_iseq_struct {
     pub flags: VALUE,
     pub wrapper: VALUE,


### PR DESCRIPTION
## Issue

`TracePoint.new(:line)` can miss the line event for an executed loop condition when peephole optimization retargets a branch past the synthetic jump that carries the line event.

One example is a guard followed by a loop:

```ruby
raise if 1 == 2
while true
  break
end
```

The same shape appears with real predicates, for example a guard followed by `while chunk = super`.

## Background

Ruby already has a coverage-specific workaround for this optimization. When line coverage is enabled, the compiler avoids the problematic jump-to-jump optimization if the skipped jump has event flags. That keeps built-in line coverage correct for this case.

Raw line TracePoint events still miss the loop line, because the workaround only applies when coverage is active. Tools that consume `RUBY_EVENT_LINE` directly can therefore disagree with built-in `Coverage`.

## Options considered

1. Keep the skipped jump with a `nop` carrier.
   This makes the event visible, but leaves an extra instruction in normal bytecode.

2. Disable the peephole optimization more generally.
   This preserves the event, but costs normal execution performance even when tracing is not active.

3. Attach the line event directly to the first predicate instruction.
   This works for ordinary predicates, but not for constant loop predicates like `while true`, where the optimized edge can still bypass the event-bearing instruction.

4. Record the skipped event as metadata on the optimized control-flow edge.
   This keeps the optimized bytecode and only adds work when tracing/coverage instrumentation is active.

## Fix

This PR implements option 4.

When the peephole optimizer retargets a branch past a jump with `RUBY_EVENT_LINE` or `RUBY_EVENT_COVERAGE_LINE`, it records that event as trace-edge metadata on the optimized branch instruction instead of stopping the optimization.

## How it works

During final ISeq emission, edge events are stored in a small per-ISeq side table containing:

- the branch instruction PC
- the preserved event flags
- the source line to report

`rb_iseq_trace_set` and local tracepoint setup include these edge events when deciding whether a branch needs to be rewritten to its `trace_*` variant.

At runtime, normal `branchif`, `branchunless`, `branchnil`, and `jump` instructions are unchanged. The extra check only runs from trace branch wrappers. If the optimized edge is actually taken, the VM emits the preserved event with the skipped source line.

This means normal execution does not get an extra instruction dispatch, and the peephole optimization remains enabled.

## Tests

Added regression tests for regular `TracePoint.new(:line)` with:

- a guard before `while true`
- a guard before `while chunk = super`

The existing coverage regression continues to assert that the loop line is covered.

Verified with:

```sh
make -j8
make test-all TESTS='test/ruby/test_settracefunc.rb'
make test-all TESTS='test/coverage/test_coverage.rb'
```

## Related issue

https://bugs.ruby-lang.org/issues/15980