### PR TITLE
Handle shape ID capacity overflow

### DIFF
--- a/shape.c
+++ b/shape.c
@@ -1343,8 +1343,15 @@ rb_shape_verify_consistency(VALUE obj, shape_id_t shape_id)
         size_t shape_id_slot_size = shape_id_capacity * sizeof(VALUE) + sizeof(struct RBasic);
         size_t actual_slot_size = rb_gc_obj_slot_size(obj);
 
-        if (shape_id_slot_size != actual_slot_size) {
-            rb_bug("shape_id capacity flags mismatch: shape_id_slot_size=%zu, gc_slot_size=%zu\n", shape_id_slot_size, actual_slot_size);
+        if (shape_id_capacity == SHAPE_ID_CAPACITY_MAX) {
+            if (actual_slot_size < SHAPE_ID_CAPACITY_MAX) {
+                rb_bug("shape_id_capacity is SHAPE_ID_CAPACITY_MAX, but actual slot size is only %zu", actual_slot_size);
+            }
+        }
+        else {
+            if (shape_id_slot_size != actual_slot_size) {
+                rb_bug("shape_id capacity flags mismatch: shape_id_slot_size=%zu, gc_slot_size=%zu\n", shape_id_slot_size, actual_slot_size);
+            }
         }
     }
 

--- a/shape.h
+++ b/shape.h
@@ -338,14 +338,26 @@ static inline size_t
 rb_obj_shape_slot_size(VALUE obj)
 {
     RUBY_ASSERT(!RB_TYPE_P(obj, T_IMEMO) || IMEMO_TYPE_P(obj, imemo_fields));
-    return rb_shape_slot_size(RBASIC_SHAPE_ID(obj));
+
+    shape_id_t shape_id = RBASIC_SHAPE_ID(obj);
+    size_t slot_size = rb_shape_slot_size(shape_id);
+
+    if (rb_shape_embedded_capacity(shape_id) == SHAPE_ID_CAPACITY_MAX) {
+        size_t gc_slot_size = rb_gc_obj_slot_size(obj);
+        RUBY_ASSERT(gc_slot_size >= slot_size);
+        return gc_slot_size;
+    }
+
+    return slot_size;
 }
 
 static inline attr_index_t
 rb_shape_capacity_for_slot_size(size_t slot_size)
 {
     size_t capacity = (slot_size - sizeof(struct RBasic)) / sizeof(VALUE);
-    RUBY_ASSERT(capacity <= SHAPE_ID_CAPACITY_MAX);
+    if (capacity > SHAPE_ID_CAPACITY_MAX) {
+        capacity = SHAPE_ID_CAPACITY_MAX;
+    }
     return (attr_index_t)capacity;
 }
 


### PR DESCRIPTION
If we allocate objects larger than 1024 bytes, the capacity in the shape ID will overflow. This commit fixes it set the capacity to SHAPE_ID_CAPACITY_MAX in that case and falls back to rb_gc_obj_slot_size instead.