### PR TITLE
Make teardown re-run guards volatile in thread_start_func_2

### DIFF
--- a/thread.c
+++ b/thread.c
@@ -713,7 +713,7 @@ thread_start_func_2(rb_thread_t *th, VALUE *stack_start)
     // Ensure that we are not joinable.
     VM_ASSERT(UNDEF_P(th->value));
 
-    int fiber_scheduler_closed = 0, event_thread_end_hooked = 0;
+    volatile int fiber_scheduler_closed = 0, event_thread_end_hooked = 0;
     VALUE result = Qundef;
 
     EC_PUSH_TAG(th->ec);


### PR DESCRIPTION
fiber_scheduler_closed and event_thread_end_hooked are set between setjmp and a possible longjmp from the fiber scheduler close or the THREAD_END event hook, and are read after that longjmp to avoid running either step twice, so C99 7.13.2.1p3 makes their values indeterminate exactly when they are needed.