### PR TITLE
Use archname input for downloaded-cache path in tarball-windows.yml

### DIFF
--- a/.github/workflows/tarball-windows.yml
+++ b/.github/workflows/tarball-windows.yml
@@ -97,7 +97,7 @@ jobs:
 
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: snapshot-*/.downloaded-cache
+          path: ${{ inputs.archname }}/.downloaded-cache
           key: downloaded-cache
 
       - name: setup env


### PR DESCRIPTION
The `actions/cache` step in the reusable `tarball-windows.yml` workflow hardcodes `snapshot-*/.downloaded-cache` as its path while the rest of the workflow is generalized over the `archname` input. Callers in this repository pass archnames like `snapshot-master`, so the glob happens to match, but when the workflow is called with a release archname such as `ruby-3.4.0-rc1` from ruby/actions the glob matches nothing and both cache save and restore become a no-op. This changes the path to `${{ inputs.archname }}/.downloaded-cache`. The `key` is left unchanged because the downloaded cache is intentionally shared across branches and archnames.

https://github.com/ruby/actions/pull/136

Generated with [Claude Code](https://claude.com/claude-code)
