### PR TITLE
cont.c: keep the fiber pointer of rb_fiber_start in a volatile local

### DIFF
--- a/cont.c
+++ b/cont.c
@@ -2632,8 +2632,9 @@ rb_fiber_set_scheduler(VALUE klass, VALUE scheduler)
 NORETURN(static void rb_fiber_terminate(rb_fiber_t *fiber, int need_interrupt, VALUE err));
 
 void
-rb_fiber_start(rb_fiber_t *fiber)
+rb_fiber_start(rb_fiber_t *fiber_arg)
 {
+    rb_fiber_t * volatile fiber = fiber_arg;
     rb_thread_t * volatile th = fiber->cont.saved_ec.thread_ptr;
 
     rb_proc_t *proc;
@@ -2651,7 +2652,7 @@ rb_fiber_start(rb_fiber_t *fiber)
 
     EC_PUSH_TAG(th->ec);
     if ((state = EC_EXEC_TAG()) == TAG_NONE) {
-        rb_context_t *cont = &VAR_FROM_MEMORY(fiber)->cont;
+        rb_context_t *cont = &fiber->cont;
         int argc;
         const VALUE *argv, args = cont->value;
         GetProcPtr(fiber->first_proc, proc);


### PR DESCRIPTION
LLVM 19 (FreeBSD clang 19.1.7, Intel oneAPI 2026.1) rematerializes the fiber parameter incorrectly after the longjmp back from the fiber body when another call in the setjmp region takes a pointer derived from it, although C11 7.13.2.1 guarantees the value of a local that is not modified between setjmp and longjmp.  Commit 3f9a000540 avoided the known instance by hoisting the call out of the region; reading the pointer from a volatile local prevents the rematerialization itself, so future changes to the region cannot reintroduce the bug (verified by re-inlining the hoisted call and running under clang 19.1.7).  This also covers the one-off VAR_FROM_MEMORY use, so replace it with a plain access.