### PR TITLE
ZJIT: Write full C method names in stats

### DIFF
--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -3741,11 +3741,18 @@ impl Assembler {
     }
 
     pub fn count_call_to(&mut self, fn_name: &str) {
+        self.count_call_to_with(|| fn_name.to_string());
+    }
+
+    /// Like [`Assembler::count_call_to`], but only builds the name when stats are
+    /// enabled. Use for callers where computing the name is non-trivial (e.g.
+    /// resolving a `Class#method` string) so no-stats builds don't pay for it.
+    pub fn count_call_to_with(&mut self, fn_name: impl FnOnce() -> String) {
         // We emit ccalls while initializing the JIT. Unfortunately, we skip those because
         // otherwise we have no counter pointers to read.
         if crate::state::ZJITState::has_instance() && get_option!(stats) {
             let ccall_counter_pointers = crate::state::ZJITState::get_ccall_counter_pointers();
-            let counter_ptr = ccall_counter_pointers.entry(fn_name.to_string()).or_insert_with(|| Box::new(0));
+            let counter_ptr = ccall_counter_pointers.entry(fn_name()).or_insert_with(|| Box::new(0));
             let counter_ptr: &mut u64 = counter_ptr.as_mut();
             self.incr_counter(Opnd::const_ptr(counter_ptr), 1.into());
         }

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -23,7 +23,7 @@ use crate::stats::{counter_ptr, with_time_stat, trace_compile_phase, Counter, Co
 use crate::{asm::CodeBlock, cruby::*, options::debug, virtualmem::CodePtr};
 use crate::backend::lir::{self, Assembler, C_ARG_OPNDS, C_RET_OPND, CFP, EC, NATIVE_BASE_PTR, Opnd, SP, SideExit, SideExitRecompile, SideExitTarget, StackMap, StackMapEntry, Target, asm_ccall, asm_comment};
 use crate::hir::{iseq_to_hir, BlockId, Invariant, RangeType, SideExitReason::{self, *}, SpecialBackrefSymbol, SpecialObjectType};
-use crate::hir::{BlockHandler, CCallVariadicData, CCallWithFrameData, Const, FieldName, FrameState, Function, Insn, InsnId, Recompile, SendDirectData, SendFallbackReason};
+use crate::hir::{BlockHandler, CCallVariadicData, CCallWithFrameData, Const, FieldName, FrameState, Function, Insn, InsnId, Recompile, SendDirectData, SendFallbackReason, qualified_method_name};
 use crate::hir_type::{types, Type};
 use crate::options::{get_option, InlineDepth, PerfMap, DEFAULT_MAX_VERSIONS};
 use crate::cast::IntoUsize;
@@ -726,7 +726,7 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
         &Insn::GuardLess { left, right, ref reason, state } => gen_guard_less(jit, asm, function, opnd!(left), opnd!(right), **reason, &function.frame_state(state)),
         &Insn::GuardGreaterEq { left, right, state, .. } => gen_guard_greater_eq(jit, asm, function, opnd!(left), opnd!(right), &function.frame_state(state)),
         Insn::PatchPoint { invariant, state } => no_output!(gen_patch_point(jit, asm, function, invariant, &function.frame_state(*state))),
-        Insn::CCall { cfunc, recv, args, name, owner: _, return_type: _, elidable: _ } => gen_ccall(asm, *cfunc, *name, opnd!(recv), opnds!(args)),
+        Insn::CCall { cfunc, recv, args, name, owner, return_type: _, elidable: _ } => gen_ccall(asm, *cfunc, *name, *owner, opnd!(recv), opnds!(args)),
         Insn::CCallWithFrame(insn) => {
             let CCallWithFrameData { cfunc, recv, name, args, cme, state, block, .. } = &**insn;
             gen_ccall_with_frame(jit, asm, function, *cfunc, *name, opnd!(recv), opnds!(args), *cme, *block, &function.frame_state(*state))
@@ -1079,7 +1079,7 @@ fn gen_ccall_with_frame(
 
     let mut cfunc_args = vec![recv];
     cfunc_args.extend(args);
-    asm.count_call_to(&name.contents_lossy());
+    asm.count_call_to_with(|| qualified_method_name(unsafe { (*cme).owner }, name));
     let result = asm.ccall(cfunc, cfunc_args);
 
     asm_comment!(asm, "pop C frame");
@@ -1096,10 +1096,10 @@ fn gen_ccall_with_frame(
 
 /// Lowering for [`Insn::CCall`]. This is a low-level raw call that doesn't know
 /// anything about the callee, so handling for e.g. GC safety is dealt with elsewhere.
-fn gen_ccall(asm: &mut Assembler, cfunc: *const u8, name: ID, recv: Opnd, args: Vec<Opnd>) -> lir::Opnd {
+fn gen_ccall(asm: &mut Assembler, cfunc: *const u8, name: ID, owner: VALUE, recv: Opnd, args: Vec<Opnd>) -> lir::Opnd {
     let mut cfunc_args = vec![recv];
     cfunc_args.extend(args);
-    asm.count_call_to(&name.contents_lossy());
+    asm.count_call_to_with(|| if owner == Qnil { name.contents_lossy().to_string() } else { qualified_method_name(owner, name) });
     asm.ccall(cfunc, cfunc_args)
 }
 
@@ -1168,7 +1168,7 @@ fn gen_ccall_variadic(
     asm.store(Opnd::mem(64, EC, RUBY_OFFSET_EC_CFP), CFP);
 
     let argv_ptr = gen_push_opnds(jit, asm, &args);
-    asm.count_call_to(&name.contents_lossy());
+    asm.count_call_to_with(|| qualified_method_name(unsafe { (*cme).owner }, name));
     let result = asm.ccall(cfunc, vec![args.len().into(), argv_ptr, recv]);
 
     asm_comment!(asm, "pop C frame");

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -1924,7 +1924,7 @@ fn id_is_empty(id: ID) -> bool {
 
 /// Construct a qualified method name for display/debug output.
 /// Returns strings like "Array#length" for instance methods or "Foo.bar" for singleton methods.
-fn qualified_method_name(class: VALUE, method_id: ID) -> String {
+pub(crate) fn qualified_method_name(class: VALUE, method_id: ID) -> String {
     let method_name = method_id.contents_lossy();
     // rb_zjit_singleton_class_p also checks if it's a class
     if unsafe { rb_zjit_singleton_class_p(class) } {


### PR DESCRIPTION
Makes methods look more like `Array#[]` than just `[]`.

Also use a thunk instead of allocating the string all the time.