### PR TITLE
Make `nmake benchmark` work on mswin

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -62,8 +62,7 @@ make benchmark ITEM=vm
 # Run some limited benchmarks in ITEM-matched files
 make benchmark ITEM=vm OPTS=--filter=block
 
-# You can specify the benchmark by an exact filename instead of using the default argument:
-# ARGS = $$(find $(srcdir)/benchmark -maxdepth 1 -name '*$(ITEM)*.yml' -o -name '*$(ITEM)*.rb')
+# You can specify the benchmark by exact filenames instead of matching ITEM:
 make benchmark ARGS=benchmark/erb_render.yml
 
 # You can specify any option via $OPTS

--- a/common.mk
+++ b/common.mk
@@ -1440,15 +1440,24 @@ COMPARE_RUBY = $(BASERUBY)
 BENCH_RUBY = $(RUNRUBY)
 BENCH_OPTS = --output=markdown --output-compare -v
 ITEM =
-ARGS = $$(find $(srcdir)/benchmark -maxdepth 1 -name '$(ITEM)' -o -name '*$(ITEM)*.yml' -o -name '*$(ITEM)*.rb' | sort)
+ARGS =
 OPTS =
 
-# See benchmark/README.md for details.
+# Select the benchmark files with Ruby instead of `find | sort`, so the
+# recipe runs on any platform regardless of the shell.  When ARGS is
+# empty, collect the files matching ITEM under benchmark/.  Executables
+# are passed with forward slashes because benchmark-driver splits them
+# with Shellwords, which eats backslashes.  See benchmark/README.md.
 benchmark: miniruby$(EXEEXT) update-benchmark-driver PHONY
-	$(BASERUBY) -rrubygems -I$(srcdir)/benchmark/lib $(srcdir)/benchmark/benchmark-driver/exe/benchmark-driver \
-	            --executables="compare-ruby::$(COMPARE_RUBY) -I$(EXTOUT)/common --disable-gem" \
-	            --executables="built-ruby::$(BENCH_RUBY) --disable-gem" \
-	            $(BENCH_OPTS) $(ARGS) $(OPTS)
+	$(BASERUBY) -rrubygems -I$(srcdir)/benchmark/lib \
+	    -e "files = %w[$(ARGS)]" \
+	    -e "files = Dir.glob(['$(ITEM)', '*$(ITEM)*.yml', '*$(ITEM)*.rb'], base: '$(srcdir)/benchmark').reject(&:empty?).sort.uniq.map {|f| '$(srcdir)/benchmark/' + f} if files.empty?" \
+	    -e "ARGV.map! {|a| a.start_with?('--executables') ? a.gsub(92.chr, '/') : a}" \
+	    -e "ARGV.concat(files)" \
+	    -e "load '$(srcdir)/benchmark/benchmark-driver/exe/benchmark-driver'" -- \
+	    --executables="compare-ruby::$(COMPARE_RUBY) -I$(EXTOUT)/common --disable-gem" \
+	    --executables="built-ruby::$(BENCH_RUBY) --disable-gem" \
+	    $(BENCH_OPTS) $(OPTS)
 
 run.gdb:
 	echo set breakpoint pending on         > run.gdb


### PR DESCRIPTION
`nmake benchmark` has been broken on mswin because the `benchmark` recipe in `common.mk` collected the benchmark files with `$$(find ... | sort)`, which cmd.exe cannot interpret:

```
	... benchmark-driver ... $(find ../../ruby/benchmark -maxdepth 1 -name 'dir_pwd' -o -name '*dir_pwd*.yml' -o -name '*dir_pwd*.rb' | sort)
'sort)' is not recognized as an internal or external command,
operable program or batch file.
NMAKE : fatal error U1077: ...
Stop.
```

Rather than branching the recipe per platform, this selects the benchmark files with Ruby (`BASERUBY`, which the whole of `common.mk` already relies on) instead of `find | sort`, so the single recipe runs on any platform regardless of the shell. When `ARGS` is empty it collects the files matching `ITEM` under `benchmark/`, matching the previous `find` behavior. The executables are passed with forward slashes because benchmark-driver splits `--executables` with `Shellwords`, which eats backslashes on Windows paths.

Verified on x64-mswin64_140 that `nmake benchmark ITEM=dir_pwd` and `nmake benchmark ARGS=benchmark/dir_pwd.yml` both succeed:

```
compare-ruby: ruby 4.0.5 (2026-05-20 revision 64336ffd0e) +PRISM [x64-mswin64_140]
built-ruby: ruby 4.1.0dev (2026-06-29T22:22:44Z master 2ce6b8e54a) +PRISM [x64-mswin64_140]
warming up.
# Iteration per second (i/s)

|     |compare-ruby|built-ruby|
|:----|-----------:|---------:|
|pwd  |      8.723M|    6.095M|
|     |       1.43x|         -|
```

The empty-`ITEM` collection (a plain `nmake benchmark` run) yields the same 379 top-level files as the old `find`, and the recipe also parses and collects correctly under POSIX `sh`.
