### PR TITLE
Define Range#begin and Range#end as optimized methods

### DIFF
--- a/internal/struct.h
+++ b/internal/struct.h
@@ -47,6 +47,8 @@ struct RStruct {
 VALUE rb_struct_init_copy(VALUE copy, VALUE s);
 VALUE rb_struct_lookup(VALUE s, VALUE idx);
 VALUE rb_struct_s_keyword_init(VALUE klass);
+void rb_struct_define_aref_method(VALUE nstr, ID name, unsigned int off);
+
 static inline long RSTRUCT_EMBED_LEN(VALUE st);
 static inline long RSTRUCT_LEN_RAW(VALUE st);
 static inline int RSTRUCT_LENINT(VALUE st);

--- a/range.c
+++ b/range.c
@@ -1362,13 +1362,6 @@ range_reverse_each(VALUE range)
  *  Related: Range#first, Range#end.
  */
 
-static VALUE
-range_begin(VALUE range)
-{
-    return RANGE_BEG(range);
-}
-
-
 /*
  *  call-seq:
  *    self.end -> object
@@ -1381,14 +1374,6 @@ range_begin(VALUE range)
  *
  *  Related: Range#begin, Range#last.
  */
-
-
-static VALUE
-range_end(VALUE range)
-{
-    return RANGE_END(range);
-}
-
 
 static VALUE
 first_i(RB_BLOCK_CALL_FUNC_ARGLIST(i, cbarg))
@@ -2980,8 +2965,8 @@ Init_Range(void)
     rb_define_method(rb_cRange, "%", range_percent_step, 1);
     rb_define_method(rb_cRange, "reverse_each", range_reverse_each, 0);
     rb_define_method(rb_cRange, "bsearch", range_bsearch, 0);
-    rb_define_method(rb_cRange, "begin", range_begin, 0);
-    rb_define_method(rb_cRange, "end", range_end, 0);
+    rb_struct_define_aref_method(rb_cRange, id_beg, 0);
+    rb_struct_define_aref_method(rb_cRange, id_end, 1);
     rb_define_method(rb_cRange, "first", range_first, -1);
     rb_define_method(rb_cRange, "last", range_last, -1);
     rb_define_method(rb_cRange, "min", range_min, -1);

--- a/struct.c
+++ b/struct.c
@@ -285,6 +285,12 @@ define_aref_method(VALUE nstr, VALUE name, VALUE off)
     rb_add_method_optimized(nstr, SYM2ID(name), OPTIMIZED_METHOD_TYPE_STRUCT_AREF, FIX2UINT(off), METHOD_VISI_PUBLIC);
 }
 
+void
+rb_struct_define_aref_method(VALUE nstr, ID name, unsigned int off)
+{
+    rb_add_method_optimized(nstr, name, OPTIMIZED_METHOD_TYPE_STRUCT_AREF, off, METHOD_VISI_PUBLIC);
+}
+
 static void
 define_aset_method(VALUE nstr, VALUE name, VALUE off)
 {


### PR DESCRIPTION
Since Range is a struct, might as well use optimized accessors.