### PR TITLE
ZJIT: Restore JITFrame after caught longjmp

### DIFF
--- a/eval_intern.h
+++ b/eval_intern.h
@@ -106,11 +106,14 @@ extern int select_large_fdset(int, fd_set *, fd_set *, fd_set *, struct timeval 
   EC_SAVE_TAG_CFP(_tag, _ec); \
   rb_vm_tag_jmpbuf_init(&_tag.buf); \
 
-// Remember the CFP as of EC_PUSH_TAG so that ZJIT can materialize frames
-// only up to longjmp's target CFP. When a C method does longjmp inside it,
-// the target CFP may not be equal to the VM_FRAME_FLAG_FINISH frame.
+// Remember the CFP and its JITFrame link as of EC_PUSH_TAG so that ZJIT can
+// materialize frames only up to longjmp's target CFP and restore the target's
+// link if it survives the jump. When a C method does longjmp inside it, the
+// target CFP may not be equal to the VM_FRAME_FLAG_FINISH frame.
 #if USE_ZJIT
-# define EC_SAVE_TAG_CFP(_tag, _ec) _tag.cfp = _ec->cfp
+# define EC_SAVE_TAG_CFP(_tag, _ec) \
+    _tag.cfp = _ec->cfp; \
+    _tag.jit_return = _ec->cfp->jit_return
 #else
 # define EC_SAVE_TAG_CFP(_tag, _ec)
 #endif
@@ -153,6 +156,12 @@ rb_ec_tag_state(const rb_execution_context_t *ec)
 {
     struct rb_vm_tag *tag = ec->tag;
     enum ruby_tag_type state = tag->state;
+#if USE_ZJIT
+    // rb_ec_tag_jump materializes through the target CFP, clearing its
+    // jit_return. The target's native stack is still live after longjmp, so
+    // reconnect it while leaving unwound frames materialized.
+    if (rb_zjit_enabled_p) tag->cfp->jit_return = tag->jit_return;
+#endif
     tag->state = TAG_NONE;
     rb_ec_vm_lock_rec_check(ec, tag->lock_rec);
     RBIMPL_ASSUME(state > TAG_NONE);

--- a/vm_core.h
+++ b/vm_core.h
@@ -1029,6 +1029,8 @@ struct rb_vm_tag {
 #if USE_ZJIT
     // ec->cfp as of EC_PUSH_TAG, which is saved for materializing JITFrame.
     rb_control_frame_t *cfp;
+    // cfp->jit_return as of EC_PUSH_TAG, restored when this tag catches a jump.
+    void *jit_return;
 #endif
 };
 

--- a/zjit/src/codegen_tests.rs
+++ b/zjit/src/codegen_tests.rs
@@ -6,7 +6,7 @@ use crate::backend::lir::Assembler;
 use crate::codegen::max_iseq_versions;
 use crate::cruby::*;
 use crate::hir::{Insn, iseq_to_hir};
-use crate::options::{get_option, rb_zjit_prepare_options, set_call_threshold, set_inline_threshold};
+use crate::options::{get_option, rb_zjit_prepare_options, set_call_threshold, set_inline_threshold, set_max_versions};
 use crate::payload::IseqVersion;
 use crate::hir::tests::hir_build_tests::assert_contains_opcode;
 use crate::payload::*;
@@ -7196,6 +7196,61 @@ fn test_regression_gc_stress_with_lazy_block_code() {
           GC.stress = false
         end
     "#), @":ok");
+}
+
+// Hash recursion uses catch/throw internally. The throw materializes a frame
+// that resumes in JIT code, so the catching tag must restore cfp->jit_return
+// before a callee side exit tries to use the frame's updated PC and stack map.
+#[test]
+fn test_restore_jit_frame_after_caught_jump() {
+    rb_zjit_prepare_options();
+    let old_call_threshold = unsafe { crate::options::rb_zjit_call_threshold };
+    let old_inline_threshold = get_option!(inline_threshold);
+    let old_max_versions = get_option!(max_versions);
+    set_call_threshold(1);
+    set_inline_threshold(0);
+    set_max_versions(2);
+    let result = inspect(r#"
+        module RestoreJITFrameAssertions
+          def assert_receiver(*)
+            raise unless is_a?(RestoreJITFrameBase)
+          end
+        end
+
+        class RestoreJITFrameBase
+          include RestoreJITFrameAssertions
+
+          def hash_class = Hash
+
+          def test
+            hash = hash_class[]
+            recursive = [hash]
+            hash[:x] = recursive
+            object = Object.new
+            lookup = { hash => object }
+
+            [recursive, [hash]].each do |key|
+              key = { x: key }
+              assert_receiver(object, lookup[key], -> { key.inspect })
+            end
+          end
+        end
+
+        class RestoreJITFrameHash < Hash
+        end
+
+        class RestoreJITFrameSubclass < RestoreJITFrameBase
+          def hash_class = RestoreJITFrameHash
+        end
+
+        RestoreJITFrameBase.new.test
+        RestoreJITFrameSubclass.new.test
+        :ok
+    "#);
+    set_max_versions(old_max_versions);
+    set_inline_threshold(old_inline_threshold);
+    set_call_threshold(old_call_threshold);
+    assert_snapshot!(result, @":ok");
 }
 
 #[test]


### PR DESCRIPTION
An internal longjmp can materialize its target CFP even when the catch resumes inside the same live JIT frame. Preserve the target's jit_return in rb_vm_tag and restore it after longjmp, leaving gen_write_jit_frame's fast path at a single store.