### PR TITLE
ZJIT (arm64): reserve one branch for in-range patch points

### DIFF
--- a/zjit/src/asm/mod.rs
+++ b/zjit/src/asm/mod.rs
@@ -93,6 +93,11 @@ impl CodeBlock {
         self.mem_block.borrow().mapped_region_size()
     }
 
+    /// Size of the region in bytes where writes could be attempted.
+    pub fn virtual_region_size(&self) -> usize {
+        self.mem_size
+    }
+
     /// Add an assembly comment if the feature is on.
     pub fn add_comment(&mut self, comment: &str) {
         if !self.keep_comments {

--- a/zjit/src/backend/arm64/mod.rs
+++ b/zjit/src/backend/arm64/mod.rs
@@ -51,14 +51,12 @@ impl CodeBlock {
     pub fn jmp_ptr_bytes(&self) -> usize {
         // b instruction's offset is encoded as imm26 times 4. It can jump to
         // +/-128MiB, so this can be used when --zjit-exec-mem-size <= 128.
-        /*
-        let num_insns = if b_offset_fits_bits(self.virtual_region_size() as i64 / 4) {
+        // The widest in-region branch spans the region minus one instruction.
+        let num_insns = if b_offset_fits_bits((self.virtual_region_size() as i64 - 4) / 4) {
             1 // b instruction
         } else {
             5 // 4 instructions to load a 64-bit absolute address + br instruction
         };
-        */
-        let num_insns = 5; // TODO: support virtual_region_size() check
         num_insns * 4
     }
 
@@ -1774,6 +1772,19 @@ mod tests {
     }
 
     #[test]
+    fn test_jmp_ptr_bytes_at_b_range_boundary() {
+        // The widest branch in a 128MiB region spans 128MiB - 4 bytes, which is
+        // still the largest offset a b can encode, so one instruction is enough.
+        let cb = CodeBlock::new_dummy_sized(128 * 1024 * 1024);
+        assert_eq!(4, cb.jmp_ptr_bytes());
+
+        // One instruction further and a b can no longer span the region, so we
+        // have to reserve room for an absolute load-address plus br.
+        let cb = CodeBlock::new_dummy_sized(128 * 1024 * 1024 + 4);
+        assert_eq!(20, cb.jmp_ptr_bytes());
+    }
+
+    #[test]
     fn test_lir_string() {
         use crate::hir::SideExitReason;
 
@@ -2057,12 +2068,8 @@ mod tests {
         assert_disasm_snapshot!(cb.disasm(), @"
         0x0: b.eq #0x50
         0x4: nop
-        0x8: nop
-        0xc: nop
-        0x10: nop
-        0x14: nop
         ");
-        assert_snapshot!(cb.hexdump(), @"800200541f2003d51f2003d51f2003d51f2003d51f2003d5");
+        assert_snapshot!(cb.hexdump(), @"800200541f2003d5");
     }
 
     #[test]
@@ -2078,12 +2085,8 @@ mod tests {
         assert_disasm_snapshot!(cb.disasm(), @"
         0x0: b.ne #8
         0x4: b #0x200000
-        0x8: nop
-        0xc: nop
-        0x10: nop
-        0x14: nop
         ");
-        assert_snapshot!(cb.hexdump(), @"41000054ffff07141f2003d51f2003d51f2003d51f2003d5");
+        assert_snapshot!(cb.hexdump(), @"41000054ffff0714");
     }
 
     #[test]


### PR DESCRIPTION
`jmp_ptr_bytes()` sets how much room to reserve for a patchable jump -- it spaces out patch points (PadPatchPoint) and bounds conditional jump width. It was hardcoded to 5 instructions, an absolute load-address plus br, with the check for the cheap case left commented out.

An arm64 `b` reaches +/-128MiB, so one 4-byte branch suffices whenever the code region fits in that range, and the default `--zjit-exec-mem-size` is 64MiB. emit_jmp_ptr already emitted just a `b` there; only the reservation was oversized, padding out up to 5x more nops than needed. Enable the check, adding the CodeBlock::virtual_region_size() accessor it calls (YJIT has the same one).

The two emit_je snapshots shrink accordingly: same instructions, fewer trailing nops.

On a branch-heavy while loop (five `if`s per iteration), `--zjit-dump-disasm` goes from 312 nops / 968 instructions to 29 / 685, and the loop runs 1.70x faster under benchmark-driver; a 3-way if/elsif loop 1.23x. The win is concentrated in branchy code, which is where the padding was. x86 is unaffected; its 5-byte jmp reservation is already minimal.

Checked with `make zjit-test` (1817 pass), test_zjit_cli.rb (23 pass), and bootstraptest under `--zjit` at call thresholds 1 and 2.

The code in this PR was written with the help of AI coding tools.