### PR TITLE
Remove unreachable require of io/wait in socket.rb

### DIFF
--- a/ext/socket/lib/socket.rb
+++ b/ext/socket/lib/socket.rb
@@ -2,11 +2,6 @@
 
 require 'socket.so'
 
-unless IO.method_defined?(:wait_writable, false)
-  # It's only required on older Rubies < v3.2:
-  require 'io/wait'
-end
-
 class Addrinfo
   # creates an Addrinfo object from the arguments.
   #


### PR DESCRIPTION
`IO#wait_writable` has been defined in core since Ruby 3.2, so the guard in `ext/socket/lib/socket.rb` never fires on the ruby built from this tree and `require 'io/wait'` is unreachable. The guard was kept for older Rubies in #6932, but the in-tree `socket.rb` only runs on the matching ruby. `ext/socket` is not managed by `tool/sync_default_gems.rb`, so removing this does not conflict with any upstream repository.
