### PR TITLE
Make sure that pm_parse_stdin_fgets() reads at most size bytes

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -11645,16 +11645,35 @@ pm_parse_stdin_eof(void *stream)
 VALUE rb_io_gets_limit_internal(VALUE io, long limit);
 
 /**
+ * The largest number of bytes a single character can occupy in any encoding
+ * that Ruby supports (CESU-8). `IO#gets(limit)` treats its argument as a soft
+ * limit: to avoid splitting a multi-byte character it may return up to
+ * `MAX_ENC_LEN - 1` more bytes than requested. Reserving `MAX_ENC_LEN` bytes of
+ * headroom therefore leaves room for both that overshoot and the terminating
+ * NUL byte.
+ *
+ * The value can be re-derived from the Ruby source tree with:
+ *
+ *   grep -Erh "max (enc|byte) length" enc | grep -Eo '[0-9]+' | sort | tail -n1
+ */
+#define MAX_ENC_LEN 6
+
+/**
  * An implementation of fgets that is suitable for use with Ruby IO objects.
  */
 static char *
 pm_parse_stdin_fgets(char *string, int size, void *stream)
 {
-    RUBY_ASSERT(size > 0);
+    RUBY_ASSERT(size > MAX_ENC_LEN);
 
     struct rb_stdin_wrapper * wrapped_stdin = (struct rb_stdin_wrapper *)stream;
 
-    VALUE line = rb_io_gets_limit_internal(wrapped_stdin->rb_stdin, size - 1);
+    /*
+     * Request fewer bytes than the buffer can hold. `gets` may return more
+     * bytes than requested when the limit falls in the middle of a multi-byte
+     * character, and the reserved headroom guarantees the result still fits.
+     */
+    VALUE line = rb_io_gets_limit_internal(wrapped_stdin->rb_stdin, size - MAX_ENC_LEN - 1);
     if (NIL_P(line)) {
         return NULL;
     }
@@ -11662,13 +11681,22 @@ pm_parse_stdin_fgets(char *string, int size, void *stream)
     const char *cstr = RSTRING_PTR(line);
     long length = RSTRING_LEN(line);
 
+    /*
+     * Defensively clamp the copy. A misbehaving `gets` may ignore the limit
+     * entirely and return an arbitrarily long string; we must never write past
+     * the caller's buffer. One byte is reserved for the NUL terminator.
+     */
+    if (length > (long) (size - 1)) {
+        length = (long) (size - 1);
+    }
+
     memcpy(string, cstr, length);
     string[length] = '\0';
 
     // We're reading strings from stdin via gets.  We'll assume that if the
     // string is smaller than the requested length, and doesn't end with a
     // newline, that we hit EOF.
-    if (length < (size - 1) && string[length - 1] != '\n') {
+    if (length < (size - MAX_ENC_LEN - 1) && string[length - 1] != '\n') {
         wrapped_stdin->eof_seen = 1;
     }
 

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -2729,6 +2729,28 @@ end
       end
     end
 
+    def test_parse_stdin_internal_line_buffer_border
+      # U+3042: HIRAGANA LETTER A (0xE3, 0x81, 0x82 in UTF-8)
+      data = ("x" * 4087) + "\u3042"
+      # %[puts "xxx...\xE3] must be 4094 or 4095 bytes data. Prism
+      # uses 4096 bytes internal line
+      # buffer. pm_parse_stdin_fgets(4096) must read 4095 or less data
+      # and append '\0' at the end. $stdin.gets(4095) reads 4095 or
+      # more data when the last character (U+3042 in this case) is a
+      # multi-byte character. If the 4094th or 4095th byte is middle
+      # of U+3042, $stdin.gets(4095) read 4097 or 4098 byte
+      # data. pm_parse_stdin_fgets() must not do it. This test checks
+      # the case.
+
+      # Use UTF-8 for the default external encoding to recognize the
+      # "\xE3\x81\x82" as a multi-byte character in $stdin.gets().
+      assert_in_out_err(["-Eutf-8"],
+                        # Ensure using UTF-8 as the script encoding.
+                        "# encoding: utf-8\n" +
+                        "puts \"#{data}\"",
+                        [data])
+    end
+
     private
 
     def compare_eval(source, raw:, location:)


### PR DESCRIPTION
This is the same change in
https://github.com/ruby/prism/pull/4172 .

Ruby has a custom `pm_source_stream_fgets_t` for stdin. We should apply the same change to `pm_parse_stdin_fgets()` to avoid reading `size` or more data.