### PR TITLE
Remove dead test exclude that doesn't exist anymore

### DIFF
--- a/test/.excludes/TestGem.rb
+++ b/test/.excludes/TestGem.rb
@@ -1,4 +1,0 @@
-if RbConfig::CONFIG["LIBRUBY_RELATIVE"] == "yes"
-  exclude(/test_looks_for_gemdeps_files_automatically_from_binstubs/,
-         "can't test before installation")
-end


### PR DESCRIPTION
TestGem#test_looks_for_gemdeps_files_automatically_from_binstubs doesn't exist anymore.