### PR TITLE
ZJIT: End blockparamproxy and block profiling experiments

### DIFF
--- a/zjit.rb
+++ b/zjit.rb
@@ -109,8 +109,6 @@ class << RubyVM::ZJIT
     print_counters_with_prefix(prefix: 'setivar_fallback_', prompt: 'setivar fallback reasons', buf:, stats:, limit: 5)
     print_counters_with_prefix(prefix: 'getivar_fallback_', prompt: 'getivar fallback reasons', buf:, stats:, limit: 5)
     print_counters_with_prefix(prefix: 'definedivar_fallback_', prompt: 'definedivar fallback reasons', buf:, stats:, limit: 5)
-    print_counters_with_prefix(prefix: 'invokeblock_handler_', prompt: 'invokeblock handler', buf:, stats:, limit: 10)
-    print_counters_with_prefix(prefix: 'getblockparamproxy_handler_', prompt: 'getblockparamproxy handler', buf:, stats:, limit: 10)
     print_counters_with_prefix(prefix: 'inline_reject_', prompt: 'HIR-level inlining rejection reasons', buf:, stats:, limit: 10)
 
     # Show most popular unsupported call features. Because each call can

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -7639,64 +7639,10 @@ fn add_iseq_to_hir(
             } else if opcode == YARVINSN_definedivar || opcode == YARVINSN_trace_definedivar {
                 profiles.profile_self(exit_id, &exit_state, self_param);
             } else if opcode == YARVINSN_invokeblock || opcode == YARVINSN_trace_invokeblock {
-                if get_option!(stats) {
-                    let iseq_insn_idx = exit_state.insn_idx;
-                    if let Some(operand_types) = payload.profile.get_operand_types(iseq_insn_idx) {
-                        if let [self_type_distribution] = &operand_types[..] {
-                            let summary = TypeDistributionSummary::new(&self_type_distribution);
-                            if summary.is_monomorphic() {
-                                let obj = summary.bucket(0).class();
-                                if unsafe { rb_IMEMO_TYPE_P(obj, imemo_iseq) == 1 } {
-                                    fun.count(block, Counter::invokeblock_handler_monomorphic_iseq);
-                                } else if unsafe { rb_IMEMO_TYPE_P(obj, imemo_ifunc) == 1 } {
-                                    fun.count(block, Counter::invokeblock_handler_monomorphic_ifunc);
-                                } else {
-                                    fun.count(block, Counter::invokeblock_handler_monomorphic_other);
-                                }
-                            } else if summary.is_skewed_polymorphic() || summary.is_polymorphic() {
-                                fun.count(block, Counter::invokeblock_handler_polymorphic);
-                            } else if summary.is_skewed_megamorphic() || summary.is_megamorphic() {
-                                fun.count(block, Counter::invokeblock_handler_megamorphic);
-                            } else {
-                                fun.count(block, Counter::invokeblock_handler_no_profiles);
-                            }
-                        } else {
-                            fun.count(block, Counter::invokeblock_handler_no_profiles);
-                        }
-                    }
-                }
+                // Do nothing
             } else if opcode == YARVINSN_getblockparamproxy || opcode == YARVINSN_trace_getblockparamproxy {
-                if get_option!(stats) {
-                    let iseq_insn_idx = exit_state.insn_idx;
-                    if let Some([block_handler_distribution]) = payload.profile.get_operand_types(iseq_insn_idx) {
-                        let summary = TypeDistributionSummary::new(block_handler_distribution);
-
-                        if summary.is_monomorphic() {
-                            let obj = summary.bucket(0).class();
-                            if unsafe { rb_IMEMO_TYPE_P(obj, imemo_iseq) == 1} {
-                                fun.count(block, Counter::getblockparamproxy_handler_iseq);
-                            } else if unsafe { rb_IMEMO_TYPE_P(obj, imemo_ifunc) == 1} {
-                                fun.count(block, Counter::getblockparamproxy_handler_ifunc);
-                            }
-                            else if obj.nil_p() {
-                                fun.count(block, Counter::getblockparamproxy_handler_nil);
-                            }
-                            else if obj.symbol_p() {
-                                fun.count(block, Counter::getblockparamproxy_handler_symbol);
-                            } else if unsafe { rb_obj_is_proc(obj).test() } {
-                                fun.count(block, Counter::getblockparamproxy_handler_proc);
-                            }
-                        } else if summary.is_polymorphic() || summary.is_skewed_polymorphic() {
-                          fun.count(block, Counter::getblockparamproxy_handler_polymorphic);
-                        } else if summary.is_megamorphic() || summary.is_skewed_megamorphic() {
-                          fun.count(block, Counter::getblockparamproxy_handler_megamorphic);
-                        }
-                    } else {
-                        fun.count(block, Counter::getblockparamproxy_handler_no_profiles);
-                    }
-                }
-            }
-            else {
+                // Do nothing
+            } else {
                 profiles.profile_stack(exit_id, &exit_state);
             }
 

--- a/zjit/src/stats.rs
+++ b/zjit/src/stats.rs
@@ -468,13 +468,6 @@ make_counters! {
     load_field_count,
     store_field_count,
 
-    invokeblock_handler_monomorphic_iseq,
-    invokeblock_handler_monomorphic_ifunc,
-    invokeblock_handler_monomorphic_other,
-    invokeblock_handler_polymorphic,
-    invokeblock_handler_megamorphic,
-    invokeblock_handler_no_profiles,
-
     // HIR-level method inliner counters. Most rejection counters are incremented
     // once per SendDirect the inliner considers. inline_reject_budget_exceeded may
     // be incremented only once, rather than once per SendDirect, if the caller
@@ -487,15 +480,6 @@ make_counters! {
     inline_reject_compile_failure,
     inline_reject_no_returns,
     inline_reject_budget_exceeded,
-
-    getblockparamproxy_handler_iseq,
-    getblockparamproxy_handler_ifunc,
-    getblockparamproxy_handler_symbol,
-    getblockparamproxy_handler_proc,
-    getblockparamproxy_handler_nil,
-    getblockparamproxy_handler_polymorphic,
-    getblockparamproxy_handler_megamorphic,
-    getblockparamproxy_handler_no_profiles,
 }
 
 /// Increase a counter by a specified amount


### PR DESCRIPTION
We don't use the counters for much these days.
