### PR TITLE
Correct sendfile() usage in copy_ext_file

### DIFF
--- a/box.c
+++ b/box.c
@@ -718,9 +718,9 @@ copy_ext_file(const char *src_path, const char *dst_path)
         goto done;
     }
 # endif
-# ifdef USE_SENDFILE
+# if defined(HAVE_SENDFILE) && defined(__linux__)
     for (;;) {
-        ssize_t written = sendfile(src_fd, dst_fd, NULL count_max);
+        ssize_t written = sendfile(dst_fd, src_fd, NULL, count_max);
         if (written == 0) goto done;
         if (written < 0) break;
     }

--- a/box.c
+++ b/box.c
@@ -756,9 +756,9 @@ copy_ext_file(const char *src_path, const char *dst_path)
         goto done;
     }
 # endif
-# ifdef USE_SENDFILE
+# if defined(HAVE_SENDFILE) && defined(__linux__)
     for (;;) {
-        ssize_t written = sendfile(src_fd, dst_fd, NULL count_max);
+        ssize_t written = sendfile(dst_fd, src_fd, NULL, count_max);
         if (written == 0) goto done;
         if (written < 0) break;
     }


### PR DESCRIPTION
`copy_ext_file`'s `sendfile()` fast path in `box.c` was dead code with a latent syntax error, hidden because the guard macro was never defined. This fixes both issues:

- Guard the block with `defined(HAVE_SENDFILE) && defined(__linux__)` instead of `USE_SENDFILE`. `USE_SENDFILE` is only ever defined in `io.c`, so this branch was never compiled here.
- Fix a missing comma after the offset argument (`NULL count_max` -> `NULL, count_max`), a syntax error that went unnoticed for the same reason.
- Swap the argument order to `(dst_fd, src_fd, ...)`, matching Linux's `sendfile(out_fd, in_fd, offset, count)` signature. The previous order was reversed.
