### PR TITLE
[DOC] Fix incorrect example values for Math.expm1

### DIFF
--- a/math.c
+++ b/math.c
@@ -469,11 +469,11 @@ math_exp(VALUE unused_obj, VALUE x)
  *
  *  Examples:
  *
- *    expm1(-INFINITY) # => 0.0
+ *    expm1(-INFINITY) # => -1.0
  *    expm1(-1.0)      # => -0.6321205588285577 # 1.0/E - 1
  *    expm1(0.0)       # => 0.0
  *    expm1(0.5)       # => 0.6487212707001282  # sqrt(E) - 1
- *    expm1(1.0)       # => 1.718281828459045   # E - 1
+ *    expm1(1.0)       # => 1.7182818284590453  # E - 1
  *    expm1(2.0)       # => 6.38905609893065    # E**2 - 1
  *    expm1(INFINITY)  # => Infinity
  *


### PR DESCRIPTION
Two example values in the `Math.expm1` documentation do not match the actual results.

```diff
- *    expm1(-INFINITY) # => 0.0
+ *    expm1(-INFINITY) # => -1.0
  *    expm1(-1.0)      # => -0.6321205588285577 # 1.0/E - 1
  *    expm1(0.0)       # => 0.0
  *    expm1(0.5)       # => 0.6487212707001282  # sqrt(E) - 1
- *    expm1(1.0)       # => 1.718281828459045   # E - 1
+ *    expm1(1.0)       # => 1.7182818284590453  # E - 1
```

## `expm1(-INFINITY)`

Documented as `0.0`, but the actual result is `-1.0`:

```console
$ ruby -e 'p Math.expm1(-Float::INFINITY)'
-1.0
```

`exp(-INFINITY) - 1` is `0 - 1`, so `-1.0` is the correct value. It also matches the documented range, `[-1.0, INFINITY]`.

This looks like it was carried over from the `Math.exp` documentation, which has `exp(-INFINITY) # => 0.0`, without subtracting 1. Every other value in the list was correctly adjusted.

## `expm1(1.0)`

Documented as `1.718281828459045`, but the actual result is `1.7182818284590453`:

```console
$ ruby -e 'p Math.expm1(1.0)'
1.7182818284590453
$ ruby -e 'p Math.exp(1.0) - 1'
1.718281828459045
```

The documented value is what `Math.exp(1.0) - 1` returns, which loses the last digit. That is precisely the precision loss `Math.expm1` exists to avoid, so it seems the examples were computed with `exp(x) - 1` rather than by calling `expm1(x)`.

## Verification

All seven example values were checked against the actual results, and only these two differed. The `Math.log1p` examples added in the same feature were checked as well and are all correct, so they are left untouched.

This change only touches comments.