### PR TITLE
ZJIT: Don't use an Assembler for generating stubs

### DIFF
--- a/zjit.rb
+++ b/zjit.rb
@@ -163,6 +163,8 @@ class << RubyVM::ZJIT
       :compile_hir_remove_duplicate_check_interrupts_time_ns,
       :compile_hir_eliminate_dead_code_time_ns,
       :compile_lir_time_ns,
+      :compile_jit_jit_stubs_time_ns,
+      :compile_function_stubs_time_ns,
       :profile_time_ns,
       :gc_time_ns,
       :invalidation_time_ns,

--- a/zjit/src/backend/arm64/mod.rs
+++ b/zjit/src/backend/arm64/mod.rs
@@ -1637,7 +1637,7 @@ impl Assembler {
 
         asm_dump!(asm, split);
 
-        trace_compile_phase("regalloc", || {
+        if asm.must_run_regalloc() { trace_compile_phase("regalloc", || {
             trace_compile_phase("number_instructions", || asm.number_instructions(0));
 
             let live_in = trace_compile_phase("analyze_liveness", || asm.analyze_liveness());
@@ -1695,7 +1695,7 @@ impl Assembler {
             });
 
             Ok(())
-        })?;
+        })?; }
         asm_dump!(asm, alloc_regs);
 
         // We are moved out of SSA after resolve_ssa

--- a/zjit/src/backend/arm64/mod.rs
+++ b/zjit/src/backend/arm64/mod.rs
@@ -904,6 +904,21 @@ impl Assembler {
         asm_local
     }
 
+    pub fn emit_call(cb: &mut CodeBlock, fptr: u64) {
+        // The offset to the call target in bytes
+        let src_addr = cb.get_write_ptr().raw_ptr(cb) as i64;
+        let dst_addr = fptr as i64;
+
+        // Use BL if the offset is short enough to encode as an immediate.
+        // Otherwise, use BLR with a register.
+        if b_offset_fits_bits((dst_addr - src_addr) / 4) {
+            bl(cb, InstructionOffset::from_bytes((dst_addr - src_addr) as i32));
+        } else {
+            emit_load_value(cb, Self::EMIT_OPND, dst_addr as u64);
+            blr(cb, Self::EMIT_OPND);
+        }
+    }
+
     /// Emit platform-specific machine code
     /// Returns a list of GC offsets. Can return failure to signal caller to retry.
     fn arm64_emit(&mut self, cb: &mut CodeBlock) -> Result<Vec<CodePtr>, CompileError> {
@@ -1446,18 +1461,7 @@ impl Assembler {
                     let fptr = &data.fptr;
                     match fptr {
                         Opnd::UImm(fptr) => {
-                            // The offset to the call target in bytes
-                            let src_addr = cb.get_write_ptr().raw_ptr(cb) as i64;
-                            let dst_addr = *fptr as i64;
-
-                            // Use BL if the offset is short enough to encode as an immediate.
-                            // Otherwise, use BLR with a register.
-                            if b_offset_fits_bits((dst_addr - src_addr) / 4) {
-                                bl(cb, InstructionOffset::from_bytes((dst_addr - src_addr) as i32));
-                            } else {
-                                emit_load_value(cb, Self::EMIT_OPND, dst_addr as u64);
-                                blr(cb, Self::EMIT_OPND);
-                            }
+                            Self::emit_call(cb, *fptr);
                         }
                         Opnd::Reg(_) => {
                             blr(cb, fptr.into());

--- a/zjit/src/backend/arm64/mod.rs
+++ b/zjit/src/backend/arm64/mod.rs
@@ -1654,7 +1654,7 @@ impl Assembler {
 
         asm_dump!(asm, split);
 
-        trace_compile_phase("regalloc", || {
+        if asm.must_run_regalloc() { trace_compile_phase("regalloc", || {
             trace_compile_phase("number_instructions", || asm.number_instructions(0));
 
             let live_in = trace_compile_phase("analyze_liveness", || asm.analyze_liveness());
@@ -1710,7 +1710,7 @@ impl Assembler {
             });
 
             Ok(())
-        })?;
+        })?; }
         asm_dump!(asm, alloc_regs);
 
         // We are moved out of SSA after resolve_ssa

--- a/zjit/src/backend/arm64/mod.rs
+++ b/zjit/src/backend/arm64/mod.rs
@@ -902,6 +902,21 @@ impl Assembler {
         asm_local
     }
 
+    pub fn emit_call(cb: &mut CodeBlock, fptr: u64) {
+        // The offset to the call target in bytes
+        let src_addr = cb.get_write_ptr().raw_ptr(cb) as i64;
+        let dst_addr = fptr as i64;
+
+        // Use BL if the offset is short enough to encode as an immediate.
+        // Otherwise, use BLR with a register.
+        if b_offset_fits_bits((dst_addr - src_addr) / 4) {
+            bl(cb, InstructionOffset::from_bytes((dst_addr - src_addr) as i32));
+        } else {
+            emit_load_value(cb, Self::EMIT_OPND, dst_addr as u64);
+            blr(cb, Self::EMIT_OPND);
+        }
+    }
+
     /// Emit platform-specific machine code
     /// Returns a list of GC offsets. Can return failure to signal caller to retry.
     fn arm64_emit(&mut self, cb: &mut CodeBlock) -> Result<Vec<CodePtr>, CompileError> {
@@ -1460,18 +1475,7 @@ impl Assembler {
                     let fptr = &data.fptr;
                     match fptr {
                         Opnd::UImm(fptr) => {
-                            // The offset to the call target in bytes
-                            let src_addr = cb.get_write_ptr().raw_ptr(cb) as i64;
-                            let dst_addr = *fptr as i64;
-
-                            // Use BL if the offset is short enough to encode as an immediate.
-                            // Otherwise, use BLR with a register.
-                            if b_offset_fits_bits((dst_addr - src_addr) / 4) {
-                                bl(cb, InstructionOffset::from_bytes((dst_addr - src_addr) as i32));
-                            } else {
-                                emit_load_value(cb, Self::EMIT_OPND, dst_addr as u64);
-                                blr(cb, Self::EMIT_OPND);
-                            }
+                            Self::emit_call(cb, *fptr);
                         }
                         Opnd::Reg(_) => {
                             blr(cb, fptr.into());

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -1664,6 +1664,8 @@ pub struct Assembler {
     /// consumes this through Insn::CCall, after it knows whether each live VReg
     /// is in a saved register or an allocator spill slot.
     stack_map: Option<StackMap>,
+
+    might_use_vregs: bool,
 }
 
 impl Assembler
@@ -1680,6 +1682,7 @@ impl Assembler
             num_vregs: 0,
             idx: 0,
             stack_map: None,
+            might_use_vregs: true,
         }
     }
 
@@ -1714,6 +1717,7 @@ impl Assembler
             label_names: old_asm.label_names.clone(),
             accept_scratch_reg: old_asm.accept_scratch_reg,
             stack_state: old_asm.stack_state.clone(),
+            might_use_vregs: old_asm.might_use_vregs,
             ..Self::new()
         };
 
@@ -1722,6 +1726,14 @@ impl Assembler
         asm.num_vregs = old_asm.num_vregs;
 
         asm
+    }
+
+    pub fn i_solemnly_swear_not_to_use_a_vreg(&mut self) {
+        self.might_use_vregs = false;
+    }
+
+    pub fn must_run_regalloc(&self) -> bool {
+        self.might_use_vregs
     }
 
     // Create a new LIR basic block.  Returns the newly created block ID
@@ -1976,6 +1988,7 @@ impl Assembler
 
     /// Build an Opnd::VReg
     pub fn new_vreg(&mut self, num_bits: u8) -> Opnd {
+        assert!(self.might_use_vregs, "Assembler is not allowed to use VRegs");
         let vreg = Opnd::VReg { idx: self.num_vregs.into(), num_bits };
         self.num_vregs += 1;
         vreg

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -1878,6 +1878,8 @@ pub struct Assembler {
     /// consumes this through Insn::CCall, after it knows whether each live VReg
     /// is in a saved register or an allocator spill slot.
     stack_map: Option<StackMap>,
+
+    might_use_vregs: bool,
 }
 
 impl Assembler
@@ -1894,6 +1896,7 @@ impl Assembler
             num_vregs: 0,
             idx: 0,
             stack_map: None,
+            might_use_vregs: true,
         }
     }
 
@@ -1928,6 +1931,7 @@ impl Assembler
             label_names: old_asm.label_names.clone(),
             accept_scratch_reg: old_asm.accept_scratch_reg,
             stack_state: old_asm.stack_state.clone(),
+            might_use_vregs: old_asm.might_use_vregs,
             ..Self::new()
         };
 
@@ -1936,6 +1940,14 @@ impl Assembler
         asm.num_vregs = old_asm.num_vregs;
 
         asm
+    }
+
+    pub fn i_solemnly_swear_not_to_use_a_vreg(&mut self) {
+        self.might_use_vregs = false;
+    }
+
+    pub fn must_run_regalloc(&self) -> bool {
+        self.might_use_vregs
     }
 
     // Create a new LIR basic block.  Returns the newly created block ID
@@ -2186,6 +2198,7 @@ impl Assembler
 
     /// Build an Opnd::VReg
     pub fn new_vreg(&mut self, num_bits: u8) -> Opnd {
+        assert!(self.might_use_vregs, "Assembler is not allowed to use VRegs");
         let vreg = Opnd::VReg { idx: self.num_vregs.into(), num_bits };
         self.num_vregs += 1;
         vreg

--- a/zjit/src/backend/x86_64/mod.rs
+++ b/zjit/src/backend/x86_64/mod.rs
@@ -670,6 +670,10 @@ impl Assembler {
         asm_local
     }
 
+    pub fn emit_call(cb: &mut CodeBlock, fptr: u64) {
+        call_ptr(cb, RAX, fptr as *const u8);
+    }
+
     /// Emit platform-specific machine code
     pub fn x86_emit(&mut self, cb: &mut CodeBlock) -> Result<Vec<CodePtr>, CompileError> {
         fn emit_csel(

--- a/zjit/src/backend/x86_64/mod.rs
+++ b/zjit/src/backend/x86_64/mod.rs
@@ -690,6 +690,10 @@ impl Assembler {
         asm_local
     }
 
+    pub fn emit_call(cb: &mut CodeBlock, fptr: u64) {
+        call_ptr(cb, RAX, fptr as *const u8);
+    }
+
     /// Emit platform-specific machine code
     pub fn x86_emit(&mut self, cb: &mut CodeBlock) -> Result<Vec<CodePtr>, CompileError> {
         fn emit_csel(

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -266,10 +266,8 @@ pub fn gen_iseq_call(cb: &mut CodeBlock, iseq_call: &IseqCallRef) -> Result<(), 
 
         // Update the JIT-to-JIT call to call the stub
         let stub_addr = stub_ptr.raw_ptr(cb);
-        let iseq = iseq_call.iseq.get();
-        iseq_call.regenerate(cb, |asm| {
-            asm_comment!(asm, "call function stub: {}", iseq_get_location(iseq, 0));
-            asm.ccall_into(C_RET_OPND, stub_addr, vec![]);
+        iseq_call.regenerate(cb, |cb| {
+            Assembler::emit_call(cb, stub_addr as u64);
         });
         Ok(())
     })
@@ -3763,11 +3761,9 @@ fn function_stub_hit_body(cb: &mut CodeBlock, iseq_call: &IseqCallRef) -> Result
     // Update the stub to call the code pointer
     let jit_entry_ptr = jit_entry_ptrs[iseq_call.jit_entry_idx.to_usize()];
     let code_addr = jit_entry_ptr.raw_ptr(cb);
-    let iseq = iseq_call.iseq.get();
     trace_compile_phase("compile_stub", || {
-        iseq_call.regenerate(cb, |asm| {
-            asm_comment!(asm, "call compiled function: {}", iseq_get_location(iseq, 0));
-            asm.ccall_into(C_RET_OPND, code_addr, vec![]);
+        iseq_call.regenerate(cb, |cb| {
+            Assembler::emit_call(cb, code_addr as u64);
         });
     });
 
@@ -4131,12 +4127,9 @@ impl IseqCall {
     }
 
     /// Regenerate a IseqCall with a given callback
-    fn regenerate(&self, cb: &mut CodeBlock, callback: impl Fn(&mut Assembler)) {
+    fn regenerate(&self, cb: &mut CodeBlock, callback: impl Fn(&mut CodeBlock)) {
         cb.with_write_ptr(self.start_addr.get().expect("expected a start address"), |cb| {
-            let mut asm = Assembler::new();
-            asm.new_block_without_id("regenerate");
-            callback(&mut asm);
-            asm.compile(cb).unwrap();
+            callback(cb);
             assert_eq!(self.end_addr.get().unwrap(), cb.get_write_ptr());
         });
     }

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -3773,6 +3773,7 @@ fn function_stub_hit_body(cb: &mut CodeBlock, iseq_call: &IseqCallRef) -> Result
 /// Compile a stub for an ISEQ called by SendDirect
 fn gen_function_stub(cb: &mut CodeBlock, iseq_call: IseqCallRef) -> Result<CodePtr, CompileError> {
     let (mut asm, scratch_reg) = Assembler::new_with_scratch_reg();
+    asm.i_solemnly_swear_not_to_use_a_vreg();
     asm.new_block_without_id("gen_function_stub");
     asm_comment!(asm, "Stub: {}", iseq_get_location(iseq_call.iseq.get(), 0));
 

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -273,16 +273,21 @@ pub fn invalidate_iseq_version(cb: &mut CodeBlock, iseq: IseqPtr, version: &mut 
 pub fn gen_iseq_call(cb: &mut CodeBlock, iseq_call: &IseqCallRef) -> Result<(), CompileError> {
     trace_compile_phase("compile_stub", || {
         // Compile a function stub
-        let stub_ptr = gen_function_stub(cb, iseq_call.clone()).inspect_err(|err| {
-            debug!("{err:?}: gen_function_stub failed: {}", iseq_get_location(iseq_call.iseq.get(), 0));
-        })?;
+        let stub_ptr =
+            crate::stats::with_time_stat(Counter::compile_function_stubs_time_ns, || {
+                gen_function_stub(cb, iseq_call.clone()).inspect_err(|err| {
+                    debug!("{err:?}: gen_function_stub failed: {}", iseq_get_location(iseq_call.iseq.get(), 0));
+                })
+            })?;
 
         // Update the JIT-to-JIT call to call the stub
         let stub_addr = stub_ptr.raw_ptr(cb);
         let iseq = iseq_call.iseq.get();
-        iseq_call.regenerate(cb, |asm| {
-            asm_comment!(asm, "call function stub: {}", iseq_get_location(iseq, 0));
-            asm.ccall_into(C_RET_OPND, stub_addr, vec![]);
+        crate::stats::with_time_stat(Counter::compile_jit_jit_stubs_time_ns, || {
+            iseq_call.regenerate(cb, |asm| {
+                asm_comment!(asm, "call function stub: {}", iseq_get_location(iseq, 0));
+                asm.ccall_into(C_RET_OPND, stub_addr, vec![]);
+            })
         });
         Ok(())
     })
@@ -393,11 +398,13 @@ fn gen_iseq_body(cb: &mut CodeBlock, iseq: IseqPtr, mut version: IseqVersionRef,
                 crate::stats::with_time_stat(Counter::compile_lir_time_ns, || gen_function(cb, iseq, version, function))?;
 
             // Stub callee ISEQs for JIT-to-JIT calls
-            trace_compile_phase("generate_jit_jit_stubs", || {
-                for iseq_call in iseq_calls.iter() {
-                    gen_iseq_call(cb, iseq_call)?;
-                }
-                Ok::<(), CompileError>(())
+            crate::stats::with_time_stat(Counter::compile_jit_jit_stubs_time_ns, || {
+                trace_compile_phase("generate_jit_jit_stubs", || {
+                    for iseq_call in iseq_calls.iter() {
+                        gen_iseq_call(cb, iseq_call)?;
+                    }
+                    Ok::<(), CompileError>(())
+                })
             })?;
 
             Ok((iseq_code_ptrs, gc_offsets, iseq_calls))
@@ -3916,11 +3923,13 @@ fn function_stub_hit_body(cb: &mut CodeBlock, iseq_call: &IseqCallRef) -> Result
     let jit_entry_ptr = jit_entry_ptrs[iseq_call.jit_entry_idx.to_usize()];
     let code_addr = jit_entry_ptr.raw_ptr(cb);
     let iseq = iseq_call.iseq.get();
-    trace_compile_phase("compile_stub", || {
-        iseq_call.regenerate(cb, |asm| {
-            asm_comment!(asm, "call compiled function: {}", iseq_get_location(iseq, 0));
-            asm.ccall_into(C_RET_OPND, code_addr, vec![]);
-        });
+    crate::stats::with_time_stat(Counter::compile_jit_jit_stubs_time_ns, || {
+        trace_compile_phase("compile_stub", || {
+            iseq_call.regenerate(cb, |asm| {
+                asm_comment!(asm, "call compiled function: {}", iseq_get_location(iseq, 0));
+                asm.ccall_into(C_RET_OPND, code_addr, vec![]);
+            });
+        })
     });
 
     Ok(jit_entry_ptr)

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -284,9 +284,8 @@ pub fn gen_iseq_call(cb: &mut CodeBlock, iseq_call: &IseqCallRef) -> Result<(), 
         let stub_addr = stub_ptr.raw_ptr(cb);
         let iseq = iseq_call.iseq.get();
         crate::stats::with_time_stat(Counter::compile_jit_jit_stubs_time_ns, || {
-            iseq_call.regenerate(cb, |asm| {
-                asm_comment!(asm, "call function stub: {}", iseq_get_location(iseq, 0));
-                asm.ccall_into(C_RET_OPND, stub_addr, vec![]);
+            iseq_call.regenerate(cb, |cb| {
+                Assembler::emit_call(cb, stub_addr as u64);
             })
         });
         Ok(())
@@ -3925,9 +3924,8 @@ fn function_stub_hit_body(cb: &mut CodeBlock, iseq_call: &IseqCallRef) -> Result
     let iseq = iseq_call.iseq.get();
     crate::stats::with_time_stat(Counter::compile_jit_jit_stubs_time_ns, || {
         trace_compile_phase("compile_stub", || {
-            iseq_call.regenerate(cb, |asm| {
-                asm_comment!(asm, "call compiled function: {}", iseq_get_location(iseq, 0));
-                asm.ccall_into(C_RET_OPND, code_addr, vec![]);
+            iseq_call.regenerate(cb, |cb| {
+                Assembler::emit_call(cb, code_addr as u64);
             });
         })
     });
@@ -4366,12 +4364,9 @@ impl IseqCall {
     }
 
     /// Regenerate a IseqCall with a given callback
-    fn regenerate(&self, cb: &mut CodeBlock, callback: impl Fn(&mut Assembler)) {
+    fn regenerate(&self, cb: &mut CodeBlock, callback: impl Fn(&mut CodeBlock)) {
         cb.with_write_ptr(self.start_addr.get().expect("expected a start address"), |cb| {
-            let mut asm = Assembler::new();
-            asm.new_block_without_id("regenerate");
-            callback(&mut asm);
-            asm.compile(cb).unwrap();
+            callback(cb);
             assert_eq!(self.end_addr.get().unwrap(), cb.get_write_ptr());
         });
     }

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -3936,6 +3936,7 @@ fn function_stub_hit_body(cb: &mut CodeBlock, iseq_call: &IseqCallRef) -> Result
 /// Compile a stub for an ISEQ called by SendDirect
 fn gen_function_stub(cb: &mut CodeBlock, iseq_call: IseqCallRef) -> Result<CodePtr, CompileError> {
     let (mut asm, scratch_reg) = Assembler::new_with_scratch_reg();
+    asm.i_solemnly_swear_not_to_use_a_vreg();
     asm.new_block_without_id("gen_function_stub");
     asm_comment!(asm, "Stub: {}", iseq_get_location(iseq_call.iseq.get(), 0));
 

--- a/zjit/src/stats.rs
+++ b/zjit/src/stats.rs
@@ -181,6 +181,8 @@ make_counters! {
         compile_hir_eliminate_empty_inline_frames_time_ns,
         compile_hir_eliminate_dead_code_time_ns,
         compile_lir_time_ns,
+        compile_jit_jit_stubs_time_ns,
+        compile_function_stubs_time_ns,
     }
 
     // Exit counters that are summed as side_exit_count


### PR DESCRIPTION
This shaves between 30ms and 100ms off of LIR:

Before:

```
plum% for i in $(seq 5); do WARMUP_ITRS=0 MIN_BENCH_ITRS=10 MIN_BENCH_TIME=0 ruby --zjit --zjit-stats benchmarks/lobsters/benchmark.rb 2>&1 | grep compile_lir; done
compile_lir_time:                                                1,655ms
compile_lir_time:                                                1,609ms
compile_lir_time:                                                1,613ms
compile_lir_time:                                                1,562ms
compile_lir_time:                                                1,697ms
```

After:

```
plum% for i in $(seq 5); do WARMUP_ITRS=0 MIN_BENCH_ITRS=10 MIN_BENCH_TIME=0 ruby --zjit --zjit-stats benchmarks/lobsters/benchmark.rb 2>&1 | grep compile_lir; done
compile_lir_time:                                               1,582ms
compile_lir_time:                                                1,588ms
compile_lir_time:                                                1,578ms
compile_lir_time:                                                1,586ms
compile_lir_time:                                                1,536ms
```