### PR TITLE
ZJIT: Optimize setivar on extended RObjects

### DIFF
--- a/zjit/src/cruby.rs
+++ b/zjit/src/cruby.rs
@@ -265,7 +265,7 @@ pub struct ShapeId(pub u32);
 pub enum ShapeLayout {
     RObject,
     RClass,
-    RData,
+    Extended,
     Other,
 }
 
@@ -288,7 +288,7 @@ impl ShapeId {
         match self.0 & SHAPE_ID_LAYOUT_MASK {
             SHAPE_ID_LAYOUT_ROBJECT => ShapeLayout::RObject,
             SHAPE_ID_LAYOUT_RCLASS => ShapeLayout::RClass,
-            SHAPE_ID_LAYOUT_EXTENDED => ShapeLayout::RData,
+            SHAPE_ID_LAYOUT_EXTENDED => ShapeLayout::Extended,
             SHAPE_ID_LAYOUT_OTHER => ShapeLayout::Other,
             layout => unreachable!("unknown shape layout bits: {layout:#x}"),
         }

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5460,18 +5460,11 @@ impl Function {
             return Err(Counter::setivar_fallback_immediate);
         }
 
-        match profiled_type.shape().layout() {
-            ShapeLayout::RObject => {
-                // OK
-            }
-            ShapeLayout::Extended => {
-                // FIXME: we side exit for now as we're missing SHAPE_ID_FL_PRIVATE_MASK handling.
-                return Err(Counter::setivar_fallback_not_t_object);
-            }
-            _ => {
-                return Err(Counter::setivar_fallback_not_t_object);
-            }
-        }
+        let extended_robject = match profiled_type.shape().layout() {
+            ShapeLayout::RObject => false,
+            ShapeLayout::Extended if profiled_type.flags().is_t_object() => true,
+            _ => return Err(Counter::setivar_fallback_not_t_object),
+        };
 
         assert!(profiled_type.shape().is_valid());
         if profiled_type.shape().is_frozen() {
@@ -5485,6 +5478,13 @@ impl Function {
         let mut ivar_index: attr_index_t = 0;
         let mut next_shape = profiled_type.shape();
         if !unsafe { rb_shape_get_iv_index(profiled_type.shape().0, id, &mut ivar_index) } {
+            // Updating the fields object's shape requires preserving its private layout and
+            // capacity bits, which can differ from the owning RObject's. Existing ivars do not
+            // change either shape, so they can still use the fast path.
+            if extended_robject {
+                return Err(Counter::setivar_fallback_shape_transition);
+            }
+
             // Current shape does not contain this ivar; do a shape transition.
             let current_shape_id = profiled_type.shape();
             let class = profiled_type.class();

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5397,7 +5397,7 @@ impl Function {
         let layout = recv_type.shape().layout();
 
         match layout {
-            ShapeLayout::RClass | ShapeLayout::RData => {
+            ShapeLayout::RClass | ShapeLayout::Extended => {
                 let offset = if layout == ShapeLayout::RClass {
                     RCLASS_OFFSET_PRIME_FIELDS_OBJ
                 } else {
@@ -5464,7 +5464,7 @@ impl Function {
             ShapeLayout::RObject => {
                 // OK
             }
-            ShapeLayout::RData => {
+            ShapeLayout::Extended => {
                 // FIXME: we side exit for now as we're missing SHAPE_ID_FL_PRIVATE_MASK handling.
                 return Err(Counter::setivar_fallback_not_t_object);
             }
@@ -5522,7 +5522,7 @@ impl Function {
             ShapeLayout::RObject => { // AKA embedded
                 (self_val, true)
             },
-            ShapeLayout::RData => { // AKA extended
+            ShapeLayout::Extended => {
                 let fields = self.load_field(block, self_val, FieldName::as_heap, ROBJECT_OFFSET_AS_HEAP_FIELDS, types::BasicObject);
                 (fields, false)
             },

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -6704,6 +6704,49 @@ mod hir_opt_tests {
     }
 
     #[test]
+    fn test_specialize_monomorphic_setivar_on_extended_robject() {
+        let obj = eval(r#"
+            class ExtendedSetIvar
+              def test(value)
+                @v0 = value
+              end
+            end
+
+            OBJ = ExtendedSetIvar.new
+            10.times { |i| OBJ.instance_variable_set(:"@v#{i}", i) }
+            OBJ.test(10)
+            TEST = ExtendedSetIvar.instance_method(:test)
+            OBJ
+        "#);
+        assert!(!obj.embedded_p());
+
+        assert_snapshot!(hir_string_proc("TEST"), @"
+        fn test@<compiled>:4:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          v2:CPtr = LoadSP
+          v3:BasicObject = LoadField v2, :value@0x1000
+          Jump bb3(v1, v3)
+        bb2():
+          EntryPoint JIT(0)
+          v6:BasicObject = LoadArg :self@0
+          v7:BasicObject = LoadArg :value@1
+          Jump bb3(v6, v7)
+        bb3(v9:BasicObject, v10:BasicObject):
+          PatchPoint SingleRactorMode
+          v17:HeapBasicObject = GuardType v9, HeapBasicObject
+          v18:CShape = LoadField v17, :shape_id@0x1001
+          v19:CShape[0x1002] = GuardBitEquals v18, CShape(0x1002) recompile
+          v20:BasicObject = LoadField v17, :as_heap@0x1003
+          StoreField v20, :@v0@0x1003, v10
+          WriteBarrier v20, v10
+          CheckInterrupts
+          Return v10
+        ");
+    }
+
+    #[test]
     fn test_specialize_monomorphic_setivar_with_shape_transition() {
         eval("
             def test = @foo = 5


### PR DESCRIPTION
* Rename `ShapeLayout::RData` to `ShapeLayout::Extended`, following the rename from `SHAPE_ID_LAYOUT_RDATA` to `SHAPE_ID_LAYOUT_EXTENDED` in https://github.com/ruby/ruby/pull/17631
* Change `prepare_optimized_setivar` to return `Ok` for the extended RObject case with an existing ivar, which `emit_optimized_setivar` can already handle.
    * When it's not an existing ivar, it still generates a fallback as before.

## Benchmark

This PR fixes a regression in optcarrot https://github.com/ruby/ruby/pull/17631#issuecomment-4971851016.

```
before: ruby 4.1.0dev (2026-07-14T20:59:18Z master 243e640982) +ZJIT +PRISM [x86_64-linux]
after: ruby 4.1.0dev (2026-07-14T21:43:34Z zjit-fix-ivar ffa7169c83) +ZJIT +PRISM [x86_64-linux]

---------  -------------  -------------  -------------  ------------
bench        before (ms)     after (ms)  after 1st itr  before/after
optcarrot  1384.4 ± 4.0%  1064.3 ± 3.8%          1.321         1.301
---------  -------------  -------------  -------------  ------------
```