### PR TITLE
gc: advance the empty-page scan in check_rvalue_consistency_force

### DIFF
--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -1520,6 +1520,7 @@ check_rvalue_consistency_force(rb_objspace_t *objspace, const VALUE obj, int ter
                     err++;
                     goto skip;
                 }
+                empty_page = empty_page->free_next;
             }
             fprintf(stderr, "check_rvalue_consistency: %p is not a Ruby object.\n", (void *)obj);
             err++;


### PR DESCRIPTION
When check_rvalue_consistency_force meets a pointer that is not in any live heap page, it scans objspace->empty_pages to give a better message ("in an empty page" vs "not a Ruby object"). The scan loop never advanced empty_page, so with a non-empty empty-pages pool it either matched the first page or spun forever on a pointer that is in no empty page -- an infinite loop in the consistency checker (reachable from GC.verify_internal_consistency and RGENGC_CHECK_MODE) exactly when it is trying to report a dangling reference. Advance through free_next like every other empty-page traversal.