### PR TITLE
Remove BSD/OS (BSDi) support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1344,10 +1344,6 @@ main()
 		AC_CHECK_FUNCS(_wfreopen_s)
 		AC_LIBOBJ([langinfo])
 		],
-[bsdi*], [	LIBS="-lm $LIBS"
-		AC_DEFINE(BROKEN_SETREUID, 1)
-		AC_DEFINE(BROKEN_SETREGID, 1)
-                ac_cv_sizeof_rlim_t=8],
 [freebsd*], [	LIBS="-lm $LIBS"
 		ac_cv_func_getpeername=no
 		ac_cv_func_getsockname=no
@@ -3112,7 +3108,7 @@ AS_IF([test "$ac_cv_header_mach_o_loader_h" = yes], [
 ])
 
 AS_CASE(["$target_os"],
-[linux* | gnu* | k*bsd*-gnu | bsdi* | kopensolaris*-gnu], [
+[linux* | gnu* | k*bsd*-gnu | kopensolaris*-gnu], [
     AS_IF([test "$rb_cv_binary_elf" = no], [
 	AC_MSG_ERROR(Not ELF)
     ], [
@@ -3147,7 +3143,7 @@ STATIC=
       # mkmf.rb's have_header() to fail if the desired resource happens to be
       # installed in the /usr/local tree.
       RUBY_APPEND_OPTION(CCDLFLAGS, -fno-common)],
-    [bsdi*|cygwin*|msys*|mingw*|aix*|interix*], [ ],
+    [cygwin*|msys*|mingw*|aix*|interix*], [ ],
     [
       RUBY_APPEND_OPTION(CCDLFLAGS, -fPIC)])
   ], [
@@ -3206,10 +3202,7 @@ AC_SUBST(EXTOBJS)
 			rb_cv_dlopen=yes],
 	[osf*], [	: ${LDSHARED='$(LD) -shared -expect_unresolved "*"'}
 			rb_cv_dlopen=yes],
-	[bsdi3*], [	AS_CASE(["$CC"],
-			[*shlicc*], [	: ${LDSHARED='$(CC) -r'}
-					rb_cv_dlopen=yes])],
-	[linux* | gnu* | k*bsd*-gnu | netbsd* | bsdi* | kopensolaris*-gnu | haiku*], [
+	[linux* | gnu* | k*bsd*-gnu | netbsd* | kopensolaris*-gnu | haiku*], [
 			: ${LDSHARED='$(CC) -shared'}
 			AS_IF([test "$rb_cv_binary_elf" = yes], [
 			    LDFLAGS="$LDFLAGS -Wl,-export-dynamic"

--- a/process.c
+++ b/process.c
@@ -154,7 +154,7 @@ static VALUE rb_cProcessTms;
 #define WSTOPSIG        WEXITSTATUS
 #endif
 
-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__bsdi__)
+#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
 #define HAVE_44BSD_SETUID 1
 #define HAVE_44BSD_SETGID 1
 #endif
@@ -164,20 +164,11 @@ static VALUE rb_cProcessTms;
 #undef HAVE_SETRGID
 #endif
 
-#ifdef BROKEN_SETREUID
-#define setreuid ruby_setreuid
-int setreuid(rb_uid_t ruid, rb_uid_t euid);
-#endif
-#ifdef BROKEN_SETREGID
-#define setregid ruby_setregid
-int setregid(rb_gid_t rgid, rb_gid_t egid);
-#endif
-
 #if defined(HAVE_44BSD_SETUID) || defined(__APPLE__)
-#if !defined(USE_SETREUID) && !defined(BROKEN_SETREUID)
+#if !defined(USE_SETREUID)
 #define OBSOLETE_SETREUID 1
 #endif
-#if !defined(USE_SETREGID) && !defined(BROKEN_SETREGID)
+#if !defined(USE_SETREGID)
 #define OBSOLETE_SETREGID 1
 #endif
 #endif
@@ -6293,21 +6284,6 @@ proc_setuid(VALUE obj, VALUE id)
 
 static rb_uid_t SAVED_USER_ID = -1;
 
-#ifdef BROKEN_SETREUID
-int
-setreuid(rb_uid_t ruid, rb_uid_t euid)
-{
-    if (ruid != (rb_uid_t)-1 && ruid != getuid()) {
-        if (euid == (rb_uid_t)-1) euid = geteuid();
-        if (setuid(ruid) < 0) return -1;
-    }
-    if (euid != (rb_uid_t)-1 && euid != geteuid()) {
-        if (seteuid(euid) < 0) return -1;
-    }
-    return 0;
-}
-#endif
-
 /*
  *  call-seq:
  *     Process::UID.change_privilege(user)   -> integer
@@ -7006,21 +6982,6 @@ rb_daemon(int nochdir, int noclose)
  */
 
 static rb_gid_t SAVED_GROUP_ID = -1;
-
-#ifdef BROKEN_SETREGID
-int
-setregid(rb_gid_t rgid, rb_gid_t egid)
-{
-    if (rgid != (rb_gid_t)-1 && rgid != getgid()) {
-        if (egid == (rb_gid_t)-1) egid = getegid();
-        if (setgid(rgid) < 0) return -1;
-    }
-    if (egid != (rb_gid_t)-1 && egid != getegid()) {
-        if (setegid(egid) < 0) return -1;
-    }
-    return 0;
-}
-#endif
 
 /*
  *  call-seq:


### PR DESCRIPTION
BSD/OS (BSDi) was discontinued in 2003 and its `bsdi*` configure target has been dead ever since. I removed the remaining `bsdi*` cases from `configure.ac` and the `__bsdi__` condition in `process.c`, together with the `BROKEN_SETREUID`/`BROKEN_SETREGID` fallback implementations that only BSD/OS ever enabled.
