### PR TITLE
Fix  MemoryView contiguity check

### DIFF
--- a/ext/-test-/memory_view/memory_view.c
+++ b/ext/-test-/memory_view/memory_view.c
@@ -160,6 +160,38 @@ memory_view_get_memory_view_info(VALUE mod, VALUE obj)
 }
 
 static VALUE
+memory_view_is_row_major_contiguous(VALUE mod, VALUE obj)
+{
+    rb_memory_view_t view;
+    VALUE result;
+
+    if (!rb_memory_view_get(obj, &view, 0)) {
+        rb_raise(rb_eArgError, "Unable to get MemoryView");
+    }
+
+    result = rb_memory_view_is_row_major_contiguous(&view) ? Qtrue : Qfalse;
+    rb_memory_view_release(&view);
+
+    return result;
+}
+
+static VALUE
+memory_view_is_column_major_contiguous(VALUE mod, VALUE obj)
+{
+    rb_memory_view_t view;
+    VALUE result;
+
+    if (!rb_memory_view_get(obj, &view, 0)) {
+        rb_raise(rb_eArgError, "Unable to get MemoryView");
+    }
+
+    result = rb_memory_view_is_column_major_contiguous(&view) ? Qtrue : Qfalse;
+    rb_memory_view_release(&view);
+
+    return result;
+}
+
+static VALUE
 memory_view_fill_contiguous_strides(VALUE mod, VALUE ndim_v, VALUE item_size_v, VALUE shape_v, VALUE row_major_p)
 {
     ssize_t i, ndim = NUM2SSIZET(ndim_v);
@@ -389,6 +421,8 @@ Init_memory_view(void)
     rb_define_module_function(mMemoryViewTestUtils, "item_size_from_format", memory_view_item_size_from_format, 1);
     rb_define_module_function(mMemoryViewTestUtils, "parse_item_format", memory_view_parse_item_format, 1);
     rb_define_module_function(mMemoryViewTestUtils, "get_memory_view_info", memory_view_get_memory_view_info, 1);
+    rb_define_module_function(mMemoryViewTestUtils, "is_row_major_contiguous", memory_view_is_row_major_contiguous, 1);
+    rb_define_module_function(mMemoryViewTestUtils, "is_column_major_contiguous", memory_view_is_column_major_contiguous, 1);
     rb_define_module_function(mMemoryViewTestUtils, "fill_contiguous_strides", memory_view_fill_contiguous_strides, 4);
     rb_define_module_function(mMemoryViewTestUtils, "ref_count_while_exporting", memory_view_ref_count_while_exporting, 2);
     rb_define_module_function(mMemoryViewTestUtils, "extract_item_members", memory_view_extract_item_members, 2);

--- a/memory_view.c
+++ b/memory_view.c
@@ -174,11 +174,9 @@ rb_memory_view_is_column_major_contiguous(const rb_memory_view_t *view)
     const ssize_t ndim = view->ndim;
     const ssize_t *shape = view->shape;
     const ssize_t *strides = view->strides;
-    ssize_t n;
-    bool trivial;
     ssize_t i;
     if (strides) {
-        n = view->item_size;
+        ssize_t n = view->item_size;
         if (ndim == 1) {
             return strides[0] == n;
         }
@@ -196,7 +194,7 @@ rb_memory_view_is_column_major_contiguous(const rb_memory_view_t *view)
             return false;
         }
 
-        trivial = true;
+        bool trivial = true;
         for (i = 0; i < ndim; ++i) {
             if (shape[i] > 1) {
                 if (!trivial) {

--- a/memory_view.c
+++ b/memory_view.c
@@ -154,6 +154,12 @@ rb_memory_view_is_row_major_contiguous(const rb_memory_view_t *view)
     const ssize_t *strides = view->strides;
     ssize_t n = view->item_size;
     ssize_t i;
+    if (!strides) {
+        return true;
+    }
+    if (ndim == 1) {
+        return strides[0] == n;
+    }
     for (i = ndim - 1; i >= 0; --i) {
         if (strides[i] != n) return false;
         n *= shape[i];
@@ -168,13 +174,39 @@ rb_memory_view_is_column_major_contiguous(const rb_memory_view_t *view)
     const ssize_t ndim = view->ndim;
     const ssize_t *shape = view->shape;
     const ssize_t *strides = view->strides;
-    ssize_t n = view->item_size;
+    ssize_t n;
+    bool trivial;
     ssize_t i;
-    for (i = 0; i < ndim; ++i) {
-        if (strides[i] != n) return false;
-        n *= shape[i];
+    if (strides) {
+        n = view->item_size;
+        if (ndim == 1) {
+            return strides[0] == n;
+        }
+        for (i = 0; i < ndim; ++i) {
+            if (strides[i] != n) return false;
+            n *= shape[i];
+        }
+        return true;
     }
-    return true;
+    else {
+        if (ndim == 1) {
+            return true;
+        }
+        if (!shape) {
+            return false;
+        }
+
+        trivial = true;
+        for (i = 0; i < ndim; ++i) {
+            if (shape[i] > 1) {
+                if (!trivial) {
+                    return false;
+                }
+                trivial = false;
+            }
+        }
+        return true;
+    }
 }
 
 /* Initialize strides array to represent the specified contiguous array. */

--- a/test/ruby/test_memory_view.rb
+++ b/test/ruby/test_memory_view.rb
@@ -287,6 +287,56 @@ class TestMemoryView < Test::Unit::TestCase
     assert_nil(memory_view_info)
   end
 
+  def test_rb_memory_view_is_row_major_contiguous
+    es = MemoryViewTestUtils::ExportableString.new("ruby")
+    assert_true(MemoryViewTestUtils.is_row_major_contiguous(es))
+
+    item_size = sizeof(:long)
+    buf1 = [ 1, 2 ].pack("l!*")
+    shape1 = [1, 1, 2]
+    strides1 = [2*item_size, 2*item_size, item_size]
+    mv1 = MemoryViewTestUtils::MultiDimensionalView.new(buf1, "l!", shape1, strides1)
+    assert_true(MemoryViewTestUtils.is_row_major_contiguous(mv1))
+
+    buf2 = [ 1, 2, 3, 4,
+             5, 6, 7, 8,
+             9, 10, 11, 12 ].pack("l!*")
+    shape2 = [3, 4]
+    mv2 = MemoryViewTestUtils::MultiDimensionalView.new(buf2, "l!", shape2, nil)
+    assert_true(MemoryViewTestUtils.is_row_major_contiguous(mv2))
+  end
+
+  def test_rb_memory_view_is_column_major_contiguous
+    es = MemoryViewTestUtils::ExportableString.new("ruby")
+    assert_true(MemoryViewTestUtils.is_column_major_contiguous(es))
+
+    item_size = sizeof(:long)
+    buf1 = [ 1, 2 ].pack("l!*")
+    shape1 = [1, 1, 2]
+    strides1 = [item_size, item_size, item_size]
+    mv1 = MemoryViewTestUtils::MultiDimensionalView.new(buf1, "l!", shape1, strides1)
+    assert_true(MemoryViewTestUtils.is_column_major_contiguous(mv1))
+
+    buf2 = [ 1, 2, 3, 4,
+             5, 6, 7, 8,
+             9, 10, 11, 12 ].pack("l!*")
+    shape2 = [3, 4]
+    mv2 = MemoryViewTestUtils::MultiDimensionalView.new(buf2, "l!", shape2, nil)
+    assert_false(MemoryViewTestUtils.is_column_major_contiguous(mv2))
+
+    buf3 = buf2
+    shape3 = shape2
+    strides3 = [item_size, 3*item_size]
+    mv3 = MemoryViewTestUtils::MultiDimensionalView.new(buf3, "l!", shape3, strides3)
+    assert_true(MemoryViewTestUtils.is_column_major_contiguous(mv3))
+
+    buf4 = [ 1, 2, 3 ].pack("l!*")
+    shape4 = shape1
+    strides4 = [item_size, item_size, 2*item_size]
+    mv4 = MemoryViewTestUtils::MultiDimensionalView.new(buf4, "l!", shape4, strides4)
+    assert_false(MemoryViewTestUtils.is_column_major_contiguous(mv4))
+  end
+
   def test_rb_memory_view_fill_contiguous_strides
     row_major_strides = MemoryViewTestUtils.fill_contiguous_strides(3, 8, [2, 3, 4], true)
     assert_equal([96, 32, 8],


### PR DESCRIPTION
Hello,

This pull request fixes the problem reported in [Bug #22193](https://bugs.ruby-lang.org/issues/22193) that `rb_memory_view_is_row_major_contiguous` and `rb_memory_view_is_column_major_contiguous` functions could dereference
`shape` and `strides` without checking whether they are `NULL`.

Thank you.

[Bug #22193]
