### PR TITLE
Remove dead test unit worker helper

### DIFF
--- a/tool/lib/test/unit.rb
+++ b/tool/lib/test/unit.rb
@@ -517,11 +517,6 @@ module Test
         worker
       end
 
-      def delete_worker(worker)
-        @workers_hash.delete worker.io
-        @workers.delete worker
-        @ios.delete worker.io
-      end
 
       def quit_workers(&cond)
         return if @workers.empty?


### PR DESCRIPTION
`Test::Unit::Parallel#delete_worker` has no callers.

The helper was extracted in 4bbb49b8. Its only call was removed by the immediately following cbbe2cbc refactor, which moved worker removal inline, leaving the helper unused ever since.

This removes the unreachable private method.

Verification: `make test-tool TESTS=testunit/test_parallel.rb` — 13 tests, 85 assertions, 0 failures.