### PR TITLE
cont.c: resolve the refinements cref before EC_PUSH_TAG

### DIFF
--- a/cont.c
+++ b/cont.c
@@ -2646,6 +2646,9 @@ rb_fiber_start(rb_fiber_t *fiber)
         th->blocking += 1;
     }
 
+    /* resolved before EC_PUSH_TAG to keep the setjmp region minimal */
+    const rb_cref_t *cref = rb_proc_refinements_cref(fiber->first_proc);
+
     EC_PUSH_TAG(th->ec);
     if ((state = EC_EXEC_TAG()) == TAG_NONE) {
         rb_context_t *cont = &VAR_FROM_MEMORY(fiber)->cont;
@@ -2659,8 +2662,7 @@ rb_fiber_start(rb_fiber_t *fiber)
         th->ec->root_svar = Qfalse;
 
         EXEC_EVENT_HOOK(th->ec, RUBY_EVENT_FIBER_SWITCH, th->self, 0, 0, 0, Qnil);
-        cont->value = rb_vm_invoke_proc(th->ec, proc, argc, argv, cont->kw_splat, VM_BLOCK_HANDLER_NONE,
-                                        rb_proc_refinements_cref(fiber->first_proc));
+        cont->value = rb_vm_invoke_proc(th->ec, proc, argc, argv, cont->kw_splat, VM_BLOCK_HANDLER_NONE, cref);
     }
     EC_POP_TAG();
 


### PR DESCRIPTION
The icc-x64 rubyci builder has been failing with heap corruption on abnormal fiber termination since cce7041630 added a call to rb_proc_refinements_cref inside rb_fiber_start's setjmp region, which looks like a miscompilation of this setjmp-sensitive function by Intel oneAPI 2026.1.  Hoist the call before EC_PUSH_TAG; the behavior is unchanged.

https://rubyci.s3.amazonaws.com/icc-x64/ruby-master/log/20260716T030004Z.fail.html.gz:

```
#217 test_fiber.rb:37: 
     Fiber.new(&Object.method(:class_eval)).resume("foo")
  #=> killed by SIGIOT (signal 6)
| bootstraptest.test_fiber.rb_37_217.rb:in 'Module#class_eval': Can't eval on top of Fiber or Thread (RuntimeError)
| free(): invalid next size (fast)
| bootstraptest.test_fiber.rb_37_217.rb: [BUG] Aborted at 0x000003ed003acabf
| ruby 4.1.0dev (2026-07-16T02:53:38Z master 11bb5c82d2) +PRISM [x86_64-linux]
| 
| -- Control frame information -----------------------------------------------
| c:0001 p:0000 s:0003 E:0004f0 l:y b:---- r:(nil) DUMMY  [FINISH]
| 
| 
| -- Threading information ---------------------------------------------------
| Total ractor count: 1
| Ruby thread count for this ractor: 1
| 
| -- Machine register context ------------------------------------------------
|  RIP: 0x00007d8a3ae9eb2c RBP: 0x00007fffab957700 RSP: 0x00007fffab9576c0
|  RAX: 0x0000000000000000 RBX: 0x00000000003acabf RCX: 0x00007d8a3ae9eb2c
|  RDX: 0x0000000000000006 RDI: 0x00000000003acabf RSI: 0x00000000003acabf
|   R8: 0x00000000ffffffff  R9: 0x0000000000000000 R10: 0x0000000000000008
|  R11: 0x0000000000000246 R12: 0x0000000000000006 R13: 0x00007fffab957840
|  R14: 0x0000000000000016 R15: 0x00007fffab957840 EFL: 0x0000000000000246
| 
| -- C level backtrace information -------------------------------------------
| /home/chkbuild/chkbuild/tmp/build/20260716T030004Z/ruby/miniruby(0x58dcc928c4b8) [0x58dcc928c4b8]
| /home/chkbuild/chkbuild/tmp/build/20260716T030004Z/ruby/miniruby(0x58dcc8f8a87c) [0x58dcc8f8a87c]
| /home/chkbuild/chkbuild/tmp/build/20260716T030004Z/ruby/miniruby(0x58dcc8f8f207) [0x58dcc8f8f207]
| /lib/x86_64-linux-gnu/libc.so.6(0x7d8a3ae45330) [0x7d8a3ae45330]
| /lib/x86_64-linux-gnu/libc.so.6(__pthread_kill_implementation+0x44) [0x7d8a3ae9eb2c] ./nptl/pthread_kill.c:43
| /lib/x86_64-linux-gnu/libc.so.6(__pthread_kill_internal) ./nptl/pthread_kill.c:78
| /lib/x86_64-linux-gnu/libc.so.6(__pthread_kill) ./nptl/pthread_kill.c:89
| /lib/x86_64-linux-gnu/libc.so.6(pthread_kill) (null):0
| /lib/x86_64-linux-gnu/libc.so.6(raise+0x1e) [0x7d8a3ae4527e] ../sysdeps/posix/raise.c:26
| /lib/x86_64-linux-gnu/libc.so.6(gsignal) (null):0
| /lib/x86_64-linux-gnu/libc.so.6(abort+0xdf) [0x7d8a3ae288ff] ./stdlib/abort.c:79
| /lib/x86_64-linux-gnu/libc.so.6(abort) (null):0
| /lib/x86_64-linux-gnu/libc.so.6(_IO_acquire_lock_fct+0x0) [0x7d8a3ae297b6] ../sysdeps/posix/libc_fatal.c:134
| /lib/x86_64-linux-gnu/libc.so.6(_IO_peekc_locked) ./libio/peekc.c:37
| /lib/x86_64-linux-gnu/libc.so.6(malloc_printerr+0x15) [0x7d8a3aea8ff5] ./malloc/malloc.c:5775
| /lib/x86_64-linux-gnu/libc.so.6(_int_free+0x27c) [0x7d8a3aeab3ec] ./malloc/malloc.c:4590
| /lib/x86_64-linux-gnu/libc.so.6(__libc_free+0x7e) [0x7d8a3aeaddce] ./malloc/malloc.c:3398
| /lib/x86_64-linux-gnu/libc.so.6(__libc_free) (null):0
| /home/chkbuild/chkbuild/tmp/build/20260716T030004Z/ruby/miniruby(ruby_xfree_sized) [0x58dcc90947f0]
| /home/chkbuild/chkbuild/tmp/build/20260716T030004Z/ruby/miniruby(0x58dcc927e701) [0x58dcc927e701]
| /home/chkbuild/chkbuild/tmp/build/20260716T030004Z/ruby/miniruby(0x58dcc9210344) [0x58dcc9210344]
| /home/chkbuild/chkbuild/tmp/build/20260716T030004Z/ruby/miniruby(0x58dcc927e442) [0x58dcc927e442]
| /home/chkbuild/chkbuild/tmp/build/20260716T030004Z/ruby/miniruby(0x58dcc90a0b27) [0x58dcc90a0b27]
| /home/chkbuild/chkbuild/tmp/build/20260716T030004Z/ruby/miniruby(0x58dcc908e7cb) [0x58dcc908e7cb]
| /home/chkbuild/chkbuild/tmp/build/20260716T030004Z/ruby/miniruby(0x58dcc8f8bb23) [0x58dcc8f8bb23]
| /home/chkbuild/chkbuild/tmp/build/20260716T030004Z/ruby/miniruby(ruby_run_node) [0x58dcc9078d36]
| /home/chkbuild/chkbuild/tmp/build/20260716T030004Z/ruby/miniruby(0x58dcc8f9b269) [0x58dcc8f9b269]
| /lib/x86_64-linux-gnu/libc.so.6(__libc_start_call_main+0x7a) [0x7d8a3ae2a1ca] ../sysdeps/nptl/libc_start_call_main.h:58
| /lib/x86_64-linux-gnu/libc.so.6(call_init+0x0) [0x7d8a3ae2a28b] ../csu/libc-start.c:360
| /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main_impl) ../csu/libc-start.c:347
| /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main) (null):0
| /home/chkbuild/chkbuild/tmp/build/20260716T030004Z/ruby/miniruby(_start) [0x58dcc8f9b115]
```