### PR TITLE
Promote Ripper DSL array elements to VALUE

### DIFF
--- a/ext/ripper/tools/dsl.rb
+++ b/ext/ripper/tools/dsl.rb
@@ -37,7 +37,8 @@ class DSL
         if empty?
           "rb_ary_new()"
         else
-          "rb_ary_new_from_args(#{size}, #{map(&:to_s).join(', ')})"
+          values = map {|value| "(VALUE)0|(#{value})"}
+          "rb_ary_new_from_args(#{size}, #{values.join(', ')})"
         end
       end
     end

--- a/test/ripper/test_ripper.rb
+++ b/test/ripper/test_ripper.rb
@@ -225,3 +225,12 @@ end
     Ripper::Lexer::State.new(Ripper.const_get(name))
   end
 end if ripper_test
+
+class TestRipper::DSL < Test::Unit::TestCase
+  def test_array_elements_are_values
+    require_relative "../../ext/ripper/tools/dsl"
+
+    code = DSL.line?("/*% ripper: [$:$, 0] %*/").generate
+    assert_include(code, "rb_ary_new_from_args(2, (VALUE)0|(p->s_lvalue), (VALUE)0|(0))")
+  end
+end if ripper_test


### PR DESCRIPTION
Ensure arguments passed through `rb_ary_new_from_args` have type `VALUE`, including when the statement-expression optimization is unavailable.
This avoids undefined behavior in variadic calls.