### PR TITLE
Make locals read after longjmp volatile in more setjmp users

### DIFF
--- a/eval.c
+++ b/eval.c
@@ -1067,12 +1067,14 @@ rb_rescue2(VALUE (* b_proc) (VALUE), VALUE data1,
 
 VALUE
 rb_vrescue2(VALUE (* b_proc) (VALUE), VALUE data1,
-            VALUE (* r_proc) (VALUE, VALUE), VALUE data2,
+            VALUE (* r_proc_arg) (VALUE, VALUE), VALUE data2_arg,
             va_list args)
 {
     enum ruby_tag_type state;
     rb_execution_context_t * volatile ec = GET_EC();
     rb_control_frame_t *volatile cfp = ec->cfp;
+    VALUE (* volatile r_proc)(VALUE, VALUE) = r_proc_arg;
+    volatile VALUE data2 = data2_arg;
     volatile VALUE result = Qfalse;
     volatile VALUE e_info = ec->errinfo;
 
@@ -1134,12 +1136,13 @@ rb_rescue(VALUE (* b_proc)(VALUE), VALUE data1,
 }
 
 VALUE
-rb_protect(VALUE (* proc) (VALUE), VALUE data, int *pstate)
+rb_protect(VALUE (* proc) (VALUE), VALUE data, int *pstate_arg)
 {
     volatile VALUE result = Qnil;
     volatile enum ruby_tag_type state;
     rb_execution_context_t * volatile ec = GET_EC();
     rb_control_frame_t *volatile cfp = ec->cfp;
+    int * volatile pstate = pstate_arg;
 
     EC_PUSH_TAG(ec);
     if ((state = EC_EXEC_TAG()) == TAG_NONE) {
@@ -1155,9 +1158,12 @@ rb_protect(VALUE (* proc) (VALUE), VALUE data, int *pstate)
 }
 
 VALUE
-rb_ec_ensure(rb_execution_context_t *ec, VALUE (*b_proc)(VALUE), VALUE data1, VALUE (*e_proc)(VALUE), VALUE data2)
+rb_ec_ensure(rb_execution_context_t *ec_arg, VALUE (*b_proc)(VALUE), VALUE data1, VALUE (*e_proc_arg)(VALUE), VALUE data2_arg)
 {
     enum ruby_tag_type state;
+    rb_execution_context_t * volatile ec = ec_arg;
+    VALUE (* volatile e_proc)(VALUE) = e_proc_arg;
+    volatile VALUE data2 = data2_arg;
     volatile VALUE result = Qnil;
     VALUE errinfo;
     EC_PUSH_TAG(ec);

--- a/eval_error.c
+++ b/eval_error.c
@@ -378,8 +378,8 @@ rb_ec_error_print_detailed0(rb_execution_context_t *const ec, const VALUE errinf
     volatile bool written = false;
     volatile VALUE emesg = emesg0;
 
-    VALUE opt = rb_hash_new();
-    VALUE highlight = rb_stderr_tty_p() ? Qtrue : Qfalse;
+    volatile VALUE opt = rb_hash_new();
+    volatile VALUE highlight = rb_stderr_tty_p() ? Qtrue : Qfalse;
     rb_hash_aset(opt, ID2SYM(rb_intern_const("highlight")), highlight);
 
     if (NIL_P(errinfo))

--- a/scheduler.c
+++ b/scheduler.c
@@ -680,8 +680,8 @@ rb_fiber_scheduler_unblock(VALUE scheduler, VALUE blocker, VALUE fiber)
     int saved_errno = errno;
 
     // We must prevent interrupts while invoking the unblock method, because otherwise fibers can be left permanently blocked if an interrupt occurs during the execution of user code. See also `rb_fiber_scheduler_fiber_interrupt`.
-    rb_execution_context_t *ec = GET_EC();
-    int saved_interrupt_mask = ec->interrupt_mask;
+    rb_execution_context_t * volatile ec = GET_EC();
+    volatile int saved_interrupt_mask = ec->interrupt_mask;
     ec->interrupt_mask |= PENDING_INTERRUPT_MASK;
 
     rb_control_frame_t *volatile cfp = ec->cfp;
@@ -1149,8 +1149,8 @@ VALUE rb_fiber_scheduler_fiber_interrupt(VALUE scheduler, VALUE fiber, VALUE exc
     enum ruby_tag_type state;
 
     // We must prevent interrupts while invoking the fiber_interrupt method, because otherwise fibers can be left permanently blocked if an interrupt occurs during the execution of user code. See also `rb_fiber_scheduler_unblock`.
-    rb_execution_context_t *ec = GET_EC();
-    int saved_interrupt_mask = ec->interrupt_mask;
+    rb_execution_context_t * volatile ec = GET_EC();
+    volatile int saved_interrupt_mask = ec->interrupt_mask;
     ec->interrupt_mask |= PENDING_INTERRUPT_MASK;
 
     rb_control_frame_t *volatile cfp = ec->cfp;

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -1479,11 +1479,12 @@ vm_frametype_name(const rb_control_frame_t *cfp);
 static VALUE
 rb_iterate0(VALUE (* it_proc) (VALUE), VALUE data1,
             const struct vm_ifunc *const ifunc,
-            rb_execution_context_t *ec)
+            rb_execution_context_t *ec_arg)
 {
     enum ruby_tag_type state;
     volatile VALUE retval = Qnil;
-    rb_control_frame_t *const cfp = ec->cfp;
+    rb_execution_context_t * volatile ec = ec_arg;
+    rb_control_frame_t *volatile const cfp = ec->cfp;
 
     EC_PUSH_TAG(ec);
     state = EC_EXEC_TAG();
@@ -2704,11 +2705,12 @@ rb_catch(const char *tag, rb_block_call_func_t func, VALUE data)
 
 static VALUE
 vm_catch_protect(VALUE tag, rb_block_call_func *func, VALUE data,
-                 enum ruby_tag_type *stateptr, rb_execution_context_t *volatile ec)
+                 enum ruby_tag_type *stateptr_arg, rb_execution_context_t *volatile ec)
 {
     enum ruby_tag_type state;
     VALUE val = Qnil;		/* OK */
     rb_control_frame_t *volatile saved_cfp = ec->cfp;
+    enum ruby_tag_type * volatile stateptr = stateptr_arg;
 
     EC_PUSH_TAG(ec);
 

--- a/vm_trace.c
+++ b/vm_trace.c
@@ -497,10 +497,12 @@ exec_hooks_unprotected(const rb_execution_context_t *ec, rb_hook_list_t *list, c
 }
 
 static int
-exec_hooks_protected(rb_execution_context_t *ec, rb_hook_list_t *list, const rb_trace_arg_t *trace_arg)
+exec_hooks_protected(rb_execution_context_t *ec_arg, rb_hook_list_t *list_arg, const rb_trace_arg_t *trace_arg)
 {
     enum ruby_tag_type state;
     volatile int raised;
+    rb_execution_context_t * volatile ec = ec_arg;
+    rb_hook_list_t * volatile list = list_arg;
 
     if (exec_hooks_precheck(ec, list, trace_arg) == 0) return 0;
 


### PR DESCRIPTION
Make locals read after longjmp volatile in more setjmp users

Audit of every EC_PUSH_TAG user, following the LLVM 19 longjmp
rematerialization bug worked around in rb_fiber_start: locals and
arguments that are read on the longjmp path but not modified inside
the tag region are made volatile.  C99 7.13.2.1p3 guarantees such
unmodified locals, but LLVM 17 and 19 have been observed to
reconstruct their values incorrectly after a longjmp (cfp in
rb_iterate0, fiber in rb_fiber_start).  volatile on a parameter may
not be effective (67d0f4821f,
https://bugs.ruby-lang.org/issues/19145), so arguments are copied
into volatile locals instead.

* vm_eval.c (rb_iterate0): cfp is compared against the escaping
  frame after a longjmp; clang 17 at -O1 with -fPIC was observed to
  clobber it during the development of the ifunc invalidation for
  https://bugs.ruby-lang.org/issues/22019.  ec is read next to it to
  rewind the frame and to rethrow.

* eval_error.c (rb_ec_error_print_detailed0): opt and highlight are
  read on the path reached by a longjmp from rb_get_backtrace while
  the other locals of the function are already volatile.

* scheduler.c (rb_fiber_scheduler_unblock, fiber_interrupt): ec and
  saved_interrupt_mask are read after a longjmp to restore
  ec->interrupt_mask; cfp next to them was already volatile.

* eval.c (rb_vrescue2): r_proc and data2 are used when the raise is
  handled.  args is left as is; a va_list cannot portably be
  volatile-qualified and is memory-backed in practice.

* eval.c (rb_protect): pstate is written through after the tag is
  popped.

* eval.c (rb_ec_ensure): ec, e_proc and data2 run the ensure proc
  after a longjmp; a clobbered e_proc would miscall it.

* vm_eval.c (vm_catch_protect): stateptr is written through after
  the pop.  tag has its address taken and stays in memory.

* vm_trace.c (exec_hooks_protected): ec and list are passed to
  exec_hooks_postcheck after the pop.

This is a followup of #17926.