### PR TITLE
[DOC] Fix Ractor.shareable_proc documentation

### DIFF
--- a/doc/language/ractor.md
+++ b/doc/language/ractor.md
@@ -513,7 +513,7 @@ See [syntax/comments.rdoc](../syntax/comments.rdoc) for more details.
 
 ### Shareable procs
 
-Procs and lambdas are normally unshareable objects, even when they are frozen. `Ractor.shareable_proc { expr }` creates a shareable Proc, and `Ractor.shareable_lambda { expr }` creates a shareable lambda. Each method returns a shareable copy of its block. When an existing Proc supplies the block, its lambda semantics are preserved. `Ractor.make_shareable` can instead make a supported existing Proc shareable in place, provided its `self` is already shareable.
+Procs and lambdas are normally unshareable objects, even when they are frozen. `Ractor.shareable_proc { expr }` creates a shareable Proc, and `Ractor.shareable_lambda { expr }` creates a shareable lambda. Each method returns a shareable copy of its block. When a supported existing Proc supplies the block, its lambda semantics are preserved. `Ractor.make_shareable` can instead make a supported existing Proc shareable in place, provided its `self` is already shareable.
 
 Whether copied or converted in place, the Proc may read outer variables whose values are shareable, provided Ruby's static analysis does not find that those variables may be reassigned in the surrounding scope or within the block. Their values are captured in an environment isolated from the original. Capturing an unshareable value or a variable that may be reassigned raises `Ractor::IsolationError`. For a Proc created by `Ractor.shareable_proc` or `Ractor.shareable_lambda`, `self` is changed to `nil` by default, although a shareable value can be provided with the `self:` keyword.
 
@@ -532,7 +532,7 @@ rescue Ractor::IsolationError
 end
 ```
 
-When a Proc supplies the body of a method dynamically defined with `Module#define_method` and the method will be used from different ractors, the Proc must be shareable. `define_method` can instead accept a `Method` or `UnboundMethod`. Another option is to use `Module#class_eval` or `Module#module_eval` with a String. Even though the shareable proc's `self` is initially bound to `nil`, `define_method` will bind `self` to the correct value in the method.
+When a Proc supplies the body of a method dynamically defined with `Module#define_method` and the method will be used from different ractors, the Proc must be shareable. Alternatively, you can use `Module#class_eval` or `Module#module_eval` with a String. Even though the shareable proc's `self` is initially bound to `nil`, `define_method` will bind `self` to the correct value in the method.
 
 ```ruby
 class A

--- a/doc/language/ractor.md
+++ b/doc/language/ractor.md
@@ -513,17 +513,20 @@ See [syntax/comments.rdoc](../syntax/comments.rdoc) for more details.
 
 ### Shareable procs
 
-Procs and lambdas are unshareable objects, even when they are frozen. To create a shareable Proc, you must use `Ractor.shareable_proc { expr }`. Much like during Ractor creation, the proc's block is isolated from its outer environment, so it cannot access variables from the outside scope. `self` is also changed within the Proc to be `nil` by default, although a `self:` keyword can be provided if you want to customize the value to a different shareable object.
+Procs and lambdas are normally unshareable objects, even when they are frozen. `Ractor.shareable_proc { expr }` creates a shareable Proc, and `Ractor.shareable_lambda { expr }` creates a shareable lambda. Each method returns a shareable copy of its block. `Ractor.make_shareable` can instead make an existing Proc shareable in place, provided its `self` is already shareable.
+
+Whether copied or converted in place, the Proc may read outer variables whose values are shareable, provided Ruby's static analysis does not find that those variables may be reassigned in the surrounding scope or within the block. Their values are captured in an environment isolated from the original. Capturing an unshareable value or a variable that may be reassigned raises `Ractor::IsolationError`. For a Proc created by `Ractor.shareable_proc` or `Ractor.shareable_lambda`, `self` is changed to `nil` by default, although a shareable value can be provided with the `self:` keyword.
 
 ```ruby
-p = Ractor.shareable_proc { p self }
-p.call #=> nil
+value = 42
+p = Ractor.shareable_proc { [self, value] }
+p.call #=> [nil, 42]
 ```
 
 ```ruby
 begin
-  a = 1
-  pr = Ractor.shareable_proc { p a }
+  values = []
+  pr = Ractor.shareable_proc { values }
   pr.call # never gets here
 rescue Ractor::IsolationError
 end
@@ -533,9 +536,7 @@ In order to dynamically define a method with `Module#define_method` that can be 
 
 ```ruby
 class A
-  define_method(:testing, Ractor.shareable_proc do
-    p self
-  end)
+  define_method(:testing, Ractor.shareable_proc { p self })
 end
 Ractor.new do
   a = A.new
@@ -543,7 +544,7 @@ Ractor.new do
 end.join
 ```
 
-This isolation must be done to prevent the method from accessing and assigning captured outer variables across ractors.
+The Proc's isolated environment prevents assignments to captured outer variables from crossing ractors.
 
 ### Ractor-local storage
 

--- a/doc/language/ractor.md
+++ b/doc/language/ractor.md
@@ -513,7 +513,7 @@ See [syntax/comments.rdoc](../syntax/comments.rdoc) for more details.
 
 ### Shareable procs
 
-Procs and lambdas are normally unshareable objects, even when they are frozen. `Ractor.shareable_proc { expr }` creates a shareable Proc, and `Ractor.shareable_lambda { expr }` creates a shareable lambda. Each method returns a shareable copy of its block. `Ractor.make_shareable` can instead make a supported existing Proc shareable in place, provided its `self` is already shareable.
+Procs and lambdas are normally unshareable objects, even when they are frozen. `Ractor.shareable_proc { expr }` creates a shareable Proc, and `Ractor.shareable_lambda { expr }` creates a shareable lambda. Each method returns a shareable copy of its block. When an existing Proc supplies the block, its lambda semantics are preserved. `Ractor.make_shareable` can instead make a supported existing Proc shareable in place, provided its `self` is already shareable.
 
 Whether copied or converted in place, the Proc may read outer variables whose values are shareable, provided Ruby's static analysis does not find that those variables may be reassigned in the surrounding scope or within the block. Their values are captured in an environment isolated from the original. Capturing an unshareable value or a variable that may be reassigned raises `Ractor::IsolationError`. For a Proc created by `Ractor.shareable_proc` or `Ractor.shareable_lambda`, `self` is changed to `nil` by default, although a shareable value can be provided with the `self:` keyword.
 
@@ -532,7 +532,7 @@ rescue Ractor::IsolationError
 end
 ```
 
-In order to dynamically define a method with `Module#define_method` that can be used from different ractors, you must define it with a shareable proc. Alternatively, you can use `Module#class_eval` or `Module#module_eval` with a String. Even though the shareable proc's `self` is initially bound to `nil`, `define_method` will bind `self` to the correct value in the method.
+When a Proc supplies the body of a method dynamically defined with `Module#define_method` and the method will be used from different ractors, the Proc must be shareable. `define_method` can instead accept a `Method` or `UnboundMethod`. Another option is to use `Module#class_eval` or `Module#module_eval` with a String. Even though the shareable proc's `self` is initially bound to `nil`, `define_method` will bind `self` to the correct value in the method.
 
 ```ruby
 class A

--- a/doc/language/ractor.md
+++ b/doc/language/ractor.md
@@ -513,7 +513,7 @@ See [syntax/comments.rdoc](../syntax/comments.rdoc) for more details.
 
 ### Shareable procs
 
-Procs and lambdas are normally unshareable objects, even when they are frozen. `Ractor.shareable_proc { expr }` creates a shareable Proc, and `Ractor.shareable_lambda { expr }` creates a shareable lambda. Each method returns a shareable copy of its block. `Ractor.make_shareable` can instead make an existing Proc shareable in place, provided its `self` is already shareable.
+Procs and lambdas are normally unshareable objects, even when they are frozen. `Ractor.shareable_proc { expr }` creates a shareable Proc, and `Ractor.shareable_lambda { expr }` creates a shareable lambda. Each method returns a shareable copy of its block. `Ractor.make_shareable` can instead make a supported existing Proc shareable in place, provided its `self` is already shareable.
 
 Whether copied or converted in place, the Proc may read outer variables whose values are shareable, provided Ruby's static analysis does not find that those variables may be reassigned in the surrounding scope or within the block. Their values are captured in an environment isolated from the original. Capturing an unshareable value or a variable that may be reassigned raises `Ractor::IsolationError`. For a Proc created by `Ractor.shareable_proc` or `Ractor.shareable_lambda`, `self` is changed to `nil` by default, although a shareable value can be provided with the `self:` keyword.
 

--- a/doc/language/ractor.md
+++ b/doc/language/ractor.md
@@ -513,7 +513,7 @@ See [syntax/comments.rdoc](../syntax/comments.rdoc) for more details.
 
 ### Shareable procs
 
-Procs and lambdas are unshareable objects, even when they are frozen. To create an unshareable Proc, you must use `Ractor.shareable_proc { expr }`. Much like during Ractor creation, the proc's block is isolated from its outer environment, so it cannot access variables from the outside scope. `self` is also changed within the Proc to be `nil` by default, although a `self:` keyword can be provided if you want to customize the value to a different shareable object.
+Procs and lambdas are unshareable objects, even when they are frozen. To create a shareable Proc, you must use `Ractor.shareable_proc { expr }`. Much like during Ractor creation, the proc's block is isolated from its outer environment, so it cannot access variables from the outside scope. `self` is also changed within the Proc to be `nil` by default, although a `self:` keyword can be provided if you want to customize the value to a different shareable object.
 
 ```ruby
 p = Ractor.shareable_proc { p self }
@@ -533,9 +533,9 @@ In order to dynamically define a method with `Module#define_method` that can be 
 
 ```ruby
 class A
-  define_method :testing, &Ractor.shareable_proc do
+  define_method(:testing, Ractor.shareable_proc do
     p self
-  end
+  end)
 end
 Ractor.new do
   a = A.new

--- a/ractor.rb
+++ b/ractor.rb
@@ -696,9 +696,10 @@ class Ractor
 
   #
   # call-seq:
-  #   Ractor.shareable_lambda(self: nil) { ... } -> lambda
+  #   Ractor.shareable_lambda(self: nil) { ... } -> proc
   #
-  # Same as Ractor.shareable_proc, but returns a lambda Proc.
+  # Same as Ractor.shareable_proc, but a literal block produces a lambda Proc.
+  # When an existing Proc supplies the block, its lambda semantics are preserved.
   #
   def self.shareable_lambda self: nil
     Primitive.attr! :use_block

--- a/ractor.rb
+++ b/ractor.rb
@@ -657,7 +657,7 @@ class Ractor
 
   #
   # call-seq:
-  #   Ractor.shareable_proc(self: nil) { ... } -> proc
+  #   Ractor.shareable_proc(self: nil) { ... } -> shareable proc
   #
   # Returns a shareable copy of the given block's Proc. The value of +self+
   # in the Proc will be replaced with the value passed via the `self:` keyword,
@@ -696,10 +696,11 @@ class Ractor
 
   #
   # call-seq:
-  #   Ractor.shareable_lambda(self: nil) { ... } -> proc
+  #   Ractor.shareable_lambda(self: nil) { ... } -> shareable proc
   #
   # Same as Ractor.shareable_proc, but a literal block produces a lambda Proc.
-  # When an existing Proc supplies the block, its lambda semantics are preserved.
+  # When a supported existing Proc supplies the block, its lambda semantics are
+  # preserved.
   #
   def self.shareable_lambda self: nil
     Primitive.attr! :use_block

--- a/ractor.rb
+++ b/ractor.rb
@@ -683,8 +683,8 @@ class Ractor
   #     Ractor.shareable_proc(self: self){}
   #     #=> self should be shareable: main (Ractor::IsolationError)
   #
-  # To make an existing Proc shareable in place, use Ractor.make_shareable;
-  # that Proc's +self+ must already be shareable.
+  # To make a supported existing Proc shareable in place, use
+  # Ractor.make_shareable; that Proc's +self+ must already be shareable.
   #
   def self.shareable_proc self: nil
     Primitive.attr! :use_block

--- a/ractor.rb
+++ b/ractor.rb
@@ -657,22 +657,34 @@ class Ractor
 
   #
   # call-seq:
-  #   Ractor.shareable_proc(self: nil){} -> shareable proc
+  #   Ractor.shareable_proc(self: nil) { ... } -> proc
   #
   # Returns a shareable copy of the given block's Proc. The value of +self+
   # in the Proc will be replaced with the value passed via the `self:` keyword,
   # or +nil+ if not given.
   #
-  # In a shareable Proc, access to any outer variables is prohibited.
+  # The Proc may read outer variables whose values are shareable, provided
+  # Ruby's static analysis does not find that the variables may be reassigned.
+  # Their current values are captured in an environment isolated from the
+  # original.
   #
   #     a = 42
-  #     Ractor.shareable_proc{ p a }
-  #     #=> can not isolate a Proc because it accesses outer variables (a). (Ractor::IsolationError)
+  #     pr = Ractor.shareable_proc { a }
+  #     pr.call #=> 42
+  #
+  # A Ractor::IsolationError is raised if an outer variable may be reassigned
+  # or its value is unshareable.
+  #
+  #     a = []
+  #     Ractor.shareable_proc { a } # Raises Ractor::IsolationError
   #
   # The value of `self` in the Proc must be a shareable object.
   #
   #     Ractor.shareable_proc(self: self){}
   #     #=> self should be shareable: main (Ractor::IsolationError)
+  #
+  # To make an existing Proc shareable in place, use Ractor.make_shareable;
+  # that Proc's +self+ must already be shareable.
   #
   def self.shareable_proc self: nil
     Primitive.attr! :use_block
@@ -684,7 +696,7 @@ class Ractor
 
   #
   # call-seq:
-  #   Ractor.shareable_lambda(self: nil){} -> shareable lambda
+  #   Ractor.shareable_lambda(self: nil) { ... } -> lambda
   #
   # Same as Ractor.shareable_proc, but returns a lambda Proc.
   #


### PR DESCRIPTION
`Ractor.shareable_proc` creates a shareable Proc, but the language guide calls the result unshareable. Shareable outer values may also be read when static analysis finds no possible reassignment, contrary to the current blanket prohibition, and the `define_method` example does not parse.

Align the `shareable_proc` and `shareable_lambda` call sequences and prose with their observable contracts, document capture and isolation behavior plus the `Ractor.make_shareable` distinction, and replace the invalid example with executable usage.