### PR TITLE
[Bug #22195] Restore AllocationError when accessing a freed IO::Buffer

### DIFF
--- a/include/ruby/io/buffer.h
+++ b/include/ruby/io/buffer.h
@@ -48,6 +48,8 @@ enum rb_io_buffer_flags {
     // A mapped buffer that is also shared.
     RB_IO_BUFFER_SHARED = 8,
 
+    // 16 is used internally by io_buffer.c.
+
     // The buffer is locked and cannot be resized.
     // More specifically, it means we can't change the base address or size.
     // A buffer is typically locked before a system call that uses the data.

--- a/io_buffer.c
+++ b/io_buffer.c
@@ -48,6 +48,9 @@ enum {
     // This is used to validate the flags given by the user.
     RB_IO_BUFFER_FLAGS_MASK = RB_IO_BUFFER_EXTERNAL | RB_IO_BUFFER_INTERNAL | RB_IO_BUFFER_MAPPED | RB_IO_BUFFER_SHARED | RB_IO_BUFFER_LOCKED | RB_IO_BUFFER_PRIVATE | RB_IO_BUFFER_READONLY,
 
+    // The buffer was released and cannot be accessed until it is re-allocated.
+    RB_IO_BUFFER_FREED = 16,
+
     RB_IO_BUFFER_DEBUG = 0,
 };
 
@@ -1045,6 +1048,10 @@ io_buffer_get_bytes_for_writing(struct rb_io_buffer *buffer, void **base, size_t
 {
     io_buffer_validate_for_writing(buffer);
 
+    if (buffer->flags & RB_IO_BUFFER_FREED) {
+        rb_raise(rb_eIOBufferAllocationError, "The buffer is not allocated!");
+    }
+
     if (buffer->base) {
         *base = buffer->base;
         *size = buffer->size;
@@ -1074,6 +1081,10 @@ static void
 io_buffer_get_bytes_for_reading(struct rb_io_buffer *buffer, const void **base, size_t *size)
 {
     io_buffer_validate_for_reading(buffer);
+
+    if (buffer->flags & RB_IO_BUFFER_FREED) {
+        rb_raise(rb_eIOBufferAllocationError, "The buffer is not allocated!");
+    }
 
     if (buffer->base) {
         *base = buffer->base;
@@ -1113,6 +1124,10 @@ rb_io_buffer_to_s(VALUE self)
 
     if (buffer->base == NULL) {
         rb_str_cat2(result, " NULL");
+    }
+
+    if (buffer->flags & RB_IO_BUFFER_FREED) {
+        rb_str_cat2(result, " FREED");
     }
 
     if (buffer->flags & RB_IO_BUFFER_EXTERNAL) {
@@ -1629,7 +1644,7 @@ rb_io_buffer_locked(VALUE self)
  *
  *    buffer = IO::Buffer.for('test')
  *    buffer.free
- *    # => #<IO::Buffer 0x0000000000000000+0 NULL>
+ *    # => #<IO::Buffer 0x0000000000000000+0 NULL FREED>
  *
  *    buffer.get_value(:U8, 0)
  *    # in `get_value': The buffer is not allocated! (IO::Buffer::AllocationError)
@@ -1650,6 +1665,7 @@ rb_io_buffer_free(VALUE self)
     }
 
     io_buffer_free(buffer);
+    buffer->flags = RB_IO_BUFFER_FREED;
 
     return self;
 }
@@ -1660,6 +1676,7 @@ VALUE rb_io_buffer_free_locked(VALUE self)
 
     io_buffer_unlock(buffer);
     io_buffer_free(buffer);
+    buffer->flags = RB_IO_BUFFER_FREED;
 
     return self;
 }
@@ -1890,6 +1907,8 @@ rb_io_buffer_resize(VALUE self, size_t size)
 
     if (buffer->base == NULL) {
         io_buffer_initialize(self, buffer, NULL, size, io_flags_for_size(size), Qnil);
+        // A re-allocated buffer is no longer freed:
+        buffer->flags &= ~RB_IO_BUFFER_FREED;
         return;
     }
 

--- a/test/ruby/test_io_buffer.rb
+++ b/test/ruby/test_io_buffer.rb
@@ -304,6 +304,7 @@ class TestIOBuffer < Test::Unit::TestCase
 
     buffer.resize(0)
     assert_equal 0, buffer.size
+    assert_equal "", buffer.get_string
 
     buffer.resize(1)
     assert_equal 1, buffer.size
@@ -325,6 +326,25 @@ class TestIOBuffer < Test::Unit::TestCase
     assert_raise(IO::Buffer::InvalidatedError) do
       slice.resize(16)
     end
+  end
+
+  def test_resize_freed
+    buffer = IO::Buffer.new(16)
+    buffer.free
+
+    buffer.resize(8)
+    assert_equal 8, buffer.size
+    assert_equal "\0" * 8, buffer.get_string
+  end
+
+  def test_resize_zero_freed
+    buffer = IO::Buffer.new(16)
+    buffer.free
+
+    # Re-allocating an empty buffer makes it accessible again:
+    buffer.resize(0)
+    assert_equal 0, buffer.size
+    assert_equal "", buffer.get_string
   end
 
   def test_compare_same_size
@@ -419,6 +439,50 @@ class TestIOBuffer < Test::Unit::TestCase
       buffer.set_string("Hola")
     end
     assert_equal "Ciao! World", hello
+  end
+
+  def test_free_raises_on_access
+    buffer = IO::Buffer.new(16)
+    buffer.free
+
+    assert_predicate buffer, :null?
+
+    assert_raise(IO::Buffer::AllocationError) {buffer.get_string}
+    assert_raise(IO::Buffer::AllocationError) {buffer.get_value(:U8, 0)}
+    assert_raise(IO::Buffer::AllocationError) {buffer.set_string("!")}
+    assert_raise(IO::Buffer::AllocationError) {buffer.dup}
+  end
+
+  def test_free_string_mapped_raises_on_access
+    buffer = IO::Buffer.for("Hello World".freeze)
+    buffer.free
+
+    assert_raise(IO::Buffer::AllocationError) {buffer.get_string}
+  end
+
+  def test_free_twice_raises_on_access
+    buffer = IO::Buffer.new(16)
+    buffer.free
+    buffer.free
+
+    assert_raise(IO::Buffer::AllocationError) {buffer.get_string}
+  end
+
+  def test_zero_length_free
+    buffer = IO::Buffer.new(0)
+    assert_equal "", buffer.get_string
+
+    buffer.free
+    assert_raise(IO::Buffer::AllocationError) {buffer.get_string}
+  end
+
+  def test_string_mapped_free_after_block
+    buffer = nil
+    IO::Buffer.for("Hello World") do |mapped|
+      buffer = mapped
+    end
+
+    assert_raise(IO::Buffer::AllocationError) {buffer.get_string}
   end
 
   def test_locked


### PR DESCRIPTION
Reading from an `IO::Buffer` after calling `#free` does not raise. It behaves like an empty buffer:

​```ruby
buffer = IO::Buffer.for("Hello World")
buffer.free
buffer.get_string # => "" (no error)
​```

Originally, accessing a freed buffer raised IO::Buffer::AllocationError. #9532 made zero-length buffer operations succeed instead of raising, and since a freed buffer also has base == NULL and size == 0, it stopped raising even though the documentation of #free still promises that access raises.

This PR marks the buffer with an internal `RB_IO_BUFFER_FREED` flag in `rb_io_buffer_free` / `rb_io_buffer_free_locked`, and restores the raise in `io_buffer_get_bytes_for_reading` / `io_buffer_get_bytes_for_writing` guarded by the flag, so that:

* Accessing a freed buffer raises `IO::Buffer::AllocationError` again, matching the documented pre-3.4 behavior.
* `#resize` still re-allocates a freed buffer, as documented ("You can resize a freed buffer to re-allocate it"), and clears the flag.
* Buffers which are merely empty, including those emptied by `resize(0)`, are not marked and keep the zero-length semantics from #9532. `IO::Buffer.new(0)` stays readable, and raises only once it is explicitly freed.