### PR TITLE
Speed up Ractor.make_shareable

### DIFF
--- a/ractor.c
+++ b/ractor.c
@@ -1337,12 +1337,14 @@ obj_traverse_i(VALUE obj, struct obj_traverse_data *data)
     }
     RB_OBJ_WRITTEN(data->rec_hash, Qundef, obj);
 
-    struct obj_traverse_callback_data d = {
-        .stop = false,
-        .data = data,
-    };
-    rb_ivar_foreach(obj, obj_traverse_ivar_foreach_i, (st_data_t)&d);
-    if (d.stop) return 1;
+    if (rb_obj_shape_has_ivars(obj)) {
+        struct obj_traverse_callback_data d = {
+            .stop = false,
+            .data = data,
+        };
+        rb_ivar_foreach(obj, obj_traverse_ivar_foreach_i, (st_data_t)&d);
+        if (d.stop) return 1;
+    }
 
     switch (BUILTIN_TYPE(obj)) {
       // no child node

--- a/ractor.c
+++ b/ractor.c
@@ -1282,6 +1282,20 @@ obj_traverse_reachable_i(VALUE obj, void *ptr)
     }
 }
 
+// Traverse obj's children via its GC mark function. Returns 1 to stop.
+static int
+obj_traverse_reachable(VALUE obj, struct obj_traverse_data *data)
+{
+    struct obj_traverse_callback_data d = {
+        .stop = false,
+        .data = data,
+    };
+    RB_VM_LOCKING_NO_BARRIER() {
+        rb_objspace_reachable_objects_from(obj, obj_traverse_reachable_i, &d);
+    }
+    return d.stop;
+}
+
 static struct st_table *
 obj_traverse_rec(struct obj_traverse_data *data)
 {
@@ -1393,17 +1407,29 @@ obj_traverse_i(VALUE obj, struct obj_traverse_data *data)
         break;
 
       case T_DATA:
-      case T_IMEMO:
         {
-            struct obj_traverse_callback_data d = {
-                .stop = false,
-                .data = data,
-            };
-            RB_VM_LOCKING_NO_BARRIER() {
-                rb_objspace_reachable_objects_from(obj, obj_traverse_reachable_i, &d);
+            void *const ptr = RTYPEDDATA_GET_DATA(obj);
+            const rb_data_type_t *type = RTYPEDDATA_TYPE(obj);
+
+            if (!ptr || !type->function.dmark) {
+                // no references (the class and ivars are handled elsewhere)
             }
-            if (d.stop) return 1;
+            else if (type->flags & RUBY_TYPED_DECL_MARKING) {
+                const size_t *offsets = (const size_t *)(uintptr_t)type->function.dmark;
+                for (; *offsets != RUBY_REF_END; offsets++) {
+                    VALUE ref = *(VALUE *)((char *)ptr + *offsets);
+                    if (obj_traverse_i(ref, data)) return 1;
+                }
+            }
+            else {
+                if (obj_traverse_reachable(obj, data)) return 1;
+            }
         }
+        break;
+
+      case T_IMEMO:
+        // TODO: Not sure this can actually happen; traverse rather than crash.
+        if (obj_traverse_reachable(obj, data)) return 1;
         break;
 
       // unreachable

--- a/ractor.c
+++ b/ractor.c
@@ -1363,7 +1363,7 @@ obj_traverse_i(VALUE obj, struct obj_traverse_data *data)
             rb_ary_cancel_sharing(obj);
 
             for (int i = 0; i < RARRAY_LENINT(obj); i++) {
-                VALUE e = rb_ary_entry(obj, i);
+                VALUE e = RARRAY_AREF(obj, i);
                 if (obj_traverse_i(e, data)) return 1;
             }
         }
@@ -1601,7 +1601,7 @@ make_shareable_check_shareable(VALUE obj)
 static enum obj_traverse_iterator_result
 mark_shareable(VALUE obj)
 {
-    if (RB_TYPE_P(obj, T_STRING)) {
+    if (RB_BUILTIN_TYPE(obj) == T_STRING) {
         rb_str_make_independent(obj);
     }
 
@@ -1939,7 +1939,7 @@ obj_traverse_replace_i(VALUE obj, struct obj_traverse_replace_data *data)
             rb_ary_cancel_sharing(obj);
 
             for (int i = 0; i < RARRAY_LENINT(obj); i++) {
-                VALUE e = rb_ary_entry(obj, i);
+                VALUE e = RARRAY_AREF(obj, i);
 
                 if (obj_traverse_replace_i(e, data)) {
                     return 1;


### PR DESCRIPTION
Cherry-picks out of #17644

* Avoid taking the VM for declaratively marked T_DATA
* Use RARRAY_AREF instead of `rb_ary_entry` (we don't need bounds checks or negative handling)
* Avoid calling rb_ivar_foreach unless ivars exist