### PR TITLE
set RUBY_DEBUG_TEST_NO_REMOTE=1 for debug.gem

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -158,6 +158,7 @@ jobs:
         env:
           RUBY_TESTOPTS: '-q --tty=no'
           TEST_BUNDLED_GEMS_ALLOW_FAILURES: ''
+          RUBY_DEBUG_TEST_NO_REMOTE: "1"
           PRECHECK_BUNDLED_GEMS: 'no'
           LAUNCHABLE_STDOUT: ${{ steps.launchable.outputs.stdout_report_path }}
           LAUNCHABLE_STDERR: ${{ steps.launchable.outputs.stderr_report_path }}


### PR DESCRIPTION
to skip remote connection tests.