### PR TITLE
Fix Ractor move source husk breaking compaction slot size invariant

### DIFF
--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -2668,3 +2668,27 @@ assert_equal 'ok', %q{
     :ok  # platform without fork
   end
 }
+
+# A moved object's source is neutralized into a RactorMovedObject husk that
+# stays in its original (possibly larger) slot. It must be given a shape whose
+# slot size matches that slot, or a later compaction in the receiver trips the
+# slot_size == shape_slot_size invariant (RGENGC_CHECK_MODE) / corrupts the slot.
+assert_equal 'ok', %q{
+  r = Ractor.new do
+    while (o = Ractor.receive)
+      begin
+        GC.compact
+      rescue NotImplementedError
+        # no-op on platforms without GC.compact (e.g. MMTk)
+      end
+    end
+    :ok
+  end
+  500.times do
+    o = Object.new
+    12.times { |i| o.instance_variable_set("@i#{i}", i) }  # overflow to a larger slot
+    r.send(o, move: true)
+  end
+  r.send(nil)
+  r.value
+}

--- a/ractor.c
+++ b/ractor.c
@@ -2081,11 +2081,17 @@ move_leave(VALUE obj, struct obj_traverse_replace_data *data)
     }
 
     VALUE flags = T_OBJECT | FL_FREEZE | (RBASIC(obj)->flags & FL_PROMOTED);
+    shape_id_t shape_id = (RBASIC_SHAPE_ID(obj) & SHAPE_ID_CAPACITY_MASK) | ROOT_SHAPE_ID | SHAPE_ID_LAYOUT_ROBJECT | SHAPE_ID_FL_FROZEN;
 
     // Avoid mutations using bind_call, etc.
     MEMZERO((char *)obj, char, sizeof(struct RBasic));
     RBASIC(obj)->flags = flags;
     RBASIC_SET_CLASS_RAW(obj, rb_cRactorMovedObject);
+
+    // The husk keeps its original (larger) slot, so give it a field-less shape
+    // sized to that slot; otherwise compaction's slot_size == shape_slot_size
+    // invariant is violated.
+    RBASIC_SET_FULL_SHAPE_ID(obj, shape_id);
     return traverse_cont;
 }
 


### PR DESCRIPTION
When an object is moved to another Ractor with `Ractor.send(obj, move: true)`, the moved-out source is neutralized into a RactorMovedObject husk by move_leave: its flags are cleared with MEMZERO (which zeroes the shape id to 0) and reset to a bare T_OBJECT. But the husk stays in the object's original, possibly larger, slot. Shape 0 implies the smallest slot, so the husk now has rb_obj_shape_slot_size(husk) != rb_gc_obj_slot_size(husk).

Since re-embeddable T_OBJECT fields landed, compaction requires every live object to satisfy rb_gc_obj_slot_size == rb_obj_shape_slot_size (asserted in gc_ref_update_object under RGENGC_CHECK_MODE). A GC.compact in the receiving Ractor walks the husk and trips the assertion; in a release build it updates references with a mismatched slot width and can corrupt the slot.

Give the husk a field-less ROOT shape sized to its physical slot. It stays field-less (so the stale body is never read as ivars) and satisfies the invariant.