### PR TITLE
[Bug #22203] Fix: Coverage (eval: true): branch entries for re-eval'd code are nondeterministically duplicated

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -627,7 +627,7 @@ setup_branch(const rb_code_location_t *loc, const char *type, VALUE structure, V
 }
 
 static VALUE
-decl_branch_base(rb_iseq_t *iseq, VALUE key, const rb_code_location_t *loc, const char *type)
+decl_branch_base(rb_iseq_t *iseq, const rb_code_location_t *loc, const char *type)
 {
     if (!branch_coverage_valid_p(iseq, loc->beg_pos.lineno)) return Qundef;
 
@@ -640,6 +640,12 @@ decl_branch_base(rb_iseq_t *iseq, VALUE key, const rb_code_location_t *loc, cons
      */
 
     VALUE structure = RARRAY_AREF(ISEQ_BRANCH_COVERAGE(iseq), 0);
+    VALUE key = rb_ary_new_from_args(5,
+                                     ID2SYM(rb_intern(type)),
+                                     INT2FIX(loc->beg_pos.lineno),
+                                     INT2FIX(loc->beg_pos.column),
+                                     INT2FIX(loc->end_pos.lineno),
+                                     INT2FIX(loc->end_pos.column));
     VALUE branch_base = rb_hash_aref(structure, key);
     VALUE branches;
 
@@ -7088,7 +7094,7 @@ compile_if(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, int 
     ADD_SEQ(ret, cond_seq);
 
     if (then_label->refcnt && else_label->refcnt) {
-        branches = decl_branch_base(iseq, PTR2NUM(node), nd_code_loc(node), type == NODE_IF ? "if" : "unless");
+        branches = decl_branch_base(iseq, nd_code_loc(node), type == NODE_IF ? "if" : "unless");
     }
 
     if (then_label->refcnt) {
@@ -7168,7 +7174,7 @@ compile_case(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const orig_nod
 
     CHECK(COMPILE(head, "case base", RNODE_CASE(node)->nd_head));
 
-    branches = decl_branch_base(iseq, PTR2NUM(node), nd_code_loc(node), "case");
+    branches = decl_branch_base(iseq, nd_code_loc(node), "case");
 
     node = RNODE_CASE(node)->nd_body;
     EXPECT_NODE("NODE_CASE", node, NODE_WHEN, COMPILE_NG);
@@ -7273,7 +7279,7 @@ compile_case2(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const orig_no
     VALUE branches = Qfalse;
     int branch_id = 0;
 
-    branches = decl_branch_base(iseq, PTR2NUM(orig_node), nd_code_loc(orig_node), "case");
+    branches = decl_branch_base(iseq, nd_code_loc(orig_node), "case");
 
     INIT_ANCHOR(body_seq);
     endlabel = NEW_LABEL(nd_line(node));
@@ -8272,7 +8278,7 @@ compile_case3(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const orig_no
     INIT_ANCHOR(body_seq);
     INIT_ANCHOR(cond_seq);
 
-    branches = decl_branch_base(iseq, PTR2NUM(node), nd_code_loc(node), "case");
+    branches = decl_branch_base(iseq, nd_code_loc(node), "case");
 
     node = RNODE_CASE3(node)->nd_body;
     EXPECT_NODE("NODE_CASE3", node, NODE_IN, COMPILE_NG);
@@ -8476,7 +8482,7 @@ compile_loop(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, in
     if (tmp_label) ADD_LABEL(ret, tmp_label);
 
     ADD_LABEL(ret, redo_label);
-    branches = decl_branch_base(iseq, PTR2NUM(node), nd_code_loc(node), type == NODE_WHILE ? "while" : "until");
+    branches = decl_branch_base(iseq, nd_code_loc(node), type == NODE_WHILE ? "while" : "until");
 
     const NODE *const coverage_node = RNODE_WHILE(node)->nd_body ? RNODE_WHILE(node)->nd_body : node;
     add_trace_branch_coverage(
@@ -9119,7 +9125,7 @@ qcall_branch_start(rb_iseq_t *iseq, LINK_ANCHOR *const recv, VALUE *branches, co
     LABEL *else_label = NEW_LABEL(nd_line(line_node));
     VALUE br = 0;
 
-    br = decl_branch_base(iseq, PTR2NUM(node), nd_code_loc(node), "&.");
+    br = decl_branch_base(iseq, nd_code_loc(node), "&.");
     *branches = br;
     ADD_INSN(recv, line_node, dup);
     ADD_INSNL(recv, line_node, branchnil, else_label);

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -1148,7 +1148,7 @@ pm_compile_conditional(rb_iseq_t *iseq, const pm_node_location_t *node_location,
 
     if (then_label->refcnt && else_label->refcnt && PM_BRANCH_COVERAGE_P(iseq)) {
         conditional_location = pm_code_location(scope_node, node);
-        branches = decl_branch_base(iseq, PTR2NUM(node), &conditional_location, type == PM_IF_NODE ? "if" : "unless");
+        branches = decl_branch_base(iseq, &conditional_location, type == PM_IF_NODE ? "if" : "unless");
     }
 
     if (then_label->refcnt) {
@@ -1278,7 +1278,7 @@ pm_compile_loop(rb_iseq_t *iseq, const pm_node_location_t *node_location, pm_nod
     // Establish branch coverage for the loop.
     if (PM_BRANCH_COVERAGE_P(iseq)) {
         rb_code_location_t loop_location = pm_code_location(scope_node, node);
-        VALUE branches = decl_branch_base(iseq, PTR2NUM(node), &loop_location, type == PM_WHILE_NODE ? "while" : "until");
+        VALUE branches = decl_branch_base(iseq, &loop_location, type == PM_WHILE_NODE ? "while" : "until");
 
         rb_code_location_t branch_location = statements != NULL ? pm_code_location(scope_node, (const pm_node_t *) statements) : loop_location;
         add_trace_branch_coverage(iseq, ret, &branch_location, branch_location.beg_pos.column, 0, "body", branches);
@@ -3789,7 +3789,7 @@ pm_compile_call(rb_iseq_t *iseq, const pm_call_node_t *call_node, LINK_ANCHOR *c
                 .end_pos = { .lineno = end_location.line, .column = end_location.column }
             };
 
-            branches = decl_branch_base(iseq, PTR2NUM(call_node), &code_location, "&.");
+            branches = decl_branch_base(iseq, &code_location, "&.");
         }
 
         PUSH_INSN(ret, location, dup);
@@ -7640,7 +7640,7 @@ pm_compile_case_node(rb_iseq_t *iseq, const pm_case_node_t *cast, const pm_node_
 
         if (PM_BRANCH_COVERAGE_P(iseq)) {
             case_location = pm_code_location(scope_node, (const pm_node_t *) cast);
-            branches = decl_branch_base(iseq, PTR2NUM(cast), &case_location, "case");
+            branches = decl_branch_base(iseq, &case_location, "case");
         }
 
         // Loop through each clauses in the case node and compile each of
@@ -7727,7 +7727,7 @@ pm_compile_case_node(rb_iseq_t *iseq, const pm_case_node_t *cast, const pm_node_
 
         if (PM_BRANCH_COVERAGE_P(iseq)) {
             case_location = pm_code_location(scope_node, (const pm_node_t *) cast);
-            branches = decl_branch_base(iseq, PTR2NUM(cast), &case_location, "case");
+            branches = decl_branch_base(iseq, &case_location, "case");
         }
 
         // This is the label where everything will fall into if none of the
@@ -7899,7 +7899,7 @@ pm_compile_case_match_node(rb_iseq_t *iseq, const pm_case_match_node_t *node, co
 
     if (PM_BRANCH_COVERAGE_P(iseq)) {
         case_location = pm_code_location(scope_node, (const pm_node_t *) node);
-        branches = decl_branch_base(iseq, PTR2NUM(node), &case_location, "case");
+        branches = decl_branch_base(iseq, &case_location, "case");
     }
 
     // If there is only one pattern, then the behavior changes a bit. It

--- a/test/coverage/test_coverage.rb
+++ b/test/coverage/test_coverage.rb
@@ -256,6 +256,23 @@ class TestCoverage < Test::Unit::TestCase
     end;
   end
 
+  def test_eval_branch_coverage
+    assert_in_out_err(ARGV, <<-"end;", ["1", "[1, 1]"], [])
+      Coverage.start(eval: true, branches: true)
+      src = "if $flag\n  :a\nelse\n  :b\nend\n"
+
+      $flag = true
+      eval(src, binding, "fake.rb", 1)
+      GC.start
+      $flag = false
+      eval(src, binding, "fake.rb", 1)
+
+      branches = Coverage.result.fetch("fake.rb")[:branches]
+      p branches.size
+      p branches.values.first.values
+    end;
+  end
+
   def test_eval_negative_lineno
     assert_in_out_err(ARGV, <<-"end;", ["[1, 1, 1]"], [])
       Coverage.start(eval: true, lines: true)


### PR DESCRIPTION
Fixes [Bug #22203](https://bugs.ruby-lang.org/issues/22203)

Branch coverage used AST node addresses as internal hash keys. Each `eval` parses a new AST, so evaluating identical source at the same path could create duplicate branch entries. Whether entries merged depended on GC timing and allocator address reuse.

Use a stable key built from branch type and source location:

```c
[type, first_lineno, first_column, last_lineno, last_column]
```

This lets repeated evaluations of identical source reuse the same branch coverage entry while preserving distinct entries at different locations. The change applies to both parse.y and Prism compilation paths.

## Reproduction

```ruby
require "coverage"

Coverage.start(eval: true, branches: true)
src = "if $flag\n  :a\nelse\n  :b\nend\n"

$flag = true
eval(src, binding, "fake.rb", 1)
GC.start
$flag = false
eval(src, binding, "fake.rb", 1)

p Coverage.result.fetch("fake.rb")[:branches]
```

Before, GC could produce two branch entries with complementary counts.
After, one entry reports both arms as executed.

## Tests

```sh
make -C build-contrib test-all TESTS='../test/coverage/test_coverage.rb'
make -C build-contrib test-all RUN_OPTS='--parser=parse.y' TESTS='../test/coverage/test_coverage.rb'
```
