### PR TITLE
file: Fix off-by-one in expand_feature trailing-separator check

### DIFF
--- a/file.c
+++ b/file.c
@@ -7162,7 +7162,7 @@ expand_feature(VALUE fname, VALUE dname, VALUE buffer, bool need_expansion)
     else {
         rb_str_set_len(buffer, 0);
         rb_str_append(buffer, dname);
-        if (!isdirsep(dname_ptr[dname_len])) {
+        if (!isdirsep(dname_ptr[dname_len - 1])) {
             rb_str_cat(buffer, "/", 1);
         }
         rb_str_append(buffer, fname);


### PR DESCRIPTION
In `expand_feature` in `file.c`, the fast path that joins a load path entry with a feature name checks `isdirsep(dname_ptr[dname_len])` to decide whether to insert a separator. That index reads the string's NUL terminator, so the check is always false and `/` is appended unconditionally. A directory name ending with a separator such as `C:/foo/` produces `C:/foo//feature`. The intended index is `dname_len - 1`, which is safe because `dname_len > 0` is asserted just above.

This is a logic fix for an optimization that never worked rather than a memory safety issue or a user visible bug. Reading `dname_ptr[dname_len]` stays inside the RSTRING buffer because it is the NUL terminator. In practice `$LOAD_PATH` entries are pre-expanded and trailing separators are normalized before reaching this code, so the doubled separator does not surface during normal `require`. For the same reason I could not write a regression test that observes the difference through `require`, so this change is justified statically.

Verified with an mswin build. `nmake btest` passes all 2029 tests and `nmake test-all` for `ruby/test_require.rb` and `ruby/test_file.rb` reports 0 failures and 0 errors.
