### PR TITLE
[DOC] Doc for Pathname#writable? and Pathname#writable_real?

### DIFF
--- a/pathname_builtin.rb
+++ b/pathname_builtin.rb
@@ -2425,7 +2425,24 @@ class Pathname    # * FileTest *
   #
   def symlink?() FileTest.symlink?(@path) end
 
-  # See <tt>FileTest.writable?</tt>.
+  # :markup: markdown
+  #
+  # call-seq:
+  #   writable? -> true or false
+  #
+  # Returns whether the path in `self` points to an entry
+  # that is writable by the owner and group of the current process:
+  #
+  # ```ruby
+  # pn = Pathname('/tmp/t.tmp')
+  # pn.write('foo')
+  # pn.writable?                 # => true
+  # pn.chmod(0o000)
+  # pn.writable?                 # => false
+  # pn.delete                    # Clean up.
+  # Pathname('nosuch').writable? # => false
+  # ```
+  #
   def writable?() FileTest.writable?(@path) end
 
   # :markup: markdown
@@ -2452,7 +2469,13 @@ class Pathname    # * FileTest *
   #
   def world_writable?() File.world_writable?(@path) end
 
-  # See <tt>FileTest.writable_real?</tt>.
+  # :markup: markdown
+  #
+  # call-seq:
+  #   writable_real? -> true or false
+  #
+  # Like #writable?, but checks against the real user and group ids
+  # instead of the effective ids.
   def writable_real?() FileTest.writable_real?(@path) end
 
   # See <tt>FileTest.zero?</tt>.


### PR DESCRIPTION
Replaces the one-line stub docs (`See <tt>FileTest.writable?</tt>.` etc.) of `Pathname#writable?` and `Pathname#writable_real?` with full docs matching the merged style of `#readable?` and `#readable_real?`.

All example outputs were verified by execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
