### PR TITLE
Add #syntax_tree to Proc, Method, UnboundMethod, and Thread::Backtrace::Location [Feature #21795]

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -313,6 +313,18 @@ node_id_for_backtrace_location(rb_execution_context_t *ec, VALUE module, VALUE l
 }
 
 static VALUE
+iseq_of_backtrace_location(rb_execution_context_t *ec, VALUE module, VALUE location)
+{
+    if (!rb_frame_info_p(location)) {
+        rb_raise(rb_eTypeError, "Thread::Backtrace::Location object expected");
+    }
+
+    const rb_iseq_t *iseq = rb_get_iseq_from_frame_info(location);
+    if (!iseq) return Qnil;
+    return rb_iseqw_new(iseq);
+}
+
+static VALUE
 ast_s_of(rb_execution_context_t *ec, VALUE module, VALUE body, VALUE keep_script_lines, VALUE error_tolerant, VALUE keep_tokens)
 {
     VALUE node, lines = Qnil;

--- a/ast.c
+++ b/ast.c
@@ -259,7 +259,41 @@ rb_ast_node_source_location(VALUE source, VALUE path, int first_lineno,
     return true;
 }
 
+static VALUE
+ast_node_find(rb_execution_context_t *ec, VALUE self, VALUE root, VALUE node_id)
+{
+    return node_find(root, NUM2INT(node_id));
+}
+
+static VALUE
+ast_node_source_hash(rb_execution_context_t *ec, VALUE self, VALUE node)
+{
+    struct ASTNodeData *data;
+    TypedData_Get_Struct(node, struct ASTNodeData, &rb_node_type, data);
+
+    rb_ast_t *ast = rb_ruby_ast_data_get(data->ast_value);
+    if (!ast->body.has_source_hash) return Qnil;
+    return ULL2NUM(ast->body.source_hash);
+}
+
 extern VALUE rb_e_script;
+
+static VALUE
+iseq_compiled_by_prism_p(rb_execution_context_t *ec, VALUE self)
+{
+    return RBOOL(ISEQ_BODY(rb_iseqw_to_iseq(self))->prism);
+}
+
+static VALUE
+source_hash_of(rb_execution_context_t *ec, VALUE self, VALUE str)
+{
+    StringValue(str);
+
+    rb_source_hash_state_t state;
+    rb_source_hash_init(&state);
+    rb_source_hash_update(&state, (const uint8_t *)RSTRING_PTR(str), (size_t)RSTRING_LEN(str));
+    return ULL2NUM(rb_source_hash_finalize(&state));
+}
 
 static VALUE
 node_id_for_backtrace_location(rb_execution_context_t *ec, VALUE module, VALUE location)

--- a/ast.rb
+++ b/ast.rb
@@ -332,3 +332,143 @@ module RubyVM::AbstractSyntaxTree
     end
   end
 end
+
+class RubyVM::InstructionSequence
+  #  call-seq:
+  #     iseq.syntax_tree -> Prism::Node | RubyVM::AbstractSyntaxTree::Node | nil
+  #
+  #  Returns the AST node that this instruction sequence was compiled from,
+  #  by re-parsing the source with the same parser that compiled it: a
+  #  Prism::Node if it was compiled by prism, or a
+  #  RubyVM::AbstractSyntaxTree::Node if it was compiled by parse.y.
+  #
+  #  Returns +nil+ whenever the node cannot be retrieved reliably. For
+  #  example: the source is not available (such as eval'ed code without
+  #  RubyVM.keep_script_lines enabled), or the source file has been modified
+  #  since it was compiled.
+  #
+  #  When a prism gem other than the default gem is loaded, a warning is
+  #  emitted in verbose mode. In that case, the loaded prism may parse the
+  #  source differently from the parser that compiled the instruction
+  #  sequence, and the returned node may not correspond to the code that
+  #  was actually executed.
+  #
+  #  This method is experimental and might change without notice.
+  def syntax_tree
+    source_hash = self.source_hash
+    return nil unless source_hash
+
+    # When the source is kept in memory (RubyVM.keep_script_lines), use it
+    # instead of the file. This also works for eval'ed code.
+    if (lines = script_lines)
+      source = lines.join
+    else
+      path = absolute_path
+      return nil unless path && File.file?(path)
+    end
+
+    node_id = self.node_id
+    if Primitive.iseq_compiled_by_prism_p
+      require "prism"
+
+      # Only the default gem prism is the same parser as the one built into
+      # the interpreter. Another prism gem is still likely to parse the
+      # source in the same way, so continue with a warning.
+      if $VERBOSE && (spec = defined?(Gem) && Gem.loaded_specs["prism"]) && !spec.default_gem?
+        warn "syntax_tree: a prism gem other than the default gem is loaded; " \
+             "the result may not correspond exactly to the compiled code"
+      end
+
+      begin
+        result = source ? Prism.parse(source, version: "current") : Prism.parse_file(path, version: "current")
+      rescue ArgumentError
+        # The loaded prism does not know the grammar of the running Ruby.
+        return nil
+      end
+      return nil unless result.success?
+
+      # Hash exactly the bytes that prism parsed. The data section after an
+      # __END__ marker is not part of the code, so the hash covers the source
+      # only up to the end of the __END__ line.
+      code = result.source.source
+      if (data_loc = result.data_loc) && (eol = code.byteindex("\n", data_loc.start_offset))
+        code = code.byteslice(0, eol + 1)
+      end
+      return nil unless Primitive.source_hash_of(code) == source_hash
+
+      root = result.value
+    else
+      begin
+        root = source ? RubyVM::AbstractSyntaxTree.parse(source, keep_script_lines: true) :
+                        RubyVM::AbstractSyntaxTree.parse_file(path, keep_script_lines: true)
+      rescue SyntaxError
+        # The source has been modified into invalid Ruby.
+        return nil
+      end
+      return nil unless Primitive.ast_node_source_hash(root) == source_hash
+
+      return Primitive.ast_node_find(root, node_id)
+    end
+
+    return root if root.node_id == node_id
+
+    queue = [root]
+    while (node = queue.shift)
+      node.compact_child_nodes.each do |child|
+        if child.node_id == node_id
+          # A block iseq refers to the block node itself. Return the outer
+          # node that owns the block (a CallNode, SuperNode, or
+          # ForwardingSuperNode) instead.
+          return child.type == :block_node ? node : child
+        end
+        queue << child
+      end
+    end
+
+    nil
+  end
+end
+
+class Proc
+  #  call-seq:
+  #     prc.syntax_tree -> Prism::Node | RubyVM::AbstractSyntaxTree::Node | nil
+  #
+  #  Returns the AST node that this proc was compiled from. See
+  #  RubyVM::InstructionSequence#syntax_tree for details and for when +nil+
+  #  is returned.
+  #
+  #  This method is experimental and might change without notice.
+  def syntax_tree
+    RubyVM::InstructionSequence.of(self)&.syntax_tree
+  end
+end
+
+class Method
+  #  call-seq:
+  #     meth.syntax_tree -> Prism::Node | RubyVM::AbstractSyntaxTree::Node | nil
+  #
+  #  Returns the AST node that this method was compiled from. Returns
+  #  +nil+ for methods not written in Ruby. See
+  #  RubyVM::InstructionSequence#syntax_tree for other cases where +nil+ is
+  #  returned.
+  #
+  #  This method is experimental and might change without notice.
+  def syntax_tree
+    RubyVM::InstructionSequence.of(self)&.syntax_tree
+  end
+end
+
+class UnboundMethod
+  #  call-seq:
+  #     meth.syntax_tree -> Prism::Node | RubyVM::AbstractSyntaxTree::Node | nil
+  #
+  #  Returns the AST node that this method was compiled from. Returns
+  #  +nil+ for methods not written in Ruby. See
+  #  RubyVM::InstructionSequence#syntax_tree for other cases where +nil+ is
+  #  returned.
+  #
+  #  This method is experimental and might change without notice.
+  def syntax_tree
+    RubyVM::InstructionSequence.of(self)&.syntax_tree
+  end
+end

--- a/ast.rb
+++ b/ast.rb
@@ -472,3 +472,39 @@ class UnboundMethod
     RubyVM::InstructionSequence.of(self)&.syntax_tree
   end
 end
+
+class Thread::Backtrace::Location
+  #  call-seq:
+  #     location.syntax_tree -> Prism::Node | RubyVM::AbstractSyntaxTree::Node | nil
+  #
+  #  Returns the AST node at this location, by re-parsing the source file. See
+  #  RubyVM::InstructionSequence#syntax_tree for when +nil+ is returned.
+  #
+  #  This method is experimental and might change without notice.
+  def syntax_tree
+    iseq = Primitive.iseq_of_backtrace_location(self)
+    return nil unless iseq
+
+    node_id = Primitive.node_id_for_backtrace_location(self)
+    return nil unless node_id
+
+    scope = iseq.syntax_tree
+    return nil unless scope
+
+    if scope.is_a?(RubyVM::AbstractSyntaxTree::Node)
+      return Primitive.ast_node_find(scope, node_id)
+    end
+
+    return scope if scope.node_id == node_id
+
+    queue = [scope]
+    while (node = queue.shift)
+      node.compact_child_nodes.each do |child|
+        return child if child.node_id == node_id
+        queue << child
+      end
+    end
+
+    nil
+  end
+end

--- a/iseq.c
+++ b/iseq.c
@@ -4599,6 +4599,24 @@ iseqw_script_lines(VALUE self)
     return ISEQ_BODY(iseq)->variable.script_lines;
 }
 
+/* Returns the hash of the source this iseq was compiled from, or nil if it
+ * is unavailable. */
+static VALUE
+iseqw_source_hash(VALUE self)
+{
+    const rb_iseq_t *iseq = iseqw_check(self);
+    if (!ISEQ_BODY(iseq)->has_source_hash) return Qnil;
+    return ULL2NUM(ISEQ_BODY(iseq)->source_hash);
+}
+
+/* Returns the node id of the AST node this iseq corresponds to. */
+static VALUE
+iseqw_node_id(VALUE self)
+{
+    const rb_iseq_t *iseq = iseqw_check(self);
+    return INT2NUM(ISEQ_BODY(iseq)->location.node_id);
+}
+
 /*
  *  Document-class: RubyVM::InstructionSequence
  *
@@ -4670,6 +4688,8 @@ Init_ISeq(void)
 
     // script lines
     rb_define_method(rb_cISeq, "script_lines", iseqw_script_lines, 0);
+    rb_define_method(rb_cISeq, "source_hash", iseqw_source_hash, 0);
+    rb_define_method(rb_cISeq, "node_id", iseqw_node_id, 0);
 
     rb_undef_method(CLASS_OF(rb_cISeq), "translate");
     rb_undef_method(CLASS_OF(rb_cISeq), "load_iseq");

--- a/test/ruby/test_proc_syntax_tree.rb
+++ b/test/ruby/test_proc_syntax_tree.rb
@@ -97,6 +97,19 @@ class TestProcSyntaxTree < Test::Unit::TestCase
     assert_equal iseq.source_hash, iseq.to_a[4][:source_hash]
   end
 
+  def test_backtrace_location_syntax_tree
+    with_loaded_file("def proc_ast_test_loc = caller_locations(0, 1).first\n") do
+      node = proc_ast_test_loc.syntax_tree
+      if PRISM
+        assert_equal :call_node, node.type
+        assert_equal "caller_locations(0, 1)", node.slice
+      else
+        assert_equal :FCALL, node.type
+      end
+    ensure
+      Object.remove_method(:proc_ast_test_loc)
+    end
+  end
 
   def test_parse_y_syntax_tree
     assert_separately(%w[--parser=parse.y], "#{<<~"begin;"}\n#{<<~'end;'}")

--- a/test/ruby/test_proc_syntax_tree.rb
+++ b/test/ruby/test_proc_syntax_tree.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+require "test/unit"
+require "tmpdir"
+
+class TestProcSyntaxTree < Test::Unit::TestCase
+  PRISM = RubyVM::InstructionSequence.compile("").to_a[4][:parser] == :prism
+
+  def with_loaded_file(source)
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, "target.rb")
+      File.write(path, source)
+      load path
+      yield path
+    end
+  end
+
+  def test_method_ast
+    with_loaded_file("def proc_ast_test_method = :ok\n") do
+      node = method(:proc_ast_test_method).syntax_tree
+      if PRISM
+        assert_equal :def_node, node.type
+        assert_equal "def proc_ast_test_method = :ok", node.slice
+      else
+        assert_equal :DEFN, node.type
+      end
+    ensure
+      Object.remove_method(:proc_ast_test_method)
+    end
+  end
+
+  def test_proc_ast
+    with_loaded_file("PROC_AST_TEST_PROC = proc { :ok }\n") do
+      node = PROC_AST_TEST_PROC.syntax_tree
+      if PRISM
+        assert_equal :call_node, node.type
+        assert_equal "proc { :ok }", node.slice
+      else
+        assert_equal :ITER, node.type
+      end
+    ensure
+      Object.send(:remove_const, :PROC_AST_TEST_PROC)
+    end
+  end
+
+  def test_returns_nil_when_source_is_modified
+    with_loaded_file("def proc_ast_test_modified = :ok\n") do |path|
+      File.write(path, "def proc_ast_test_modified = :changed\n")
+      assert_nil method(:proc_ast_test_modified).syntax_tree
+
+      File.write(path, "def proc_ast_test_modified = (\n")
+      assert_nil method(:proc_ast_test_modified).syntax_tree
+    ensure
+      Object.remove_method(:proc_ast_test_modified)
+    end
+  end
+
+  def test_ignores_the_data_section
+    with_loaded_file("def proc_ast_test_data = :ok\n__END__\noriginal\n") do |path|
+      File.write(path, "def proc_ast_test_data = :ok\n__END__\nchanged\n")
+      refute_nil method(:proc_ast_test_data).syntax_tree
+    ensure
+      Object.remove_method(:proc_ast_test_data)
+    end
+  end
+
+  def test_eval_with_keep_script_lines
+    assert_separately([], "#{<<~"begin;"}\n#{<<~'end;'}")
+    begin;
+      RubyVM.keep_script_lines = true
+      eval("def proc_ast_test_eval_ksl = :ok\nPROC_AST_TEST_KSL = proc { :ok }\n", binding, "(eval-ksl)", 1)
+
+      refute_nil method(:proc_ast_test_eval_ksl).syntax_tree
+      refute_nil PROC_AST_TEST_KSL.syntax_tree
+    end;
+  end
+
+  def test_returns_nil_for_eval
+    assert_nil eval("proc { :ok }").syntax_tree
+  end
+
+  def test_returns_nil_for_c_method
+    assert_nil method(:puts).syntax_tree
+  end
+
+  def test_source_hash_survives_binary_round_trip
+    with_loaded_file("def proc_ast_test_binary = :ok\n") do |path|
+      iseq = RubyVM::InstructionSequence.compile_file(path)
+      loaded = RubyVM::InstructionSequence.load_from_binary(iseq.to_binary)
+
+      assert_equal iseq.source_hash, loaded.source_hash
+      assert_equal (PRISM ? :program_node : :SCOPE), loaded.syntax_tree.type
+    end
+  end
+
+  def test_source_hash_in_to_a
+    iseq = RubyVM::InstructionSequence.compile("x = 1")
+    assert_equal iseq.source_hash, iseq.to_a[4][:source_hash]
+  end
+
+
+  def test_parse_y_syntax_tree
+    assert_separately(%w[--parser=parse.y], "#{<<~"begin;"}\n#{<<~'end;'}")
+    begin;
+      require "tmpdir"
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "target.rb")
+        File.write(path, "def proc_ast_test_parse_y = :ok\n")
+        load path
+
+        node = method(:proc_ast_test_parse_y).syntax_tree
+        assert_equal RubyVM::AbstractSyntaxTree::Node, node.class
+        assert_equal :DEFN, node.type
+
+        File.write(path, "def proc_ast_test_parse_y = :changed\n")
+        assert_nil method(:proc_ast_test_parse_y).syntax_tree
+
+        File.write(path, "def proc_ast_test_parse_y = (\n")
+        assert_nil method(:proc_ast_test_parse_y).syntax_tree
+      end
+    end;
+  end
+end


### PR DESCRIPTION
An experimental implementation of [Feature #21795].

`#syntax_tree` returns the AST node that a proc or method was compiled from, by re-parsing the source with the same parser that compiled it: a Prism node for prism, or a RubyVM::AbstractSyntaxTree::Node for `--parser=parse.y`.

* A source hash is stored in each ISeq at parse time and validated when re-parsing, so nil is returned if the source file has been modified. The hash is also wanted for [Bug #22203].
* Only the default prism gem is the same parser as the built-in one; when another prism gem is loaded, a warning is emitted in verbose mode.
* For a proc defined by a block, the outer node that owns the block (e.g. CallNode) is returned rather than the block node itself.