### PR TITLE
[Bug #22194] Fix: File.realpath and File.realdirpath handle differently path encoding incompatible with a filesystem's one

### DIFF
--- a/file.c
+++ b/file.c
@@ -5020,12 +5020,10 @@ rb_check_realpath_emulate(VALUE basedir, VALUE path, rb_encoding *origenc, enum 
         return Qnil;
 
     if (origenc && origenc != rb_enc_get(resolved)) {
-        if (rb_enc_str_asciionly_p(resolved)) {
-            rb_enc_associate(resolved, origenc);
-        }
-        else {
+        if (!rb_enc_str_asciionly_p(resolved)) {
             resolved = rb_str_conv_enc(resolved, NULL, origenc);
         }
+        rb_enc_associate(resolved, origenc);
     }
 
     RB_GC_GUARD(unresolved_path);

--- a/test/ruby/test_file.rb
+++ b/test/ruby/test_file.rb
@@ -285,6 +285,24 @@ class TestFile < Test::Unit::TestCase
     }
   end
 
+  def test_realdirpath_encoding
+    fsenc = Encoding.find("filesystem")
+    name = "test_dir_\u{1f98a}".encode(fsenc)
+    origenc = Encoding.find("ISO-8859-1")
+
+    Dir.mktmpdir('rubytest-realdirpath') {|tmpdir|
+      Dir.mkdir(File.join(tmpdir, name))
+      path = ".".encode(origenc)
+      expected = File.realpath(path, File.join(tmpdir, name))
+      actual = File.realdirpath(path, File.join(tmpdir, name))
+
+      assert_equal(expected, actual)
+      assert_equal(origenc, actual.encoding)
+    }
+  rescue Encoding::UndefinedConversionError
+    omit "filesystem encoding cannot represent the test path"
+  end
+
   def test_realpath_special_symlink
     IO.pipe do |r, w|
       if File.pipe?(path = "/dev/fd/#{r.fileno}")


### PR DESCRIPTION
Fixes [Bug #22194](https://bugs.ruby-lang.org/issues/22194)

`File.realpath` and `File.realdirpath` returned different encodings when the input path encoding was incompatible with the filesystem encoding.

`File.realpath` restores the caller's original encoding after resolving the path. The emulated resolver used by `File.realdirpath` converted non-ASCII paths but did not associate the original encoding afterward.

Always associate the resolved path with `origenc`, matching `File.realpath`.

## Reproduction

```ruby
path = ".".encode(Encoding.find("ISO-8859-1"))

File.realpath(path, "test_dir_🦊").encoding
# => #<Encoding:ISO-8859-1>

File.realdirpath(path, "test_dir_🦊").encoding
# Before: #<Encoding:UTF-8>
# After:  #<Encoding:ISO-8859-1>
```

## Tests

```sh
make -C build-contrib test-all TESTS='../test/ruby/test_file.rb'
```