### PR TITLE
Disable DTrace on FreeBSD/aarch64

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3810,6 +3810,13 @@ AS_CASE(["${enable_dtrace}"],
 ], [
     rb_cv_dtrace_available=no
 ])
+AS_CASE(["$target_cpu-$target_os"], [aarch64-freebsd* | arm64-freebsd*], [dnl
+    # FreeBSD's libdtrace mishandles is-enabled probes on aarch64: dt_modtext()
+    # rewrites the call site to a bare nop without clearing the return register,
+    # so RUBY_DTRACE_*_ENABLED() returns a garbage value and fires probes even
+    # when no consumer is attached. See dt_link.c dt_modtext() for __aarch64__.
+    rb_cv_dtrace_available=no
+])
 AS_IF([test "${enable_dtrace}" = yes], [dnl
     AS_IF([test -z "$DTRACE"], [dnl
 	AC_MSG_ERROR([dtrace(1) is missing])


### PR DESCRIPTION
FreeBSD's `libdtrace` mishandles is-enabled probes on aarch64. Its `dt_modtext()` rewrites the probe call site to a bare `nop` without clearing the return register, unlike the x86 path which writes an `eax`-zeroing sequence. As a result `RUBY_DTRACE_*_ENABLED()` reads whatever happened to be in `w0` and reports the probe as enabled even when no consumer is attached.

Once a probe spuriously fires, `rb_dtrace_setup()` calls `rb_class_path()`, which allocates a fresh class-name `String` on every cfunc invocation. That breaks the object allocation count assertions in `TestStringMemory`, `TestHashOnly#test_AREF_fstring_key` and `TestGc#test_stat` on the `freebsd15-arm` builder, which has failed continuously since `5b5d1fb5e97` re-enabled DTrace on FreeBSD. A bisect over the chkbuild logs pins the first failing build to that commit, and the same revision passes on macOS arm64 where the platform `dtrace` patches the call site correctly.

This scopes the override to aarch64 only. amd64 FreeBSD uses the correct x86 path and stays enabled. The proper fix belongs upstream in FreeBSD's `dt_modtext()`, which should emit `mov w0, wzr` at the is-enabled site.
