### PR TITLE
ZJIT: Place CheckInterrupts at the top of a loop

### DIFF
--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -7497,12 +7497,14 @@ fn insn_idx_at_offset(idx: u32, offset: i64) -> u32 {
 
 struct BytecodeInfo {
     jump_targets: Vec<u32>,
+    loop_targets_requiring_check_interrupts: HashSet<u32>,
 }
 
 fn compute_bytecode_info(iseq: *const rb_iseq_t, opt_table: &[u32]) -> BytecodeInfo {
     let iseq_size = unsafe { get_iseq_encoded_size(iseq) };
     let mut insn_idx = 0;
     let mut jump_targets: HashSet<u32> = opt_table.iter().copied().collect();
+    let mut loop_targets_requiring_check_interrupts: HashSet<u32> = HashSet::new();
     while insn_idx < iseq_size {
         // Get the current pc and opcode
         let pc = unsafe { rb_iseq_pc_at_idx(iseq, insn_idx) };
@@ -7523,7 +7525,13 @@ fn compute_bytecode_info(iseq: *const rb_iseq_t, opt_table: &[u32]) -> BytecodeI
             YARVINSN_branchunless | YARVINSN_jump | YARVINSN_branchif | YARVINSN_branchnil
             | YARVINSN_branchunless_without_ints | YARVINSN_jump_without_ints | YARVINSN_branchif_without_ints | YARVINSN_branchnil_without_ints => {
                 let offset = get_arg(pc, 0).as_i64();
-                jump_targets.insert(insn_idx_at_offset(insn_idx, offset));
+                let target = insn_idx_at_offset(insn_idx, offset);
+                jump_targets.insert(target);
+                // We only care about backward branches for CheckInterrupts, and only from opcode
+                // variants that actually check for interrupts.
+                if offset < 0 && matches!(opcode, YARVINSN_branchunless | YARVINSN_jump | YARVINSN_branchif | YARVINSN_branchnil) {
+                    loop_targets_requiring_check_interrupts.insert(target);
+                }
             }
             YARVINSN_opt_new => {
                 let offset = get_arg(pc, 1).as_i64();
@@ -7539,7 +7547,7 @@ fn compute_bytecode_info(iseq: *const rb_iseq_t, opt_table: &[u32]) -> BytecodeI
     }
     let mut result = jump_targets.into_iter().collect::<Vec<_>>();
     result.sort();
-    BytecodeInfo { jump_targets: result }
+    BytecodeInfo { jump_targets: result, loop_targets_requiring_check_interrupts }
 }
 
 #[derive(Debug, PartialEq, Clone, Copy)]
@@ -7801,7 +7809,7 @@ fn add_iseq_to_hir(
         .get(jit_entry_start..)
         .expect("JIT entry index must be within the callee opt table")
         .iter().copied().map(VALUE::as_u32).collect::<Vec<_>>();
-    let BytecodeInfo { jump_targets } = compute_bytecode_info(iseq, &jit_entry_insns);
+    let BytecodeInfo { jump_targets, loop_targets_requiring_check_interrupts } = compute_bytecode_info(iseq, &jit_entry_insns);
 
     let compile_jit_entries = matches!(mode, AddIseqMode::Standalone) && iseq_supports_jit_entry(iseq);
 
@@ -7895,7 +7903,13 @@ fn add_iseq_to_hir(
         // Start the block off with a Snapshot so that if we need to insert a new Guard later on
         // and we don't have a Snapshot handy, we can just iterate backward (at the earliest, to
         // the beginning of the block).
-        fun.push_insn(block, Insn::Snapshot { state: Box::new(state.clone()) });
+        state.insn_idx = insn_idx as usize;
+        // Get the current pc and opcode
+        state.pc = unsafe { rb_iseq_pc_at_idx(iseq, insn_idx) };
+        let exit_id = fun.push_insn(block, Insn::Snapshot { state: Box::new(state.clone()) });
+        if loop_targets_requiring_check_interrupts.contains(&insn_idx) {
+            fun.push_insn(block, Insn::CheckInterrupts { state: exit_id });
+        }
         while insn_idx < iseq_size {
             state.insn_idx = insn_idx as usize;
             // Get the current pc and opcode
@@ -8407,9 +8421,6 @@ fn add_iseq_to_hir(
                 }
                 YARVINSN_branchunless | YARVINSN_branchunless_without_ints => {
                     let offset = get_arg(pc, 0).as_i64();
-                    if opcode == YARVINSN_branchunless && offset < 0 {
-                        fun.push_insn(block, Insn::CheckInterrupts { state: exit_id });
-                    }
                     let val = state.stack_pop()?;
                     let test_id = fun.push_insn(block, Insn::Test { val });
                     let target_idx = insn_idx_at_offset(insn_idx, offset);
@@ -8435,9 +8446,6 @@ fn add_iseq_to_hir(
                 }
                 YARVINSN_branchif | YARVINSN_branchif_without_ints => {
                     let offset = get_arg(pc, 0).as_i64();
-                    if opcode == YARVINSN_branchif && offset < 0 {
-                        fun.push_insn(block, Insn::CheckInterrupts { state: exit_id });
-                    }
                     let val = state.stack_pop()?;
                     let test_id = fun.push_insn(block, Insn::Test { val });
                     let target_idx = insn_idx_at_offset(insn_idx, offset);
@@ -8464,9 +8472,6 @@ fn add_iseq_to_hir(
                 }
                 YARVINSN_branchnil | YARVINSN_branchnil_without_ints => {
                     let offset = get_arg(pc, 0).as_i64();
-                    if opcode == YARVINSN_branchnil && offset < 0 {
-                        fun.push_insn(block, Insn::CheckInterrupts { state: exit_id });
-                    }
                     let val = state.stack_pop()?;
                     let test_id = fun.push_insn(block, Insn::HasType { val, expected: types::NilClass });
                     let target_idx = insn_idx_at_offset(insn_idx, offset);
@@ -8528,9 +8533,6 @@ fn add_iseq_to_hir(
                 }
                 YARVINSN_jump | YARVINSN_jump_without_ints => {
                     let offset = get_arg(pc, 0).as_i64();
-                    if opcode == YARVINSN_jump && offset < 0 {
-                        fun.push_insn(block, Insn::CheckInterrupts { state: exit_id });
-                    }
                     let target_idx = insn_idx_at_offset(insn_idx, offset);
                     let target = insn_idx_to_block[&target_idx];
                     let _branch_id = fun.push_insn(block, Insn::Jump(

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -17924,17 +17924,17 @@ mod hir_opt_tests {
           v23:Fixnum[10] = Const Value(10)
           PatchPoint MethodRedefined(Integer@0x1000, <@0x1008, cme:0x1010)
           v94:BoolExact = FixnumLt v19, v23
+          v28:CBool = Test v94
+          CondBranch v28, bb4(v18, v19), bb7()
+        bb4(v38:HeapBasicObject, v39:Fixnum):
           CheckInterrupts
-          v29:CBool = Test v94
-          CondBranch v29, bb4(v18, v19), bb7()
-        bb4(v39:HeapBasicObject, v40:Fixnum):
           PatchPoint SingleRactorMode
-          v46:CShape = LoadField v39, :shape_id@0x1038
+          v46:CShape = LoadField v38, :shape_id@0x1038
           v48:CShape[0x1039] = Const CShape(0x1039)
           v49:CBool = IsBitEqual v46, v48
           CondBranch v49, bb9(), bb10()
         bb9():
-          v51:BasicObject = LoadField v39, :@levar@0x103a
+          v51:BasicObject = LoadField v38, :@levar@0x103a
           Jump bb8(v51)
         bb10():
           v53:CShape[0x103b] = GuardBitEquals v46, CShape(0x103b) recompile
@@ -17942,17 +17942,17 @@ mod hir_opt_tests {
           Jump bb8(v55)
         bb8(v47:BasicObject):
           v58:CBool = Test v47
-          CondBranch v58, bb5(v39, v40), bb12()
+          CondBranch v58, bb5(v38, v39), bb12()
         bb12():
           PatchPoint NoEPEscape(set_value_loop)
           PatchPoint SingleRactorMode
-          v68:CShape = LoadField v39, :shape_id@0x1038
+          v68:CShape = LoadField v38, :shape_id@0x1038
           v69:CShape[0x103b] = GuardBitEquals v68, CShape(0x103b) recompile
-          StoreField v39, :@levar@0x103a, v40
-          WriteBarrier v39, v40
+          StoreField v38, :@levar@0x103a, v39
+          WriteBarrier v38, v39
           v72:CShape[0x1039] = Const CShape(0x1039)
-          StoreField v39, :shape_id@0x1038, v72
-          Jump bb5(v39, v40)
+          StoreField v38, :shape_id@0x1038, v72
+          Jump bb5(v38, v39)
         bb5(v76:HeapBasicObject, v77:Fixnum):
           PatchPoint NoEPEscape(set_value_loop)
           v84:Fixnum[1] = Const Value(1)
@@ -17960,9 +17960,9 @@ mod hir_opt_tests {
           v98:Fixnum = FixnumAdd v77, v84
           Jump bb6(v76, v98)
         bb7():
-          v34:NilClass = Const Value(nil)
+          v33:NilClass = Const Value(nil)
           CheckInterrupts
-          Return v34
+          Return v33
         ");
     }
 

--- a/zjit/src/hir/tests.rs
+++ b/zjit/src/hir/tests.rs
@@ -94,12 +94,12 @@ mod snapshot_tests {
           Jump bb3(v7, v8, v9)
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           v14:Any = Snapshot FrameState { pc: 0x1008, stack: [], locals: [a=v12, b=v13] }
-          v15:Any = Snapshot FrameState { pc: 0x1010, stack: [], locals: [a=v12, b=v13] }
+          v15:Any = Snapshot FrameState { pc: 0x1008, stack: [], locals: [a=v12, b=v13] }
           PatchPoint NoTracePoint
-          v17:Any = Snapshot FrameState { pc: 0x1018, stack: [v12], locals: [a=v12, b=v13] }
-          v18:Any = Snapshot FrameState { pc: 0x1020, stack: [v12, v13], locals: [a=v12, b=v13] }
+          v17:Any = Snapshot FrameState { pc: 0x1010, stack: [v12], locals: [a=v12, b=v13] }
+          v18:Any = Snapshot FrameState { pc: 0x1018, stack: [v12, v13], locals: [a=v12, b=v13] }
           v19:ArrayExact = NewArray v12, v13
-          v20:Any = Snapshot FrameState { pc: 0x1028, stack: [v19], locals: [a=v12, b=v13] }
+          v20:Any = Snapshot FrameState { pc: 0x1020, stack: [v19], locals: [a=v12, b=v13] }
           PatchPoint NoTracePoint
           CheckInterrupts
           Return v19
@@ -1876,19 +1876,19 @@ pub(crate) mod hir_build_tests {
         bb5(v25:BasicObject, v26:BasicObject, v27:BasicObject):
           v31:Fixnum[0] = Const Value(0)
           v34:BasicObject = Send v27, :>, v31 # SendFallbackReason: Uncategorized(opt_gt)
+          v36:CBool = Test v34
+          v37:Truthy = RefineType v34, Truthy
+          CondBranch v36, bb4(v25, v26, v27), bb6()
+        bb4(v49:BasicObject, v50:BasicObject, v51:BasicObject):
           CheckInterrupts
-          v37:CBool = Test v34
-          v38:Truthy = RefineType v34, Truthy
-          CondBranch v37, bb4(v25, v26, v27), bb6()
-        bb4(v50:BasicObject, v51:BasicObject, v52:BasicObject):
           v57:Fixnum[1] = Const Value(1)
-          v60:BasicObject = Send v51, :+, v57 # SendFallbackReason: Uncategorized(opt_plus)
+          v60:BasicObject = Send v50, :+, v57 # SendFallbackReason: Uncategorized(opt_plus)
           v65:Fixnum[1] = Const Value(1)
-          v68:BasicObject = Send v52, :-, v65 # SendFallbackReason: Uncategorized(opt_minus)
-          Jump bb5(v50, v60, v68)
+          v68:BasicObject = Send v51, :-, v65 # SendFallbackReason: Uncategorized(opt_minus)
+          Jump bb5(v49, v60, v68)
         bb6():
-          v40:Falsy = RefineType v34, Falsy
-          v42:NilClass = Const Value(nil)
+          v39:Falsy = RefineType v34, Falsy
+          v41:NilClass = Const Value(nil)
           CheckInterrupts
           Return v26
         ");


### PR DESCRIPTION
Like the interpreter, only check for the interrupt after popping.
