### PR TITLE
mkmf: warn when nmake will not handle spaces in paths

### DIFF
--- a/lib/mkmf.rb
+++ b/lib/mkmf.rb
@@ -2082,6 +2082,9 @@ SRC
     verbose = with_config('verbose') ?  "1" : (CONFIG['MKMF_VERBOSE'] || "0")
     vpath = $VPATH.dup
     CONFIG["hdrdir"] ||= $hdrdir
+    if $mswin and dir = [CONFIG["srcdir"], $extmk ? CONFIG["topdir"] : $topdir, CONFIG["hdrdir"], $arch_hdrdir].compact.find {|d| /\s/ =~ d.to_s}
+      warn "mkmf: nmake cannot handle spaces in paths: #{dir}"
+    end
     mk << %{
 SHELL = /bin/sh
 

--- a/lib/mkmf.rb
+++ b/lib/mkmf.rb
@@ -2082,7 +2082,7 @@ SRC
     verbose = with_config('verbose') ?  "1" : (CONFIG['MKMF_VERBOSE'] || "0")
     vpath = $VPATH.dup
     CONFIG["hdrdir"] ||= $hdrdir
-    if $mswin and dir = [CONFIG["srcdir"], $extmk ? CONFIG["topdir"] : $topdir, CONFIG["hdrdir"], $arch_hdrdir].compact.find {|d| /\s/ =~ d.to_s}
+    if $mswin and dir = [CONFIG["srcdir"], $extmk ? CONFIG["topdir"] : $topdir, CONFIG["hdrdir"], $arch_hdrdir].compact.find {|d| /\s/ =~ d}
       warn "mkmf: nmake cannot handle spaces in paths: #{dir}"
     end
     mk << %{


### PR DESCRIPTION
Building a C extension with `nmake` from a source directory whose path contains spaces fails with a confusing `LNK1181` error about a missing object file. `String#unspace` escapes whitespace with a backslash, which is a GNU make convention that `nmake` does not interpret, so the generated Makefile contains a line like `srcdir = V:/tmp/wp09\ space/myext` and the `{$(srcdir)}.c` inference rule silently never fires.

This cannot be fixed by switching to quoting. I tested `nmake` inference paths with a directory containing spaces in every available form, bare, quoted inside the macro, and `{"$(srcdir)"}`, and none of them fire, while an identical control case without spaces does. Quoting the whole reference as `"$(srcdir)/file.c"` only works in ordinary dependency lines, not in inference rules, and 8.3 short names are unavailable on some volumes such as ReFS Dev Drives. A source directory with spaces is therefore structurally unsupported by `nmake`.

Since a real fix is not possible on the mkmf side, this change makes `configuration` warn at Makefile creation time (`mkmf: nmake cannot handle spaces in paths: <dir>`) instead of failing later at link time. The check inspects `CONFIG["srcdir"]` rather than the `srcdir` argument because the argument may still contain macro references, and it is gated on `$mswin` rather than `$nmake` because `$nmake` depends on `ENV["MAKE"]` and is not set in a plain `extconf.rb` run. If a stronger response is preferred here, such as raising an error, I am happy to change it.
