### PR TITLE
ZJIT: Reprofile whole ISEQ before recompilation

### DIFF
--- a/zjit/bindgen/src/main.rs
+++ b/zjit/bindgen/src/main.rs
@@ -110,6 +110,7 @@ fn main() {
         .allowlist_function("rb_funcallv")
         .allowlist_function("rb_protect")
         .allowlist_function("rb_zjit_profile_disable")
+        .allowlist_function("rb_zjit_profile_enable")
         .allowlist_function("rb_zjit_insn_to_bare_insn")
         .allowlist_function("rb_zjit_hash_new_size")
         .allowlist_function("rb_zjit_class_allocate_instance_fastpath")

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -3339,8 +3339,15 @@ fn gen_stack_overflow_check(jit: &mut JITState, asm: &mut Assembler, function: &
 
 /// Convert ISEQ into High-level IR
 fn compile_iseq(iseq: IseqPtr) -> Result<Function, CompileError> {
-    // Convert ZJIT instructions back to bare instructions
-    unsafe { crate::cruby::rb_zjit_profile_disable(iseq) };
+    let payload = get_or_create_iseq_payload(iseq);
+    let final_version = payload.versions.len() + 1 >= max_iseq_versions();
+
+    // Lazy compilation can bypass the interpreter profiling threshold. Make
+    // sure the first non-final version still has zjit_* instructions for later
+    // exits. Later versions keep those instructions without re-enabling them.
+    if payload.versions.is_empty() && !final_version {
+        unsafe { crate::cruby::rb_zjit_profile_enable(iseq) };
+    }
 
     // Reject ISEQs with very large temp stacks.
     // We cannot encode too large offsets to access locals in arm64.
@@ -3364,6 +3371,17 @@ fn compile_iseq(iseq: IseqPtr) -> Result<Function, CompileError> {
         trace_compile_phase("optimize", || function.optimize());
     }
     function.dump_hir();
+
+    // Keep zjit_* instructions profiling through every version that can be
+    // recompiled. The final version cannot use another profile, so remove the
+    // interpreter profiling overhead then. This applies only to the compiled
+    // root; an inlined ISEQ can also belong to another non-final compiled owner.
+    // Do this after building HIR because a recursive inline can re-enable
+    // profiling on the same ISEQ.
+    if final_version {
+        unsafe { crate::cruby::rb_zjit_profile_disable(iseq) };
+    }
+
     Ok(function)
 }
 
@@ -3437,8 +3455,8 @@ macro_rules! c_callable {
 pub(crate) use c_callable;
 
 c_callable! {
-    /// Called from JIT side-exit code to profile operands and trigger recompilation.
-    /// Once enough profiles are gathered, invalidates the compiled unit for recompilation.
+    /// Called from a recompile side exit to invalidate the compiled unit once
+    /// its interpreter profiling window has completed.
     ///
     /// `compiled_iseq_raw` is the ISEQ that was actually compiled. For an exit out
     /// of inlined code, the inliner folds the callee's body into the outer ISEQ, so
@@ -3467,12 +3485,9 @@ c_callable! {
                 crate::profile::profile_recompile_insn(ec)
             });
 
-            // Once we have enough profiles, invalidate the compiled unit so it
-            // recompiles and reads the freshly recorded profile. We invalidate
-            // `compiled_iseq` rather than `frame_iseq` because an inlined callee has no
-            // compiled code of its own; the outer function it was folded into is what
-            // actually got compiled.
             if should_recompile {
+                // An inlined callee has no compiled version of its own, so invalidate
+                // the outer ISEQ that contains the failing guard.
                 let payload = get_or_create_iseq_payload(compiled_iseq);
                 if let Some(version) = payload.versions.last_mut() {
                     let cb = ZJITState::get_code_block();

--- a/zjit/src/codegen_tests.rs
+++ b/zjit/src/codegen_tests.rs
@@ -6,7 +6,7 @@ use crate::backend::lir::Assembler;
 use crate::codegen::max_iseq_versions;
 use crate::cruby::*;
 use crate::hir::{Insn, iseq_to_hir};
-use crate::options::{get_option, rb_zjit_prepare_options, set_call_threshold, set_inline_threshold};
+use crate::options::{get_option, rb_zjit_prepare_options, set_call_threshold, set_inline_threshold, set_num_profiles};
 use crate::payload::IseqVersion;
 use crate::hir::tests::hir_build_tests::assert_contains_opcode;
 use crate::payload::*;
@@ -120,6 +120,29 @@ fn test_putobject() {
         test
         test
     "), @"1");
+}
+
+#[test]
+fn test_recompile_exit_waits_for_interpreter_profiles() {
+    set_call_threshold(2);
+    set_num_profiles(2);
+    eval("
+        def recompile_profile_window(a, b) = a + b
+        recompile_profile_window(1, 2)
+        recompile_profile_window(1, 2)
+    ");
+
+    let iseq = get_method_iseq("self", "recompile_profile_window");
+    assert_eq!(get_or_create_iseq_payload(iseq).versions.len(), 1);
+
+    eval("recompile_profile_window(1.5, 2.5)");
+    eval("recompile_profile_window(1.5, 2.5)");
+    assert_eq!(get_or_create_iseq_payload(iseq).versions.len(), 1);
+
+    eval("recompile_profile_window(1.5, 2.5)");
+    let payload = get_or_create_iseq_payload(iseq);
+    assert_eq!(payload.versions.len(), 1);
+    assert!(unsafe { payload.versions.last().unwrap().as_ref() }.is_invalidated());
 }
 
 #[test]

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -2235,6 +2235,7 @@ unsafe extern "C" {
     pub fn rb_iseqw_to_iseq(iseqw: VALUE) -> *const rb_iseq_t;
     pub fn rb_iseq_label(iseq: *const rb_iseq_t) -> VALUE;
     pub fn rb_iseq_defined_string(type_: defined_type) -> VALUE;
+    pub fn rb_zjit_profile_enable(iseq: *const rb_iseq_t);
     pub fn rb_zjit_hash_new_size() -> usize;
     pub fn rb_zjit_class_allocate_instance_fastpath(
         klass: VALUE,

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -7479,9 +7479,9 @@ impl FrameState {
         args
     }
 
-    /// Get the opcode for the current instruction
+    /// Get the bare opcode for the current instruction.
     pub fn get_opcode(&self) -> i32 {
-        unsafe { rb_iseq_opcode_at_pc(self.iseq, self.pc) }
+        unsafe { rb_zjit_insn_to_bare_insn(rb_iseq_opcode_at_pc(self.iseq, self.pc)) }
     }
 
     pub fn print<'a>(&'a self, ptr_map: &'a PtrPrintMap) -> FrameStatePrinter<'a> {
@@ -7793,6 +7793,15 @@ fn add_iseq_to_hir(
     iseq: *const rb_iseq_t,
     mode: AddIseqMode,
 ) -> Result<AddIseqResult, ParseError> {
+    // An inlined ISEQ may not have run in the interpreter enough to install
+    // profiling instructions of its own. Its materialized frame needs them so
+    // a recompile exit can profile the rest of the callee normally. The callee
+    // is shared state, so one outer ISEQ reaching its final version cannot
+    // disable profiling needed by a different non-final outer ISEQ.
+    if matches!(mode, AddIseqMode::Inlined { .. }) {
+        unsafe { rb_zjit_profile_enable(iseq) };
+    }
+
     let payload = get_or_create_iseq_payload(iseq);
     let mut profiles = ProfileOracle::new();
 

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -5602,11 +5602,15 @@ mod hir_opt_tests {
           v36:NilClass = Const Value(nil)
           Jump bb8(v36, v13)
         bb8(v26:BasicObject, v27:BasicObject):
-          v39:BasicObject = Send v24, &block, :then, v26 # SendFallbackReason: Send: block argument is not nil
+          v56:NilClass = GuardBitEquals v26, Value(nil) recompile
+          PatchPoint MethodRedefined(Integer@0x1008, then@0x1010, cme:0x1018)
+          PushInlineFrame v24 (0x1040)
+          v76:BasicObject = InvokeBuiltin <inline_expr>, v24
           CheckInterrupts
-          Return v39
+          PopInlineFrame
+          Return v76
         bb4(v44:BasicObject, v45:Falsy, v46:BasicObject):
-          v50:StaticSymbol[:skip] = Const Value(VALUE(0x1008))
+          v50:StaticSymbol[:skip] = Const Value(VALUE(0x1048))
           CheckInterrupts
           Return v50
         ");
@@ -9175,12 +9179,17 @@ mod hir_opt_tests {
           Jump bb3(v6, v7)
         bb3(v9:HeapBasicObject, v10:BasicObject):
           v17:Fixnum[5] = Const Value(5)
+          v21:CBool = HasType v10, ObjectSubclass[class_exact:C]
+          CondBranch v21, bb5(), bb6()
+        bb5():
+          v24:ObjectSubclass[class_exact:C] = RefineType v10, ObjectSubclass[class_exact:C]
           PatchPoint MethodRedefined(C@0x1008, foo=@0x1010, cme:0x1018)
-          v28:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C] recompile
-          v30:CShape = LoadField v28, :shape_id@0x1040
-          v31:CShape[0x1041] = GuardBitEquals v30, CShape(0x1041)
-          StoreField v28, :@foo@0x1042, v17
-          WriteBarrier v28, v17
+          SetIvar v24, :@foo, v17
+          Jump bb4(v17)
+        bb6():
+          v27:BasicObject = Send v10, :foo=, v17 # SendFallbackReason: SendWithoutBlock: polymorphic fallback
+          Jump bb4(v27)
+        bb4(v20:BasicObject):
           CheckInterrupts
           Return v17
         ");
@@ -18809,27 +18818,25 @@ mod hir_opt_tests {
         bb4():
           PatchPoint NoEPEscape(f)
           v44:Fixnum[1] = Const Value(1)
-          v48:CBool = HasType v12, Flonum
+          v48:CBool = HasType v12, Fixnum
           CondBranch v48, bb10(), bb11()
         bb10():
-          v51:Flonum = RefineType v12, Flonum
-          PatchPoint MethodRedefined(Float@0x1008, +@0x1010, cme:0x1018)
-          v86:Float = FloatAdd v51, v44
+          v51:Fixnum = RefineType v12, Fixnum
+          PatchPoint MethodRedefined(Integer@0x1008, +@0x1010, cme:0x1018)
+          v86:Fixnum = FixnumAdd v51, v44
           Jump bb9(v86)
         bb11():
-          v54:CBool = HasType v12, Fixnum
+          v54:CBool = HasType v12, Flonum
           CondBranch v54, bb12(), bb13()
         bb12():
-          v57:Fixnum = RefineType v12, Fixnum
-          PatchPoint MethodRedefined(Integer@0x1040, +@0x1010, cme:0x1048)
-          v89:Fixnum = FixnumAdd v57, v44
+          v57:Flonum = RefineType v12, Flonum
+          PatchPoint MethodRedefined(Float@0x1040, +@0x1010, cme:0x1048)
+          v89:Float = FloatAdd v57, v44
           Jump bb9(v89)
         bb13():
-          PatchPoint MethodRedefined(Float@0x1008, +@0x1010, cme:0x1018)
-          v92:Flonum = GuardType v12, Flonum recompile
-          v93:Float = FloatAdd v92, v44
-          Jump bb9(v93)
-        bb9(v47:Float|Fixnum):
+          v60:BasicObject = Send v12, :+, v44 # SendFallbackReason: SendWithoutBlock: polymorphic fallback
+          Jump bb9(v60)
+        bb9(v47:BasicObject):
           PatchPoint SingleRactorMode
           v69:CShape = LoadField v11, :shape_id@0x1001
           v70:CShape[0x1002] = Const CShape(0x1002)

--- a/zjit/src/options.rs
+++ b/zjit/src/options.rs
@@ -647,6 +647,14 @@ pub fn set_inline_threshold(inline_threshold: InlineThreshold) {
     unsafe { OPTIONS.as_mut().unwrap().inline_threshold = inline_threshold; }
 }
 
+/// Update --zjit-num-profiles for testing
+#[cfg(test)]
+pub fn set_num_profiles(num_profiles: NumProfiles) {
+    rb_zjit_prepare_options();
+    unsafe { OPTIONS.as_mut().unwrap().num_profiles = num_profiles; }
+    update_profile_threshold();
+}
+
 /// Enable --zjit-stats for testing
 #[cfg(test)]
 pub fn enable_zjit_stats() {

--- a/zjit/src/profile.rs
+++ b/zjit/src/profile.rs
@@ -112,46 +112,47 @@ fn profile_insn_sample(
 fn profile_insn(bare_opcode: ruby_vminsn_type, ec: EcPtr) {
     let profiler = &mut Profiler::new(ec);
     let profile = &mut get_or_create_iseq_payload(profiler.iseq).profile;
-    let _ = profile_insn_sample(bare_opcode, profiler, profile);
 
-    // Once we profile the instruction enough times, we stop profiling it.
+    if profile.entry_mut(profiler.insn_idx).profiles_remaining == 0 {
+        return;
+    }
+
+    let _ = profile_insn_sample(bare_opcode, profiler, profile);
     let entry = profile.entry_mut(profiler.insn_idx);
     entry.profiles_remaining = entry.profiles_remaining.saturating_sub(1);
-    if entry.profiles_remaining == 0 {
-        unsafe { rb_zjit_iseq_insn_set(profiler.iseq, profiler.insn_idx as u32, bare_opcode); }
-    }
 }
 
-/// Profile the instruction at the current CFP for a recompile side exit.
+/// Start or observe a whole-ISEQ interpreter profiling window after a
+/// recompile exit. Return true once the instruction at the current control
+/// frame has collected enough samples to compile the next version.
 pub fn profile_recompile_insn(ec: EcPtr) -> bool {
-    let profiler = &mut Profiler::new(ec);
-    let pc = unsafe { get_cfp_pc(profiler.cfp) };
-    let bare_opcode = unsafe {
-        rb_zjit_insn_to_bare_insn(rb_iseq_opcode_at_pc(profiler.iseq, pc))
-    } as ruby_vminsn_type;
+    let profiler = &Profiler::new(ec);
     let profile = &mut get_or_create_iseq_payload(profiler.iseq).profile;
 
-    let is_send = matches!(bare_opcode, YARVINSN_send | YARVINSN_opt_send_without_block);
-    // For now, send recompile exits only fill in missing profiles. Once the send site
-    // has finished profiling, don't recompile it on later exits.
-    if is_send && profile.done_profiling_at(profiler.insn_idx) {
-        return false;
-    }
-    // For now, non-send recompile exits reset the profiling counter before requesting recompilation
-    // so that we can collect enough samples.
-    if !is_send && profile.done_profiling_at(profiler.insn_idx) {
-        profile.entry_mut(profiler.insn_idx)
-            .set_profiles_remaining(get_option!(num_profiles));
+    if profile.entry_mut(profiler.insn_idx).recompile_profile_started {
+        let entry = profile.entry_mut(profiler.insn_idx);
+        let done = entry.profiles_remaining == 0;
+        if done {
+            entry.recompile_profile_started = false;
+        }
+        return done;
     }
 
-    // If this opcode can't be sampled here, this exit has no profile data to collect.
-    if !profile_insn_sample(bare_opcode, profiler, profile) {
-        return false;
+    let num_profiles = get_option!(num_profiles);
+    if num_profiles == 0 {
+        return true;
+    }
+
+    // Re-arm existing entries so the interpreter profiles the whole ISEQ, not
+    // just the instruction that caused the exit. A newly reached zjit_* site
+    // creates its entry with the same initial counter in entry_mut().
+    for entry in &mut profile.entries {
+        entry.profiles_remaining = num_profiles;
     }
 
     let entry = profile.entry_mut(profiler.insn_idx);
-    entry.profiles_remaining = entry.profiles_remaining.saturating_sub(1);
-    entry.profiles_remaining == 0
+    entry.recompile_profile_started = true;
+    false
 }
 
 /// Return the argc as stated in the calldata plus:
@@ -413,8 +414,10 @@ pub struct ProfileEntry {
     insn_idx: u32,
     /// Type information of YARV instruction operands
     opnd_types: Vec<TypeDistribution>,
-    /// Number of profiles remaining before recompilation. Counts down from --zjit-num-profiles.
+    /// Number of samples left in this instruction's current profiling window.
     profiles_remaining: NumProfiles,
+    /// Whether a recompile exit is waiting for this entry's counter to reach zero.
+    recompile_profile_started: bool,
 }
 
 impl ProfileEntry {
@@ -451,6 +454,7 @@ impl IseqProfile {
                     insn_idx: idx,
                     opnd_types: Vec::new(),
                     profiles_remaining: get_option!(num_profiles),
+                    recompile_profile_started: false,
                 });
                 &mut self.entries[i]
             }
@@ -462,11 +466,6 @@ impl IseqProfile {
         let idx = insn_idx as u32;
         self.entries.binary_search_by_key(&idx, |e| e.insn_idx)
             .ok().map(|i| &self.entries[i])
-    }
-
-    /// Check if enough profiles have been gathered for this instruction.
-    pub fn done_profiling_at(&self, insn_idx: YarvInsnIdx) -> bool {
-        self.entry(insn_idx).map_or(false, |e| e.profiles_remaining == 0)
     }
 
     /// Get profiled operand types for a given instruction index


### PR DESCRIPTION
WIP: debugging a test_ractor failure. Leaving `zjit_` instructions enabled seems to make Ractors very slow.