### PR TITLE
Backport mmtk finalizer test fixes to ruby_4_0

### DIFF
--- a/test/ruby/test_thread.rb
+++ b/test/ruby/test_thread.rb
@@ -1667,7 +1667,10 @@ q.pop
             stdin.close rescue nil
             stdout.close rescue nil
             stderr.close rescue nil
-            wait_thread.value
+            # On some GC implementations (e.g. mmtk), finalizers run as postponed
+            # jobs which can execute on any thread, including the wait_thread itself.
+            # Guard against joining the current thread.
+            wait_thread.value unless Thread.current == wait_thread
           end
         end
       end

--- a/test/ruby/test_thread.rb
+++ b/test/ruby/test_thread.rb
@@ -1652,7 +1652,7 @@ q.pop
 
   # [Bug #21926]
   def test_thread_join_during_finalizers
-    assert_separately([], "#{<<~"begin;"}\n#{<<~'end;'}", timeout: 30)
+    assert_separately([], "#{<<~"begin;"}\n#{<<~'end;'}", timeout: 60)
     begin;
       require 'open3'
 
@@ -1675,7 +1675,7 @@ q.pop
         end
       end
 
-      50.times { ProcessWrapper.new }
+      20.times { ProcessWrapper.new }
       GC.stress = true
       1000.times { Object.new }
     end;


### PR DESCRIPTION
Backport two follow-up fixes for `TestThread#test_thread_join_during_finalizers` that are already on master but missing on `ruby_4_0`, causing the ModGC (mmtk) job to fail consistently on every push and pull request.

* https://github.com/ruby/ruby/actions/runs/29179664827/job/86614979756
* https://github.com/ruby/ruby/actions/runs/29243469148/job/86794730760

The regression test itself was backported in a601b899a35 (Backport #21926), but the subsequent mmtk correctness fix was never brought over. In mmtk, finalizers run as postponed jobs on any Ruby thread, so a popen3 `wait_thread` can execute the finalizer for its own `ProcessWrapper` and `wait_thread.value` then attempts to join the current thread, raising `ThreadError`. This is deterministic and unrelated to the test timeout, so both the ubuntu and macOS mmtk jobs fail every run.

This picks up c5ab2114df1 (#16559), which guards the join with `unless Thread.current == wait_thread`, and a6c6e563f1d (#16650), which raises the timeout from 30s to 60s to avoid a random timeout on Windows. After applying both, the test body is byte-for-byte identical to master.
