### PR TITLE
Backport 8b22811652 to ruby_4_0: Disable git background maintenance in bundler specs

### DIFF
--- a/spec/bundler/spec_helper.rb
+++ b/spec/bundler/spec_helper.rb
@@ -115,6 +115,16 @@ RSpec.configure do |config|
       ENV["GIT_CONFIG_NOSYSTEM"] = "1"
     end
 
+    # Disable git background maintenance. Since Git 2.46, commands like
+    # `git commit` spawn a detached `git maintenance run --auto` process,
+    # which briefly creates `.git/objects/maintenance.lock`. That races with
+    # specs copying repositories with FileUtils.cp_r, causing flaky ENOENT
+    # failures. GIT_CONFIG_COUNT is available since Git 2.31 and silently
+    # ignored by older versions.
+    ENV["GIT_CONFIG_COUNT"] = "1"
+    ENV["GIT_CONFIG_KEY_0"] = "maintenance.auto"
+    ENV["GIT_CONFIG_VALUE_0"] = "false"
+
     # Don't wrap output in tests
     ENV["THOR_COLUMNS"] = "10000"
 


### PR DESCRIPTION
Backport of https://github.com/ruby/ruby/commit/8b228116526879481df12ad34f15148b7d55c3b2. Since Git 2.46, `git commit` spawns a detached `git maintenance run --auto` process whose `.git/objects/maintenance.lock` races with `FileUtils.cp_r` in bundler specs, causing flaky `Errno::ENOENT` failures on macOS CI runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)