### PR TITLE
Suppress cl.exe C4003 warning in RUBY_DTRACE_GC_HOOK

### DIFF
--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -74,8 +74,11 @@ rb_hrtime_sub(rb_hrtime_t a, rb_hrtime_t b)
 
 #include "probes.h"
 
+/* cl.exe's traditional preprocessor passes __VA_ARGS__ to a nested macro as
+ * a single argument; the extra expansion re-scans it into separate ones. */
+#define RUBY_DTRACE_GC_HOOK_EXPAND(expr) expr
 #define RUBY_DTRACE_GC_HOOK(name, ...) \
-    do {if (RUBY_DTRACE_GC_##name##_ENABLED()) RUBY_DTRACE_GC_##name(__VA_ARGS__);} while (0)
+    do {if (RUBY_DTRACE_GC_##name##_ENABLED()) RUBY_DTRACE_GC_HOOK_EXPAND(RUBY_DTRACE_GC_##name(__VA_ARGS__));} while (0)
 
 #if USE_ZJIT
 # include "gc/default/zjit_fastpath.h"


### PR DESCRIPTION
cl.exe's traditional preprocessor passes `__VA_ARGS__` to a nested macro as a single argument. The dummy `RUBY_DTRACE_GC_SWEEP_PAGE` macro generated by `tool/gen_dummy_probes.rb` takes four parameters, so every mswin build warns:

```
gc/default/default.c(4395): warning C4003: not enough arguments for function-like macro invocation 'RUBY_DTRACE_GC_SWEEP_PAGE'
```

Wrap the probe invocation in `RUBY_DTRACE_GC_HOOK` with an identity macro so that the expanded `__VA_ARGS__` is re-scanned and split into separate arguments. Verified with cl 19.51 that the warning disappears under both the traditional preprocessor and `/Zc:preprocessor`, and that a macro which actually uses its parameters still receives the four arguments correctly. Conforming preprocessors are unaffected because the extra expansion is an identity.
