### PR TITLE
[DOC] Fix Regexp.union string handling

### DIFF
--- a/re.c
+++ b/re.c
@@ -4561,15 +4561,14 @@ rb_reg_s_union(VALUE self, VALUE args0)
  *    Regexp.union(*patterns) -> regexp
  *    Regexp.union(array_of_patterns) -> regexp
  *
- *  Returns a new regexp that is the union of the given patterns:
+ *  Returns a regexp that is the union of the given patterns:
  *
  *    r = Regexp.union(%w[cat dog])      # => /cat|dog/
  *    r.match('cat')      # => #<MatchData "cat">
  *    r.match('dog')      # => #<MatchData "dog">
  *    r.match('cog')      # => nil
  *
- *  For each pattern that is a string, <tt>::escape</tt> is applied so that the
- *  string is matched literally:
+ *  Each string pattern is escaped so that it is matched literally:
  *
  *    Regexp.union('penzance')             # => /penzance/
  *    Regexp.union('a+b*c')                # => /a\+b\*c/

--- a/re.c
+++ b/re.c
@@ -4568,7 +4568,8 @@ rb_reg_s_union(VALUE self, VALUE args0)
  *    r.match('dog')      # => #<MatchData "dog">
  *    r.match('cog')      # => nil
  *
- *  For each pattern that is a string, <tt>Regexp.new(pattern)</tt> is used:
+ *  For each pattern that is a string, <tt>::escape</tt> is applied so that the
+ *  string is matched literally:
  *
  *    Regexp.union('penzance')             # => /penzance/
  *    Regexp.union('a+b*c')                # => /a\+b\*c/


### PR DESCRIPTION
`Regexp.union` escapes string arguments so metacharacters are matched literally; it does not pass strings to `Regexp.new`. The synopsis also avoids promising a new object because a single regexp argument is returned by identity.