### PR TITLE
[DOC] Fix Range#step return value example

### DIFF
--- a/range.c
+++ b/range.c
@@ -422,7 +422,7 @@ range_step_size(VALUE range, VALUE args, VALUE eobj)
  *  Iterates over the elements of range in steps of +s+. The iteration is performed
  *  by <tt>+</tt> operator:
  *
- *    (0..6).step(2) { puts _1 } #=> 0..6
+ *    (0..6).step(2) { puts _1 }
  *    # Prints: 0, 2, 4, 6
  *
  *    # Iterate between two dates in step of 1 day (24 hours)

--- a/range.c
+++ b/range.c
@@ -422,7 +422,7 @@ range_step_size(VALUE range, VALUE args, VALUE eobj)
  *  Iterates over the elements of range in steps of +s+. The iteration is performed
  *  by <tt>+</tt> operator:
  *
- *    (0..6).step(2) { puts _1 } #=> 1..5
+ *    (0..6).step(2) { puts _1 } #=> 0..6
  *    # Prints: 0, 2, 4, 6
  *
  *    # Iterate between two dates in step of 1 day (24 hours)


### PR DESCRIPTION
Block-form `Range#step` returns its receiver, as the call sequence states. The example currently reports an unrelated `1..5` range; remove that incorrect and redundant result annotation so the example focuses on the values yielded.