### PR TITLE
Remove obsolete Windows toolchain remnants

### DIFF
--- a/cygwin/GNUmakefile.in
+++ b/cygwin/GNUmakefile.in
@@ -16,7 +16,6 @@ ifeq ($(target_os),cygwin)
   DLL_BASE_NAME := $(LIBRUBY_SO:.dll=)
 else
   DLL_BASE_NAME := $(RUBY_SO_NAME)
-  DLLWRAP += -mno-cygwin
   VPATH := $(VPATH):$(srcdir)/win32
   ifneq ($(filter -flto%,$(LDFLAGS)),)
     miniruby$(EXEEXT): XLDFLAGS += -Wno-maybe-uninitialized

--- a/win32/mkexports.rb
+++ b/win32/mkexports.rb
@@ -102,7 +102,7 @@ class Exports::Mswin < Exports
   end
 
   def each_export(objs)
-    noprefix = ($arch ||= nil and /^(sh|i\d86)/ !~ $arch)
+    noprefix = ($arch ||= nil and /^i\d86/ !~ $arch)
     objs = objs.collect {|s| s.tr('/', '\\')}
     filetype = nil
     objdump(objs) do |l|

--- a/win32/setup.mak
+++ b/win32/setup.mak
@@ -33,7 +33,6 @@ i386-mswin32: -prologue- -i386- -epilogue-
 i486-mswin32: -prologue- -i486- -epilogue-
 i586-mswin32: -prologue- -i586- -epilogue-
 i686-mswin32: -prologue- -i686- -epilogue-
-alpha-mswin32: -prologue- -alpha- -epilogue-
 x64-mswin64: -prologue- -x64- -epilogue-
 arm64-mswin64: -prologue- -arm64- -epilogue-
 
@@ -232,14 +231,6 @@ MACHINE = x86
 !if defined($(CPU))
 $(CPU) = $(PROCESSOR_LEVEL)
 !endif
-#endif
-
--alpha-: -osname32-
-	@$(CPP) -Tc <<"checking if compiler is for $(@:-=)" >>$(MAKEFILE)
-#ifndef _M_ALPHA
-#error Not compiler for $(@:-=)
-#else
-MACHINE = $(@:-=)
 #endif
 <<
 

--- a/win32/setup.mak
+++ b/win32/setup.mak
@@ -213,7 +213,7 @@ set /a MSC_VER_UPPER = MSC_VER/20*20+19
 #elif _MSC_VER >= 1900
 set /a MSC_VER_LOWER = MSC_VER/10*10+0
 set /a MSC_VER_UPPER = MSC_VER/10*10+9
-#elif _MSC_VER < 1400
+#else
 # error Unsupported VC++ compiler
 #endif
 set MSC_VER

--- a/win32/win32.c
+++ b/win32/win32.c
@@ -6708,9 +6708,6 @@ rb_w32_pipe(int fds[2])
 static int
 console_emulator_p(void)
 {
-#ifdef _WIN32_WCE
-    return FALSE;
-#else
     const void *const func = WriteConsoleW;
     HMODULE k;
     MEMORY_BASIC_INFORMATION m;
@@ -6722,7 +6719,6 @@ console_emulator_p(void)
     k = GetModuleHandle("kernel32.dll");
     if (!k) return FALSE;
     return (HMODULE)m.AllocationBase != k;
-#endif
 }
 
 /* License: Ruby's */


### PR DESCRIPTION
This removes leftovers for toolchains that can no longer build Ruby. The Windows CE guard in `win32/win32.c`, DEC Alpha AXP detection in `win32/setup.mak`, the SuperH pattern in `win32/mkexports.rb`, and the `-mno-cygwin` flag in `cygwin/GNUmakefile.in` all target platforms that no supported compiler produces. The supported floor is MSVC 1900 in `win32/Makefile.sub` and Windows 10 in `doc/distribution/windows.md`, so none of these paths are reachable.

One change tightens an existing check rather than just deleting dead code. `win32/Makefile.sub` already errors on `_MSC_VER < 1900`, but `win32/setup.mak` only rejected pre-VC8 compilers and let `1400..1899` pass the setup pass silently. It now fails at the setup pass with the actual minimum.

Removing the `-alpha-` rule also restores a terminator that had gone missing. Since `b5ecfd1eba` the inline file for `-generic-` had lost its own `<<` and swallowed the whole `-alpha-` rule, feeding an `#error` line to the preprocessor whose failure was silently discarded by the `findstr` pipe. Deleting the block makes that `<<` terminate `-generic-` again.

I verified a clean mswin build from `configure` with `nmake check`. `btest` and `test-spec` are fully green, and `test-all` has no failures related to this change. The generated `x64-vcruntime140-ruby410.def` is byte-identical before and after the `mkexports.rb` change. The `-mno-cygwin` removal only affects `--disable-shared` mingw builds and cannot be exercised by an mswin build, and the usual mingw CI is a shared build that never reaches that line, so it is left to CI.
