### PR TITLE
dln_find: Fix drive-letter check and separator joining on DOSISH

### DIFF
--- a/dln_find.c
+++ b/dln_find.c
@@ -234,7 +234,11 @@ dln_find_1(const char *fname, const char *path, char *fbuf, size_t size,
             }
 
             /* add a "/" between directory and filename */
+#if defined(DOSISH)
+            if (ep[-1] != '/' && ep[-1] != '\\')
+#else
             if (ep[-1] != '/')
+#endif
                 *bp++ = '/';
         }
 

--- a/dln_find.c
+++ b/dln_find.c
@@ -128,7 +128,7 @@ dln_find_1(const char *fname, const char *path, char *fbuf, size_t size,
 # define CharNext(p) ((p)+1)
 # endif
 # ifdef DOSISH_DRIVE_LETTER
-    if (((p[0] | 0x20) - 'a') < 26  && p[1] == ':') {
+    if ((unsigned char)((p[0] | 0x20) - 'a') < 26u  && p[1] == ':') {
         p += 2;
         is_abs = 1;
     }


### PR DESCRIPTION
The drive-letter check in `dln_find_1`, `((p[0] | 0x20) - 'a') < 26`, is a signed comparison. A non-alphabetic first character such as a digit yields a negative value that satisfies it, so a name like `4:foo` is misjudged as drive-absolute and returned as-is instead of being searched in `PATH`. Other drive-letter checks such as `has_drive_letter` in `file.c` use `ISALPHA`. Casting to `unsigned char` restores the intended a-z range check.

When joining a search path component with the file name, only `/` was recognized as a trailing separator, so a `PATH` entry ending with a backslash produced a doubled separator like `C:\bin\/foo.exe`. The check now also accepts `\` on DOSISH.

A regression test is impractical because such strings reach `dln_find_exe_r` only through process spawning's `PATH` search. Verified on x64-mswin64_140 with btest and `test/ruby/test_process.rb`, no failures.
