### PR TITLE
Do not run GC while inserting to the ports table

### DIFF
--- a/internal/st.h
+++ b/internal/st.h
@@ -17,4 +17,7 @@ st_table *rb_st_init_existing_strtable_with_size(st_table *tab, st_index_t size)
 void rb_st_free_embedded_table(st_table *tab);
 #define st_free_embedded_table rb_st_free_embedded_table
 
+int rb_st_insert_no_rebuild(st_table *tab, st_data_t key, st_data_t value);
+#define st_insert_no_rebuild rb_st_insert_no_rebuild
+
 #endif

--- a/ractor_sync.c
+++ b/ractor_sync.c
@@ -397,11 +397,33 @@ ractor_add_port(rb_ractor_t *r, st_data_t id)
 
     RUBY_DEBUG_LOG("id:%u", (unsigned int)id);
 
+    // Rebuilding the table on insertion can run GC by the allocation and the
+    // GC acquires the VM lock, which is prohibited under the ractor lock.
+    st_table *const old_tab = r->sync.ports;
+    bool inserted;
+
     RACTOR_LOCK(r);
     {
-        st_insert(r->sync.ports, id, (st_data_t)rq);
+        inserted = st_insert_no_rebuild(old_tab, id, (st_data_t)rq) >= 0;
     }
     RACTOR_UNLOCK(r);
+
+    if (!inserted) {
+        // The table is full. Rebuild it outside of the ractor lock (mutators
+        // are serialized by the per-ractor GVL) and swap it under the lock
+        // to exclude the readers (other ractors).
+        st_table *const new_tab = st_copy(old_tab);
+        st_insert(new_tab, id, (st_data_t)rq);
+
+        RACTOR_LOCK(r);
+        {
+            VM_ASSERT(r->sync.ports == old_tab);
+            r->sync.ports = new_tab;
+        }
+        RACTOR_UNLOCK(r);
+
+        st_free_table(old_tab);
+    }
 }
 
 static void

--- a/ractor_sync.c
+++ b/ractor_sync.c
@@ -446,11 +446,33 @@ ractor_add_port(rb_ractor_t *r, st_data_t id)
 
     RUBY_DEBUG_LOG("id:%u", (unsigned int)id);
 
+    // Rebuilding the table on insertion can run GC by the allocation and the
+    // GC acquires the VM lock, which is prohibited under the ractor lock.
+    st_table *const old_tab = r->sync.ports;
+    bool inserted;
+
     RACTOR_LOCK(r);
     {
-        st_insert(r->sync.ports, id, (st_data_t)rq);
+        inserted = st_insert_no_rebuild(old_tab, id, (st_data_t)rq) >= 0;
     }
     RACTOR_UNLOCK(r);
+
+    if (!inserted) {
+        // The table is full. Rebuild it outside of the ractor lock (mutators
+        // are serialized by the per-ractor GVL) and swap it under the lock
+        // to exclude the readers (other ractors).
+        st_table *const new_tab = st_copy(old_tab);
+        st_insert(new_tab, id, (st_data_t)rq);
+
+        RACTOR_LOCK(r);
+        {
+            VM_ASSERT(r->sync.ports == old_tab);
+            r->sync.ports = new_tab;
+        }
+        RACTOR_UNLOCK(r);
+
+        st_free_table(old_tab);
+    }
 }
 
 static void

--- a/st.c
+++ b/st.c
@@ -1242,6 +1242,21 @@ st_insert(st_table *tab, st_data_t key, st_data_t value)
     return 1;
 }
 
+#ifdef RUBY
+/* Insert (KEY, VALUE) into table TAB like st_insert(), but return -1
+   without any change when st_insert() would rebuild the table.  The
+   insertion is guaranteed to be allocation (and GC) free when it is done. */
+int
+st_insert_no_rebuild(st_table *tab, st_data_t key, st_data_t value)
+{
+    if (tab->entries_bound == get_allocated_entries(tab)) {
+        /* st_insert() will rebuild the table */
+        return -1;
+    }
+    return st_insert(tab, key, value);
+}
+#endif
+
 /* Insert (KEY, VALUE, HASH) into table TAB.  The table should not have
    entry with KEY before the insertion.  */
 static inline void

--- a/st.c
+++ b/st.c
@@ -1245,6 +1245,21 @@ st_insert(st_table *tab, st_data_t key, st_data_t value)
     return 1;
 }
 
+#ifdef RUBY
+/* Insert (KEY, VALUE) into table TAB like st_insert(), but return -1
+   without any change when st_insert() would rebuild the table.  The
+   insertion is guaranteed to be allocation (and GC) free when it is done. */
+int
+st_insert_no_rebuild(st_table *tab, st_data_t key, st_data_t value)
+{
+    if (tab->entries_bound == get_allocated_entries(tab)) {
+        /* st_insert() will rebuild the table */
+        return -1;
+    }
+    return st_insert(tab, key, value);
+}
+#endif
+
 /* Insert (KEY, VALUE, HASH) into table TAB.  The table should not have
    entry with KEY before the insertion.  */
 static inline void

--- a/test/ruby/test_ractor.rb
+++ b/test/ruby/test_ractor.rb
@@ -229,6 +229,24 @@ class TestRactor < Test::Unit::TestCase
     RUBY
   end
 
+  def test_create_many_ports_with_gc_stress
+    # Rebuilding the ports table on insertion can run GC under the ractor lock.
+    # It is a prohibited lock ordering, asserted in vm_lock_enter() on RUBY_DEBUG builds.
+    assert_ractor(<<~'RUBY')
+      r = Ractor.new { Ractor.receive } # enter multi-ractor mode and keep it
+      begin
+        GC.stress = true
+        ports = 40.times.map { Ractor::Port.new }
+      ensure
+        GC.stress = false
+      end
+      assert_equal 40, ports.count
+      ports.each(&:close)
+      r.send(nil)
+      r.join
+    RUBY
+  end
+
   def test_fork_raise_isolation_error
     assert_ractor(<<~'RUBY')
       ractor = Ractor.new do

--- a/test/ruby/test_ractor.rb
+++ b/test/ruby/test_ractor.rb
@@ -231,6 +231,24 @@ class TestRactor < Test::Unit::TestCase
     RUBY
   end
 
+  def test_create_many_ports_with_gc_stress
+    # Rebuilding the ports table on insertion can run GC under the ractor lock.
+    # It is a prohibited lock ordering, asserted in vm_lock_enter() on RUBY_DEBUG builds.
+    assert_ractor(<<~'RUBY')
+      r = Ractor.new { Ractor.receive } # enter multi-ractor mode and keep it
+      begin
+        GC.stress = true
+        ports = 40.times.map { Ractor::Port.new }
+      ensure
+        GC.stress = false
+      end
+      assert_equal 40, ports.count
+      ports.each(&:close)
+      r.send(nil)
+      r.join
+    RUBY
+  end
+
   def test_fork_raise_isolation_error
     assert_ractor(<<~'RUBY')
       ractor = Ractor.new do


### PR DESCRIPTION
`st_insert` to `r->sync.ports` under the ractor lock can rebuild the table and the allocation for the rebuilding can run GC, which acquires the VM lock (and can run the VM barrier). Acquiring the VM lock under a ractor lock is a prohibited lock ordering: it can deadlock with the VM barrier and it is detected by the assertion in vm_lock_enter() on RACTOR_CHECK_MODE builds.

Introduce st_insert_no_rebuild(), which fails instead of rebuilding (allocating) the table, and use it under the ractor lock. Only when the table is full, rebuild the table by copying outside of the ractor lock and swap it under the lock to exclude the readers.