### PR TITLE
Remove unreferenced VM option macros from vm_opts.h

### DIFF
--- a/vm_opts.h
+++ b/vm_opts.h
@@ -44,7 +44,6 @@
 /* VM running option */
 #define OPT_CHECKED_RUN              1
 #define OPT_INLINE_METHOD_CACHE      1
-#define OPT_GLOBAL_METHOD_CACHE      1
 
 #ifndef OPT_IC_FOR_IVAR
 #define OPT_IC_FOR_IVAR 1
@@ -53,7 +52,6 @@
 /* architecture independent, affects generated code */
 #define OPT_OPERANDS_UNIFICATION     1
 #define OPT_INSTRUCTIONS_UNIFICATION 0
-#define OPT_UNIFY_ALL_COMBINATION    0
 
 /* misc */
 #ifndef OPT_SUPPORT_JOKE


### PR DESCRIPTION
`OPT_GLOBAL_METHOD_CACHE` and `OPT_UNIFY_ALL_COMBINATION` in `vm_opts.h` have no consumers left anywhere in the tree. The former guarded the global method cache, which was removed by b9007b6c548f91e88fd3f2ffa23de740431fa969 as part of the Ruby 3.0 method cache rework ([Feature #16614]). The latter was only read by the pre-2017 `insns2vm` generator, and the current `tool/ruby_vm` generator never references it. I confirmed that the generated `.inc` files are byte-identical after the removal because `tool/ruby_vm/loaders/vm_opts_h.rb` keys are only consumed for `INSTRUCTIONS_UNIFICATION` and the `DEFINE_INSN_IF` keys in `insns.def`.
