### PR TITLE
Move MAX_EMBEDDED_MEMBERS into test

### DIFF
--- a/test/ruby/test_struct.rb
+++ b/test/ruby/test_struct.rb
@@ -41,14 +41,14 @@ module TestStruct
     end
   end
 
-  MAX_EMBEDDED_MEMBERS = (
-    GC::INTERNAL_CONSTANTS[:RVARGC_MAX_ALLOCATE_SIZE] -
-    GC::INTERNAL_CONSTANTS[:RBASIC_SIZE] -
-    GC::INTERNAL_CONSTANTS[:RVALUE_OVERHEAD]
-  ) / RbConfig::SIZEOF["void*"]
-
   def test_larger_than_largest_pool
-    count = MAX_EMBEDDED_MEMBERS + 1
+    max_embedded_members = (
+      GC::INTERNAL_CONSTANTS[:RVARGC_MAX_ALLOCATE_SIZE] -
+      GC::INTERNAL_CONSTANTS[:RBASIC_SIZE] -
+      GC::INTERNAL_CONSTANTS[:RVALUE_OVERHEAD]
+    ) / RbConfig::SIZEOF["void*"]
+
+    count = max_embedded_members + 1
     list = Array(0..count)
     klass = @Struct.new(*list.map { |i| :"a_#{i}"})
     struct = klass.new(*list)


### PR DESCRIPTION
Some of the constants may be undefined in MMTk, so we need to skip this test.