### PR TITLE
Remove Interix support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3143,7 +3143,7 @@ STATIC=
       # mkmf.rb's have_header() to fail if the desired resource happens to be
       # installed in the /usr/local tree.
       RUBY_APPEND_OPTION(CCDLFLAGS, -fno-common)],
-    [cygwin*|msys*|mingw*|aix*|interix*], [ ],
+    [cygwin*|msys*|mingw*|aix*], [ ],
     [
       RUBY_APPEND_OPTION(CCDLFLAGS, -fPIC)])
   ], [
@@ -3204,9 +3204,6 @@ AC_SUBST(EXTOBJS)
 			AS_IF([test "$rb_cv_binary_elf" = yes], [
 			    LDFLAGS="$LDFLAGS -Wl,-export-dynamic"
 			])
-			rb_cv_dlopen=yes],
-	[interix*], [	: ${LDSHARED='$(CC) -shared'}
-			XLDFLAGS="$XLDFLAGS -Wl,-E"
 			rb_cv_dlopen=yes],
 	[freebsd*|dragonfly*], [
 			: ${LDSHARED='$(CC) -shared'}
@@ -3729,9 +3726,6 @@ AS_CASE("$enable_shared", [yes], [
 	    LIBRUBY_DLDFLAGS="$LIBRUBY_DLDFLAGS "'-Wl,-unexported_symbol,*_threadptr_*'
 	])
 	LIBRUBY_DLDFLAGS="$LIBRUBY_DLDFLAGS "' $(XLDFLAGS)'
-	],
-    [interix*], [
-	LIBRUBYARG_SHARED='-L. -L${libdir} -l$(RUBY_SO_NAME)'
 	],
     [cygwin*|msys*|mingw*|mswin*], [
 	LIBRUBY_RELATIVE=yes

--- a/dln.c
+++ b/dln.c
@@ -384,9 +384,6 @@ dln_open(const char *file)
 # ifndef RTLD_LAZY
 #  define RTLD_LAZY 1
 # endif
-# ifdef __INTERIX
-#  undef RTLD_GLOBAL
-# endif
 # ifndef RTLD_GLOBAL
 #  define RTLD_GLOBAL 0
 # endif


### PR DESCRIPTION
Interix (Microsoft Windows Services for UNIX / Subsystem for UNIX-based Applications) was removed from Windows in 8.1 and Server 2012 R2 and its support has long ended, so I removed the remaining `interix*` case arms in `configure.ac` and the `__INTERIX` guard in `dln.c`. The `bsdi*` pattern sharing one case arm is intentionally left untouched because BSD/OS removal is handled separately. After this change the only remaining mentions of Interix are historical entries in `doc/ChangeLog`.
