### PR TITLE
ZJIT: Re-profile whole ISEQ in non-final versions

### DIFF
--- a/zjit/bindgen/src/main.rs
+++ b/zjit/bindgen/src/main.rs
@@ -110,6 +110,7 @@ fn main() {
         .allowlist_function("rb_funcallv")
         .allowlist_function("rb_protect")
         .allowlist_function("rb_zjit_profile_disable")
+        .allowlist_function("rb_zjit_profile_enable")
         .allowlist_function("rb_zjit_insn_to_bare_insn")
         .allowlist_function("rb_zjit_hash_new_size")
         .allowlist_function("rb_zjit_class_allocate_instance_fastpath")

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -17,6 +17,7 @@ use crate::invariants::{
 };
 use crate::gc::append_gc_offsets;
 use crate::payload::{IseqCodePtrs, IseqStatus, IseqVersion, IseqVersionRef, JITFrame, get_or_create_iseq_payload};
+use crate::profile::reset_profiles_remaining;
 use crate::state::ZJITState;
 use crate::stats::{CompileError, exit_counter_for_compile_error, exit_counter_for_unhandled_hir_insn, incr_counter, incr_counter_by, send_fallback_counter, send_fallback_counter_for_method_type, send_fallback_counter_for_super_method_type, send_fallback_counter_ptr_for_opcode, send_fallback_counter_for_optimized_method_type};
 use crate::stats::{counter_ptr, with_time_stat, trace_compile_phase, Counter, Counter::{compile_time_ns, exit_compile_error}};
@@ -3361,6 +3362,10 @@ fn compile_iseq(iseq: IseqPtr) -> Result<Function, CompileError> {
         trace_compile_phase("optimize", || function.optimize());
     }
     function.dump_hir();
+    let non_final_version = get_or_create_iseq_payload(iseq).versions.len() + 1 < max_iseq_versions();
+    if non_final_version {
+        reset_profiles_remaining(iseq);
+    }
     Ok(function)
 }
 

--- a/zjit/src/codegen_tests.rs
+++ b/zjit/src/codegen_tests.rs
@@ -123,6 +123,28 @@ fn test_putobject() {
 }
 
 #[test]
+fn test_recompile_exit_waits_for_interpreter_profiles() {
+    set_call_threshold(2);
+    eval("
+        def recompile_profile_window(a, b) = a + b
+        recompile_profile_window(1, 2)
+        recompile_profile_window(1, 2)
+    ");
+
+    let iseq = get_method_iseq("self", "recompile_profile_window");
+    let num_profiles = get_option!(num_profiles);
+    for _ in 0..num_profiles {
+        eval("recompile_profile_window(1.5, 2.5)");
+    }
+    let payload = get_or_create_iseq_payload(iseq);
+    assert!(!unsafe { payload.versions.last().unwrap().as_ref() }.is_invalidated());
+
+    eval("recompile_profile_window(1.5, 2.5)");
+    let payload = get_or_create_iseq_payload(iseq);
+    assert!(unsafe { payload.versions.last().unwrap().as_ref() }.is_invalidated());
+}
+
+#[test]
 fn test_dupstring() {
     eval(r##"
         def test = "#{""}"

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -2271,6 +2271,7 @@ unsafe extern "C" {
     pub fn rb_iseqw_to_iseq(iseqw: VALUE) -> *const rb_iseq_t;
     pub fn rb_iseq_label(iseq: *const rb_iseq_t) -> VALUE;
     pub fn rb_iseq_defined_string(type_: defined_type) -> VALUE;
+    pub fn rb_zjit_profile_enable(iseq: *const rb_iseq_t);
     pub fn rb_zjit_hash_new_size() -> usize;
     pub fn rb_zjit_class_allocate_instance_fastpath(
         klass: VALUE,

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -6,9 +6,7 @@
 #![allow(clippy::if_same_then_else)]
 #![allow(clippy::match_like_matches_macro)]
 use crate::{
-    backend::lir::C_ARG_OPNDS,
-    cast::IntoUsize, codegen::{max_iseq_versions}, cruby::*, invariants::{self, iseq_seen_ep_escape}, payload::get_or_create_iseq_payload, options::{debug, get_option, DumpHIR, InlineDepth}, state::ZJITState, json::Json,
-    state,
+    backend::lir::C_ARG_OPNDS, cast::IntoUsize, codegen::max_iseq_versions, cruby::*, invariants::{self, iseq_seen_ep_escape}, json::Json, options::{DumpHIR, InlineDepth, debug, get_option}, payload::get_or_create_iseq_payload, profile::reset_profiles_remaining, state::{self, ZJITState},
 };
 use std::{
     cell::RefCell, collections::{HashMap, HashSet, VecDeque}, ffi::{c_void, c_uint, c_int, CStr}, fmt::Display, mem::{align_of, size_of}, ptr, slice::Iter,
@@ -9750,6 +9748,10 @@ fn add_iseq_to_hir(
             Some(DumpHIR::Debug) => println!("Initial HIR:\n{:#?}", fun),
             None => {},
         }
+    }
+    if matches!(mode, AddIseqMode::Inlined { .. }) {
+        // Materialized inlined frames also need fresh interpreter profiles.
+        reset_profiles_remaining(iseq);
     }
 
     Ok(AddIseqResult { body_entry_block, profiles })

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -5602,11 +5602,15 @@ mod hir_opt_tests {
           v36:NilClass = Const Value(nil)
           Jump bb8(v36, v13)
         bb8(v26:BasicObject, v27:BasicObject):
-          v39:BasicObject = Send v24, &block, :then, v26 # SendFallbackReason: Send: block argument is not nil
+          v56:NilClass = GuardBitEquals v26, Value(nil) recompile
+          PatchPoint MethodRedefined(Integer@0x1008, then@0x1010, cme:0x1018)
+          PushInlineFrame v24 (0x1040)
+          v76:BasicObject = InvokeBuiltin <inline_expr>, v24
           CheckInterrupts
-          Return v39
+          PopInlineFrame
+          Return v76
         bb4(v44:BasicObject, v45:Falsy, v46:BasicObject):
-          v50:StaticSymbol[:skip] = Const Value(VALUE(0x1008))
+          v50:StaticSymbol[:skip] = Const Value(VALUE(0x1048))
           CheckInterrupts
           Return v50
         ");
@@ -9175,12 +9179,17 @@ mod hir_opt_tests {
           Jump bb3(v6, v7)
         bb3(v9:HeapBasicObject, v10:BasicObject):
           v17:Fixnum[5] = Const Value(5)
+          v21:CBool = HasType v10, ObjectSubclass[class_exact:C]
+          CondBranch v21, bb5(), bb6()
+        bb5():
+          v24:ObjectSubclass[class_exact:C] = RefineType v10, ObjectSubclass[class_exact:C]
           PatchPoint MethodRedefined(C@0x1008, foo=@0x1010, cme:0x1018)
-          v28:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C] recompile
-          v30:CShape = LoadField v28, :shape_id@0x1040
-          v31:CShape[0x1041] = GuardBitEquals v30, CShape(0x1041)
-          StoreField v28, :@foo@0x1042, v17
-          WriteBarrier v28, v17
+          SetIvar v24, :@foo, v17
+          Jump bb4(v17)
+        bb6():
+          v27:BasicObject = Send v10, :foo=, v17 # SendFallbackReason: Send: polymorphic fallback
+          Jump bb4(v27)
+        bb4(v20:BasicObject):
           CheckInterrupts
           Return v17
         ");
@@ -18809,27 +18818,25 @@ mod hir_opt_tests {
         bb4():
           PatchPoint NoEPEscape(f)
           v44:Fixnum[1] = Const Value(1)
-          v48:CBool = HasType v12, Flonum
+          v48:CBool = HasType v12, Fixnum
           CondBranch v48, bb10(), bb11()
         bb10():
-          v51:Flonum = RefineType v12, Flonum
-          PatchPoint MethodRedefined(Float@0x1008, +@0x1010, cme:0x1018)
-          v86:Float = FloatAdd v51, v44
+          v51:Fixnum = RefineType v12, Fixnum
+          PatchPoint MethodRedefined(Integer@0x1008, +@0x1010, cme:0x1018)
+          v86:Fixnum = FixnumAdd v51, v44
           Jump bb9(v86)
         bb11():
-          v54:CBool = HasType v12, Fixnum
+          v54:CBool = HasType v12, Flonum
           CondBranch v54, bb12(), bb13()
         bb12():
-          v57:Fixnum = RefineType v12, Fixnum
-          PatchPoint MethodRedefined(Integer@0x1040, +@0x1010, cme:0x1048)
-          v89:Fixnum = FixnumAdd v57, v44
+          v57:Flonum = RefineType v12, Flonum
+          PatchPoint MethodRedefined(Float@0x1040, +@0x1010, cme:0x1048)
+          v89:Float = FloatAdd v57, v44
           Jump bb9(v89)
         bb13():
-          PatchPoint MethodRedefined(Float@0x1008, +@0x1010, cme:0x1018)
-          v92:Flonum = GuardType v12, Flonum recompile
-          v93:Float = FloatAdd v92, v44
-          Jump bb9(v93)
-        bb9(v47:Float|Fixnum):
+          v60:BasicObject = Send v12, :+, v44 # SendFallbackReason: Send: polymorphic fallback
+          Jump bb9(v60)
+        bb9(v47:BasicObject):
           PatchPoint SingleRactorMode
           v69:CShape = LoadField v11, :shape_id@0x1001
           v70:CShape[0x1002] = Const CShape(0x1002)

--- a/zjit/src/profile.rs
+++ b/zjit/src/profile.rs
@@ -122,36 +122,21 @@ fn profile_insn(bare_opcode: ruby_vminsn_type, ec: EcPtr) {
     }
 }
 
-/// Profile the instruction at the current CFP for a recompile side exit.
+/// Return whether the interpreter finished profiling the current instruction.
 pub fn profile_recompile_insn(ec: EcPtr) -> bool {
-    let profiler = &mut Profiler::new(ec);
-    let pc = unsafe { get_cfp_pc(profiler.cfp) };
-    let bare_opcode = unsafe {
-        rb_zjit_insn_to_bare_insn(rb_iseq_opcode_at_pc(profiler.iseq, pc))
-    } as ruby_vminsn_type;
-    let profile = &mut get_or_create_iseq_payload(profiler.iseq).profile;
+    let profiler = &Profiler::new(ec);
+    get_or_create_iseq_payload(profiler.iseq).profile.done_profiling_at(profiler.insn_idx)
+}
 
-    let is_send = matches!(bare_opcode, YARVINSN_send | YARVINSN_opt_send_without_block);
-    // For now, send recompile exits only fill in missing profiles. Once the send site
-    // has finished profiling, don't recompile it on later exits.
-    if is_send && profile.done_profiling_at(profiler.insn_idx) {
-        return false;
+/// Reset existing profile counters and install profiling instructions throughout an ISEQ.
+/// Newly reached instructions initialize their counters from the same option.
+pub(crate) fn reset_profiles_remaining(iseq: IseqPtr) {
+    let profile = &mut get_or_create_iseq_payload(iseq).profile;
+    let num_profiles = get_option!(num_profiles);
+    for entry in &mut profile.entries {
+        entry.profiles_remaining = num_profiles;
     }
-    // For now, non-send recompile exits reset the profiling counter before requesting recompilation
-    // so that we can collect enough samples.
-    if !is_send && profile.done_profiling_at(profiler.insn_idx) {
-        profile.entry_mut(profiler.insn_idx)
-            .set_profiles_remaining(get_option!(num_profiles));
-    }
-
-    // If this opcode can't be sampled here, this exit has no profile data to collect.
-    if !profile_insn_sample(bare_opcode, profiler, profile) {
-        return false;
-    }
-
-    let entry = profile.entry_mut(profiler.insn_idx);
-    entry.profiles_remaining = entry.profiles_remaining.saturating_sub(1);
-    entry.profiles_remaining == 0
+    unsafe { rb_zjit_profile_enable(iseq) };
 }
 
 /// Return the argc as stated in the calldata plus:


### PR DESCRIPTION
Closes https://github.com/Shopify/ruby/issues/1000

This PR moves the responsibility of profiling for recompile exits from the exits themselves to `zjit_` instructions on the interpreter. It allows ZJIT to collect profiles from a whole ISEQ to compile non-first versions, not just from an exit.

* Reset `profiles_remaining` for each instruction to `num-profiles` after the ISEQ is compiled.
* `Recompile` exits only check `done_profiling_at` and issue a recompile as needed, without calling `profile_insn_sample` by itself.

## Benchmark

```
before: ruby 4.1.0dev (2026-07-16T00:11:36Z master 6e055f5692) +ZJIT +PRISM [x86_64-linux]
after: ruby 4.1.0dev (2026-07-16T01:16:37Z zjit-reprofile-non.. a6c4979bab) +ZJIT +PRISM [x86_64-linux]

---------  -------------  ------------  -------------  ------------
bench        before (ms)    after (ms)  after 1st itr  before/after
optcarrot  1130.1 ± 3.9%  966.6 ± 1.2%          1.142         1.169
---------  -------------  ------------  -------------  ------------
```

### ZJIT stats

On optcarrot,

```diff
-Top-20 calls to C functions from JIT code (99.9% of total 61,226,338):
+Top-20 calls to C functions from JIT code (100.0% of total 51,027,297):
                    rb_ary_push: 12,448,704 (20.3%)
                 rb_fix_mod_fix: 12,226,463 (20.0%)
-  rb_vm_opt_send_without_block:  7,852,884 (12.8%)
                    rb_fix_aref:  7,157,466 (11.7%)
-     rb_vm_getinstancevariable:  4,490,164 ( 7.3%)
             rb_gc_writebarrier:  3,943,383 ( 6.4%)
                       Array#[]:  3,940,523 ( 6.4%)
+  rb_vm_opt_send_without_block:  3,819,154 ( 7.5%)
-     rb_vm_setinstancevariable:  2,183,243 ( 3.6%)
              rb_vm_splat_array:  1,677,153 ( 2.7%)
             rb_jit_fix_div_fix:  1,610,734 ( 2.6%)
                      Array#[]=:  1,540,315 ( 2.5%)
                  Array#rotate!:  1,493,428 ( 2.4%)
                   rb_hash_aref:    199,190 ( 0.3%)
```