### PR TITLE
Add String#blank?

### DIFF
--- a/benchmark/string_blank_p.yml
+++ b/benchmark/string_blank_p.yml
@@ -1,0 +1,19 @@
+prelude: |
+  empty = ""
+  ascii_blank_short = " \t\r\n"
+  ascii_blank_long = " " * 1024
+  ascii_nonblank_short = "hello"
+  ascii_nonblank_long = " " * 1023 + "x"
+  unicode_blank = "\u3000"
+  unicode_nonblank = "\u3000" * 255 + "x"
+
+benchmark:
+  blank_empty: empty.blank?
+  blank_ascii_short: ascii_blank_short.blank?
+  blank_ascii_long: ascii_blank_long.blank?
+  nonblank_ascii_short: ascii_nonblank_short.blank?
+  nonblank_ascii_long: ascii_nonblank_long.blank?
+  blank_unicode: unicode_blank.blank?
+  nonblank_unicode: unicode_nonblank.blank?
+
+loop_count: 1_000_000

--- a/doc/string.rb
+++ b/doc/string.rb
@@ -197,6 +197,7 @@
 # - #bytesize: Returns the count of bytes.
 # - #count: Returns the count of substrings matching given strings.
 # - #empty?: Returns whether the length of +self+ is zero.
+# - #blank?: Returns whether the string is empty or contains only whitespace characters.
 # - #length (aliased as #size): Returns the count of characters (not bytes).
 #
 # _Substrings_

--- a/string.c
+++ b/string.c
@@ -2468,6 +2468,57 @@ rb_str_empty(VALUE str)
 
 /*
  *  call-seq:
+ *    blank? -> true or false
+ *
+ *  Returns whether +self+ is empty or contains only whitespace characters.
+ *  Whitespace is determined by +self+'s encoding. For Unicode encodings,
+ *  whitespace is defined by the Unicode +White_Space+ property:
+ *
+ *    ''.blank?       # => true
+ *    '   '.blank?    # => true
+ *    "\t\n\r".blank? # => true
+ *    "\u00a0".blank?  # => true
+ *    'hello'.blank?  # => false
+ *
+ *  Raises ArgumentError if an invalid byte sequence is encountered while
+ *  scanning +self+.
+ *
+ *  Related: see {Querying}[rdoc-ref:String@Querying].
+ */
+
+static VALUE
+rb_str_blank_p(VALUE str)
+{
+    rb_encoding *enc = rb_enc_get(str);
+    const char *ptr = RSTRING_PTR(str);
+    const char *end = RSTRING_END(str);
+    const int ascii_compatible = rb_enc_asciicompat(enc);
+
+    while (ptr < end) {
+        unsigned char byte = (unsigned char)*ptr;
+
+        if (ascii_compatible && byte < 0x80) {
+            if (byte != 0x20 && !(0x09 <= byte && byte <= 0x0d)) {
+                return Qfalse;
+            }
+            ptr++;
+        }
+        else {
+            int length;
+            OnigCodePoint codepoint = rb_enc_codepoint_len(ptr, end, &length, enc);
+
+            if (!rb_enc_isspace(codepoint, enc)) {
+                return Qfalse;
+            }
+            ptr += length;
+        }
+    }
+
+    return Qtrue;
+}
+
+/*
+ *  call-seq:
  *    self + other_string -> new_string
  *
  *  Returns a new string containing +other_string+ concatenated to +self+:
@@ -12889,6 +12940,7 @@ Init_String(void)
     rb_define_method(rb_cString, "size", rb_str_length, 0);
     rb_define_method(rb_cString, "bytesize", rb_str_bytesize, 0);
     rb_define_method(rb_cString, "empty?", rb_str_empty, 0);
+    rb_define_method(rb_cString, "blank?", rb_str_blank_p, 0);
     rb_define_method(rb_cString, "=~", rb_str_match, 1);
     rb_define_method(rb_cString, "match", rb_str_match_m, -1);
     rb_define_method(rb_cString, "match?", rb_str_match_m_p, -1);

--- a/test/ruby/test_string.rb
+++ b/test/ruby/test_string.rb
@@ -1288,6 +1288,71 @@ CODE
     assert_not_empty(S("not"))
   end
 
+  def test_blank?
+    # An empty string is blank.
+    assert_predicate(S(""), :blank?)
+
+    # ASCII whitespace is blank, individually and as a run.
+    assert_predicate(S(" "), :blank?)
+    assert_predicate(S("\t\n\v\f\r"), :blank?)
+
+    # Every Unicode White_Space code point is blank under a Unicode encoding.
+    unicode_ws = [
+      "\u{9}", "\u{A}", "\u{B}", "\u{C}", "\u{D}",  # HORIZONTAL TAB..CARRIAGE RETURN
+      "\u{20}",                                       # SPACE
+      "\u{85}",                                       # NEXT LINE (NEL)
+      "\u{A0}",                                       # NO-BREAK SPACE
+      "\u{1680}",                                     # OGHAM SPACE MARK
+      "\u{2000}", "\u{2001}", "\u{2002}", "\u{2003}", "\u{2004}",
+      "\u{2005}", "\u{2006}", "\u{2007}", "\u{2008}", "\u{2009}", "\u{200A}",
+      "\u{2028}",                                     # LINE SEPARATOR
+      "\u{2029}",                                     # PARAGRAPH SEPARATOR
+      "\u{202F}",                                     # NARROW NO-BREAK SPACE
+      "\u{205F}",                                     # MEDIUM MATHEMATICAL SPACE
+      "\u{3000}",                                     # IDEOGRAPHIC SPACE
+    ]
+    unicode_ws.each do |c|
+      assert_predicate(S(c), :blank?, "U+%04X should be blank" % c.ord)
+    end
+    # A run composed solely of assorted Unicode White_Space is still blank.
+    assert_predicate(S(unicode_ws.join), :blank?)
+
+    # Any non-space content makes the string non-blank.
+    assert_not_predicate(S("x"), :blank?)
+    assert_not_predicate(S(" \tfoo"), :blank?)
+
+    # Invisible but non-White_Space code points are NOT blank.
+    assert_not_predicate(S("\u{0}"), :blank?)      # NUL
+    assert_not_predicate(S("\u{200B}"), :blank?)   # ZERO WIDTH SPACE
+    assert_not_predicate(S("\u{FEFF}"), :blank?)   # ZERO WIDTH NO-BREAK SPACE (BOM)
+    assert_not_predicate(S("\u{180E}"), :blank?)   # MONGOLIAN VOWEL SEPARATOR (no longer White_Space)
+
+    # U+00A0 is blank under UTF-8, but a standalone 0xA0 byte under
+    # ASCII-8BIT has no Unicode meaning and is not blank.
+    assert_predicate(S("\u{A0}"), :blank?)
+    assert_not_predicate(S("\xA0").force_encoding(Encoding::ASCII_8BIT), :blank?)
+
+    # White_Space holds across other Unicode/single-byte encodings too:
+    # U+3000 under UTF-16LE and U+00A0 under ISO-8859-1 are both blank.
+    assert_predicate(S("\u{3000}").encode("UTF-16LE"), :blank?)
+    assert_predicate(S("\u{A0}").encode("ISO-8859-1"), :blank?)
+
+    # Malformed UTF-8 consisting only of an invalid byte raises ArgumentError.
+    assert_raise(ArgumentError) { S("\xFF").force_encoding(Encoding::UTF_8).blank? }
+
+    # A frozen whitespace string is still blank.
+    assert_predicate(S(" ").freeze, :blank?)
+
+    # A non-whitespace character under UTF-16LE is not blank.
+    assert_not_predicate(S("x").encode("UTF-16LE"), :blank?)
+
+    utf16le_dagger = S("  ").force_encoding(Encoding::UTF_16LE)
+    assert_not_predicate(utf16le_dagger, :blank?)
+
+    # An ASCII-space prefix does not mask malformed UTF-8 reached while scanning.
+    assert_raise(ArgumentError) { S(" \xFF").force_encoding(Encoding::UTF_8).blank? }
+  end
+
   def test_end_with?
     assert_send([S("hello"), :end_with?, S("llo")])
     assert_not_send([S("hello"), :end_with?, S("ll")])


### PR DESCRIPTION
# Add `String#blank?` for Unicode whitespace

## Summary

Add `String#blank?`, returning `true` when the receiver is empty or every character is whitespace according to its encoding. For Unicode encodings, whitespace follows the Unicode `White_Space` property.

This adds only `String#blank?`, it does not add `present?` or a protocol across other core classes.

## Motivation and existing use

Checking whether user input is empty or contains only whitespace is common in web applications, including form validation and parameter handling. Active Support provides this operation as `String#blank?`, but its regexp-based implementation is slower than a native scan.

The [`fast_blank`](https://github.com/SamSaffron/fast_blank) gem addresses that cost with a C extension for string blankness and has [more than 62 million downloads on RubyGems](https://rubygems.org/gems/fast_blank). Its `blank_as?` method provides the Unicode-aware behavior of Active Support's `String#blank?`, while its `blank?` method follows `String#strip` semantics and does not recognize all Unicode whitespace.

Providing `String#blank?` in Ruby core makes the Active Support-compatible behavior built in, encoding-aware, and allocation-free. It directly replaces Active Support's String predicate where that is the only behavior needed. Applications calling `String#blank_as?` from `fast_blank` can migrate those call sites to `String#blank?` and remove the native dependency. It is not an exact replacement for `fast_blank`'s default `String#blank?`, because strings containing Unicode whitespace may produce different results.

The scope remains limited to strings. This PR does not add `present?` or Active Support's cross-object blank protocol for objects such as `nil`, arrays, and hashes.

## Prior discussion and naming

This behavior was discussed in [Feature #12306](https://bugs.ruby-lang.org/issues/12306). In [note #42](https://bugs.ruby-lang.org/issues/12306#note-42), Matz wrote that adding a predicate which checks whether a string contains only characters with the Unicode space property was acceptable. He explicitly declined `present?` and said that `blank?`, while not his ideal name, was still acceptable.

The discussion did not end with that note. Nobu proposed `String#space_only?` in [note #43](https://bugs.ruby-lang.org/issues/12306#note-43), analogous to `ascii_only?`, and Sam Saffron supported that name in [note #44](https://bugs.ruby-lang.org/issues/12306#note-44). This PR deliberately retains `blank?`: it is the established Active Support String API, provides direct compatibility for existing callers, and was the name accepted as viable by Matz. The PR implements only this narrow String predicate, not `present?` or Active Support's cross-object blank protocol.

## Semantics

```ruby
"".blank?          # => true
" \t\r\n".blank?  # => true
"\u00a0".blank?   # => true
"\u3000".blank?   # => true
" hello ".blank?  # => false
"\u200b".blank?   # => false
"\0".blank?       # => false
```

The empty string is blank. Invisible characters which do not have the Unicode `White_Space` property, such as U+200B ZERO WIDTH SPACE and U+FEFF ZERO WIDTH NO-BREAK SPACE/BOM, are not blank. NUL is not whitespace.

If scanning reaches a byte sequence that is invalid for the receiver's encoding, `blank?` raises `ArgumentError`, consistent with the regexp-based Active Support implementation.

## Implementation

The implementation scans once and returns immediately on the first non-whitespace character. ASCII-compatible strings use a direct byte fast path for ASCII whitespace. Non-ASCII characters are decoded with `rb_enc_codepoint_len` and classified with `rb_enc_isspace`, keeping Ruby's generated encoding tables as the source of truth.

The method allocates no objects.

## Performance

A Ruby implementation using `empty? || /\A[[:space:]]*\z/.match?(self)` was used as an executable semantic prototype. Local direct-call benchmarks on arm64 Darwin with Ruby 4.0.5 found that the regexp implementation remained roughly 2–4x slower than native scanning for representative non-empty strings, including with YJIT enabled.

The ASCII byte fast path also outperformed `fast_blank`'s code-point-at-a-time scan for longer ASCII strings in the same exploratory benchmark. Non-ASCII input falls back to Ruby's encoding-aware property lookup rather than duplicating the Unicode whitespace list.

The in-tree `benchmark/string_blank_p.yml` benchmark tracks `String#blank?` performance across empty, short and long ASCII, and Unicode inputs.

## Credit

This work was informed by Sam Saffron's [`fast_blank`](https://github.com/SamSaffron/fast_blank), especially its `blank_as?` implementation: decode characters, reject the first non-whitespace code point, and avoid allocations.