### PR TITLE
Include ivar name and class name in the Ractor isolation error message

### DIFF
--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -864,6 +864,25 @@ assert_equal "can not get unshareable values from instance variables of classes/
   end
 RUBY
 
+# setting an ivar of a class/module from a non-main Ractor reports the ivar and class
+assert_equal "can not set instance variables of classes/modules by non-main Ractors (@iv from C)", <<~'RUBY', frozen_string_literal: false
+  class C
+    @iv = 'str'
+  end
+
+  r = Ractor.new do
+    class C
+      @iv = 'other'
+    end
+  end
+
+  begin
+    r.value
+  rescue Ractor::RemoteError => e
+    e.cause.message
+  end
+RUBY
+
 # ivar in shareable-objects are not allowed to access from non-main Ractor
 assert_equal 'can not access instance variables of shareable objects from non-main Ractors', %q{
   shared = Ractor.new{}

--- a/variable.c
+++ b/variable.c
@@ -1199,11 +1199,16 @@ rb_alias_variable(ID name1, ID name2)
 }
 
 static void
-IVAR_ACCESSOR_SHOULD_BE_MAIN_RACTOR(ID id)
+IVAR_ACCESSOR_SHOULD_BE_MAIN_RACTOR(VALUE obj, ID id)
 {
     if (UNLIKELY(!rb_ractor_main_p())) {
         if (rb_is_instance_id(id)) { // check only normal ivars
-            rb_raise(rb_eRactorIsolationError, "can not set instance variables of classes/modules by non-main Ractors");
+            rb_raise(
+                rb_eRactorIsolationError,
+                "can not set instance variables of classes/modules by non-main Ractors (%"PRIsVALUE" from %"PRIsVALUE")",
+                rb_id2str(id),
+                obj
+            );
         }
     }
 }
@@ -1595,7 +1600,7 @@ rb_ivar_delete(VALUE obj, ID id, VALUE undef)
     int type = BUILTIN_TYPE(obj);
 
     if (type == T_CLASS || type == T_MODULE) {
-        IVAR_ACCESSOR_SHOULD_BE_MAIN_RACTOR(id);
+        IVAR_ACCESSOR_SHOULD_BE_MAIN_RACTOR(obj, id);
 
         if (rb_multi_ractor_p()) {
             concurrent = true;
@@ -1968,7 +1973,7 @@ ivar_set(VALUE obj, ID id, VALUE val)
       case T_CLASS:
       case T_MODULE:
         {
-            IVAR_ACCESSOR_SHOULD_BE_MAIN_RACTOR(id);
+            IVAR_ACCESSOR_SHOULD_BE_MAIN_RACTOR(obj, id);
             bool dontcare;
             return class_ivar_set(obj, id, val, &dontcare);
         }
@@ -2262,7 +2267,7 @@ rb_field_foreach(VALUE obj, rb_ivar_foreach_callback_func *func, st_data_t arg, 
       case T_CLASS:
       case T_MODULE:
         {
-            IVAR_ACCESSOR_SHOULD_BE_MAIN_RACTOR(0);
+            IVAR_ACCESSOR_SHOULD_BE_MAIN_RACTOR(obj, 0);
             VALUE fields_obj = RCLASS_WRITABLE_FIELDS_OBJ(obj);
             if (fields_obj) {
                 imemo_fields_each(fields_obj, func, arg, ivar_only);


### PR DESCRIPTION
### Problem

When a Ractor isolation error happens due to setting an ivar on a class, the message doesn't include the name of the ivar and neither the name of the class. It makes it difficult to track down where the isolation problem comes from.

I'd like the message to be similar as what we get when a Ractor access an unshareable ivar.

This is the current behaviour

```ruby
  class Foo
    def self.foo
      @foo ||= "test"
    end
  end

  Ractor.new do
    Foo.foo # can not set instance variables of classes/modules by non-main Ractors
  end.join

  Foo.foo

  Ractor.new do
    Foo.foo # can not get unshareable values from instance variables of classes/modules from non-main Ractors (@foo from Foo)
  end.join
```

### Solution

Modify the error message to include the ivar name and the class/module name.