### PR TITLE
Fix data race in rb_iseq_original_iseq

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -1003,10 +1003,10 @@ rb_iseq_translate_threaded_code(rb_iseq_t *iseq)
 VALUE *
 rb_iseq_original_iseq(const rb_iseq_t *iseq) /* cold path */
 {
-    VALUE *original_code;
+    VALUE *original_code = RUBY_ATOMIC_PTR_LOAD(ISEQ_BODY(iseq)->variable.original_iseq);
 
-    if (ISEQ_ORIGINAL_ISEQ(iseq)) return ISEQ_ORIGINAL_ISEQ(iseq);
-    original_code = ISEQ_ORIGINAL_ISEQ_ALLOC(iseq, ISEQ_BODY(iseq)->iseq_size);
+    if (original_code) return original_code;
+    original_code = ALLOC_N(VALUE, ISEQ_BODY(iseq)->iseq_size);
     MEMCPY(original_code, ISEQ_BODY(iseq)->iseq_encoded, VALUE, ISEQ_BODY(iseq)->iseq_size);
 
 #if OPT_DIRECT_THREADED_CODE || OPT_CALL_THREADED_CODE
@@ -1022,6 +1022,15 @@ rb_iseq_original_iseq(const rb_iseq_t *iseq) /* cold path */
         }
     }
 #endif
+
+    /* Concurrent callers can each build a copy; publish only fully
+     * translated code and keep the first one. */
+    VALUE *prev = ATOMIC_PTR_CAS(ISEQ_BODY(iseq)->variable.original_iseq,
+                                 NULL, original_code);
+    if (prev) {
+        SIZED_FREE_N(original_code, ISEQ_BODY(iseq)->iseq_size);
+        return prev;
+    }
     return original_code;
 }
 

--- a/iseq.h
+++ b/iseq.h
@@ -75,13 +75,6 @@ ISEQ_ORIGINAL_ISEQ_CLEAR(const rb_iseq_t *iseq)
     }
 }
 
-static inline VALUE *
-ISEQ_ORIGINAL_ISEQ_ALLOC(const rb_iseq_t *iseq, long size)
-{
-    return ISEQ_BODY(iseq)->variable.original_iseq =
-        ALLOC_N(VALUE, size);
-}
-
 #define ISEQ_TRACE_EVENTS (RUBY_EVENT_LINE  | \
                            RUBY_EVENT_CLASS | \
                            RUBY_EVENT_END   | \


### PR DESCRIPTION
The translated code cache was published before its contents were initialized, so a concurrent caller could read direct-threaded addresses as instruction numbers.  Reachable since Proc#refined started dumping the same iseq from multiple Ractors. Build the buffer locally and publish it with CAS after translation.

This fixes: https://ci.rvm.jp/results/trunk_asan@ruby-sp2/6416785

```
  1) Failure:
TestProc#test_refined_non_main_ractor [/tmp/ruby/src/trunk_asan/test/ruby/test_proc.rb:619]:
pid 741789 killed by SIGSEGV (signal 11)
| -:11: [BUG] Segmentation fault at 0x000024933beaa598
| ruby 4.1.0dev (2026-07-16T03:10:43Z master a78c2d52dc) +PRISM [x86_64-linux]
| 
| -- Control frame information -----------------------------------------------
| c:0003 p:---- s:0012 e:000011 l:y b:0001 r:(nil) CFUNC  :refined
| c:0002 p:0019 s:0007 E:000058 l:n b:---- r:(nil) BLOCK  -:11 [FINISH]
| c:0001 p:---- s:0003 e:000002 l:y b:---- r:(nil) DUMMY  [FINISH]
| 
| -- Ruby level backtrace information ----------------------------------------
| -:11:in 'block (2 levels) in <main>'
| -:11:in 'refined'
| 
| -- Threading information ---------------------------------------------------
| Total ractor count: 5
| Ruby thread count for this ractor: 1
| 
| -- Machine register context ------------------------------------------------
|  RIP: 0x000061874a844382 RBP: 0x0000754681db1950 RSP: 0x0000754681db17a0
|  RAX: 0x00002492bbeb2598 RBX: 0x0000754681db17a0 RCX: 0x00007586a0414250
|  RDX: 0x00007546811b1140 RDI: 0x00012495df592cc0 RSI: 0x000061874a51f580
|   R8: 0x00000ea95022e200  R9: 0x00007946a0bef300 R10: 0x000075c6a0428070
|  R11: 0x00000eb0d408244f R12: 0x0000000000000000 R13: 0x00007546a02800f8
|  R14: 0x00000000fffffffe R15: 0x00007586a0412250 EFL: 0x0000000000010212
| 
| -- C level backtrace information -------------------------------------------
| /tmp/ruby/build/trunk_asan/ruby(___interceptor_backtrace) [0x61874a0efb6a]
| /tmp/ruby/build/trunk_asan/ruby(rb_print_backtrace+0x14) [0x61874a5a8a05] /tmp/ruby/src/trunk_asan/vm_dump.c:1113
| /tmp/ruby/build/trunk_asan/ruby(rb_vm_bugreport) /tmp/ruby/src/trunk_asan/vm_dump.c:1475
| /tmp/ruby/build/trunk_asan/ruby(rb_bug_for_fatal_signal+0x2ee) [0x61874a91774e] /tmp/ruby/src/trunk_asan/error.c:1140
| /tmp/ruby/build/trunk_asan/ruby(sigsegv+0xdd) [0x61874a41543d] /tmp/ruby/src/trunk_asan/signal.c:948
| /lib/x86_64-linux-gnu/libc.so.6(0x7946a1245330) [0x7946a1245330]
| /tmp/ruby/build/trunk_asan/ruby(insn_op_types+0x12) [0x61874a844382] ./insns_info.inc:522
| /tmp/ruby/build/trunk_asan/ruby(ibf_dump_code) /tmp/ruby/src/trunk_asan/compile.c:13027
| /tmp/ruby/build/trunk_asan/ruby(ibf_dump_iseq_each) /tmp/ruby/src/trunk_asan/compile.c:13711
| /tmp/ruby/build/trunk_asan/ruby(ibf_dump_iseq_list_i) /tmp/ruby/src/trunk_asan/compile.c:14075
| /tmp/ruby/build/trunk_asan/ruby(st_general_foreach+0x28d) [0x61874a427a6d] /tmp/ruby/src/trunk_asan/st.c:1621
| /tmp/ruby/build/trunk_asan/ruby(rb_st_foreach+0xc8) [0x61874a428f18] /tmp/ruby/src/trunk_asan/st.c:1718
| /tmp/ruby/build/trunk_asan/ruby(ibf_dump_iseq_list+0x128) [0x61874a843868] /tmp/ruby/src/trunk_asan/compile.c:14090
| /tmp/ruby/build/trunk_asan/ruby(iseq_ibf_dump_0+0x29b) [0x61874a7b6d6b] /tmp/ruby/src/trunk_asan/compile.c:14904
| /tmp/ruby/build/trunk_asan/ruby(rb_iseq_dup_with_independent_caches+0x1ef) [0x61874a7c8bcf] /tmp/ruby/src/trunk_asan/compile.c:15189
| /tmp/ruby/build/trunk_asan/ruby(proc_refined+0x508) [0x61874a30cd88] /tmp/ruby/src/trunk_asan/proc.c:532
| /tmp/ruby/build/trunk_asan/ruby(vm_call_cfunc_with_frame_+0x45c) [0x61874a57a12c] /tmp/ruby/src/trunk_asan/vm_insnhelper.c:3825
| /tmp/ruby/build/trunk_asan/ruby(vm_exec_core+0xc0c3) [0x61874a527c83] /tmp/ruby/src/trunk_asan/vm_insnhelper.c:6097
| /tmp/ruby/build/trunk_asan/ruby(rb_vm_exec+0x3ea) [0x61874a51756a] /tmp/ruby/src/trunk_asan/vm.c:2846
| /tmp/ruby/build/trunk_asan/ruby(vm_invoke_proc+0x935) [0x61874a552d75] /tmp/ruby/src/trunk_asan/vm.c:1854
| /tmp/ruby/build/trunk_asan/ruby(thread_do_start_proc+0x67a) [0x61874a4b36da] /tmp/ruby/src/trunk_asan/thread.c:622
| /tmp/ruby/build/trunk_asan/ruby(thread_start_func_2+0x628) [0x61874a4b1be8] /tmp/ruby/src/trunk_asan/thread.c:666
| /tmp/ruby/build/trunk_asan/ruby(call_thread_start_func_2+0x3e) [0x61874a4b11ad] /tmp/ruby/src/trunk_asan/thread_pthread.c:2382
| /tmp/ruby/build/trunk_asan/ruby(nt_start) /tmp/ruby/src/trunk_asan/thread_pthread.c:2427
| /tmp/ruby/build/trunk_asan/ruby(0x61874a147e6b) [0x61874a147e6b]
| /lib/x86_64-linux-gnu/libc.so.6(start_thread+0x384) [0x7946a129caa4] ./nptl/pthread_create.c:447
| /lib/x86_64-linux-gnu/libc.so.6(clone3+0x2c) [0x7946a1329c6c] ../sysdeps/unix/sysv/linux/x86_64/clone3.S:78
| /lib/x86_64-linux-gnu/libc.so.6(__GI___clone3) (null):0
Finished tests in 340.962893s, 105.0994 tests/s, 22670.8864 assertions/s.
| /lib/x86_64-linux-gnu/libc.so.6(__clone3) (null):0
| 
| -- Other runtime information -----------------------------------------------
| 
| * Loaded script: -
| 
| * Ruby Box: disabled
| * Loaded features:
| 
|     0 enumerator.so
|     1 monitor.so
|     2 thread.rb
|     3 fiber.so
|     4 rational.so
|     5 complex.so
|     6 pathname.so
|     7 ruby2_keywords.rb
|     8 set.rb
|     9 /tmp/ruby/build/trunk_asan/.ext/x86_64-linux/enc/encdb.so
|    10 /tmp/ruby/build/trunk_asan/.ext/x86_64-linux/enc/trans/transdb.so
|    11 /tmp/ruby/src/trunk_asan/lib/open3/version.rb
|    12 /tmp/ruby/src/trunk_asan/lib/open3.rb
|    13 /tmp/ruby/src/trunk_asan/lib/timeout.rb
|    14 /tmp/ruby/build/trunk_asan/rbconfig.rb
|    15 /tmp/ruby/src/trunk_asan/tool/lib/find_executable.rb
|    16 /tmp/ruby/build/trunk_asan/.ext/x86_64-linux/rbconfig/sizeof.so
|    17 /tmp/ruby/src/trunk_asan/tool/lib/envutil.rb
|    18 /tmp/ruby/src/trunk_asan/tool/lib/colorize.rb
|    19 /tmp/ruby/src/trunk_asan/tool/lib/leakchecker.rb
|    20 /tmp/ruby/src/trunk_asan/lib/prettyprint.rb
|    21 /tmp/ruby/src/trunk_asan/lib/pp.rb
|    22 /tmp/ruby/src/trunk_asan/tool/lib/test/unit/assertions.rb
|    23 /tmp/ruby/build/trunk_asan/.ext/x86_64-linux/-test-/sanitizers.so
|    24 /tmp/ruby/build/trunk_asan/.ext/x86_64-linux/io/console.so
|    25 /tmp/ruby/src/trunk_asan/tool/lib/core_assertions.rb
|    26 /tmp/ruby/src/trunk_asan/tool/lib/test/unit/testcase.rb
|    27 /tmp/ruby/src/trunk_asan/tool/lib/test/jobserver.rb
|    28 /tmp/ruby/src/trunk_asan/lib/optparse.rb
|    29 /tmp/ruby/src/trunk_asan/tool/lib/test/unit.rb
| 
| AddressSanitizer:DEADLYSIGNAL
```
