### PR TITLE
Disable SimpleCov in bundled gem tests

### DIFF
--- a/tool/test-bundled-gems.rb
+++ b/tool/test-bundled-gems.rb
@@ -6,6 +6,11 @@ require_relative 'lib/gem_env'
 
 ENV.delete("GNUMAKEFLAGS")
 
+# net-imap's test helper enables SimpleCov, but its released versions still
+# call the pre-1.0.0 `SimpleCov.formatters=` API that breaks with simplecov
+# 1.0.0. Coverage of bundled gems is not collected in CI, so disable it.
+ENV["SIMPLECOV_DISABLE"] = "1"
+
 github_actions = ENV["GITHUB_ACTIONS"] == "true"
 
 allowed_failures = ENV['TEST_BUNDLED_GEMS_ALLOW_FAILURES'] || ''


### PR DESCRIPTION
net-imap's released test helper (`test/lib/helper.rb`) still calls the　pre-1.0.0 `SimpleCov.formatters=` API. With simplecov 1.0.0, that setter　calls `.empty?` on the anonymous class returned by　`SimpleCov::Formatter::MultiFormatter.new`, so `rake test` aborts with a　`NoMethodError` before any test runs. This breaks every `test-bundled-gems` job on `ruby_3_4` (net-imap 0.5.15).

Coverage of bundled gems is not collected in CI, so the simplest fix is to　opt out via the `SIMPLECOV_DISABLE` environment variable that net-imap's　helper already honors. This avoids pinning simplecov's version and needs no　change once net-imap ships a patch release.