### PR TITLE
ZJIT: fix gen_new_hash to use proper shape_id in flags

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -32,6 +32,7 @@
 #include "internal/class.h"
 #include "internal/cont.h"
 #include "internal/error.h"
+#include "internal/gc.h"
 #include "internal/hash.h"
 #include "internal/object.h"
 #include "internal/proc.h"
@@ -44,6 +45,7 @@
 #include "ruby/st.h"
 #include "ruby/util.h"
 #include "ruby_assert.h"
+#include "shape.h"
 #include "symbol.h"
 #include "ruby/thread_native.h"
 #include "ruby/ractor.h"
@@ -1463,9 +1465,14 @@ hash_alloc(VALUE klass)
 
 #if USE_ZJIT
 size_t
-rb_zjit_hash_new_size(void)
+rb_zjit_hash_new_size(VALUE *flags_out)
 {
-    return hash_slot_size(sizeof(st_table) > sizeof(ar_table));
+    size_t size = hash_slot_size(sizeof(st_table) > sizeof(ar_table));
+    // mimic rb_newobj()
+    shape_id_t shape_id = rb_shape_transition_slot_size(ROOT_SHAPE_ID | SHAPE_ID_LAYOUT_OTHER,
+                                                        rb_gc_size_slot_size(size));
+    *flags_out = T_HASH | ((VALUE)shape_id << SHAPE_FLAG_SHIFT);
+    return size;
 }
 #endif
 

--- a/zjit.h
+++ b/zjit.h
@@ -93,7 +93,7 @@ void rb_zjit_invalidate_root_box(void);
 void rb_zjit_jit_frame_update_references(zjit_jit_frame_t *jit_frame);
 void rb_zjit_materialize_frames(const rb_execution_context_t *ec, rb_control_frame_t *cfp);
 void rb_zjit_materialize_frames_for_longjmp(const rb_execution_context_t *ec, rb_control_frame_t *cfp);
-size_t rb_zjit_hash_new_size(void);
+size_t rb_zjit_hash_new_size(VALUE *flags_out);
 bool rb_zjit_class_allocate_instance_fastpath(VALUE klass, size_t *size_out, shape_id_t *shape_id_out);
 bool rb_zjit_str_resurrect_fastpath(VALUE str, bool chilled, size_t *size_out, VALUE *flags_out, long *len_out, size_t *byte_size_out);
 bool rb_zjit_array_dup_can_fastpath(VALUE ary, size_t *alloc_size_out, VALUE *flags_out, long *len_out);

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -2475,11 +2475,11 @@ fn gen_new_hash(
     if elements.is_empty() {
         gen_prepare_leaf_call_with_gc(asm, state);
 
-        let alloc_size = unsafe { rb_zjit_hash_new_size() };
-        let flags = RUBY_T_HASH as u64;
+        let mut flags = VALUE(0);
+        let alloc_size = unsafe { rb_zjit_hash_new_size(&mut flags) };
         let klass = unsafe { rb_cHash };
 
-        gc_fastpath::gc_fastpath_new_obj(jit, asm, alloc_size, flags, klass,
+        gc_fastpath::gc_fastpath_new_obj(jit, asm, alloc_size, flags.into(), klass,
             |asm, hash| {
                 asm.store(Opnd::mem(VALUE_BITS, hash, RUBY_OFFSET_RHASH_IFNONE), Qnil.into());
             },
@@ -2494,11 +2494,11 @@ fn gen_new_hash(
 
         let num_pairs = elements.len() / 2;
         let hash = if num_pairs <= RUBY_RHASH_AR_TABLE_MAX_SIZE as usize {
-            let alloc_size = unsafe { rb_zjit_hash_new_size() };
-            let flags = RUBY_T_HASH as u64;
+            let mut flags = VALUE(0);
+            let alloc_size = unsafe { rb_zjit_hash_new_size(&mut flags) };
             let klass = unsafe { rb_cHash };
 
-            gc_fastpath::gc_fastpath_new_obj(jit, asm, alloc_size, flags, klass,
+            gc_fastpath::gc_fastpath_new_obj(jit, asm, alloc_size, flags.into(), klass,
                 |asm, hash| {
                     asm.store(Opnd::mem(VALUE_BITS, hash, RUBY_OFFSET_RHASH_IFNONE), Qnil.into());
                 },

--- a/zjit/src/codegen_tests.rs
+++ b/zjit/src/codegen_tests.rs
@@ -3351,6 +3351,34 @@ fn test_new_hash_dynamic_sym_keys_gc_stress() {
     "#), @r#"[Hash, 2, [3], [3]]"#);
 }
 
+// The NewHash inline-alloc fast path must bake the slot-size shape_id into the
+// object flags. Without it, a cross-ractor move sizes the destination object
+// from a zero shape_id, so the moved hash is allocated too small and its keys
+// are corrupted.
+#[test]
+fn test_new_hash_sym_keys_ractor_move() {
+    eval("
+        def create_hash
+          { an_object: Array.new, hi: true, bonjour: true }
+        end
+    ");
+    assert_contains_opcode("create_hash", YARVINSN_newhash);
+    assert_snapshot!(inspect("
+        r = Ractor.new do
+          h = receive
+          30.times { |i| h[i] = true }
+          h.keys.delete_if { |k| Integer === k }
+        end
+
+        create_hash
+        create_hash
+
+        h = create_hash
+        r.send(h, move: true)
+        r.value
+    "), @"[:an_object, :hi, :bonjour]");
+}
+
 #[test]
 fn test_object_alloc_gc_stress() {
     eval("

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -2272,7 +2272,7 @@ unsafe extern "C" {
     pub fn rb_iseq_label(iseq: *const rb_iseq_t) -> VALUE;
     pub fn rb_iseq_defined_string(type_: defined_type) -> VALUE;
     pub fn rb_zjit_profile_enable(iseq: *const rb_iseq_t);
-    pub fn rb_zjit_hash_new_size() -> usize;
+    pub fn rb_zjit_hash_new_size(flags_out: *mut VALUE) -> usize;
     pub fn rb_zjit_class_allocate_instance_fastpath(
         klass: VALUE,
         size_out: *mut usize,


### PR DESCRIPTION
If the shape capacity isn't set on an object, one thing that fails is moving it across Ractors. The new object created in the dst Ractor needs to be big enough to embed the contents if the src was embedded.