### PR TITLE
Fix: Avoid hangs in fast_fallback tests under scheduling jitter

### DIFF
--- a/test/socket/test_tcp.rb
+++ b/test/socket/test_tcp.rb
@@ -230,16 +230,22 @@ class TestSocket_TCPSocket < Test::Unit::TestCase
     port = server.addr[1]
     delay_time = 25 # Socket::RESOLUTION_DELAY (private) is 50ms
 
-    server_thread = Thread.new { server.accept }
+    accepted = nil
+    server_thread = Thread.new { accepted = server.accept }
     socket = TCPSocket.new(
       "localhost",
       port,
       fast_fallback: true,
       test_mode_settings: { delay: { ipv6: delay_time } }
     )
-    assert_true(socket.remote_address.ipv6?)
+    # Another process may be listening on the same port on 127.0.0.1.
+    omit "connected to an unrelated process on the same port" unless socket.remote_address.ipv6?
+    server_thread.join(3)
+    assert_not_nil(accepted, "server did not accept the connection")
+    assert_equal(socket.local_address.to_sockaddr, accepted.remote_address.to_sockaddr)
   ensure
-    server_thread&.value&.close
+    stop_accept_thread(server_thread, socket)
+    accepted&.close
     server&.close
     socket&.close
   end
@@ -252,16 +258,21 @@ class TestSocket_TCPSocket < Test::Unit::TestCase
     server.bind(Socket.pack_sockaddr_in(0, ipv4_address))
     port = server.connect_address.ip_port
 
-    server_thread = Thread.new { server.listen(1); server.accept }
+    accepted = nil
+    server_thread = Thread.new { server.listen(1); accepted, _ = server.accept }
     socket = TCPSocket.new(
       "localhost",
       port,
       fast_fallback: true,
       test_mode_settings: { delay: { ipv4: 10 } }
     )
-    assert_equal(ipv4_address, socket.remote_address.ip_address)
+    # Another process may be listening on the same port on ::1.
+    omit "connected to an unrelated process on the same port" if socket.remote_address.ipv6?
+    server_thread.join(3)
+    assert_not_nil(accepted, "server did not accept the connection")
+    assert_equal(socket.local_address.to_sockaddr, accepted.remote_address.to_sockaddr)
   ensure
-    accepted, _ = server_thread&.value
+    stop_accept_thread(server_thread, socket)
     accepted&.close
     server&.close
     socket&.close
@@ -274,16 +285,21 @@ class TestSocket_TCPSocket < Test::Unit::TestCase
     server.bind(Socket.pack_sockaddr_in(0, "127.0.0.1"))
     port = server.connect_address.ip_port
 
-    server_thread = Thread.new { server.listen(1); server.accept }
+    accepted = nil
+    server_thread = Thread.new { server.listen(1); accepted, _ = server.accept }
     socket = TCPSocket.new(
       "localhost",
       port,
       fast_fallback: true,
       test_mode_settings: { delay: { ipv6: 25 } }
     )
-    assert_true(socket.remote_address.ipv4?)
+    # Another process may be listening on the same port on ::1.
+    omit "connected to an unrelated process on the same port" if socket.remote_address.ipv6?
+    server_thread.join(3)
+    assert_not_nil(accepted, "server did not accept the connection")
+    assert_equal(socket.local_address.to_sockaddr, accepted.remote_address.to_sockaddr)
   ensure
-    accepted, _ = server_thread&.value
+    stop_accept_thread(server_thread, socket)
     accepted&.close
     server&.close
     socket&.close
@@ -419,5 +435,16 @@ class TestSocket_TCPSocket < Test::Unit::TestCase
     server_thread&.value&.close
     server&.close
     socket&.close
+  end
+
+  private
+
+  # On success, wait for the accept thread to finish. If the test failed
+  # before the client connected, `server.accept` never returns, so kill
+  # the thread instead of waiting for it.
+  def stop_accept_thread(server_thread, socket)
+    return unless server_thread
+    server_thread.join(1) if socket
+    server_thread.kill.join
   end
 end if defined?(TCPSocket)


### PR DESCRIPTION
Some fast_fallback tests inject an artificial delay to test timing-sensitive behavior. Under CI's parallel test execution, threadscheduling jitter can make the delay longer than expected, and in that case these tests may fail to connect to the server process they are actually supposed to connect to.

For example:

1. The IPv6 name resolution is artificially delayed by 25ms, so the IPv4 name resolution succeeds first.
2. If the IPv6 name resolution succeeds within 25ms, the client starts connecting to the `::1` server process and the test passes. However, if the IPv6 name resolution is delayed by more than 50ms for some reason, fast_fallback starts connecting to `127.0.0.1` instead, by design.
3. If another test happens to have a server listening on `127.0.0.1` with the same port number, the connection accidentally succeeds.
4. The `::1` server process is left waiting, and the thread cleanup hangs.

To address this, the listening server process now receives the result of `accept` through a local variable instead of `Thread#value`. On success, it joins the thread with a short timeout; otherwise, it terminates the thread with `Thread#kill.join`.

This change is expected to prevent hangs even when such a wrong connection occurs.