### PR TITLE
[DOC] Fix Float#ceil granularity definition

### DIFF
--- a/numeric.c
+++ b/numeric.c
@@ -2164,8 +2164,8 @@ flo_floor(int argc, VALUE *argv, VALUE num)
  *  returns an Integer based on a computed granularity:
  *
  *  - The granularity is `10 ** ndigits.abs`.
- *  - The returned value is the largest multiple of the granularity
- *    that is less than or equal to `self`.
+ *  - The returned value is the smallest multiple of the granularity
+ *    that is greater than or equal to `self`.
  *
  *  Examples with positive `self`:
  *


### PR DESCRIPTION
`Float#ceil` returns the smallest granularity multiple greater than or equal to `self`. The current non-positive-precision description instead states the floor inequality.