### PR TITLE
[ruby_3_3] Backport tarball-test workflow fixes (#17917, #17877)

### DIFF
--- a/.github/workflows/tarball-macos.yml
+++ b/.github/workflows/tarball-macos.yml
@@ -12,6 +12,11 @@ on:
         required: false
         type: boolean
         default: false
+      full-matrix:
+        description: 'Run the full test matrix (nightly schedule and release verification). Off, the default, runs a single smoke check.'
+        required: false
+        type: boolean
+        default: false
     secrets:
       SIMPLER_ALERTS_URL:
         required: false
@@ -24,16 +29,17 @@ permissions:
 jobs:
   macos:
     strategy:
+      # The smoke matrix keeps only what is tarball-specific: that the
+      # packaged tarball configures, builds and installs. macos.yml runs the
+      # same test tasks from the git tree on every PR/push already.
+      # macos-15-intel: the runner image ships a pre-installed Ruby under
+      # /usr/local whose gems dir collides with the default prefix on Intel.
+      # Use an isolated prefix so RDoc generation does not scan that stale
+      # default-gem stub.
       matrix:
-        test_task: [check, test-bundled-gems, test-bundler-parallel]
-        os: [macos-26, macos-15, macos-14]
-        include:
-          - os: macos-15-intel
-            test_task: check
-            # The runner image ships a pre-installed Ruby under /usr/local whose
-            # gems dir collides with the default prefix on Intel. Use an isolated
-            # prefix so RDoc generation does not scan that stale default-gem stub.
-            prefix: /tmp/ruby-prefix
+        test_task: ${{ inputs.full-matrix && fromJSON('["check", "test-bundled-gems", "test-bundler-parallel"]') || fromJSON('["check"]') }}
+        os: ${{ inputs.full-matrix && fromJSON('["macos-26", "macos-15", "macos-14"]') || fromJSON('["macos-26"]') }}
+        include: ${{ inputs.full-matrix && fromJSON('[{"os":"macos-15-intel", "test_task":"check", "prefix":"/tmp/ruby-prefix"}]') || fromJSON('[]') }}
       fail-fast: false
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/tarball-test.yml
+++ b/.github/workflows/tarball-test.yml
@@ -83,6 +83,11 @@ jobs:
     uses: ./.github/workflows/tarball-macos.yml
     with:
       archname: snapshot-${{ needs.tarball.outputs.branch }}
+      # Full fan-out only for workflow_dispatch (nightly schedule and release
+      # verification); pull requests and pushes run a single smoke check.
+      # Only macOS is trimmed: its org-wide concurrency pool of 50 runners
+      # saturates during peak hours, while Linux and Windows have headroom.
+      full-matrix: ${{ github.event_name == 'workflow_dispatch' }}
       notify-release-channel: ${{ github.event_name == 'workflow_dispatch' && inputs.notify-release-channel || false }}
     secrets:
       SIMPLER_ALERTS_URL: ${{ secrets.SIMPLER_ALERTS_URL }}

--- a/.github/workflows/tarball-windows.yml
+++ b/.github/workflows/tarball-windows.yml
@@ -84,7 +84,7 @@ jobs:
 
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
-          path: snapshot-*/.downloaded-cache
+          path: ${{ inputs.archname }}/.downloaded-cache
           key: downloaded-cache
 
       - name: setup env


### PR DESCRIPTION
Backport of #17917 and #17877.

The `actions/cache` step in the reusable `tarball-windows.yml` workflow hardcoded `snapshot-*/.downloaded-cache` as its path while the rest of the workflow is generalized over the `archname` input. When ruby/actions calls this workflow with a release archname such as `ruby-3.4.0-rc1`, the glob matches nothing, so both cache save and restore become a no-op. This changes the path to `${{ inputs.archname }}/.downloaded-cache` (#17917).

The macOS `tarball-test` fan-out (10 jobs, about 117 runner-minutes) repeats test tasks that `macos.yml` already runs from the git tree on every event; what is tarball-specific is only that the packaged tarball configures, builds and installs. Run a single smoke check on `macos-26` for pull requests and pushes, and keep the full matrix for `workflow_dispatch`, which is how the nightly schedule and release verification invoke it. Only macOS is trimmed: its org-wide concurrency pool of 50 runners saturates during peak hours and has been delaying release jobs, while Linux and Windows share a pool with headroom (#17877).
