### PR TITLE
gc.c: re-embed T_OBJECT during `gc_compact_finish`

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -377,15 +377,6 @@ void
 rb_gc_obj_changed_slot_size(VALUE obj, size_t slot_size)
 {
     shape_id_t shape_id = rb_obj_shape_transition_capacity(obj, rb_shape_capacity_for_slot_size(slot_size));
-
-    if (RB_TYPE_P(obj, T_OBJECT) && FL_TEST_RAW(obj, ROBJECT_HEAP) && !rb_obj_shape_complex_p(obj)) {
-        VALUE *embedded_fields = ROBJECT_EMBEDDED_FIELDS(obj);
-        VALUE *extended_fields = ROBJECT_FIELDS(obj);
-        MEMCPY(embedded_fields, extended_fields, VALUE, RSHAPE_LEN(RBASIC_SHAPE_ID(obj)));
-        FL_UNSET_RAW(obj, ROBJECT_HEAP);
-        shape_id = rb_shape_transition_robject(shape_id);
-    }
-
     RBASIC_SET_FULL_SHAPE_ID(obj, shape_id);
 }
 
@@ -3668,14 +3659,28 @@ gc_ref_update_array(void *objspace, VALUE v)
 static void
 gc_ref_update_object(void *objspace, VALUE v)
 {
+    RUBY_ASSERT(rb_gc_obj_slot_size(v) == rb_obj_shape_slot_size(v));
+    shape_id_t shape_id = RBASIC_SHAPE_ID(v);
+
     if (FL_TEST_RAW(v, ROBJECT_HEAP)) {
         UPDATE_IF_MOVED(objspace, ROBJECT(v)->as.extended);
-    }
-    else {
-        VALUE *ptr = ROBJECT_FIELDS(v);
-        for (uint32_t i = 0; i < ROBJECT_FIELDS_COUNT(v); i++) {
-            UPDATE_IF_MOVED(objspace, ptr[i]);
+
+        if (!rb_shape_complex_p(shape_id) && rb_shape_embedded_capacity(shape_id) >= RSHAPE_LEN(shape_id)) {
+            VALUE *embedded_fields = ROBJECT_EMBEDDED_FIELDS(v);
+            VALUE *extended_fields = ROBJECT_FIELDS(v);
+            MEMCPY(embedded_fields, extended_fields, VALUE, RSHAPE_LEN(shape_id));
+            FL_UNSET_RAW(v, ROBJECT_HEAP);
+            RBASIC_SET_FULL_SHAPE_ID(v, rb_shape_transition_robject(shape_id));
+            rb_gc_writebarrier_remember(v);
         }
+        else {
+            return;
+        }
+    }
+
+    VALUE *ptr = ROBJECT_FIELDS(v);
+    for (uint32_t i = 0; i < ROBJECT_FIELDS_COUNT(v); i++) {
+        UPDATE_IF_MOVED(objspace, ptr[i]);
     }
 }
 

--- a/test/ruby/test_gc_compact.rb
+++ b/test/ruby/test_gc_compact.rb
@@ -485,4 +485,24 @@ class TestGCCompact < Test::Unit::TestCase
       assert_equal("hello", obj.instance_variable_get(:@str))
     RUBY
   end
+
+  def test_object_reembedding
+    assert_separately([], <<~'RUBY')
+      GC.auto_compact = true
+
+      objs = []
+      30.times.map { Class.new }.map do |k|
+        50.times.each do
+          obj = k.new
+          rand(0..30).times do |i|
+            obj.instance_variable_set(:"@v#{i}", i)
+          end
+          objs << obj
+        end
+      end
+
+      GC.verify_compaction_references(expand_heap: true, toward: :empty)
+      assert :ok
+    RUBY
+  end
 end


### PR DESCRIPTION
Doing it in `rb_gc_obj_changed_slot_size` is wrong as the object could still be moved back because of `invalidate_moved_plane`.