### PR TITLE
ZJIT: Profile caller splat length distributions

### DIFF
--- a/zjit.rb
+++ b/zjit.rb
@@ -116,6 +116,7 @@ class << RubyVM::ZJIT
     # use multiple complex features, a decrease in this number does not
     # necessarily mean an increase in number of optimized calls.
     print_counters_with_prefix(prefix: 'complex_arg_pass_', prompt: 'popular complex argument-parameter features not optimized', buf:, stats:, limit: 10)
+    print_counters_with_prefix(prefix: 'caller_splat_profile_', prompt: 'caller splat length profiles', buf:, stats:, limit: 10)
 
     # Show exit counters, ordered by the typical amount of exits for the prefix at the time
     print_counters_with_prefix(prefix: 'compile_error_', prompt: 'compile error reasons', buf:, stats:, limit: 20)

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -3853,9 +3853,12 @@ impl Function {
         result
     }
 
-    fn count_complex_call_features(&mut self, block: BlockId, ci_flags: c_uint) {
+    fn count_complex_call_features(&mut self, block: BlockId, ci_flags: c_uint, state: InsnId) {
         use Counter::*;
-        if 0 != ci_flags & VM_CALL_ARGS_SPLAT     { self.count(block, complex_arg_pass_caller_splat);      }
+        if 0 != ci_flags & VM_CALL_ARGS_SPLAT {
+            self.count(block, complex_arg_pass_caller_splat);
+            self.count_caller_splat_profile(block, state);
+        }
         if 0 != ci_flags & VM_CALL_ARGS_BLOCKARG  { self.count(block, complex_arg_pass_caller_blockarg);   }
         if 0 != ci_flags & VM_CALL_KWARG          { self.count(block, complex_arg_pass_caller_kwarg);      }
         if 0 != ci_flags & VM_CALL_KW_SPLAT       { self.count(block, complex_arg_pass_caller_kw_splat);   }
@@ -3863,6 +3866,21 @@ impl Function {
         if 0 != ci_flags & VM_CALL_SUPER          { self.count(block, complex_arg_pass_caller_super);      }
         if 0 != ci_flags & VM_CALL_ZSUPER         { self.count(block, complex_arg_pass_caller_zsuper);     }
         if 0 != ci_flags & VM_CALL_FORWARDING     { self.count(block, complex_arg_pass_caller_forwarding); }
+    }
+
+    fn count_caller_splat_profile(&mut self, block: BlockId, state: InsnId) {
+        let state = self.frame_state(state);
+        let summary = get_or_create_iseq_payload(state.iseq).profile.get_splat_length_summary(state.insn_idx);
+        let counter = match summary {
+            None => Counter::caller_splat_profile_no_profiles,
+            Some(summary) if summary.is_monomorphic() => Counter::caller_splat_profile_monomorphic,
+            Some(summary) if summary.is_polymorphic() => Counter::caller_splat_profile_polymorphic,
+            Some(summary) if summary.is_skewed_polymorphic() => Counter::caller_splat_profile_skewed_polymorphic,
+            Some(summary) if summary.is_megamorphic() => Counter::caller_splat_profile_megamorphic,
+            Some(summary) if summary.is_skewed_megamorphic() => Counter::caller_splat_profile_skewed_megamorphic,
+            Some(_) => unreachable!(),
+        };
+        self.count(block, counter);
     }
 
     fn rewrite_if_frozen(&mut self, block: BlockId, orig_insn_id: InsnId, self_val: InsnId, klass: u32, bop: u32, state: InsnId) {
@@ -4183,7 +4201,7 @@ impl Function {
                         // Mask out ARGS_BLOCKARG only if we've already handled the nil block arg case above.
                         let flags_for_check = if stripped_nil_block { flags & !VM_CALL_ARGS_BLOCKARG } else { flags };
                         if def_type != VM_METHOD_TYPE_OPTIMIZED && def_type != VM_METHOD_TYPE_CFUNC && unspecializable_call_type(flags_for_check) {
-                            self.count_complex_call_features(block, flags);
+                            self.count_complex_call_features(block, flags, state);
                             self.set_dynamic_send_reason(insn_id, ComplexArgPass);
                             self.push_insn_id(block, insn_id); continue;
                         }
@@ -4325,7 +4343,7 @@ impl Function {
                             match (opt_type, args.as_slice()) {
                                 (OptimizedMethodType::Call, _) => {
                                     if flags & (VM_CALL_ARGS_SPLAT | VM_CALL_KWARG) != 0 {
-                                        self.count_complex_call_features(block, flags);
+                                        self.count_complex_call_features(block, flags, state);
                                         self.set_dynamic_send_reason(insn_id, ComplexArgPass);
                                         self.push_insn_id(block, insn_id); continue;
                                     }
@@ -4344,7 +4362,7 @@ impl Function {
                                 }
                                 (OptimizedMethodType::StructAref, &[]) | (OptimizedMethodType::StructAset, &[_]) => {
                                     if unspecializable_call_type(flags) {
-                                        self.count_complex_call_features(block, flags);
+                                        self.count_complex_call_features(block, flags, state);
                                         self.set_dynamic_send_reason(insn_id, ComplexArgPass);
                                         self.push_insn_id(block, insn_id); continue;
                                     }
@@ -4433,7 +4451,7 @@ impl Function {
                                 if unspecializable_c_call_type(ci_flags) {
                                     // Only count features NOT already counted in type_specialize.
                                     if !unspecializable_call_type(ci_flags) {
-                                        fun.count_complex_call_features(block, ci_flags);
+                                        fun.count_complex_call_features(block, ci_flags, state);
                                     }
                                     fun.set_dynamic_send_reason(send_insn_id, ComplexArgPass);
                                     return Err(());

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -13522,6 +13522,84 @@ mod hir_opt_tests {
     }
 
     #[test]
+    fn dont_specialize_call_to_iseq_with_monomorphic_caller_splat() {
+        enable_zjit_stats();
+        eval("
+            def foo(*args) = args
+            def test(args) = foo(*args)
+            test([1])
+            test([2])
+        ");
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:3:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          v2:CPtr = LoadSP
+          v3:BasicObject = LoadField v2, :args@0x1000
+          Jump bb3(v1, v3)
+        bb2():
+          EntryPoint JIT(0)
+          v6:BasicObject = LoadArg :self@0
+          v7:BasicObject = LoadArg :args@1
+          IncrCounterPtr
+          Jump bb3(v6, v7)
+        bb3(v10:BasicObject, v11:BasicObject):
+          IncrCounter zjit_insn_count
+          IncrCounter zjit_insn_count
+          IncrCounter zjit_insn_count
+          v20:ArrayExact = ToArray v11
+          IncrCounter zjit_insn_count
+          IncrCounter complex_arg_pass_caller_splat
+          IncrCounter caller_splat_profile_monomorphic
+          v23:BasicObject = Send v10, :foo, v20 # SendFallbackReason: Complex argument passing
+          IncrCounter zjit_insn_count
+          CheckInterrupts
+          Return v23
+        ");
+    }
+
+    #[test]
+    fn dont_specialize_call_to_iseq_with_polymorphic_caller_splat() {
+        enable_zjit_stats();
+        set_call_threshold(3);
+        eval("
+            def foo(*args) = args
+            def test(args) = foo(*args)
+            test([1])
+            test([1, 2])
+            test([3])
+        ");
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:3:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          v2:CPtr = LoadSP
+          v3:BasicObject = LoadField v2, :args@0x1000
+          Jump bb3(v1, v3)
+        bb2():
+          EntryPoint JIT(0)
+          v6:BasicObject = LoadArg :self@0
+          v7:BasicObject = LoadArg :args@1
+          IncrCounterPtr
+          Jump bb3(v6, v7)
+        bb3(v10:BasicObject, v11:BasicObject):
+          IncrCounter zjit_insn_count
+          IncrCounter zjit_insn_count
+          IncrCounter zjit_insn_count
+          v20:ArrayExact = ToArray v11
+          IncrCounter zjit_insn_count
+          IncrCounter complex_arg_pass_caller_splat
+          IncrCounter caller_splat_profile_polymorphic
+          v23:BasicObject = Send v10, :foo, v20 # SendFallbackReason: Complex argument passing
+          IncrCounter zjit_insn_count
+          CheckInterrupts
+          Return v23
+        ");
+    }
+
+    #[test]
     fn test_inline_symbol_to_sym() {
         eval(r#"
             def test(o) = o.to_sym

--- a/zjit/src/profile.rs
+++ b/zjit/src/profile.rs
@@ -100,6 +100,7 @@ fn profile_insn_sample(
             let argc = num_arguments_on_stack(cd);
             // Profile all the arguments and self (+1).
             profile_operands(profiler, profile, argc + 1);
+            profile_splat_length(profiler, profile, unsafe { (*cd).ci });
         }
         YARVINSN_splatkw => profile_operands(profiler, profile, 2),
         _ => return false,
@@ -154,6 +155,10 @@ pub type TypeDistribution = Distribution<ProfiledType, DISTRIBUTION_SIZE>;
 
 pub type TypeDistributionSummary = DistributionSummary<ProfiledType, DISTRIBUTION_SIZE>;
 
+pub type SplatLengthDistribution = Distribution<usize, DISTRIBUTION_SIZE>;
+
+pub type SplatLengthDistributionSummary = DistributionSummary<usize, DISTRIBUTION_SIZE>;
+
 /// Profile the Type of top-`n` stack operands
 fn profile_operands(profiler: &mut Profiler, profile: &mut IseqProfile, n: usize) {
     let entry = profile.entry_mut(profiler.insn_idx);
@@ -169,6 +174,28 @@ fn profile_operands(profiler: &mut Profiler, profile: &mut IseqProfile, n: usize
         VALUE::from(profiler.iseq).write_barrier(ty.class());
         profile_type.observe(ty);
     }
+}
+
+fn profile_splat_length(profiler: &mut Profiler, profile: &mut IseqProfile, ci: *const rb_callinfo) {
+    let flags = unsafe { rb_vm_ci_flag(ci) };
+    if flags & VM_CALL_ARGS_SPLAT == 0 {
+        return;
+    }
+
+    let kwarg = unsafe { rb_vm_ci_kwarg(ci) };
+    let caller_kw_count = if kwarg.is_null() { 0 } else { (unsafe { get_cikw_keyword_len(kwarg) }) as usize };
+    let splat_pos = usize::from(flags & VM_CALL_ARGS_BLOCKARG != 0)
+        + usize::from(flags & VM_CALL_KW_SPLAT != 0)
+        + caller_kw_count;
+    let splat_array = profiler.peek_at_stack(splat_pos as isize);
+    if !unsafe { RB_TYPE_P(splat_array, RUBY_T_ARRAY) } {
+        return;
+    }
+
+    let Ok(length) = usize::try_from(unsafe { rb_jit_array_len(splat_array) }) else {
+        return;
+    };
+    profile.entry_mut(profiler.insn_idx).splat_lengths.observe(length);
 }
 
 fn profile_self(profiler: &mut Profiler, profile: &mut IseqProfile) {
@@ -225,6 +252,7 @@ fn profile_invokesuper(profiler: &mut Profiler, profile: &mut IseqProfile) {
 
     // Profile all the arguments and self (+1).
     profile_operands(profiler, profile, (argc + 1) as usize);
+    profile_splat_length(profiler, profile, unsafe { (*cd).ci });
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -398,6 +426,8 @@ pub struct ProfileEntry {
     insn_idx: u32,
     /// Type information of YARV instruction operands
     opnd_types: Vec<TypeDistribution>,
+    /// Observed lengths of the caller splat array.
+    splat_lengths: SplatLengthDistribution,
     /// Number of profiles remaining before recompilation. Counts down from --zjit-num-profiles.
     profiles_remaining: NumProfiles,
 }
@@ -435,6 +465,7 @@ impl IseqProfile {
                 self.entries.insert(i, ProfileEntry {
                     insn_idx: idx,
                     opnd_types: Vec::new(),
+                    splat_lengths: SplatLengthDistribution::new(),
                     profiles_remaining: get_option!(num_profiles),
                 });
                 &mut self.entries[i]
@@ -457,6 +488,11 @@ impl IseqProfile {
     /// Get profiled operand types for a given instruction index
     pub fn get_operand_types(&self, insn_idx: YarvInsnIdx) -> Option<&[TypeDistribution]> {
         self.entry(insn_idx).map(|e| e.opnd_types.as_slice()).filter(|s| !s.is_empty())
+    }
+
+    pub fn get_splat_length_summary(&self, insn_idx: YarvInsnIdx) -> Option<SplatLengthDistributionSummary> {
+        self.entry(insn_idx)
+            .map(|entry| SplatLengthDistributionSummary::new(&entry.splat_lengths))
     }
 
     pub fn get_super_method_entry(&self, insn_idx: YarvInsnIdx) -> Option<*const rb_callable_method_entry_t> {

--- a/zjit/src/profile.rs
+++ b/zjit/src/profile.rs
@@ -155,9 +155,13 @@ pub type TypeDistribution = Distribution<ProfiledType, DISTRIBUTION_SIZE>;
 
 pub type TypeDistributionSummary = DistributionSummary<ProfiledType, DISTRIBUTION_SIZE>;
 
-pub type SplatLengthDistribution = Distribution<usize, DISTRIBUTION_SIZE>;
+pub type SplatLength = u32;
 
-pub type SplatLengthDistributionSummary = DistributionSummary<usize, DISTRIBUTION_SIZE>;
+/// `None` records an unknown length so this distribution covers the same
+/// executions as the operand type profile.
+pub type SplatLengthDistribution = Distribution<Option<SplatLength>, DISTRIBUTION_SIZE>;
+
+pub type SplatLengthDistributionSummary = DistributionSummary<Option<SplatLength>, DISTRIBUTION_SIZE>;
 
 /// Profile the Type of top-`n` stack operands
 fn profile_operands(profiler: &mut Profiler, profile: &mut IseqProfile, n: usize) {
@@ -178,24 +182,26 @@ fn profile_operands(profiler: &mut Profiler, profile: &mut IseqProfile, n: usize
 
 fn profile_splat_length(profiler: &mut Profiler, profile: &mut IseqProfile, ci: *const rb_callinfo) {
     let flags = unsafe { rb_vm_ci_flag(ci) };
+    // Only call sites with VM_CALL_ARGS_SPLAT have a splat array on the stack.
     if flags & VM_CALL_ARGS_SPLAT == 0 {
         return;
     }
 
     let kwarg = unsafe { rb_vm_ci_kwarg(ci) };
     let caller_kw_count = if kwarg.is_null() { 0 } else { (unsafe { get_cikw_keyword_len(kwarg) }) as usize };
+    // Starting at the top of the stack, skip the block argument, keyword-splat
+    // hash, and explicit keyword values to reach the splat array.
     let splat_pos = usize::from(flags & VM_CALL_ARGS_BLOCKARG != 0)
         + usize::from(flags & VM_CALL_KW_SPLAT != 0)
         + caller_kw_count;
     let splat_array = profiler.peek_at_stack(splat_pos as isize);
-    if !unsafe { RB_TYPE_P(splat_array, RUBY_T_ARRAY) } {
-        return;
-    }
-
-    let Ok(length) = usize::try_from(unsafe { rb_jit_array_len(splat_array) }) else {
-        return;
+    let length = if unsafe { RB_TYPE_P(splat_array, RUBY_T_ARRAY) } {
+        SplatLength::try_from(unsafe { rb_jit_array_len(splat_array) }).ok()
+    } else {
+        None
     };
-    profile.entry_mut(profiler.insn_idx).splat_lengths.observe(length);
+    profile.splat_lengths.entry(profiler.insn_idx)
+        .or_insert_with(SplatLengthDistribution::new).observe(length);
 }
 
 fn profile_self(profiler: &mut Profiler, profile: &mut IseqProfile) {
@@ -426,8 +432,6 @@ pub struct ProfileEntry {
     insn_idx: u32,
     /// Type information of YARV instruction operands
     opnd_types: Vec<TypeDistribution>,
-    /// Observed lengths of the caller splat array.
-    splat_lengths: SplatLengthDistribution,
     /// Number of profiles remaining before recompilation. Counts down from --zjit-num-profiles.
     profiles_remaining: NumProfiles,
 }
@@ -445,7 +449,10 @@ pub struct IseqProfile {
     entries: Vec<ProfileEntry>,
 
     /// Method entries for `super` calls (stored as VALUE to be GC-safe)
-    super_cme: HashMap<YarvInsnIdx, TypeDistribution>
+    super_cme: HashMap<YarvInsnIdx, TypeDistribution>,
+
+    /// Observed lengths of caller splat arrays for call instructions.
+    splat_lengths: HashMap<YarvInsnIdx, SplatLengthDistribution>,
 }
 
 impl IseqProfile {
@@ -453,6 +460,7 @@ impl IseqProfile {
         Self {
             entries: Vec::new(),
             super_cme: HashMap::new(),
+            splat_lengths: HashMap::new(),
         }
     }
 
@@ -465,7 +473,6 @@ impl IseqProfile {
                 self.entries.insert(i, ProfileEntry {
                     insn_idx: idx,
                     opnd_types: Vec::new(),
-                    splat_lengths: SplatLengthDistribution::new(),
                     profiles_remaining: get_option!(num_profiles),
                 });
                 &mut self.entries[i]
@@ -491,8 +498,8 @@ impl IseqProfile {
     }
 
     pub fn get_splat_length_summary(&self, insn_idx: YarvInsnIdx) -> Option<SplatLengthDistributionSummary> {
-        self.entry(insn_idx)
-            .map(|entry| SplatLengthDistributionSummary::new(&entry.splat_lengths))
+        self.splat_lengths.get(&insn_idx)
+            .map(SplatLengthDistributionSummary::new)
     }
 
     pub fn get_super_method_entry(&self, insn_idx: YarvInsnIdx) -> Option<*const rb_callable_method_entry_t> {

--- a/zjit/src/stats.rs
+++ b/zjit/src/stats.rs
@@ -436,6 +436,14 @@ make_counters! {
     // Unsupported argument conversions
     complex_arg_pass_keyword_to_positional_hash,
 
+    // Caller splat length profile shapes
+    caller_splat_profile_no_profiles,
+    caller_splat_profile_monomorphic,
+    caller_splat_profile_polymorphic,
+    caller_splat_profile_skewed_polymorphic,
+    caller_splat_profile_megamorphic,
+    caller_splat_profile_skewed_megamorphic,
+
     // Writes to the VM frame
     vm_write_jit_frame_count,
     vm_write_sp_count,


### PR DESCRIPTION
Related to: https://github.com/Shopify/ruby/issues/1004

Before specializing sends with caller splats, collect the distribution of caller splat array lengths.

The splat length determines how many `ArrayAref` operations and positional arguments a `SendDirect` path needs. Specializing for only one observed length could cause repeated side exits when a call site sees varying lengths, so we need to understand whether these profiles are monomorphic or polymorphic first.

This does not change caller splat specialization or fallback behavior yet.

```diff
# on liquid-render
Top-1 popular complex argument-parameter features not optimized (100.0% of total 4,341,452):
  caller_splat: 4,341,452 (100.0%)
+ Top-2 caller splat length profiles (100.0% of total 4,341,452):
+   polymorphic: 4,255,087 (98.0%)
+   monomorphic:    86,365 ( 2.0%)

# on railsbench
Top-7 popular complex argument-parameter features not optimized (100.0% of total 4,832,676):
           param_forwardable: 2,673,942 (55.3%)
             caller_kw_splat:   596,099 (12.3%)
                caller_splat:   584,388 (12.1%)
  keyword_to_positional_hash:   423,919 ( 8.8%)
             caller_blockarg:   301,509 ( 6.2%)
                param_kwrest:   251,206 ( 5.2%)
                caller_kwarg:     1,613 ( 0.0%)
+ Top-3 caller splat length profiles (100.0% of total 584,388):
+          monomorphic: 583,777 (99.9%)
+          polymorphic:     487 ( 0.1%)
+   skewed_polymorphic:     124 ( 0.0%)
```