### PR TITLE
Relax vm_cc_cme/vm_cc_call assertions under multi-ractor, extension-s…

### DIFF
--- a/vm_callinfo.h
+++ b/vm_callinfo.h
@@ -439,11 +439,26 @@ vm_cc_valid(const struct rb_callcache *cc)
     return !UNDEF_P(cc->klass);
 }
 
+/* Whether another ractor may have invalidated this cc mid-use (see
+ * vm_cc_invalidate()). Extensions cannot use rb_multi_ractor_p() here: with
+ * assertions enabled at -O0 (e.g. --enable-yjit=dev on macOS) the inline
+ * materializes references to core-internal globals (ruby_current_vm_ptr,
+ * ruby_single_main_ractor) that are not exported to them, and objspace.bundle
+ * fails to load. RUBY_EXPORT marks a core TU. */
+#ifdef RUBY_EXPORT
+# define VM_CC_RACED_P() rb_multi_ractor_p()
+#else
+# define VM_CC_RACED_P() true
+#endif
+
 static inline const struct rb_callable_method_entry_struct *
 vm_cc_cme(const struct rb_callcache *cc)
 {
     VM_ASSERT(IMEMO_TYPE_P(cc, imemo_callcache));
-    VM_ASSERT(cc->klass != Qundef || !vm_cc_markable(cc) || vm_cc_invalid_super(cc));
+    // VM_CC_RACED_P(): another ractor can invalidate this cc (klass = Qundef)
+    // while a call using it is in flight; cme_/call_ stay intact, so the call
+    // proceeds with the method resolved before the redefinition.
+    VM_ASSERT(cc->klass != Qundef || !vm_cc_markable(cc) || vm_cc_invalid_super(cc) || VM_CC_RACED_P());
     VM_ASSERT(cc_check_class(cc->klass));
     VM_ASSERT(cc->call_ == NULL   || // not initialized yet
               !vm_cc_markable(cc) ||
@@ -458,7 +473,7 @@ vm_cc_call(const struct rb_callcache *cc)
 {
     VM_ASSERT(IMEMO_TYPE_P(cc, imemo_callcache));
     VM_ASSERT(cc->call_ != NULL);
-    VM_ASSERT(cc->klass != Qundef || !vm_cc_markable(cc) || vm_cc_invalid_super(cc));
+    VM_ASSERT(cc->klass != Qundef || !vm_cc_markable(cc) || vm_cc_invalid_super(cc) || VM_CC_RACED_P());
     VM_ASSERT(cc_check_class(cc->klass));
     return cc->call_;
 }


### PR DESCRIPTION
…afely

Same relaxation as PR #17873: another ractor can invalidate a cc (klass = Qundef) while a call using it is in flight; cme_/call_ stay intact, so the call proceeds with the method resolved before the redefinition (same treatment as vm_cc_invalidate).

Route the check through VM_CC_RACED_P(), which extensions see as a constant: ext/objspace/objspace_dump.c includes vm_callinfo.h and calls vm_cc_cme, and with assertions enabled at -O0 (--enable-yjit/zjit=dev on macOS) a direct rb_multi_ractor_p() there materializes references to the core-internal globals ruby_current_vm_ptr / ruby_single_main_ractor, which are hidden from extensions -- objspace.bundle then fails to load ("symbol not found in flat namespace '_ruby_current_vm_ptr'", the five JIT-dev CI failures on #17873). At -O1+ the compiler proves the first disjunct from the caller's Qundef guard and dead-codes the call, which is why only the -O0 dev jobs saw it. Verified both ways on the objspace_dump.c TU: PR state at -O0+RUBY_DEBUG has both unresolved globals; with VM_CC_RACED_P() it has none.