### PR TITLE
remove unnecessary Inline keyword

### DIFF
--- a/st.c
+++ b/st.c
@@ -3268,7 +3268,7 @@ set_foreach_check(set_table *tab, set_foreach_check_callback_func *func, st_data
 
 /* Set up array KEYS by at most SIZE keys of head table TAB entries.
    Return the number of keys set up in array KEYS.  */
-inline st_index_t
+st_index_t
 set_keys(set_table *tab, st_data_t *keys, st_index_t size)
 {
     st_index_t i, bound;


### PR DESCRIPTION
Oddly, when building with msvc (19.44), the linking fails only while disabling optimization (using the /Od option).
```
linking miniruby.exe
   Creating library miniruby.lib and object miniruby.exp
set.obj : error LNK2019: unresolved external symbol rb_set_keys referenced in function set_i_to_a
miniruby.exe : fatal error LNK1120: 1 unresolved externals
```