### PR TITLE
Turn off macos segv handler testing in CI

### DIFF
--- a/test/-ext-/bug_reporter/test_bug_reporter.rb
+++ b/test/-ext-/bug_reporter/test_bug_reporter.rb
@@ -6,6 +6,7 @@ require_relative '../../lib/parser_support'
 
 class TestBugReporter < Test::Unit::TestCase
   def test_bug_reporter_add
+    omit if macos? && ENV["CI"] # we're getting timeouts even after 100s in CI
     description = RUBY_DESCRIPTION
     description = description.sub(/\+PRISM /, '') unless ParserSupport.prism_enabled_in_subprocess?
     expected_stderr = [

--- a/test/ruby/test_rubyoptions.rb
+++ b/test/ruby/test_rubyoptions.rb
@@ -845,6 +845,7 @@ class TestRubyOptions < Test::Unit::TestCase
   end
 
   def assert_segv(args, message=nil, list: SEGVTest::ExpectedStderrList, **opt, &block)
+    omit if macos? && ENV["CI"] # we're getting timeouts even after 100s in CI, not sure why.
     # We want YJIT to be enabled in the subprocess if it's enabled for us
     # so that the Ruby description matches.
     env = Hash === args.first ? args.shift : {}


### PR DESCRIPTION
For whatever reason we're getting timeouts after 100s. Since there is so much async-signal-unsafe code in the crash handler, it could be many things. It's best to turn it off until we can reproduce it locally and fix it (assuming we can).