### PR TITLE
Remove dead RubyGems Cargo target helpers

### DIFF
--- a/lib/rubygems/ext/cargo_builder.rb
+++ b/lib/rubygems/ext/cargo_builder.rb
@@ -269,9 +269,6 @@ EOF
     LinkFlagConverter.convert(arg)
   end
 
-  def msvc_target?
-    makefile_config("target_os").include?("msvc")
-  end
 
   def darwin_target?
     makefile_config("target_os").include?("darwin")
@@ -281,10 +278,6 @@ EOF
     makefile_config("target_os").include?("mingw")
   end
 
-  def win_target?
-    target_platform = RbConfig::CONFIG["target_os"]
-    !!Gem::WIN_PATTERNS.find {|r| target_platform =~ r }
-  end
 
   # Interpolate substitution vars in the arg (i.e. $(DEFFILE))
   def maybe_resolve_ldflag_variable(input_arg, dest_dir, crate_name)


### PR DESCRIPTION
msvc_target? lost its last caller in 12a5fa40 when link-flag handling moved to LinkFlagConverter. win_target? lost its last caller in 5c018cdd when SOEXT lookup moved to RbConfig.