### PR TITLE
Fix GC.stress for object allocation

### DIFF
--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -2759,6 +2759,12 @@ newobj_bump_pointer_miss(rb_objspace_t *objspace, rb_ractor_newobj_cache_t *gc_c
 static VALUE
 newobj_alloc(rb_objspace_t *objspace, rb_ractor_newobj_cache_t *gc_cache, size_t heap_idx, bool vm_locked)
 {
+    if (RB_UNLIKELY(ruby_gc_stressful)) {
+        if (!garbage_collect(objspace, GPR_FLAG_NEWOBJ)) {
+            rb_memerror();
+        }
+    }
+
     VALUE obj = ractor_cache_allocate_slot(objspace, gc_cache, heap_idx);
 
     if (RB_UNLIKELY(obj == Qfalse)) {

--- a/test/ruby/test_gc.rb
+++ b/test/ruby/test_gc.rb
@@ -851,6 +851,17 @@ class TestGc < Test::Unit::TestCase
     assert_nil(GC.verify_internal_consistency)
   end
 
+  def test_gc_stress_on_obj_allocation
+    EnvUtil.under_gc_stress do
+      count = GC.count
+      iters = 100
+      iters.times do
+        Object.new
+      end
+      assert_operator(GC.count - count, :>=, iters)
+    end
+  end
+
   def test_gc_stress_on_realloc
     assert_normal_exit(<<-'end;', '[Bug #9859]')
       class C


### PR DESCRIPTION
GC stress was broken for object allocation.