### PR TITLE
[DOC] Only document `.c` in subfolders

### DIFF
--- a/.document
+++ b/.document
@@ -43,10 +43,10 @@ lib
 ext
 
 # GC is split between gc.rb and gc/default/default.c
-gc/default
+gc/default/*.c
 
 # For `prism`, ruby code is in lib and c in the prism folder
-prism
+prism/*.c
 
 # rdoc files
 NEWS.md


### PR DESCRIPTION
`prism` contains `prism/srcs.mk`. RDoc picks it up even though it is not C/Ruby or anything else recognizable.

It currently doesn't apply to `gc/default` but it could in the future, so I made it more specific too.

Removes this:
<img width="1381" height="867" alt="image" src="https://github.com/user-attachments/assets/a05727d6-e87a-45ba-9acc-1dc6bc34e357" />
