### PR TITLE
Remove unused static variables

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -1316,7 +1316,7 @@ $(MAINOBJ): $(srcdir)/$(MAINSRC)
 probes.dmyh:
 	$(BASERUBY) $(tooldir)/gen_dummy_probes.rb $(srcdir)/probes.d > $@
 
-probes.h: {$(VPATH)}probes.$(DTRACE_EXT)
+probes.h: {$(VPATH)}probes.$(DTRACE_EXT) $(srcdir)/vm_opts.h
 
 prereq: incs srcs preludes PHONY
 

--- a/vm.c
+++ b/vm.c
@@ -5194,15 +5194,6 @@ usage_analysis_register_clear(VALUE self)
     return usage_analysis_clear(self, usage_hash);
 }
 
-#else
-
-MAYBE_UNUSED(static void (*ruby_vm_collect_usage_func_insn)(int insn)) = 0;
-MAYBE_UNUSED(static void (*ruby_vm_collect_usage_func_operand)(int insn, int n, VALUE op)) = 0;
-MAYBE_UNUSED(static void (*ruby_vm_collect_usage_func_register)(int reg, int isset)) = 0;
-
-#endif
-
-#if VM_COLLECT_USAGE_DETAILS
 /* @param insn instruction number */
 static void
 vm_collect_usage_insn(int insn)


### PR DESCRIPTION
These variables are used only when `VM_COLLECT_USAGE_DETAILS` is true.
Also fix missing dependency of probes.h.