### PR TITLE
ZJIT: 2 ARM64 padding related cleanups

### DIFF
--- a/zjit/src/backend/arm64/mod.rs
+++ b/zjit/src/backend/arm64/mod.rs
@@ -113,7 +113,7 @@ fn emit_jmp_ptr_with_invalidation(cb: &mut CodeBlock, dst_ptr: CodePtr) {
     });
 }
 
-fn emit_jmp_ptr(cb: &mut CodeBlock, dst_ptr: CodePtr, padding: bool) {
+fn emit_jmp_ptr(cb: &mut CodeBlock, dst_ptr: CodePtr) {
     let src_addr = cb.get_write_ptr().as_offset();
     let dst_addr = dst_ptr.as_offset();
 
@@ -121,7 +121,7 @@ fn emit_jmp_ptr(cb: &mut CodeBlock, dst_ptr: CodePtr, padding: bool) {
     // branch instruction. Otherwise, we'll move the
     // destination into a register and use the branch
     // register instruction.
-    let num_insns = if b_offset_fits_bits((dst_addr - src_addr) / 4) {
+    if b_offset_fits_bits((dst_addr - src_addr) / 4) {
         b(cb, InstructionOffset::from_bytes((dst_addr - src_addr) as i32));
         1
     } else {
@@ -129,16 +129,6 @@ fn emit_jmp_ptr(cb: &mut CodeBlock, dst_ptr: CodePtr, padding: bool) {
         br(cb, Assembler::EMIT_OPND);
         num_insns + 1
     };
-
-    if padding {
-        // Make sure it's always a consistent number of
-        // instructions in case it gets patched and has to
-        // use the other branch.
-        assert!(num_insns * 4 <= cb.jmp_ptr_bytes());
-        for _ in num_insns..(cb.jmp_ptr_bytes() / 4) {
-            nop(cb);
-        }
-    }
 }
 
 /// Emit the required instructions to load the given value into the
@@ -1478,7 +1468,7 @@ impl Assembler {
                 Insn::Jmp(target) => {
                     match *target {
                         Target::CodePtr(dst_ptr) => {
-                            emit_jmp_ptr(cb, dst_ptr, true);
+                            emit_jmp_ptr(cb, dst_ptr);
                         },
                         Target::Label(label_idx) => {
                             // Reserve space for a single B instruction

--- a/zjit/src/backend/arm64/mod.rs
+++ b/zjit/src/backend/arm64/mod.rs
@@ -99,20 +99,6 @@ impl From<&Opnd> for A64Opnd {
     }
 }
 
-/// Call emit_jmp_ptr and immediately invalidate the written range.
-/// This is needed when next_page also moves other_cb that is not invalidated
-/// by compile_with_regs. Doing it here allows you to avoid invalidating a lot
-/// more than necessary when other_cb jumps from a position early in the page.
-/// This invalidates a small range of cb twice, but we accept the small cost.
-fn emit_jmp_ptr_with_invalidation(cb: &mut CodeBlock, dst_ptr: CodePtr) {
-    let start = cb.get_write_ptr();
-    emit_jmp_ptr(cb, dst_ptr, true);
-    let end = cb.get_write_ptr();
-    trace_compile_phase("invalidate_icache", || {
-        unsafe { rb_jit_icache_invalidate(start.raw_ptr(cb) as _, end.raw_ptr(cb) as _) };
-    });
-}
-
 fn emit_jmp_ptr(cb: &mut CodeBlock, dst_ptr: CodePtr) {
     let src_addr = cb.get_write_ptr().as_offset();
     let dst_addr = dst_ptr.as_offset();


### PR DESCRIPTION
- **ZJIT: A64: No padding for LIR Jump as we do not re-patch**
- **ZJIT: A64: Delete emit_jmp_ptr_with_invalidation()**

Follow-up to #17992
