### PR TITLE
Relax vm_cc_cme/vm_cc_call assertions under multi-ractor

### DIFF
--- a/vm_callinfo.h
+++ b/vm_callinfo.h
@@ -443,7 +443,9 @@ static inline const struct rb_callable_method_entry_struct *
 vm_cc_cme(const struct rb_callcache *cc)
 {
     VM_ASSERT(IMEMO_TYPE_P(cc, imemo_callcache));
-    VM_ASSERT(cc->klass != Qundef || !vm_cc_markable(cc) || vm_cc_invalid_super(cc));
+    // rb_multi_ractor_p(): a refinement cc may be invalidated by another ractor
+    // mid-call (see vm_cc_invalidate() above).
+    VM_ASSERT(cc->klass != Qundef || !vm_cc_markable(cc) || vm_cc_invalid_super(cc) || rb_multi_ractor_p());
     VM_ASSERT(cc_check_class(cc->klass));
     VM_ASSERT(cc->call_ == NULL   || // not initialized yet
               !vm_cc_markable(cc) ||
@@ -458,7 +460,8 @@ vm_cc_call(const struct rb_callcache *cc)
 {
     VM_ASSERT(IMEMO_TYPE_P(cc, imemo_callcache));
     VM_ASSERT(cc->call_ != NULL);
-    VM_ASSERT(cc->klass != Qundef || !vm_cc_markable(cc) || vm_cc_invalid_super(cc));
+    // rb_multi_ractor_p(): see vm_cc_cme().
+    VM_ASSERT(cc->klass != Qundef || !vm_cc_markable(cc) || vm_cc_invalid_super(cc) || rb_multi_ractor_p());
     VM_ASSERT(cc_check_class(cc->klass));
     return cc->call_;
 }


### PR DESCRIPTION
vm_cc_cme() and vm_cc_call() assert that a markable, non-invalid_super callcache is valid (cc->klass \!= Qundef) when its cme/handler is read:

    VM_ASSERT(cc->klass \!= Qundef || \!vm_cc_markable(cc) || vm_cc_invalid_super(cc));

This trips (abort under RUBY_DEBUG) when several ractors use refinements concurrently. A refinement cc is invalidated VM-wide by rb_clear_all_refinement_method_cache() (under RB_VM_LOCK, setting cc->klass = Qundef) whenever any ractor clears refinement caches. That can race with another ractor that already fetched the same cc for an in-flight call and is about to read its cme in vm_call_method(), firing the assertion.

This is a debug-only invariant violation, not a correctness or memory-safety issue:

- vm_cc_invalidate() only clears klass; cc->cme_ is left intact.
- A refinement cc's cme is reachable only through the cc and is marked only while the cc is valid (imemo.c), but it can be reclaimed only by a global, stop-the-world GC. That cannot interleave within a ractor's synchronous send (method lookup -> vm_cc_cme -> frame setup), so the mid-call read never observes a freed cme.
- The invalidated cc is not reused for dispatch: the call site re-checks vm_cc_valid() and performs a fresh lookup on the next call.

Guard both assertions with rb_multi_ractor_p(), mirroring the existing workaround in vm_cc_invalidate() (same file). NDEBUG builds are unaffected.