### PR TITLE
win32: Fix a double free and a stack over-read in path handling

### DIFF
--- a/win32/win32.c
+++ b/win32/win32.c
@@ -1955,7 +1955,10 @@ get_handle_pathname(HANDLE fh, WCHAR **pathptr, DWORD add)
     WCHAR *path = malloc((len + add + 1) * sizeof(WCHAR));
     if (!(*pathptr = path)) return 0;
     len = GetFinalPathNameByHandleW(fh, path, len + 1, 0);
-    if (!len) free(path);
+    if (!len) {
+        free(path);
+        *pathptr = NULL;
+    }
     return len;
 }
 

--- a/win32/win32.c
+++ b/win32/win32.c
@@ -4015,6 +4015,13 @@ socketpair_unix_path(struct sockaddr_un *sock_un)
         case 0:
             /* user temp dir from TMP or TEMP env var, it ends with a backslash */
             path_len = GetTempPathW(maxpath, wpath);
+            if (path_len == 0 || path_len > maxpath) {
+                /* The env var path did not fit in wpath (GetTempPathW then
+                 * returns the required length and leaves wpath unfilled), or
+                 * the call failed.  Skip to the next candidate directory
+                 * instead of reading past wpath in WideCharToMultiByte. */
+                continue;
+            }
             break;
         case 1:
             wcsncpy(wpath, L"C:/Temp/", maxpath);


### PR DESCRIPTION
This fixes two memory safety defects in `win32/win32.c`, found by a static audit of the win32 layer.

The first is a double free in `get_handle_pathname`. When the second `GetFinalPathNameByHandleW` call fails after the first one succeeded (handle or volume errors, or a path length race between the two calls), the function freed the buffer but left `*pathptr` pointing at it. `winnt_stat` receives that pointer as `finalname` and frees it again on return. The fix clears `*pathptr` on the failure path. The other caller `open_dir_handle` unconditionally reassigns its pointer on failure, so it was unaffected, but now every caller gets a NULL pointer instead of a dangling one.

The second is a stack out-of-bounds read in `socketpair_unix_path`. `wpath` has the same element count as `sun_path` (108). When `TMP`/`TEMP` expands to a path longer than that, `GetTempPathW` returns the required length without filling the buffer, and the following `WideCharToMultiByte` read `path_len` (> 108) WCHARs from the 108-element stack buffer. The fix validates the return value and falls through to the next candidate directory (`C:/Temp/`), which matches the loop's existing fallback design.

Both conditions are hard to trigger deterministically from Ruby code (the first needs a race or transient volume error, the second a 107+ character `%TEMP%` plus `AF_UNIX` socketpair support), so no regression test is included; the static evidence above is the justification.

Verified on x64-mswin64_140 with an in-place worktree build: `nmake btest` passes all tests, and `nmake test-all` for `ruby/test_file.rb`, `ruby/test_dir.rb`, `ruby/test_process.rb`, and `socket/test_unix.rb` reports 0 failures. With `TMP`/`TEMP` set to a 132-character directory, `Socket.pair(:UNIX, :STREAM)` now succeeds via the `C:/Temp/` fallback instead of reading past the buffer.
