### PR TITLE
Implement GC fast path for new_range_fixnum

### DIFF
--- a/range.c
+++ b/range.c
@@ -21,12 +21,15 @@
 #include "id.h"
 #include "internal.h"
 #include "internal/array.h"
+#include "internal/class.h"
 #include "internal/compar.h"
 #include "internal/enum.h"
 #include "internal/enumerator.h"
 #include "internal/error.h"
 #include "internal/numeric.h"
 #include "internal/range.h"
+#include "shape.h"
+#include "zjit.h"
 
 VALUE rb_cRange;
 static ID id_beg, id_end, id_excl;
@@ -77,6 +80,28 @@ rb_range_new(VALUE beg, VALUE end, int exclude_end)
     range_init(range, beg, end, RBOOL(exclude_end));
     return range;
 }
+
+#if USE_ZJIT
+void
+rb_zjit_range_new_fastpath(bool exclude_end, size_t *alloc_size_out, VALUE *flags_out)
+{
+    const long len = 2;
+    size_t size = offsetof(struct RStruct, as.ary) + (sizeof(VALUE) * len);
+    if (RCLASS_MAX_IV_COUNT(rb_cRange) > 0) {
+        size += sizeof(VALUE);
+    }
+
+    VALUE flags = T_STRUCT | (len << RSTRUCT_EMBED_LEN_SHIFT) | RANGE_FL_INIT | FL_FREEZE;
+    if (exclude_end) flags |= RANGE_FL_EXCL;
+
+    shape_id_t shape_id = rb_shape_transition_slot_size(ROOT_SHAPE_ID | SHAPE_ID_LAYOUT_EXTENDED,
+                                                         rb_gc_size_slot_size(size));
+    shape_id = rb_shape_transition_frozen(shape_id);
+
+    *alloc_size_out = size;
+    *flags_out = flags | ((VALUE)shape_id << SHAPE_FLAG_SHIFT);
+}
+#endif
 
 static void
 range_modify(VALUE range)

--- a/zjit.h
+++ b/zjit.h
@@ -97,6 +97,7 @@ size_t rb_zjit_hash_new_size(void);
 bool rb_zjit_class_allocate_instance_fastpath(VALUE klass, size_t *size_out, shape_id_t *shape_id_out);
 bool rb_zjit_str_resurrect_fastpath(VALUE str, bool chilled, size_t *size_out, VALUE *flags_out, long *len_out, size_t *byte_size_out);
 bool rb_zjit_array_dup_can_fastpath(VALUE ary, size_t *alloc_size_out, VALUE *flags_out, long *len_out);
+void rb_zjit_range_new_fastpath(bool exclude_end, size_t *alloc_size_out, VALUE *flags_out);
 
 // Special value for cfp->jit_return that means "this is a C method frame, use
 // rb_zjit_c_frame as the JITFrame". We don't control the native stack layout

--- a/zjit/bindgen/src/main.rs
+++ b/zjit/bindgen/src/main.rs
@@ -116,6 +116,7 @@ fn main() {
         .allowlist_function("rb_zjit_class_allocate_instance_fastpath")
         .allowlist_function("rb_zjit_str_resurrect_fastpath")
         .allowlist_function("rb_zjit_array_dup_can_fastpath")
+        .allowlist_function("rb_zjit_range_new_fastpath")
 
         // For crashing
         .allowlist_function("rb_bug")

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -621,7 +621,7 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
             gen_new_hash(jit, asm, function, opnds!(elements), sym_keys, &function.frame_state(*state))
         }
         Insn::NewRange { low, high, flag, state } => gen_new_range(jit, asm, function, opnd!(low), opnd!(high), *flag, &function.frame_state(*state)),
-        Insn::NewRangeFixnum { low, high, flag, state } => gen_new_range_fixnum(asm, opnd!(low), opnd!(high), *flag, &function.frame_state(*state)),
+        Insn::NewRangeFixnum { low, high, flag, state } => gen_new_range_fixnum(jit, asm, opnd!(low), opnd!(high), *flag, &function.frame_state(*state)),
         Insn::ArrayDup { val, state } => gen_array_dup(jit, asm, function, *val, opnd!(val), &function.frame_state(*state)),
         Insn::AdjustBounds { index, length } => gen_adjust_bounds(asm, opnd!(index), opnd!(length)),
         Insn::ArrayAref { array, index, .. } => gen_array_aref(asm, opnd!(array), opnd!(index)),
@@ -2535,14 +2535,32 @@ fn gen_new_range(
 }
 
 fn gen_new_range_fixnum(
+    jit: &mut JITState,
     asm: &mut Assembler,
     low: lir::Opnd,
     high: lir::Opnd,
     flag: RangeType,
     state: &FrameState,
 ) -> lir::Opnd {
-    gen_prepare_leaf_call_with_gc(asm, state);
-    asm_ccall!(asm, rb_range_new, low, high, (flag as i64).into())
+    let mut alloc_size = 0;
+    let mut flags = VALUE(0);
+    let exclude_end = matches!(flag, RangeType::Exclusive);
+    unsafe {
+        rb_zjit_range_new_fastpath(exclude_end, &mut alloc_size, &mut flags)
+    };
+
+    let klass = unsafe { rb_cRange };
+    gc_fastpath::gc_fastpath_new_obj(jit, asm, alloc_size, flags.as_u64(), klass,
+        &|asm, range| {
+            asm.store(Opnd::mem(VALUE_BITS, range, RUBY_OFFSET_RSTRUCT_FIELDS_OBJ), Opnd::UImm(0));
+            asm.store(Opnd::mem(VALUE_BITS, range, RUBY_OFFSET_RSTRUCT_AS_ARY), low);
+            asm.store(Opnd::mem(VALUE_BITS, range, RUBY_OFFSET_RSTRUCT_AS_ARY + SIZEOF_VALUE_I32), high);
+        },
+        |asm| {
+            gen_prepare_leaf_call_with_gc(asm, state);
+
+            asm_ccall!(asm, rb_range_new, low, high, (flag as i64).into())
+        })
 }
 
 fn gen_object_alloc(jit: &JITState, asm: &mut Assembler, function: &Function, val: lir::Opnd, state: &FrameState) -> lir::Opnd {

--- a/zjit/src/cruby.rs
+++ b/zjit/src/cruby.rs
@@ -1213,6 +1213,7 @@ mod manual_defs {
     pub const RUBY_OFFSET_RARRAY_AS_ARY: i32 = 16; // struct RArray, subfield "as.ary"
 
     pub const RUBY_OFFSET_RSTRUCT_AS_HEAP_PTR: i32 = 32; // struct RStruct, subfield "as.heap.ptr"
+    pub const RUBY_OFFSET_RSTRUCT_FIELDS_OBJ: i32 = 16; // struct RStruct, field "fields_obj"
     pub const RUBY_OFFSET_RSTRUCT_AS_ARY: i32 = 24; // struct RStruct, subfield "as.ary"
 
     pub const RUBY_OFFSET_RSTRING_AS_HEAP_PTR: i32 = 24; // struct RString, subfield "as.heap.ptr"

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -2292,6 +2292,11 @@ unsafe extern "C" {
         flags_out: *mut VALUE,
         len_out: *mut ::std::os::raw::c_long,
     ) -> bool;
+    pub fn rb_zjit_range_new_fastpath(
+        exclude_end: bool,
+        alloc_size_out: *mut usize,
+        flags_out: *mut VALUE,
+    );
     pub fn rb_profile_frames(
         start: ::std::os::raw::c_int,
         limit: ::std::os::raw::c_int,


### PR DESCRIPTION
Benchmark:

```ruby
i = 0
def run(max)
  i = 0
  while i < max
    a = i..100
    i += 1
  end
end

30.times { run(2) }
run(10_000_000)
```

Result:

    Benchmark 1: master
      Time (mean ± σ):     229.8 ms ±   3.2 ms    [User: 221.7 ms, System: 6.2 ms]
      Range (min … max):   226.3 ms … 235.2 ms    12 runs

    Benchmark 2: branch
      Time (mean ± σ):      67.4 ms ±   2.0 ms    [User: 60.4 ms, System: 5.3 ms]
      Range (min … max):    65.1 ms …  75.1 ms    43 runs

    Summary
      branch ran
        3.41 ± 0.11 times faster than master