### PR TITLE
[DOC] Fix Dir scan documentation

### DIFF
--- a/dir.c
+++ b/dir.c
@@ -3731,10 +3731,12 @@ dir_collect_children(VALUE dir)
 
 /*
  * call-seq:
- *   children -> array
+ *   scan {|entry_name, entry_type| ... } -> nil
+ *   scan -> [[entry_name, entry_type], ...]
  *
- * Returns an array of the entry names in +self+ along with their type
- * except for <tt>'.'</tt> and <tt>'..'</tt>:
+ * With a block, yields each entry name and its type; otherwise, returns an
+ * array of entry-name and entry-type pairs. Entries <tt>'.'</tt> and
+ * <tt>'..'</tt> are excluded:
  *
  *   dir = Dir.new('/example')
  *   dir.scan # => [["config.h", :file], ["lib", :directory], ["main.rb", :file]]
@@ -3789,20 +3791,18 @@ dir_s_children(int argc, VALUE *argv, VALUE io)
  *   Dir.scan(dirpath) -> [[entry_name, entry_type], ...]
  *   Dir.scan(dirpath, encoding: 'UTF-8') -> [[entry_name, entry_type], ...]
  *
- * Yields or returns an array of the entry names in the directory at +dirpath+
- * associated with their type, except for <tt>'.'</tt> and <tt>'..'</tt>;
- * sets the given encoding onto each returned entry name.
+ * With a block, yields each entry name and its type; otherwise, returns an
+ * array of entry-name and entry-type pairs from the directory at +dirpath+.
+ * Entries <tt>'.'</tt> and <tt>'..'</tt> are excluded. The given +encoding+ is
+ * used as the external encoding for each entry name.
  *
- *  The type symbol is one of:
- *  ``<code>:file</code>'', ``<code>:directory</code>'',
- *  ``<code>:characterSpecial</code>'', ``<code>:blockSpecial</code>'',
- *  ``<code>:fifo</code>'', ``<code>:link</code>'',
- *  or ``<code>:socket</code>'':
+ * The type symbol is one of +:file+, +:directory+, +:characterSpecial+,
+ * +:blockSpecial+, +:fifo+, +:link+, +:socket+, or +:unknown+:
  *
- *   Dir.children('/example') # => [["config.h", :file], ["lib", :directory], ["main.rb", :file]]
- *   Dir.children('/example').first.first.encoding
+ *   Dir.scan('/example') # => [["config.h", :file], ["lib", :directory], ["main.rb", :file]]
+ *   Dir.scan('/example').first.first.encoding
  *   # => #<Encoding:UTF-8>
- *   Dir.children('/example', encoding: 'US-ASCII').first.encoding
+ *   Dir.scan('/example', encoding: 'US-ASCII').first.first.encoding
  *   # => #<Encoding:US-ASCII>
  *
  * See {String Encoding}[rdoc-ref:encodings.rdoc@String+Encoding].

--- a/dir.c
+++ b/dir.c
@@ -3734,9 +3734,9 @@ dir_collect_children(VALUE dir)
  *   scan {|entry_name, entry_type| ... } -> nil
  *   scan -> [[entry_name, entry_type], ...]
  *
- * With a block, yields each entry name and its type; otherwise, returns an
- * array of entry-name and entry-type pairs. Entries <tt>'.'</tt> and
- * <tt>'..'</tt> are excluded:
+ * With no block, returns an array of entry-name and entry-type pairs.
+ * With a block, yields each entry name and its type, and returns +nil+.
+ * Entries <tt>'.'</tt> and <tt>'..'</tt> are excluded:
  *
  *   dir = Dir.new('/example')
  *   dir.scan # => [["config.h", :file], ["lib", :directory], ["main.rb", :file]]
@@ -3791,10 +3791,10 @@ dir_s_children(int argc, VALUE *argv, VALUE io)
  *   Dir.scan(dirpath) -> [[entry_name, entry_type], ...]
  *   Dir.scan(dirpath, encoding: 'UTF-8') -> [[entry_name, entry_type], ...]
  *
- * With a block, yields each entry name and its type; otherwise, returns an
- * array of entry-name and entry-type pairs from the directory at +dirpath+.
- * Entries <tt>'.'</tt> and <tt>'..'</tt> are excluded. The given +encoding+ is
- * used as the external encoding for each entry name.
+ * With no block, returns an array of entry-name and entry-type pairs from the
+ * directory at +dirpath+. With a block, yields each entry name and its type,
+ * and returns +nil+. Entries <tt>'.'</tt> and <tt>'..'</tt> are excluded. The
+ * given +encoding+ is used as the external encoding for each entry name.
  *
  * The type symbol is one of +:file+, +:directory+, +:characterSpecial+,
  * +:blockSpecial+, +:fifo+, +:link+, +:socket+, or +:unknown+:

--- a/dir.c
+++ b/dir.c
@@ -3731,15 +3731,25 @@ dir_collect_children(VALUE dir)
 
 /*
  * call-seq:
+ *   scan -> entries
  *   scan {|entry_name, entry_type| ... } -> nil
- *   scan -> [[entry_name, entry_type], ...]
  *
- * With no block, returns an array of entry-name and entry-type pairs.
- * With a block, yields each entry name and its type, and returns +nil+.
- * Entries <tt>'.'</tt> and <tt>'..'</tt> are excluded:
+ * Scans the entries in +self+, except for <tt>'.'</tt> and <tt>'..'</tt>.
+ *
+ * With no block given, returns +entries+, an array of 2-element arrays.
+ * Each nested array contains an entry name and its type:
  *
  *   dir = Dir.new('/example')
  *   dir.scan # => [["config.h", :file], ["lib", :directory], ["main.rb", :file]]
+ *
+ * With a block given, calls the block with each entry name and its type;
+ * returns +nil+:
+ *
+ *   entries = []
+ *   dir.scan do |entry_name, entry_type|
+ *     entries << [entry_name, entry_type]
+ *   end # => nil
+ *   entries # => [["config.h", :file], ["lib", :directory], ["main.rb", :file]]
  *
  */
 static VALUE
@@ -3786,20 +3796,33 @@ dir_s_children(int argc, VALUE *argv, VALUE io)
 
 /*
  * call-seq:
+ *   Dir.scan(dirpath) -> entries
+ *   Dir.scan(dirpath, encoding: 'UTF-8') -> entries
  *   Dir.scan(dirpath) {|entry_name, entry_type| ... } -> nil
  *   Dir.scan(dirpath, encoding: 'UTF-8') {|entry_name, entry_type| ... } -> nil
- *   Dir.scan(dirpath) -> [[entry_name, entry_type], ...]
- *   Dir.scan(dirpath, encoding: 'UTF-8') -> [[entry_name, entry_type], ...]
  *
- * With no block, returns an array of entry-name and entry-type pairs from the
- * directory at +dirpath+. With a block, yields each entry name and its type,
- * and returns +nil+. Entries <tt>'.'</tt> and <tt>'..'</tt> are excluded. The
- * given +encoding+ is used as the external encoding for each entry name.
+ * Scans the entries in the directory at +dirpath+, except for <tt>'.'</tt>
+ * and <tt>'..'</tt>.
  *
- * The type symbol is one of +:file+, +:directory+, +:characterSpecial+,
- * +:blockSpecial+, +:fifo+, +:link+, +:socket+, or +:unknown+:
+ * With no block given, returns +entries+, an array of 2-element arrays.
+ * Each nested array contains an entry name and its type:
  *
  *   Dir.scan('/example') # => [["config.h", :file], ["lib", :directory], ["main.rb", :file]]
+ *
+ * With a block given, calls the block with each entry name and its type;
+ * returns +nil+:
+ *
+ *   entries = []
+ *   Dir.scan('/example') do |entry_name, entry_type|
+ *     entries << [entry_name, entry_type]
+ *   end # => nil
+ *   entries # => [["config.h", :file], ["lib", :directory], ["main.rb", :file]]
+ *
+ * The type symbol is one of +:file+, +:directory+, +:characterSpecial+,
+ * +:blockSpecial+, +:fifo+, +:link+, +:socket+, or +:unknown+.
+ *
+ * The given +encoding+ is used as the external encoding for each entry name:
+ *
  *   Dir.scan('/example').first.first.encoding
  *   # => #<Encoding:UTF-8>
  *   Dir.scan('/example', encoding: 'US-ASCII').first.first.encoding


### PR DESCRIPTION
`Dir#scan` currently has a copied `children` call sequence and omits its block form. Correct the block and array contracts for both scan methods, along with the class examples, type list (including `:unknown`), and external-encoding wording.