### PR TITLE
Skip mingw workflow on all dependabot PRs

### DIFF
--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -79,7 +79,7 @@ jobs:
       || contains(github.event.head_commit.message, '[DOC]')
       || contains(github.event.pull_request.title, '[DOC]')
       || contains(github.event.pull_request.labels.*.name, 'Documentation')
-      || (github.event.pull_request.user.login == 'dependabot[bot]' && !startsWith(github.head_ref, 'dependabot/vcpkg'))
+      || (github.event.pull_request.user.login == 'dependabot[bot]')
       )}}
 
     steps:


### PR DESCRIPTION
The mingw workflow carried the same dependabot exception as windows.yml, which keeps the workflow running on branches starting with dependabot/vcpkg so that vcpkg builtin-baseline bumps get build coverage. That exception makes sense for windows.yml because the MSVC build fetches its libraries through vcpkg. The mingw build installs everything through MSYS2 pacman packages and never touches vcpkg, so running it on vcpkg bump PRs only wastes runner time. This change drops the exception and skips the workflow on all dependabot PRs, matching the plain condition already used by tarball-test.yml. The dependabot/cargo exceptions in the YJIT and ZJIT workflows are left as is since those builds do consume the bumped cargo dependencies.