### PR TITLE
YJIT: Avoid argument types for forwarding callees

### DIFF
--- a/test/ruby/test_yjit.rb
+++ b/test/ruby/test_yjit.rb
@@ -854,6 +854,27 @@ class TestYJIT < Test::Unit::TestCase
     RUBY
   end
 
+  def test_forwarding_callee_does_not_map_arguments_to_locals
+    assert_compiles(
+      <<~'RUBY', call_threshold: 1, code_gc: true, result: [:ok, :ok], verify_ctx: true
+      class ForwardingReceiver
+        def foo(...) = :ok
+      end
+
+      def delegate(...)
+        receiver = ForwardingReceiver.new
+        if defined?(receiver.foo)
+          receiver.foo(...)
+        else
+          receiver.__send__(:foo, ...)
+        end
+      end
+
+      2.times.map { delegate(nil, "string") }
+      RUBY
+    )
+  end
+
   def test_send_block
     # Setlocal_wc_0 sometimes side-exits on write barrier
     assert_compiles(<<~'RUBY', result: "b:n/b:y/b:y/b:n")
@@ -1997,7 +2018,8 @@ class TestYJIT < Test::Unit::TestCase
     frozen_string_literal: nil,
     mem_size: nil,
     code_gc: false,
-    no_send_fallbacks: false
+    no_send_fallbacks: false,
+    verify_ctx: false
   )
     reset_stats = <<~RUBY
       RubyVM::YJIT.runtime_stats
@@ -2032,7 +2054,7 @@ class TestYJIT < Test::Unit::TestCase
       #{write_results}
     RUBY
 
-    status, out, err, stats = eval_with_jit(script, call_threshold:, mem_size:, code_gc:)
+    status, out, err, stats = eval_with_jit(script, call_threshold:, mem_size:, code_gc:, verify_ctx:)
 
     assert status.success?, "exited with status #{status.to_i}, stderr:\n#{err}"
 
@@ -2097,7 +2119,9 @@ class TestYJIT < Test::Unit::TestCase
     s.chars.map { |c| c.ascii_only? ? c : "\\u%x" % c.codepoints[0] }.join
   end
 
-  def eval_with_jit(script, call_threshold: 1, timeout: 1000, mem_size: nil, code_gc: false)
+  def eval_with_jit(
+    script, call_threshold: 1, timeout: 1000, mem_size: nil, code_gc: false, verify_ctx: false
+  )
     args = [
       "--disable-gems",
       "--yjit-call-threshold=#{call_threshold}",
@@ -2105,6 +2129,7 @@ class TestYJIT < Test::Unit::TestCase
     ]
     args << "--yjit-exec-mem-size=#{mem_size}" if mem_size
     args << "--yjit-code-gc" if code_gc
+    args << "--yjit-verify-ctx" if verify_ctx
     args << "-e" << script_shell_encode(script)
     stats_r, stats_w = IO.pipe
     # Separate thread so we don't deadlock when

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -8290,17 +8290,14 @@ fn gen_send_iseq(
         callee_ctx.set_inline_block(iseq);
     }
 
-    // Set the argument types in the callee's context
-    for arg_idx in 0..argc {
-        let stack_offs: u8 = (argc - arg_idx - 1).try_into().unwrap();
-        let arg_type = asm.ctx.get_opnd_type(StackOpnd(stack_offs));
-        callee_ctx.set_local_type(arg_idx.try_into().unwrap(), arg_type);
-    }
-
-    // If we're in a forwarding callee, there will be one unknown type
-    // written in to the local table (the caller's CI object)
-    if forwarding {
-        callee_ctx.set_local_type(0, Type::Unknown)
+    // Forwarding callees store a callinfo object rather than arguments in
+    // their local table, so their argument types do not map to local types.
+    if !forwarding {
+        for arg_idx in 0..argc {
+            let stack_offs: u8 = (argc - arg_idx - 1).try_into().unwrap();
+            let arg_type = asm.ctx.get_opnd_type(StackOpnd(stack_offs));
+            callee_ctx.set_local_type(arg_idx.try_into().unwrap(), arg_type);
+        }
     }
 
     // Set the receiver type in the callee's context


### PR DESCRIPTION
Forwarding callees keep call information, not arguments, in their local table.
Mapping caller argument types to those slots could make YJIT carry a `CString` type for an uninitialized `nil` local and fail context verification.

Skip local argument type propagation for forwarding callees and cover the `defined?` delegator shape with context verification and code GC enabled.
