### PR TITLE
Bump net-imap to 0.4.25 for Ruby 3.3

### DIFF
--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -12,7 +12,7 @@ test-unit       3.6.1   https://github.com/test-unit/test-unit
 rexml           3.4.4   https://github.com/ruby/rexml
 rss             0.3.1   https://github.com/ruby/rss
 net-ftp         0.3.4   https://github.com/ruby/net-ftp
-net-imap        0.4.21  https://github.com/ruby/net-imap
+net-imap        0.4.25  https://github.com/ruby/net-imap
 net-pop         0.1.2   https://github.com/ruby/net-pop
 net-smtp        0.5.1   https://github.com/ruby/net-smtp
 matrix          0.4.2   https://github.com/ruby/matrix


### PR DESCRIPTION
This backports the June 2026 net-imap security releases to the Ruby 3.3 line by bumping the bundled `net-imap` gem from `0.4.21` to `0.4.25` in `gems/bundled_gems`. `net-imap` is a bundled gem with no vendored source in the tree, so the version pin is the only change required.

Version `0.4.25` carries the v0.4-stable backports of CVE-2026-47240 (command injection via non-synchronizing literal in the `raw` argument), CVE-2026-47242 (command injection via unvalidated `ID` and `ENABLE` arguments), and CVE-2026-47241 (denial of service via incomplete `raw` argument validation). This brings the 3.3 line in line with the fixes already shipped on master, 4.0, and 3.4.
