### PR TITLE
Make triggered_bits volatile in rb_postponed_job_flush

### DIFF
--- a/vm_trace.c
+++ b/vm_trace.c
@@ -1972,7 +1972,7 @@ rb_postponed_job_flush(rb_vm_t *vm)
     ccan_list_append_list(&tmp, &vm->workqueue);
     rb_nativethread_lock_unlock(&vm->workqueue_lock);
 
-    rb_atomic_t triggered_bits = RUBY_ATOMIC_EXCHANGE(pjq->triggered_bitset, 0);
+    volatile rb_atomic_t triggered_bits = RUBY_ATOMIC_EXCHANGE(pjq->triggered_bitset, 0);
 
     /* jobs targeted at this Ractor (rb_postponed_job_trigger_for_ractor) */
     triggered_bits |= RUBY_ATOMIC_EXCHANGE(rb_ec_ractor_ptr(ec)->postponed_job_triggered_bits, 0);


### PR DESCRIPTION
triggered_bits is modified between EC_EXEC_TAG and a possible longjmp (a postponed job can raise) and is read after EC_POP_TAG to re-post the bits that have not been executed yet, so C99 7.13.2.1p3 makes its value indeterminate exactly on that path.  The neighboring saved_mask and saved_errno are already volatile for the same reason.

Found by a heuristic checker for non-volatile locals read on the longjmp path: https://gist.github.com/shugo/2d659157532d7488979fd923e56f7ed3