### PR TITLE
[DOC] Remove stale option documentation from man/ruby.1

### DIFF
--- a/man/erb.1
+++ b/man/erb.1
@@ -1,5 +1,5 @@
 .\"Ruby is copyrighted by Yukihiro Matsumoto <matz@netlab.jp>.
-.Dd July 10, 2026
+.Dd July 23, 2026
 .Dt ERB 1 "Ruby Programmer's Reference Guide"
 .Os UNIX
 .Sh NAME

--- a/man/goruby.1
+++ b/man/goruby.1
@@ -1,5 +1,5 @@
 .\"Ruby is copyrighted by Yukihiro Matsumoto <matz@netlab.jp>.
-.Dd May 24, 2026
+.Dd July 23, 2026
 .Dt GORUBY 1 "Ruby Programmer's Reference Guide"
 .Os UNIX
 .Sh NAME

--- a/man/ruby.1
+++ b/man/ruby.1
@@ -1,5 +1,5 @@
 .\"Ruby is copyrighted by Yukihiro Matsumoto <matz@netlab.jp>.
-.Dd July 10, 2026
+.Dd July 23, 2026
 .Dt RUBY 1 "Ruby Programmer's Reference Guide"
 .Os UNIX
 .Sh NAME
@@ -16,7 +16,6 @@
 .Op Fl F Ns Op Ar pattern
 .Op Fl I Ar directory
 .Op Fl K Ns Op Ar c
-.Op Fl T Ns Op Ar level
 .Op Fl W Ns Op Ar level
 .Op Fl e Ar command
 .Op Fl i Ns Op Ar extension
@@ -232,9 +231,6 @@ would be
 but it does not work if the script is being interpreted by
 .Xr csh 1 .
 .Pp
-.It Fl T Ns Op Ar level=1
-Turns on taint checks at the specified level (default 1).
-.Pp
 .It Fl U
 Sets the default value for internal encodings
 .Pf ( Li "Encoding.default_internal" ) to UTF-8.
@@ -444,8 +440,7 @@ Show long help message (same as
 .Fl -help).
 .It Sy syntax
 Check syntax (same as
-.Fl c
-.Fl -yydebug).
+.Fl c).
 .Pp
 .El
 .Pp
@@ -500,7 +495,7 @@ e.g.
 .Dl RUBYOPT="-w -Ke"
 .Pp
 Note that RUBYOPT can contain only
-.Fl d , Fl E , Fl I , Fl K , Fl r , Fl T , Fl U , Fl v , Fl w , Fl W, Fl -debug ,
+.Fl d , Fl E , Fl I , Fl K , Fl r , Fl U , Fl v , Fl w , Fl W, Fl -debug ,
 .Fl -disable- Ns Ar FEATURE
 and
 .Fl -enable- Ns Ar FEATURE .


### PR DESCRIPTION
- Drop the `-T` (taint check) option from the SYNOPSIS, the option list, and the RUBYOPT description; it was removed in Ruby 3.0 by 0dbf6e46fb ([Feature #17157]).
- `--dump=syntax` is equivalent to `-c` alone, not `-c --yydebug`: both set only `DUMP_BIT(syntax)` in ruby.c and print `Syntax OK`; `--yydebug` is a separate dump option.
- Update the `.Dd` date accordingly (`make update-man-date`).

Verified with `groff -mdoc -z` (no warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
