### PR TITLE
Remove workarounds for GCC 3 and GCC 4.6-4.8

### DIFF
--- a/eval_intern.h
+++ b/eval_intern.h
@@ -125,9 +125,8 @@ extern int select_large_fdset(int, fd_set *, fd_set *, fd_set *, struct timeval 
 
 #define EC_REPUSH_TAG() (void)(_ec->tag = &_tag)
 
-#if defined __GNUC__ && __GNUC__ == 4 && (__GNUC_MINOR__ >= 6 && __GNUC_MINOR__ <= 8) || defined __clang__
-/* This macro prevents GCC 4.6--4.8 from emitting maybe-uninitialized warnings.
- * This macro also prevents Clang from dumping core in EC_EXEC_TAG().
+#if defined __clang__
+/* This macro prevents Clang from dumping core in EC_EXEC_TAG().
  * (I confirmed Clang 4.0.1 and 5.0.0.)
  */
 # define VAR_FROM_MEMORY(var) __extension__(*(__typeof__(var) volatile *)&(var))

--- a/iseq.c
+++ b/iseq.c
@@ -1359,8 +1359,8 @@ rb_iseq_compile_with_option(VALUE src, VALUE file, VALUE realpath, VALUE line, V
 {
     rb_iseq_t *iseq = NULL;
     rb_compile_option_t option;
-#if !defined(__GNUC__) || (__GNUC__ == 4 && __GNUC_MINOR__ == 8)
-# define INITIALIZED volatile /* suppress warnings by gcc 4.8 */
+#if !defined(__GNUC__)
+# define INITIALIZED volatile /* suppress warnings */
 #else
 # define INITIALIZED /* volatile */
 #endif

--- a/vm_exec.h
+++ b/vm_exec.h
@@ -93,16 +93,7 @@ error !
 /* token threaded code */
 
 /* dispatcher */
-#if defined(__GNUC__) && (defined(__i386__) || defined(__x86_64__)) && __GNUC__ == 3
-#define DISPATCH_ARCH_DEPEND_WAY(addr) \
-  __asm__ __volatile__("jmp *%0;\t# -- inserted by vm.h\t[length = 2]" : : "r" (addr))
-
-#else
-#define DISPATCH_ARCH_DEPEND_WAY(addr) \
-                                /* do nothing */
-#endif
 #define TC_DISPATCH(insn)  \
-  DISPATCH_ARCH_DEPEND_WAY(insns_address_table[GET_CURRENT_INSN()]); \
   INSN_DISPATCH_SIG(insn); \
   RB_GNUC_EXTENSION_BLOCK(goto *insns_address_table[GET_CURRENT_INSN()]); \
   rb_bug("tc error");


### PR DESCRIPTION
Since `configure.ac` assumes GCC 4.9 or later, the GCC 3 only `DISPATCH_ARCH_DEPEND_WAY` asm hint in `vm_exec.h`, the GCC 4.6-4.8 arm of the `VAR_NOCLOBBERED` condition in `eval_intern.h`, and the GCC 4.8 arm of the `INITIALIZED` condition in `iseq.c` are all dead, so I removed them while keeping the Clang and non-GCC sides untouched.

The CI in `.github/workflows/compilers.yml` verifies GCC 7 at the lowest and otherwise runs against GCC 9 through 15, so none of these branches were exercised by either the documented floor or CI.
