### PR TITLE
ZJIT: Don't call find() all over the optimizer

### DIFF
--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -447,7 +447,9 @@ fn gen_function(cb: &mut CodeBlock, iseq: IseqPtr, version: IseqVersionRef, func
 
             // Compile all parameters
             for (idx, &insn_id) in block.params().enumerate() {
-                match function.find(insn_id) {
+                let insn_id = function.find_id(insn_id);
+                // Param does not have operands, so fake a ResolvedInsnId.
+                match crate::hir::ResolvedInsnId(insn_id).insn(function) {
                     Insn::Param => {
                         jit.opnds[insn_id.0] = Some(gen_param(&mut asm, idx));
                     },
@@ -459,7 +461,9 @@ fn gen_function(cb: &mut CodeBlock, iseq: IseqPtr, version: IseqVersionRef, func
             // so that calling convention registers are reserved early, like Param.
             if function.is_entry_block(block_id) {
                 for &insn_id in block.insns() {
-                    if let Insn::LoadArg { idx, .. } = function.find(insn_id) {
+                    let insn_id = function.find_id(insn_id);
+                    // Param does not have operands, so fake a ResolvedInsnId.
+                    if let &Insn::LoadArg { idx, .. } = crate::hir::ResolvedInsnId(insn_id).insn(function) {
                         jit.opnds[insn_id.0] = Some(gen_param(&mut asm, idx as usize));
                     }
                 }

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5786,8 +5786,8 @@ impl Function {
             let old_insns = std::mem::take(&mut self.blocks[block.0].insns);
             assert!(self.blocks[block.0].insns.is_empty());
             for insn_id in old_insns {
-                match self.find(insn_id) {
-                    Insn::Send { state, reason: SendFallbackReason::SendNoProfiles, .. } => {
+                match self.resolve(insn_id).insn(self) {
+                    &Insn::Send { state, reason: SendFallbackReason::SendNoProfiles, .. } => {
                         self.push_insn(block, Insn::SideExit { state, reason: Box::new(SideExitReason::NoProfileSend), recompile: Some(Recompile) });
                         // SideExit is a terminator; don't add remaining instructions
                         break;

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5806,8 +5806,8 @@ impl Function {
             let old_insns = std::mem::take(&mut self.blocks[block.0].insns);
             let mut new_insns = vec![];
             for insn_id in old_insns {
-                let replacement_insn: InsnId = match self.find(insn_id) {
-                    Insn::StoreField { recv, offset, val, .. } => {
+                let replacement_insn: InsnId = match self.resolve(insn_id).insn(self) {
+                    &Insn::StoreField { recv, offset, val, .. } => {
                         let key = (self.chase_insn(recv), offset);
                         let heap_entry = compile_time_heap.get(&key).copied();
                         // TODO(Jacob): Switch from actual to partial equality
@@ -5820,7 +5820,7 @@ impl Function {
                         compile_time_heap.insert(key, val);
                         insn_id
                     },
-                    Insn::LoadField { recv, offset, return_type, .. } => {
+                    &Insn::LoadField { recv, offset, return_type, .. } => {
                         let key = (self.chase_insn(recv), offset);
                         match compile_time_heap.entry(key) {
                             std::collections::hash_map::Entry::Occupied(entry) => {
@@ -5831,7 +5831,7 @@ impl Function {
                                 // type than the cached entry (`CPtr` vs `BasicObject`). While the loaded value would be the same in either case, the
                                 // difference in associated type causes type checking to fail. Consequently, we conservatively retain the duplicate `LoadField`.
                                 // The `optimize_load_store_does_not_alias_loads_with_incompatible_return_types` test checks the problematic case.
-                                let can_forward_cached_insn = match self.find(cached_insn) {
+                                let can_forward_cached_insn = match self.resolve(cached_insn).insn(self) {
                                     Insn::LoadField { return_type : cached_return_type,.. } => cached_return_type.is_subtype(return_type),
                                     _ => true
                                 };
@@ -5850,7 +5850,7 @@ impl Function {
                         }
                         insn_id
                     }
-                    Insn::WriteBarrier { .. } => {
+                    &Insn::WriteBarrier { .. } => {
                         // Currently, WriteBarrier write effects are Allocator and Memory when we'd really like them to be flags.
                         // We don't use LoadField for mark bits so we can ignore them for now.
                         // But flags does not exist in our effects abstract heap modeling and we don't want to add special casing to effects.

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -3195,6 +3195,12 @@ impl Function {
         }
     }
 
+    /// Do a shallow look up of the instruction ID in the union-find. Does inspect or rewrite any
+    /// operands.
+    pub fn find_id(&self, insn_id: InsnId) -> InsnId {
+        self.union_find.borrow().find_const(insn_id)
+    }
+
     /// Return a copy of the instruction where the instruction and its operands have been read from
     /// the union-find table (to find the current most-optimized version of this instruction). See
     /// [`UnionFind`] for more.

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -2722,6 +2722,25 @@ impl CompilePolicy {
     }
 }
 
+/// A wrapper around [`InsnId`] that indicates the instruction's operands have been resolved.
+pub struct ResolvedInsnId(pub InsnId);
+
+impl ResolvedInsnId {
+    /// Return a mutable reference to the instruction at `insn_id` (after resolving via
+    /// union-find). Assumes the operands are resolved through union-find already. Use
+    /// [`Function::resolve`] to resolve operands before calling this.
+    pub fn insn_mut(self, fun: &mut Function) -> &mut Insn {
+        &mut fun.insns[self.0.0]
+    }
+
+    /// Return a reference to the instruction at `insn_id` (after resolving via union-find).
+    /// Assumes the operands are resolved through union-find already. Use [`Function::resolve`] to
+    /// resolve operands before calling this.
+    pub fn insn(self, fun: &Function) -> &Insn {
+        &fun.insns[self.0.0]
+    }
+}
+
 /// A [`Function`], which is analogous to a Ruby ISeq, is a control-flow graph of [`Block`]s
 /// containing instructions.
 #[derive(Debug)]
@@ -3191,6 +3210,9 @@ impl Function {
     ///   _ => {}
     /// }
     /// ```
+    ///
+    /// You should prefer [`Function::resolve`] and [`ResolvedInsnId::insn`] when you want to read an
+    /// instruction without cloning it.
     pub fn find(&self, insn_id: InsnId) -> Insn {
         macro_rules! find {
             ( $x:expr ) => {
@@ -3207,6 +3229,25 @@ impl Function {
             *operand = find!(*operand);
         });
         result
+    }
+
+    /// Make the operands of the instruction at `find(insn_id)` point to the current representative
+    /// of each operand.
+    ///
+    /// Meant to be used in tandem with [`ResolvedInsnId::insn`]. Example:
+    ///
+    /// ```ignore
+    /// match func.resolve(insn_id).insn(func) {
+    ///   ...
+    /// }
+    /// ```
+    pub fn resolve(&mut self, insn_id: InsnId) -> ResolvedInsnId {
+        let union_find = self.union_find.borrow();
+        let insn_id = union_find.find_const(insn_id);
+        self.insns[insn_id.0].for_each_operand_mut(&mut |operand: &mut InsnId| {
+            *operand = union_find.find_const(*operand);
+        });
+        ResolvedInsnId(insn_id)
     }
 
     /// Update DynamicSendReason for the instruction at insn_id
@@ -5913,18 +5954,18 @@ impl Function {
             let old_insns = std::mem::take(&mut self.blocks[block.0].insns);
             let mut new_insns = vec![];
             for insn_id in old_insns {
-                let replacement_id = match self.find(insn_id) {
-                    Insn::GuardType { val, guard_type, .. } if self.is_a(val, guard_type) => {
+                let replacement_id = match self.resolve(insn_id).insn(self) {
+                    &Insn::GuardType { val, guard_type, .. } if self.is_a(val, guard_type) => {
                         self.make_equal_to(insn_id, val);
                         // Don't bother re-inferring the type of val; we already know it.
                         continue;
                     }
-                    Insn::RefineType { val, new_type, .. } if self.is_a(val, new_type) => {
+                    &Insn::RefineType { val, new_type, .. } if self.is_a(val, new_type) => {
                         self.make_equal_to(insn_id, val);
                         // Don't bother re-inferring the type of val; we already know it.
                         continue;
                     }
-                    Insn::LoadField { recv, offset, return_type, .. } if return_type.is_subtype(types::BasicObject) &&
+                    &Insn::LoadField { recv, offset, return_type, .. } if return_type.is_subtype(types::BasicObject) &&
                             u32::try_from(offset).is_ok() => {
                         let offset = (offset as u32).to_usize();
                         let recv_type = self.type_of(recv);
@@ -5937,7 +5978,7 @@ impl Function {
                             _ => insn_id,
                         }
                     }
-                    Insn::LoadField { recv, offset, return_type, .. } if return_type.is_subtype(types::CShape) &&
+                    &Insn::LoadField { recv, offset, return_type, .. } if return_type.is_subtype(types::CShape) &&
                             u32::try_from(offset).is_ok() => {
                         let offset = (offset as u32).to_usize();
                         let recv_type = self.type_of(recv);
@@ -5950,7 +5991,7 @@ impl Function {
                             _ => insn_id,
                         }
                     }
-                    Insn::ArrayLength { array } => {
+                    &Insn::ArrayLength { array } => {
                         match self.type_of(array).ruby_object() {
                             Some(array_obj) if array_obj.is_frozen() => {
                                 let length = unsafe { rb_jit_array_len(array_obj) };
@@ -5959,14 +6000,14 @@ impl Function {
                             _ => insn_id,
                         }
                     }
-                    Insn::UnboxFixnum { val } => {
+                    &Insn::UnboxFixnum { val } => {
                         let recv_type = self.type_of(val);
                         match recv_type.fixnum_value() {
                             Some(val) => self.new_insn(Insn::Const { val: Const::CInt64(val) }),
                             _ => insn_id,
                         }
                     },
-                    Insn::GuardGreaterEq { left, right, state, reason } => {
+                    &Insn::GuardGreaterEq { left, right, state, ref reason } => {
                         let left_num = self.type_of(left).cint64_value();
                         let right_num = self.type_of(right).cint64_value();
                         match (left_num, right_num) {
@@ -5974,11 +6015,11 @@ impl Function {
                                 self.make_equal_to(insn_id, left);
                                 continue
                             },
-                            (Some(_), Some(_)) => self.new_insn(Insn::SideExit { state, reason, recompile: None }),
+                            (Some(_), Some(_)) => self.new_insn(Insn::SideExit { state, reason: reason.clone(), recompile: None }),
                             _ => insn_id,
                         }
                     },
-                    Insn::GuardLess { left, right, state, reason } => {
+                    &Insn::GuardLess { left, right, state, ref reason } => {
                         let left_num = self.type_of(left).cint64_value();
                         let right_num = self.type_of(right).cint64_value();
                         match (left_num, right_num) {
@@ -5986,11 +6027,11 @@ impl Function {
                                 self.make_equal_to(insn_id, left);
                                 continue
                             },
-                            (Some(_), Some(_)) => self.new_insn(Insn::SideExit { state, reason, recompile: None }),
+                            (Some(_), Some(_)) => self.new_insn(Insn::SideExit { state, reason: reason.clone(), recompile: None }),
                             _ => insn_id,
                         }
                     },
-                    Insn::GuardBitEquals { val, expected, .. } => {
+                    &Insn::GuardBitEquals { val, expected, .. } => {
                         let recv_type = self.type_of(val);
                         if recv_type.has_value(expected) {
                             self.make_equal_to(insn_id, val);
@@ -5999,7 +6040,7 @@ impl Function {
                             insn_id
                         }
                     }
-                    Insn::IsA { val, class } => 'is_a: {
+                    &Insn::IsA { val, class } => 'is_a: {
                         let class_type = self.type_of(class);
                         if !class_type.is_subtype(types::Class) {
                             break 'is_a insn_id;
@@ -6017,7 +6058,7 @@ impl Function {
                             insn_id
                         }
                     }
-                    Insn::StringEqual { left, right } => {
+                    &Insn::StringEqual { left, right } => {
                         let left = self.chase_insn(left);
                         let right = self.chase_insn(right);
                         // If both operands resolve to the same SSA value,
@@ -6039,7 +6080,7 @@ impl Function {
                             }
                         }
                     }
-                    Insn::FixnumAdd { left, right, .. } => {
+                    &Insn::FixnumAdd { left, right, .. } => {
                         match (self.type_of(left).fixnum_value(), self.type_of(right).fixnum_value()) {
                             (Some(0), _) => { self.make_equal_to(insn_id, right); continue; }
                             (_, Some(0)) => { self.make_equal_to(insn_id, left); continue; }
@@ -6050,7 +6091,7 @@ impl Function {
                             _ => None,
                         })
                     }
-                    Insn::FixnumSub { left, right, .. } => {
+                    &Insn::FixnumSub { left, right, .. } => {
                         match (self.type_of(left).fixnum_value(), self.type_of(right).fixnum_value()) {
                             (_, Some(0)) => { self.make_equal_to(insn_id, left); continue; }
                             _ => {}
@@ -6060,7 +6101,7 @@ impl Function {
                             _ => None,
                         })
                     }
-                    Insn::FixnumMult { left, right, .. } => {
+                    &Insn::FixnumMult { left, right, .. } => {
                         match (self.type_of(left).fixnum_value(), self.type_of(right).fixnum_value()) {
                             (Some(1), _) => { self.make_equal_to(insn_id, right); continue; }
                             (_, Some(1)) => { self.make_equal_to(insn_id, left); continue; }
@@ -6072,7 +6113,7 @@ impl Function {
                             _ => None,
                         })
                     }
-                    Insn::FixnumDiv { left, right, .. } => {
+                    &Insn::FixnumDiv { left, right, .. } => {
                         match (self.type_of(left).fixnum_value(), self.type_of(right).fixnum_value()) {
                             (_, Some(1)) => { self.make_equal_to(insn_id, left); continue; }
                             _ => {}
@@ -6088,7 +6129,7 @@ impl Function {
                             _ => None,
                         })
                     }
-                    Insn::FixnumMod { left, right, .. } => {
+                    &Insn::FixnumMod { left, right, .. } => {
                         self.fold_fixnum_bop(insn_id, left, right, |l, r| match (l, r) {
                             (Some(l), Some(r)) if r != 0 => {
                                 let l_obj = VALUE::fixnum_from_isize(l as isize);
@@ -6098,61 +6139,61 @@ impl Function {
                             _ => None,
                         })
                     }
-                    Insn::FixnumXor { left, right, .. } => {
+                    &Insn::FixnumXor { left, right, .. } => {
                         self.fold_fixnum_bop(insn_id, left, right, |l, r| match (l, r) {
                             (Some(l), Some(r)) => Some(l ^ r),
                             _ => None,
                         })
                     }
-                    Insn::FixnumAnd { left, right, .. } => {
+                    &Insn::FixnumAnd { left, right, .. } => {
                         self.fold_fixnum_bop(insn_id, left, right, |l, r| match (l, r) {
                             (Some(l), Some(r)) => Some(l & r),
                             _ => None,
                         })
                     }
-                    Insn::FixnumOr { left, right, .. } => {
+                    &Insn::FixnumOr { left, right, .. } => {
                         self.fold_fixnum_bop(insn_id, left, right, |l, r| match (l, r) {
                             (Some(l), Some(r)) => Some(l | r),
                             _ => None,
                         })
                     }
-                    Insn::FixnumEq { left, right, .. } => {
+                    &Insn::FixnumEq { left, right, .. } => {
                         self.fold_fixnum_pred(insn_id, left, right, |l, r| match (l, r) {
                             (Some(l), Some(r)) => Some(l == r),
                             _ => None,
                         })
                     }
-                    Insn::FixnumNeq { left, right, .. } => {
+                    &Insn::FixnumNeq { left, right, .. } => {
                         self.fold_fixnum_pred(insn_id, left, right, |l, r| match (l, r) {
                             (Some(l), Some(r)) => Some(l != r),
                             _ => None,
                         })
                     }
-                    Insn::FixnumLt { left, right, .. } => {
+                    &Insn::FixnumLt { left, right, .. } => {
                         self.fold_fixnum_pred(insn_id, left, right, |l, r| match (l, r) {
                             (Some(l), Some(r)) => Some(l < r),
                             _ => None,
                         })
                     }
-                    Insn::FixnumLe { left, right, .. } => {
+                    &Insn::FixnumLe { left, right, .. } => {
                         self.fold_fixnum_pred(insn_id, left, right, |l, r| match (l, r) {
                             (Some(l), Some(r)) => Some(l <= r),
                             _ => None,
                         })
                     }
-                    Insn::FixnumGt { left, right, .. } => {
+                    &Insn::FixnumGt { left, right, .. } => {
                         self.fold_fixnum_pred(insn_id, left, right, |l, r| match (l, r) {
                             (Some(l), Some(r)) => Some(l > r),
                             _ => None,
                         })
                     }
-                    Insn::FixnumGe { left, right, .. } => {
+                    &Insn::FixnumGe { left, right, .. } => {
                         self.fold_fixnum_pred(insn_id, left, right, |l, r| match (l, r) {
                             (Some(l), Some(r)) => Some(l >= r),
                             _ => None,
                         })
                     }
-                    Insn::ArrayAref { array, index }
+                    &Insn::ArrayAref { array, index }
                         if self.type_of(array).ruby_object_known()
                             && self.type_of(index).is_subtype(types::CInt64) => {
                         let array_obj = self.type_of(array).ruby_object().unwrap();
@@ -6164,7 +6205,7 @@ impl Function {
                             _ => insn_id,
                         }
                     }
-                    Insn::AdjustBounds { index, .. } => {
+                    &Insn::AdjustBounds { index, .. } => {
                         // If index is known nonnegative, then we don't need to adjust bounds.
                         if self.type_of(index).known_nonnegative() {
                             self.make_equal_to(insn_id, index);
@@ -6174,25 +6215,25 @@ impl Function {
                             insn_id
                         }
                     }
-                    Insn::Test { val } if self.type_of(val).is_known_falsy() => {
+                    &Insn::Test { val } if self.type_of(val).is_known_falsy() => {
                         self.new_insn(Insn::Const { val: Const::CBool(false) })
                     }
-                    Insn::Test { val } if self.type_of(val).is_known_truthy() => {
+                    &Insn::Test { val } if self.type_of(val).is_known_truthy() => {
                         self.new_insn(Insn::Const { val: Const::CBool(true) })
                     }
-                    Insn::Test { val: test_val } => {
-                        if let Insn::BoxBool { val: bool_val } = self.find(test_val) {
+                    &Insn::Test { val: test_val } => {
+                        if let &Insn::BoxBool { val: bool_val } = self.resolve(test_val).insn(self) {
                             self.make_equal_to(insn_id, bool_val);
                             continue;
                         } else {
                             insn_id
                         }
                     }
-                    Insn::CondBranch { val, if_true, .. } if self.is_a(val, Type::from_cbool(true)) => {
-                        self.new_insn(Insn::Jump(if_true))
+                    &Insn::CondBranch { val, ref if_true, .. } if self.is_a(val, Type::from_cbool(true)) => {
+                        self.new_insn(Insn::Jump(if_true.clone()))
                     }
-                    Insn::CondBranch { val, if_false, .. } if self.is_a(val, Type::from_cbool(false)) => {
-                        self.new_insn(Insn::Jump(if_false))
+                    &Insn::CondBranch { val, ref if_false, .. } if self.is_a(val, Type::from_cbool(false)) => {
+                        self.new_insn(Insn::Jump(if_false.clone()))
                     }
                     _ => insn_id,
                 };

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -6285,19 +6285,24 @@ impl Function {
     }
 
     fn absorb_dst_block(&mut self, num_in_edges: &[u32], block: BlockId) -> bool {
-        let Some(terminator_id) = self.blocks[block.0].insns.last()
+        let Some(&terminator_id) = self.blocks[block.0].insns.last()
             else { return false };
-        let Insn::Jump(BranchEdge { target, args }) = self.find(*terminator_id)
+        let &mut Insn::Jump(ref mut edge) = self.resolve(terminator_id).insn_mut(self)
             else { return false };
-        if target == block {
+        if edge.target == block {
             // Can't absorb self
             return false;
         }
-        if num_in_edges[target.0] != 1 {
+        if num_in_edges[edge.target.0] != 1 {
             // Can't absorb block if it's the target of more than one branch
             return false;
         }
         // Link up params with block args
+        let args = std::mem::take(&mut edge.args);
+        let target = edge.target;
+        // Drop the borrow of edge, which drops the borrow of self, which allows us to mutate self
+        // again.
+        let _ = edge;
         let params = std::mem::take(&mut self.blocks[target.0].params);
         assert_eq!(args.len(), params.len());
         for (arg, param) in args.iter().zip(params) {

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -6357,7 +6357,9 @@ impl Function {
             let insns = std::mem::take(&mut self.blocks[block_id.0].insns);
             let mut new_insns = Vec::with_capacity(insns.len());
             for insn_id in insns {
-                let insn = self.find(insn_id);
+                // PatchPoint is never in union-find and it does not have operands, so fake a
+                // ResolvedInsnId.
+                let insn = ResolvedInsnId(insn_id).insn(self);
                 if let Insn::PatchPoint { invariant, .. } = insn {
                     if !seen.insert(invariant) {
                         continue;

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5810,7 +5810,7 @@ impl Function {
         for block in self.reverse_post_order() {
             let mut compile_time_heap: HashMap<(InsnId, i32), InsnId>  = HashMap::new();
             let old_insns = std::mem::take(&mut self.blocks[block.0].insns);
-            let mut new_insns = vec![];
+            let mut new_insns = Vec::with_capacity(old_insns.len());
             for insn_id in old_insns {
                 let replacement_insn: InsnId = match self.resolve(insn_id).insn(self) {
                     &Insn::StoreField { recv, offset, val, .. } => {
@@ -5958,7 +5958,7 @@ impl Function {
         // function-level infer_types after each pruned branch.
         for block in self.reverse_post_order() {
             let old_insns = std::mem::take(&mut self.blocks[block.0].insns);
-            let mut new_insns = vec![];
+            let mut new_insns = Vec::with_capacity(old_insns.len());
             for insn_id in old_insns {
                 let replacement_id = match self.resolve(insn_id).insn(self) {
                     &Insn::GuardType { val, guard_type, .. } if self.is_a(val, guard_type) => {


### PR DESCRIPTION
`find()` allocates a lot. Add a new `resolve()` function (which we can rename as needed) that rewrites operands in-place. Return a reference to `insns` instead of allocating a new object, which works in most cases.

This PR cuts overall HIR optimize time from 960ms to 840ms on lobsters.