### PR TITLE
CI: reduce GitHub-hosted macOS runner usage

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -30,12 +30,12 @@ jobs:
           - test_task: check
             os: macos-15
             configure_args: '--with-gcc=gcc-14'
+          # No dedicated --with-gmp job: gmp is enabled by default and
+          # setup/macos passes --with-gmp-dir to every job, so each check
+          # here already builds and tests with -lgmp.
           - test_task: check
             os: macos-26
             configure_args: '--with-jemalloc --with-opt-dir=$(brew --prefix jemalloc)'
-          - test_task: check
-            os: macos-26
-            configure_args: '--with-gmp'
           - test_task: test-all
             test_opts: --repeat-count=2
             os: macos-26

--- a/.github/workflows/tarball-macos.yml
+++ b/.github/workflows/tarball-macos.yml
@@ -12,6 +12,11 @@ on:
         required: false
         type: boolean
         default: false
+      full-matrix:
+        description: 'Run the full test matrix (nightly schedule and release verification). Off, the default, runs a single smoke check.'
+        required: false
+        type: boolean
+        default: false
     secrets:
       SIMPLER_ALERTS_URL:
         required: false
@@ -24,16 +29,17 @@ permissions:
 jobs:
   macos:
     strategy:
+      # The smoke matrix keeps only what is tarball-specific: that the
+      # packaged tarball configures, builds and installs. macos.yml runs the
+      # same test tasks from the git tree on every PR/push already.
+      # macos-15-intel: the runner image ships a pre-installed Ruby under
+      # /usr/local whose gems dir collides with the default prefix on Intel.
+      # Use an isolated prefix so RDoc generation does not scan that stale
+      # default-gem stub.
       matrix:
-        test_task: [check, test-bundled-gems, test-bundler-parallel]
-        os: [macos-26, macos-15, macos-14]
-        include:
-          - os: macos-15-intel
-            test_task: check
-            # The runner image ships a pre-installed Ruby under /usr/local whose
-            # gems dir collides with the default prefix on Intel. Use an isolated
-            # prefix so RDoc generation does not scan that stale default-gem stub.
-            prefix: /tmp/ruby-prefix
+        test_task: ${{ inputs.full-matrix && fromJSON('["check", "test-bundled-gems", "test-bundler-parallel"]') || fromJSON('["check"]') }}
+        os: ${{ inputs.full-matrix && fromJSON('["macos-26", "macos-15", "macos-14"]') || fromJSON('["macos-26"]') }}
+        include: ${{ inputs.full-matrix && fromJSON('[{"os":"macos-15-intel", "test_task":"check", "prefix":"/tmp/ruby-prefix"}]') || fromJSON('[]') }}
       fail-fast: false
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/tarball-test.yml
+++ b/.github/workflows/tarball-test.yml
@@ -83,6 +83,11 @@ jobs:
     uses: ./.github/workflows/tarball-macos.yml
     with:
       archname: snapshot-${{ needs.tarball.outputs.branch }}
+      # Full fan-out only for workflow_dispatch (nightly schedule and release
+      # verification); pull requests and pushes run a single smoke check.
+      # Only macOS is trimmed: its org-wide concurrency pool of 50 runners
+      # saturates during peak hours, while Linux and Windows have headroom.
+      full-matrix: ${{ github.event_name == 'workflow_dispatch' }}
       notify-release-channel: ${{ github.event_name == 'workflow_dispatch' && inputs.notify-release-channel || false }}
     secrets:
       SIMPLER_ALERTS_URL: ${{ secrets.SIMPLER_ALERTS_URL }}

--- a/.github/workflows/yjit-macos.yml
+++ b/.github/workflows/yjit-macos.yml
@@ -32,35 +32,6 @@ env:
   CARGO_HTTP_MULTIPLEXING: false
 
 jobs:
-  cargo:
-    name: cargo test
-
-    runs-on: macos-26
-
-    if: >-
-      ${{!(false
-      || contains(github.event.head_commit.message, '[DOC]')
-      || contains(github.event.pull_request.title, '[DOC]')
-      || contains(github.event.pull_request.labels.*.name, 'Documentation')
-      || (github.event.pull_request.user.login == 'dependabot[bot]' && !startsWith(github.head_ref, 'dependabot/cargo'))
-      )}}
-
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
-      - run: RUST_BACKTRACE=1 cargo test
-        working-directory: yjit
-
-      # Also compile and test with all features enabled
-      - run: RUST_BACKTRACE=1 cargo test --all-features
-        working-directory: yjit
-
-      # Check that we can build in release mode too
-      - run: cargo build --release
-        working-directory: yjit
-
   make:
     strategy:
       matrix:
@@ -68,6 +39,10 @@ jobs:
           - test_task: 'check'
             configure: '--enable-yjit'
             yjit_opts: '--yjit'
+            # Run the Rust unit tests on one entry only; a separate job
+            # would occupy another runner from the org-wide macOS
+            # concurrency pool just for ~1 minute of cargo.
+            cargo: true
           - test_task: 'check'
             configure: '--enable-yjit=dev'
             yjit_opts: '--yjit-call-threshold=1 --yjit-verify-ctx --yjit-code-gc'
@@ -176,6 +151,25 @@ jobs:
           PRECHECK_BUNDLED_GEMS: 'no'
         if: ${{ matrix.test_task == 'check' && matrix.skipped_tests }}
         continue-on-error: ${{ matrix.continue-on-skipped_tests || false }}
+
+      # Run even when an earlier test step failed, so a Ruby-side failure
+      # does not mask the Rust unit test result.
+      - name: cargo test
+        run: RUST_BACKTRACE=1 cargo test
+        working-directory: src/yjit
+        if: ${{ matrix.cargo && !cancelled() }}
+
+      # Also compile and test with all features enabled
+      - name: cargo test --all-features
+        run: RUST_BACKTRACE=1 cargo test --all-features
+        working-directory: src/yjit
+        if: ${{ matrix.cargo && !cancelled() }}
+
+      # Check that we can build in release mode too
+      - name: cargo build --release
+        run: cargo build --release
+        working-directory: src/yjit
+        if: ${{ matrix.cargo && !cancelled() }}
 
       - name: Dump crash logs
         if: ${{ failure() }}


### PR DESCRIPTION
The org-wide concurrency limit for GitHub-hosted macOS runners is 50 jobs shared by every repository in the ruby organization, while Linux and Windows runners share a 500-job pool with headroom. Each push or pull request event currently starts 31 macOS jobs taking about 360 runner-minutes, so the macOS pool saturates during peak hours and queued jobs, including release verification, wait behind CI.

This PR trims the three largest sources of avoidable macOS usage. `tarball-test` now runs a single smoke `check` on `macos-26` for pull requests and pushes and keeps the full 10-job matrix for `workflow_dispatch`, which is how the nightly schedule and release verification invoke it. What is tarball-specific is only that the packaged tarball configures, builds and installs, and `macos.yml` already runs the same test tasks from the git tree on every event. Only macOS is trimmed. Linux and Windows keep their full tarball matrices.

The dedicated `cargo test` job in `yjit-macos.yml` occupied a runner for less than a minute of work. The Rust unit tests now run as steps of the `--enable-yjit` matrix entry, which stays shorter than the `--enable-yjit=dev` long pole, and they are guarded with `!cancelled()` so a Ruby-side test failure does not mask the Rust result.

The `--with-gmp` job in `macos.yml` duplicated the plain check job. GMP is enabled by default and `setup/macos` passes `--with-gmp-dir` to every job, so the plain check already builds and tests with `-lgmp`, as verified in CI logs.

Together these changes reduce each event from 31 macOS jobs and about 360 runner-minutes to 20 jobs and about 235 runner-minutes, taking the busiest measured hour from about 156% of macOS pool capacity to about 106%.
