### PR TITLE
[Feature #18915] Add `AbstractMethodError`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,12 @@ Note that each entry is kept to a minimum, see links for details.
 
 Note: We're only listing outstanding class updates.
 
+* AbstractMethodError
+
+    * `AbstractMethodError` is added as a new subclass of `ScriptError`.
+      It is intended to be raised by a superclass method that expects
+      subclasses to override it.  [[Feature #18915]]
+
 * C API
 
     * `RB_NOGVL_PENDING_INTR_FAIL` is added as a flag for `rb_nogvl`.
@@ -216,6 +222,7 @@ A lot of work has gone into making Ractors more stable, performant, and usable. 
 
 [Feature #8948]: https://bugs.ruby-lang.org/issues/8948
 [Feature #15330]: https://bugs.ruby-lang.org/issues/15330
+[Feature #18915]: https://bugs.ruby-lang.org/issues/18915
 [Feature #21390]: https://bugs.ruby-lang.org/issues/21390
 [Feature #21768]: https://bugs.ruby-lang.org/issues/21768
 [Feature #21785]: https://bugs.ruby-lang.org/issues/21785

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,12 @@ Note that each entry is kept to a minimum, see links for details.
 
 Note: We're only listing outstanding class updates.
 
+* AbstractMethodError
+
+    * `AbstractMethodError` is added as a new subclass of `ScriptError`.
+      It is intended to be raised by a superclass method that expects
+      subclasses to override it.  [[Feature #18915]]
+
 * C API
 
     * `RB_NOGVL_PENDING_INTR_FAIL` is added as a flag for `rb_nogvl`.
@@ -330,6 +336,7 @@ A lot of work has gone into making Ractors more stable, performant, and usable. 
 [Feature #8948]: https://bugs.ruby-lang.org/issues/8948
 [Feature #9779]: https://bugs.ruby-lang.org/issues/9779
 [Feature #15330]: https://bugs.ruby-lang.org/issues/15330
+[Feature #18915]: https://bugs.ruby-lang.org/issues/18915
 [Feature #20163]: https://bugs.ruby-lang.org/issues/20163
 [Feature #21390]: https://bugs.ruby-lang.org/issues/21390
 [Feature #21768]: https://bugs.ruby-lang.org/issues/21768

--- a/error.c
+++ b/error.c
@@ -1447,6 +1447,7 @@ VALUE rb_eNoMatchingPatternKeyError;
 VALUE rb_eScriptError;
 VALUE rb_eSyntaxError;
 VALUE rb_eLoadError;
+VALUE rb_eAbstractMethodError;
 
 VALUE rb_eSystemCallError;
 VALUE rb_mErrno;
@@ -3479,10 +3480,9 @@ syserr_eqq(VALUE self, VALUE exc)
 /*
  *  Document-class: ScriptError
  *
- *  ScriptError is the superclass for errors raised when a script
- *  can not be executed because of a +LoadError+,
- *  +NotImplementedError+ or a +SyntaxError+. Note these type of
- *  +ScriptErrors+ are not +StandardError+ and will not be
+ *  ScriptError is the superclass for +AbstractMethodError+,
+ *  +LoadError+, +NotImplementedError+ and +SyntaxError+.
+ *  Note these type of +ScriptErrors+ are not +StandardError+ and will not be
  *  rescued unless it is specified explicitly (or its ancestor
  *  +Exception+).
  */
@@ -3510,6 +3510,25 @@ syserr_eqq(VALUE self, VALUE exc)
  *  <em>raises the exception:</em>
  *
  *     LoadError: no such file to load -- this/file/does/not/exist
+ */
+
+/*
+ *  Document-class: AbstractMethodError
+ *
+ *  Raised when an abstract method is called; that is, a method that is
+ *  expected to be overridden in a subclass.
+ *
+ *     class Shape
+ *       def area
+ *         raise AbstractMethodError, "subclass must implement #area"
+ *       end
+ *     end
+ *
+ *     Shape.new.area
+ *
+ *  <em>raises the exception:</em>
+ *
+ *     AbstractMethodError: subclass must implement #area
  */
 
 /*
@@ -3674,6 +3693,7 @@ syserr_eqq(VALUE self, VALUE exc)
  *
  *  * NoMemoryError
  *  * ScriptError
+ *    * AbstractMethodError
  *    * LoadError
  *    * NotImplementedError
  *    * SyntaxError
@@ -3813,6 +3833,7 @@ Init_Exception(void)
     /* the path that failed to load */
     rb_attr(rb_eLoadError, path, TRUE, FALSE, FALSE);
 
+    rb_eAbstractMethodError = rb_define_class("AbstractMethodError", rb_eScriptError);
     rb_eNotImpError = rb_define_class("NotImplementedError", rb_eScriptError);
 
     rb_eNameError     = rb_define_class("NameError", rb_eStandardError);

--- a/error.c
+++ b/error.c
@@ -1446,6 +1446,7 @@ VALUE rb_eNoMatchingPatternKeyError;
 VALUE rb_eScriptError;
 VALUE rb_eSyntaxError;
 VALUE rb_eLoadError;
+VALUE rb_eAbstractMethodError;
 
 VALUE rb_eSystemCallError;
 VALUE rb_mErrno;
@@ -3407,10 +3408,9 @@ syserr_eqq(VALUE self, VALUE exc)
 /*
  *  Document-class: ScriptError
  *
- *  ScriptError is the superclass for errors raised when a script
- *  can not be executed because of a +LoadError+,
- *  +NotImplementedError+ or a +SyntaxError+. Note these type of
- *  +ScriptErrors+ are not +StandardError+ and will not be
+ *  ScriptError is the superclass for +AbstractMethodError+,
+ *  +LoadError+, +NotImplementedError+ and +SyntaxError+.
+ *  Note these type of +ScriptErrors+ are not +StandardError+ and will not be
  *  rescued unless it is specified explicitly (or its ancestor
  *  +Exception+).
  */
@@ -3438,6 +3438,25 @@ syserr_eqq(VALUE self, VALUE exc)
  *  <em>raises the exception:</em>
  *
  *     LoadError: no such file to load -- this/file/does/not/exist
+ */
+
+/*
+ *  Document-class: AbstractMethodError
+ *
+ *  Raised when an abstract method is called; that is, a method that is
+ *  expected to be overridden in a subclass.
+ *
+ *     class Shape
+ *       def area
+ *         raise AbstractMethodError, "subclass must implement #area"
+ *       end
+ *     end
+ *
+ *     Shape.new.area
+ *
+ *  <em>raises the exception:</em>
+ *
+ *     AbstractMethodError: subclass must implement #area
  */
 
 /*
@@ -3602,6 +3621,7 @@ syserr_eqq(VALUE self, VALUE exc)
  *
  *  * NoMemoryError
  *  * ScriptError
+ *    * AbstractMethodError
  *    * LoadError
  *    * NotImplementedError
  *    * SyntaxError
@@ -3741,6 +3761,7 @@ Init_Exception(void)
     /* the path that failed to load */
     rb_attr(rb_eLoadError, path, TRUE, FALSE, FALSE);
 
+    rb_eAbstractMethodError = rb_define_class("AbstractMethodError", rb_eScriptError);
     rb_eNotImpError = rb_define_class("NotImplementedError", rb_eScriptError);
 
     rb_eNameError     = rb_define_class("NameError", rb_eStandardError);

--- a/include/ruby/internal/globals.h
+++ b/include/ruby/internal/globals.h
@@ -144,6 +144,7 @@ RUBY_EXTERN VALUE rb_eScriptError;               /**< `ScriptError` exception. *
 RUBY_EXTERN VALUE rb_eNameError;                 /**< `NameError` exception. */
 RUBY_EXTERN VALUE rb_eSyntaxError;               /**< `SyntaxError` exception. */
 RUBY_EXTERN VALUE rb_eLoadError;                 /**< `LoadError` exception. */
+RUBY_EXTERN VALUE rb_eAbstractMethodError;       /**< `AbstractMethodError` exception. */
 
 RUBY_EXTERN VALUE rb_eMathDomainError;           /**< `Math::DomainError` exception. */
 

--- a/spec/ruby/optional/capi/constants_spec.rb
+++ b/spec/ruby/optional/capi/constants_spec.rb
@@ -173,6 +173,12 @@ describe "C-API exception constant" do
     @s = CApiConstantsSpecs.new
   end
 
+  ruby_version_is "4.1" do
+    specify "rb_eAbstractMethodError references the AbstractMethodError class" do
+      @s.rb_eAbstractMethodError.should == AbstractMethodError
+    end
+  end
+
   specify "rb_eArgError references the ArgumentError class" do
     @s.rb_eArgError.should == ArgumentError
   end

--- a/spec/ruby/optional/capi/ext/constants_spec.c
+++ b/spec/ruby/optional/capi/ext/constants_spec.c
@@ -48,6 +48,9 @@ defconstfunc(rb_cTime)
 defconstfunc(rb_cThread)
 defconstfunc(rb_cTrueClass)
 defconstfunc(rb_cUnboundMethod)
+#ifdef RUBY_VERSION_IS_4_1
+defconstfunc(rb_eAbstractMethodError)
+#endif
 defconstfunc(rb_eArgError)
 defconstfunc(rb_eEncodingError)
 defconstfunc(rb_eEncCompatError)
@@ -128,6 +131,9 @@ void Init_constants_spec(void) {
   rb_define_method(cls, "rb_cThread", constants_spec_rb_cThread, 0);
   rb_define_method(cls, "rb_cTrueClass", constants_spec_rb_cTrueClass, 0);
   rb_define_method(cls, "rb_cUnboundMethod", constants_spec_rb_cUnboundMethod, 0);
+#ifdef RUBY_VERSION_IS_4_1
+  rb_define_method(cls, "rb_eAbstractMethodError", constants_spec_rb_eAbstractMethodError, 0);
+#endif
   rb_define_method(cls, "rb_eArgError", constants_spec_rb_eArgError, 0);
   rb_define_method(cls, "rb_eEncodingError", constants_spec_rb_eEncodingError, 0);
   rb_define_method(cls, "rb_eEncCompatError", constants_spec_rb_eEncCompatError, 0);

--- a/test/ruby/test_exception.rb
+++ b/test/ruby/test_exception.rb
@@ -1552,4 +1552,20 @@ $stderr = $stdout; raise "\x82\xa0"') do |outs, errs, status|
       x(&a)
     end
   end
+
+  def test_abstract_method_error
+    assert_operator(AbstractMethodError, :<, ScriptError)
+    assert_not_operator(AbstractMethodError, :<, StandardError)
+
+    assert_equal("AbstractMethodError", AbstractMethodError.new.message)
+
+    error = assert_raise(AbstractMethodError) do
+      begin
+        raise AbstractMethodError, "subclass must implement"
+      rescue
+        flunk("AbstractMethodError must not be rescued by a bare rescue")
+      end
+    end
+    assert_equal("subclass must implement", error.message)
+  end
 end

--- a/test/ruby/test_exception.rb
+++ b/test/ruby/test_exception.rb
@@ -1589,4 +1589,20 @@ $stderr = $stdout; raise "\x82\xa0"') do |outs, errs, status|
       x(&a)
     end
   end
+
+  def test_abstract_method_error
+    assert_operator(AbstractMethodError, :<, ScriptError)
+    assert_not_operator(AbstractMethodError, :<, StandardError)
+
+    assert_equal("AbstractMethodError", AbstractMethodError.new.message)
+
+    error = assert_raise(AbstractMethodError) do
+      begin
+        raise AbstractMethodError, "subclass must implement"
+      rescue
+        flunk("AbstractMethodError must not be rescued by a bare rescue")
+      end
+    end
+    assert_equal("subclass must implement", error.message)
+  end
 end


### PR DESCRIPTION
Raising `NotImplementedError` from a superclass method that expects subclasses to override it is a misuse of that exception, which is meant for features unavailable on the current platform. Since this use case is common in practice, introduce `AbstractMethodError` as a dedicated built-in exception class for it.

It inherits from `ScriptError`, like `NotImplementedError`, so it is not caught by a bare rescue and must be rescued explicitly. The existing `NotImplementedError` is left unchanged for compatibility.

No code in this repository needs to be migrated to the new class. The abstract method uses of `NotImplementedError` found here all live in code synced from upstream repositories, so they should be changed upstream if at all. For example:

- `Delegator#__getobj__` and `#__setobj__` (ruby/delegate)
- `Resolv::DNS::Resource#encode_rdata` and `.decode_rdata` (ruby/resolv)
- `Gem::BasicSpecification` and other base classes (rubygems/rubygems)
- `TSort#tsort_each_node` and `#tsort_each_child` (ruby/tsort, vendored here through rubygems/rubygems)
- `Lrama::Grammar::Code` and `Lrama::Parser` (ruby/lrama)

Note that `AbstractMethodError` is a sibling of `NotImplementedError`, not a subclass, so such migrations change which rescue clauses match and need to be decided per library after this feature is released.

The RBS signature for the new class needs to be added separately in ruby/rbs, since the core signatures are not part of this repository.

Resolves https://bugs.ruby-lang.org/issues/18915.