### PR TITLE
Avoid duplicated `.gdbinit` loads by `RUNRUBY_USE_GDB=true`

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -1469,8 +1469,9 @@ run.gdb:
 	echo '# handle SIGINT nostop'         >> run.gdb
 	echo '# handle SIGPIPE nostop'        >> run.gdb
 	echo '# b rb_longjmp'                 >> run.gdb
-	echo source $(srcdir)/breakpoints.gdb >> run.gdb
-	echo source $(srcdir)/.gdbinit        >> run.gdb
+	echo directory $(srcdir)              >> run.gdb
+	echo source -s breakpoints.gdb        >> run.gdb
+	echo source -s .gdbinit               >> run.gdb
 	echo 'set $$_exitcode = -999'         >> run.gdb
 	echo run                              >> run.gdb
 	echo 'if $$_exitcode != -999'         >> run.gdb

--- a/tool/runruby.rb
+++ b/tool/runruby.rb
@@ -163,10 +163,12 @@ ENV.update env
 if debugger
   case debugger
   when :gdb
-    debugger = %W'gdb -x #{srcdir}/.gdbinit'
+    debugger = %W'gdb'
     if File.exist?(gdb = 'run.gdb') or
       File.exist?(gdb = File.join(abs_archdir, 'run.gdb'))
       debugger.push('-x', gdb)
+    else
+      debugger.push('-x', "#{srcdir}/.gdbinit")
     end
     debugger << '--args'
   when :lldb


### PR DESCRIPTION
If we use out-of-source build and have `${BUILD_DIR}/run.gdb` (by `make run.gdb`), `${SOURCE_DIR}/.gdbinit` is loaded twice because `run.gdb` loads `${SOURCE_DIR}/.gdbinit`.

If we have `run.gdb`, we don't need `-x ${SOURCE_DIR}/.gdbinit`.

There is one more problem for `${BUILD_DIR}/run.gdb` and `${SOURCE_DIR}/.gdbinit`. `source -s misc/gdb.py` in `${SOURCE_DIR}/.gdbinit` is failed when we use out-of-source build and `${BUILD_DIR}/run.gdb` because `${SOURCE_DIR}` isn't included in search path of `source`. If we have `directory $(srcdir)` in `${BUILD_DIR}/run.gdb`, `source -s misc/gdb.py` works in `${SOURCE_DIR}/.gdbinit` that is loaded from `${BUILD_DIR}/run.gdb`.