### PR TITLE
gc.c: remember T_OBJECT after re-embedding

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -384,6 +384,7 @@ rb_gc_obj_changed_slot_size(VALUE obj, size_t slot_size)
         MEMCPY(embedded_fields, extended_fields, VALUE, RSHAPE_LEN(RBASIC_SHAPE_ID(obj)));
         FL_UNSET_RAW(obj, ROBJECT_HEAP);
         shape_id = rb_shape_transition_robject(shape_id);
+        rb_gc_writebarrier_remember(obj);
     }
 
     RBASIC_SET_FULL_SHAPE_ID(obj, shape_id);


### PR DESCRIPTION
Followup: https://github.com/ruby/ruby/pull/17631

Based on the logic from https://github.com/ruby/ruby/commit/7c874e9f17b58a728788b4ebfc131a0efb18cde1, but cleaner.

@shugo does this solve the issue in your branch?