### PR TITLE
[DOC] Fix typos in doc/

### DIFF
--- a/doc/distribution/windows.md
+++ b/doc/distribution/windows.md
@@ -297,7 +297,7 @@ to their base names.
 
 Although no icons are distributed with the ruby source, you can use
 anything you like. You will be able to find many images by search engines.
-For example, followings are made from [Ruby logo kit]:
+For example, the following are made from [Ruby logo kit]:
 
 * Small [favicon] in the official site
 

--- a/doc/language/options.md
+++ b/doc/language/options.md
@@ -293,7 +293,7 @@ $ popd
 
 This option and [option `-C`][-C] will
 be applied in the order in the command line; expansion of `-I` options
-are affected by preceeding `-C` options.
+are affected by preceding `-C` options.
 
 ```console
 $ ruby -C / -Ilib -C usr -Ilib -e 'puts $:[0, 2]'

--- a/doc/maintainers.md
+++ b/doc/maintainers.md
@@ -390,7 +390,7 @@ consensus on ruby-core/ruby-dev.
 
 ## Bundled gems upstream repositories and maintainers
 
-The maintanance policy of bundled gems is different from Module Maintainers above.
+The maintenance policy of bundled gems is different from Module Maintainers above.
 Please check the policies for each repository.
 
 The ruby core team tries to maintain the repositories with no maintainers.

--- a/doc/syntax/layout.rdoc
+++ b/doc/syntax/layout.rdoc
@@ -51,7 +51,7 @@ These works:
         2
 
     File.read "test.txt",         # incomplete without something after ,
-              enconding: "utf-8"
+              encoding: "utf-8"
 
 These would not:
 


### PR DESCRIPTION
- doc/language/options.md: `preceeding` -> `preceding`
- doc/maintainers.md: `maintanance` -> `maintenance`
- doc/syntax/layout.rdoc: `enconding` -> `encoding` (the `File.read` keyword in the line-continuation example)
- doc/distribution/windows.md: `followings are` -> `the following are`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
