### PR TITLE
Fix broken RDoc examples that raise or fail to run

### DIFF
--- a/array.c
+++ b/array.c
@@ -7723,7 +7723,7 @@ rb_ary_repeated_combination(VALUE ary, VALUE num)
  *  If no argument is given, returns an array of 1-element arrays,
  *  each containing an element of +self+:
  *
- *    a.product # => [[0], [1], [2]]
+ *    [0, 1, 2].product # => [[0], [1], [2]]
  *
  *  With a block given, calls the block with each combination; returns +self+:
  *

--- a/doc/stringio/stringio.md
+++ b/doc/stringio/stringio.md
@@ -173,7 +173,7 @@ strio.gets  # Raises IOError: not opened for reading
 Mode specified as one of:
 
 - String: `'r+'`.
-- Constant: `File::RDRW`.
+- Constant: `File::RDWR`.
 
 Initial state:
 

--- a/hash.c
+++ b/hash.c
@@ -2097,7 +2097,7 @@ rb_hash_stlike_lookup(VALUE hash, st_data_t key, st_data_t *pval)
  *
  *  If the key is found, returns its value:
  *
- *    {foo: 0, bar: 1, baz: 2}
+ *    h = {foo: 0, bar: 1, baz: 2}
  *    h[:bar] # => 1
  *
  *  Otherwise, returns a default value (see {Hash Default}[rdoc-ref:Hash@Hash+Default]).

--- a/pathname_builtin.rb
+++ b/pathname_builtin.rb
@@ -305,7 +305,7 @@ class Pathname
   # :markup: markdown
   #
   # call-seq:
-  #   mkpath(permissions = 0775) -> self
+  #   mkpath(mode: nil) -> self
   #
   # Creates a directory at the path in `self`;
   # creates intermediate directories as needed:
@@ -318,7 +318,7 @@ class Pathname
   # pn.rmtree     # Clean up.
   # ```
   #
-  # Directories are created with the given permissions;
+  # When `mode` is given, directories are created with those permissions;
   # see {File Permissions}[rdoc-ref:File@File+Permissions].
   # The permissions for already-existing directories are not changed.
   def mkpath(mode: nil)

--- a/set.c
+++ b/set.c
@@ -1198,7 +1198,7 @@ set_i_intersection(VALUE set, VALUE other)
  *
  *  Returns whether the given +object+ is an element of +self+:
  *
- *    set = [0, :zero, '0']
+ *    set = Set[0, :zero, '0']
  *    set.include?('0')    # => true
  *    set.include?('zero') # => false
  *
@@ -1585,7 +1585,7 @@ set_each_i(st_data_t key, st_data_t dummy)
  *
  *    sum = 0
  *    Set[1, 2, 3].each {|i| sum += i }
- *    sum => 6
+ *    sum # => 6
  *
  *  With no block given, returns an Enumerator.
  */


### PR DESCRIPTION
While auditing the RDoc documentation, I found several example snippets that raise or otherwise fail when run as written.

The first commit fixes examples that do not run at all. `Hash#[]` began its example with a bare `{foo: 0, bar: 1, baz: 2}` literal and then referenced an undefined `h` on the next line, raising `NameError`. `Array#product` similarly referenced an undefined `a` in a section otherwise written with array literals; it now reads `[0, 1, 2].product`, matching the documented `[[0], [1], [2]]` result. The StringIO guide listed the read/write mode constant as `File::RDRW`, which does not exist; the correct constant is `File::RDWR`. `Pathname#mkpath` advertised `mkpath(permissions = 0775) -> self`, but the implementation is keyword-only (`def mkpath(mode: nil)`), so a positional argument raises `ArgumentError`; the call-seq and body now describe the `mode:` keyword.

The second commit fixes two `Set` examples. `Set#include?` built its receiver from an `Array` literal (`set = [0, :zero, '0']`), so the `hash`/`eql?` semantics the surrounding text describes did not apply; it now uses `Set[0, :zero, '0']`. `Set#each` ended with `sum => 6`, which parses as a rightward-assignment pattern match rather than an output comment; it is now `sum # => 6`.

Each corrected example was run against `ruby 4.1.0dev` and produces the output shown in the documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
