### PR TITLE
win32: a backslash before whitespace escaped the closing quote

### DIFF
--- a/test/ruby/test_process.rb
+++ b/test/ruby/test_process.rb
@@ -1251,6 +1251,20 @@ class TestProcess < Test::Unit::TestCase
     end
   end
 
+  def test_argv_backslash_before_space
+    return unless windows?
+    [
+      ["AA\\ ", "BB"],
+      ["AA\\  ", "BB"],
+      ["AA\\\\ ", "BB"],
+      ["AA ", "BB"],           # control: no backslash
+      ["AA\\", "BB"],          # control: no space after the backslash
+    ].each do |args|
+      out = IO.popen([EnvUtil.rubybin, "-e", "STDOUT.binmode; print Marshal.dump(ARGV)", *args], "rb", &:read)
+      assert_equal(args, Marshal.load(out), "[Bug #22201] argv did not round-trip: #{args.inspect}")
+    end
+  end
+
   def test_exec_wordsplit
     with_tmpchdir {|d|
       File.write("script", <<-'End')

--- a/win32/win32.c
+++ b/win32/win32.c
@@ -1746,6 +1746,7 @@ w32_cmdvector(const WCHAR *cmd, char ***vec, UINT cp, rb_encoding *enc)
                     *ptr = 0;
                     done = 1;
                 }
+                slashes = 0;
                 break;
 
               case L'*':


### PR DESCRIPTION
Inside double quotes, the escape was cancelled by almost any character but not by whitespace, so `"AA\ " BB` came out as a single argument.

https://bugs.ruby-lang.org/issues/22201