### PR TITLE
[DOC] Fix typos in C comments

### DIFF
--- a/include/ruby/internal/intern/thread.h
+++ b/include/ruby/internal/intern/thread.h
@@ -61,7 +61,7 @@ int rb_thread_wait_fd(int fd);
 int rb_thread_fd_writable(int fd);
 
 /**
- * This funciton is now a no-op. It was previously used to interrupt threads
+ * This function is now a no-op. It was previously used to interrupt threads
  * that were using the given file descriptor and wait for them to finish.
  *
  * @deprecated Use IO with RUBY_IO_MODE_EXTERNAL and `rb_io_close` instead.

--- a/include/ruby/st.h
+++ b/include/ruby/st.h
@@ -89,7 +89,7 @@ struct st_table {
        [0,allocated_entries].  */
     st_index_t entries_start, entries_bound;
     /* Array of size 2^entry_power.
-       Optionnally followed by an array of bins used for access by keys.  */
+       Optionally followed by an array of bins used for access by keys.  */
     st_table_entry *entries;
 };
 

--- a/parser_st.h
+++ b/parser_st.h
@@ -93,7 +93,7 @@ struct parser_st_table {
        [0,allocated_entries].  */
     parser_st_index_t entries_start, entries_bound;
     /* Array of size 2^entry_power.
-       Optionnally followed by an array of bins used for access by keys.  */
+       Optionally followed by an array of bins used for access by keys.  */
     parser_st_table_entry *entries;
 };
 

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -2456,7 +2456,7 @@ rb_obj_instance_exec(int argc, const VALUE *argv, VALUE self)
  *      Foo.new.greeting
  *
  *  However, constant and class variable lookup differs between
- *  +string+ and block. When +string+ is given, contant and class
+ *  +string+ and block. When +string+ is given, constant and class
  *  variables are looked up in the context of +self+. When a block
  *  is given, the context of the lookup is not changed:
  *


### PR DESCRIPTION
- vm_eval.c: `contant` -> `constant` (RDoc for `Module#module_eval`; the sentence two lines above spells it correctly)
- include/ruby/internal/intern/thread.h: `funciton` -> `function`
- include/ruby/st.h, parser_st.h: `Optionnally` -> `Optionally`

Comment-only changes; no code is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
