### PR TITLE
Make Time.at w/ in: 1.8x faster

### DIFF
--- a/time.c
+++ b/time.c
@@ -4140,7 +4140,7 @@ static VALUE
 time_zonelocal(VALUE time, VALUE off)
 {
     VALUE zone = off;
-    if (zone_localtime(zone, time)) return time;
+    if (maybe_tzobj_p(zone) && zone_localtime(zone, time)) return time;
 
     if (NIL_P(off = utc_offset_arg(off))) {
         off = zone;

--- a/time.c
+++ b/time.c
@@ -2233,6 +2233,10 @@ invalid_utc_offset(VALUE zone)
 static VALUE
 utc_offset_arg(VALUE arg)
 {
+    if (RB_INTEGER_TYPE_P(arg)) {
+        return arg;
+    }
+
     VALUE tmp;
     if (!NIL_P(tmp = rb_check_string_type(arg))) {
         int n = 0;


### PR DESCRIPTION
[Make Time.at w/ in: 1.5x faster](https://github.com/ruby/ruby/commit/13336233a27cf2ac16ecd81d992db2609f952233) 

```
$ ips --ruby 'ruby-dev --yjit' --ruby 'ruby-master --yjit' -e 'Time.at(1_700_000_000, in: 0)'
ruby 4.1.0dev (2026-07-15T17:09:20Z master 6cd755deab) +YJIT +PRISM [arm64-darwin25]
Time.at(1_700_000_000, in: 0):     8.920M i/s (± 2.0%, GC  3.3%)

ruby 4.1.0dev (2026-07-15T17:09:20Z master 6cd755deab) +YJIT +PRISM [arm64-darwin25]
Time.at(1_700_000_000, in: 0):     5.894M i/s (± 0.5%, GC  4.2%)

Summary
  ruby ruby-dev --yjit ran
    1.51 ± 0.03 times faster than ruby ruby-master --yjit
```

Other callers of zone_localtime use maybe_tzobj_p to short circuit the
utc_to_local respond_to?/call, but this one didn't.

---

[Make Time.at w/ in: another 1.2x faster](https://github.com/ruby/ruby/commit/0bdf2580e8f97e4d281f5bb23addca1049ea4c88) 

```
$ ips --ruby 'ruby-maybe --yjit' --ruby 'ruby-dev --yjit' -e 'Time.at(1_700_000_000, in: 0)'
ruby 4.1.0dev (2026-07-15T17:09:20Z master 6cd755deab) +YJIT +PRISM [arm64-darwin25]
Time.at(1_700_000_000, in: 0):     8.944M i/s (± 0.7%, GC  3.2%)

ruby 4.1.0dev (2026-07-15T17:09:20Z master 6cd755deab) +YJIT +PRISM [arm64-darwin25]
Time.at(1_700_000_000, in: 0):    10.925M i/s (± 0.9%, GC  4.0%)

Summary
  ruby ruby-dev --yjit ran
    1.22 ± 0.01 times faster than ruby ruby-maybe --yjit
```

utc_offset_arg checks whether its argument can be to_str'd, which
Integer's (should) not be, so we can fast path it to speed it up