### PR TITLE
ZJIT: gen new array embedded fastpath

### DIFF
--- a/array.c
+++ b/array.c
@@ -2925,6 +2925,23 @@ rb_ary_resurrect(VALUE ary)
     return ary_make_partial(ary, rb_cArray, 0, RARRAY_LEN(ary));
 }
 
+#if USE_ZJIT
+bool
+rb_zjit_array_new_can_fastpath(long len, size_t *alloc_size_out, VALUE *flags_out)
+{
+    if (!ary_embeddable_p(len)) {
+        return false;
+    }
+    long embed_size = ary_embed_size(len);
+    shape_id_t shape_id = rb_shape_transition_slot_size(ROOT_SHAPE_ID | SHAPE_ID_LAYOUT_OTHER,
+                                                        rb_gc_size_slot_size(embed_size));
+
+    *alloc_size_out = embed_size;
+    *flags_out = T_ARRAY | RARRAY_EMBED_FLAG | ((VALUE)len << RARRAY_EMBED_LEN_SHIFT) | ((VALUE)shape_id << SHAPE_FLAG_SHIFT);
+    return true;
+}
+#endif
+
 extern VALUE rb_output_fs;
 
 static void ary_join_1(VALUE obj, VALUE ary, VALUE sep, long i, VALUE result, int *first);

--- a/array.c
+++ b/array.c
@@ -2937,27 +2937,29 @@ rb_ary_resurrect(VALUE ary)
 
 #if USE_ZJIT
 bool
-rb_zjit_array_dup_can_fastpath(VALUE ary, size_t *alloc_size_out, VALUE *flags_out, long *len_out)
+rb_zjit_array_new_can_fastpath(long len, size_t *alloc_size_out, VALUE *flags_out)
 {
-    long len = RARRAY_LEN(ary);
-    long embed_capa = (sizeof(struct RArray) - offsetof(struct RArray, as.ary)) / sizeof(VALUE);
+    if (!ary_embeddable_p(len)) {
+        return false;
+    }
+    long embed_size = ary_embed_size(len);
 
-    if (len > embed_capa) return false;
-
-    *alloc_size_out = sizeof(struct RArray);
+    *alloc_size_out = embed_size;
     *flags_out = T_ARRAY | RARRAY_EMBED_FLAG | ((VALUE)len << RARRAY_EMBED_LEN_SHIFT);
-    *len_out = len;
     return true;
 }
 
-void
-rb_zjit_array_new_fastpath(size_t *alloc_size_out, VALUE *flags_out)
+bool
+rb_zjit_array_dup_can_fastpath(VALUE ary, size_t *alloc_size_out, VALUE *flags_out, long *len_out)
 {
-    size_t size = sizeof(struct RArray);
-    shape_id_t shape_id = rb_shape_transition_slot_size(ROOT_SHAPE_ID | SHAPE_ID_LAYOUT_OTHER,
-                                                        rb_gc_size_slot_size(size));
-    *alloc_size_out = size;
-    *flags_out = T_ARRAY | RARRAY_EMBED_FLAG | ((VALUE)shape_id << SHAPE_FLAG_SHIFT);
+    long len = RARRAY_LEN(ary);
+    if (!rb_zjit_array_new_can_fastpath(len, alloc_size_out, flags_out)) {
+        return false;
+    }
+    else {
+        *len_out = len;
+        return true;
+    }
 }
 #endif
 

--- a/depend
+++ b/depend
@@ -279,6 +279,7 @@ array.$(OBJEXT): {$(VPATH)}thread_native.h
 array.$(OBJEXT): {$(VPATH)}util.h
 array.$(OBJEXT): {$(VPATH)}vm_core.h
 array.$(OBJEXT): {$(VPATH)}vm_opts.h
+array.$(OBJEXT): {$(VPATH)}zjit.h
 ast.$(OBJEXT): $(CCAN_DIR)/check_type/check_type.h
 ast.$(OBJEXT): $(CCAN_DIR)/container_of/container_of.h
 ast.$(OBJEXT): $(CCAN_DIR)/list/list.h

--- a/zjit.h
+++ b/zjit.h
@@ -95,6 +95,7 @@ void rb_zjit_materialize_frames(const rb_execution_context_t *ec, rb_control_fra
 size_t rb_zjit_hash_new_size(void);
 bool rb_zjit_class_allocate_instance_fastpath(VALUE klass, size_t *size_out, shape_id_t *shape_id_out);
 bool rb_zjit_str_resurrect_fastpath(VALUE str, bool chilled, size_t *size_out, VALUE *flags_out, long *len_out, size_t *byte_size_out);
+bool rb_zjit_array_new_can_fastpath(long len, size_t *alloc_size_out, VALUE *flags_out);
 
 // Special value for cfp->jit_return that means "this is a C method frame, use
 // rb_zjit_c_frame as the JITFrame". We don't control the native stack layout

--- a/zjit.h
+++ b/zjit.h
@@ -137,6 +137,7 @@ VALUE rb_zjit_new_obj_shape(VALUE flags, size_t alloc_size);
 bool rb_zjit_class_allocate_instance_fastpath(VALUE klass, size_t *size_out, VALUE *flags_out);
 bool rb_zjit_str_resurrect_fastpath(VALUE str, bool chilled, size_t *size_out, VALUE *flags_out, long *len_out, size_t *byte_size_out);
 bool rb_zjit_array_dup_can_fastpath(VALUE ary, size_t *alloc_size_out, VALUE *flags_out, long *len_out);
+bool rb_zjit_array_new_can_fastpath(long len, size_t *alloc_size_out, VALUE *flags_out);
 bool rb_zjit_hash_dup_can_fastpath(VALUE hash, size_t *alloc_size_out, VALUE *flags_out, VALUE *ifnone_out, long *bound_out);
 void rb_zjit_range_new_fastpath(bool exclude_end, size_t *alloc_size_out, VALUE *flags_out);
 void rb_zjit_array_new_fastpath(size_t *alloc_size_out, VALUE *flags_out);

--- a/zjit/bindgen/src/main.rs
+++ b/zjit/bindgen/src/main.rs
@@ -115,6 +115,7 @@ fn main() {
         .allowlist_function("rb_zjit_hash_new_size")
         .allowlist_function("rb_zjit_class_allocate_instance_fastpath")
         .allowlist_function("rb_zjit_str_resurrect_fastpath")
+        .allowlist_function("rb_zjit_array_new_can_fastpath")
 
         // For crashing
         .allowlist_function("rb_bug")

--- a/zjit/bindgen/src/main.rs
+++ b/zjit/bindgen/src/main.rs
@@ -117,9 +117,9 @@ fn main() {
         .allowlist_function("rb_zjit_class_allocate_instance_fastpath")
         .allowlist_function("rb_zjit_str_resurrect_fastpath")
         .allowlist_function("rb_zjit_array_dup_can_fastpath")
+        .allowlist_function("rb_zjit_array_new_can_fastpath")
         .allowlist_function("rb_zjit_hash_dup_can_fastpath")
         .allowlist_function("rb_zjit_range_new_fastpath")
-        .allowlist_function("rb_zjit_array_new_fastpath")
 
         // For crashing
         .allowlist_function("rb_bug")

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -2143,23 +2143,40 @@ fn gen_new_array(
     elements: Vec<Opnd>,
     state: &FrameState,
 ) -> lir::Opnd {
-    gen_prepare_leaf_call_with_gc(asm, state);
-
     let num: c_long = elements.len().try_into().expect("Unable to fit length of elements into c_long");
 
-    if !elements.is_empty() {
-        let argv = gen_push_opnds(jit, asm, &elements);
-        return asm_ccall!(asm, rb_ec_ary_new_from_values, EC, num.into(), argv);
+    // When the new array would be embedded, bump-allocate it inline and initialize the elements
+    // directly. The fresh object is young and white, so those writes need no write barriers.
+    let mut alloc_size: usize = 0;
+    let mut flags = VALUE(0);
+    let mut argv = Opnd::UImm(0);
+    // NOTE: we can't use gen_push_opnds in slow path because jit var. can't be borrowed properly
+    if elements.len() > 0 {
+        argv = asm.alloc_stack(jit, elements.len());
+    }
+    if unsafe { rb_zjit_array_new_can_fastpath(num, &mut alloc_size, &mut flags) } {
+        let klass = unsafe { rb_cArray };
+        return gc_fastpath::gc_fastpath_new_obj(jit, asm, alloc_size, flags.as_u64(), klass,
+            &|asm, ary| {
+                for (i, &elem) in elements.iter().enumerate() {
+                    let offset = RUBY_OFFSET_RARRAY_AS_ARY + (i as i32) * SIZEOF_VALUE_I32;
+                    asm.store(Opnd::mem(VALUE_BITS, ary, offset), elem);
+                }
+            },
+            |asm| {
+                gen_prepare_leaf_call_with_gc(asm, state);
+                if elements.len() > 0 {
+                    gen_write_operands_to_native_stack(asm, &elements, argv);
+                }
+                asm_ccall!(asm, rb_ec_ary_new_from_values, EC, num.into(), argv)
+            });
     }
 
-    let alloc_size = std::mem::size_of::<RArray>();
-
-    let flags = (RUBY_T_ARRAY as u64) | (RARRAY_EMBED_FLAG as u64);
-    let klass = unsafe { rb_cArray };
-
-    gc_fastpath::gc_fastpath_new_obj(jit, asm, alloc_size, flags, klass, &|_asm, _obj| {}, |asm| {
-        asm_ccall!(asm, rb_ec_ary_new_from_values, EC, 0i64.into(), Opnd::UImm(0))
-    })
+    gen_prepare_leaf_call_with_gc(asm, state);
+    if elements.len() > 0 {
+        gen_write_operands_to_native_stack(asm, &elements, argv);
+    }
+    asm_ccall!(asm, rb_ec_ary_new_from_values, EC, num.into(), argv)
 }
 
 /// Adjust potentially-negative index by the given length, returning the adjusted index. If still negative,
@@ -3916,12 +3933,16 @@ fn gen_push_opnds(jit: &JITState, asm: &mut Assembler, opnds: &[Opnd]) -> lir::O
         Opnd::UImm(0)
     };
 
-    // Write operands into stack slots allocated by asm.alloc_stack()
-    for (idx, &opnd) in opnds.iter().enumerate() {
-        asm.mov(Opnd::mem(VALUE_BITS, argv, idx as i32 * SIZEOF_VALUE_I32), opnd);
-    }
+    gen_write_operands_to_native_stack(asm, opnds, argv);
 
     argv
+}
+
+/// Write operands into stack slots previously reserved by asm.alloc_stack().
+fn gen_write_operands_to_native_stack(asm: &mut Assembler, opnds: &[Opnd], stack: lir::Opnd) {
+    for (idx, &opnd) in opnds.iter().enumerate() {
+        asm.mov(Opnd::mem(VALUE_BITS, stack, idx as i32 * SIZEOF_VALUE_I32), opnd);
+    }
 }
 
 fn gen_toregexp(jit: &mut JITState, asm: &mut Assembler, function: &Function, opt: usize, values: Vec<Opnd>, state: &FrameState) -> Opnd {

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -2225,23 +2225,40 @@ fn gen_new_array(
     elements: Vec<Opnd>,
     state: &FrameState,
 ) -> lir::Opnd {
-    gen_prepare_leaf_call_with_gc(asm, state);
-
     let num: c_long = elements.len().try_into().expect("Unable to fit length of elements into c_long");
 
-    if !elements.is_empty() {
-        let argv = gen_push_opnds(jit, asm, &elements);
-        return asm_ccall!(asm, rb_ec_ary_new_from_values, EC, num.into(), argv);
+    let mut alloc_size: usize = 0;
+    let mut flags = VALUE(0);
+    let mut argv = Opnd::UImm(0);
+    // NOTE: we can't use gen_push_opnds in slow path because jit var can't be borrowed properly
+    if elements.len() > 0 {
+        argv = asm.alloc_stack(jit, elements.len());
+    }
+    // When the new array would be embedded, bump-allocate it inline and initialize the elements
+    // directly. The fresh object is young and white, so those writes need no write barriers.
+    if unsafe { rb_zjit_array_new_can_fastpath(num, &mut alloc_size, &mut flags) } {
+        let klass = unsafe { rb_cArray };
+        return gc_fastpath::gc_fastpath_new_obj(jit, asm, function, state, alloc_size, flags.into(), klass,
+            |asm, ary| {
+                for (i, &elem) in elements.iter().enumerate() {
+                    let offset = RUBY_OFFSET_RARRAY_AS_ARY + (i as i32) * SIZEOF_VALUE_I32;
+                    asm.store(Opnd::mem(VALUE_BITS, ary, offset), elem);
+                }
+            },
+            |asm| {
+                gen_prepare_leaf_call_with_gc(asm, state);
+                if elements.len() > 0 {
+                    gen_write_operands(asm, &elements, argv);
+                }
+                asm_ccall!(asm, rb_ec_ary_new_from_values, EC, num.into(), argv)
+            });
     }
 
-    let mut alloc_size: usize = 0;
-    let mut flags: VALUE = VALUE(0);
-    unsafe { rb_zjit_array_new_fastpath(&mut alloc_size, &mut flags) };
-    let klass = unsafe { rb_cArray };
-
-    gc_fastpath::gc_fastpath_new_obj(jit, asm, function, state, alloc_size, flags.into(), klass, |_asm, _obj| {}, |asm| {
-        asm_ccall!(asm, rb_ec_ary_new_from_values, EC, 0i64.into(), Opnd::UImm(0))
-    })
+    gen_prepare_leaf_call_with_gc(asm, state);
+    if elements.len() > 0 {
+        gen_write_operands(asm, &elements, argv);
+    }
+    asm_ccall!(asm, rb_ec_ary_new_from_values, EC, num.into(), argv)
 }
 
 /// Adjust potentially-negative index by the given length, returning the adjusted index. If still negative,
@@ -4084,12 +4101,16 @@ fn gen_push_opnds(jit: &JITState, asm: &mut Assembler, opnds: &[Opnd]) -> lir::O
         Opnd::UImm(0)
     };
 
-    // Write operands into stack slots allocated by asm.alloc_stack()
-    for (idx, &opnd) in opnds.iter().enumerate() {
-        asm.mov(Opnd::mem(VALUE_BITS, argv, idx as i32 * SIZEOF_VALUE_I32), opnd);
-    }
+    gen_write_operands(asm, opnds, argv);
 
     argv
+}
+
+/// Write operands into stack slots previously reserved by asm.alloc_stack().
+fn gen_write_operands(asm: &mut Assembler, opnds: &[Opnd], stack: lir::Opnd) {
+    for (idx, &opnd) in opnds.iter().enumerate() {
+        asm.mov(Opnd::mem(VALUE_BITS, stack, idx as i32 * SIZEOF_VALUE_I32), opnd);
+    }
 }
 
 fn gen_toregexp(jit: &mut JITState, asm: &mut Assembler, function: &Function, opt: usize, values: Vec<Opnd>, state: &FrameState) -> Opnd {

--- a/zjit/src/codegen_tests.rs
+++ b/zjit/src/codegen_tests.rs
@@ -3705,6 +3705,45 @@ fn test_new_array_order() {
 }
 
 #[test]
+fn test_new_array_embedded_gc_stress() {
+    eval(r#"
+        def make(a) = [a, a, a]
+    "#);
+    assert_contains_opcode("make", YARVINSN_newarray);
+    assert_snapshot!(assert_compiles(r#"
+        begin
+          GC.stress = true
+          s = "x"
+          make(s)
+          a = make(s)
+          a << :extra
+          [a.frozen?, a.class, a]
+        ensure
+          GC.stress = false
+        end
+    "#), @r#"[false, Array, ["x", "x", "x", :extra]]"#);
+}
+
+#[test]
+fn test_new_array_embedded_memcpy_gc_stress() {
+    eval(r#"
+        def make(a) = [a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a] # size: 17
+    "#);
+    assert_contains_opcode("make", YARVINSN_newarray);
+    assert_snapshot!(assert_compiles(r#"
+        begin
+          GC.stress = true
+          s = "y"
+          make(s)
+          m = make(s)
+          [m.frozen?, m.length, m.class]
+        ensure
+          GC.stress = false
+        end
+    "#), @r#"[false, 17, Array]"#);
+}
+
+#[test]
 fn test_array_dup() {
     assert_snapshot!(inspect("
         def test = [1,2,3]

--- a/zjit/src/codegen_tests.rs
+++ b/zjit/src/codegen_tests.rs
@@ -4251,6 +4251,45 @@ fn test_new_array_order() {
 }
 
 #[test]
+fn test_new_array_embedded_gc_stress() {
+    eval(r#"
+        def make(a) = [a, a, a]
+    "#);
+    assert_contains_opcode("make", YARVINSN_newarray);
+    assert_snapshot!(assert_compiles(r#"
+        begin
+          GC.stress = true
+          s = "x"
+          make(s)
+          a = make(s)
+          a << :extra
+          [a.frozen?, a.class, a]
+        ensure
+          GC.stress = false
+        end
+    "#), @r#"[false, Array, ["x", "x", "x", :extra]]"#);
+}
+
+#[test]
+fn test_new_array_embedded_memcpy_gc_stress() {
+    eval(r#"
+        def make(a) = [a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a] # size: 17
+    "#);
+    assert_contains_opcode("make", YARVINSN_newarray);
+    assert_snapshot!(assert_compiles(r#"
+        begin
+          GC.stress = true
+          s = "y"
+          make(s)
+          m = make(s)
+          [m.frozen?, m.length, m.class]
+        ensure
+          GC.stress = false
+        end
+    "#), @r#"[false, 17, Array]"#);
+}
+
+#[test]
 fn test_array_dup() {
     assert_snapshot!(inspect("
         def test = [1,2,3]

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -2286,6 +2286,11 @@ unsafe extern "C" {
         len_out: *mut ::std::os::raw::c_long,
         byte_size_out: *mut usize,
     ) -> bool;
+    pub fn rb_zjit_array_new_can_fastpath(
+        len: ::std::os::raw::c_long,
+        alloc_size_out: *mut usize,
+        flags_out: *mut VALUE,
+    ) -> bool;
     pub fn rb_profile_frames(
         start: ::std::os::raw::c_int,
         limit: ::std::os::raw::c_int,

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -2305,6 +2305,11 @@ unsafe extern "C" {
         flags_out: *mut VALUE,
         len_out: *mut ::std::os::raw::c_long,
     ) -> bool;
+    pub fn rb_zjit_array_new_can_fastpath(
+        len: ::std::os::raw::c_long,
+        alloc_size_out: *mut usize,
+        flags_out: *mut VALUE,
+    ) -> bool;
     pub fn rb_zjit_hash_dup_can_fastpath(
         hash: VALUE,
         alloc_size_out: *mut usize,
@@ -2317,7 +2322,6 @@ unsafe extern "C" {
         alloc_size_out: *mut usize,
         flags_out: *mut VALUE,
     );
-    pub fn rb_zjit_array_new_fastpath(alloc_size_out: *mut usize, flags_out: *mut VALUE);
     pub fn rb_profile_frames(
         start: ::std::os::raw::c_int,
         limit: ::std::os::raw::c_int,


### PR DESCRIPTION
Previously, only empty arrays were taking the gen_new_array fastpath. Now, if an array can be embedded it will take the fastpath.