### PR TITLE
Remove GCC 4.4 specific workarounds

### DIFF
--- a/bignum.c
+++ b/bignum.c
@@ -3440,9 +3440,6 @@ absint_numwords_generic(size_t numbytes, int nlz_bits_in_msbyte, size_t word_num
         INTEGER_PACK_NATIVE_BYTE_ORDER);
 
     if (sign == 2) {
-#if defined __GNUC__ && (__GNUC__ == 4 && __GNUC_MINOR__ == 4)
-        *nlz_bits_ret = 0;
-#endif
         return (size_t)-1;
     }
     *nlz_bits_ret = nlz_bits;

--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -4136,10 +4136,6 @@ gc_sweep_start_heap(rb_objspace_t *objspace, rb_heap_t *heap)
     }
 }
 
-#if defined(__GNUC__) && __GNUC__ == 4 && __GNUC_MINOR__ == 4
-__attribute__((noinline))
-#endif
-
 #if GC_CAN_COMPILE_COMPACTION
 static void gc_sort_heap_by_compare_func(rb_objspace_t *objspace, gc_compact_compare_func compare_func);
 static int compare_pinned_slots(const void *left, const void *right, void *d);


### PR DESCRIPTION
`bignum.c` carries a dummy assignment that silenced a GCC 4.4 `maybe-uninitialized` false positive, and `gc/default/default.c` carries a floating `noinline` attribute added for a GCC 4.4 miscompilation on Ubuntu 10.04. Since `configure.ac` assumes GCC 4.9 or later, both blocks guarded by `__GNUC__ == 4 && __GNUC_MINOR__ == 4` are compiled out on every supported compiler, so I removed them.
