### PR TITLE
[Bug #22197] Show the original definition module in backtrace labels

### DIFF
--- a/imemo.c
+++ b/imemo.c
@@ -325,6 +325,8 @@ mark_and_move_method_entry(rb_method_entry_t *ment, bool reference_updating)
     rb_gc_mark_and_move(&ment->defined_class);
 
     if (def) {
+        rb_gc_mark_and_move(&def->original_module);
+
         switch (def->type) {
           case VM_METHOD_TYPE_ISEQ:
             if (def->body.iseq.iseqptr) {

--- a/method.h
+++ b/method.h
@@ -203,6 +203,7 @@ struct rb_method_definition_struct {
     } body;
 
     ID original_id;
+    VALUE original_module; /* module in which the method definition is; see location_original_module() */
     uintptr_t method_serial;
     const rb_box_t *box;
 };

--- a/spec/ruby/core/thread/backtrace/location/fixtures/classes.rb
+++ b/spec/ruby/core/thread/backtrace/location/fixtures/classes.rb
@@ -68,6 +68,30 @@ module ThreadBacktraceLocationSpecs
   def original_method = LABEL.call
   alias_method :aliased_method, :original_method
 
+  # [Bug #22197]: an alias in a subclass, and define_method with an UnboundMethod
+  # from another module, should report the module where the body was originally
+  # defined -- not the subclass/class where the copy was installed.
+  class AliasParent
+    def alias_original = LABEL.call
+  end
+  class AliasChild < AliasParent
+    alias_method :alias_in_subclass, :alias_original
+  end
+
+  module DefineMethodSource
+    def define_method_original = LABEL.call
+  end
+  class DefineMethodTarget
+    define_method(:defined_from_other_module, DefineMethodSource.instance_method(:define_method_original))
+  end
+  class DefineMethodSingletonTarget; end
+  class << DefineMethodSingletonTarget
+    define_method(:defined_on_singleton, DefineMethodSource.instance_method(:define_method_original))
+  end
+  class DefineMethodSameNameTarget
+    define_method(:define_method_original, DefineMethodSource.instance_method(:define_method_original))
+  end
+
   module M
     class C
       def regular_instance_method = LABEL.call

--- a/spec/ruby/core/thread/backtrace/location/label_spec.rb
+++ b/spec/ruby/core/thread/backtrace/location/label_spec.rb
@@ -124,6 +124,24 @@ describe 'Thread::Backtrace::Location#label' do
       ThreadBacktraceLocationSpecs::INSTANCE.aliased_method.should == "ThreadBacktraceLocationSpecs#original_method"
     end
 
+    ruby_version_is "4.1" do # [Bug #22197]
+      it "shows the defining class for a method aliased in a subclass" do
+        ThreadBacktraceLocationSpecs::AliasChild.new.alias_in_subclass.should == "ThreadBacktraceLocationSpecs::AliasParent#alias_original"
+      end
+
+      it "shows the source module for a method defined via define_method with an UnboundMethod from another module" do
+        ThreadBacktraceLocationSpecs::DefineMethodTarget.new.defined_from_other_module.should == "ThreadBacktraceLocationSpecs::DefineMethodSource#define_method_original"
+      end
+
+      it "shows the source module for define_method with an UnboundMethod installed on a singleton class" do
+        ThreadBacktraceLocationSpecs::DefineMethodSingletonTarget.defined_on_singleton.should == "ThreadBacktraceLocationSpecs::DefineMethodSource#define_method_original"
+      end
+
+      it "shows the source module for define_method with an UnboundMethod installed under its original name" do
+        ThreadBacktraceLocationSpecs::DefineMethodSameNameTarget.new.define_method_original.should == "ThreadBacktraceLocationSpecs::DefineMethodSource#define_method_original"
+      end
+    end
+
     # A wide variety of cases.
     # These show interesting cases when trying to determine the name statically/at parse time
     describe "is correct for" do

--- a/test/ruby/test_backtrace.rb
+++ b/test/ruby/test_backtrace.rb
@@ -2,6 +2,39 @@
 require 'test/unit'
 require 'tempfile'
 
+module Bug22197
+  class Parent
+    def original
+      caller_locations(0, 1).first
+    end
+  end
+
+  class Child < Parent
+    alias_method :aliased, :original
+  end
+
+  module Original
+    def original
+      caller_locations(0, 1).first
+    end
+  end
+
+  class A
+    define_method(:a, Original.instance_method(:original))
+  end
+
+  class WithClassMethod
+    def self.cm
+      caller_locations(0, 1).first
+    end
+  end
+
+  class SingletonTarget; end
+  class << SingletonTarget
+    define_method(:on_singleton, Original.instance_method(:original))
+  end
+end
+
 class TestBacktrace < Test::Unit::TestCase
   def test_exception
     bt = Fiber.new{
@@ -215,6 +248,38 @@ class TestBacktrace < Test::Unit::TestCase
     [1].group_by do
       assert_equal 'label_caller', label_caller
     end
+  end
+
+  def test_original_definition_module # [Bug #22197]
+    # An alias in a subclass reports the module where the body was defined,
+    # not the subclass where the alias was installed.
+    loc = Bug22197::Child.new.aliased
+    assert_equal 'Bug22197::Parent#original', loc.label
+    assert_match(/:in 'Bug22197::Parent#original'\z/, loc.to_s)
+
+    # define_method(UnboundMethod) reports the source module, not the target class.
+    loc = Bug22197::A.new.a
+    assert_equal 'Bug22197::Original#original', loc.label
+    assert_match(/:in 'Bug22197::Original#original'\z/, loc.to_s)
+
+    # ... including when installed on a singleton class, where the target owner
+    # would otherwise render as a phantom "SingletonTarget.original".
+    loc = Bug22197::SingletonTarget.on_singleton
+    assert_equal 'Bug22197::Original#original', loc.label
+    assert_match(/:in 'Bug22197::Original#original'\z/, loc.to_s)
+
+    # Regression guard: a plain class method keeps its own "Class.method" label
+    # rather than borrowing the lexical nesting from the iseq cref.
+    loc = Bug22197::WithClassMethod.cm
+    assert_equal 'Bug22197::WithClassMethod.cm', loc.label
+    assert_match(/:in 'Bug22197::WithClassMethod.cm'\z/, loc.to_s)
+
+    # Regression guard: a plain singleton method keeps its bare label.
+    obj = Object.new
+    def obj.singleton_m
+      caller_locations(0, 1).first
+    end
+    assert_equal 'singleton_m', obj.singleton_m.label
   end
 
   def test_caller_limit_cfunc_iseq_no_pc

--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -289,18 +289,79 @@ location_cfunc_p(rb_backtrace_location_t *loc)
     }
 }
 
+/* Return the module where the running method body was actually defined.
+ *
+ * For an alias or a method installed via define_method(UnboundMethod), the CME's
+ * owner and defined_class point at the site where the alias/copy was installed,
+ * not where the body was originally defined. Combined with the method name (taken
+ * from the original definition) that yields a "Class#method" pair which never
+ * existed -- e.g. an alias in a subclass reported as Child#original instead of
+ * Parent#original, or define_method(Original.instance_method(:m)) reported as
+ * A#m instead of Original#m ([Bug #22197]).
+ *
+ * Only a shared definition (def->aliased) can carry a misleading owner, so plain
+ * defs -- including singleton (def obj.m) and class (def self.m) methods -- keep
+ * their owner untouched. For a shared def, rb_alias() copies the real module into
+ * defined_class (owner != defined_class), while define_method() overwrites both
+ * owner and defined_class with the install class, leaving the original module
+ * recoverable only from the iseq's cref. */
+static VALUE
+location_original_defined_class(const rb_callable_method_entry_t *cme)
+{
+    if (!cme) return Qnil;
+
+    const rb_method_entry_t *me = (const rb_method_entry_t *)cme;
+
+    /* Unwrap the explicit alias/refined wrappers (the defined_class == 0 form). */
+    while (me->def) {
+        if (me->def->type == VM_METHOD_TYPE_ALIAS) {
+            me = me->def->body.alias.original_me;
+        }
+        else if (me->def->type == VM_METHOD_TYPE_REFINED && me->def->body.refined.orig_me) {
+            me = me->def->body.refined.orig_me;
+        }
+        else {
+            break;
+        }
+    }
+
+    VALUE owner = me->owner;
+
+    if (me->def && me->def->aliased) {
+        VALUE defined_class = me->defined_class;
+        if (RB_TYPE_P(defined_class, T_ICLASS)) {
+            defined_class = RBASIC_CLASS(defined_class);
+        }
+        /* rb_alias() copied the real module here. */
+        if (defined_class && !NIL_P(defined_class) && defined_class != owner) {
+            return defined_class;
+        }
+        /* define_method(UnboundMethod) overwrote owner and defined_class alike;
+         * the original module survives only on the iseq's cref. A body written
+         * as `def self.m` / `def obj.m` records its *lexical* class in cref, not
+         * the singleton class it lives on, so when owner is exactly the singleton
+         * of cref's class (e.g. an aliased class method) keep owner instead. */
+        if (me->def->type == VM_METHOD_TYPE_ISEQ && me->def->body.iseq.cref) {
+            VALUE cref_class = CREF_CLASS(me->def->body.iseq.cref);
+            if (RB_TYPE_P(owner, T_CLASS) && RCLASS_SINGLETON_P(owner) &&
+                    RCLASS_ATTACHED_OBJECT(owner) == cref_class) {
+                return owner;
+            }
+            return cref_class;
+        }
+    }
+
+    return owner;
+}
+
 static VALUE
 location_label(rb_backtrace_location_t *loc)
 {
     if (location_cfunc_p(loc)) {
-        return rb_gen_method_name(loc->cme->owner, rb_id2str(loc->cme->def->original_id));
+        return rb_gen_method_name(location_original_defined_class(loc->cme), rb_id2str(loc->cme->def->original_id));
     }
     else {
-        VALUE owner = Qnil;
-        if (loc->cme) {
-            owner = loc->cme->owner;
-        }
-        return calculate_iseq_label(owner, loc->iseq);
+        return calculate_iseq_label(location_original_defined_class(loc->cme), loc->iseq);
     }
 }
 /*
@@ -482,13 +543,13 @@ location_to_str(rb_backtrace_location_t *loc)
             file = GET_VM()->progname;
             lineno = 0;
         }
-        name = rb_gen_method_name(loc->cme->owner, rb_id2str(loc->cme->def->original_id));
+        name = rb_gen_method_name(location_original_defined_class(loc->cme), rb_id2str(loc->cme->def->original_id));
     }
     else {
         file = rb_iseq_path(loc->iseq);
         lineno = calc_lineno(loc->iseq, loc->pc);
         if (loc->cme) {
-            owner = loc->cme->owner;
+            owner = location_original_defined_class(loc->cme);
         }
         name = calculate_iseq_label(owner, loc->iseq);
     }

--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -292,76 +292,44 @@ location_cfunc_p(rb_backtrace_location_t *loc)
 /* Return the module where the running method body was actually defined.
  *
  * For an alias or a method installed via define_method(UnboundMethod), the CME's
- * owner and defined_class point at the site where the alias/copy was installed,
- * not where the body was originally defined. Combined with the method name (taken
- * from the original definition) that yields a "Class#method" pair which never
- * existed -- e.g. an alias in a subclass reported as Child#original instead of
- * Parent#original, or define_method(Original.instance_method(:m)) reported as
- * A#m instead of Original#m ([Bug #22197]).
+ * owner points at the site where the alias/copy was installed, not where the body
+ * was originally defined. Combined with the method name (taken from the original
+ * definition) that yields a "Class#method" pair which never existed -- e.g. an
+ * alias in a subclass reported as Child#original instead of Parent#original, or
+ * define_method(Original.instance_method(:m)) reported as A#m instead of
+ * Original#m ([Bug #22197]).
  *
- * Only a shared definition (def->aliased) can carry a misleading owner, so plain
- * defs -- including singleton (def obj.m) and class (def self.m) methods -- keep
- * their owner untouched. For a shared def, rb_alias() copies the real module into
- * defined_class (owner != defined_class), while define_method() overwrites both
- * owner and defined_class with the install class, leaving the original module
- * recoverable only from the iseq's cref. */
+ * The definition module is recorded once on the (reference-counted, shared)
+ * method definition when the body is first created, so every alias/define_method
+ * copy keeps pointing at the original module.
+ *
+ * The exception is module_function, which installs the instance method's *shared*
+ * def onto the module's singleton class as well: that copy must be labeled as a
+ * class method of the module (M.f), i.e. by its owner. Such a copy is exactly the
+ * one whose owner is the singleton class of the definition module. */
 static VALUE
-location_original_defined_class(const rb_callable_method_entry_t *cme)
+location_original_module(const rb_callable_method_entry_t *cme)
 {
-    if (!cme) return Qnil;
-
-    const rb_method_entry_t *me = (const rb_method_entry_t *)cme;
-
-    /* Unwrap the explicit alias/refined wrappers (the defined_class == 0 form). */
-    while (me->def) {
-        if (me->def->type == VM_METHOD_TYPE_ALIAS) {
-            me = me->def->body.alias.original_me;
-        }
-        else if (me->def->type == VM_METHOD_TYPE_REFINED && me->def->body.refined.orig_me) {
-            me = me->def->body.refined.orig_me;
-        }
-        else {
-            break;
-        }
+    if (!cme || !cme->def) return Qnil;
+    VALUE owner = cme->owner;
+    VALUE defined_in = cme->def->original_module;
+    if (!defined_in) return owner;
+    if (defined_in != owner &&
+            RB_TYPE_P(owner, T_CLASS) && RCLASS_SINGLETON_P(owner) &&
+            RCLASS_ATTACHED_OBJECT(owner) == defined_in) {
+        return owner;
     }
-
-    VALUE owner = me->owner;
-
-    if (me->def && me->def->aliased) {
-        VALUE defined_class = me->defined_class;
-        if (RB_TYPE_P(defined_class, T_ICLASS)) {
-            defined_class = RBASIC_CLASS(defined_class);
-        }
-        /* rb_alias() copied the real module here. */
-        if (defined_class && !NIL_P(defined_class) && defined_class != owner) {
-            return defined_class;
-        }
-        /* define_method(UnboundMethod) overwrote owner and defined_class alike;
-         * the original module survives only on the iseq's cref. A body written
-         * as `def self.m` / `def obj.m` records its *lexical* class in cref, not
-         * the singleton class it lives on, so when owner is exactly the singleton
-         * of cref's class (e.g. an aliased class method) keep owner instead. */
-        if (me->def->type == VM_METHOD_TYPE_ISEQ && me->def->body.iseq.cref) {
-            VALUE cref_class = CREF_CLASS(me->def->body.iseq.cref);
-            if (RB_TYPE_P(owner, T_CLASS) && RCLASS_SINGLETON_P(owner) &&
-                    RCLASS_ATTACHED_OBJECT(owner) == cref_class) {
-                return owner;
-            }
-            return cref_class;
-        }
-    }
-
-    return owner;
+    return defined_in;
 }
 
 static VALUE
 location_label(rb_backtrace_location_t *loc)
 {
     if (location_cfunc_p(loc)) {
-        return rb_gen_method_name(location_original_defined_class(loc->cme), rb_id2str(loc->cme->def->original_id));
+        return rb_gen_method_name(location_original_module(loc->cme), rb_id2str(loc->cme->def->original_id));
     }
     else {
-        return calculate_iseq_label(location_original_defined_class(loc->cme), loc->iseq);
+        return calculate_iseq_label(location_original_module(loc->cme), loc->iseq);
     }
 }
 /*
@@ -543,13 +511,13 @@ location_to_str(rb_backtrace_location_t *loc)
             file = GET_VM()->progname;
             lineno = 0;
         }
-        name = rb_gen_method_name(location_original_defined_class(loc->cme), rb_id2str(loc->cme->def->original_id));
+        name = rb_gen_method_name(location_original_module(loc->cme), rb_id2str(loc->cme->def->original_id));
     }
     else {
         file = rb_iseq_path(loc->iseq);
         lineno = calc_lineno(loc->iseq, loc->pc);
         if (loc->cme) {
-            owner = location_original_defined_class(loc->cme);
+            owner = location_original_module(loc->cme);
         }
         name = calculate_iseq_label(owner, loc->iseq);
     }

--- a/vm_method.c
+++ b/vm_method.c
@@ -1153,12 +1153,18 @@ rb_method_definition_set(const rb_method_entry_t *me, rb_method_definition_t *de
             return;
           case VM_METHOD_TYPE_REFINED:
             {
-                RB_OBJ_WRITE(me, &def->body.refined.orig_me, (rb_method_entry_t *)opts);
+                const rb_method_entry_t *orig_me = (const rb_method_entry_t *)opts;
+                RB_OBJ_WRITE(me, &def->body.refined.orig_me, orig_me);
+                RB_OBJ_WRITE(me, &def->original_module, orig_me->def->original_module);
                 return;
             }
           case VM_METHOD_TYPE_ALIAS:
-            RB_OBJ_WRITE(me, &def->body.alias.original_me, (rb_method_entry_t *)opts);
-            return;
+            {
+                const rb_method_entry_t *orig_me = (const rb_method_entry_t *)opts;
+                RB_OBJ_WRITE(me, &def->body.alias.original_me, orig_me);
+                RB_OBJ_WRITE(me, &def->original_module, orig_me->def->original_module);
+                return;
+            }
           case VM_METHOD_TYPE_ZSUPER:
           case VM_METHOD_TYPE_UNDEF:
           case VM_METHOD_TYPE_MISSING:
@@ -1171,6 +1177,8 @@ static void
 method_definition_reset(const rb_method_entry_t *me)
 {
     rb_method_definition_t *def = me->def;
+
+    RB_OBJ_WRITTEN(me, Qundef, def->original_module);
 
     switch (def->type) {
       case VM_METHOD_TYPE_ISEQ:
@@ -1536,6 +1544,7 @@ rb_method_entry_make(VALUE klass, ID mid, VALUE defined_class, rb_method_visibil
           def->body.cfunc.invoker = ractor_safe_call_cfunc_m1;
           def->body.cfunc.argc = -1;
         }
+        RB_OBJ_WRITE(me, &def->original_module, me->owner);
     }
     rb_method_definition_set(me, def, opts);
 
@@ -1663,6 +1672,7 @@ get_overloaded_cme(const rb_callable_method_entry_t *cme)
 
         RB_OBJ_WRITE(me, &def->body.iseq.cref, cme->def->body.iseq.cref);
         RB_OBJ_WRITE(me, &def->body.iseq.iseqptr, ISEQ_BODY(cme->def->body.iseq.iseqptr)->mandatory_only_iseq);
+        RB_OBJ_WRITE(me, &def->original_module, cme->def->original_module);
 
         ASSERT_vm_locking();
         st_insert(overloaded_cme_table(), (st_data_t)cme, (st_data_t)me);


### PR DESCRIPTION
Fixes https://bugs.ruby-lang.org/issues/22197

The first commit tries to fix the issue without adding any new field but it gets messy and hard to reason about.
The second commit adds `original_module` next to `original_id` in `struct rb_method_definition_struct` which is a natural way to track this.