### PR TITLE
[ruby/mkmf]: avoid resolving echo from PATH

### DIFF
--- a/lib/mkmf.rb
+++ b/lib/mkmf.rb
@@ -2091,7 +2091,7 @@ V0 = $(V:0=)
 Q1 = $(V:1=)
 Q = $(Q1:0=@)
 ECHO1 = $(V:1=@ #{CONFIG['NULLCMD']})
-ECHO = $(ECHO1:0=@ echo)
+ECHO = $(ECHO1:0=@ #{$nmake ? "echo" : "/bin/echo"})
 NULLCMD = #{CONFIG['NULLCMD']}
 
 #### Start of system configuration section. ####

--- a/test/mkmf/test_makefile.rb
+++ b/test/mkmf/test_makefile.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+class TestMkmfMakefile < TestMkmf
+  def test_echo_command
+    create_makefile("test")
+
+    assert_include File.read("Makefile"), "ECHO = $(ECHO1:0=@ #{$nmake ? "echo" : "/bin/echo"})"
+  end
+
+  def test_echo_does_not_resolve_from_path
+    omit "POSIX Makefile only" if $nmake
+
+    Dir.mkdir("fake-bin")
+    File.write("fake-bin/echo", <<~SH)
+      #!/bin/sh
+      touch path-echo-used
+      exit 77
+    SH
+    File.chmod(0o755, "fake-bin/echo")
+
+    env = {"PATH" => [File.expand_path("fake-bin"), ENV.fetch("PATH")].join(File::PATH_SEPARATOR)}
+
+    create_makefile("test")
+
+    File.open("Makefile", "a") do |f|
+      f.puts
+      f.puts "test-echo:"
+      f.puts "\t$(ECHO) testing"
+    end
+
+    assert(system(env, ENV["MAKE"] || RbConfig::CONFIG["MAKE"] || "make", "test-echo"))
+    assert_not_predicate(Pathname("path-echo-used"), :exist?)
+  end
+end


### PR DESCRIPTION
## Summary

Generated POSIX Makefiles currently define `ECHO` using an unqualified `echo` command:

```make
ECHO = $(ECHO1:0=@ echo)
```

This resolves `echo` through `PATH`. If another executable named `echo` appears earlier in `PATH`, generated extension Makefiles may invoke that executable instead of the system command.

Use `/bin/echo` for POSIX Makefiles while preserving `echo` for `nmake`:

```ruby
ECHO = $(ECHO1:0=@ #{$nmake ? "echo" : "/bin/echo"})
```

## Background

This behavior was encountered while building the `kino` gem, where a RubyGems executable named `echo` appeared earlier in `PATH` and was invoked by the generated Makefile.

It was initially addressed downstream in:

* [`yaroslav/kino#4`](https://github.com/yaroslav/kino/pull/4)
* [`oxidize-rb/rb-sys#748`](https://github.com/oxidize-rb/rb-sys/pull/748)

The `rb-sys` change applies the same workaround to its generated Makefiles. Since the original `ECHO` definition comes from `mkmf`, fixing it here addresses the underlying behavior for generated POSIX Makefiles and can make the downstream workaround unnecessary.

## Tests

Add two tests:

1. Verify the generated `ECHO` definition:

   * `/bin/echo` for POSIX Makefiles.
   * `echo` for `nmake`.

2. Add a POSIX-only regression test that:

   * creates a failing executable named `echo`;
   * places it first in `PATH`;
   * generates an `mkmf` Makefile;
   * invokes a target using `$(ECHO)`; and
   * verifies that the fake executable was not invoked.

The regression test is omitted for `nmake` because it uses a different Makefile implementation.

## Validation

Before the change, the regression test fails because the fake `echo` executable is invoked:

```text
make[1]: *** [Makefile:213: test-echo] Error 77
```

After the change:

```text
2 tests, 7 assertions, 0 failures, 0 errors, 0 skips
```

The complete `mkmf` test suite also passes:

```text
149 tests, 719 assertions, 0 failures, 0 errors, 0 skips
```

`make check` also passes.

## Scope

This change is limited to the `mkmf` Makefile generation logic and its associated tests:

* `lib/mkmf.rb`
* `test/mkmf/test_makefile.rb`

The separate `ECHO` definition in `ext/extmk.rb` is left unchanged because it is outside the reproduced `mkmf` behavior.