### PR TITLE
Fix freeing of complex IMEMO/fields

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -1380,7 +1380,7 @@ rb_gc_imemo_needs_cleanup_p(VALUE obj)
         return ((rb_imemo_tmpbuf_t *)obj)->ptr != NULL;
 
       case imemo_fields:
-        return FL_TEST_RAW(obj, OBJ_FIELD_HEAP);
+        return rb_obj_shape_complex_p(obj);
     }
     UNREACHABLE_RETURN(true);
 }

--- a/imemo.c
+++ b/imemo.c
@@ -613,7 +613,7 @@ static inline void
 imemo_fields_free(struct rb_fields *fields)
 {
     if (rb_obj_shape_complex_p((VALUE)fields)) {
-        st_free_table(&fields->as.complex.table);
+        st_free_embedded_table(&fields->as.complex.table);
     }
 }
 


### PR DESCRIPTION
Followup: https://github.com/ruby/ruby/pull/17863

The only fields that need cleanup are complex ones, and the free function had to be updated.