### PR TITLE
gc: remember re-embedded objects when compaction changes slot size

### DIFF
--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -7610,6 +7610,14 @@ gc_move(rb_objspace_t *objspace, VALUE src, VALUE dest, struct heap_page *src_pa
     }
 
     RVALUE_AGE_SET(dest, age);
+
+    /* A re-embedded object (rb_gc_obj_changed_slot_size) references its
+     * former fields_obj's contents directly; the write-barrier history
+     * lived on the discarded fields_obj, so remember the object. */
+    if (src_slot_size != slot_size && age >= RVALUE_OLD_AGE && !remembered) {
+        rgengc_remember(objspace, dest);
+    }
+
     /* Assign forwarding address */
     RMOVED(src)->flags = T_MOVED;
     RMOVED(src)->dummy = Qundef;


### PR DESCRIPTION
When gc_move relocates an object to a different slot size,
rb_gc_obj_changed_slot_size may re-embed it: the fields move from the
fields_obj into the object itself and the object references them
directly.  The write-barrier history for those (possibly young) values
lived on the discarded fields_obj, so an old unremembered object then
violates the O->Y invariant, which gc_verify_internal_consistency
reports as a WB miss.  Remember the object on such moves.

Remembering inside rb_gc_obj_changed_slot_size (as #17866 tried) does
not work for this path: gc_move calls it before the destination's age
bits are restored, so RVALUE_OLD_P is false there, and gc_move
overwrites the destination's remembered bits afterwards anyway.
