### PR TITLE
Disable SimpleCov for bundled gem tests

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -1609,7 +1609,7 @@ no-install-for-test-bundled-gems: no-update-default-gemspecs
 yes-install-for-test-bundled-gems: yes-update-default-gemspecs
 	$(XRUBY) -C "$(srcdir)" -r./tool/lib/gem_env.rb bin/gem \
 		install --no-document --conservative \
-		"hoe" "json-schema:5.1.0" "test-unit-rr" "simplecov" "rspec" "zeitwerk" \
+		"hoe" "json-schema:5.1.0" "test-unit-rr" "rspec" "zeitwerk" \
 		"sinatra" "rack" "tilt" "mustermann" "base64" "compact_index" "rack-test" "logger" "kpeg" "tracer" "minitest-mock"
 
 test-bundled-gems-fetch: yes-test-bundled-gems-fetch

--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -12,7 +12,7 @@ rake                13.4.2  https://github.com/ruby/rake
 test-unit           3.7.8   https://github.com/test-unit/test-unit
 rexml               3.4.4   https://github.com/ruby/rexml
 rss                 0.3.3   https://github.com/ruby/rss
-net-imap            0.6.4.1 https://github.com/ruby/net-imap 20d4f2c39dcc12307a6b30b497565770e89b66e3
+net-imap            0.6.4.1 https://github.com/ruby/net-imap
 net-smtp            0.5.1   https://github.com/ruby/net-smtp
 matrix              0.4.3   https://github.com/ruby/matrix
 prime               0.1.4   https://github.com/ruby/prime

--- a/tool/test-bundled-gems.rb
+++ b/tool/test-bundled-gems.rb
@@ -9,6 +9,11 @@ require_relative 'lib/test/jobserver'
 
 ENV.delete("GNUMAKEFLAGS")
 
+# net-imap's test helper enables SimpleCov, but its released versions still
+# call the pre-1.0.0 `SimpleCov.formatters=` API that breaks with simplecov
+# 1.0.0. Coverage of bundled gems is not collected in CI, so disable it.
+ENV["SIMPLECOV_DISABLE"] = "1"
+
 github_actions = ENV["GITHUB_ACTIONS"] == "true"
 
 DEFAULT_ALLOWED_FAILURES = RUBY_PLATFORM =~ /mswin|mingw/ ? [


### PR DESCRIPTION
net-imap's test helper enables SimpleCov, but its released versions still call the pre-1.0.0 `SimpleCov.formatters=` API. This raises `NoMethodError` under simplecov 1.0.0 and breaks `make test-bundled-gems`. Coverage of bundled gems is not collected in CI, so `tool/test-bundled-gems.rb` now sets `SIMPLECOV_DISABLE`. The net-imap helper guards its `require "simplecov"` on that variable, so the require never runs and simplecov no longer needs to be installed. `common.mk` drops `simplecov` from the test gem installation accordingly.

The net-imap entry in `gems/bundled_gems` was pinned to revision `20d4f2c3` so its tests would run against a SimpleCov 1.0.0 compatible helper. With coverage disabled that pin is no longer needed, so the released gem is used directly.
