### PR TITLE
Fast path `match?` for anchored literal `Regexp` patterns

### DIFF
--- a/benchmark/string_match_p_literal.yml
+++ b/benchmark/string_match_p_literal.yml
@@ -1,0 +1,34 @@
+prelude: |
+  str          = 'haystack contains a needle here'
+  str_no_hit   = 'haystack contains no matches here'
+  exact        = 'needle'
+  exact_wrong  = 'poodle'
+  exact_longer = 'needles'
+
+  re_prefix       = /\Ahaystack/
+  re_prefix_miss  = /\Aneedle/
+  re_suffix       = /here\z/
+  re_suffix_miss  = /haystack\z/
+  re_exact        = /\Aneedle\z/
+  re_unanchored   = /needle/
+
+benchmark:
+  prefix_hit_match_p:      str.match?(re_prefix)
+  prefix_hit_start_with:   str.start_with?('haystack')
+  prefix_miss_match_p:     str.match?(re_prefix_miss)
+  prefix_miss_start_with:  str.start_with?('needle')
+
+  suffix_hit_match_p:      str.match?(re_suffix)
+  suffix_hit_end_with:     str.end_with?('here')
+  suffix_miss_match_p:     str.match?(re_suffix_miss)
+  suffix_miss_end_with:    str.end_with?('haystack')
+
+  exact_hit_match_p:       exact.match?(re_exact)
+  exact_hit_eq:            exact == 'needle'
+  exact_wrong_match_p:     exact_wrong.match?(re_exact)
+  exact_wrong_eq:          exact_wrong == 'needle'
+  exact_longer_match_p:    exact_longer.match?(re_exact)
+  exact_longer_eq:         exact_longer == 'needle'
+
+  unanchored_hit_match_p:  str.match?(re_unanchored)
+  unanchored_miss_match_p: str_no_hit.match?(re_unanchored)

--- a/re.c
+++ b/re.c
@@ -4057,11 +4057,93 @@ rb_reg_match_m_p(int argc, VALUE *argv, VALUE re)
     return rb_reg_match_p(re, argv[0], pos);
 }
 
+enum reg_literal_kind {
+    REG_LITERAL_NONE,
+    REG_LITERAL_PREFIX,  /* /\Afoo/   */
+    REG_LITERAL_SUFFIX,  /* /foo\z/   */
+    REG_LITERAL_EXACT,   /* /\Afoo\z/ */
+};
+
+static enum reg_literal_kind
+reg_classify_literal(VALUE re, const char **lit_ptr, long *lit_len)
+{
+    OnigOptionType opts = RREGEXP_PTR(re)->options;
+    if (opts & (ONIG_OPTION_IGNORECASE | ONIG_OPTION_EXTEND | ONIG_OPTION_MULTILINE)) {
+        return REG_LITERAL_NONE;
+    }
+
+    const char *src = RREGEXP_SRC_PTR(re);
+    long len = RREGEXP_SRC_LEN(re);
+
+    int has_prefix = 0;
+    if (len >= 2 && src[0] == '\\' && src[1] == 'A') {
+        has_prefix = 1;
+        src += 2;
+        len -= 2;
+    }
+    int has_suffix = 0;
+    if (len >= 2 && src[len-2] == '\\' && src[len-1] == 'z') {
+        has_suffix = 1;
+        len -= 2;
+    }
+    if (!has_prefix && !has_suffix) return REG_LITERAL_NONE;
+
+    /* ASCII bytes never appear as trailing bytes of a multibyte sequence in
+     * ASCII-compat encodings, so a raw byte scan is safe. */
+    for (long i = 0; i < len; i++) {
+        unsigned char c = (unsigned char)src[i];
+        if (c >= 0x80) return REG_LITERAL_NONE;
+        switch (c) {
+          case '.': case '*': case '+': case '?':
+          case '(': case ')': case '[': case ']':
+          case '{': case '}': case '|': case '^':
+          case '$': case '\\': case '#':
+            return REG_LITERAL_NONE;
+        }
+    }
+
+    *lit_ptr = src;
+    *lit_len = len;
+    if (has_prefix && has_suffix) return REG_LITERAL_EXACT;
+    if (has_prefix) return REG_LITERAL_PREFIX;
+    return REG_LITERAL_SUFFIX;
+}
+
 VALUE
 rb_reg_match_p(VALUE re, VALUE str, long pos)
 {
     if (NIL_P(str)) return Qfalse;
     str = SYMBOL_P(str) ? rb_sym2str(str) : StringValue(str);
+
+    if (pos == 0) {
+        const char *src = RREGEXP_SRC_PTR(re);
+        long src_len = RREGEXP_SRC_LEN(re);
+        /* Cheap byte-level anchor check to skip classifier work on the common
+         * unanchored path. */
+        int has_anchor = src_len >= 2 &&
+            ((src[0] == '\\' && src[1] == 'A') ||
+             (src[src_len-2] == '\\' && src[src_len-1] == 'z'));
+        if (has_anchor && rb_enc_asciicompat(rb_enc_get(str))) {
+            const char *lit_ptr;
+            long lit_len;
+            long slen = RSTRING_LEN(str);
+            switch (reg_classify_literal(re, &lit_ptr, &lit_len)) {
+              case REG_LITERAL_NONE:
+                break;
+              case REG_LITERAL_PREFIX:
+                if (slen < lit_len) return Qfalse;
+                return RBOOL(memcmp(RSTRING_PTR(str), lit_ptr, lit_len) == 0);
+              case REG_LITERAL_SUFFIX:
+                if (slen < lit_len) return Qfalse;
+                return RBOOL(memcmp(RSTRING_PTR(str) + slen - lit_len,
+                                    lit_ptr, lit_len) == 0);
+              case REG_LITERAL_EXACT:
+                if (slen != lit_len) return Qfalse;
+                return RBOOL(lit_len == 0 || memcmp(RSTRING_PTR(str), lit_ptr, lit_len) == 0);
+            }
+        }
+    }
+
     if (pos) {
         if (pos < 0) {
             pos += NUM2LONG(rb_str_length(str));


### PR DESCRIPTION
For a Regexp like `/\Afoo/`, `/foo\z/`, or `/\Afoo\z/`, the anchor locks the match to one end of the string, so `match?` can dispatch straight to a memcmp instead of invoking the regex engine. This PR adds that fast path. In benchmarks it matches or beats `start_with?` and `end_with?` in every case, so RuboCop's [Performance/StartWith][sw] and [Performance/EndWith][ew] cops should no longer be needed. `match?(/\Afoo\z/)` also gets 2x faster as a side effect.

The classifier scans the Regexp source rather than reading Onigmo's compiled bytecode, which felt easier to reason about for encoding safety. Any escape sequence like `\d` is rejected because `\\` is in the metacharacter blacklist, which should also cover any regex metacharacter added to Ruby later, though it's worth a second pair of eyes. Patterns with active options (`/i`, `/m`, `/x`), non-ASCII bytes, `^`/`$` line anchors, or a non-zero match offset skip the fast path.

The unanchored `match?(/foo/)` case is left out on purpose. Onigmo already runs it through Boyer-Moore, and any pre-check I could think of would tax every unanchored call by a few nanoseconds. Caching the classification on the Regexp struct might be one way forward, but seems worth its own discussion.

[sw]: https://docs.rubocop.org/rubocop-performance/latest/cops_performance.html#performancestartwith
[ew]: https://docs.rubocop.org/rubocop-performance/latest/cops_performance.html#performanceendwith

<details>
<summary>Benchmark, macOS arm64, higher is better, averaged across three runs</summary>

| Case                                    | baseline | this PR | speedup |
|:----------------------------------------|---------:|--------:|--------:|
| `match?(/\Afoo/)` hit                   |    15.1M |   30.6M |   2.02x |
| `match?(/\Afoo/)` miss                  |    23.8M |   32.6M |   1.37x |
| `match?(/foo\z/)` hit                   |    15.1M |   32.7M |   2.16x |
| `match?(/foo\z/)` miss                  |    22.0M |   30.4M |   1.38x |
| `match?(/\Afoo\z/)` hit                 |    15.4M |   31.3M |   2.03x |
| `match?(/\Afoo\z/)` wrong same length   |    22.9M |   30.8M |   1.35x |
| `match?(/\Afoo\z/)` different length    |    15.0M |   33.8M |   2.26x |

</details>

<details>
<summary>match? vs specialized methods after this PR</summary>

| Case                    | this PR `match?` | specialized method  | ratio |
|:------------------------|-----------------:|--------------------:|------:|
| `match?(/\Afoo/)` hit   |            30.6M | `start_with?` 29.2M | 1.05x |
| `match?(/\Afoo/)` miss  |            32.6M | `start_with?` 26.6M | 1.22x |
| `match?(/foo\z/)` hit   |            32.7M | `end_with?`   27.9M | 1.17x |
| `match?(/foo\z/)` miss  |            30.4M | `end_with?`   28.9M | 1.05x |
| `match?(/\Afoo\z/)` hit |            31.3M | `==`          38.8M | 0.81x |

</details>

<details>
<summary>Unanchored path stays in noise</summary>

| Case                         | baseline | this PR | ratio |
|:-----------------------------|---------:|--------:|------:|
| `str.match?(/needle/)` hit   |    15.4M |   15.0M | 0.97x |
| `str.match?(/needle/)` miss  |    21.7M |   22.2M | 1.02x |

</details>