### PR TITLE
Revert "Guard fiber target across `fiber_store`."

### DIFF
--- a/cont.c
+++ b/cont.c
@@ -2697,13 +2697,6 @@ fiber_switch(rb_fiber_t *fiber, int argc, const VALUE *argv, int kw_splat, rb_fi
 
     VM_ASSERT(FIBER_RUNNABLE_P(fiber));
 
-    /*
-     * Keep the target fiber object alive across fiber_store.  The raw
-     * rb_fiber_t pointer is used after the coroutine switch, and GC may run
-     * while this C frame is suspended.
-     */
-    VALUE fiber_value = fiber->cont.self;
-
     rb_fiber_t *current_fiber = fiber_current();
 
     VM_ASSERT(!current_fiber->resuming_fiber);
@@ -2735,7 +2728,6 @@ fiber_switch(rb_fiber_t *fiber, int argc, const VALUE *argv, int kw_splat, rb_fi
         fiber_stack_release(fiber);
     }
 #endif
-    RB_GC_GUARD(fiber_value);
 
     if (fiber_current()->blocking) {
         th->blocking += 1;

--- a/test/ruby/test_fiber.rb
+++ b/test/ruby/test_fiber.rb
@@ -498,40 +498,6 @@ class TestFiber < Test::Unit::TestCase
     assert_equal :ok, ret, '[Bug #14642]'
   end
 
-  def test_gc_during_nested_resume_yield
-    assert_normal_exit <<-'RUBY', '[Bug #22196]', timeout: 10
-      parent = child1 = child2 = nil
-
-      parent = Fiber.new do
-        child1 = Fiber.new do
-          parent.resume
-        end
-
-        child2 = Fiber.new do
-          GC.start
-          parent.resume
-        end
-
-        Fiber.yield
-
-        child1 = nil
-
-        Fiber.yield
-      end
-
-      parent.resume
-
-      child = child1
-      child1 = nil
-      child.resume
-      child = nil
-
-      child = child2
-      child2 = nil
-      child.resume
-    RUBY
-  end
-
   def test_machine_stack_gc
     assert_normal_exit <<-RUBY, '[Bug #14561]', timeout: 10
       enum = Enumerator.new { |y| y << 1 }


### PR DESCRIPTION
Sorry, I incorrectly merged this into Ruby ruby_3_4 - it should go into master and then be back ported.

Reverts ruby/ruby#17951

