### PR TITLE
Ractor: restrict class/module modification to the creator Ractor

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -273,6 +273,21 @@ Ruby 4.0 bundled RubyGems and Bundler version 4. see the following links for det
 
 ## Compatibility issues
 
+* A class or module can now be modified only by the Ractor which created it,
+  its *owner*.  Defining, removing or undefining methods, `alias`, changing
+  visibility, `include`/`prepend`, `Module#refine`, defining or removing
+  constants, registering an `autoload`, writing the class's own instance
+  variables and class variables, `Module#freeze` and
+  `Module#set_temporary_name` raise `Ractor::IsolationError` in any other
+  Ractor.  Reading is unchanged.  Everything defined at boot or by the main
+  Ractor, `require`d libraries included, is owned by the main Ractor, so a
+  non-main Ractor can no longer monkey-patch it; and since defining a constant
+  in a foreign class is prohibited, it can not define a top-level class or
+  module name either.  In exchange a Ractor has full use of the classes it
+  creates itself, including unshareable constant, instance variable and class
+  variable values, which not even the main Ractor could do before.  See
+  doc/language/ractor.md. [[Feature #22226]]
+
 * `Kernel#at_exit` and `END {}` now raise `Ractor::IsolationError` when called
   in a non-main Ractor.  Previously the registered handler ran in the main
   Ractor at process exit, which was confusing. [[Feature #22139]]
@@ -382,6 +397,7 @@ A lot of work has gone into making Ractors more stable, performant, and usable. 
 [Feature #22175]: https://bugs.ruby-lang.org/issues/22175
 [Feature #22185]: https://bugs.ruby-lang.org/issues/22185
 [Feature #22205]: https://bugs.ruby-lang.org/issues/22205
+[Feature #22226]: https://bugs.ruby-lang.org/issues/22226
 [Feature #22238]: https://bugs.ruby-lang.org/issues/22238
 [PR #17201]: https://github.com/ruby/ruby/pull/17201
 [GH-psych #805]: https://github.com/ruby/psych/pull/805

--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -868,8 +868,8 @@ assert_equal '99', %q{
   Ractor.new { inner = 99; eval("inner").to_s }.value
 }
 
-# ivar in shareable-objects are not allowed to access from non-main Ractor
-assert_equal "can not get unshareable values from instance variables of classes/modules from non-main Ractors (@iv from C)", <<~'RUBY', frozen_string_literal: false
+# ivar in shareable-objects are not allowed to access from non-owner Ractor
+assert_equal "can not get unshareable values from instance variables of classes/modules created by another Ractor (@iv from C)", <<~'RUBY', frozen_string_literal: false
   class C
     @iv = 'str'
   end
@@ -1175,7 +1175,7 @@ assert_equal 'true', %q{
 }
 
 # Getting non-shareable objects via constants by other Ractors is not allowed
-assert_equal 'can not access non-shareable objects in constant C::CONST by non-main Ractor.', <<~'RUBY', frozen_string_literal: false
+assert_equal 'can not access non-shareable objects in constant C::CONST of a class/module created by another Ractor.', <<~'RUBY', frozen_string_literal: false
   class C
     CONST = 'str'
   end
@@ -1190,7 +1190,7 @@ assert_equal 'can not access non-shareable objects in constant C::CONST by non-m
   RUBY
 
 # Constant cache should care about non-shareable constants
-assert_equal "can not access non-shareable objects in constant Object::STR by non-main Ractor.", <<~'RUBY', frozen_string_literal: false
+assert_equal "can not access non-shareable objects in constant Object::STR of a class/module created by another Ractor.", <<~'RUBY', frozen_string_literal: false
   STR = "hello"
   def str; STR; end
   s = str() # fill const cache
@@ -1202,7 +1202,7 @@ assert_equal "can not access non-shareable objects in constant Object::STR by no
 RUBY
 
 # The correct constant path shall be reported
-assert_equal "can not access non-shareable objects in constant Object::STR by non-main Ractor.", <<~'RUBY', frozen_string_literal: false
+assert_equal "can not access non-shareable objects in constant Object::STR of a class/module created by another Ractor.", <<~'RUBY', frozen_string_literal: false
   STR = "hello"
   module M
     def self.str; STR; end
@@ -1215,8 +1215,8 @@ assert_equal "can not access non-shareable objects in constant Object::STR by no
   end
 RUBY
 
-# Setting non-shareable objects into constants by other Ractors is not allowed
-assert_equal 'can not set constants with non-shareable objects by non-main Ractors', <<~'RUBY', frozen_string_literal: false
+# Setting constants of classes created by other Ractors is not allowed
+assert_equal 'can not set constants of classes/modules created by another Ractor', <<~'RUBY', frozen_string_literal: false
   class C
   end
   r = Ractor.new do
@@ -1730,17 +1730,10 @@ assert_equal 'true', %q{
 }
 
 # check method cache invalidation
+# (the owner Ractor redefines methods while another Ractor calls them)
 assert_equal 'true', %q{
   class Foo
     def hello = nil
-  end
-
-  r1 = Ractor.new do
-    1000.times do
-      class Foo
-        def hello = nil
-      end
-    end
   end
 
   r2 = Ractor.new do
@@ -1750,7 +1743,12 @@ assert_equal 'true', %q{
     end
   end
 
-  r1.value
+  1000.times do
+    class Foo
+      def hello = nil
+    end
+  end
+
   r2.value
 
   true
@@ -2582,21 +2580,23 @@ RUBY
 assert_equal 'ok', <<~'RUBY'
 
 begin
-  CLASSES = 1000.times.map { Class.new }.freeze
-
+  # Each Ractor creates its own class (it can only define bmethods on classes
+  # it owns) and returns it after defining the bmethod.
   # This would be better to run in parallel, but there's a bug with lambda
   # creation and YJIT causing crashes in dev mode
-  ractors = CLASSES.map do |klass|
-    Ractor.new(klass) do |klass|
+  ractors = 1000.times.map do
+    Ractor.new do
+      klass = Class.new
       Ractor.receive
       klass.define_method(:foo) {}
+      klass
     end
   end
 
-  ractors.each do |ractor|
+  CLASSES = ractors.map do |ractor|
     ractor << nil
-    ractor.join
-  end
+    ractor.value
+  end.freeze
 
   ractors.clear
   GC.start

--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -1307,6 +1307,76 @@ assert_equal 'true', %q{
   end.value
 }
 
+# A moved object takes its singleton class's ownership with it, so the receiver
+# can keep defining singleton methods on it
+assert_equal '[:from_main, :from_ractor]', %q{
+  o = Object.new
+  def o.foo = :from_main   # materializes the singleton class here, in the main Ractor
+
+  r = Ractor.new do
+    x = Ractor.receive
+    def x.bar = :from_ractor
+    [x.foo, x.bar]
+  end
+  r.send(o, move: true)
+  r.value.inspect
+}
+
+# ... the whole eigenclass chain goes with it, so `class << obj.singleton_class`
+# keeps working for the receiver
+assert_equal 'true', %q{
+  o = Object.new
+  def o.foo = :main
+  o.singleton_class.singleton_class    # materialize it here, in the main Ractor
+
+  port = Ractor::Port.new
+  r = Ractor.new(port) do |port|
+    x = Ractor.receive
+    x.singleton_class.singleton_class.define_method(:mm) { :sub }
+    port << x.singleton_class.mm
+  end
+  r.send(o, move: true)
+  res = port.receive
+  r.join
+  (res == :sub).to_s
+}
+
+# ... but the move is refused when that singleton class holds unshareable values,
+# which the sender would keep while the receiver became their owner
+assert_equal 'can not move an object whose singleton class has variable @iv referring to an unshareable object', <<~'RUBY', frozen_string_literal: false
+  o = Object.new
+  o.singleton_class.instance_variable_set(:@iv, 'sender')
+
+  r = Ractor.new { Ractor.receive }
+  msg = begin
+    r.send(o, move: true)
+    'no error'
+  rescue Ractor::IsolationError => e
+    e.message
+  end
+  r.send(1)
+  r.join
+  msg
+  RUBY
+
+# ... and it comes back when the object is moved back
+assert_equal '[:from_main, :from_ractor, :from_main_again]', %q{
+  o = Object.new
+  def o.foo = :from_main
+
+  port = Ractor::Port.new
+  r = Ractor.new(port) do |port|
+    x = Ractor.receive
+    def x.bar = :from_ractor
+    port.send(x, move: true)
+  end
+  r.send(o, move: true)
+
+  back = port.receive
+  def back.baz = :from_main_again
+  [back.foo, back.bar, back.baz].inspect
+}
+
 # Getting non-shareable objects via constants by other Ractors is not allowed
 assert_equal 'can not access non-shareable objects in constant C::CONST of a class/module created by another Ractor.', <<~'RUBY', frozen_string_literal: false
   class C

--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -1377,6 +1377,97 @@ assert_equal '[:from_main, :from_ractor, :from_main_again]', %q{
   [back.foo, back.bar, back.baz].inspect
 }
 
+# A Ractor has full use of the cvars of a class it created, unshareable values included
+assert_equal 'not shareable', %q{
+  Ractor.new do
+    k = Class.new
+    k.class_variable_set(:@@cv, +'not shareable')
+    k.class_variable_get(:@@cv)
+  end.value
+}
+
+# The owner is the owner of the class the cvar is stored in, not of the receiver
+assert_equal 'can not set class variable @@cv of C, which was created by another Ractor', %q{
+  class C
+    @@cv = 1
+  end
+
+  r = Ractor.new do
+    # a subclass created by this Ractor, but @@cv lives in C
+    Class.new(C).class_variable_set(:@@cv, 2)
+  end
+
+  begin
+    r.join
+  rescue Ractor::RemoteError => e
+    e.cause.message
+  end
+}
+
+# Removing a cvar of a class created by another Ractor is not allowed
+assert_equal 'can not set class variable @@cv of C, which was created by another Ractor', %q{
+  class C
+    @@cv = 1
+  end
+
+  r = Ractor.new do
+    C.send(:remove_class_variable, :@@cv)
+  end
+
+  begin
+    r.join
+  rescue Ractor::RemoteError => e
+    e.cause.message
+  end
+}
+
+# Freezing a class created by another Ractor is not allowed
+assert_equal 'can not modify String because it is created by another Ractor', %q{
+  r = Ractor.new do
+    String.freeze
+  end
+
+  begin
+    r.join
+  rescue Ractor::RemoteError => e
+    e.cause.message
+  end
+}
+
+# Freezing a class the Ractor created itself is allowed, and freezing an
+# already frozen class stays a no-op for everybody
+assert_equal 'true true', %q{
+  FROZEN = Class.new.freeze
+
+  Ractor.new do
+    own = Class.new
+    own.freeze
+    "#{own.frozen?} #{FROZEN.freeze.frozen?}"
+  end.value
+}
+
+# set_temporary_name on a class created by another Ractor is not allowed
+assert_equal 'can not modify C because it is created by another Ractor', %q{
+  class C; end
+
+  r = Ractor.new do
+    C.set_temporary_name('other')
+  end
+
+  begin
+    r.join
+  rescue Ractor::RemoteError => e
+    e.cause.message
+  end
+}
+
+# set_temporary_name on a module the Ractor created itself is allowed
+assert_equal 'mine', %q{
+  Ractor.new do
+    Module.new.set_temporary_name('mine').name
+  end.value
+}
+
 # Getting non-shareable objects via constants by other Ractors is not allowed
 assert_equal 'can not access non-shareable objects in constant C::CONST of a class/module created by another Ractor.', <<~'RUBY', frozen_string_literal: false
   class C

--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -1264,6 +1264,49 @@ assert_equal 'can not modify M because it is created by another Ractor', %q{
   end
 }
 
+# Changing method visibility on a class created by another Ractor is not allowed
+assert_equal 'can not modify C because it is created by another Ractor', %q{
+  class C
+    def m; end
+  end
+
+  r = Ractor.new do
+    C.send(:private, :m)
+  end
+
+  begin
+    r.join
+  rescue Ractor::RemoteError => e
+    e.cause.message
+  end
+}
+
+# ... and neither is module_function with a method name
+assert_equal 'can not modify M because it is created by another Ractor', %q{
+  module M
+    def m; end
+  end
+
+  r = Ractor.new do
+    M.send(:module_function, :m)
+  end
+
+  begin
+    r.join
+  rescue Ractor::RemoteError => e
+    e.cause.message
+  end
+}
+
+# Visibility changes on a class the Ractor created itself are allowed
+assert_equal 'true', %q{
+  Ractor.new do
+    k = Class.new { def m; end }
+    k.send(:private, :m)
+    k.private_method_defined?(:m).to_s
+  end.value
+}
+
 # Getting non-shareable objects via constants by other Ractors is not allowed
 assert_equal 'can not access non-shareable objects in constant C::CONST of a class/module created by another Ractor.', <<~'RUBY', frozen_string_literal: false
   class C

--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -869,8 +869,8 @@ assert_equal '99', %q{
   Ractor.new { inner = 99; eval("inner").to_s }.value
 }
 
-# ivar in shareable-objects are not allowed to access from non-main Ractor
-assert_equal "can not get unshareable values from instance variables of classes/modules from non-main Ractors (@iv from C)", <<~'RUBY', frozen_string_literal: false
+# ivar in shareable-objects are not allowed to access from non-owner Ractor
+assert_equal "can not get unshareable values from instance variables of classes/modules created by another Ractor (@iv from C)", <<~'RUBY', frozen_string_literal: false
   class C
     @iv = 'str'
   end
@@ -1175,8 +1175,97 @@ assert_equal 'true', %q{
   r.value
 }
 
+# A shareable object belongs to no single Ractor, so its singleton class is the
+# main Ractor's rather than the one which materialized it
+assert_equal 'true', %q{
+  r = Ractor.new do
+    begin
+      Ractor.main.define_singleton_method(:zzz) { :sub }
+      :not_raised
+    rescue Ractor::IsolationError
+      :raised
+    end
+  end
+  raised = r.value
+  Ractor.main.define_singleton_method(:zzz) { :main }
+  (raised == :raised && Ractor.main.zzz == :main).to_s
+}
+
+# The constant inline cache is keyed on the Ractor which filled it, so a non-owner
+# can not be handed an unshareable constant through a cache the owner primed
+assert_equal 'Ractor::IsolationError', %q{
+  port = Ractor::Port.new
+  r = Ractor.new(port) do |port|
+    k = Class.new
+    k.const_set(:X, [1, 2, 3])
+    m = Module.new
+    m.const_set(:K, k)
+    m.module_eval("def self.rd = K::X")
+    m.rd                       # the owner fills the cache
+    port << m
+    Ractor.receive
+  end
+  m = port.receive
+  res = begin
+    m.rd
+    'no error'
+  rescue Ractor::IsolationError
+    'Ractor::IsolationError'
+  end
+  r << nil
+  r.join
+  res
+}
+
+# Class#initialize writes the superclass of an uninitialized class, so it is
+# owner-only like any other modification
+assert_equal 'can not modify K because it is created by another Ractor', %q{
+  K = Class.allocate
+
+  r = Ractor.new { K.send(:initialize, Struct) }
+
+  begin
+    r.join
+  rescue Ractor::RemoteError => e
+    e.cause.message
+  end
+}
+
+# Module#refine writes its refinement tables into the receiver, so the receiver
+# must be owned too
+assert_equal 'can not modify M because it is created by another Ractor', %q{
+  module M; end
+
+  r = Ractor.new do
+    M.send(:refine, Class.new) { def z = 1 }
+  end
+
+  begin
+    r.join
+  rescue Ractor::RemoteError => e
+    e.cause.message
+  end
+}
+
+# ... and so does Module#ruby2_keywords, which rewrites a method definition
+assert_equal 'can not modify M because it is created by another Ractor', %q{
+  module M
+    def m(*a) = a
+  end
+
+  r = Ractor.new do
+    M.send(:ruby2_keywords, :m)
+  end
+
+  begin
+    r.join
+  rescue Ractor::RemoteError => e
+    e.cause.message
+  end
+}
+
 # Getting non-shareable objects via constants by other Ractors is not allowed
-assert_equal 'can not access non-shareable objects in constant C::CONST by non-main Ractor.', <<~'RUBY', frozen_string_literal: false
+assert_equal 'can not access non-shareable objects in constant C::CONST of a class/module created by another Ractor.', <<~'RUBY', frozen_string_literal: false
   class C
     CONST = 'str'
   end
@@ -1191,7 +1280,7 @@ assert_equal 'can not access non-shareable objects in constant C::CONST by non-m
   RUBY
 
 # Constant cache should care about non-shareable constants
-assert_equal "can not access non-shareable objects in constant Object::STR by non-main Ractor.", <<~'RUBY', frozen_string_literal: false
+assert_equal "can not access non-shareable objects in constant Object::STR of a class/module created by another Ractor.", <<~'RUBY', frozen_string_literal: false
   STR = "hello"
   def str; STR; end
   s = str() # fill const cache
@@ -1203,7 +1292,7 @@ assert_equal "can not access non-shareable objects in constant Object::STR by no
 RUBY
 
 # The correct constant path shall be reported
-assert_equal "can not access non-shareable objects in constant Object::STR by non-main Ractor.", <<~'RUBY', frozen_string_literal: false
+assert_equal "can not access non-shareable objects in constant Object::STR of a class/module created by another Ractor.", <<~'RUBY', frozen_string_literal: false
   STR = "hello"
   module M
     def self.str; STR; end
@@ -1216,8 +1305,8 @@ assert_equal "can not access non-shareable objects in constant Object::STR by no
   end
 RUBY
 
-# Setting non-shareable objects into constants by other Ractors is not allowed
-assert_equal 'can not set constants with non-shareable objects by non-main Ractors', <<~'RUBY', frozen_string_literal: false
+# Setting constants of classes created by other Ractors is not allowed
+assert_equal 'can not set constants of classes/modules created by another Ractor', <<~'RUBY', frozen_string_literal: false
   class C
   end
   r = Ractor.new do
@@ -1733,17 +1822,10 @@ assert_equal 'true', %q{
 }
 
 # check method cache invalidation
+# (the owner Ractor redefines methods while another Ractor calls them)
 assert_equal 'true', %q{
   class Foo
     def hello = nil
-  end
-
-  r1 = Ractor.new do
-    1000.times do
-      class Foo
-        def hello = nil
-      end
-    end
   end
 
   r2 = Ractor.new do
@@ -1753,7 +1835,12 @@ assert_equal 'true', %q{
     end
   end
 
-  r1.value
+  1000.times do
+    class Foo
+      def hello = nil
+    end
+  end
+
   r2.value
 
   true
@@ -2603,21 +2690,23 @@ RUBY
 assert_equal 'ok', <<~'RUBY'
 
 begin
-  CLASSES = 1000.times.map { Class.new }.freeze
-
+  # Each Ractor creates its own class (it can only define bmethods on classes
+  # it owns) and returns it after defining the bmethod.
   # This would be better to run in parallel, but there's a bug with lambda
   # creation and YJIT causing crashes in dev mode
-  ractors = CLASSES.map do |klass|
-    Ractor.new(klass) do |klass|
+  ractors = 1000.times.map do
+    Ractor.new do
+      klass = Class.new
       Ractor.receive
       klass.define_method(:foo) {}
+      klass
     end
   end
 
-  ractors.each do |ractor|
+  CLASSES = ractors.map do |ractor|
     ractor << nil
-    ractor.join
-  end
+    ractor.value
+  end.freeze
 
   ractors.clear
   GC.start

--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -1045,8 +1045,8 @@ assert_equal '1234', %q{
   values.join
 }
 
-# Reading non-shareable cvar from non-main Ractor is not allowed
-assert_equal 'can not read non-shareable class variable @@cv from non-main Ractors (C)', %q{
+# Reading non-shareable cvar of a class created by another Ractor is not allowed
+assert_equal 'can not read non-shareable class variable @@cv of C, which was created by another Ractor', %q{
   class C
     @@cv = 'str'
   end
@@ -1064,8 +1064,8 @@ assert_equal 'can not read non-shareable class variable @@cv from non-main Racto
   end
 }
 
-# also cached non-shareable cvar read from non-main Ractor is not allowed
-assert_equal 'can not read non-shareable class variable @@cv from non-main Ractors (C)', %q{
+# also cached non-shareable cvar read of a foreign class is not allowed
+assert_equal 'can not read non-shareable class variable @@cv of C, which was created by another Ractor', %q{
   class C
     @@cv = 'str'
     def self.cv
@@ -1129,8 +1129,8 @@ assert_equal 'hello', %q{
   Ractor.new { C.cv }.value
 }
 
-# Writing cvar from non-main Ractor is not allowed
-assert_equal 'can not set class variables from non-main Ractors (@@cv from C)', %q{
+# Writing a cvar of a class created by another Ractor is not allowed
+assert_equal 'can not set class variable @@cv of C, which was created by another Ractor', %q{
   class C
     @@cv = 'str'
     def self.cv=(v)

--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -1305,6 +1305,65 @@ assert_equal "can not access non-shareable objects in constant Object::STR of a 
   end
 RUBY
 
+# Copying a class/module created by another Ractor raises if its constants or
+# fields refer to unshareable objects
+assert_equal 'can not copy a class/module created by another Ractor because constant CONST refers to an unshareable object', <<~'RUBY', frozen_string_literal: false
+  class C
+    CONST = 'str'
+  end
+
+  r = Ractor.new { C.dup }
+
+  begin
+    r.join
+  rescue Ractor::RemoteError => e
+    e.cause.message
+  end
+  RUBY
+
+assert_equal 'can not copy a class/module created by another Ractor because variable @iv refers to an unshareable object', <<~'RUBY', frozen_string_literal: false
+  class C
+    @iv = 'str'
+  end
+
+  r = Ractor.new { C.dup }
+
+  begin
+    r.join
+  rescue Ractor::RemoteError => e
+    e.cause.message
+  end
+  RUBY
+
+# ... the metaclass is checked too, because the copy carries it over
+assert_equal 'can not copy a class/module created by another Ractor because variable @secret refers to an unshareable object', <<~'RUBY', frozen_string_literal: false
+  class C; end
+  C.singleton_class.instance_variable_set(:@secret, 'str')
+
+  r = Ractor.new { C.dup }
+
+  begin
+    r.join
+  rescue Ractor::RemoteError => e
+    e.cause.message
+  end
+  RUBY
+
+# ... and the copy of a class which refers to nothing unshareable belongs to the
+# copying Ractor, which is a way to modify a foreign class without mutating it
+assert_equal 'copy orig', %q{
+  class C
+    CONST = 1
+    def m = 'orig'
+  end
+
+  Ractor.new do
+    k = C.dup
+    k.class_eval { def m = 'copy' }
+    "#{k.new.m} #{C.new.m}"
+  end.value
+}
+
 # Setting constants of classes created by other Ractors is not allowed
 assert_equal 'can not set constants of classes/modules created by another Ractor', <<~'RUBY', frozen_string_literal: false
   class C

--- a/class.c
+++ b/class.c
@@ -973,6 +973,43 @@ rb_module_check_initializable(VALUE mod)
     }
 }
 
+static enum rb_id_table_iterator_result
+init_copy_check_const_i(ID id, VALUE v, void *data)
+{
+    const rb_const_entry_t *ce = (const rb_const_entry_t *)v;
+    if (!UNDEF_P(ce->value) && !rb_ractor_shareable_p(ce->value)) {
+        rb_raise(rb_eRactorIsolationError,
+                 "can not copy a class/module created by another Ractor because "
+                 "constant %"PRIsVALUE" refers to an unshareable object", rb_id2str(id));
+    }
+    return ID_TABLE_CONTINUE;
+}
+
+static int
+init_copy_check_field_i(ID id, VALUE val, st_data_t arg)
+{
+    if ((rb_is_instance_id(id) || rb_is_class_id(id)) && !rb_ractor_shareable_p(val)) {
+        rb_raise(rb_eRactorIsolationError,
+                 "can not copy a class/module created by another Ractor because "
+                 "variable %"PRIsVALUE" refers to an unshareable object", rb_id2str(id));
+    }
+    return ST_CONTINUE;
+}
+
+// When copying a class/module created by another Ractor, the copy belongs to
+// the current Ractor, so its tables must not leak unshareable objects owned
+// by the source's Ractor.
+static void
+init_copy_owner_check(VALUE orig)
+{
+    if (!rb_class_owned_p(orig)) {
+        if (RCLASS_CONST_TBL(orig)) {
+            rb_id_table_foreach(RCLASS_CONST_TBL(orig), init_copy_check_const_i, NULL);
+        }
+        rb_ivar_foreach_buffered(orig, init_copy_check_field_i, 0);
+    }
+}
+
 /* :nodoc: */
 VALUE
 rb_mod_init_copy(VALUE clone, VALUE orig)
@@ -994,6 +1031,8 @@ rb_mod_init_copy(VALUE clone, VALUE orig)
 
     RUBY_ASSERT(RB_TYPE_P(orig, T_CLASS) || RB_TYPE_P(orig, T_MODULE));
     RUBY_ASSERT(BUILTIN_TYPE(clone) == BUILTIN_TYPE(orig));
+
+    init_copy_owner_check(orig);
 
     rb_class_set_initialized(clone);
 

--- a/class.c
+++ b/class.c
@@ -31,6 +31,7 @@
 #include "ruby/st.h"
 #include "vm_core.h"
 #include "ruby/ractor.h"
+#include "ractor_core.h"
 #include "yjit.h"
 #include "zjit.h"
 
@@ -599,6 +600,13 @@ class_alloc0(enum ruby_value_type type, VALUE klass, bool boxable)
 
     memset(RCLASS_EXT_PRIME(obj), 0, sizeof(rb_classext_t));
 
+    // The creating Ractor owns the new class/module (owner_ractor == 0 means
+    // the main Ractor; iclasses have no meaningful owner). Singleton classes
+    // of classes/modules override this to inherit the attached object's owner.
+    if (type != T_ICLASS && UNLIKELY(!rb_ractor_main_p())) {
+        RCLASS_SET_OWNER_RACTOR((VALUE)obj, GET_RACTOR()->pub.self);
+    }
+
     /* ZALLOC
       RCLASS_CONST_TBL(obj) = 0;
       RCLASS_M_TBL(obj) = 0;
@@ -626,6 +634,31 @@ class_alloc(enum ruby_value_type type, VALUE klass)
 {
     bool boxable = rb_box_available() && BOX_MASTER_P(rb_current_box());
     return class_alloc0(type, klass, boxable);
+}
+
+bool
+rb_class_owned_p(VALUE klass)
+{
+    // The owner Ractor object is marked from the classext, so the comparison
+    // is never against a dangling/reused reference. Classes whose owner
+    // Ractor has terminated are permanently read-only for everybody.
+    VALUE owner = RCLASS_OWNER_RACTOR(klass);
+    if (LIKELY(!owner)) {
+        return rb_ractor_main_p();
+    }
+    else {
+        return owner == GET_RACTOR()->pub.self;
+    }
+}
+
+void
+rb_class_owner_check(VALUE klass)
+{
+    if (UNLIKELY(!rb_class_owned_p(klass))) {
+        rb_raise(rb_eRactorIsolationError,
+                 "can not modify %"PRIsVALUE" because it is created by another Ractor",
+                 rb_class_path(klass));
+    }
 }
 
 static VALUE
@@ -1189,6 +1222,9 @@ make_metaclass(VALUE klass)
     VALUE metaclass = class_boot_boxable(Qundef, FL_TEST_RAW(klass, RCLASS_BOXABLE));
 
     FL_SET(metaclass, FL_SINGLETON);
+    // A metaclass is owned by the owner of the class it is attached to,
+    // not by the Ractor which happened to trigger its lazy creation.
+    RCLASS_SET_OWNER_RACTOR(metaclass, RCLASS_OWNER_RACTOR(klass));
     rb_singleton_class_attached(metaclass, klass);
 
     if (META_CLASS_OF_CLASS_CLASS_P(klass)) {
@@ -1224,6 +1260,11 @@ make_singleton_class(VALUE obj)
     VALUE orig_class = METACLASS_OF(obj);
     VALUE klass = class_alloc0(T_CLASS, rb_cClass, FL_TEST_RAW(orig_class, RCLASS_BOXABLE));
     FL_SET(klass, FL_SINGLETON);
+    if (RB_TYPE_P(obj, T_MODULE)) {
+        // The singleton class of a module is owned by the module's owner,
+        // not by the Ractor which happened to trigger its lazy creation.
+        RCLASS_SET_OWNER_RACTOR(klass, RCLASS_OWNER_RACTOR(obj));
+    }
     class_initialize_method_table(klass);
     class_associate_super(klass, orig_class, true);
     if (orig_class && !UNDEF_P(orig_class)) {

--- a/class.c
+++ b/class.c
@@ -976,6 +976,54 @@ rb_module_check_initializable(VALUE mod)
     }
 }
 
+static enum rb_id_table_iterator_result
+init_copy_check_const_i(ID id, VALUE v, void *data)
+{
+    const rb_const_entry_t *ce = (const rb_const_entry_t *)v;
+    if (!UNDEF_P(ce->value) && !rb_ractor_shareable_p(ce->value)) {
+        rb_raise(rb_eRactorIsolationError,
+                 "can not copy a class/module created by another Ractor because "
+                 "constant %"PRIsVALUE" refers to an unshareable object", rb_id2str(id));
+    }
+    return ID_TABLE_CONTINUE;
+}
+
+static int
+init_copy_check_field_i(ID id, VALUE val, st_data_t arg)
+{
+    if ((rb_is_instance_id(id) || rb_is_class_id(id)) && !rb_ractor_shareable_p(val)) {
+        rb_raise(rb_eRactorIsolationError,
+                 "can not copy a class/module created by another Ractor because "
+                 "variable %"PRIsVALUE" refers to an unshareable object", rb_id2str(id));
+    }
+    return ST_CONTINUE;
+}
+
+// The copy belongs to the copying Ractor, so it must not carry over unshareable
+// objects owned by the source's Ractor.
+static void
+init_copy_check_tables(VALUE klass)
+{
+    if (RCLASS_CONST_TBL(klass)) {
+        rb_id_table_foreach(RCLASS_CONST_TBL(klass), init_copy_check_const_i, NULL);
+    }
+    rb_ivar_foreach_buffered(klass, init_copy_check_field_i, 0);
+}
+
+static void
+init_copy_owner_check(VALUE orig)
+{
+    if (!rb_class_owned_p(orig)) {
+        init_copy_check_tables(orig);
+
+        // rb_singleton_class_clone_and_attach copies the metaclass's tables too
+        VALUE meta = METACLASS_OF(orig);
+        if (RCLASS_SINGLETON_P(meta)) {
+            init_copy_check_tables(meta);
+        }
+    }
+}
+
 /* :nodoc: */
 VALUE
 rb_mod_init_copy(VALUE clone, VALUE orig)
@@ -997,6 +1045,8 @@ rb_mod_init_copy(VALUE clone, VALUE orig)
 
     RUBY_ASSERT(RB_TYPE_P(orig, T_CLASS) || RB_TYPE_P(orig, T_MODULE));
     RUBY_ASSERT(BUILTIN_TYPE(clone) == BUILTIN_TYPE(orig));
+
+    init_copy_owner_check(orig);
 
     rb_class_set_initialized(clone);
 

--- a/class.c
+++ b/class.c
@@ -654,6 +654,28 @@ class_owner_name(VALUE klass)
     return (RB_TYPE_P(obj, T_CLASS) || RB_TYPE_P(obj, T_MODULE)) ? rb_class_path(obj) : rb_any_to_s(obj);
 }
 
+/* The eigenclass of klass, if it has one of its own, else 0. */
+static VALUE
+class_own_metaclass(VALUE klass)
+{
+    VALUE meta = METACLASS_OF(klass);
+    return (RCLASS_SINGLETON_P(meta) && RCLASS_ATTACHED_OBJECT(meta) == klass) ? meta : 0;
+}
+
+/* Only for a singleton class whose attached object has just changed hands through
+ * Ractor#send(move: true).  Deliberately unreachable from Ruby. */
+void
+rb_class_take_ownership(VALUE klass)
+{
+    // keep class_alloc0's "0 means main" encoding
+    rb_serial_t id = rb_ractor_main_p() ? 0 : rb_ractor_id(GET_RACTOR());
+
+    // and up the eigenclass chain: each one belongs to the class below it
+    do {
+        RCLASS_SET_OWNER_RACTOR_ID(klass, id);
+    } while ((klass = class_own_metaclass(klass)) != 0);
+}
+
 void
 rb_class_owner_check(VALUE klass)
 {
@@ -1001,6 +1023,42 @@ init_copy_check_field_i(ID id, VALUE val, st_data_t arg)
 
 // The copy belongs to the copying Ractor, so it must not carry over unshareable
 // objects owned by the source's Ractor.
+static enum rb_id_table_iterator_result
+move_check_const_i(ID id, VALUE v, void *data)
+{
+    const rb_const_entry_t *ce = (const rb_const_entry_t *)v;
+    if (!UNDEF_P(ce->value) && !rb_ractor_shareable_p(ce->value)) {
+        rb_raise(rb_eRactorIsolationError,
+                 "can not move an object whose singleton class has constant %"PRIsVALUE
+                 " referring to an unshareable object", rb_id2str(id));
+    }
+    return ID_TABLE_CONTINUE;
+}
+
+static int
+move_check_field_i(ID id, VALUE val, st_data_t arg)
+{
+    if ((rb_is_instance_id(id) || rb_is_class_id(id)) && !rb_ractor_shareable_p(val)) {
+        rb_raise(rb_eRactorIsolationError,
+                 "can not move an object whose singleton class has variable %"PRIsVALUE
+                 " referring to an unshareable object", rb_id2str(id));
+    }
+    return ST_CONTINUE;
+}
+
+/* The receiver of a moved object becomes the owner of its singleton class
+ * (rb_class_take_ownership), so nothing the sender keeps may stay readable there. */
+void
+rb_class_check_singleton_movable(VALUE klass)
+{
+    do {
+        if (RCLASS_CONST_TBL(klass)) {
+            rb_id_table_foreach(RCLASS_CONST_TBL(klass), move_check_const_i, NULL);
+        }
+        rb_ivar_foreach_buffered(klass, move_check_field_i, 0);
+    } while ((klass = class_own_metaclass(klass)) != 0);
+}
+
 static void
 init_copy_check_tables(VALUE klass)
 {

--- a/class.c
+++ b/class.c
@@ -32,6 +32,7 @@
 #include "ruby/st.h"
 #include "vm_core.h"
 #include "ruby/ractor.h"
+#include "ractor_core.h"
 #include "yjit.h"
 #include "zjit.h"
 
@@ -600,6 +601,12 @@ class_alloc0(enum ruby_value_type type, VALUE klass, bool boxable)
 
     memset(RCLASS_EXT_PRIME(obj), 0, sizeof(rb_classext_t));
 
+    // The creating Ractor owns the new class/module; an iclass has no owner.
+    // Singleton classes of classes/modules override this below.
+    if (type != T_ICLASS && UNLIKELY(!rb_ractor_main_p())) {
+        RCLASS_SET_OWNER_RACTOR_ID((VALUE)obj, rb_ractor_id(GET_RACTOR()));
+    }
+
     /* ZALLOC
       RCLASS_CONST_TBL(obj) = 0;
       RCLASS_M_TBL(obj) = 0;
@@ -627,6 +634,34 @@ class_alloc(enum ruby_value_type type, VALUE klass)
 {
     bool boxable = rb_box_available() && BOX_MASTER_P(rb_current_box());
     return class_alloc0(type, klass, boxable);
+}
+
+bool
+rb_class_owned_by_ractor_p(rb_serial_t owner_id)
+{
+    return owner_id == rb_ractor_id(GET_RACTOR());
+}
+
+/* A singleton class has no class path of its own, so name it by the object it
+ * belongs to, as rb_class_modify_check does for a frozen one.  No dispatch: the
+ * object belongs to another Ractor. */
+static VALUE
+class_owner_name(VALUE klass)
+{
+    if (!RCLASS_SINGLETON_P(klass)) return rb_class_path(klass);
+
+    VALUE obj = RCLASS_ATTACHED_OBJECT(klass);
+    return (RB_TYPE_P(obj, T_CLASS) || RB_TYPE_P(obj, T_MODULE)) ? rb_class_path(obj) : rb_any_to_s(obj);
+}
+
+void
+rb_class_owner_check(VALUE klass)
+{
+    if (UNLIKELY(!rb_class_owned_p(klass))) {
+        rb_raise(rb_eRactorIsolationError,
+                 "can not modify %"PRIsVALUE" because it is created by another Ractor",
+                 class_owner_name(klass));
+    }
 }
 
 static VALUE
@@ -1188,6 +1223,8 @@ make_metaclass(VALUE klass)
     VALUE metaclass = class_boot_boxable(Qundef, FL_TEST_RAW(klass, RCLASS_BOXABLE));
 
     FL_SET(metaclass, FL_SINGLETON);
+    // owned by the attached class's owner, not by whoever triggered the lazy creation
+    RCLASS_SET_OWNER_RACTOR_ID(metaclass, RCLASS_OWNER_RACTOR_ID(klass));
     rb_singleton_class_attached(metaclass, klass);
 
     if (META_CLASS_OF_CLASS_CLASS_P(klass)) {
@@ -1223,6 +1260,15 @@ make_singleton_class(VALUE obj)
     VALUE orig_class = METACLASS_OF(obj);
     VALUE klass = class_alloc0(T_CLASS, rb_cClass, FL_TEST_RAW(orig_class, RCLASS_BOXABLE));
     FL_SET(klass, FL_SINGLETON);
+    if (RB_TYPE_P(obj, T_MODULE)) {
+        // as in make_metaclass: the module's owner, not the lazy creator
+        RCLASS_SET_OWNER_RACTOR_ID(klass, RCLASS_OWNER_RACTOR_ID(obj));
+    }
+    else if (rb_ractor_shareable_p(obj)) {
+        // A shareable object is no single Ractor's, so its singleton class stays the
+        // main Ractor's rather than being claimed by whoever materialized it.
+        RCLASS_SET_OWNER_RACTOR_ID(klass, 0);
+    }
     class_initialize_method_table(klass);
     class_associate_super(klass, orig_class, true);
     if (orig_class && !UNDEF_P(orig_class)) {

--- a/doc/language/ractor.md
+++ b/doc/language/ractor.md
@@ -345,6 +345,54 @@ To isolate unshareable objects across ractors, we introduced additional language
 
 Note that when not using ractors, these additional semantics are not needed (100% compatible with Ruby 2).
 
+### Class and module ownership
+
+Every class/module records the Ractor that created it as its *owner*. Only the owner Ractor can modify the class/module:
+
+* defining, removing or undefining methods, `alias`, and changing method visibility
+* `include`/`prepend` into the class/module, and refining it with `Module#refine`
+* defining or removing constants, and registering `autoload`
+* setting instance variables of the class/module object
+
+Reading (calling methods, instantiating, reading constants and instance variables, subclassing, and so on) is allowed from any Ractor as before.
+
+Ownership bounds *who may write* a class/module, not *what readers may see*. Reads are not synchronized and a class modification is not atomic, so a non-owner Ractor can still observe a class/module while its owner is modifying it: after the first `def` of a `class ... end` body but before the second, or while `include`/`prepend` is rewiring the ancestor chain. What ownership guarantees is a single writer per class/module, not a consistent view for readers.
+
+All classes/modules defined at boot or by code run by the main Ractor (including `require`d libraries) are owned by the main Ractor, so non-main ractors can not monkey-patch them:
+
+```ruby
+r = Ractor.new do
+  class String            # reopening itself is harmless, but...
+    def foo; end          # ...defining a method on a class created by
+  end                     # another Ractor raises
+end
+begin
+  r.join
+rescue Ractor::RemoteError => e
+  e.cause.message #=> "can not modify String because it is created by another Ractor"
+end
+```
+
+In exchange, a Ractor can fully use the classes/modules it created itself, including things which were previously allowed only on the main Ractor:
+
+```ruby
+Ractor.new do
+  k = Class.new do
+    def hello = "hello"
+  end
+  k.const_set(:CONST, [1, 2, 3])       # even unshareable constant values
+  k.instance_variable_set(:@iv, [4, 5]) # even unshareable ivar values
+  k.new.hello
+end.value #=> "hello"
+```
+
+Notes:
+
+* A singleton class (and a metaclass) is owned by the owner of the object it is attached to, not by the Ractor which happened to trigger its lazy creation. So `def C.foo` is allowed exactly for the owner of `C`.
+* Classes/modules whose owner Ractor has terminated become permanently read-only for every Ractor.
+* Since defining a constant in a class/module created by another Ractor is prohibited, a non-main Ractor can not define a top-level class name (it would write a constant into `Object`). Define classes under your own namespace instead: `m = Module.new; m.const_set(:Foo, Class.new)`.
+* Copying a class/module created by another Ractor with `Class#dup`/`Object#clone` creates a copy owned by the copying Ractor; it raises `Ractor::IsolationError` if the source's constants or instance variables refer to unshareable objects.
+
 ### Global variables
 
 Only the main Ractor can access global variables.
@@ -366,7 +414,7 @@ Note that some special global variables, such as `$stdin`, `$stdout` and `$stder
 
 ### Instance variables of shareable objects
 
-Instance variables of classes/modules can be accessed from non-main ractors only if their values are shareable objects.
+Instance variables of classes/modules can be accessed from non-owner ractors only if their values are shareable objects.
 
 ```ruby
 class C
@@ -380,7 +428,7 @@ p Ractor.new do
 end.value #=> 1
 ```
 
-Otherwise, only the main Ractor can access instance variables of shareable objects.
+Otherwise, only the owner Ractor can access instance variables of classes/modules. Setting them is prohibited for non-owner ractors regardless of the value.
 
 ```ruby
 class C
@@ -393,14 +441,14 @@ Ractor.new do
       p @iv
     rescue Ractor::IsolationError
       p $!.message
-      #=> "can not get unshareable values from instance variables of classes/modules from non-main Ractors"
+      #=> "can not get unshareable values from instance variables of classes/modules created by another Ractor (@iv from C)"
     end
 
     begin
       @iv = 42
     rescue Ractor::IsolationError
       p $!.message
-      #=> "can not set instance variables of classes/modules by non-main Ractors"
+      #=> "can not set instance variables of classes/modules created by another Ractor"
     end
   end
 end.join
@@ -423,7 +471,7 @@ end
 
 ### Class variables
 
-Only the main Ractor can access class variables.
+Class variables are shared across the whole inheritance chain (and the class they are actually stored in can even change over time), so no single owner Ractor can be defined for them. Therefore they are not covered by the ownership relaxation above: only the main Ractor can write class variables, and only into classes/modules it owns. Non-shareable class variable values can only be read by the main Ractor.
 
 ```ruby
 class C
@@ -446,7 +494,7 @@ end
 
 ### Constants
 
-Only the main Ractor can read constants which refer to an unshareable object.
+Only the owner Ractor of the class/module the constant is defined in can read constants which refer to an unshareable object.
 
 ```ruby
 class C
@@ -462,7 +510,7 @@ rescue => e
 end
 ```
 
-Only the main Ractor can define constants which refer to an unshareable object.
+Defining constants in a class/module created by another Ractor is prohibited, regardless of the value. The owner can define constants with any values, but constants which refer to unshareable objects can only be read back by the owner.
 
 ```ruby
 class C

--- a/doc/language/ractor.md
+++ b/doc/language/ractor.md
@@ -345,6 +345,60 @@ To isolate unshareable objects across ractors, we introduced additional language
 
 Note that when not using ractors, these additional semantics are not needed (100% compatible with Ruby 2).
 
+### Class and module ownership
+
+Every class/module records the Ractor that created it as its *owner*. Only the owner Ractor can modify the class/module:
+
+* defining, removing or undefining methods, `alias`, and changing method visibility
+* `include`/`prepend` into the class/module, and refining it with `Module#refine`
+* defining or removing constants, and registering `autoload`
+* setting instance variables of the class/module object
+* setting and removing class variables stored in the class/module
+* `Module#freeze` and `Module#set_temporary_name`
+
+Reading (calling methods, instantiating, reading constants and instance variables, subclassing, and so on) is allowed from any Ractor as before.
+
+Ownership bounds *who may write* a class/module, not *what readers may see*. Reads are not synchronized and a class modification is not atomic, so a non-owner Ractor can still observe a class/module while its owner is modifying it: after the first `def` of a `class ... end` body but before the second, or while `include`/`prepend` is rewiring the ancestor chain. What ownership guarantees is a single writer per class/module, not a consistent view for readers.
+
+That single writer is not always the class's own owner. `M.include(N)` and `M.prepend(N)` rewire the ancestor chain of every class that already includes `M`, whoever owns those classes: modifying `M` is `M`'s owner's right, and a class which includes a module created by another Ractor accepts that. So a class is written by its own owner and by the owners of the modules it includes.
+
+All classes/modules defined at boot or by code run by the main Ractor (including `require`d libraries) are owned by the main Ractor, so non-main ractors can not monkey-patch them:
+
+```ruby
+r = Ractor.new do
+  class String            # reopening itself is harmless, but...
+    def foo; end          # ...defining a method on a class created by
+  end                     # another Ractor raises
+end
+begin
+  r.join
+rescue Ractor::RemoteError => e
+  e.cause.message #=> "can not modify String because it is created by another Ractor"
+end
+```
+
+In exchange, a Ractor can fully use the classes/modules it created itself, including things which were previously allowed only on the main Ractor:
+
+```ruby
+Ractor.new do
+  k = Class.new do
+    def hello = "hello"
+  end
+  k.const_set(:CONST, [1, 2, 3])       # even unshareable constant values
+  k.instance_variable_set(:@iv, [4, 5]) # even unshareable ivar values
+  k.new.hello
+end.value #=> "hello"
+```
+
+Notes:
+
+* A singleton class (and a metaclass) is owned by the owner of the object it is attached to, not by the Ractor which happened to trigger its lazy creation. So `def C.foo` is allowed exactly for the owner of `C`. A shareable object belongs to no single Ractor, so the singleton class of one is owned by the main Ractor.
+* Classes/modules whose owner Ractor has terminated become permanently read-only for every Ractor.
+* Since defining a constant in a class/module created by another Ractor is prohibited, a non-main Ractor can not define a top-level class name (it would write a constant into `Object`). Define classes under your own namespace instead: `m = Module.new; m.const_set(:Foo, Class.new)`.
+* Copying a class/module created by another Ractor with `Class#dup`/`Object#clone` creates a copy owned by the copying Ractor; it raises `Ractor::IsolationError` if the source's constants or instance variables refer to unshareable objects.
+* `Ractor#send(obj, move: true)` hands a materialized singleton class over with its object, so the receiver can go on defining singleton methods on it. The move is refused if that singleton class holds unshareable constants or variables, which would stay reachable by the sender.
+* `require` runs on the main Ractor whichever Ractor calls it, so a library defines its classes as the main Ractor's. `load` does not: loading a file which defines a top-level name from a non-main Ractor raises `Ractor::IsolationError`, like writing that constant directly.
+
 ### Global variables
 
 Only the main Ractor can access global variables.
@@ -366,7 +420,7 @@ Note that some special global variables, such as `$stdin`, `$stdout` and `$stder
 
 ### Instance variables of shareable objects
 
-Instance variables of classes/modules can be accessed from non-main ractors only if their values are shareable objects.
+Instance variables of classes/modules can be accessed from non-owner ractors only if their values are shareable objects.
 
 ```ruby
 class C
@@ -380,7 +434,7 @@ p Ractor.new do
 end.value #=> 1
 ```
 
-Otherwise, only the main Ractor can access instance variables of shareable objects.
+Otherwise, only the owner Ractor can access instance variables of classes/modules. Setting them is prohibited for non-owner ractors regardless of the value.
 
 ```ruby
 class C
@@ -393,14 +447,14 @@ Ractor.new do
       p @iv
     rescue Ractor::IsolationError
       p $!.message
-      #=> "can not get unshareable values from instance variables of classes/modules from non-main Ractors"
+      #=> "can not get unshareable values from instance variables of classes/modules created by another Ractor (@iv from C)"
     end
 
     begin
       @iv = 42
     rescue Ractor::IsolationError
       p $!.message
-      #=> "can not set instance variables of classes/modules by non-main Ractors"
+      #=> "can not set instance variables of classes/modules created by another Ractor"
     end
   end
 end.join
@@ -423,30 +477,38 @@ end
 
 ### Class variables
 
-Only the main Ractor can access class variables.
+A class variable is shared across the whole inheritance chain, and the class it is actually stored in can change over time (a subclass's definition can be taken over by an ancestor). The Ractor that decides access is therefore the owner of the class the variable is *stored in*, not of the receiver it was looked up through. Only that Ractor can write the variable, and only that Ractor can read a value which is not shareable.
 
 ```ruby
 class C
-  @@cv = 'str'
+  @@cv = 'str' # unshareable object
 end
 
-r = Ractor.new do
+Ractor.new do
   class C
-    p @@cv
+    begin
+      p @@cv # stored in C, which is owned by the main Ractor
+    rescue Ractor::IsolationError
+      p $!.message
+      #=> "can not read non-shareable class variable @@cv of C, which was created by another Ractor"
+    end
   end
-end
+end.join
+```
 
+A Ractor has full use of the class variables of the classes it created itself:
 
-begin
-  r.join
-rescue => e
-  e.class #=> Ractor::IsolationError
-end
+```ruby
+Ractor.new do
+  k = Class.new
+  k.class_variable_set(:@@count, 'not shareable')
+  k.class_variable_get(:@@count)
+end.value #=> "not shareable"
 ```
 
 ### Constants
 
-Only the main Ractor can read constants which refer to an unshareable object.
+Only the owner Ractor of the class/module the constant is defined in can read constants which refer to an unshareable object.
 
 ```ruby
 class C
@@ -462,7 +524,7 @@ rescue => e
 end
 ```
 
-Only the main Ractor can define constants which refer to an unshareable object.
+Defining constants in a class/module created by another Ractor is prohibited, regardless of the value. The owner can define constants with any values, but constants which refer to unshareable objects can only be read back by the owner.
 
 ```ruby
 class C

--- a/eval.c
+++ b/eval.c
@@ -452,6 +452,7 @@ rb_class_modify_check(VALUE klass)
         }
         rb_error_frozen_object(klass);
     }
+    rb_class_owner_check(klass);
 }
 
 NORETURN(static void rb_longjmp(rb_execution_context_t *, enum ruby_tag_type, volatile VALUE, VALUE));
@@ -1631,6 +1632,10 @@ rb_mod_refine(VALUE module, VALUE klass)
     }
 
     ensure_class_or_module(klass);
+
+    // Refining a class physically installs refined method entries into the
+    // target class's method table, so the target must be owned.
+    rb_class_owner_check(klass);
 
     rb_refinement_setup(&data, module, klass);
 

--- a/eval.c
+++ b/eval.c
@@ -456,6 +456,7 @@ rb_class_modify_check(VALUE klass)
         }
         rb_error_frozen_object(klass);
     }
+    rb_class_owner_check(klass);
 }
 
 NORETURN(static void rb_longjmp(rb_execution_context_t *, enum ruby_tag_type, volatile VALUE, VALUE));
@@ -1635,6 +1636,11 @@ rb_mod_refine(VALUE module, VALUE klass)
     }
 
     ensure_class_or_module(klass);
+
+    // refine installs refined method entries into the target's method table, and
+    // rb_refinement_setup writes the refinement tables into the receiver
+    rb_class_owner_check(module);
+    rb_class_owner_check(klass);
 
     rb_refinement_setup(&data, module, klass);
 

--- a/gc.c
+++ b/gc.c
@@ -3110,6 +3110,11 @@ gc_mark_classext_module(rb_classext_t *ext, bool prime, VALUE box_value, void *a
         gc_mark_internal(RCLASSEXT_SUBCLASSES(ext));
     }
     gc_mark_internal(RCLASSEXT_CLASSPATH(ext));
+    if (RCLASSEXT_OWNER_RACTOR(ext)) {
+        // Keep the owner Ractor object alive so that ownership comparison
+        // never sees a dangling/reused reference.
+        gc_mark_internal(RCLASSEXT_OWNER_RACTOR(ext));
+    }
 }
 
 static void
@@ -3851,6 +3856,7 @@ update_classext_values(rb_objspace_t *objspace, rb_classext_t *ext, bool is_icla
     UPDATE_IF_MOVED(objspace, RCLASSEXT_ORIGIN(ext));
     UPDATE_IF_MOVED(objspace, RCLASSEXT_REFINED_CLASS(ext));
     UPDATE_IF_MOVED(objspace, RCLASSEXT_CLASSPATH(ext));
+    UPDATE_IF_MOVED(objspace, RCLASSEXT_OWNER_RACTOR(ext));
     if (is_iclass) {
         UPDATE_IF_MOVED(objspace, RCLASSEXT_INCLUDER(ext));
     }

--- a/gc.c
+++ b/gc.c
@@ -5740,7 +5740,7 @@ rb_raw_obj_info_buitin_type(char *const buff, const size_t buff_size, const VALU
             else if (rb_ractor_p(obj)) {
                 rb_ractor_t *r = (void *)DATA_PTR(obj);
                 if (r) {
-                    APPEND_F("r:%d", r->pub.id);
+                    APPEND_F("r:%"PRI_SERIALT_PREFIX"u", r->pub.id);
                 }
             }
             break;

--- a/internal/class.h
+++ b/internal/class.h
@@ -40,6 +40,15 @@ struct rb_classext_struct {
     VALUE super;
     VALUE fields_obj; // Fields are either ivar or other internal properties stored inline
     VALUE classpath;
+    /**
+     * The Ractor object (pub.self) of the Ractor that created this
+     * class/module; only that Ractor can modify the class. 0 means the main
+     * Ractor (so single-Ractor programs get no extra GC edges). Marked from
+     * the classext, so a terminated owner leaves a small object shell and
+     * its classes become permanently read-only. Internal only: never exposed
+     * to Ruby. Meaningful only in the prime classext; always 0 for T_ICLASS.
+     */
+    VALUE owner_ractor;
     struct rb_id_table *m_tbl;
     struct rb_id_table *const_tbl;
     struct rb_id_table *callable_m_tbl;
@@ -114,6 +123,26 @@ static inline void RCLASS_SET_PRIME_CLASSEXT_WRITABLE(VALUE obj, bool writable);
 
 #define RCLASS_EXT_PRIME(c) (&((struct RClass_and_rb_classext_t*)(c))->classext)
 #define RCLASS_EXT_PRIME_P(ext, c) (&((struct RClass_and_rb_classext_t*)(c))->classext == ext)
+
+// Class ownership (the Ractor that created the class/module).
+// The owner is stored only in the prime classext. See the comment on
+// rb_classext_struct::owner_ractor.
+#define RCLASSEXT_OWNER_RACTOR(ext) (ext->owner_ractor)
+
+static inline VALUE
+RCLASS_OWNER_RACTOR(VALUE klass)
+{
+    return RCLASS_EXT_PRIME(klass)->owner_ractor;
+}
+
+static inline void
+RCLASS_SET_OWNER_RACTOR(VALUE klass, VALUE ractor)
+{
+    RB_OBJ_WRITE(klass, &RCLASS_EXT_PRIME(klass)->owner_ractor, ractor);
+}
+
+bool rb_class_owned_p(VALUE klass);          // true if the current Ractor created klass
+void rb_class_owner_check(VALUE klass);      // raise Ractor::IsolationError unless rb_class_owned_p(klass)
 
 static inline rb_classext_t * RCLASS_EXT_READABLE_IN_BOX(VALUE obj, const rb_box_t *box);
 static inline rb_classext_t * RCLASS_EXT_READABLE(VALUE obj);

--- a/internal/class.h
+++ b/internal/class.h
@@ -12,6 +12,7 @@
 #include "id_table.h"           /* for struct rb_id_table */
 #include "internal/box.h"
 #include "internal/serial.h"    /* for rb_serial_t */
+#include "ractor_core.h"        /* for rb_ractor_main_p */
 #include "internal/static_assert.h"
 #include "internal/variable.h"  /* for rb_class_ivar_set */
 #include "ruby/internal/stdbool.h"     /* for bool */
@@ -65,6 +66,11 @@ struct rb_classext_struct {
             const VALUE includer;
         } iclass;
     } as;
+    /* Id of the Ractor that created this class/module; only that Ractor may modify
+     * it.  0 is the main Ractor, so a program that never leaves it stores nothing.
+     * Ids are never reused, so a terminated owner leaves the class read-only for
+     * everybody.  Prime classext only; always 0 for T_ICLASS. */
+    rb_serial_t owner_ractor_id;
     uint16_t superclass_depth;
     attr_index_t max_iv_count;
     uint8_t variation_count;
@@ -114,6 +120,35 @@ static inline void RCLASS_SET_PRIME_CLASSEXT_WRITABLE(VALUE obj, bool writable);
 
 #define RCLASS_EXT_PRIME(c) (&((struct RClass_and_rb_classext_t*)(c))->classext)
 #define RCLASS_EXT_PRIME_P(ext, c) (&((struct RClass_and_rb_classext_t*)(c))->classext == ext)
+
+// Class ownership. See rb_classext_struct::owner_ractor_id.
+#define RCLASSEXT_OWNER_RACTOR_ID(ext) (ext->owner_ractor_id)
+
+static inline rb_serial_t
+RCLASS_OWNER_RACTOR_ID(VALUE klass)
+{
+    return RCLASS_EXT_PRIME(klass)->owner_ractor_id;
+}
+
+static inline void
+RCLASS_SET_OWNER_RACTOR_ID(VALUE klass, rb_serial_t ractor_id)
+{
+    // not a VALUE: no write barrier, nothing for the GC to mark or move
+    RCLASS_EXT_PRIME(klass)->owner_ractor_id = ractor_id;
+}
+
+bool rb_class_owned_by_ractor_p(rb_serial_t owner_id); // rb_class_owned_p's slow half
+void rb_class_owner_check(VALUE klass);      // raise Ractor::IsolationError unless rb_class_owned_p(klass)
+
+// true if the current Ractor created klass.  Inline because the class ivar and
+// constant read paths take it on every access.
+static inline bool
+rb_class_owned_p(VALUE klass)
+{
+    rb_serial_t owner_id = RCLASS_OWNER_RACTOR_ID(klass);
+    if (LIKELY(!owner_id)) return rb_ractor_main_p(); // the only case single-Ractor programs take
+    return rb_class_owned_by_ractor_p(owner_id);
+}
 
 static inline rb_classext_t * RCLASS_EXT_READABLE_IN_BOX(VALUE obj, const rb_box_t *box);
 static inline rb_classext_t * RCLASS_EXT_READABLE(VALUE obj);

--- a/internal/class.h
+++ b/internal/class.h
@@ -139,6 +139,8 @@ RCLASS_SET_OWNER_RACTOR_ID(VALUE klass, rb_serial_t ractor_id)
 
 bool rb_class_owned_by_ractor_p(rb_serial_t owner_id); // rb_class_owned_p's slow half
 void rb_class_owner_check(VALUE klass);      // raise Ractor::IsolationError unless rb_class_owned_p(klass)
+void rb_class_take_ownership(VALUE klass);   // for a moved object's singleton class only
+void rb_class_check_singleton_movable(VALUE klass); // raise if it holds unshareable values
 
 // true if the current Ractor created klass.  Inline because the class ivar and
 // constant read paths take it on every access.

--- a/object.c
+++ b/object.c
@@ -2205,6 +2205,8 @@ rb_class_initialize(int argc, VALUE *argv, VALUE klass)
 {
     VALUE super;
 
+    // an uninitialized class is still somebody's, and this writes its superclass
+    rb_class_modify_check(klass);
     if (RCLASS_SUPER(klass) != 0 || klass == rb_cBasicObject) {
         rb_raise(rb_eTypeError, "already initialized class");
     }

--- a/object.c
+++ b/object.c
@@ -1856,6 +1856,10 @@ rb_mod_to_s(VALUE klass)
 static VALUE
 rb_mod_freeze(VALUE mod)
 {
+    // a permanent modification; already frozen changes no state, so stays a no-op
+    if (!OBJ_FROZEN(mod)) {
+        rb_class_owner_check(mod);
+    }
     rb_class_name(mod);
     return rb_obj_freeze(mod);
 }

--- a/ractor.c
+++ b/ractor.c
@@ -9,6 +9,7 @@
 #include "vm_sync.h"
 #include "ractor_core.h"
 #include "internal/array.h"
+#include "internal/class.h"
 #include "internal/complex.h"
 #include "internal/cont.h"
 #include "internal/error.h"
@@ -2857,6 +2858,13 @@ move_preflight(VALUE obj, struct move_preflight_ctx *ctx)
     st_insert(seen, (st_data_t)obj, 0);
     ctx->nodes++;
 
+    /* The receiver takes over a materialized singleton class, so its contents have to
+     * be movable too. */
+    VALUE klass = RBASIC_CLASS(obj);
+    if (RB_UNLIKELY(klass && FL_TEST_RAW(klass, FL_SINGLETON))) {
+        rb_class_check_singleton_movable(klass);
+    }
+
     switch (BUILTIN_TYPE(obj)) {
       case T_STRING:
       case T_OBJECT:
@@ -3093,6 +3101,8 @@ courier_apply_klass(VALUE shell, VALUE klass)
     }
     if (RB_UNLIKELY(FL_TEST_RAW(klass, FL_SINGLETON))) {
         rb_singleton_class_attached(klass, shell);
+        /* the singleton class follows its object, which is now this Ractor's */
+        rb_class_take_ownership(klass);
     }
 }
 

--- a/ractor.c
+++ b/ractor.c
@@ -79,7 +79,7 @@ ASSERT_ractor_locking(rb_ractor_t *r)
 static void
 ractor_lock(rb_ractor_t *r, const char *file, int line)
 {
-    RUBY_DEBUG_LOG2(file, line, "locking r:%u%s", r->pub.id, rb_current_ractor_raw(false) == r ? " (self)" : "");
+    RUBY_DEBUG_LOG2(file, line, "locking r:%"PRI_SERIALT_PREFIX"u%s", r->pub.id, rb_current_ractor_raw(false) == r ? " (self)" : "");
 
     ASSERT_ractor_unlocking(r);
     rb_native_mutex_lock(&r->sync.lock);
@@ -98,7 +98,7 @@ ractor_lock(rb_ractor_t *r, const char *file, int line)
     }
 #endif
 
-    RUBY_DEBUG_LOG2(file, line, "locked  r:%u%s", r->pub.id, rb_current_ractor_raw(false) == r ? " (self)" : "");
+    RUBY_DEBUG_LOG2(file, line, "locked  r:%"PRI_SERIALT_PREFIX"u%s", r->pub.id, rb_current_ractor_raw(false) == r ? " (self)" : "");
 }
 
 static void
@@ -128,7 +128,7 @@ ractor_unlock(rb_ractor_t *r, const char *file, int line)
 
     rb_native_mutex_unlock(&r->sync.lock);
 
-    RUBY_DEBUG_LOG2(file, line, "r:%u%s", r->pub.id, rb_current_ractor_raw(false) == r ? " (self)" : "");
+    RUBY_DEBUG_LOG2(file, line, "r:%"PRI_SERIALT_PREFIX"u%s", r->pub.id, rb_current_ractor_raw(false) == r ? " (self)" : "");
 }
 
 static void
@@ -175,7 +175,7 @@ ractor_status_str(enum ractor_status status)
 static void
 ractor_status_set(rb_ractor_t *r, enum ractor_status status)
 {
-    RUBY_DEBUG_LOG("r:%u [%s]->[%s]", r->pub.id, ractor_status_str(r->status_), ractor_status_str(status));
+    RUBY_DEBUG_LOG("r:%"PRI_SERIALT_PREFIX"u [%s]->[%s]", r->pub.id, ractor_status_str(r->status_), ractor_status_str(status));
 
     // check 1
     if (r->status_ != ractor_created) {
@@ -424,7 +424,7 @@ static void
 ractor_free(void *ptr)
 {
     rb_ractor_t *r = (rb_ractor_t *)ptr;
-    RUBY_DEBUG_LOG("free r:%d", rb_ractor_id(r));
+    RUBY_DEBUG_LOG("free r:%"PRI_SERIALT_PREFIX"u", rb_ractor_id(r));
 
     free_targeted_hooks(&r->pub.targeted_hooks);
     rb_thread_sched_destroy(&r->threads.sched);
@@ -520,26 +520,27 @@ RACTOR_PTR(VALUE self)
 }
 
 #define MAIN_RACTOR_ID 1
-static rb_atomic_t ractor_last_id = MAIN_RACTOR_ID;
+static rb_serial_t ractor_last_id = MAIN_RACTOR_ID;
 
 #include "ractor_sync.c"
 
 // creation/termination
 
-static uint32_t
+/* Ids are never reused, so they must not wrap either: 64 bits, which rules out an
+ * atomic (there is no portable 64-bit one).  Serialized by the VM lock, or by the
+ * GVL before there is a second Ractor to take it against -- the same condition
+ * vm_insert_ractor0 asserts. */
+static rb_serial_t
 ractor_next_id(void)
 {
-    uint32_t id;
-
-    id = (uint32_t)(RUBY_ATOMIC_FETCH_ADD(ractor_last_id, 1) + 1);
-
-    return id;
+    VM_ASSERT(RB_VM_LOCKED_P() || !rb_multi_ractor_p());
+    return ++ractor_last_id;
 }
 
 static void
 vm_insert_ractor0(rb_vm_t *vm, rb_ractor_t *r, bool single_ractor_mode)
 {
-    RUBY_DEBUG_LOG("r:%u ractor.cnt:%u++", r->pub.id, vm->ractor.cnt);
+    RUBY_DEBUG_LOG("r:%"PRI_SERIALT_PREFIX"u ractor.cnt:%u++", r->pub.id, vm->ractor.cnt);
     VM_ASSERT(single_ractor_mode || RB_VM_LOCKED_P());
 
     /* Incremental marking only runs in a single-objspace world, and nothing later can
@@ -846,8 +847,10 @@ ractor_create(rb_execution_context_t *ec, VALUE self, VALUE loc, VALUE name, VAL
     rb_ractor_t *r = RACTOR_PTR(rv);
     ractor_init(r, name, loc);
 
-    r->pub.id = ractor_next_id();
-    RUBY_DEBUG_LOG("r:%u", r->pub.id);
+    RB_VM_LOCKING() {
+        r->pub.id = ractor_next_id();
+    }
+    RUBY_DEBUG_LOG("r:%"PRI_SERIALT_PREFIX"u", r->pub.id);
 
     rb_ractor_t *cr = rb_ec_ractor_ptr(ec);
     r->verbose = cr->verbose;
@@ -973,7 +976,7 @@ rb_ractor_living_threads_insert(rb_ractor_t *r, rb_thread_t *th)
 
     RACTOR_LOCK(r);
     {
-        RUBY_DEBUG_LOG("r(%d)->threads.cnt:%d++", r->pub.id, r->threads.cnt);
+        RUBY_DEBUG_LOG("r(%"PRI_SERIALT_PREFIX"u)->threads.cnt:%d++", r->pub.id, r->threads.cnt);
         ccan_list_add_tail(&r->threads.set, &th->lt_node);
         r->threads.cnt++;
     }
@@ -1145,7 +1148,7 @@ ractor_terminal_interrupt_all(rb_vm_t *vm)
         rb_ractor_t *r = 0;
         ccan_list_for_each(&vm->ractor.set, r, vmlr_node) {
             if (r != vm->ractor.main_ractor) {
-                RUBY_DEBUG_LOG("r:%d", rb_ractor_id(r));
+                RUBY_DEBUG_LOG("r:%"PRI_SERIALT_PREFIX"u", rb_ractor_id(r));
                 rb_ractor_terminate_interrupt_main_thread(r);
             }
         }
@@ -1362,7 +1365,7 @@ rb_ractor_dump(void)
 
     ccan_list_for_each(&vm->ractor.set, r, vmlr_node) {
         if (r != vm->ractor.main_ractor) {
-            fprintf(stderr, "r:%u (%s)\n", r->pub.id, ractor_status_str(r->status_));
+            fprintf(stderr, "r:%"PRI_SERIALT_PREFIX"u (%s)\n", r->pub.id, ractor_status_str(r->status_));
         }
     }
 }

--- a/ractor.rb
+++ b/ractor.rb
@@ -380,7 +380,7 @@ class Ractor
   def inspect
     loc  = __builtin_cexpr! %q{ RACTOR_PTR(self)->loc }
     name = __builtin_cexpr! %q{ RACTOR_PTR(self)->name }
-    id   = __builtin_cexpr! %q{ UINT2NUM(rb_ractor_id(RACTOR_PTR(self))) }
+    id   = __builtin_cexpr! %q{ ULL2NUM(rb_ractor_id(RACTOR_PTR(self))) }
     status = __builtin_cexpr! %q{
       rb_str_new2(RACTOR_PTR(self)->status_ == ractor_terminated ? "terminated" : "running")
     }
@@ -852,7 +852,7 @@ class Ractor
     #    port.inspect -> string
     def inspect
       "#<Ractor::Port to:\##{
-        __builtin_cexpr! "SIZET2NUM(rb_ractor_id(ractor_port_ptr_check(self)->r))"
+        __builtin_cexpr! "ULL2NUM(rb_ractor_id(ractor_port_ptr_check(self)->r))"
       } id:#{
         __builtin_cexpr! "SIZET2NUM(ractor_port_id(RACTOR_PORT_PTR(self)))"
       }>"

--- a/ractor_core.h
+++ b/ractor_core.h
@@ -334,7 +334,7 @@ rb_ractor_set_current_ec_(rb_ractor_t *cr, rb_execution_context_t *ec, const cha
 void rb_vm_ractor_blocking_cnt_inc(rb_vm_t *vm, rb_ractor_t *cr, const char *file, int line);
 void rb_vm_ractor_blocking_cnt_dec(rb_vm_t *vm, rb_ractor_t *cr, const char *file, int line);
 
-static inline uint32_t
+static inline rb_serial_t
 rb_ractor_id(const rb_ractor_t *r)
 {
     return r->pub.id;

--- a/ractor_core.h
+++ b/ractor_core.h
@@ -1,3 +1,5 @@
+#ifndef RUBY_RACTOR_CORE_H
+#define RUBY_RACTOR_CORE_H
 #include "internal/gc.h"
 #include "ruby/ruby.h"
 #include "ruby/ractor.h"
@@ -389,3 +391,5 @@ rb_ractor_ignore_belonging(bool flag)
 #define rb_ractor_confirm_belonging(obj) obj
 #define rb_ractor_ignore_belonging(flag) (0)
 #endif
+
+#endif /* RUBY_RACTOR_CORE_H */

--- a/ractor_sync.c
+++ b/ractor_sync.c
@@ -1306,7 +1306,7 @@ ractor_wakeup_all(rb_ractor_t *r, enum ractor_wakeup_status wakeup_status)
 {
     ASSERT_ractor_unlocking(r);
 
-    RUBY_DEBUG_LOG("r:%u wakeup:%s", rb_ractor_id(r), wakeup_status_str(wakeup_status));
+    RUBY_DEBUG_LOG("r:%"PRI_SERIALT_PREFIX"u wakeup:%s", rb_ractor_id(r), wakeup_status_str(wakeup_status));
 
     bool wakeup_p = false;
 
@@ -1556,7 +1556,7 @@ ractor_send_basket(rb_execution_context_t *ec, const struct ractor_port *rp, str
 {
     bool closed = false;
 
-    RUBY_DEBUG_LOG("port:%u@r%u b:%s v:%p", (unsigned int)ractor_port_id(rp), rb_ractor_id(rp->r), basket_type_name(b->type), (void *)b->p.v);
+    RUBY_DEBUG_LOG("port:%u@r%"PRI_SERIALT_PREFIX"u b:%s v:%p", (unsigned int)ractor_port_id(rp), rb_ractor_id(rp->r), basket_type_name(b->type), (void *)b->p.v);
 
     RACTOR_LOCK(rp->r);
     {
@@ -1578,7 +1578,7 @@ ractor_send_basket(rb_execution_context_t *ec, const struct ractor_port *rp, str
         ractor_wakeup_all(rp->r, wakeup_by_send);
     }
     else {
-        RUBY_DEBUG_LOG("closed:%u@r%u", (unsigned int)ractor_port_id(rp), rb_ractor_id(rp->r));
+        RUBY_DEBUG_LOG("closed:%u@r%"PRI_SERIALT_PREFIX"u", (unsigned int)ractor_port_id(rp), rb_ractor_id(rp->r));
 
         /* Nothing took the basket: it was not enqueued, so free it whether or not the
          * caller wants the error raised. */

--- a/test/ruby/test_iseq.rb
+++ b/test/ruby/test_iseq.rb
@@ -878,17 +878,27 @@ class TestISeq < Test::Unit::TestCase
 
   def test_mandatory_only_redef
     assert_separately ['-W0'], <<~RUBY
-      r = Ractor.new{
-        Float(10)
-        module Kernel
-          undef Float
-          def Float(n)
-            :new
-          end
-        end
+      port = Ractor::Port.new
+      r = Ractor.new(port){|port|
+        Float(10) # fill the mandatory only cache
+        port << :filled
+        Ractor.receive
         GC.start
         Float(30)
       }
+
+      port.receive
+
+      # Kernel is created by the main Ractor, so only the main Ractor can
+      # redefine it. The redefinition should be visible from the other Ractor.
+      module Kernel
+        undef Float
+        def Float(n)
+          :new
+        end
+      end
+
+      r << :redefined
       assert_equal :new, r.value
     RUBY
   end

--- a/test/ruby/test_iseq.rb
+++ b/test/ruby/test_iseq.rb
@@ -893,17 +893,27 @@ class TestISeq < Test::Unit::TestCase
 
   def test_mandatory_only_redef
     assert_separately ['-W0'], <<~RUBY
-      r = Ractor.new{
-        Float(10)
-        module Kernel
-          undef Float
-          def Float(n)
-            :new
-          end
-        end
+      port = Ractor::Port.new
+      r = Ractor.new(port){|port|
+        Float(10) # fill the mandatory only cache
+        port << :filled
+        Ractor.receive
         GC.start
         Float(30)
       }
+
+      port.receive
+
+      # Kernel is created by the main Ractor, so only the main Ractor can
+      # redefine it. The redefinition should be visible from the other Ractor.
+      module Kernel
+        undef Float
+        def Float(n)
+          :new
+        end
+      end
+
+      r << :redefined
       assert_equal :new, r.value
     RUBY
   end

--- a/thread.c
+++ b/thread.c
@@ -971,7 +971,7 @@ thread_create_core(VALUE thval, struct thread_create_params *params)
         RBASIC_CLEAR_CLASS(th->pending_interrupt_mask_stack);
     }
 
-    RUBY_DEBUG_LOG("r:%u th:%u", rb_ractor_id(th->ractor), rb_th_serial(th));
+    RUBY_DEBUG_LOG("r:%"PRI_SERIALT_PREFIX"u th:%u", rb_ractor_id(th->ractor), rb_th_serial(th));
 
     rb_ractor_living_threads_insert(th->ractor, th);
 

--- a/thread_sched.c
+++ b/thread_sched.c
@@ -155,7 +155,7 @@ ractor_sched_dump_(const char *file, int line, rb_vm_t *vm)
     ccan_list_for_each(&vm->ractor.sched.grq, r, threads.sched.grq_node) {
         i++;
         if (i>10) rb_bug("!!");
-        fprintf(stderr, "  %d ready:%d\n", i, rb_ractor_id(r));
+        fprintf(stderr, "  %d ready:%"PRI_SERIALT_PREFIX"u\n", i, rb_ractor_id(r));
     }
 }
 
@@ -235,7 +235,7 @@ ASSERT_thread_sched_locked(struct rb_thread_sched *sched, rb_thread_t *th)
 
 
 RBIMPL_ATTR_MAYBE_UNUSED()
-static unsigned int
+static rb_serial_t
 rb_ractor_serial(const rb_ractor_t *r)
 {
     if (r) {
@@ -277,9 +277,9 @@ ractor_sched_lock_(rb_vm_t *vm, rb_ractor_t *cr, const char *file, int line)
     rb_native_mutex_lock(&vm->ractor.sched.lock);
 
 #if VM_CHECK_MODE
-    RUBY_DEBUG_LOG2(file, line, "cr:%u prev_owner:%u", rb_ractor_serial(cr), rb_ractor_serial(vm->ractor.sched.lock_owner));
+    RUBY_DEBUG_LOG2(file, line, "cr:%"PRI_SERIALT_PREFIX"u prev_owner:%"PRI_SERIALT_PREFIX"u", rb_ractor_serial(cr), rb_ractor_serial(vm->ractor.sched.lock_owner));
 #else
-    RUBY_DEBUG_LOG2(file, line, "cr:%u", rb_ractor_serial(cr));
+    RUBY_DEBUG_LOG2(file, line, "cr:%"PRI_SERIALT_PREFIX"u", rb_ractor_serial(cr));
 #endif
 
     ractor_sched_set_locked(vm, cr);
@@ -288,7 +288,7 @@ ractor_sched_lock_(rb_vm_t *vm, rb_ractor_t *cr, const char *file, int line)
 static void
 ractor_sched_unlock_(rb_vm_t *vm, rb_ractor_t *cr, const char *file, int line)
 {
-    RUBY_DEBUG_LOG2(file, line, "cr:%u", rb_ractor_serial(cr));
+    RUBY_DEBUG_LOG2(file, line, "cr:%"PRI_SERIALT_PREFIX"u", rb_ractor_serial(cr));
 
     ractor_sched_set_unlocked(vm, cr);
     rb_native_mutex_unlock(&vm->ractor.sched.lock);
@@ -1306,7 +1306,7 @@ ractor_sched_enq(rb_vm_t *vm, rb_ractor_t *r)
         vm->ractor.sched.grq_cnt++;
         VM_ASSERT(grq_size(vm, cr) == vm->ractor.sched.grq_cnt);
 
-        RUBY_DEBUG_LOG("r:%u th:%u grq_cnt:%u", rb_ractor_id(r), rb_th_serial(sched->running), vm->ractor.sched.grq_cnt);
+        RUBY_DEBUG_LOG("r:%"PRI_SERIALT_PREFIX"u th:%u grq_cnt:%u", rb_ractor_id(r), rb_th_serial(sched->running), vm->ractor.sched.grq_cnt);
 
         rb_native_cond_signal(&vm->ractor.sched.cond);
 

--- a/variable.c
+++ b/variable.c
@@ -1199,12 +1199,11 @@ rb_alias_variable(ID name1, ID name2)
 }
 
 static void
-IVAR_ACCESSOR_SHOULD_BE_MAIN_RACTOR(ID id)
+class_ivar_set_ractor_check(VALUE klass, ID id)
 {
-    if (UNLIKELY(!rb_ractor_main_p())) {
-        if (rb_is_instance_id(id)) { // check only normal ivars
-            rb_raise(rb_eRactorIsolationError, "can not set instance variables of classes/modules by non-main Ractors");
-        }
+    if (rb_is_instance_id(id) && // check only normal ivars
+        UNLIKELY(!rb_class_owned_p(klass))) {
+        rb_raise(rb_eRactorIsolationError, "can not set instance variables of classes/modules created by another Ractor");
     }
 }
 
@@ -1234,6 +1233,12 @@ ivar_ractor_check(VALUE obj, ID id)
         UNLIKELY(!rb_ractor_main_p()) &&
         UNLIKELY(rb_ractor_shareable_p(obj))) {
 
+        if (RB_TYPE_P(obj, T_CLASS) || RB_TYPE_P(obj, T_MODULE)) {
+            // classes/modules are checked by their owner Ractor
+            // (class_ivar_set_ractor_check, rb_class_owned_p) at each
+            // read/write site instead
+            return;
+        }
         rb_raise(rb_eRactorIsolationError, "can not access instance variables of shareable objects from non-main Ractors");
     }
 }
@@ -1493,11 +1498,11 @@ rb_ivar_lookup(VALUE obj, ID id, VALUE undef)
     }
 
     if (is_class && val != undef && rb_is_instance_id(id)) {
-        if (UNLIKELY(!rb_ractor_main_p()) && !rb_ractor_shareable_p(val)) {
+        if (UNLIKELY(!rb_class_owned_p(obj)) && !rb_ractor_shareable_p(val)) {
             rb_raise(
                 rb_eRactorIsolationError,
-                "can not get unshareable values from instance variables of classes/modules from "
-                "non-main Ractors (%"PRIsVALUE" from %"PRIsVALUE")",
+                "can not get unshareable values from instance variables of classes/modules "
+                "created by another Ractor (%"PRIsVALUE" from %"PRIsVALUE")",
                 rb_id2str(id),
                 obj
             );
@@ -1530,9 +1535,9 @@ rb_ivar_get_at(VALUE obj, attr_index_t index, ID id)
             VALUE fields_obj = RCLASS_WRITABLE_FIELDS_OBJ(obj);
             VALUE val = rb_imemo_fields_ptr(fields_obj)[index];
 
-            if (UNLIKELY(!rb_ractor_main_p()) && !rb_ractor_shareable_p(val)) {
+            if (UNLIKELY(!rb_class_owned_p(obj)) && !rb_ractor_shareable_p(val)) {
                 rb_raise(rb_eRactorIsolationError,
-                        "can not get unshareable values from instance variables of classes/modules from non-main Ractors");
+                        "can not get unshareable values from instance variables of classes/modules created by another Ractor");
             }
 
             return val;
@@ -1585,7 +1590,7 @@ rb_ivar_delete(VALUE obj, ID id, VALUE undef)
     int type = BUILTIN_TYPE(obj);
 
     if (type == T_CLASS || type == T_MODULE) {
-        IVAR_ACCESSOR_SHOULD_BE_MAIN_RACTOR(id);
+        class_ivar_set_ractor_check(obj, id);
 
         if (rb_multi_ractor_p()) {
             concurrent = true;
@@ -1958,7 +1963,7 @@ ivar_set(VALUE obj, ID id, VALUE val)
       case T_CLASS:
       case T_MODULE:
         {
-            IVAR_ACCESSOR_SHOULD_BE_MAIN_RACTOR(id);
+            class_ivar_set_ractor_check(obj, id);
             bool dontcare;
             return class_ivar_set(obj, id, val, &dontcare);
         }
@@ -2235,7 +2240,7 @@ rb_field_foreach(VALUE obj, rb_ivar_foreach_callback_func *func, st_data_t arg, 
       case T_CLASS:
       case T_MODULE:
         {
-            IVAR_ACCESSOR_SHOULD_BE_MAIN_RACTOR(0);
+            class_ivar_set_ractor_check(obj, 0);
             VALUE fields_obj = RCLASS_WRITABLE_FIELDS_OBJ(obj);
             if (fields_obj) {
                 imemo_fields_each(fields_obj, func, arg, ivar_only);
@@ -2798,6 +2803,8 @@ rb_autoload_str(VALUE module, ID name, VALUE feature)
         rb_raise(rb_eNameError, "autoload must be constant name: %"PRIsVALUE"", QUOTE_ID(name));
     }
 
+    rb_class_owner_check(module);
+
     Check_Type(feature, T_STRING);
     if (!RSTRING_LEN(feature)) {
         rb_raise(rb_eArgError, "empty feature name");
@@ -3218,9 +3225,9 @@ rb_const_get_0(VALUE klass, ID id, int exclude, int recurse, int visibility)
     VALUE found_in;
     VALUE c = rb_const_search(klass, id, exclude, recurse, visibility, &found_in);
     if (!UNDEF_P(c)) {
-        if (UNLIKELY(!rb_ractor_main_p())) {
+        if (UNLIKELY(!rb_class_owned_p(found_in))) {
             if (!rb_ractor_shareable_p(c)) {
-                rb_raise(rb_eRactorIsolationError, "can not access non-shareable objects in constant %"PRIsVALUE"::%"PRIsVALUE" by non-main Ractor.", rb_class_path(found_in), rb_id2str(id));
+                rb_raise(rb_eRactorIsolationError, "can not access non-shareable objects in constant %"PRIsVALUE"::%"PRIsVALUE" of a class/module created by another Ractor.", rb_class_path(found_in), rb_id2str(id));
             }
         }
         return c;
@@ -3432,6 +3439,7 @@ rb_const_remove(VALUE mod, ID id)
     rb_const_entry_t *ce;
 
     rb_check_frozen(mod);
+    rb_class_owner_check(mod);
 
     ce = rb_const_lookup(mod, id);
 
@@ -3728,8 +3736,8 @@ const_set(VALUE klass, ID id, VALUE val)
                  QUOTE_ID(id));
     }
 
-    if (!rb_ractor_main_p() && !rb_ractor_shareable_p(val)) {
-        rb_raise(rb_eRactorIsolationError, "can not set constants with non-shareable objects by non-main Ractors");
+    if (UNLIKELY(!rb_class_owned_p(klass))) {
+        rb_raise(rb_eRactorIsolationError, "can not set constants of classes/modules created by another Ractor");
     }
 
     check_before_mod_set(klass, id, val, "constant");

--- a/variable.c
+++ b/variable.c
@@ -1207,8 +1207,16 @@ class_ivar_set_ractor_check(VALUE klass, ID id)
     }
 }
 
+// Class variables are shared across the whole inheritance chain (and their
+// storage location can even migrate over time), so no single owner Ractor can
+// be defined for them. They are not covered by the class ownership
+// relaxation: only the main Ractor can set them, and non-shareable values can
+// only be read from the main Ractor, as before. Note that the ownership
+// *restriction* still applies on top of this: rb_cvar_set() additionally
+// checks that the class the variable is actually written into is owned, so
+// class fields keep a single writer Ractor.
 static void
-CVAR_ACCESSOR_SHOULD_BE_MAIN_RACTOR(VALUE klass, ID id)
+cvar_set_ractor_check(VALUE klass, ID id)
 {
     if (UNLIKELY(!rb_ractor_main_p())) {
         rb_raise(rb_eRactorIsolationError, "can not set class variables from non-main Ractors (%"PRIsVALUE" from %"PRIsVALUE")", rb_id2str(id), klass);
@@ -4070,7 +4078,9 @@ cvar_overtaken(VALUE front, VALUE target, ID id)
                        ID2SYM(id), rb_class_name(original_module(front)),
                        rb_class_name(original_module(target)));
         }
-        if (BUILTIN_TYPE(front) == T_CLASS) {
+        if (BUILTIN_TYPE(front) == T_CLASS && rb_class_owned_p(front)) {
+            // Removing the duplicated entry is just clean-up; skip it when
+            // `front` is owned by another Ractor (its owner will clean it up).
             rb_ivar_delete(front, id, Qundef);
         }
     }
@@ -4105,7 +4115,7 @@ find_cvar(VALUE klass, VALUE * front, VALUE * target, ID id)
 void
 rb_cvar_set(VALUE klass, ID id, VALUE val)
 {
-    CVAR_ACCESSOR_SHOULD_BE_MAIN_RACTOR(klass, id);
+    cvar_set_ractor_check(klass, id);
 
     VALUE tmp, front = 0, target = 0;
 
@@ -4121,6 +4131,10 @@ rb_cvar_set(VALUE klass, ID id, VALUE val)
     if (RB_TYPE_P(target, T_ICLASS)) {
         target = RBASIC(target)->klass;
     }
+    // cvars are outside the ownership relaxation, but a write still must not
+    // cross the ownership boundary (e.g. main writing into another Ractor's
+    // class), so that class fields keep a single writer Ractor.
+    rb_class_owner_check(target);
     check_before_mod_set(target, id, val, "class variable");
 
     bool new_cvar = rb_class_ivar_set(target, id, val);

--- a/variable.c
+++ b/variable.c
@@ -312,6 +312,8 @@ set_sub_temporary_name(VALUE mod, VALUE name)
 VALUE
 rb_mod_set_temporary_name(VALUE mod, VALUE name)
 {
+    rb_class_owner_check(mod);
+
     // We don't allow setting the name if the classpath is already permanent:
     if (RCLASS_PERMANENT_CLASSPATH_P(mod)) {
         rb_raise(rb_eRuntimeError, "can't change permanent name");

--- a/variable.c
+++ b/variable.c
@@ -1222,20 +1222,24 @@ class_ivar_set_ractor_check(VALUE klass, ID id)
     }
 }
 
+// klass is the class the variable is stored in, not the receiver: which one that
+// is can migrate (cvar_overtaken), and it is the one with a single writer.
 static void
-CVAR_ACCESSOR_SHOULD_BE_MAIN_RACTOR(VALUE klass, ID id)
+cvar_set_ractor_check(VALUE klass, ID id)
 {
-    if (UNLIKELY(!rb_ractor_main_p())) {
-        rb_raise(rb_eRactorIsolationError, "can not set class variables from non-main Ractors (%"PRIsVALUE" from %"PRIsVALUE")", rb_id2str(id), klass);
+    if (UNLIKELY(!rb_class_owned_p(klass))) {
+        rb_raise(rb_eRactorIsolationError,
+                 "can not set class variable %"PRIsVALUE" of %"PRIsVALUE", which was created by another Ractor",
+                 rb_id2str(id), klass);
     }
 }
 
 static void
 cvar_read_ractor_check(VALUE klass, ID id, VALUE val)
 {
-    if (UNLIKELY(!rb_ractor_main_p()) && !rb_ractor_shareable_p(val)) {
+    if (UNLIKELY(!rb_class_owned_p(klass)) && !rb_ractor_shareable_p(val)) {
         rb_raise(rb_eRactorIsolationError,
-                 "can not read non-shareable class variable %"PRIsVALUE" from non-main Ractors (%"PRIsVALUE")",
+                 "can not read non-shareable class variable %"PRIsVALUE" of %"PRIsVALUE", which was created by another Ractor",
                  rb_id2str(id), klass);
     }
 }
@@ -4188,7 +4192,8 @@ cvar_overtaken(VALUE front, VALUE target, ID id)
                        ID2SYM(id), rb_class_name(original_module(front)),
                        rb_class_name(original_module(target)));
         }
-        if (BUILTIN_TYPE(front) == T_CLASS) {
+        if (BUILTIN_TYPE(front) == T_CLASS && rb_class_owned_p(front)) {
+            // only clean-up, and reachable from reads: never write a foreign class
             rb_ivar_delete(front, id, Qundef);
         }
     }
@@ -4223,8 +4228,6 @@ find_cvar(VALUE klass, VALUE * front, VALUE * target, ID id)
 void
 rb_cvar_set(VALUE klass, ID id, VALUE val)
 {
-    CVAR_ACCESSOR_SHOULD_BE_MAIN_RACTOR(klass, id);
-
     VALUE tmp, front = 0, target = 0;
 
     tmp = klass;
@@ -4239,6 +4242,7 @@ rb_cvar_set(VALUE klass, ID id, VALUE val)
     if (RB_TYPE_P(target, T_ICLASS)) {
         target = RBASIC(target)->klass;
     }
+    cvar_set_ractor_check(target, id);
     check_before_mod_set(target, id, val, "class variable");
 
     bool new_cvar = rb_class_ivar_set(target, id, val);
@@ -4293,7 +4297,10 @@ rb_cvar_find(VALUE klass, ID id, VALUE *front)
                           klass, ID2SYM(id));
     }
     cvar_overtaken(*front, target, id);
-    cvar_read_ractor_check(klass, id, value);
+    if (RB_TYPE_P(target, T_ICLASS)) {
+        target = RBASIC(target)->klass;
+    }
+    cvar_read_ractor_check(target, id, value);
     return (VALUE)value;
 }
 
@@ -4472,6 +4479,7 @@ rb_mod_remove_cvar(VALUE mod, VALUE name)
         goto not_defined;
     }
     rb_check_frozen(mod);
+    cvar_set_ractor_check(mod, id);
     val = rb_ivar_delete(mod, id, Qundef);
     if (!UNDEF_P(val)) {
         return (VALUE)val;

--- a/variable.c
+++ b/variable.c
@@ -1214,12 +1214,11 @@ rb_alias_variable(ID name1, ID name2)
 }
 
 static void
-IVAR_ACCESSOR_SHOULD_BE_MAIN_RACTOR(ID id)
+class_ivar_set_ractor_check(VALUE klass, ID id)
 {
-    if (UNLIKELY(!rb_ractor_main_p())) {
-        if (rb_is_instance_id(id)) { // check only normal ivars
-            rb_raise(rb_eRactorIsolationError, "can not set instance variables of classes/modules by non-main Ractors");
-        }
+    if (rb_is_instance_id(id) && // check only normal ivars
+        UNLIKELY(!rb_class_owned_p(klass))) {
+        rb_raise(rb_eRactorIsolationError, "can not set instance variables of classes/modules created by another Ractor");
     }
 }
 
@@ -1249,6 +1248,10 @@ ivar_ractor_check(VALUE obj, ID id)
         UNLIKELY(!rb_ractor_main_p()) &&
         UNLIKELY(rb_ractor_shareable_p(obj))) {
 
+        if (RB_TYPE_P(obj, T_CLASS) || RB_TYPE_P(obj, T_MODULE)) {
+            // classes/modules are owner-checked at each read/write site instead
+            return;
+        }
         rb_raise(rb_eRactorIsolationError, "can not access instance variables of shareable objects from non-main Ractors");
     }
 }
@@ -1561,11 +1564,11 @@ rb_ivar_lookup(VALUE obj, ID id, VALUE undef)
     }
 
     if (is_class && val != undef && rb_is_instance_id(id)) {
-        if (UNLIKELY(!rb_ractor_main_p()) && !rb_ractor_shareable_p(val)) {
+        if (UNLIKELY(!rb_class_owned_p(obj)) && !rb_ractor_shareable_p(val)) {
             rb_raise(
                 rb_eRactorIsolationError,
-                "can not get unshareable values from instance variables of classes/modules from "
-                "non-main Ractors (%"PRIsVALUE" from %"PRIsVALUE")",
+                "can not get unshareable values from instance variables of classes/modules "
+                "created by another Ractor (%"PRIsVALUE" from %"PRIsVALUE")",
                 rb_id2str(id),
                 obj
             );
@@ -1598,9 +1601,9 @@ rb_ivar_get_at(VALUE obj, attr_index_t index, ID id)
             VALUE fields_obj = RCLASS_WRITABLE_FIELDS_OBJ(obj);
             VALUE val = rb_imemo_fields_ptr(fields_obj)[index];
 
-            if (UNLIKELY(!rb_ractor_main_p()) && !rb_ractor_shareable_p(val)) {
+            if (UNLIKELY(!rb_class_owned_p(obj)) && !rb_ractor_shareable_p(val)) {
                 rb_raise(rb_eRactorIsolationError,
-                        "can not get unshareable values from instance variables of classes/modules from non-main Ractors");
+                        "can not get unshareable values from instance variables of classes/modules created by another Ractor");
             }
 
             return val;
@@ -1653,7 +1656,7 @@ rb_ivar_delete(VALUE obj, ID id, VALUE undef)
     int type = BUILTIN_TYPE(obj);
 
     if (type == T_CLASS || type == T_MODULE) {
-        IVAR_ACCESSOR_SHOULD_BE_MAIN_RACTOR(id);
+        class_ivar_set_ractor_check(obj, id);
 
         if (rb_multi_ractor_p()) {
             concurrent = true;
@@ -2047,7 +2050,7 @@ ivar_set(VALUE obj, ID id, VALUE val)
       case T_CLASS:
       case T_MODULE:
         {
-            IVAR_ACCESSOR_SHOULD_BE_MAIN_RACTOR(id);
+            class_ivar_set_ractor_check(obj, id);
             bool dontcare;
             return class_ivar_set(obj, id, val, &dontcare);
         }
@@ -2333,7 +2336,8 @@ rb_field_foreach(VALUE obj, rb_ivar_foreach_callback_func *func, st_data_t arg, 
       case T_CLASS:
       case T_MODULE:
         {
-            IVAR_ACCESSOR_SHOULD_BE_MAIN_RACTOR(0);
+            // No owner check: every caller of this walk uses the names only for a
+            // class/module.  Values are checked where they are read (rb_ivar_lookup).
             VALUE fields_obj = RCLASS_WRITABLE_FIELDS_OBJ(obj);
             if (fields_obj) {
                 imemo_fields_each(fields_obj, func, arg, ivar_only);
@@ -2896,6 +2900,8 @@ rb_autoload_str(VALUE module, ID name, VALUE feature)
         rb_raise(rb_eNameError, "autoload must be constant name: %"PRIsVALUE"", QUOTE_ID(name));
     }
 
+    rb_class_owner_check(module);
+
     Check_Type(feature, T_STRING);
     if (!RSTRING_LEN(feature)) {
         rb_raise(rb_eArgError, "empty feature name");
@@ -3337,9 +3343,9 @@ rb_const_get_0(VALUE klass, ID id, int exclude, int recurse, int visibility)
     VALUE found_in;
     VALUE c = rb_const_search(klass, id, exclude, recurse, visibility, &found_in);
     if (!UNDEF_P(c)) {
-        if (UNLIKELY(!rb_ractor_main_p())) {
+        if (UNLIKELY(!rb_class_owned_p(found_in))) {
             if (!rb_ractor_shareable_p(c)) {
-                rb_raise(rb_eRactorIsolationError, "can not access non-shareable objects in constant %"PRIsVALUE"::%"PRIsVALUE" by non-main Ractor.", rb_class_path(found_in), rb_id2str(id));
+                rb_raise(rb_eRactorIsolationError, "can not access non-shareable objects in constant %"PRIsVALUE"::%"PRIsVALUE" of a class/module created by another Ractor.", rb_class_path(found_in), rb_id2str(id));
             }
         }
         return c;
@@ -3551,6 +3557,7 @@ rb_const_remove(VALUE mod, ID id)
     rb_const_entry_t *ce;
 
     rb_check_frozen(mod);
+    rb_class_owner_check(mod);
 
     ce = rb_const_lookup(mod, id);
 
@@ -3847,8 +3854,8 @@ const_set(VALUE klass, ID id, VALUE val)
                  QUOTE_ID(id));
     }
 
-    if (!rb_ractor_main_p() && !rb_ractor_shareable_p(val)) {
-        rb_raise(rb_eRactorIsolationError, "can not set constants with non-shareable objects by non-main Ractors");
+    if (UNLIKELY(!rb_class_owned_p(klass))) {
+        rb_raise(rb_eRactorIsolationError, "can not set constants of classes/modules created by another Ractor");
     }
 
     check_before_mod_set(klass, id, val, "constant");

--- a/vm_core.h
+++ b/vm_core.h
@@ -2434,7 +2434,7 @@ rb_exec_event_hook_orig(rb_execution_context_t *ec, rb_hook_list_t *hooks, rb_ev
 
 struct rb_ractor_pub {
     VALUE self;
-    uint32_t id;
+    rb_serial_t id;
     rb_hook_list_t hooks;
     st_table targeted_hooks; // also called "local hooks". {ISEQ => hook_list, def => hook_list...}
     unsigned int targeted_hooks_cnt; // ex: tp.enabled(target: method(:puts))

--- a/vm_core.h
+++ b/vm_core.h
@@ -263,10 +263,13 @@ struct iseq_inline_constant_cache_entry {
 
     VALUE value;
     const rb_cref_t *ic_cref;
+    /* Ractor that filled this entry.  An unshareable value may be handed out again
+     * only to that Ractor: it is the one that passed the owner check. */
+    rb_serial_t ractor_id;
 };
 STATIC_ASSERT(sizeof_iseq_inline_constant_cache_entry,
-              (offsetof(struct iseq_inline_constant_cache_entry, ic_cref) +
-               sizeof(const rb_cref_t *)) <= RVALUE_SIZE);
+              (offsetof(struct iseq_inline_constant_cache_entry, ractor_id) +
+               sizeof(rb_serial_t)) <= RVALUE_SIZE);
 
 struct iseq_inline_constant_cache {
     struct iseq_inline_constant_cache_entry *entry;

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1109,10 +1109,10 @@ vm_get_ev_const(rb_execution_context_t *ec, VALUE orig_klass, ID id, bool allow_
                             return 1;
                         }
                         else {
-                            if (UNLIKELY(!rb_ractor_main_p())) {
+                            if (UNLIKELY(!rb_class_owned_p(klass))) {
                                 if (!rb_ractor_shareable_p(val)) {
                                     rb_raise(rb_eRactorIsolationError,
-                                             "can not access non-shareable objects in constant %"PRIsVALUE"::%"PRIsVALUE" by non-main ractor.", rb_class_path(klass), rb_id2str(id));
+                                             "can not access non-shareable objects in constant %"PRIsVALUE"::%"PRIsVALUE" of a class/module created by another Ractor.", rb_class_path(klass), rb_id2str(id));
                                 }
                             }
                             return val;
@@ -1222,10 +1222,10 @@ vm_getivar(VALUE obj, ID id, const rb_iseq_t *iseq, IVC ic, const struct rb_call
       case T_CLASS:
       case T_MODULE:
         {
-            if (UNLIKELY(!rb_ractor_main_p())) {
-                // For two reasons we can only use the fast path on the main
-                // ractor.
-                // First, only the main ractor is allowed to set ivars on classes
+            if (UNLIKELY(!rb_class_owned_p(obj))) {
+                // For two reasons we can only use the fast path on the Ractor
+                // that owns the class.
+                // First, only the owner Ractor is allowed to set ivars on classes
                 // and modules. So we can skip locking.
                 // Second, other ractors need to check the shareability of the
                 // values returned from the class ivars.
@@ -1395,7 +1395,7 @@ NOINLINE(static VALUE vm_setivar_class(VALUE obj, VALUE val, rb_setivar_cache ca
 static VALUE
 vm_setivar_class(VALUE obj, VALUE val, rb_setivar_cache cache)
 {
-    if (UNLIKELY(!rb_ractor_main_p())) {
+    if (UNLIKELY(!rb_class_owned_p(obj))) {
         return Qundef;
     }
 

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1559,7 +1559,10 @@ vm_getclassvariable(const rb_iseq_t *iseq, const rb_control_frame_t *reg_cfp, ID
     const rb_cref_t *cref;
     cref = vm_get_cref(GET_EP());
 
-    if (ic->entry && ic->entry->global_cvar_state == GET_GLOBAL_CVAR_STATE() && ic->entry->cref == cref && LIKELY(rb_ractor_main_p())) {
+    // The fast path skips rb_cvar_find's checks, so it is for class_value's owner:
+    // the sole writer, and the only one allowed to see an unshareable value.
+    if (ic->entry && ic->entry->global_cvar_state == GET_GLOBAL_CVAR_STATE() && ic->entry->cref == cref &&
+        LIKELY(rb_class_owned_p(ic->entry->class_value))) {
         RB_DEBUG_COUNTER_INC(cvar_read_inline_hit);
 
         VALUE v = rb_ivar_lookup(ic->entry->class_value, id, Qundef);
@@ -1585,7 +1588,9 @@ vm_setclassvariable(const rb_iseq_t *iseq, const rb_control_frame_t *reg_cfp, ID
     const rb_cref_t *cref;
     cref = vm_get_cref(GET_EP());
 
-    if (ic->entry && ic->entry->global_cvar_state == GET_GLOBAL_CVAR_STATE() && ic->entry->cref == cref && LIKELY(rb_ractor_main_p())) {
+    // as on the read side: the fast path writes straight into class_value
+    if (ic->entry && ic->entry->global_cvar_state == GET_GLOBAL_CVAR_STATE() && ic->entry->cref == cref &&
+        LIKELY(rb_class_owned_p(ic->entry->class_value))) {
         RB_DEBUG_COUNTER_INC(cvar_write_inline_hit);
 
         rb_class_ivar_set(ic->entry->class_value, id, val);

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1142,10 +1142,10 @@ vm_get_ev_const(rb_execution_context_t *ec, VALUE orig_klass, ID id, bool allow_
                             return 1;
                         }
                         else {
-                            if (UNLIKELY(!rb_ractor_main_p())) {
+                            if (UNLIKELY(!rb_class_owned_p(klass))) {
                                 if (!rb_ractor_shareable_p(val)) {
                                     rb_raise(rb_eRactorIsolationError,
-                                             "can not access non-shareable objects in constant %"PRIsVALUE"::%"PRIsVALUE" by non-main ractor.", rb_class_path(klass), rb_id2str(id));
+                                             "can not access non-shareable objects in constant %"PRIsVALUE"::%"PRIsVALUE" of a class/module created by another Ractor.", rb_class_path(klass), rb_id2str(id));
                                 }
                             }
                             return val;
@@ -1255,10 +1255,10 @@ vm_getivar(VALUE obj, ID id, const rb_iseq_t *iseq, IVC ic, const struct rb_call
       case T_CLASS:
       case T_MODULE:
         {
-            if (UNLIKELY(!rb_ractor_main_p())) {
-                // For two reasons we can only use the fast path on the main
-                // ractor.
-                // First, only the main ractor is allowed to set ivars on classes
+            if (UNLIKELY(!rb_class_owned_p(obj))) {
+                // For two reasons we can only use the fast path on the Ractor
+                // that owns the class.
+                // First, only the owner Ractor is allowed to set ivars on classes
                 // and modules. So we can skip locking.
                 // Second, other ractors need to check the shareability of the
                 // values returned from the class ivars.
@@ -1428,7 +1428,7 @@ NOINLINE(static VALUE vm_setivar_class(VALUE obj, VALUE val, rb_setivar_cache ca
 static VALUE
 vm_setivar_class(VALUE obj, VALUE val, rb_setivar_cache cache)
 {
-    if (UNLIKELY(!rb_ractor_main_p())) {
+    if (UNLIKELY(!rb_class_owned_p(obj))) {
         return Qundef;
     }
 
@@ -6708,9 +6708,11 @@ vm_ic_track_const_chain(rb_control_frame_t *cfp, IC ic, const ID *segments)
 
 // For JIT inlining
 static inline bool
-vm_inlined_ic_hit_p(VALUE flags, VALUE value, const rb_cref_t *ic_cref, const VALUE *reg_ep)
+vm_inlined_ic_hit_p(VALUE flags, VALUE value, const rb_cref_t *ic_cref, rb_serial_t ractor_id, const VALUE *reg_ep)
 {
-    if ((flags & IMEMO_CONST_CACHE_SHAREABLE) || rb_ractor_main_p()) {
+    // Not rb_ractor_main_p(): an owner Ractor may now cache an unshareable constant
+    // of its own class, and only it may be handed that value back.
+    if ((flags & IMEMO_CONST_CACHE_SHAREABLE) || ractor_id == rb_ractor_id(GET_RACTOR())) {
         VM_ASSERT(ractor_incidental_shareable_p(flags & IMEMO_CONST_CACHE_SHAREABLE, value));
 
         return (ic_cref == NULL || // no need to check CREF
@@ -6723,7 +6725,7 @@ static bool
 vm_ic_hit_p(const struct iseq_inline_constant_cache_entry *ice, const VALUE *reg_ep)
 {
     VM_ASSERT(IMEMO_TYPE_P(ice, imemo_constcache));
-    return vm_inlined_ic_hit_p(ice->flags, ice->value, ice->ic_cref, reg_ep);
+    return vm_inlined_ic_hit_p(ice->flags, ice->value, ice->ic_cref, ice->ractor_id, reg_ep);
 }
 
 // YJIT needs this function to never allocate and never raise
@@ -6745,6 +6747,7 @@ vm_ic_update(const rb_iseq_t *iseq, IC ic, VALUE val, const VALUE *reg_ep, const
     struct iseq_inline_constant_cache_entry *ice = SHAREABLE_IMEMO_NEW(struct iseq_inline_constant_cache_entry, imemo_constcache, 0);
     RB_OBJ_WRITE(ice, &ice->value, val);
     ice->ic_cref = vm_get_const_key_cref(reg_ep);
+    ice->ractor_id = rb_ractor_id(GET_RACTOR());
 
     if (rb_ractor_shareable_p(val)) {
         RUBY_ASSERT((rb_gc_verify_shareable(val), 1));

--- a/vm_method.c
+++ b/vm_method.c
@@ -3000,7 +3000,10 @@ set_method_visibility(VALUE self, int argc, const VALUE *argv, rb_method_visibil
 {
     int i;
 
+    // Not rb_class_modify_check: that also marks a module initialized, which this
+    // path has never done.
     rb_check_frozen(self);
+    rb_class_owner_check(self);
     if (argc == 0) {
         rb_warning("%"PRIsVALUE" with no argument is just ignored",
                    QUOTE_ID(rb_frame_callee()));

--- a/vm_method.c
+++ b/vm_method.c
@@ -3196,6 +3196,7 @@ rb_mod_ruby2_keywords(int argc, VALUE *argv, VALUE module)
 
     rb_check_arity(argc, 1, UNLIMITED_ARGUMENTS);
     rb_check_frozen(module);
+    rb_class_owner_check(module);
 
     for (i = 0; i < argc; i++) {
         VALUE v = argv[i];

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -453,6 +453,7 @@ pub struct iseq_inline_constant_cache_entry {
     pub flags: VALUE,
     pub value: VALUE,
     pub ic_cref: *const rb_cref_t,
+    pub ractor_id: rb_serial_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -593,6 +593,7 @@ pub struct iseq_inline_constant_cache_entry {
     pub flags: VALUE,
     pub value: VALUE,
     pub ic_cref: *const rb_cref_t,
+    pub ractor_id: rb_serial_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]


### PR DESCRIPTION
## Summary

This PR introduces per-class *ownership* for Ractors: a class/module can be modified only by the Ractor that created it (the *owner*). Reading is allowed from any Ractor as before.

Motivations:

* The current rules special-case the main Ractor in several places (class ivars, unshareable constants, class variables). Ownership generalizes most of these rules: the old rules become "the owner of boot-time classes is the main Ractor", and non-main Ractors get full use of the classes they create themselves.
* Restricting each class's user-visible mutation to a single Ractor keeps class internals (method tables, constant tables, fields) single-writer, which is a useful invariant for future synchronization and caching work.
* As a user-visible consequence, a class can no longer be redefined by a Ractor which did not create it (e.g. a non-main Ractor monkey-patching `String`).

  Note that this is **not** isolation in a strong sense: reads stay unsynchronized and a class modification is not atomic, so a non-owner Ractor can still observe a class in the middle of being modified by its owner -- after the first `def` of a `class ... end` body but before the second, or while `include`/`prepend` is rewiring the ancestor chain. What ownership guarantees is a single writer per class, not a consistent view for readers.

  Nor is that single writer always the class's own owner. `M.include(N)` and `M.prepend(N)` rewire the ancestor chain of every class that already includes `M`, whoever owns those classes: modifying `M` is `M`'s owner's right, and a class which includes a module created by another Ractor accepts that.

## Specification

A class/module records its creator Ractor as its owner. Only the owner can perform:

* method definition/removal/undef, `alias`, visibility changes, `Module#ruby2_keywords`
* `include`/`prepend` into the class/module, and `Module#refine` targeting it
* constant definition/removal, `autoload` registration
* instance variable writes on the class/module object
* class variable writes and removal, for the variables stored in that class/module
* `Module#freeze` and `Module#set_temporary_name`
* `Class#initialize`, which writes the superclass of a not-yet-initialized class

Non-owner Ractors get `Ractor::IsolationError`. Reading (method calls, instantiation, subclassing, constant/ivar reads) is unchanged.

Relaxations (previously "main Ractor only", now "owner only"):

* A Ractor can set instance variables, **unshareable** constant values, and class variables on classes it created. Unshareable values can only be read back by the owner (the same rule that previously applied to the main Ractor).

Details:

* **Singleton classes/metaclasses** are owned by the owner of the object they are attached to, not by the Ractor that happened to trigger their lazy creation. So `def C.foo` is allowed exactly for the owner of `C`, regardless of which Ractor first touched `C.singleton_class`. `Ractor#send(move: true)` hands the attached object over, so the singleton class's ownership moves with it -- otherwise whether the receiver could define singleton methods on an object it now exclusively holds would depend on whether the singleton class happened to be materialized before the move. The eigenclass chain above it goes too, since each of those is attached to the class below it. The move is refused when any of them holds unshareable constants or variables: the receiver would become their owner, and so allowed to read them, while the sender still holds the objects themselves.
* A **shareable object** belongs to no single Ractor, so the singleton class of one is owned by the main Ractor rather than by whichever Ractor materialized it. Otherwise a Ractor doing `def Ractor.main.foo` would take ownership of `Ractor.main`'s singleton class and the main Ractor could no longer modify its own object.
* **Class variables** are shared across the inheritance chain, and the class a variable is actually stored in can migrate over time (`cvar_overtaken`). The Ractor that decides access is therefore the owner of the class the variable is *stored in*, not of the receiver it was looked up through. That is a single well-defined owner at any moment, and it is the same single writer the rest of that class's fields already have.
* **Owner termination**: classes whose owner Ractor has terminated become permanently read-only for every Ractor. The owner is stored as a Ractor id, which a monotonic counter hands out and never reuses, so the comparison can never meet a dangling or recycled identity; once the owner is gone no live Ractor carries its id. There is intentionally no API to look up ownership, and no way to transfer it other than the singleton class following its object through `move: true`.
* **Copying foreign classes**: `Class#dup`/`clone` of a class created by another Ractor produces a copy owned by the copying Ractor. It raises if the source's constants/ivars refer to unshareable objects (they would otherwise leak across Ractors); the metaclass is checked as well, since `rb_singleton_class_clone_and_attach` copies its tables into the copy's own metaclass. Copying classes with only shareable values works, which offers a mutation-free alternative to monkey-patching a foreign class.
* Since defining a constant in a foreign class is prohibited, a non-main Ractor can not define a top-level class or module name (both write a constant into `Object`). They can be defined under a module the Ractor creates itself instead (`mod = Module.new; mod.const_set(:Foo, Class.new)`).

  Note that reopening an existing class is a lookup, not a constant write, so `Ractor.new { class C; end }` is allowed for an already defined `C` -- it is the body that raises.

  `require` and `require_relative` are unaffected: a non-main Ractor already delegates them to the main Ractor, so a library defines its classes as the main Ractor's, as before. `load` is not delegated, so loading a file which defines a top-level name from a non-main Ractor now raises, like writing that constant directly.

### Change since the acceptance in [note 6]

matz accepted the proposal with class variables left out of the ownership rules, as an experiment, while saying he expected that to change ("I am not comfortable with the result that nobody can write a class variable of a class created in a non-main Ractor -- not its owner, and not the main Ractor either"). This PR now makes that change rather than shipping the state he was uncomfortable with: class variables follow the owner of the class they are stored in, so a Ractor gets full use of the class variables of the classes it created, and the main Ractor still cannot reach into a Ractor's class.

`freeze` and `Module#set_temporary_name` are owner-only as requested in the same note.

## Incompatibilities

Everything below was measured on master and on this branch, from a non-owner Ractor against a class created by the main Ractor.

Previously allowed, now `Ractor::IsolationError`:

| operation | master | this PR |
|---|---|---|
| `def`, `define_method` | OK | `IsolationError` |
| `alias_method` | OK | `IsolationError` |
| `remove_method`, `undef_method` | OK | `IsolationError` |
| `public`, `private`, `protected` | OK | `IsolationError` |
| `private_class_method` | OK | `IsolationError` |
| `module_function :name` | OK | `IsolationError` |
| `include`, `prepend` | OK | `IsolationError` |
| `refine` (either the refined class or the receiver module) | OK | `IsolationError` |
| `ruby2_keywords` | OK | `IsolationError` |
| `Class#initialize` on an uninitialized foreign class | OK | `IsolationError` |
| `const_set` (shareable value) | OK | `IsolationError` |
| `remove_const` | OK | `IsolationError` |
| `autoload` | OK | `IsolationError` |
| `remove_class_variable` | OK | `IsolationError` |
| `Module#freeze` | OK | `IsolationError` |
| `Module#set_temporary_name` | OK | `IsolationError` |
| `dup`/`clone` of a class holding unshareable values | OK | `IsolationError` |
| `send(move: true)` of an object whose singleton class holds unshareable values | OK | `IsolationError` |
| `load` of a file defining a top-level name | OK | `IsolationError` |

Already refused before this PR, unchanged: `const_set` with an unshareable value, reading an unshareable constant, setting a class ivar (shareable or not), `remove_instance_variable`, `class_variable_set`, reading an unshareable class variable.

Still allowed, unchanged: calling methods, instantiating, subclassing, reading shareable constants/ivars/class variables, `extend` on your own object, `freeze` on an already frozen class, bare `module_function`, and `dup`/`clone` of a class whose contents are all shareable.

Hooks such as `Class#inherited` that mutate the superclass (registry patterns) now fail when the subclass is created by a different Ractor; lazy-definition patterns (`const_missing`/`method_missing` + define) fail on first touch from a non-owner Ractor. Eager loading before spawning Ractors avoids both.

Note that the lazy-definition case is only a problem for a class that is *shared*. An object whose accessors are defined on its own singleton class (OpenStruct and friends) works when it is built and used within one Ractor, because that Ractor owns the singleton class, and it keeps working across `move: true` now that the singleton class's ownership moves too.

One caveat for OpenStruct specifically, unrelated to ownership and unchanged by this PR: it builds its accessors with `define_singleton_method`, and a method defined from a Proc cannot be called from another Ractor ("defined with an un-shareable Proc in a different Ractor") on master today either. So a moved OpenStruct is still unusable for that older reason. An object whose singleton methods come from `def obj.foo` moves and keeps working.

Two notes on measuring the last two rows: `Module#set_temporary_name` raises `RuntimeError` ("can't change permanent name") for a module already assigned to a constant, so the row above is an anonymous module handed to the Ractor as an argument -- master renames it, this PR refuses. And `dup` of a foreign class is refused only when the source's constants or ivars hold unshareable values; a class with shareable contents copies fine, which is the intended escape hatch.

## Bug fixes included

* `cvar_overtaken()` physically deleted a duplicated cvar entry from the `front` class, reachable even from **read** paths (`rb_cvar_find`), i.e. a cross-Ractor write triggered by a read. The clean-up is now skipped unless the current Ractor owns `front`.
* `Module#remove_class_variable` had no Ractor check at all, so any Ractor could delete a class variable out of a foreign class.
* The **constant** inline cache had the same shape of problem, and the relaxation turns it into a hole: `vm_inlined_ic_hit_p()` hits when the cached value is shareable **or the reader is the main Ractor**, which was sound only because a non-main Ractor could not have an unshareable constant at all. Now it can, so an owner priming the cache would hand that value to any other Ractor reading through the same iseq, never reaching the owner check in `vm_get_ev_const()`. The entry records the Ractor which filled it instead -- the one that passed the check -- which also gives a non-main owner a constant cache fast path it never had (every read of its own unshareable constants used to miss).
* The class variable inline caches keyed their fast path on `rb_ractor_main_p()`, and the fast path writes straight into `ic->entry->class_value` without going through `rb_cvar_set`. The main Ractor running a method of a foreign class therefore skipped the ownership check entirely.

## Implementation notes

* The owner is `rb_classext_t::owner_ractor_id` (prime classext only), an `rb_serial_t`. `0` means the main Ractor, so single-Ractor programs store nothing. An id rather than the Ractor object: there is nothing for the GC to mark or to update on compaction, and a class does not keep its creator Ractor alive for the rest of the process. Ractor ids are never reused, which is also what makes the "owner terminated" rule hold without holding the object.
* Which is why the first commit widens the Ractor id from 32 to 64 bits. The 32 bit counter wraps after ~4e9 Ractors and comes back onto ids that are still in use -- and the wrapped value is `0`, which several callers read as "the main Ractor". That is not out of reach: a few thousand `Ractor.new` per second is days, not years. There is no portable 64 bit atomic, so the id is taken under the VM lock, which `Ractor.new` acquires a few frames later anyway. `rb_serial_t` matches `ec->ractor_id` and a bmethod's `defined_ractor_id`, which already held the id that way, and neither `rb_ractor_pub` nor `rb_classext_t` grows -- both had the padding for it.
* `rb_class_owned_p()` is inline, with only the non-main-owner half out of line, because it sits on the class ivar and constant read paths where it replaces what used to be a single load of `ruby_single_main_ractor`.
* Method-table-related checks funnel through `rb_class_modify_check()`. That includes visibility: `set_method_visibility()` only called `rb_check_frozen()`, so `public`/`private`/`protected`/`module_function` reached the method table without the ownership check even though the specification lists them; it now goes through `rb_class_modify_check()` like every other method table modification. Bare `module_function` only sets the visibility of the current scope, so it stays unchecked -- the definitions that follow are checked as definitions. Three more paths reach a class without going through `rb_class_modify_check()` and get a check of their own: `Module#refine` (which writes its refinement tables into the receiver as well as into the refined class), `Class#initialize` (which writes the superclass of a not-yet-initialized class, and had no frozen check either), and `Module#ruby2_keywords`.
* The remaining checks: constant/ivar/cvar checks replace the previous `rb_ractor_main_p()` checks in variable.c. The class-ivar and class-variable fast paths in vm_insnhelper.c switch from "main Ractor" to "owner Ractor", which keeps them valid (the owner is the only writer; its threads are serialized by the per-Ractor lock) and lets a non-main owner reach a fast path it could not before.
* No Ruby-level API is added.

## Tests

* bootstraptest/test_ractor.rb updated for the new messages, plus cases for class variables under ownership, `freeze` and `set_temporary_name`; two tests that assumed cross-Ractor method definition were rewritten preserving their intent (cross-Ractor method cache invalidation, bmethods outliving their defining Ractor).
* `TestISeq#test_mandatory_only_redef` rewritten the same way: the Ractor fills the mandatory-only cache and the owner (main) Ractor performs the redefinition, synchronized with a `Ractor::Port`.
* Cases for the above: the constant inline cache not handing a non-owner an unshareable constant, the singleton class of a shareable object, the eigenclass chain following a `move: true` and the move being refused when it holds unshareable values, the metaclass being checked on `dup`, and `Class#initialize`/`refine`/`ruby2_keywords`.
* `make test-all` (36839 tests, 7927629 assertions, 0 failures / 0 errors), `make test-spec` (33067 examples, 0 failures / 0 errors / 0 tagged) and `bootstraptest/test_ractor.rb` (193 tests) all pass. `test-all` for `ruby/` and the Ractor bootstraptest also pass under `--yjit` and `--zjit`. The build is warning-free.

## Future work

* Integration with `Ruby::Box` for top-level class/module names in non-main Ractors, to be settled with the `Ruby::Box` author.

