### PR TITLE
dtoa.c: load the 5-powers cache pointers atomically

### DIFF
--- a/missing/dtoa.c
+++ b/missing/dtoa.c
@@ -511,6 +511,9 @@ extern double rnd_prod(double, double), rnd_quot(double, double);
 #ifndef ATOMIC_PTR_CAS
 #define ATOMIC_PTR_CAS(var, old, new) ((var) = (new), (void *)(old))
 #endif
+#ifndef RUBY_ATOMIC_PTR_LOAD
+#define RUBY_ATOMIC_PTR_LOAD(var) (var)
+#endif
 #ifndef LIKELY
 #define LIKELY(x) (x)
 #endif
@@ -863,10 +866,10 @@ pow5mult(Bigint *b, int k)
     }
 
 #define b_cache(var, addr, new_expr) \
-    if ((var = addr) != 0) {} else { \
+    if ((var = RUBY_ATOMIC_PTR_LOAD(addr)) != 0) {} else { \
         Bigint *tmp = 0; \
         ACQUIRE_DTOA_LOCK(1); \
-        if (!(var = addr) && (var = (new_expr)) != 0) { \
+        if (!(var = RUBY_ATOMIC_PTR_LOAD(addr)) && (var = (new_expr)) != 0) { \
             var->next = 0; \
             tmp = ATOMIC_PTR_CAS(addr, NULL, var); \
         } \


### PR DESCRIPTION
pow5mult's b_cache publishes new cache nodes with ATOMIC_PTR_CAS (release), but both readers -- the fast-path check and the recheck before allocating -- were plain loads racing with that CAS: a data race in the C11 sense, and what TSan reports as `race:pow5mult` under parallel Ractor float<->string conversion. Harmless on current targets (the reader dereferences through the loaded pointer, so address dependency orders the accesses), but easy to make formally correct: read the cache head/next through RUBY_ATOMIC_PTR_LOAD. The lock-free CAS scheme is unchanged.