### PR TITLE
[ruby/time] Exclude _xmlschema from RDoc

### DIFF
--- a/lib/time.rb
+++ b/lib/time.rb
@@ -668,7 +668,7 @@ class Time
     private
 
     if RUBY_VERSION >= "3.2"
-      def _xmlschema(pattern, time)
+      def _xmlschema(pattern, time) # :nodoc:
         if pattern.match?(time)
           new(time)
         else
@@ -676,7 +676,7 @@ class Time
         end
       end
     else
-      def _xmlschema(pattern, time)
+      def _xmlschema(pattern, time) # :nodoc:
         if pattern =~ time
           year = $1.to_i
           mon = $2.to_i


### PR DESCRIPTION
## Summary

Exclude the private `Time._xmlschema` implementations from RDoc using `:nodoc:`.

After `_xmlschema` was split into version-dependent definitions, RDoc reports the private helper as undocumented.

Since `_xmlschema` is an internal implementation detail rather than part of the public API, mark both definitions with `:nodoc:` so they are excluded from the generated documentation.

## Validation

Validated with:

```sh
make XRUBY=ruby RDOC_DEPENDS= RBCONFIG=update-rbconfig rdoc-coverage
```
