### PR TITLE
imemo.c: embed the `st_table` inside `rb_fields`

### DIFF
--- a/depend
+++ b/depend
@@ -16680,7 +16680,6 @@ shape.$(OBJEXT): $(top_srcdir)/internal/object.h
 shape.$(OBJEXT): $(top_srcdir)/internal/sanitizers.h
 shape.$(OBJEXT): $(top_srcdir)/internal/serial.h
 shape.$(OBJEXT): $(top_srcdir)/internal/set_table.h
-shape.$(OBJEXT): $(top_srcdir)/internal/st.h
 shape.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
 shape.$(OBJEXT): $(top_srcdir)/internal/string.h
 shape.$(OBJEXT): $(top_srcdir)/internal/struct.h

--- a/depend
+++ b/depend
@@ -16680,6 +16680,7 @@ shape.$(OBJEXT): $(top_srcdir)/internal/object.h
 shape.$(OBJEXT): $(top_srcdir)/internal/sanitizers.h
 shape.$(OBJEXT): $(top_srcdir)/internal/serial.h
 shape.$(OBJEXT): $(top_srcdir)/internal/set_table.h
+shape.$(OBJEXT): $(top_srcdir)/internal/st.h
 shape.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
 shape.$(OBJEXT): $(top_srcdir)/internal/string.h
 shape.$(OBJEXT): $(top_srcdir)/internal/struct.h

--- a/gc.c
+++ b/gc.c
@@ -1101,9 +1101,9 @@ rb_newobj_of(VALUE klass, VALUE flags, size_t size)
 static
 VALUE class_allocate_complex_instance(VALUE klass, uint32_t capacity)
 {
-    shape_id_t initial_shape_id = rb_shape_transition_robject(0);
-    VALUE obj = rb_newobj_of_with_shape(klass, T_OBJECT, initial_shape_id, sizeof(struct RObject));
-    rb_obj_init_complex(obj, rb_st_init_numtable_with_size(capacity));
+    VALUE obj = rb_newobj_of_with_shape(klass, T_OBJECT, rb_shape_transition_extended(ROOT_COMPLEX_SHAPE_ID), sizeof(struct RObject));
+    VALUE fields_obj = rb_imemo_fields_new_complex(obj, ROOT_COMPLEX_SHAPE_ID, capacity, false);
+    ROBJECT_SET_EXTENDED(obj, fields_obj);
     return obj;
 }
 

--- a/gc.c
+++ b/gc.c
@@ -377,15 +377,6 @@ void
 rb_gc_obj_changed_slot_size(VALUE obj, size_t slot_size)
 {
     shape_id_t shape_id = rb_obj_shape_transition_capacity(obj, rb_shape_capacity_for_slot_size(slot_size));
-
-    if (RB_TYPE_P(obj, T_OBJECT) && FL_TEST_RAW(obj, ROBJECT_HEAP) && !rb_obj_shape_complex_p(obj)) {
-        VALUE *embedded_fields = ROBJECT_EMBEDDED_FIELDS(obj);
-        VALUE *extended_fields = ROBJECT_FIELDS(obj);
-        MEMCPY(embedded_fields, extended_fields, VALUE, RSHAPE_LEN(RBASIC_SHAPE_ID(obj)));
-        FL_UNSET_RAW(obj, ROBJECT_HEAP);
-        shape_id = rb_shape_transition_robject(shape_id);
-    }
-
     RBASIC_SET_FULL_SHAPE_ID(obj, shape_id);
 }
 
@@ -3668,14 +3659,28 @@ gc_ref_update_array(void *objspace, VALUE v)
 static void
 gc_ref_update_object(void *objspace, VALUE v)
 {
+    RUBY_ASSERT(rb_gc_obj_slot_size(v) == rb_obj_shape_slot_size(v));
+    shape_id_t shape_id = RBASIC_SHAPE_ID(v);
+
     if (FL_TEST_RAW(v, ROBJECT_HEAP)) {
         UPDATE_IF_MOVED(objspace, ROBJECT(v)->as.extended);
-    }
-    else {
-        VALUE *ptr = ROBJECT_FIELDS(v);
-        for (uint32_t i = 0; i < ROBJECT_FIELDS_COUNT(v); i++) {
-            UPDATE_IF_MOVED(objspace, ptr[i]);
+
+        if (!rb_shape_complex_p(shape_id) && rb_shape_embedded_capacity(shape_id) >= RSHAPE_LEN(shape_id)) {
+            VALUE *embedded_fields = ROBJECT_EMBEDDED_FIELDS(v);
+            VALUE *extended_fields = ROBJECT_FIELDS(v);
+            MEMCPY(embedded_fields, extended_fields, VALUE, RSHAPE_LEN(shape_id));
+            FL_UNSET_RAW(v, ROBJECT_HEAP);
+            RBASIC_SET_FULL_SHAPE_ID(v, rb_shape_transition_robject(shape_id));
+            rb_gc_writebarrier_remember(v);
         }
+        else {
+            return;
+        }
+    }
+
+    VALUE *ptr = ROBJECT_FIELDS(v);
+    for (uint32_t i = 0; i < ROBJECT_FIELDS_COUNT(v); i++) {
+        UPDATE_IF_MOVED(objspace, ptr[i]);
     }
 }
 

--- a/imemo.c
+++ b/imemo.c
@@ -131,11 +131,11 @@ rb_imemo_cdhash_new(size_t size, const struct st_hash_type *type)
 }
 
 static VALUE
-imemo_fields_new(VALUE owner, VALUE flags, shape_id_t shape_id, size_t size, bool is_shareable)
+imemo_fields_new(VALUE owner, shape_id_t shape_id, size_t size, bool is_shareable)
 {
     RUBY_ASSERT(rb_gc_size_allocatable_p(size));
 
-    flags |= T_IMEMO | (imemo_fields << FL_USHIFT) | (is_shareable ? FL_SHAREABLE : 0);
+    VALUE flags = T_IMEMO | (imemo_fields << FL_USHIFT) | (is_shareable ? FL_SHAREABLE : 0);
     // imemo fields objects should always have "RObject" layout.  The
     // layout in the shape describes the layout of the thing on which it is set.
     // Imemo fields have the same layout as robject, therefore the layout
@@ -150,7 +150,7 @@ rb_imemo_fields_new(VALUE owner, shape_id_t shape_id, bool shareable)
     size_t capa = RSHAPE(shape_id)->capacity;
     size_t embedded_size = offsetof(struct rb_fields, as.embed) + capa * sizeof(VALUE);
 
-    VALUE fields = imemo_fields_new(owner, 0, shape_id, embedded_size, shareable);
+    VALUE fields = imemo_fields_new(owner, shape_id, embedded_size, shareable);
     RUBY_ASSERT(IMEMO_TYPE_P(fields, imemo_fields));
     RUBY_ASSERT(rb_shape_embedded_capacity(RBASIC_SHAPE_ID(fields)) >= capa);
 
@@ -158,20 +158,19 @@ rb_imemo_fields_new(VALUE owner, shape_id_t shape_id, bool shareable)
 }
 
 VALUE
-rb_imemo_fields_new_complex(VALUE owner, shape_id_t shape_id, size_t capa, bool shareable)
+rb_imemo_fields_new_complex_empty(VALUE owner)
 {
-    st_table *tbl = st_init_numtable_with_size(capa);
-    VALUE fields = imemo_fields_new(owner, OBJ_FIELD_HEAP, shape_id, sizeof(struct rb_fields), shareable);
-    IMEMO_OBJ_FIELDS(fields)->as.complex.table = tbl;
-    return fields;
+    return imemo_fields_new(owner, ROOT_SHAPE_ID, sizeof(struct rb_fields), false);
 }
 
-static int
-imemo_fields_trigger_wb_i(st_data_t key, st_data_t value, st_data_t arg)
+VALUE
+rb_imemo_fields_new_complex(VALUE owner, shape_id_t shape_id, size_t capa, bool shareable)
 {
-    VALUE field_obj = (VALUE)arg;
-    RB_OBJ_WRITTEN(field_obj, Qundef, (VALUE)value);
-    return ST_CONTINUE;
+    st_table tbl;
+    st_init_existing_numtable_with_size(&tbl, capa);
+    VALUE fields = imemo_fields_new(owner, shape_id, sizeof(struct rb_fields), shareable);
+    MEMCPY(&IMEMO_OBJ_FIELDS(fields)->as.complex.table, &tbl, st_table, 1);
+    return fields;
 }
 
 static int
@@ -182,32 +181,25 @@ imemo_fields_complex_wb_i(st_data_t key, st_data_t value, st_data_t arg)
 }
 
 VALUE
-rb_imemo_fields_new_complex_tbl(VALUE owner, shape_id_t shape_id, st_table *tbl, bool shareable)
-{
-    VALUE fields = imemo_fields_new(owner, OBJ_FIELD_HEAP, shape_id, sizeof(struct rb_fields), shareable);
-    IMEMO_OBJ_FIELDS(fields)->as.complex.table = tbl;
-    st_foreach(tbl, imemo_fields_trigger_wb_i, (st_data_t)fields);
-    return fields;
-}
-
-VALUE
 rb_imemo_fields_clone(VALUE fields_obj)
 {
     shape_id_t shape_id = RBASIC_SHAPE_ID(fields_obj);
+    VALUE owner = rb_imemo_fields_owner(fields_obj);
     VALUE clone;
 
     if (rb_shape_complex_p(shape_id)) {
         st_table *src_table = rb_imemo_fields_complex_tbl(fields_obj);
 
-        st_table *dest_table = xcalloc(1, sizeof(st_table));
-        clone = rb_imemo_fields_new_complex_tbl(rb_imemo_fields_owner(fields_obj), shape_id, dest_table, false /* TODO: check */);
-
+        // We start with ROOT_SHAPE_ID so that if GC trigger in `st_replace` it won't try
+        // to mark an uninitialized table.
+        clone = imemo_fields_new(owner, ROOT_SHAPE_ID, sizeof(struct rb_fields), false /* TODO: check */);
+        st_table *dest_table = rb_imemo_fields_complex_tbl(clone);
         st_replace(dest_table, src_table);
-
         st_foreach(dest_table, imemo_fields_complex_wb_i, (st_data_t)clone);
+        RBASIC_SET_FULL_SHAPE_ID(clone, shape_id);
     }
     else {
-        clone = rb_imemo_fields_new(rb_imemo_fields_owner(fields_obj), shape_id, false /* TODO: check */);
+        clone = rb_imemo_fields_new(owner, shape_id, false /* TODO: check */);
         VALUE *fields = rb_imemo_fields_ptr(clone);
         attr_index_t fields_count = RSHAPE_LEN(shape_id);
         MEMCPY(fields, rb_imemo_fields_ptr(fields_obj), VALUE, fields_count);
@@ -297,7 +289,7 @@ rb_imemo_memsize(VALUE obj)
         break;
       case imemo_fields:
         if (rb_obj_shape_complex_p(obj)) {
-            size += st_memsize(IMEMO_OBJ_FIELDS(obj)->as.complex.table);
+            size += st_memsize(rb_imemo_fields_complex_tbl(obj)) - sizeof(st_table);
         }
 
         break;
@@ -620,9 +612,8 @@ rb_free_const_table(struct rb_id_table *tbl)
 static inline void
 imemo_fields_free(struct rb_fields *fields)
 {
-    if (FL_TEST_RAW((VALUE)fields, OBJ_FIELD_HEAP)) {
-        RUBY_ASSERT(rb_shape_complex_p(RBASIC_SHAPE_ID((VALUE)fields)));
-        st_free_table(fields->as.complex.table);
+    if (rb_obj_shape_complex_p((VALUE)fields)) {
+        st_free_table(&fields->as.complex.table);
     }
 }
 

--- a/internal/imemo.h
+++ b/internal/imemo.h
@@ -245,8 +245,7 @@ struct rb_fields {
             VALUE fields[1];
         } embed;
         struct {
-            // TODO: the st_table should be embedded
-            st_table *table;
+            st_table table;
         } complex;
     } as;
 };
@@ -281,7 +280,7 @@ rb_imemo_subclasses_entries(VALUE v)
 VALUE rb_imemo_fields_new(VALUE owner, /* shape_id_t */ uint32_t shape_id, bool shareable);
 VALUE rb_imemo_subclasses_new(uint32_t capacity);
 VALUE rb_imemo_fields_new_complex(VALUE owner, /* shape_id_t */ uint32_t shape_id, size_t capa, bool shareable);
-VALUE rb_imemo_fields_new_complex_tbl(VALUE owner, /* shape_id_t */ uint32_t shape_id, st_table *tbl, bool shareable);
+VALUE rb_imemo_fields_new_complex_empty(VALUE owner);
 VALUE rb_imemo_fields_clone(VALUE fields_obj);
 void rb_imemo_fields_clear(VALUE fields_obj);
 
@@ -303,15 +302,9 @@ rb_imemo_fields_ptr(VALUE fields_obj)
     RUBY_ASSERT(IMEMO_TYPE_P(fields_obj, imemo_fields) || RB_TYPE_P(fields_obj, T_OBJECT));
 
     if (UNLIKELY(FL_TEST_RAW(fields_obj, OBJ_FIELD_HEAP))) {
-        if (RB_TYPE_P(fields_obj, T_OBJECT)) {
-            fields_obj = ROBJECT(fields_obj)->as.extended;
-        }
+        RUBY_ASSERT(RB_TYPE_P(fields_obj, T_OBJECT));
+        fields_obj = ROBJECT(fields_obj)->as.extended;
         RUBY_ASSERT(IMEMO_TYPE_P(fields_obj, imemo_fields));
-
-        // This will go away once we embed the `st_table` inside `IMEMO/fields`.
-        if (UNLIKELY(FL_TEST_RAW(fields_obj, OBJ_FIELD_HEAP))) {
-            return (VALUE *)IMEMO_OBJ_FIELDS(fields_obj)->as.complex.table;
-        }
     }
 
     return IMEMO_OBJ_FIELDS(fields_obj)->as.embed.fields;
@@ -325,13 +318,13 @@ rb_imemo_fields_complex_tbl(VALUE fields_obj)
     }
 
     RUBY_ASSERT(IMEMO_TYPE_P(fields_obj, imemo_fields));
-    RUBY_ASSERT(FL_TEST_RAW(fields_obj, OBJ_FIELD_HEAP));
+    RUBY_ASSERT(!FL_TEST_RAW(fields_obj, OBJ_FIELD_HEAP));
 
     // Some codepaths unconditionally access the fields_ptr, and assume it can be used as st_table if the
     // shape is complex.
-    RUBY_ASSERT((st_table *)rb_imemo_fields_ptr(fields_obj) == IMEMO_OBJ_FIELDS(fields_obj)->as.complex.table);
+    RUBY_ASSERT((st_table *)rb_imemo_fields_ptr(fields_obj) == &IMEMO_OBJ_FIELDS(fields_obj)->as.complex.table);
 
-    return IMEMO_OBJ_FIELDS(fields_obj)->as.complex.table;
+    return &IMEMO_OBJ_FIELDS(fields_obj)->as.complex.table;
 }
 
 #endif /* INTERNAL_IMEMO_H */

--- a/internal/variable.h
+++ b/internal/variable.h
@@ -47,8 +47,8 @@ void rb_gvar_box_dynamic(const char *name);
  */
 VALUE rb_mod_set_temporary_name(VALUE, VALUE);
 
+void rb_obj_replace_fields(VALUE obj, VALUE fields_obj);
 void rb_obj_copy_ivs_to_hash_table(VALUE obj, st_table *table);
-void rb_obj_init_complex(VALUE obj, st_table *table);
 void rb_evict_ivars_to_hash(VALUE obj);
 VALUE rb_obj_field_get(VALUE obj, shape_id_t target_shape_id);
 void rb_ivar_set_internal(VALUE obj, ID id, VALUE val);

--- a/internal/variable.h
+++ b/internal/variable.h
@@ -49,7 +49,7 @@ VALUE rb_mod_set_temporary_name(VALUE, VALUE);
 
 void rb_obj_replace_fields(VALUE obj, VALUE fields_obj);
 void rb_obj_copy_ivs_to_hash_table(VALUE obj, st_table *table);
-void rb_evict_ivars_to_hash(VALUE obj);
+VALUE rb_obj_complex_fields_build(VALUE obj);
 VALUE rb_obj_field_get(VALUE obj, shape_id_t target_shape_id);
 void rb_ivar_set_internal(VALUE obj, ID id, VALUE val);
 void rb_ivar_foreach_buffered(VALUE obj, int (*func)(ID name, VALUE val, st_data_t arg), st_data_t arg);

--- a/internal/variable.h
+++ b/internal/variable.h
@@ -48,7 +48,6 @@ void rb_gvar_box_dynamic(const char *name);
 VALUE rb_mod_set_temporary_name(VALUE, VALUE);
 
 void rb_obj_replace_fields(VALUE obj, VALUE fields_obj);
-void rb_obj_copy_ivs_to_hash_table(VALUE obj, st_table *table);
 VALUE rb_obj_complex_fields_build(VALUE obj);
 VALUE rb_obj_field_get(VALUE obj, shape_id_t target_shape_id);
 void rb_ivar_set_internal(VALUE obj, ID id, VALUE val);

--- a/object.c
+++ b/object.c
@@ -339,7 +339,11 @@ rb_obj_copy_ivar(VALUE dest, VALUE obj)
     shape_id_t src_shape_id = RBASIC_SHAPE_ID(obj);
 
     if (rb_shape_complex_p(src_shape_id)) {
-        rb_shape_copy_complex_ivars(dest, obj, src_shape_id, ROBJECT_FIELDS_HASH(obj));
+        VALUE fields_obj = ROBJECT_FIELDS_OBJ(obj);
+        VALUE clone = rb_imemo_fields_new_complex_empty(dest);
+        rb_shape_copy_complex_ivars(clone, fields_obj);
+        ROBJECT_SET_EXTENDED(dest, clone);
+        RBASIC_SET_SHAPE_ID_WITH_LAYOUT(dest, ROOT_COMPLEX_SHAPE_ID, SHAPE_ID_LAYOUT_EXTENDED);
         return;
     }
 
@@ -348,10 +352,10 @@ rb_obj_copy_ivar(VALUE dest, VALUE obj)
 
     shape_id_t dest_shape_id = rb_shape_rebuild(initial_shape_id, src_shape_id);
     if (UNLIKELY(rb_shape_complex_p(dest_shape_id))) {
-        st_table *table = rb_st_init_numtable_with_size(src_num_ivs);
+        VALUE fields_obj = rb_imemo_fields_new_complex(dest, dest_shape_id, rb_ivar_count(obj), false);
+        st_table *table = rb_imemo_fields_complex_tbl(fields_obj);
         rb_obj_copy_ivs_to_hash_table(obj, table);
-        rb_obj_init_complex(dest, table);
-
+        rb_obj_replace_fields(dest, fields_obj);
         return;
     }
 

--- a/object.c
+++ b/object.c
@@ -337,16 +337,6 @@ rb_obj_copy_ivar(VALUE dest, VALUE obj)
     }
 
     shape_id_t src_shape_id = RBASIC_SHAPE_ID(obj);
-
-    if (rb_shape_complex_p(src_shape_id)) {
-        VALUE fields_obj = ROBJECT_FIELDS_OBJ(obj);
-        VALUE clone = rb_imemo_fields_new_complex_empty(dest);
-        rb_shape_copy_complex_ivars(clone, fields_obj);
-        ROBJECT_SET_EXTENDED(dest, clone);
-        RBASIC_SET_SHAPE_ID_WITH_LAYOUT(dest, ROOT_COMPLEX_SHAPE_ID, SHAPE_ID_LAYOUT_EXTENDED);
-        return;
-    }
-
     shape_id_t initial_shape_id = RBASIC_SHAPE_ID(dest);
     RUBY_ASSERT(RSHAPE_TYPE_P(initial_shape_id, SHAPE_ROOT));
 

--- a/object.c
+++ b/object.c
@@ -342,10 +342,7 @@ rb_obj_copy_ivar(VALUE dest, VALUE obj)
 
     shape_id_t dest_shape_id = rb_shape_rebuild(initial_shape_id, src_shape_id);
     if (UNLIKELY(rb_shape_complex_p(dest_shape_id))) {
-        VALUE fields_obj = rb_imemo_fields_new_complex(dest, dest_shape_id, rb_ivar_count(obj), false);
-        st_table *table = rb_imemo_fields_complex_tbl(fields_obj);
-        rb_obj_copy_ivs_to_hash_table(obj, table);
-        rb_obj_replace_fields(dest, fields_obj);
+        rb_obj_replace_fields(dest, rb_obj_complex_fields_build(obj));
         return;
     }
 

--- a/shape.c
+++ b/shape.c
@@ -33,8 +33,6 @@
 #define MAX_SHAPE_ID (INVALID_SHAPE_ID - 1)
 #define ANCESTOR_SEARCH_MAX_DEPTH 2
 
-static ID id_object_id;
-
 // Should be on its own cache line
 static RUBY_ALIGNAS(128) rb_atomic_t redblack_cache_size;
 
@@ -701,7 +699,7 @@ rb_shape_transition_object_id(shape_id_t original_shape_id)
     bool dont_care;
     rb_shape_t *shape = NULL;
     if (LIKELY(original_shape->next_field_index < rb_shape_max_capacity())) {
-        shape = get_next_shape_internal(original_shape, id_object_id, SHAPE_OBJ_ID, &dont_care, true);
+        shape = get_next_shape_internal(original_shape, rb_shape_tree.id_object_id, SHAPE_OBJ_ID, &dont_care, true);
     }
     if (!shape) {
         return rb_shape_layout(original_shape_id) | ROOT_COMPLEX_WITH_OBJ_ID | RSHAPE_FLAGS(original_shape_id);
@@ -1612,7 +1610,7 @@ Init_default_shapes(void)
         rb_memerror();
     }
 
-    id_object_id = rb_make_internal_id();
+    rb_shape_tree.id_object_id = rb_make_internal_id();
 
 #ifdef HAVE_MMAP
     size_t shape_cache_mmap_size = rb_size_mul_or_raise(REDBLACK_CACHE_SIZE, sizeof(redblack_node_t), rb_eRuntimeError);
@@ -1647,11 +1645,11 @@ Init_default_shapes(void)
     RUBY_ASSERT(!(SHAPE_OFFSET(root) & SHAPE_ID_HAS_IVAR_MASK));
 
     bool dontcare;
-    rb_shape_t *root_with_obj_id = get_next_shape_internal(root, id_object_id, SHAPE_OBJ_ID, &dontcare, true);
+    rb_shape_t *root_with_obj_id = get_next_shape_internal(root, rb_shape_tree.id_object_id, SHAPE_OBJ_ID, &dontcare, true);
     RUBY_ASSERT(root_with_obj_id);
     RUBY_ASSERT(SHAPE_OFFSET(root_with_obj_id) == ROOT_SHAPE_WITH_OBJ_ID);
     RUBY_ASSERT(root_with_obj_id->type == SHAPE_OBJ_ID);
-    RUBY_ASSERT(root_with_obj_id->edge_name == id_object_id);
+    RUBY_ASSERT(root_with_obj_id->edge_name == rb_shape_tree.id_object_id);
     RUBY_ASSERT(root_with_obj_id->next_field_index == 1);
     RUBY_ASSERT(!(SHAPE_OFFSET(root_with_obj_id) & SHAPE_ID_HAS_IVAR_MASK));
     (void)root_with_obj_id;

--- a/shape.c
+++ b/shape.c
@@ -1094,8 +1094,16 @@ shape_rebuild(rb_shape_t *initial_shape, rb_shape_t *dest_shape)
 shape_id_t
 rb_shape_rebuild(shape_id_t initial_shape_id, shape_id_t dest_shape_id)
 {
-    RUBY_ASSERT(!rb_shape_complex_p(initial_shape_id));
-    RUBY_ASSERT(!rb_shape_complex_p(dest_shape_id));
+    RUBY_ASSERT(RSHAPE_TYPE_P(initial_shape_id, SHAPE_ROOT));
+
+    if (RB_UNLIKELY(rb_shape_complex_p(initial_shape_id))) {
+        // The class has been marked as too complex.
+        return initial_shape_id;
+    }
+
+    if (RB_UNLIKELY(rb_shape_complex_p(dest_shape_id))) {
+        return rb_shape_transition_complex(initial_shape_id);
+    }
 
     shape_id_t next_shape_id;
     // The shape has a SHAPE_OBJ_ID edge, it needs to be rebuilt.

--- a/shape.c
+++ b/shape.c
@@ -9,7 +9,6 @@
 #include "internal/object.h"
 #include "internal/symbol.h"
 #include "internal/variable.h"
-#include "internal/st.h"
 #include "variable.h"
 #include <stdbool.h>
 
@@ -1153,24 +1152,6 @@ rb_shape_copy_fields(VALUE dest, VALUE *dest_buf, shape_id_t dest_shape_id, VALU
             src_shape = RSHAPE(src_shape->parent_offset);
         }
     }
-}
-
-void
-rb_shape_copy_complex_ivars(VALUE dest, VALUE src)
-{
-    RUBY_ASSERT(IMEMO_TYPE_P(src, imemo_fields));
-    RUBY_ASSERT(IMEMO_TYPE_P(dest, imemo_fields));
-
-    shape_id_t dest_shape_id = RBASIC_SHAPE_ID(src);
-    st_table *dest_table = rb_imemo_fields_complex_tbl(dest);
-    st_replace(dest_table, rb_imemo_fields_complex_tbl(src));
-
-    if (rb_shape_has_object_id(dest_shape_id)) {
-        st_data_t stkey = (st_data_t)id_object_id;
-        st_delete(dest_table, &stkey, NULL);
-    }
-
-    RBASIC_SET_SHAPE_ID(dest, ROOT_COMPLEX_SHAPE_ID);
 }
 
 size_t

--- a/shape.c
+++ b/shape.c
@@ -9,6 +9,7 @@
 #include "internal/object.h"
 #include "internal/symbol.h"
 #include "internal/variable.h"
+#include "internal/st.h"
 #include "variable.h"
 #include <stdbool.h>
 
@@ -1147,16 +1148,21 @@ rb_shape_copy_fields(VALUE dest, VALUE *dest_buf, shape_id_t dest_shape_id, VALU
 }
 
 void
-rb_shape_copy_complex_ivars(VALUE dest, VALUE obj, shape_id_t src_shape_id, st_table *fields_table)
+rb_shape_copy_complex_ivars(VALUE dest, VALUE src)
 {
-    // obj is COMPLEX so we can copy its iv_hash
-    st_table *table = st_copy(fields_table);
-    if (rb_shape_has_object_id(src_shape_id)) {
-        st_data_t id = (st_data_t)id_object_id;
-        st_delete(table, &id, NULL);
+    RUBY_ASSERT(IMEMO_TYPE_P(src, imemo_fields));
+    RUBY_ASSERT(IMEMO_TYPE_P(dest, imemo_fields));
+
+    shape_id_t dest_shape_id = RBASIC_SHAPE_ID(src);
+    st_table *dest_table = rb_imemo_fields_complex_tbl(dest);
+    st_replace(dest_table, rb_imemo_fields_complex_tbl(src));
+
+    if (rb_shape_has_object_id(dest_shape_id)) {
+        st_data_t stkey = (st_data_t)id_object_id;
+        st_delete(dest_table, &stkey, NULL);
     }
-    rb_obj_init_complex(dest, table);
-    rb_gc_writebarrier_remember(dest);
+
+    RBASIC_SET_SHAPE_ID(dest, ROOT_COMPLEX_SHAPE_ID);
 }
 
 size_t
@@ -1295,36 +1301,39 @@ rb_shape_verify_consistency(VALUE obj, shape_id_t shape_id)
 
     rb_shape_t *shape = RSHAPE(shape_id);
 
-    bool has_object_id = false;
-    while (shape->parent_offset != INVALID_SHAPE_ID) {
-        if (shape->type == SHAPE_OBJ_ID) {
-            has_object_id = true;
-            break;
-        }
-        shape = RSHAPE(shape->parent_offset);
-    }
-
-    if (rb_shape_has_object_id(shape_id)) {
-        if (!has_object_id) {
-            rb_bug("shape_id claim having obj_id but doesn't shape_id=%u, obj=%s", shape_id, rb_obj_info(obj));
-        }
-    }
-    else {
-        if (has_object_id) {
-            rb_bug("shape_id claim not having obj_id but it does shape_id=%u, obj=%s", shape_id, rb_obj_info(obj));
-        }
-    }
-
     // Make sure SHAPE_ID_HAS_IVAR_MASK is valid.
     if (rb_shape_complex_p(shape_id)) {
         RUBY_ASSERT(shape_id & SHAPE_ID_HAS_IVAR_MASK);
 
         // Ensure complex object don't appear as embedded
-        if (RB_TYPE_P(obj, T_OBJECT) || IMEMO_TYPE_P(obj, imemo_fields)) {
+        if (RB_TYPE_P(obj, T_OBJECT)) {
             RUBY_ASSERT(FL_TEST_RAW(obj, ROBJECT_HEAP));
+        }
+        else if (IMEMO_TYPE_P(obj, imemo_fields)) {
+            RUBY_ASSERT(!FL_TEST_RAW(obj, ROBJECT_HEAP));
         }
     }
     else {
+        bool has_object_id = false;
+        while (shape->parent_offset != INVALID_SHAPE_ID) {
+            if (shape->type == SHAPE_OBJ_ID) {
+                has_object_id = true;
+                break;
+            }
+            shape = RSHAPE(shape->parent_offset);
+        }
+
+        if (rb_shape_has_object_id(shape_id)) {
+            if (!has_object_id) {
+                rb_bug("shape_id claim having obj_id but doesn't shape_id=%u, obj=%s", shape_id, rb_obj_info(obj));
+            }
+        }
+        else {
+            if (has_object_id) {
+                rb_bug("shape_id claim not having obj_id but it does shape_id=%u, obj=%s", shape_id, rb_obj_info(obj));
+            }
+        }
+
         attr_index_t ivar_count = RSHAPE_LEN(shape_id);
         if (has_object_id) {
             ivar_count--;

--- a/shape.h
+++ b/shape.h
@@ -267,7 +267,7 @@ shape_id_t rb_shape_transition_add_ivar_no_warnings(shape_id_t shape_id, ID id, 
 shape_id_t rb_shape_object_id(shape_id_t original_shape_id);
 shape_id_t rb_shape_rebuild(shape_id_t initial_shape_id, shape_id_t dest_shape_id);
 void rb_shape_copy_fields(VALUE dest, VALUE *dest_buf, shape_id_t dest_shape_id, VALUE *src_buf, shape_id_t src_shape_id);
-void rb_shape_copy_complex_ivars(VALUE dest, VALUE obj, shape_id_t src_shape_id, st_table *fields_table);
+void rb_shape_copy_complex_ivars(VALUE dest, VALUE src);
 
 static inline bool
 rb_shape_frozen_p(shape_id_t shape_id)
@@ -498,9 +498,21 @@ rb_obj_using_gen_fields_table_p(VALUE obj)
 }
 
 static inline shape_id_t
+rb_shape_transition_layout(shape_id_t shape_id, shape_id_t layout)
+{
+    return (shape_id & (~SHAPE_ID_LAYOUT_MASK)) | layout;
+}
+
+static inline shape_id_t
 rb_shape_transition_robject(shape_id_t shape_id)
 {
-    return (shape_id & ~SHAPE_ID_LAYOUT_MASK) | SHAPE_ID_LAYOUT_ROBJECT;
+    return rb_shape_transition_layout(shape_id, SHAPE_ID_LAYOUT_ROBJECT);
+}
+
+static inline shape_id_t
+rb_shape_transition_extended(shape_id_t shape_id)
+{
+    return rb_shape_transition_layout(shape_id, SHAPE_ID_LAYOUT_EXTENDED);
 }
 
 static inline shape_id_t
@@ -546,12 +558,6 @@ static inline shape_id_t
 rb_shape_transition_slot_size(shape_id_t shape_id, size_t slot_size)
 {
     return rb_shape_transition_capacity(shape_id, rb_shape_capacity_for_slot_size(slot_size));
-}
-
-static inline shape_id_t
-rb_shape_transition_layout(shape_id_t shape_id, shape_id_t layout)
-{
-    return (shape_id & (~SHAPE_ID_LAYOUT_MASK)) | layout;
 }
 
 shape_id_t rb_shape_transition_object_id(shape_id_t shape_id);

--- a/shape.h
+++ b/shape.h
@@ -134,6 +134,7 @@ enum shape_flags {
 typedef struct {
     rb_shape_t *shape_list;
     attr_index_t max_capacity;
+    ID id_object_id;
 } rb_shape_tree_t;
 
 RUBY_SYMBOL_EXPORT_BEGIN

--- a/shape.h
+++ b/shape.h
@@ -267,7 +267,6 @@ shape_id_t rb_shape_transition_add_ivar_no_warnings(shape_id_t shape_id, ID id, 
 shape_id_t rb_shape_object_id(shape_id_t original_shape_id);
 shape_id_t rb_shape_rebuild(shape_id_t initial_shape_id, shape_id_t dest_shape_id);
 void rb_shape_copy_fields(VALUE dest, VALUE *dest_buf, shape_id_t dest_shape_id, VALUE *src_buf, shape_id_t src_shape_id);
-void rb_shape_copy_complex_ivars(VALUE dest, VALUE src);
 
 static inline bool
 rb_shape_frozen_p(shape_id_t shape_id)

--- a/test/ruby/test_gc_compact.rb
+++ b/test/ruby/test_gc_compact.rb
@@ -485,4 +485,24 @@ class TestGCCompact < Test::Unit::TestCase
       assert_equal("hello", obj.instance_variable_get(:@str))
     RUBY
   end
+
+  def test_object_reembedding
+    assert_separately([], <<~'RUBY')
+      GC.auto_compact = true
+
+      objs = []
+      30.times.map { Class.new }.map do |k|
+        50.times.each do
+          obj = k.new
+          rand(0..30).times do |i|
+            obj.instance_variable_set(:"@v#{i}", i)
+          end
+          objs << obj
+        end
+      end
+
+      GC.verify_compaction_references(expand_heap: true, toward: :empty)
+      assert :ok
+    RUBY
+  end
 end

--- a/test/ruby/test_object_id.rb
+++ b/test/ruby/test_object_id.rb
@@ -2,8 +2,10 @@ require 'test/unit'
 require "securerandom"
 
 class TestObjectId < Test::Unit::TestCase
+  SomeClass = Class.new
+
   def setup
-    @obj = Object.new
+    @obj = SomeClass.new
   end
 
   def test_dup_new_id

--- a/variable.c
+++ b/variable.c
@@ -2285,27 +2285,15 @@ rb_copy_generic_ivar(VALUE dest, VALUE obj)
             goto clear;
         }
 
-        if (rb_shape_complex_p(src_shape_id)) {
-            VALUE clone = rb_imemo_fields_new_complex_empty(dest);
-            rb_shape_copy_complex_ivars(clone, fields_obj);
-            rb_obj_set_fields(dest, clone, 0, 0);
-            return;
-        }
-
-        shape_id_t dest_shape_id = src_shape_id;
         shape_id_t initial_shape_id = rb_obj_shape_id(dest);
+        shape_id_t dest_shape_id = rb_shape_rebuild(initial_shape_id, src_shape_id);
 
-        if (!rb_shape_canonical_p(src_shape_id)) {
-            RUBY_ASSERT(RSHAPE_TYPE_P(initial_shape_id, SHAPE_ROOT));
-
-            dest_shape_id = rb_shape_rebuild(initial_shape_id, src_shape_id);
-            if (UNLIKELY(rb_shape_complex_p(dest_shape_id))) {
-                new_fields_obj = rb_imemo_fields_new_complex(dest, dest_shape_id, rb_ivar_count(obj), false);
-                st_table *table = rb_imemo_fields_complex_tbl(new_fields_obj);
-                rb_obj_copy_ivs_to_hash_table(obj, table);
-                rb_obj_replace_fields(dest, new_fields_obj);
-                return;
-            }
+        if (UNLIKELY(rb_shape_complex_p(dest_shape_id))) {
+            new_fields_obj = rb_imemo_fields_new_complex(dest, dest_shape_id, rb_ivar_count(obj), false);
+            st_table *table = rb_imemo_fields_complex_tbl(new_fields_obj);
+            rb_obj_copy_ivs_to_hash_table(obj, table);
+            rb_obj_replace_fields(dest, new_fields_obj);
+            return;
         }
 
         if (!RSHAPE_LEN(dest_shape_id)) {

--- a/variable.c
+++ b/variable.c
@@ -2282,7 +2282,8 @@ rb_copy_generic_ivar(VALUE dest, VALUE obj)
     if (fields_obj) {
         unsigned long src_num_ivs = rb_ivar_count(fields_obj);
         if (!src_num_ivs) {
-            goto clear;
+            rb_free_generic_ivar(dest);
+            return;
         }
 
         shape_id_t initial_shape_id = rb_obj_shape_id(dest);
@@ -2308,10 +2309,6 @@ rb_copy_generic_ivar(VALUE dest, VALUE obj)
 
         rb_obj_replace_fields(dest, new_fields_obj);
     }
-    return;
-
-  clear:
-    rb_free_generic_ivar(dest);
 }
 
 void

--- a/variable.c
+++ b/variable.c
@@ -1603,33 +1603,19 @@ rb_attr_get(VALUE obj, ID id)
     return rb_ivar_lookup(obj, id, Qnil);
 }
 
-void rb_obj_copy_fields_to_hash_table(VALUE obj, st_table *table);
-static VALUE imemo_fields_complex_from_obj(VALUE owner, VALUE source_fields_obj, shape_id_t shape_id);
+static VALUE imemo_fields_evacutate_to_complex(VALUE owner, VALUE source_fields_obj, shape_id_t shape_id, int extra_capa);
 
-// Copy all object fields, including ivars and internal object_id, etc
 static shape_id_t
-rb_evict_fields_to_hash(VALUE obj)
+rb_obj_convert_too_complex(VALUE obj, VALUE fields_obj, shape_id_t shape_id)
 {
     RUBY_ASSERT(RB_TYPE_P(obj, T_OBJECT));
     RUBY_ASSERT(!rb_obj_shape_complex_p(obj));
 
-    shape_id_t new_shape_id = rb_obj_shape_transition_complex(obj);
-    VALUE fields_obj = rb_imemo_fields_new_complex(obj, new_shape_id, RSHAPE_LEN(RBASIC_SHAPE_ID(obj)), false);
-    st_table *table = rb_imemo_fields_complex_tbl(fields_obj);
-    rb_obj_copy_fields_to_hash_table(obj, table);
-    ROBJECT_SET_EXTENDED(obj, fields_obj);
-    RBASIC_SET_FULL_SHAPE_ID(obj, rb_shape_transition_extended(new_shape_id));
-
-    return new_shape_id;
-}
-
-VALUE
-rb_obj_complex_fields_build(VALUE obj)
-{
-    VALUE fields_obj = rb_imemo_fields_new_complex(obj, ROOT_COMPLEX_SHAPE_ID, rb_ivar_count(obj), false);
-    st_table *table = rb_imemo_fields_complex_tbl(fields_obj);
-    rb_obj_copy_ivs_to_hash_table(obj, table);
-    return fields_obj;
+    shape_id = rb_shape_transition_complex(shape_id);
+    VALUE new_fields_obj = imemo_fields_evacutate_to_complex(obj, fields_obj, shape_id, 1);
+    ROBJECT_SET_EXTENDED(obj, new_fields_obj);
+    RBASIC_SET_SHAPE_ID_WITH_LAYOUT(obj, shape_id, SHAPE_ID_LAYOUT_EXTENDED);
+    return shape_id;
 }
 
 static VALUE
@@ -1676,7 +1662,7 @@ rb_ivar_delete(VALUE obj, ID id, VALUE undef)
 
     if (UNLIKELY(rb_shape_complex_p(next_shape_id))) {
         if (UNLIKELY(!rb_shape_complex_p(old_shape_id))) {
-            fields_obj = imemo_fields_complex_from_obj(obj, fields_obj, next_shape_id);
+            fields_obj = imemo_fields_evacutate_to_complex(obj, fields_obj, next_shape_id, -1);
         }
         st_data_t key = id;
         if (!st_delete(rb_imemo_fields_complex_tbl(fields_obj), &key, (st_data_t *)&val)) {
@@ -1776,14 +1762,29 @@ imemo_fields_complex_from_obj_i(ID key, VALUE val, st_data_t arg)
 }
 
 static VALUE
-imemo_fields_complex_from_obj(VALUE owner, VALUE source_fields_obj, shape_id_t shape_id)
+imemo_fields_complex_from_obj(VALUE owner, VALUE source, shape_id_t shape_id, bool ivar_only, int extra_capa)
 {
-    attr_index_t len = source_fields_obj ? RSHAPE_LEN(RBASIC_SHAPE_ID(source_fields_obj)) : 0;
-    VALUE fields_obj = rb_imemo_fields_new_complex(owner, shape_id, len + 1, RB_OBJ_SHAREABLE_P(owner));
+    attr_index_t len = source ? RSHAPE_LEN(RBASIC_SHAPE_ID(source)) : 0;
+    int capa = (len + extra_capa);
+    RUBY_ASSERT(capa >= 0);
 
-    rb_field_foreach(source_fields_obj, imemo_fields_complex_from_obj_i, (st_data_t)fields_obj, false);
+    VALUE fields_obj = rb_imemo_fields_new_complex(owner, shape_id, capa, RB_OBJ_SHAREABLE_P(owner));
+
+    rb_field_foreach(source, imemo_fields_complex_from_obj_i, (st_data_t)fields_obj, ivar_only);
 
     return fields_obj;
+}
+
+static VALUE
+imemo_fields_evacutate_to_complex(VALUE owner, VALUE source, shape_id_t shape_id, int extra_capa)
+{
+    return imemo_fields_complex_from_obj(owner, source, shape_id, false, extra_capa);
+}
+
+VALUE
+rb_obj_complex_fields_build(VALUE obj)
+{
+    return imemo_fields_complex_from_obj(obj, obj, ROOT_COMPLEX_SHAPE_ID, true, 0);
 }
 
 static VALUE
@@ -1823,7 +1824,7 @@ imemo_fields_set(VALUE owner, VALUE fields_obj, shape_id_t target_shape_id, ID f
             }
         }
         else {
-            fields_obj = imemo_fields_complex_from_obj(owner, original_fields_obj, target_shape_id);
+            fields_obj = imemo_fields_evacutate_to_complex(owner, original_fields_obj, target_shape_id, 1);
             current_shape_id = target_shape_id;
         }
 
@@ -1892,39 +1893,18 @@ generic_ivar_set(VALUE obj, ID id, VALUE val)
     return generic_field_set(obj, target_shape_id, id, val);
 }
 
-static int
-rb_obj_copy_ivs_to_hash_table_i(ID key, VALUE val, st_data_t arg)
-{
-    RUBY_ASSERT(!st_lookup((st_table *)arg, (st_data_t)key, NULL));
-
-    st_add_direct((st_table *)arg, (st_data_t)key, (st_data_t)val);
-    return ST_CONTINUE;
-}
-
-void
-rb_obj_copy_ivs_to_hash_table(VALUE obj, st_table *table)
-{
-    rb_ivar_foreach(obj, rb_obj_copy_ivs_to_hash_table_i, (st_data_t)table);
-}
-
-void
-rb_obj_copy_fields_to_hash_table(VALUE obj, st_table *table)
-{
-    rb_field_foreach(obj, rb_obj_copy_ivs_to_hash_table_i, (st_data_t)table, false);
-}
-
 static attr_index_t
 obj_field_set(VALUE obj, shape_id_t target_shape_id, ID field_name, VALUE val)
 {
+    // may be T_OBJECT or imemo_fields
+    VALUE fields_obj = ROBJECT_FIELDS_OBJ(obj);
     shape_id_t current_shape_id = RBASIC_SHAPE_ID(obj);
 
     if (UNLIKELY(rb_shape_complex_p(target_shape_id))) {
         if (UNLIKELY(!rb_shape_complex_p(current_shape_id))) {
-            current_shape_id = rb_evict_fields_to_hash(obj);
+            current_shape_id = rb_obj_convert_too_complex(obj, fields_obj, current_shape_id);
+            fields_obj = ROBJECT_FIELDS_OBJ(obj);
         }
-
-        // may be T_OBJECT or imemo_fields
-        VALUE fields_obj = ROBJECT_FIELDS_OBJ(obj);
 
         RUBY_ASSERT(rb_obj_shape_complex_p(obj));
         RUBY_ASSERT(rb_obj_shape_complex_p(fields_obj));
@@ -1946,9 +1926,6 @@ obj_field_set(VALUE obj, shape_id_t target_shape_id, ID field_name, VALUE val)
     }
     else {
         attr_index_t index = RSHAPE_INDEX(target_shape_id);
-
-        // may be T_OBJECT or imemo_fields
-        VALUE fields_obj = ROBJECT_FIELDS_OBJ(obj);
 
         if (index < RSHAPE_LEN(current_shape_id)) {
             // Replace existing value;
@@ -4591,7 +4568,7 @@ class_fields_ivar_set(VALUE klass, VALUE fields_obj, ID id, VALUE val, bool conc
     next_shape_id = generic_shape_ivar(fields_obj, id, &new_ivar);
 
     if (UNLIKELY(rb_shape_complex_p(next_shape_id))) {
-        fields_obj = imemo_fields_complex_from_obj(klass, fields_obj, next_shape_id);
+        fields_obj = imemo_fields_evacutate_to_complex(klass, fields_obj, next_shape_id, 1);
         goto complex;
     }
 

--- a/variable.c
+++ b/variable.c
@@ -1623,20 +1623,13 @@ rb_evict_fields_to_hash(VALUE obj)
     return new_shape_id;
 }
 
-void
-rb_evict_ivars_to_hash(VALUE obj)
+VALUE
+rb_obj_complex_fields_build(VALUE obj)
 {
-    RUBY_ASSERT(RB_TYPE_P(obj, T_OBJECT));
-    RUBY_ASSERT(!rb_obj_shape_complex_p(obj));
-
-    shape_id_t new_shape_id = rb_obj_shape_transition_complex(obj);
-    VALUE fields_obj = rb_imemo_fields_new_complex(obj, new_shape_id, rb_ivar_count(obj), false);
+    VALUE fields_obj = rb_imemo_fields_new_complex(obj, ROOT_COMPLEX_SHAPE_ID, rb_ivar_count(obj), false);
     st_table *table = rb_imemo_fields_complex_tbl(fields_obj);
     rb_obj_copy_ivs_to_hash_table(obj, table);
-    ROBJECT_SET_EXTENDED(obj, fields_obj);
-    RBASIC_SET_FULL_SHAPE_ID(obj, rb_shape_transition_extended(new_shape_id));
-
-    RUBY_ASSERT(rb_obj_shape_complex_p(obj));
+    return fields_obj;
 }
 
 static VALUE
@@ -2290,10 +2283,7 @@ rb_copy_generic_ivar(VALUE dest, VALUE obj)
         shape_id_t dest_shape_id = rb_shape_rebuild(initial_shape_id, src_shape_id);
 
         if (UNLIKELY(rb_shape_complex_p(dest_shape_id))) {
-            new_fields_obj = rb_imemo_fields_new_complex(dest, dest_shape_id, rb_ivar_count(obj), false);
-            st_table *table = rb_imemo_fields_complex_tbl(new_fields_obj);
-            rb_obj_copy_ivs_to_hash_table(obj, table);
-            rb_obj_replace_fields(dest, new_fields_obj);
+            rb_obj_replace_fields(dest, rb_obj_complex_fields_build(obj));
             return;
         }
 

--- a/variable.c
+++ b/variable.c
@@ -1606,49 +1606,35 @@ rb_attr_get(VALUE obj, ID id)
 void rb_obj_copy_fields_to_hash_table(VALUE obj, st_table *table);
 static VALUE imemo_fields_complex_from_obj(VALUE owner, VALUE source_fields_obj, shape_id_t shape_id);
 
-static shape_id_t
-obj_transition_complex(VALUE obj, st_table *table)
-{
-    RUBY_ASSERT(!rb_obj_shape_complex_p(obj));
-    RUBY_ASSERT(!RB_TYPE_P(obj, T_IMEMO));
-
-    shape_id_t shape_id = rb_obj_shape_transition_complex(obj);
-    VALUE fields_obj = rb_imemo_fields_new_complex_tbl(obj, shape_id, table, RB_OBJ_SHAREABLE_P(obj));
-
-    rb_obj_set_fields(obj, fields_obj, 0, 0);
-    RBASIC_SET_SHAPE_ID(obj, shape_id);
-
-    RUBY_ASSERT(FL_TEST_RAW(fields_obj, ROBJECT_HEAP));
-    RUBY_ASSERT(rb_obj_shape_complex_p(obj));
-    RUBY_ASSERT(rb_obj_shape_complex_p(fields_obj));
-
-    return shape_id;
-}
-
 // Copy all object fields, including ivars and internal object_id, etc
 static shape_id_t
 rb_evict_fields_to_hash(VALUE obj)
 {
+    RUBY_ASSERT(RB_TYPE_P(obj, T_OBJECT));
     RUBY_ASSERT(!rb_obj_shape_complex_p(obj));
 
-    st_table *table = st_init_numtable_with_size(RSHAPE_LEN(RBASIC_SHAPE_ID(obj)));
+    shape_id_t new_shape_id = rb_obj_shape_transition_complex(obj);
+    VALUE fields_obj = rb_imemo_fields_new_complex(obj, new_shape_id, RSHAPE_LEN(RBASIC_SHAPE_ID(obj)), false);
+    st_table *table = rb_imemo_fields_complex_tbl(fields_obj);
     rb_obj_copy_fields_to_hash_table(obj, table);
-    shape_id_t new_shape_id = obj_transition_complex(obj, table);
+    ROBJECT_SET_EXTENDED(obj, fields_obj);
+    RBASIC_SET_FULL_SHAPE_ID(obj, rb_shape_transition_extended(new_shape_id));
 
-    RUBY_ASSERT(rb_obj_shape_complex_p(obj));
     return new_shape_id;
 }
 
 void
 rb_evict_ivars_to_hash(VALUE obj)
 {
+    RUBY_ASSERT(RB_TYPE_P(obj, T_OBJECT));
     RUBY_ASSERT(!rb_obj_shape_complex_p(obj));
 
-    st_table *table = st_init_numtable_with_size(rb_ivar_count(obj));
-
-    // Evacuate all previous values from shape into id_table
+    shape_id_t new_shape_id = rb_obj_shape_transition_complex(obj);
+    VALUE fields_obj = rb_imemo_fields_new_complex(obj, new_shape_id, rb_ivar_count(obj), false);
+    st_table *table = rb_imemo_fields_complex_tbl(fields_obj);
     rb_obj_copy_ivs_to_hash_table(obj, table);
-    obj_transition_complex(obj, table);
+    ROBJECT_SET_EXTENDED(obj, fields_obj);
+    RBASIC_SET_FULL_SHAPE_ID(obj, rb_shape_transition_extended(new_shape_id));
 
     RUBY_ASSERT(rb_obj_shape_complex_p(obj));
 }
@@ -1781,23 +1767,6 @@ VALUE
 rb_attr_delete(VALUE obj, ID id)
 {
     return rb_ivar_delete(obj, id, Qnil);
-}
-
-void
-rb_obj_init_complex(VALUE obj, st_table *table)
-{
-    // This method is meant to be called on newly allocated object.
-    RUBY_ASSERT(rb_shape_canonical_p(RBASIC_SHAPE_ID(obj)));
-    RUBY_ASSERT(RSHAPE_LEN(RBASIC_SHAPE_ID(obj)) == 0);
-
-    if (rb_obj_shape_complex_p(obj)) {
-        shape_id_t shape_id = rb_obj_shape_transition_complex(obj);
-        VALUE fields_obj = rb_imemo_fields_new_complex_tbl(obj, shape_id, table, false);
-        ROBJECT_SET_EXTENDED(obj, fields_obj);
-    }
-    else {
-        obj_transition_complex(obj, table);
-    }
 }
 
 static int
@@ -2317,7 +2286,9 @@ rb_copy_generic_ivar(VALUE dest, VALUE obj)
         }
 
         if (rb_shape_complex_p(src_shape_id)) {
-            rb_shape_copy_complex_ivars(dest, obj, src_shape_id, rb_imemo_fields_complex_tbl(fields_obj));
+            VALUE clone = rb_imemo_fields_new_complex_empty(dest);
+            rb_shape_copy_complex_ivars(clone, fields_obj);
+            rb_obj_set_fields(dest, clone, 0, 0);
             return;
         }
 
@@ -2329,9 +2300,10 @@ rb_copy_generic_ivar(VALUE dest, VALUE obj)
 
             dest_shape_id = rb_shape_rebuild(initial_shape_id, src_shape_id);
             if (UNLIKELY(rb_shape_complex_p(dest_shape_id))) {
-                st_table *table = rb_st_init_numtable_with_size(src_num_ivs);
+                new_fields_obj = rb_imemo_fields_new_complex(dest, dest_shape_id, rb_ivar_count(obj), false);
+                st_table *table = rb_imemo_fields_complex_tbl(new_fields_obj);
                 rb_obj_copy_ivs_to_hash_table(obj, table);
-                rb_obj_init_complex(dest, table);
+                rb_obj_replace_fields(dest, new_fields_obj);
                 return;
             }
         }

--- a/variable.c
+++ b/variable.c
@@ -2185,7 +2185,7 @@ each_hash_iv(st_data_t id, st_data_t val, st_data_t data)
 {
     struct iv_itr_data * itr_data = (struct iv_itr_data *)data;
     rb_ivar_foreach_callback_func *callback = itr_data->func;
-    if (is_internal_id((ID)id)) {
+    if ((ID)id == rb_shape_tree.id_object_id) {
         return ST_CONTINUE;
     }
     return callback((ID)id, (VALUE)val, itr_data->arg);

--- a/variable.h
+++ b/variable.h
@@ -12,7 +12,6 @@
 
 #include "shape.h"
 
-void rb_copy_complex_ivars(VALUE dest, VALUE obj, shape_id_t src_shape_id, st_table *fields_table);
 VALUE rb_obj_fields(VALUE obj, ID field_name);
 
 static inline VALUE


### PR DESCRIPTION
Followup: https://github.com/ruby/ruby/pull/17631

Now that complex `RObject` always have an IMEMO/fields, we no longer need to have an external `st_table` to replicate the memory layout of `RObject`.