### PR TITLE
Guard fiber target across `fiber_store`.

### DIFF
--- a/cont.c
+++ b/cont.c
@@ -2697,6 +2697,13 @@ fiber_switch(rb_fiber_t *fiber, int argc, const VALUE *argv, int kw_splat, rb_fi
 
     VM_ASSERT(FIBER_RUNNABLE_P(fiber));
 
+    /*
+     * Keep the target fiber object alive across fiber_store.  The raw
+     * rb_fiber_t pointer is used after the coroutine switch, and GC may run
+     * while this C frame is suspended.
+     */
+    VALUE fiber_value = fiber->cont.self;
+
     rb_fiber_t *current_fiber = fiber_current();
 
     VM_ASSERT(!current_fiber->resuming_fiber);
@@ -2728,6 +2735,7 @@ fiber_switch(rb_fiber_t *fiber, int argc, const VALUE *argv, int kw_splat, rb_fi
         fiber_stack_release(fiber);
     }
 #endif
+    RB_GC_GUARD(fiber_value);
 
     if (fiber_current()->blocking) {
         th->blocking += 1;

--- a/test/ruby/test_fiber.rb
+++ b/test/ruby/test_fiber.rb
@@ -498,6 +498,40 @@ class TestFiber < Test::Unit::TestCase
     assert_equal :ok, ret, '[Bug #14642]'
   end
 
+  def test_gc_during_nested_resume_yield
+    assert_normal_exit <<-'RUBY', '[Bug #22196]', timeout: 10
+      parent = child1 = child2 = nil
+
+      parent = Fiber.new do
+        child1 = Fiber.new do
+          parent.resume
+        end
+
+        child2 = Fiber.new do
+          GC.start
+          parent.resume
+        end
+
+        Fiber.yield
+
+        child1 = nil
+
+        Fiber.yield
+      end
+
+      parent.resume
+
+      child = child1
+      child1 = nil
+      child.resume
+      child = nil
+
+      child = child2
+      child2 = nil
+      child.resume
+    RUBY
+  end
+
   def test_machine_stack_gc
     assert_normal_exit <<-RUBY, '[Bug #14561]', timeout: 10
       enum = Enumerator.new { |y| y << 1 }


### PR DESCRIPTION
`fiber_switch` keeps using the target `rb_fiber_t` pointer after `fiber_store` returns. GC may run while this C frame is suspended, so the target Fiber object needs to stay alive across the switch.

## Root cause analysis

* `fiber_switch` receives the target fiber as a raw `rb_fiber_t *fiber`.
* It stores data into that target and then calls `fiber_store(fiber, th)`, which switches away from the current fiber.
* While this native `fiber_switch` frame is suspended, Ruby code in another fiber can run GC.
* If Ruby code has dropped the last Ruby-level reference to the target Fiber object, GC can free the Fiber and its `rb_fiber_t`.
* When the suspended `fiber_switch` frame resumes, it still reads `fiber`, e.g. to check `FIBER_TERMINATED_P(fiber)` and maybe release the stack. That read becomes a use-after-free.

The reduced regression test reproduces that exact shape:

1. The parent fiber creates `child1` and `child2`, then yields to root.
2. Root resumes `child1`.
3. `child1` resumes the parent.
4. The parent clears its Ruby reference to `child1`, then calls `Fiber.yield`. This enters `fiber_switch` with `child1` as the target and suspends before returning from `fiber_store`.
5. `child1` terminates and root later resumes `child2`.
6. `child2` runs `GC.start`, which can collect `child1` while the parent's `fiber_switch` frame still holds only the raw `rb_fiber_t *`.
7. `child2` resumes the parent, and the suspended `fiber_switch` frame reads the stale `fiber` pointer.

The previous fix for [Bug #21955](https://bugs.ruby-lang.org/issues/21955) made this stale-pointer read visible for `Fiber.yield`. Before that change, the post-`fiber_store` terminated-target check was guarded by `resuming_fiber`:

```c
if (resuming_fiber && FIBER_TERMINATED_P(fiber)) {
```

`resuming_fiber` distinguishes the switch shape:

| Operation | `fiber_switch` target | `resuming_fiber` | `yielding` |
| --- | --- | --- | --- |
| `Fiber#resume` | resumed fiber | target fiber | `false` |
| `Fiber.yield` | return fiber | `NULL` | `true` |
| `Fiber#transfer` | transferred-to fiber | `NULL` | `false` |

So the old condition skipped this check for `Fiber.yield` and `Fiber#transfer`. Bug #21955 removed the `resuming_fiber &&` guard so terminated targets are handled for those paths too. That is the correct semantic direction, but it means `Fiber.yield` now also reads the target `fiber` pointer after returning from `fiber_store`, so the target Fiber object must be kept alive across the switch.

This patch keeps `fiber->cont.self` live with `RB_GC_GUARD` until after the final post-`fiber_store` use of the raw `fiber` pointer, and adds a regression test for the nested resume/yield case from [Bug #22196](https://bugs.ruby-lang.org/issues/22196).

## Validation

* Stock 3.4.10 ASan build reproduces the heap-use-after-free at `fiber_switch` / `rb_fiber_yield_kw` with the reduced pure Ruby repro.
* Patched ASan build passes:
  ```
  make test-all TESTS="test/ruby/test_fiber.rb" TESTOPTS="--name=/test_gc_during_nested_resume_yield/"
  Result: 1 tests, 5 assertions, 0 failures, 0 errors.
  ```

Fixes [Bug #22196]
