### PR TITLE
[Misc #22206] Fix snapshot dependency generation

### DIFF
--- a/tool/make-snapshot
+++ b/tool/make-snapshot
@@ -486,7 +486,6 @@ def package(vcs, rev, destdir, tmp = nil)
         end
       end
       mk << commonmk.gsub(/\{\$([^(){}]*)[^{}]*\}/, "").sub(/^revision\.tmp::$/, '\& Makefile')
-      mk << File.read("defs/gmake.mk")
       mk << <<-'APPEND'
 
 update-download:: touch-unicode-files
@@ -503,7 +502,9 @@ touch-unicode-files:
       clean.create(".revision.time")
       ENV["CACHE_SAVE"] = "no"
       make = MAKE.new(args)
-      return unless make.run("fix-depends")
+      if File.file?("tool/mkdepend.rb")
+        return unless make.run("fix-depends")
+      end
       return unless make.run("update-download")
       clean.push("rbconfig.rb", ".rbconfig.time", "enc.mk", "ext/ripper/y.output", ".revision.time")
       Dir.glob("**/*") do |dest|

--- a/tool/test/test_mkdepend.rb
+++ b/tool/test/test_mkdepend.rb
@@ -861,7 +861,11 @@ class TestMkdepend < Test::Unit::TestCase
     )
     assert_include(snapshot, 'args["MKDEPEND_FILES"] = "--scope=core"')
     assert_include(snapshot, 'args["MKDEPEND_OPTIONS"] = ""')
-    assert_include(snapshot, 'make.run("fix-depends")')
+    assert_match(
+      %r{if File\.file\?\("tool/mkdepend\.rb"\).*make\.run\("fix-depends"\)}m,
+      snapshot,
+    )
+    assert_not_include(snapshot, 'File.read("defs/gmake.mk")')
   end
 
   def test_file_without_markers_is_not_updated


### PR DESCRIPTION
Skip dependency generation when exporting stable branches that predate the Ruby dependency scanner.  Avoid loading GNU make definitions into the temporary Makefile so snapshot generation also works with BSD make.