### PR TITLE
ZJIT: Re-enable RData setivar optimizations

### DIFF
--- a/zjit/src/cruby_methods.rs
+++ b/zjit/src/cruby_methods.rs
@@ -536,7 +536,7 @@ fn guard_string_coderange(fun: &mut hir::Function, block: hir::BlockId, args: &[
     let flags = fun.load_rbasic_flags(block, recv);
     let mask = fun.push_insn(block, hir::Insn::Const { val: hir::Const::CUInt64(RUBY_ENC_CODERANGE_MASK.into()) });
     let cr = fun.push_insn(block, hir::Insn::IntAnd { left: flags, right: mask });
-    let min_known = fun.push_insn(block, hir::Insn::Const { val: hir::Const::CInt64(RUBY_ENC_CODERANGE_7BIT.into()) });
+    let min_known = fun.push_insn(block, hir::Insn::Const { val: hir::Const::CUInt64(RUBY_ENC_CODERANGE_7BIT.into()) });
     Some(fun.push_insn(block, hir::Insn::GuardGreaterEq { left: cr, right: min_known, reason: Box::new(SideExitReason::GuardGreaterEq), state }))
 }
 

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -3269,7 +3269,7 @@ impl Function {
             Insn::FixnumAnd  { .. } => types::Fixnum,
             Insn::FixnumOr   { .. } => types::Fixnum,
             Insn::FixnumXor  { .. } => types::Fixnum,
-            Insn::IntAnd { .. } => types::CInt64,
+            Insn::IntAnd { left, .. } => self.type_of(*left).unspecialized(),
             Insn::IntOr { left, .. } => self.type_of(*left).unspecialized(),
             Insn::FixnumLShift { .. } => types::Fixnum,
             Insn::FixnumRShift { .. } => types::Fixnum,
@@ -5510,9 +5510,15 @@ impl Function {
             let shape_id_offset = unsafe { rb_shape_id_offset() };
 
             if !embedded {
-                let stripped_shape = ShapeId(spec.next_shape.0 & !SHAPE_ID_FL_PRIVATE_MASK);
-                let stripped_val = self.push_insn(block, Insn::Const { val: Const::CShape(stripped_shape) });
-                self.push_insn(block, Insn::StoreField { recv: ivar_storage, id: FieldName::shape_id, offset: shape_id_offset, val: stripped_val, num_bits: types::CShape.num_bits() });
+                // Transition the shape of the storage object but leave the
+                // SHAPE_ID_FL_PRIVATE_MASK bits unchanged.
+                debug_assert_eq!(types::CShape.num_bits(), 32);
+                let owner_next_shape_masked = self.push_insn(block, Insn::Const { val: Const::CUInt32(spec.next_shape.0 & !SHAPE_ID_FL_PRIVATE_MASK) });
+                let storage_current_shape = self.load_shape(block, ivar_storage);
+                let private_mask = self.push_insn(block, Insn::Const { val: Const::CUInt32(SHAPE_ID_FL_PRIVATE_MASK) });
+                let storage_current_shape_masked = self.push_insn(block, Insn::IntAnd { left: storage_current_shape, right: private_mask });
+                let storage_next_shape = self.push_insn(block, Insn::IntOr { left: storage_current_shape_masked, right: owner_next_shape_masked });
+                self.push_insn(block, Insn::StoreField { recv: ivar_storage, id: FieldName::shape_id, offset: shape_id_offset, val: storage_next_shape, num_bits: types::CShape.num_bits() });
             }
             self.push_insn(block, Insn::StoreField { recv: self_val, id: FieldName::shape_id, offset: shape_id_offset, val: shape_id, num_bits: types::CShape.num_bits() });
         }
@@ -6924,6 +6930,11 @@ impl Function {
                     self.assert_subtype(insn_id, right, types::CInt64)
                 } else if left_type.is_subtype(types::CUInt64) {
                     self.assert_subtype(insn_id, right, types::CUInt64)
+                } else if left_type.is_subtype(types::CShape) {
+                    debug_assert_eq!(types::CShape.num_bits(), 32);
+                    self.assert_subtype(insn_id, right, types::CUInt32)
+                } else if left_type.is_subtype(types::CUInt32) {
+                    self.assert_subtype(insn_id, right, types::CUInt32)
                 } else {
                     let all_ints = types::CInt64.union(types::CUInt64);
                     self.assert_subtype(insn_id, left, all_ints)?;

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5435,10 +5435,7 @@ impl Function {
         }
 
         match profiled_type.shape().layout() {
-            ShapeLayout::RObject => {
-                // OK
-            }
-            ShapeLayout::RData => {
+            ShapeLayout::RObject | ShapeLayout::RData => {
                 // OK
             }
             _ => {
@@ -5511,7 +5508,7 @@ impl Function {
 
             if !embedded {
                 // Transition the shape of the storage object but leave the
-                // SHAPE_ID_FL_PRIVATE_MASK bits unchanged.
+                // SHAPE_ID_FL_PRIVATE_MASK bits unchanged. See `RBASIC_SET_SHAPE_ID`.
                 debug_assert_eq!(types::CShape.num_bits(), 32);
                 let owner_next_shape_masked = self.push_insn(block, Insn::Const { val: Const::CUInt32(spec.next_shape.0 & !SHAPE_ID_FL_PRIVATE_MASK) });
                 let storage_current_shape = self.load_shape(block, ivar_storage);

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -7028,8 +7028,14 @@ impl Function {
             }
             Insn::GuardLess { left, right, .. }
             | Insn::GuardGreaterEq { left, right, .. } => {
-                self.assert_subtype(insn_id, left, types::CInt64)?;
-                self.assert_subtype(insn_id, right, types::CInt64)
+                // TODO: Expand this to other matching C integer sizes when we need them.
+                let left_type = self.type_of(left);
+                if left_type.is_subtype(types::CInt64) {
+                    self.assert_subtype(insn_id, right, types::CInt64)
+                } else {
+                    self.assert_subtype(insn_id, left, types::CUInt64)?;
+                    self.assert_subtype(insn_id, right, types::CUInt64)
+                }
             },
             Insn::StringGetbyte { string, index } => {
                 self.assert_subtype(insn_id, string, types::String)?;

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5439,8 +5439,7 @@ impl Function {
                 // OK
             }
             ShapeLayout::RData => {
-                // FIXME: we side exit for now as we're missing SHAPE_ID_FL_PRIVATE_MASK handling.
-                return Err(Counter::setivar_fallback_not_t_object);
+                // OK
             }
             _ => {
                 return Err(Counter::setivar_fallback_not_t_object);
@@ -5462,8 +5461,6 @@ impl Function {
             // Current shape does not contain this ivar; do a shape transition.
             let current_shape_id = profiled_type.shape();
             let class = profiled_type.class();
-            // We're only looking at T_OBJECT so ignore all of the imemo stuff.
-            assert!(profiled_type.flags().is_t_object());
             next_shape = ShapeId(unsafe { rb_shape_transition_add_ivar_no_warnings(current_shape_id.0, id, class) });
             // If the VM ran out of shapes, or this class generated too many leaf,
             // it may be de-optimized into OBJ_COMPLEX_SHAPE (hash-table).
@@ -5513,10 +5510,9 @@ impl Function {
             let shape_id_offset = unsafe { rb_shape_id_offset() };
 
             if !embedded {
-                // FIXME: We need to strip the SHAPE_ID_FL_PRIVATE_MASK from the shape for `ivar_storage`.
-                // see `RBASIC_SET_SHAPE_ID`.
-                // This path is currently dead code, see the FIXME in `prepare_optimized_setivar`
-                self.push_insn(block, Insn::StoreField { recv: ivar_storage, id: FieldName::shape_id, offset: shape_id_offset, val: shape_id, num_bits: types::CShape.num_bits() });
+                let stripped_shape = ShapeId(spec.next_shape.0 & !SHAPE_ID_FL_PRIVATE_MASK);
+                let stripped_val = self.push_insn(block, Insn::Const { val: Const::CShape(stripped_shape) });
+                self.push_insn(block, Insn::StoreField { recv: ivar_storage, id: FieldName::shape_id, offset: shape_id_offset, val: stripped_val, num_bits: types::CShape.num_bits() });
             }
             self.push_insn(block, Insn::StoreField { recv: self_val, id: FieldName::shape_id, offset: shape_id_offset, val: shape_id, num_bits: types::CShape.num_bits() });
         }

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -9781,6 +9781,83 @@ mod hir_opt_tests {
     }
 
     #[test]
+    fn test_optimize_setivar_on_t_data() {
+        // T_DATA uses fields_obj for instance variables.
+        eval("
+            class C < Thread
+              def test = @a = 2
+            end
+            obj = C.new { }
+            obj.join
+            obj.instance_variable_set(:@a, 1)
+            obj.test
+            TEST = C.instance_method(:test)
+        ");
+        assert_snapshot!(hir_string_proc("TEST"), @"
+        fn test@<compiled>:3:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          Jump bb3(v1)
+        bb2():
+          EntryPoint JIT(0)
+          v4:BasicObject = LoadArg :self@0
+          Jump bb3(v4)
+        bb3(v6:BasicObject):
+          v10:Fixnum[2] = Const Value(2)
+          PatchPoint SingleRactorMode
+          v14:HeapBasicObject = GuardType v6, HeapBasicObject
+          v15:CShape = LoadField v14, :shape_id@0x1000
+          v16:CShape[0x1001] = GuardBitEquals v15, CShape(0x1001) recompile
+          v17:BasicObject = LoadField v14, :as_heap@0x1002
+          StoreField v17, :@a@0x1002, v10
+          WriteBarrier v17, v10
+          CheckInterrupts
+          Return v10
+        ");
+    }
+
+    #[test]
+    fn test_optimize_setivar_on_t_data_with_transition() {
+        // T_DATA uses fields_obj for instance variables.
+        eval("
+            class C < Thread
+              def test = @b = 2
+            end
+            obj = C.new { }
+            obj.join
+            obj.test
+            TEST = C.instance_method(:test)
+        ");
+        assert_snapshot!(hir_string_proc("TEST"), @"
+        fn test@<compiled>:3:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          Jump bb3(v1)
+        bb2():
+          EntryPoint JIT(0)
+          v4:BasicObject = LoadArg :self@0
+          Jump bb3(v4)
+        bb3(v6:BasicObject):
+          v10:Fixnum[2] = Const Value(2)
+          PatchPoint SingleRactorMode
+          v14:HeapBasicObject = GuardType v6, HeapBasicObject
+          v15:CShape = LoadField v14, :shape_id@0x1000
+          v16:CShape[0x1001] = GuardBitEquals v15, CShape(0x1001) recompile
+          v17:BasicObject = LoadField v14, :as_heap@0x1002
+          StoreField v17, :@b@0x1002, v10
+          WriteBarrier v17, v10
+          v20:CShape[0x1003] = Const CShape(0x1003)
+          v21:CShape[0x1004] = Const CShape(0x1004)
+          StoreField v17, :shape_id@0x1000, v21
+          StoreField v14, :shape_id@0x1000, v20
+          CheckInterrupts
+          Return v10
+        ");
+    }
+
+    #[test]
     fn test_optimize_send_with_block() {
         eval(r#"
             def test = [1, 2, 3].map { |x| x * 2 }

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -9849,8 +9849,12 @@ mod hir_opt_tests {
           StoreField v17, :@b@0x1002, v10
           WriteBarrier v17, v10
           v20:CShape[0x1003] = Const CShape(0x1003)
-          v21:CShape[0x1004] = Const CShape(0x1004)
-          StoreField v17, :shape_id@0x1000, v21
+          v21:CUInt32[8] = Const CUInt32(8)
+          v22:CShape = LoadField v17, :shape_id@0x1000
+          v23:CUInt32[1677197312] = Const CUInt32(1677197312)
+          v24:CShape = IntAnd v22, v23
+          v25:CShape = IntOr v24, v21
+          StoreField v17, :shape_id@0x1000, v25
           StoreField v14, :shape_id@0x1000, v20
           CheckInterrupts
           Return v10

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -12571,9 +12571,9 @@ mod hir_opt_tests {
           v23:StringExact = GuardType v10, StringExact recompile
           v24:CUInt64 = LoadField v23, :RBASIC_FLAGS@0x1040
           v25:CUInt64[3145728] = Const CUInt64(3145728)
-          v26:CInt64 = IntAnd v24, v25
-          v27:CInt64[1048576] = Const CInt64(1048576)
-          v28:CInt64 = GuardGreaterEq v26, v27
+          v26:CUInt64 = IntAnd v24, v25
+          v27:CUInt64[1048576] = Const CUInt64(1048576)
+          v28:CUInt64 = GuardGreaterEq v26, v27
           v29:CInt64[1048576] = Const CInt64(1048576)
           v30:CBool = IsBitEqual v28, v29
           v31:BoolExact = BoxBool v30


### PR DESCRIPTION
On transition, this requires loading and masking the storage's shape.