### PR TITLE
Keep room in the token buffer for the terminator

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -7728,7 +7728,7 @@ tokspace(struct parser_params *p, int n)
     p->tokidx += n;
 
     if (p->tokidx >= p->toksiz) {
-        do {p->toksiz *= 2;} while (p->toksiz < p->tokidx);
+        do {p->toksiz *= 2;} while (p->toksiz <= p->tokidx);
         REALLOC_N(p->tokenbuf, char, p->toksiz);
     }
     return &p->tokenbuf[p->tokidx-n];


### PR DESCRIPTION
tokspace stops doubling as soon as the buffer reaches the token's length, so a copy that lands exactly on the end leaves tokfix writing its terminator one byte past it.  No caller passes a large enough n to reach that today, but the invariant tokfix relies on is worth holding.