### PR TITLE
win32/setup.mak: fix dead vs2022-fp-bug check

### DIFF
--- a/win32/setup.mak
+++ b/win32/setup.mak
@@ -160,11 +160,10 @@ main(void)
     return c != value_nan();
 }
 <<
-	@( \
-	  $(CC) -O2 $@.c && .\$@ || \
-	  (set bug=%ERRORLEVEL% & \
-	  echo This compiler has an optimization bug) \
-	) & $(WIN32DIR:/=\)\rm.bat $@.* & exit /b %bug%
+	@($(CC) -O2 $@.c && .\$@) || \
+	  (echo This compiler has an optimization bug & \
+	  $(WIN32DIR:/=\)\rm.bat $@.* & exit /b 1)
+	@$(WIN32DIR:/=\)\rm.bat $@.*
 
 -version-: nul verconf.mk
 


### PR DESCRIPTION
The `vs2022-fp-bug` target in `win32/setup.mak` is supposed to abort the build when the compiler miscompiles the `__assume`/`isnan` sequence, but it never did. Because of the line continuations the whole recipe collapses into a single `cmd.exe` line, so `%ERRORLEVEL%` and `%bug%` are expanded once at parse time before the compile ever runs. `exit /b %bug%` therefore always ran `exit /b` with the pre-run (empty) value and the check passed even when the test program returned non-zero.

This reworks the recipe so the compile-and-run itself is the thing that fails. On the failure path `($(CC) -O2 $@.c && .\$@)` returns non-zero, the `||` branch prints the message, cleans up, and `exit /b 1` propagates the failure to `nmake`. The success path cleans up on a separate recipe line.

Verified on Windows with a real compiler and with a deliberately broken test program (`return 1;` substituted for the real check).

Before the fix, the broken test program still passed:

```
checking for vs2022 fp bug
vs2022-fp-bug.c
NaN=>n
This compiler has an optimization bug
```

`nmake` exited 0 and the residue was left behind despite the printed warning.

After the fix, the same broken test program stops the build:

```
checking for vs2022 fp bug
vs2022-fp-bug.c
NaN=>n
This compiler has an optimization bug
NMAKE : fatal error U1077: '(cl -nologo -O2 vs2022-fp-bug.c && .\vs2022-fp-bug) || ...' : return code '0x1'
Stop.
```

`nmake` exits non-zero and `vs2022-fp-bug.*` is removed. A real (non-buggy) compiler still passes cleanly with no leftover files.
