### PR TITLE
Right size temporary dump objects

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -1118,18 +1118,17 @@ robject_embedded_size(uint32_t fields_count)
 }
 
 VALUE
-rb_class_allocate_instance(VALUE klass)
+rb_class_allocate_instance_capa(VALUE klass, attr_index_t max_iv_count)
 {
-    uint32_t index_tbl_num_entries = RCLASS_MAX_IV_COUNT(klass);
     VALUE obj;
 
     // Directly start as COMPLEX if we know we're over the limit.
     RUBY_ASSERT(rb_shape_max_capacity() > 0);
-    if (RB_UNLIKELY(index_tbl_num_entries > rb_shape_max_capacity())) {
-        obj = class_allocate_complex_instance(klass, index_tbl_num_entries);
+    if (RB_UNLIKELY(max_iv_count > rb_shape_max_capacity())) {
+        obj = class_allocate_complex_instance(klass, max_iv_count);
     }
     else {
-        size_t size = robject_embedded_size(index_tbl_num_entries);
+        size_t size = robject_embedded_size(max_iv_count);
 
         // There might be a NEWOBJ tracepoint callback, and it may set fields.
         // So the shape must be passed to `NEWOBJ_OF`.
@@ -1154,6 +1153,12 @@ rb_class_allocate_instance(VALUE klass)
 #endif
 
     return obj;
+}
+
+VALUE
+rb_class_allocate_instance(VALUE klass)
+{
+    return rb_class_allocate_instance_capa(klass, RCLASS_MAX_IV_COUNT(klass));
 }
 
 #if USE_ZJIT

--- a/internal/object.h
+++ b/internal/object.h
@@ -13,6 +13,7 @@
 /* object.c */
 
 VALUE rb_class_allocate_instance(VALUE klass);
+VALUE rb_class_allocate_instance_capa(VALUE klass, uint8_t /* attr_index_t */ max_iv_count);
 VALUE rb_class_search_ancestor(VALUE klass, VALUE super);
 NORETURN(void rb_undefined_alloc(VALUE klass));
 double rb_num_to_dbl(VALUE val);

--- a/process.c
+++ b/process.c
@@ -648,7 +648,7 @@ rb_process_status_for(rb_pid_t pid, int status, int error)
 static VALUE
 process_status_dump(VALUE status)
 {
-    VALUE dump = rb_class_new_instance(0, 0, rb_cObject);
+    VALUE dump = rb_class_allocate_instance_capa(rb_cObject, 2);
     struct rb_process_status *data;
     TypedData_Get_Struct(status, struct rb_process_status, &rb_process_status_type, data);
     if (data->pid) {

--- a/range.c
+++ b/range.c
@@ -26,6 +26,7 @@
 #include "internal/enumerator.h"
 #include "internal/error.h"
 #include "internal/numeric.h"
+#include "internal/object.h"
 #include "internal/range.h"
 
 VALUE rb_cRange;
@@ -2384,7 +2385,7 @@ r_cover_p(VALUE range, VALUE beg, VALUE end, VALUE val)
 static VALUE
 range_dumper(VALUE range)
 {
-    VALUE v = rb_obj_alloc(rb_cObject);
+    VALUE v = rb_class_allocate_instance_capa(rb_cObject, 3);
 
     rb_ivar_set(v, id_excl, RANGE_EXCL(range));
     rb_ivar_set(v, id_beg, RANGE_BEG(range));

--- a/set.c
+++ b/set.c
@@ -9,6 +9,7 @@
 #include "internal/bits.h"
 #include "internal/error.h"
 #include "internal/hash.h"
+#include "internal/object.h"
 #include "internal/proc.h"
 #include "internal/sanitizers.h"
 #include "internal/set_table.h"
@@ -2228,7 +2229,7 @@ set_i_to_h(VALUE set)
 static VALUE
 compat_dumper(VALUE set)
 {
-    VALUE dumper = rb_class_new_instance(0, 0, rb_cObject);
+    VALUE dumper = rb_class_allocate_instance_capa(rb_cObject, 1);
     rb_ivar_set(dumper, id_i_hash, set_i_to_h(set));
     return dumper;
 }


### PR DESCRIPTION
The Range Marshal compat dumper would allocate
an Object with no size information, hence get a 32B slot with enough space for 2 ivars, then insert 3 ivars causing it to spill.

This isn't a big problem, but somewhat shows that the interface isn't WVA aware.

By introducing `rb_class_allocate_instance_capa` we can directly allocate an object with enough room.