### PR TITLE
[DOC] Remove stale catch table annotation from --dump=insns example

### DIFF
--- a/doc/language/option_dump.md
+++ b/doc/language/option_dump.md
@@ -16,7 +16,7 @@ The supported dump items:
 
     ```sh
     $ ruby --dump=insns t.rb
-    == disasm: #<ISeq:<main>@t.rb:1 (1,0)-(1,10)> (catch: FALSE)
+    == disasm: #<ISeq:<main>@t.rb:1 (1,0)-(1,10)>
     0000 putself                                                          (   1)[Li]
     0001 dupstring                              "Foo"
     0003 opt_send_without_block                 <calldata!mid:puts, argc:1, FCALL|ARGS_SIMPLE>


### PR DESCRIPTION
The `(catch: ...)` annotation in the disasm header was removed in Ruby 3.3 by ce99e50ede (Move catch_except_p to compile_data), so the `--dump=insns` example output no longer matches. Verified against current output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
