### PR TITLE
[ruby/prism] Fix assume warning

### DIFF
--- a/prism/compiler/assume.h
+++ b/prism/compiler/assume.h
@@ -10,12 +10,12 @@
  * range analysis so it can prune impossible paths. Use it to communicate an
  * invariant the caller guarantees but that the compiler cannot otherwise prove.
  */
-#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L /* C23 or later */ && !defined(__APPLE__)
-    #define PRISM_ASSUME(expr_) [[assume(expr_)]]
-#elif defined(__clang__)
+#if defined(__clang__)
     #define PRISM_ASSUME(expr_) __builtin_assume(expr_)
 #elif defined(_MSC_VER)
     #define PRISM_ASSUME(expr_) __assume(expr_)
+#elif defined(__GNUC__) && (__GNUC__ >= 13)
+    #define PRISM_ASSUME(expr_) __attribute__((assume(expr_)))
 #elif defined(__GNUC__)
     #define PRISM_ASSUME(expr_) ((expr_) ? (void) 0 : __builtin_unreachable())
 #else


### PR DESCRIPTION
That attribute is C++23, not C23

https://github.com/ruby/prism/commit/5e4f45712e