### PR TITLE
win32: escape a trailing backslash when quoting an argument

### DIFF
--- a/test/ruby/test_process.rb
+++ b/test/ruby/test_process.rb
@@ -1236,6 +1236,21 @@ class TestProcess < Test::Unit::TestCase
     }
   end
 
+  def test_spawn_trailing_backslash
+    return unless windows?
+    [
+      ["AA BB\\"],
+      ["AA BB\\", "CC"],
+      ["AA BB\\\\", "CC"],
+      ["C:\\Program Files\\Foo\\", "--verbose"],
+      ["AA BB", "CC"],          # control: no trailing backslash
+      ["AA\\", "CC"],           # control: no space, so it is not quoted
+    ].each do |args|
+      out = IO.popen([EnvUtil.rubybin, "-e", "STDOUT.binmode; print Marshal.dump(ARGV)", *args], "rb", &:read)
+      assert_equal(args, Marshal.load(out), "[Bug #22199] argv did not round-trip: #{args.inspect}")
+    end
+  end
+
   def test_exec_wordsplit
     with_tmpchdir {|d|
       File.write("script", <<-'End')

--- a/win32/win32.c
+++ b/win32/win32.c
@@ -1080,7 +1080,7 @@ rb_w32_get_osfhandle(int fh)
 
 /* License: Ruby's */
 static int
-join_argv(char *cmd, char *const *argv, BOOL escape, UINT cp, int backslash)
+join_argv(char *cmd, char *const *argv, BOOL escape, UINT cp, int backslash, BOOL quote_bs)
 {
     const char *p, *s;
     char *q, *const *t;
@@ -1131,7 +1131,7 @@ join_argv(char *cmd, char *const *argv, BOOL escape, UINT cp, int backslash)
             }
         }
         len += (n = p - s) + 1;
-        if (quote) len++;
+        if (quote) len += (quote_bs ? bs : 0) + 1;
         if (q) {
             memcpy(q, s, n);
             if (backslash > 0) {
@@ -1140,7 +1140,14 @@ join_argv(char *cmd, char *const *argv, BOOL escape, UINT cp, int backslash)
                 translate_char(q, '/', '\\', cp);
             }
             q += n;
-            if (quote) *q++ = '"';
+            if (quote) {
+                // See [Bug #22199]
+                if (quote_bs && bs) {
+                    memset(q, '\\', bs);
+                    q += bs;
+                }
+                *q++ = '"';
+            }
             *q++ = ' ';
         }
     }
@@ -1483,20 +1490,20 @@ w32_spawn_process(int mode, const char *prog, char *const *argv,
         char *progs[2];
         progs[0] = (char *)prog;
         progs[1] = NULL;
-        len = join_argv(NULL, progs, ntcmd, cp, 1);
+        len = join_argv(NULL, progs, ntcmd, cp, 1, FALSE);
         if (c_switch) len += 3;
         else ++argv;
-        if (argv[0]) len += join_argv(NULL, argv, ntcmd, cp, 0);
+        if (argv[0]) len += join_argv(NULL, argv, ntcmd, cp, 0, FALSE);
         cmd = ALLOCV(v, len);
-        join_argv(cmd, progs, ntcmd, cp, 1);
+        join_argv(cmd, progs, ntcmd, cp, 1, FALSE);
         if (c_switch) strlcat(cmd, " /c", len);
-        if (argv[0]) join_argv(cmd + strlcat(cmd, " ", len), argv, ntcmd, cp, 0);
+        if (argv[0]) join_argv(cmd + strlcat(cmd, " ", len), argv, ntcmd, cp, 0, FALSE);
         prog = c_switch ? shell : 0;
     }
     else {
-        len = join_argv(NULL, argv, FALSE, cp, 1);
+        len = join_argv(NULL, argv, FALSE, cp, 1, TRUE);
         cmd = ALLOCV(v, len);
-        join_argv(cmd, argv, FALSE, cp, 1);
+        join_argv(cmd, argv, FALSE, cp, 1, TRUE);
     }
 
     if (!e && cmd && !(wcmd = mbstr_to_wstr(cp, cmd, -1, NULL))) e = E2BIG;


### PR DESCRIPTION
An argument ending in a backslash arrived corrupted: the backslash escaped the closing quote that Kernel#system had added.

```
PS C:\> ruby -ve "system('python3','-c','import sys; print(sys.argv[1])', 'AA BB\\')"
ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x64-mingw-ucrt]
AA BB"
```

cmd.exe does not interpret backslash escapes, so the escaping is done only when the call does not go through it.

https://bugs.ruby-lang.org/issues/22199