### PR TITLE
Also output mandatory only ISEQ in dumps

### DIFF
--- a/iseq.c
+++ b/iseq.c
@@ -3002,6 +3002,10 @@ rb_iseq_disasm_recursive(const rb_iseq_t *iseq, VALUE indent)
         n += rb_iseq_disasm_insn(str, code, n, iseq, child);
     }
 
+    if (body->mandatory_only_iseq) {
+        rb_ary_push(child, (VALUE)body->mandatory_only_iseq);
+    }
+
     for (l = 0; l < RARRAY_LEN(child); l++) {
         VALUE isv = rb_ary_entry(child, l);
         if (done_iseq && st_is_member(done_iseq, (st_data_t)isv)) continue;

--- a/test/ruby/test_iseq.rb
+++ b/test/ruby/test_iseq.rb
@@ -524,6 +524,12 @@ class TestISeq < Test::Unit::TestCase
     assert_equal [:&], param_names
   end
 
+  def test_disasm_mandatory_only_overloaded
+    disasm = RubyVM::InstructionSequence.disasm(Time.method(:at))
+    assert_include disasm, "<builtin!time_s_at1/1>"
+    assert_include disasm, "<builtin!time_s_at/4>"
+  end
+
   def strip_lineno(source)
     source.gsub(/^.*?: /, "")
   end


### PR DESCRIPTION
Methods with mandatory only support only dumps the ISEQ of the case with all the arguments and not the mandatory only case. This commit changes it to also dump the mandatory only ISEQ.