### PR TITLE
Fix a family of races between Ractors, terminating threads, and GC.compact

### DIFF
--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -2620,3 +2620,31 @@ assert_equal 'ok', %q{
 
   :ok
 }
+
+# A thread terminating (here: the pipe writer) while another Ractor runs a
+# compaction barrier must not corrupt the machine context of a thread blocked
+# in IO, whose locked read buffer lives only on that machine stack.
+assert_equal 'ok', %q{
+  Warning[:experimental] = false
+  can_compact = begin
+    GC.compact
+    true
+  rescue NotImplementedError
+    false
+  end
+  if can_compact
+    b = Ractor.new do
+      10.times do
+        r, w = IO.pipe
+        t = Thread.new { w.write("x" * 40); w.close }
+        r.read
+        r.close
+        t.join
+      end
+      :ok
+    end
+    a = Ractor.new { 20.times { GC.compact }; :ok }
+    [a, b].each(&:value)
+  end
+  :ok
+}

--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -2648,3 +2648,23 @@ assert_equal 'ok', %q{
   end
   :ok
 }
+
+# Forking while other Ractors are alive takes a VM barrier in the parent; the
+# child inherits that scheduler/barrier state and must reset it. Exercises the
+# parent-side fork barrier and the child teardown, then checks the surviving
+# Ractors still work.
+assert_equal 'ok', %q{
+  begin
+    rs = 5.times.map { Ractor.new { Ractor.receive } }
+    10.times do
+      pid = fork { GC.start }
+      _, status = Process.waitpid2(pid)
+      raise "child failed" unless status.success?
+    end
+    rs.each { |r| r.send(nil) }
+    rs.each(&:value)
+    :ok
+  rescue NotImplementedError
+    :ok  # platform without fork
+  end
+}

--- a/ractor_sync.c
+++ b/ractor_sync.c
@@ -126,7 +126,9 @@ ractor_port_receive(rb_execution_context_t *ec, VALUE self)
         rb_raise(rb_eRactorError, "only allowed from the creator Ractor of this port");
     }
 
-    return ractor_receive(ec, rp);
+    VALUE v = ractor_receive(ec, rp);
+    RB_GC_GUARD(self);
+    return v;
 }
 
 static VALUE
@@ -134,6 +136,7 @@ ractor_port_send(rb_execution_context_t *ec, VALUE self, VALUE obj, VALUE move)
 {
     const struct ractor_port *rp = RACTOR_PORT_PTR(self);
     ractor_send(ec, rp, obj, RTEST(move));
+    RB_GC_GUARD(self);
     return self;
 }
 

--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -1664,16 +1664,13 @@ rb_ractor_sched_barrier_join(rb_vm_t *vm, rb_ractor_t *cr)
         ractor_sched_lock(vm, cr);
         {
             // running_cnt
-            /* A not-yet-running thread (blocking/terminating, joined only to
-             * sync) must not be counted, or barrier_waiting_cnt > running_cnt-1. */
-            if (cr->threads.sched.is_running) {
-                vm->ractor.sched.barrier_waiting_cnt++;
-                RUBY_DEBUG_LOG("waiting_cnt:%u serial:%u", vm->ractor.sched.barrier_waiting_cnt, barrier_serial);
-                ractor_sched_barrier_join_signal_locked(vm);
-            }
-            else {
-                RUBY_DEBUG_LOG("join without counting (not running) serial:%u", barrier_serial);
-            }
+            /* Every joiner is a member of the running set: a dying thread now
+             * leaves the living set before handing over its scheduler slot. */
+            VM_ASSERT(ractor_sched_running_threads_contain_p(vm, GET_THREAD()));
+            vm->ractor.sched.barrier_waiting_cnt++;
+            RUBY_DEBUG_LOG("waiting_cnt:%u serial:%u", vm->ractor.sched.barrier_waiting_cnt, barrier_serial);
+
+            ractor_sched_barrier_join_signal_locked(vm);
             ractor_sched_barrier_join_wait_locked(vm, cr->threads.sched.running);
         }
         ractor_sched_unlock(vm, cr);

--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -1744,6 +1744,12 @@ thread_sched_atfork(struct rb_thread_sched *sched)
 
     ccan_list_head_init(&vm->ractor.sched.grq);
     vm->ractor.sched.grq_cnt = 0; // the list was just emptied; reset the count with it
+    // A fork during a VM barrier leaves the child with barrier state that can
+    // never complete (the other ractors are gone); reset it like the rest.
+    vm->ractor.sched.barrier_waiting = false;
+    vm->ractor.sched.barrier_waiting_cnt = 0;
+    vm->ractor.sched.barrier_ractor = NULL;
+    vm->ractor.sched.barrier_lock_rec = 0;
     // Threads that were winding down in the parent do not exist in the child;
     // without this reset the child's ruby_vm_destruct would wait for their
     // reclaim (which never comes) forever.

--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -2503,6 +2503,7 @@ thread_sched_reclaim(struct coroutine_context *dead_co)
         SIZED_FREE(tctx);
         // pairs with the increment at the top of coroutine_thread_terminated:
         // a waiting VM destruct may proceed once this reclaim is done
+        VM_ASSERT(RUBY_ATOMIC_LOAD(GET_VM()->ractor.sched.winding_cnt) > 0);
         RUBY_ATOMIC_DEC(GET_VM()->ractor.sched.winding_cnt);
         return true;
     }

--- a/thread_pthread_mn.c
+++ b/thread_pthread_mn.c
@@ -481,6 +481,7 @@ coroutine_thread_terminated(rb_thread_t *th)
     // r/sched must not be touched. That order is safe only for it: with
     // no successor, sched->running stays NULL, so the removal's VM lock
     // never joins a barrier (vm_need_barrier requires a running thread).
+    VM_ASSERT(sched->running == th); // th owns the slot through the removal
     if (!last) rb_ractor_living_threads_remove(r, th);
 
     thread_sched_lock(sched, th);
@@ -505,6 +506,10 @@ coroutine_thread_terminated(rb_thread_t *th)
     thread_sched_unlock(sched, th);
 
     if (last) {
+        // The reverse order is safe only with no successor: running == NULL
+        // means the removal's VM lock cannot join a barrier (vm_need_barrier).
+        VM_ASSERT(sched->running == NULL);
+        VM_ASSERT(wake_th == NULL);
         // Last access to th/r: the removal may unlink the Ractor, after
         // which the GC may collect th and r.
         rb_ractor_living_threads_remove(r, th);

--- a/thread_pthread_mn.c
+++ b/thread_pthread_mn.c
@@ -448,9 +448,8 @@ native_thread_check_and_create_shared(rb_vm_t *vm)
 }
 
 // A coroutine thread's epilogue, run from thread_start_func_2 while th is
-// still valid (and, until the living-set removal, still GC-reachable).
-// Everything that touches th happens here; co_start then only makes the
-// final transfer, touching the execution-owned tctx alone.
+// still valid. Everything that touches th happens here; co_start then only
+// makes the final transfer, touching the execution-owned tctx alone.
 static void
 coroutine_thread_terminated(rb_thread_t *th)
 {
@@ -470,6 +469,20 @@ coroutine_thread_terminated(rb_thread_t *th)
 
     rb_thread_t *wake_th;
 
+    // Leave the living set BEFORE handing over the scheduler slot: the
+    // removal's VM-lock work (ractor_check_blocking, a barrier join) then
+    // runs as an ordinary counted running thread. Afterwards th may be
+    // unreachable, but no GC can complete while th still owns the slot
+    // (a barrier waits for it to join), so the handoff below may keep
+    // touching th/sched.
+    //
+    // The Ractor's last thread is the exception and keeps the reverse
+    // order (below): its removal unlinks the Ractor itself, after which
+    // r/sched must not be touched. That order is safe only for it: with
+    // no successor, sched->running stays NULL, so the removal's VM lock
+    // never joins a barrier (vm_need_barrier requires a running thread).
+    if (!last) rb_ractor_living_threads_remove(r, th);
+
     thread_sched_lock(sched, th);
     {
         // designate the successor (running = next from readyq, or NULL); for
@@ -477,12 +490,12 @@ coroutine_thread_terminated(rb_thread_t *th)
         thread_sched_to_dead_common(sched, th);
 
         // Only the successor WE designated here may be enqueued by this
-        // epilogue (below, after the living-set removal). If readyq was
-        // empty, running is now NULL and a waker (e.g. the timer thread)
-        // that later installs a runnable thread enqueues the Ractor itself
-        // -- enqueuing "whatever is running" at that point would duplicate
-        // its entry. While running is non-NULL, nobody else re-assigns it,
-        // so wake_th stays valid until we enqueue.
+        // epilogue (below). If readyq was empty, running is now NULL and a
+        // waker (e.g. the timer thread) that later installs a runnable
+        // thread enqueues the Ractor itself -- enqueuing "whatever is
+        // running" at that point would duplicate its entry. While running
+        // is non-NULL, nobody else re-assigns it, so wake_th stays valid
+        // until we enqueue.
         wake_th = is_dnt ? NULL : sched->running;
 
         tctx->nt = th->nt;        // stash the final transfer target for co_start
@@ -491,14 +504,10 @@ coroutine_thread_terminated(rb_thread_t *th)
     }
     thread_sched_unlock(sched, th);
 
-    // Leave the living set. This is the dying thread's last access to th --
-    // the removal needs the current ec (VM lock), and after it the GC may
-    // collect th (and, for a Ractor's main thread, the Ractor).
-    // (interrupt_lock stays valid up to here -- a concurrent terminate_all
-    // may interrupt any still-listed thread; it is destroyed in thread_free.)
-    rb_ractor_living_threads_remove(r, th);
-
     if (last) {
+        // Last access to th/r: the removal may unlink the Ractor, after
+        // which the GC may collect th and r.
+        rb_ractor_living_threads_remove(r, th);
         rb_current_ec_set(NULL); // TLS only; r may be collectable already
     }
     else {


### PR DESCRIPTION
A family of independent bugs, all surfaced by one stress test: a short-lived
thread terminating (and a blocked `IO#read`) while another Ractor drives
`GC.compact`. Found while root-causing intermittent `test_ractor.rb` timeouts
in CI (supersedes #17806 / #17804).

## Thread teardown vs the Ractor barrier

1. **Remove a dying coroutine thread from the living set before its handoff** —
   `coroutine_thread_terminated` designated its successor before leaving the
   living set, so its barrier-join work ran detached: it corrupted the
   successor's saved machine context (a blocked `IO#read`'s locked buffer was
   then swept and used after free), joined a barrier it was no longer counted
   in (hang), and made a stale will-block decision. Do the removal first, while
   the thread still owns its scheduler slot. The last thread keeps the reverse
   order (no successor => its removal never joins a barrier).
2. **Count every Ractor barrier joiner again** — with the reorder above every
   joiner is a running-set member, so the `is_running` guard from 3fa1c8708 is
   removed and the invariant asserted instead.
3. **Reset the Ractor barrier state in the child after fork** — a fork under the
   VM barrier left the child with `barrier_waiting` set and an owner that no
   longer exists, so its next barrier could never complete.
4. **Assert the serial-epilogue ordering invariants** — encode the above as
   `VM_ASSERT`s.

## Ractor port relocation

5. **Guard the port VALUE across receive/send** — `ractor_port_receive`/`send`
   cache a raw `struct ractor_port *` into the port's embedded
   (`RUBY_TYPED_EMBEDDABLE`) data and keep using it across a GC safepoint
   (receive parks; send allocates the basket). The port is only marked movably,
   so a concurrent `GC.compact` relocates it and the cached pointer dangles —
   the receiver then polls a stale, reused slot's port id forever, hanging
   `Ractor#value`. `RB_GC_GUARD(self)` pins it via the conservative stack scan.

## Verification

- ASAN: the stress test crashes 15/15 on master, 0/48 with the reorder.
- `make btest` / `make test-all`: green (35795 tests, 0F0E).
- The `test_ractor.rb:2627` timeout that recurred on earlier attempts (2-3 CI
  jobs per run) no longer reproduces: the port-relocation fix was verified with
  the crash caught red-handed in an instrumented CI dump (the receiver's cached
  pointer differing from the live, relocated port), then confirmed by two green
  omnibus runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

