### PR TITLE
ZJIT: Trace fallbacks in Perfetto

### DIFF
--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -1186,6 +1186,7 @@ fn gen_ccall_variadic(
 
 /// Emit an uncached instance variable lookup
 fn gen_getivar(asm: &mut Assembler, recv: Opnd, id: ID, ic: *const iseq_inline_iv_cache_entry, state: &FrameState) -> Opnd {
+    gen_trace_fallback(asm, "getivar");
     if ic.is_null() {
         asm_ccall!(asm, rb_ivar_get, recv, id.0.into())
     } else {
@@ -1196,6 +1197,7 @@ fn gen_getivar(asm: &mut Assembler, recv: Opnd, id: ID, ic: *const iseq_inline_i
 
 /// Emit an uncached instance variable store
 fn gen_setivar(jit: &mut JITState, asm: &mut Assembler, function: &Function, recv: Opnd, id: ID, ic: *const iseq_inline_iv_cache_entry, val: Opnd, state: &FrameState) {
+    gen_trace_fallback(asm, "setivar");
     // Setting an ivar can raise FrozenError, so we need proper frame state for exception handling.
     gen_prepare_non_leaf_call(jit, asm, function, state);
     if ic.is_null() {
@@ -1468,6 +1470,24 @@ fn gen_param(asm: &mut Assembler, _idx: usize) -> lir::Opnd {
     vreg
 }
 
+fn gen_trace_fallback(asm: &mut Assembler, reason: &str) {
+    if !get_option!(trace_fallbacks) {
+        return;
+    }
+    let reason_cstr = std::ffi::CString::new(reason.to_string())
+        .unwrap_or_else(|_| std::ffi::CString::new("unknown").unwrap());
+    let reason_ptr = reason_cstr.into_raw() as *const u8;
+    use crate::state::rb_zjit_record_fallback_stack;
+    asm_ccall!(asm, rb_zjit_record_fallback_stack, Opnd::const_ptr(reason_ptr));
+}
+
+fn gen_trace_send_fallback(asm: &mut Assembler, reason: &SendFallbackReason) {
+    if !get_option!(trace_fallbacks) {
+        return;
+    }
+    gen_trace_fallback(asm, &format!("{reason}"));
+}
+
 /// Compile a dynamic dispatch with block
 fn gen_send(
     jit: &mut JITState,
@@ -1479,6 +1499,7 @@ fn gen_send(
     reason: SendFallbackReason,
 ) -> lir::Opnd {
     gen_incr_send_fallback_counter(asm, reason);
+    gen_trace_send_fallback(asm, &reason);
 
     gen_prepare_fallback_call(jit, asm, function, state);
     asm_comment!(asm, "call #{} with dynamic dispatch", ruby_call_method_name(cd));
@@ -1503,6 +1524,7 @@ fn gen_send_forward(
     reason: SendFallbackReason,
 ) -> lir::Opnd {
     gen_incr_send_fallback_counter(asm, reason);
+    gen_trace_send_fallback(asm, &reason);
 
     gen_prepare_fallback_call(jit, asm, function, state);
 
@@ -1527,6 +1549,7 @@ fn gen_send_without_block(
     reason: SendFallbackReason,
 ) -> lir::Opnd {
     gen_incr_send_fallback_counter(asm, reason);
+    gen_trace_send_fallback(asm, &reason);
 
     gen_prepare_fallback_call(jit, asm, function, state);
     asm_comment!(asm, "call #{} with dynamic dispatch", ruby_call_method_name(cd));
@@ -1821,6 +1844,7 @@ fn gen_invokeblock(
     reason: SendFallbackReason,
 ) -> lir::Opnd {
     gen_incr_send_fallback_counter(asm, reason);
+    gen_trace_send_fallback(asm, &reason);
 
     gen_prepare_fallback_call(jit, asm, function, state);
 
@@ -1988,6 +2012,7 @@ fn gen_invokesuper(
     reason: SendFallbackReason,
 ) -> lir::Opnd {
     gen_incr_send_fallback_counter(asm, reason);
+    gen_trace_send_fallback(asm, &reason);
 
     gen_prepare_fallback_call(jit, asm, function, state);
     asm_comment!(asm, "call super with dynamic dispatch");
@@ -2012,6 +2037,7 @@ fn gen_invokesuperforward(
     reason: SendFallbackReason,
 ) -> lir::Opnd {
     gen_incr_send_fallback_counter(asm, reason);
+    gen_trace_send_fallback(asm, &reason);
 
     gen_prepare_fallback_call(jit, asm, function, state);
     asm_comment!(asm, "call super with dynamic dispatch (forwarding)");

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -4071,16 +4071,12 @@ impl Function {
                             | ReceiverTypeResolution::SkewedPolymorphic { profiled_type } => (profiled_type.class(), Some(profiled_type)),
                             ReceiverTypeResolution::SkewedMegamorphic { .. }
                             | ReceiverTypeResolution::Megamorphic => {
-                                if get_option!(stats) {
-                                    self.set_dynamic_send_reason(insn_id, SendMegamorphic);
-                                }
+                                self.set_dynamic_send_reason(insn_id, SendMegamorphic);
                                 self.push_insn_id(block, insn_id);
                                 continue;
                             }
                             ReceiverTypeResolution::Polymorphic => {
-                                if get_option!(stats) {
-                                    self.set_dynamic_send_reason(insn_id, SendPolymorphic);
-                                }
+                                self.set_dynamic_send_reason(insn_id, SendPolymorphic);
                                 self.push_insn_id(block, insn_id);
                                 continue;
                             }

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -8446,7 +8446,7 @@ mod hir_opt_tests {
           v60:TrueClass = Const Value(true)
           Jump bb7(v60)
         bb11():
-          v48:BasicObject = Send v31, :! # SendFallbackReason: Send: polymorphic fallback
+          v48:BasicObject = Send v31, :! # SendFallbackReason: Send: polymorphic call site
           Jump bb7(v48)
         bb7(v35:BasicObject):
           CheckInterrupts
@@ -9187,7 +9187,7 @@ mod hir_opt_tests {
           SetIvar v24, :@foo, v17
           Jump bb4(v17)
         bb6():
-          v27:BasicObject = Send v10, :foo=, v17 # SendFallbackReason: Send: polymorphic fallback
+          v27:BasicObject = Send v10, :foo=, v17 # SendFallbackReason: Send: polymorphic call site
           Jump bb4(v27)
         bb4(v20:BasicObject):
           CheckInterrupts
@@ -9770,7 +9770,7 @@ mod hir_opt_tests {
           v31:BasicObject = GetIvar v19, :@foo
           Jump bb4(v31)
         bb6():
-          v22:BasicObject = Send v10, :foo # SendFallbackReason: Send: polymorphic fallback
+          v22:BasicObject = Send v10, :foo # SendFallbackReason: Send: polymorphic call site
           Jump bb4(v22)
         bb4(v15:BasicObject):
           CheckInterrupts
@@ -16728,7 +16728,7 @@ mod hir_opt_tests {
           v45:Fixnum[4] = Const Value(4)
           Jump bb4(v45)
         bb8():
-          v28:BasicObject = Send v10, :foo # SendFallbackReason: Send: polymorphic fallback
+          v28:BasicObject = Send v10, :foo # SendFallbackReason: Send: polymorphic call site
           Jump bb4(v28)
         bb4(v15:BasicObject):
           v31:Fixnum[2] = Const Value(2)
@@ -16781,7 +16781,7 @@ mod hir_opt_tests {
           PatchPoint MethodRedefined(Integer@0x1040, itself@0x1010, cme:0x1018)
           Jump bb4(v25)
         bb8():
-          v28:BasicObject = Send v10, :itself # SendFallbackReason: Send: polymorphic fallback
+          v28:BasicObject = Send v10, :itself # SendFallbackReason: Send: polymorphic call site
           Jump bb4(v28)
         bb4(v15:BasicObject):
           CheckInterrupts
@@ -16837,7 +16837,7 @@ mod hir_opt_tests {
           v40:StringExact = CCallVariadic v25, :Integer#to_s@0x1040
           Jump bb4(v40)
         bb8():
-          v28:BasicObject = Send v10, :to_s # SendFallbackReason: Send: polymorphic fallback
+          v28:BasicObject = Send v10, :to_s # SendFallbackReason: Send: polymorphic call site
           Jump bb4(v28)
         bb4(v15:BasicObject):
           CheckInterrupts
@@ -16890,7 +16890,7 @@ mod hir_opt_tests {
           v40:BasicObject = CCallWithFrame v25, :Float#to_s@0x1040
           Jump bb4(v40)
         bb8():
-          v28:BasicObject = Send v10, :to_s # SendFallbackReason: Send: polymorphic fallback
+          v28:BasicObject = Send v10, :to_s # SendFallbackReason: Send: polymorphic call site
           Jump bb4(v28)
         bb4(v15:BasicObject):
           CheckInterrupts
@@ -16943,7 +16943,7 @@ mod hir_opt_tests {
           v38:StringExact = InvokeBuiltin leaf <inline_expr>, v25
           Jump bb4(v38)
         bb8():
-          v28:BasicObject = Send v10, :to_s # SendFallbackReason: Send: polymorphic fallback
+          v28:BasicObject = Send v10, :to_s # SendFallbackReason: Send: polymorphic call site
           Jump bb4(v28)
         bb4(v15:BasicObject):
           CheckInterrupts
@@ -16992,7 +16992,7 @@ mod hir_opt_tests {
           v31:Fixnum[3] = Const Value(3)
           Jump bb4(v31)
         bb6():
-          v22:BasicObject = Send v10, :foo # SendFallbackReason: Send: polymorphic fallback
+          v22:BasicObject = Send v10, :foo # SendFallbackReason: Send: polymorphic call site
           Jump bb4(v22)
         bb4(v15:BasicObject):
           CheckInterrupts
@@ -18510,7 +18510,7 @@ mod hir_opt_tests {
           v45:BasicObject = CCallWithFrame v30, :Float#*@0x1040, v13
           Jump bb4(v45)
         bb8():
-          v33:BasicObject = Send v12, :*, v13 # SendFallbackReason: Send: polymorphic fallback
+          v33:BasicObject = Send v12, :*, v13 # SendFallbackReason: Send: polymorphic call site
           Jump bb4(v33)
         bb4(v20:BasicObject):
           CheckInterrupts
@@ -18834,7 +18834,7 @@ mod hir_opt_tests {
           v89:Float = FloatAdd v57, v44
           Jump bb9(v89)
         bb13():
-          v60:BasicObject = Send v12, :+, v44 # SendFallbackReason: Send: polymorphic fallback
+          v60:BasicObject = Send v12, :+, v44 # SendFallbackReason: Send: polymorphic call site
           Jump bb9(v60)
         bb9(v47:BasicObject):
           PatchPoint SingleRactorMode

--- a/zjit/src/options.rs
+++ b/zjit/src/options.rs
@@ -123,6 +123,12 @@ pub struct Options {
     /// Frequency of tracing side exits.
     pub trace_side_exits_sample_interval: usize,
 
+    /// Trace and write fallback source maps to /tmp for stackprof.
+    pub trace_fallbacks: bool,
+
+    /// Frequency of tracing fallbacks.
+    pub trace_fallbacks_sample_interval: usize,
+
     /// Trace compilation phases as Perfetto duration events.
     pub trace_compiles: bool,
 
@@ -203,6 +209,8 @@ impl Default for Options {
             dump_disasm: None,
             trace_side_exits: None,
             trace_side_exits_sample_interval: 0,
+            trace_fallbacks: false,
+            trace_fallbacks_sample_interval: 0,
             trace_compiles: false,
             trace_invalidation: false,
             perf: None,
@@ -501,6 +509,17 @@ fn parse_option(str_ptr: *const std::os::raw::c_char) -> Option<()> {
             }
             // `sample_interval ` must provide a string that can be validly parsed to a `usize`.
             options.trace_side_exits_sample_interval = sample_interval.parse::<usize>().ok()?;
+        }
+
+        ("trace-fallbacks", "") => {
+            options.trace_fallbacks = true;
+        }
+
+        ("trace-fallbacks-sample-rate", sample_interval) => {
+            // If not already set, then set it.
+            options.trace_fallbacks = true;
+            // `sample_interval ` must provide a string that can be validly parsed to a `usize`.
+            options.trace_fallbacks_sample_interval = sample_interval.parse::<usize>().ok()?;
         }
 
         ("trace-compiles", "") => options.trace_compiles = true,

--- a/zjit/src/state.rs
+++ b/zjit/src/state.rs
@@ -132,7 +132,7 @@ impl ZJITState {
         let materialize_exit_trampoline = gen_materialize_exit_trampoline(&mut cb, exit_trampoline).unwrap();
         let function_stub_hit_trampoline = gen_function_stub_hit_trampoline(&mut cb).unwrap();
 
-        let perfetto_tracer = if get_option!(trace_side_exits).is_some() || get_option!(trace_compiles) || get_option!(trace_invalidation) {
+        let perfetto_tracer = if get_option!(trace_side_exits).is_some() || get_option!(trace_compiles) || get_option!(trace_invalidation) || get_option!(trace_fallbacks) {
             Some(PerfettoTracer::new())
         } else {
             None
@@ -494,6 +494,41 @@ pub extern "C" fn rb_zjit_record_exit_stack(reason: *const std::ffi::c_char) {
     };
 
     tracer.write_event("side_exit", reason_str, &frames);
+}
+
+/// Record a backtrace with ZJIT fallbacks as a Perfetto trace event
+#[unsafe(no_mangle)]
+pub extern "C" fn rb_zjit_record_fallback_stack(reason: *const std::ffi::c_char) {
+    if !zjit_enabled_p() || !get_option!(trace_fallbacks) {
+        return;
+    }
+
+    let tracer = match ZJITState::get_tracer() {
+        Some(t) => t,
+        None => return,
+    };
+
+    // When `trace_fallbacks_sample_interval` is non-zero, apply sampling.
+    if get_option!(trace_fallbacks_sample_interval) != 0 {
+        if tracer.skipped_samples < get_option!(trace_fallbacks_sample_interval) {
+            tracer.skipped_samples += 1;
+            return;
+        } else {
+            tracer.skipped_samples = 0;
+        }
+    }
+
+    // Collect profile frames
+    let frames = capture_ruby_frames();
+
+    // Get the reason string
+    let reason_str = if reason.is_null() {
+        "unknown"
+    } else {
+        unsafe { std::ffi::CStr::from_ptr(reason).to_str().unwrap_or("unknown") }
+    };
+
+    tracer.write_event("fallback", reason_str, &frames);
 }
 
 /// Wrap a closure in a Perfetto duration event with category "invalidation"


### PR DESCRIPTION
This lets us see stack traces for send, ivar fallbacks.
