### PR TITLE
Remove dead SyntaxSuggest context helper

### DIFF
--- a/lib/syntax_suggest/display_invalid_blocks.rb
+++ b/lib/syntax_suggest/display_invalid_blocks.rb
@@ -67,17 +67,5 @@ module SyntaxSuggest
       @io.puts(document)
     end
 
-    private def code_with_context
-      lines = CaptureCodeContext.new(
-        blocks: @blocks,
-        code_lines: @code_lines
-      ).call
-
-      DisplayCodeWithLineNumbers.new(
-        lines: lines,
-        terminal: @terminal,
-        highlight_lines: @invalid_lines
-      ).call
-    end
   end
 end


### PR DESCRIPTION
code_with_context has had no caller since it was introduced in 490af8db. display_block builds and renders the context directly.