### PR TITLE
Remove unused CEscape gensym helper

### DIFF
--- a/tool/ruby_vm/helpers/c_escape.rb
+++ b/tool/ruby_vm/helpers/c_escape.rb
@@ -9,8 +9,6 @@
 # conditions  mentioned in  the file  COPYING are  met.  Consult  the file  for
 # details.
 
-require 'securerandom'
-
 module RubyVM::CEscape
   module_function
 
@@ -20,11 +18,6 @@ module RubyVM::CEscape
       raise Encoding::CompatibilityError, "must be ASCII-compatible (#{str.encoding})"
     end
     return "/* #{str.gsub('*/', '*\\/').gsub('/*', '/\\*')} */"
-  end
-
-  # Mimic gensym of CL.
-  def gensym prefix = 'gensym_'
-    return as_tr_cpp "#{prefix}#{SecureRandom.uuid}"
   end
 
   # Mimic AS_TR_CPP() of autoconf.


### PR DESCRIPTION
`RubyVM::CEscape.gensym` has no callers.

The helper was copied into the rewritten VM generator helpers in f6ea3763 but no generated-code path has called it since. Removing it also removes the file's now-unused `securerandom` dependency.

Verification:
- Loaded CEscape and exercised `commentify`, `as_tr_cpp`, and `rstring2cstr` without loading `SecureRandom`.
- Generated `vm.inc` successfully through `tool/insns2vm.rb`.