### PR TITLE
Fix mk_builtin_loader.rb for CRLF source checkouts

### DIFF
--- a/tool/mk_builtin_loader.rb
+++ b/tool/mk_builtin_loader.rb
@@ -117,8 +117,8 @@ def visit_call_node(source, node, name, locals, requires, bs, inlines)
       raise "argc (#{argc}) of inline! should be 1" if argc != 1
 
       # The string literal keeps the line endings of the source file; normalize
-      # CRLF so the generated code does not depend on how it was checked out.
-      text = extract_string_literal(args[0]).gsub(/\r\n/, "\n").rstrip
+      # them so the generated code does not depend on how it was checked out.
+      text = extract_string_literal(args[0]).encode(universal_newline: true).rstrip
       lineno = line_number(source, node)
 
       case primitive_macro

--- a/tool/mk_builtin_loader.rb
+++ b/tool/mk_builtin_loader.rb
@@ -116,7 +116,9 @@ def visit_call_node(source, node, name, locals, requires, bs, inlines)
       # an inline function, and then continue the visit.
       raise "argc (#{argc}) of inline! should be 1" if argc != 1
 
-      text = extract_string_literal(args[0]).rstrip
+      # The string literal keeps the line endings of the source file; normalize
+      # CRLF so the generated code does not depend on how it was checked out.
+      text = extract_string_literal(args[0]).gsub(/\r\n/, "\n").rstrip
       lineno = line_number(source, node)
 
       case primitive_macro
@@ -184,7 +186,10 @@ def collect_builtins(dump_ast, file)
     exit(1)
   end
 
-  source = File.read(file)
+  # dump_ast reports byte offsets against the raw file bytes, so the source
+  # must be read in binary mode; text mode would convert CRLF to LF on Windows
+  # and shift every offset.
+  source = File.binread(file)
   root = JSON.parse(stdout)
   visit_node(source, root, "top", nil, requires = [], builtins = [], inlines = [])
 


### PR DESCRIPTION
When the source tree is checked out with CRLF line endings, which is what git's `core.autocrlf=true` default produces on Windows, rbinc generation emits broken inline C and the mswin build fails to compile `array.c` with `error C2065: 'n': undeclared identifier`.

`tool/dump_ast.c` parses the file with prism from the raw bytes, so the byte offsets in its JSON output count CRLF line endings. `tool/mk_builtin_loader.rb` read the same file with `File.read` in text mode, which converts CRLF to LF on Windows, so every offset pointed past the intended position and the computed line numbers came out too large. The wrong line numbers missed the `LOCALS_DB` lookup keyed by the line numbers from `RubyVM::InstructionSequence.compile_file`, so the locals of `Primitive.cexpr!` were silently dropped and the generated inline functions referenced locals such as `n` without fetching them from the environment.

This patch reads the source in binary mode so that the loader and prism agree on byte offsets, and normalizes CRLF in the extracted C snippets so that CRLF and LF checkouts generate identical rbinc files. Verified by regenerating `array.rbinc` and `gc.rbinc` from CRLF and LF copies of the same sources. The outputs are byte-identical and match the previous output for LF sources.

ruby/ruby's own Windows CI does not hit this because `.github/actions/setup/directories` forces `core.autocrlf=false` before checkout, but any Windows developer cloning with the git default and building mswin from git does.
