### PR TITLE
[Bug #22197] Fix: Backtraces show methods which do not exist

### DIFF
--- a/test/ruby/test_backtrace.rb
+++ b/test/ruby/test_backtrace.rb
@@ -3,6 +3,26 @@ require 'test/unit'
 require 'tempfile'
 
 class TestBacktrace < Test::Unit::TestCase
+  class LabelAliasSource
+    def original
+      caller_locations(0, 1).first
+    end
+  end
+
+  class LabelAlias < LabelAliasSource
+    alias aliased original
+  end
+
+  module LabelCopiedSource
+    def original
+      caller_locations(0, 1).first
+    end
+  end
+
+  class LabelCopied
+    define_method :copied, LabelCopiedSource.instance_method(:original)
+  end
+
   def test_exception
     bt = Fiber.new{
       begin
@@ -317,6 +337,16 @@ class TestBacktrace < Test::Unit::TestCase
       raise
     rescue
       assert_equal("TestBacktrace##{__method__}", caller_locations(0, 1)[0].label)
+    end
+  end
+
+  def test_caller_locations_label_uses_original_method_owner
+    {
+      LabelAlias.new.aliased => "TestBacktrace::LabelAliasSource#original",
+      LabelCopied.new.copied => "TestBacktrace::LabelCopiedSource#original",
+    }.each do |location, expected_label|
+      assert_equal(expected_label, location.label)
+      assert_match(/:in '#{Regexp.escape(expected_label)}'\z/, location.to_s)
     end
   end
 

--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -290,17 +290,24 @@ location_cfunc_p(rb_backtrace_location_t *loc)
 }
 
 static VALUE
+location_iseq_owner(const rb_callable_method_entry_t *cme)
+{
+    if (cme && cme->def->type == VM_METHOD_TYPE_ISEQ &&
+        cme->called_id != cme->def->original_id) {
+        const rb_cref_t *cref = cme->def->body.iseq.cref;
+        if (cref) return CREF_CLASS(cref);
+    }
+    return cme ? cme->owner : Qnil;
+}
+
+static VALUE
 location_label(rb_backtrace_location_t *loc)
 {
     if (location_cfunc_p(loc)) {
         return rb_gen_method_name(loc->cme->owner, rb_id2str(loc->cme->def->original_id));
     }
     else {
-        VALUE owner = Qnil;
-        if (loc->cme) {
-            owner = loc->cme->owner;
-        }
-        return calculate_iseq_label(owner, loc->iseq);
+        return calculate_iseq_label(location_iseq_owner(loc->cme), loc->iseq);
     }
 }
 /*
@@ -487,9 +494,7 @@ location_to_str(rb_backtrace_location_t *loc)
     else {
         file = rb_iseq_path(loc->iseq);
         lineno = calc_lineno(loc->iseq, loc->pc);
-        if (loc->cme) {
-            owner = loc->cme->owner;
-        }
+        owner = location_iseq_owner(loc->cme);
         name = calculate_iseq_label(owner, loc->iseq);
     }
 


### PR DESCRIPTION
Fixes [[Bug #22197](https://bugs.ruby-lang.org/issues/22197)]

When an alias or `define_method` copies a method, the call entry can have a different owner from the ISEQ that defines the method body. Backtraces then combine the new owner with the original method name and may report methods that do not exist.

Use the ISEQ definition owner only when `called_id` differs from `original_id`. This preserves the existing labels for normal methods and anonymous classes.

Tests:
```sh
# From an out-of-tree build directory created per Building Ruby:
make test-all TESTS="../test/ruby/test_backtrace.rb"
```