### PR TITLE
ZJIT: Fix C function pointer normalization

### DIFF
--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -2238,13 +2238,13 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
             Insn::FixnumBitCheck {val, index} => { write!(f, "FixnumBitCheck {val}, {index}") },
             Insn::CCall { cfunc, recv, args, name, owner, return_type: _, elidable: _ } => {
                 let display_name = if *owner == Qnil { name.contents_lossy().to_string() } else { qualified_method_name(*owner, *name) };
-                write!(f, "CCall {recv}, :{}@{:p}", display_name, self.ptr_map.map_ptr(cfunc))?;
+                write!(f, "CCall {recv}, :{}@{:p}", display_name, self.ptr_map.map_ptr(*cfunc))?;
                 write_separated!(f, ", ", ", ", args);
                 Ok(())
             },
             Insn::CCallWithFrame(insn) => {
                 let CCallWithFrameData { cfunc, recv, args, name, cme, block, .. } = &**insn;
-                write!(f, "CCallWithFrame {recv}, :{}@{:p}", qualified_method_name(unsafe { (**cme).owner }, *name), self.ptr_map.map_ptr(cfunc))?;
+                write!(f, "CCallWithFrame {recv}, :{}@{:p}", qualified_method_name(unsafe { (**cme).owner }, *name), self.ptr_map.map_ptr(*cfunc))?;
                 write_separated!(f, ", ", ", ", args);
                 match block {
                     Some(BlockHandler::BlockIseq(blockiseq)) =>
@@ -2257,7 +2257,7 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
             },
             Insn::CCallVariadic(insn) => {
                 let CCallVariadicData { cfunc, recv, args, name, cme, .. } = &**insn;
-                write!(f, "CCallVariadic {recv}, :{}@{:p}", qualified_method_name(unsafe { (**cme).owner }, *name), self.ptr_map.map_ptr(cfunc))?;
+                write!(f, "CCallVariadic {recv}, :{}@{:p}", qualified_method_name(unsafe { (**cme).owner }, *name), self.ptr_map.map_ptr(*cfunc))?;
                 write_separated!(f, ", ", ", ", args);
                 Ok(())
             },

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -5543,7 +5543,7 @@ mod hir_opt_tests {
           Jump bb6(v22, v22)
         bb5():
           v24:BasicObject = LoadField v18, :VM_ENV_DATA_INDEX_SPECVAL@0x1003
-          v25:BasicObject = CCall v24, :rb_obj_is_proc@0x1008
+          v25:BasicObject = CCall v24, :rb_obj_is_proc@0x1004
           v26:TrueClass = GuardBitEquals v25, Value(true) recompile
           Jump bb6(v24, v10)
         bb6(v16:BasicObject, v17:BasicObject):
@@ -5817,7 +5817,7 @@ mod hir_opt_tests {
         bb5():
           v24:CInt64 = LoadField v18, :VM_ENV_DATA_INDEX_SPECVAL@0x1003
           v26:BasicObject = LoadField v18, :VM_ENV_DATA_INDEX_SPECVAL@0x1003
-          v27:BasicObject = CCall v26, :rb_obj_is_proc@0x1008
+          v27:BasicObject = CCall v26, :rb_obj_is_proc@0x1004
           v28:TrueClass = Const Value(true)
           v29:CBool = IsBitEqual v27, v28
           CondBranch v29, bb7(), bb11()
@@ -5836,7 +5836,7 @@ mod hir_opt_tests {
           v39:CBool = IsBitEqual v38, v37
           CondBranch v39, bb9(), bb13()
         bb9():
-          v41:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1010))
+          v41:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
           Jump bb6(v41, v10)
         bb6(v16:BasicObject, v17:BasicObject):
           v45:BasicObject = Send v14, &block, :then, v16 # SendFallbackReason: Send: block argument is not nil
@@ -9353,7 +9353,7 @@ mod hir_opt_tests {
           v12:CShape = LoadField v11, :shape_id@0x1000
           v13:CShape[0x1001] = GuardBitEquals v12, CShape(0x1001) recompile
           v14:CAttrIndex[0] = Const CAttrIndex(0)
-          v15:BasicObject = CCall v11, :rb_ivar_get_at_no_ractor_check@0x1008, v14
+          v15:BasicObject = CCall v11, :rb_ivar_get_at_no_ractor_check@0x1002, v14
           CheckInterrupts
           Return v15
         ");
@@ -11648,7 +11648,7 @@ mod hir_opt_tests {
           v25:CallableMethodEntry[VALUE(0x1048)] = GuardBitEquals v24, Value(VALUE(0x1048))
           v26:RubyValue = LoadField v23, :VM_ENV_DATA_INDEX_SPECVAL@0x1050
           v27:FalseClass = GuardBitEquals v26, Value(false)
-          v28:BasicObject = CCallVariadic v9, :Array#[]@0x1058, v10
+          v28:BasicObject = CCallVariadic v9, :Array#[]@0x1051, v10
           CheckInterrupts
           Return v28
         ");
@@ -16250,7 +16250,7 @@ mod hir_opt_tests {
           v20:CallableMethodEntry[VALUE(0x1040)] = GuardBitEquals v19, Value(VALUE(0x1040))
           v21:RubyValue = LoadField v18, :VM_ENV_DATA_INDEX_SPECVAL@0x1048
           v22:FalseClass = GuardBitEquals v21, Value(false)
-          v23:Fixnum = CCall v6, :Hash#size@0x1050
+          v23:Fixnum = CCall v6, :Hash#size@0x1049
           CheckInterrupts
           Return v23
         ");
@@ -16288,7 +16288,7 @@ mod hir_opt_tests {
           v20:CallableMethodEntry[VALUE(0x1040)] = GuardBitEquals v19, Value(VALUE(0x1040))
           v21:RubyValue = LoadField v18, :VM_ENV_DATA_INDEX_SPECVAL@0x1048
           v22:FalseClass = GuardBitEquals v21, Value(false)
-          v23:ArrayExact = CCallWithFrame v6, :Array#reverse@0x1050
+          v23:ArrayExact = CCallWithFrame v6, :Array#reverse@0x1049
           CheckInterrupts
           Return v23
         ");
@@ -16341,7 +16341,7 @@ mod hir_opt_tests {
           v40:CallableMethodEntry[VALUE(0x1048)] = GuardBitEquals v39, Value(VALUE(0x1048))
           v41:RubyValue = LoadField v38, :VM_ENV_DATA_INDEX_SPECVAL@0x1050
           v42:FalseClass = GuardBitEquals v41, Value(false)
-          v43:StringExact = CCallVariadic v24, :Array#join@0x1058, v25
+          v43:StringExact = CCallVariadic v24, :Array#join@0x1051, v25
           CheckInterrupts
           Return v43
         ");
@@ -16471,7 +16471,7 @@ mod hir_opt_tests {
           v46:CallableMethodEntry[VALUE(0x1048)] = GuardBitEquals v45, Value(VALUE(0x1048))
           v47:RubyValue = LoadField v44, :VM_ENV_DATA_INDEX_SPECVAL@0x1050
           v48:FalseClass = GuardBitEquals v47, Value(false)
-          v49:BasicObject = CCallVariadic v28, :String#byteindex@0x1058, v29, v30
+          v49:BasicObject = CCallVariadic v28, :String#byteindex@0x1051, v29, v30
           CheckInterrupts
           Return v49
         ");

--- a/zjit/src/hir/tests.rs
+++ b/zjit/src/hir/tests.rs
@@ -17,6 +17,74 @@ mod size_tests {
 }
 
 #[cfg(test)]
+mod printer_tests {
+    use super::*;
+
+    fn print_same_cfunc_twice(make_insn: impl Fn() -> Insn) -> (String, String) {
+        let mut ptr_map = PtrPrintMap::identity();
+        ptr_map.map_ptrs = true;
+
+        // Keep both printers alive so their cloned instructions cannot reuse storage.
+        let first = make_insn().print(&ptr_map, None);
+        let second = make_insn().print(&ptr_map, None);
+        (format!("{first}"), format!("{second}"))
+    }
+
+    #[test]
+    fn cfunc_pointer_printing_uses_the_pointer_value() {
+        let printed = crate::cruby::with_rubyvm(|| {
+            let cfunc = std::ptr::without_provenance::<u8>(0x1234);
+            let name = ID!(to_s);
+            let cme = unsafe { rb_callable_method_entry(rb_cInteger, name) };
+            assert!(!cme.is_null());
+
+            let ccall = print_same_cfunc_twice(|| Insn::CCall {
+                cfunc,
+                recv: InsnId(0),
+                args: vec![],
+                name,
+                owner: Qnil,
+                return_type: types::Any,
+                elidable: false,
+            });
+            let ccall_with_frame = print_same_cfunc_twice(|| {
+                Insn::CCallWithFrame(Box::new(CCallWithFrameData {
+                    cd: std::ptr::null(),
+                    cfunc,
+                    recv: InsnId(0),
+                    args: vec![],
+                    cme,
+                    name,
+                    state: InsnId(0),
+                    return_type: types::Any,
+                    elidable: false,
+                    block: None,
+                }))
+            });
+            let ccall_variadic = print_same_cfunc_twice(|| {
+                Insn::CCallVariadic(Box::new(CCallVariadicData {
+                    cfunc,
+                    recv: InsnId(0),
+                    args: vec![],
+                    cme,
+                    name,
+                    state: InsnId(0),
+                    return_type: types::Any,
+                    elidable: false,
+                    block: None,
+                }))
+            });
+
+            [ccall, ccall_with_frame, ccall_variadic]
+        });
+
+        for (first, second) in printed {
+            assert_eq!(first, second);
+        }
+    }
+}
+
+#[cfg(test)]
 mod snapshot_tests {
     use super::*;
     use insta::assert_snapshot;
@@ -3790,7 +3858,7 @@ pub(crate) mod hir_build_tests {
           Jump bb6(v22, v22)
         bb5():
           v24:BasicObject = LoadField v18, :VM_ENV_DATA_INDEX_SPECVAL@0x1003
-          v25:BasicObject = CCall v24, :rb_obj_is_proc@0x1008
+          v25:BasicObject = CCall v24, :rb_obj_is_proc@0x1004
           v26:TrueClass = GuardBitEquals v25, Value(true) recompile
           Jump bb6(v24, v10)
         bb6(v16:BasicObject, v17:BasicObject):
@@ -4007,7 +4075,7 @@ pub(crate) mod hir_build_tests {
           Jump bb10()
         bb10():
           v26:BasicObject = LoadField v18, :VM_ENV_DATA_INDEX_SPECVAL@0x1003
-          v27:BasicObject = CCall v26, :rb_obj_is_proc@0x1008
+          v27:BasicObject = CCall v26, :rb_obj_is_proc@0x1004
           v28:TrueClass = Const Value(true)
           v29:CBool = IsBitEqual v27, v28
           CondBranch v29, bb7(), bb11()
@@ -4026,7 +4094,7 @@ pub(crate) mod hir_build_tests {
           v39:CBool = IsBitEqual v38, v37
           CondBranch v39, bb9(), bb13()
         bb9():
-          v41:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1010))
+          v41:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
           Jump bb6(v41, v10)
         bb6(v16:BasicObject, v17:BasicObject):
           v45:BasicObject = Send v14, &block, :then, v16 # SendFallbackReason: Uncategorized(send)
@@ -4264,7 +4332,7 @@ pub(crate) mod hir_build_tests {
           Jump bb6(v25, v25)
         bb5():
           v27:BasicObject = LoadField v21, :VM_ENV_DATA_INDEX_SPECVAL@0x1004
-          v28:BasicObject = CCall v27, :rb_obj_is_proc@0x1008
+          v28:BasicObject = CCall v27, :rb_obj_is_proc@0x1005
           v29:TrueClass = GuardBitEquals v28, Value(true) recompile
           Jump bb6(v27, v13)
         bb6(v19:BasicObject, v20:BasicObject):
@@ -4308,7 +4376,7 @@ pub(crate) mod hir_build_tests {
           Jump bb6(v25, v25)
         bb5():
           v27:BasicObject = LoadField v21, :VM_ENV_DATA_INDEX_SPECVAL@0x1004
-          v28:BasicObject = CCall v27, :rb_obj_is_proc@0x1008
+          v28:BasicObject = CCall v27, :rb_obj_is_proc@0x1005
           v29:TrueClass = GuardBitEquals v28, Value(true) recompile
           Jump bb6(v27, v13)
         bb6(v19:BasicObject, v20:BasicObject):


### PR DESCRIPTION
This PR fixes a random test failure I saw at https://github.com/ruby/ruby/actions/runs/29533327572/job/87738572256.

`cfunc` was referring to the address of `CCall*::cfunc` field, not the address of the C func itself. So they could return different addresses even if they share the same C function.

This PR fixes it to use `*cfunc` instead, which resolves a mapped address based on the C function address.