### PR TITLE
Crash handler assumes box is present

### DIFF
--- a/box.c
+++ b/box.c
@@ -103,6 +103,7 @@ rb_main_box(void)
     return main_box;
 }
 
+// NOTE: must be called by Ruby thread
 const rb_box_t *
 rb_current_box(void)
 {
@@ -121,6 +122,7 @@ rb_current_box(void)
     return rb_vm_current_box(GET_EC());
 }
 
+// NOTE: must be called by Ruby thread
 const rb_box_t *
 rb_loading_box(void)
 {
@@ -132,6 +134,7 @@ rb_loading_box(void)
     return rb_vm_loading_box(GET_EC());
 }
 
+// NOTE: must be called by Ruby thread
 const rb_box_t *
 rb_current_box_in_crash_report(void)
 {

--- a/vm_dump.c
+++ b/vm_dump.c
@@ -1419,15 +1419,19 @@ rb_vm_bugreport(const void *ctx, FILE *errout)
     enum {other_runtime_info = 0};
 #endif
     const rb_vm_t *const vm = GET_VM();
-    const rb_box_t *current_box = rb_current_box_in_crash_report();
     const rb_execution_context_t *ec = rb_current_execution_context(false);
-    VALUE loaded_features;
+    rb_box_t *current_box = NULL;
+    VALUE loaded_features = 0;
+    if (ec) {
+        current_box = (rb_box_t*)rb_current_box_in_crash_report();
+    }
+    else {
+        current_box = (rb_box_t*)rb_main_box();
+        if (!current_box) current_box = (rb_box_t*)rb_root_box();
+    }
 
     if (current_box) {
         loaded_features = current_box->loaded_features;
-    }
-    else {
-        loaded_features = rb_root_box()->loaded_features;
     }
 
     if (vm && ec) {


### PR DESCRIPTION
rb_current_box_in_crash_report() calls GET_EC(), which assumes ec is present. The crash handler should work when called from non-Ruby threads (no ec).