### PR TITLE
[DOC] Fix ENV.reject block result description

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -6686,19 +6686,19 @@ env_except(int argc, VALUE *argv, VALUE _)
 }
 
 /*
- * call-seq:
- *   ENV.reject { |name, value| block } -> hash of name/value pairs
- *   ENV.reject                         -> an_enumerator
+ *  call-seq:
+ *    ENV.reject {|name, value| ... } -> hash
+ *    ENV.reject                      -> new_enumerator
  *
- * Yields each environment variable name and its value as a 2-element Array.
- * Returns a Hash whose items are determined by the block.
- * When the block returns a truthy value, the name/value pair is ignored;
- * otherwise the pair is added to the return Hash:
- *   ENV.replace('foo' => '0', 'bar' => '1', 'baz' => '2')
- *   ENV.reject { |name, value| name.start_with?('b') } # => {"foo"=>"0"}
- * Returns an Enumerator if no block given:
- *   e = ENV.reject
- *   e.each { |name, value| name.start_with?('b') } # => {"foo"=>"0"}
+ *  Yields each environment variable name and its value as a 2-element Array.
+ *  Returns a Hash whose items are determined by the block.
+ *  When the block returns a truthy value, the name/value pair is ignored;
+ *  otherwise the pair is added to the return Hash:
+ *
+ *    ENV.replace('foo' => '0', 'bar' => '1', 'baz' => '2')
+ *    ENV.reject { |name, value| name.start_with?('b') } # => {"foo"=>"0"}
+ *
+ *  Returns a new Enumerator if no block is given.
  */
 static VALUE
 env_reject(VALUE _)

--- a/hash.c
+++ b/hash.c
@@ -6692,8 +6692,8 @@ env_except(int argc, VALUE *argv, VALUE _)
  *
  * Yields each environment variable name and its value as a 2-element Array.
  * Returns a Hash whose items are determined by the block.
- * When the block returns a truthy value, the name/value pair is added to the return Hash;
- * otherwise the pair is ignored:
+ * When the block returns a truthy value, the name/value pair is ignored;
+ * otherwise the pair is added to the return Hash:
  *   ENV.replace('foo' => '0', 'bar' => '1', 'baz' => '2')
  *   ENV.reject { |name, value| name.start_with?('b') } # => {"foo"=>"0"}
  * Returns an Enumerator if no block given:

--- a/hash.c
+++ b/hash.c
@@ -5955,7 +5955,7 @@ env_each_pair(VALUE ehash)
  *
  * Similar to ENV.delete_if, but returns +nil+ if no changes were made.
  *
- * Yields each environment variable name and its value as a 2-element Array,
+ * Calls the block with each environment variable name and value,
  * deleting each environment variable for which the block returns a truthy value,
  * and returning ENV (if any deletions) or +nil+ (if not):
  *   ENV.replace('foo' => '0', 'bar' => '1', 'baz' => '2')
@@ -6690,7 +6690,7 @@ env_except(int argc, VALUE *argv, VALUE _)
  *    ENV.reject {|name, value| ... } -> hash
  *    ENV.reject                      -> new_enumerator
  *
- *  Yields each environment variable name and its value as a 2-element Array.
+ *  Calls the block with each environment variable name and value.
  *  Returns a Hash whose items are determined by the block.
  *  When the block returns a truthy value, the name/value pair is ignored;
  *  otherwise the pair is added to the return Hash:


### PR DESCRIPTION
`ENV.reject` omits name/value pairs when the block returns a truthy value. The current documentation reverses that behavior despite the example showing the correct result.