### PR TITLE
ZJIT: Rename rb_jit_* functions to rb_builtin_*

### DIFF
--- a/array.c
+++ b/array.c
@@ -2711,21 +2711,21 @@ ary_enum_length(VALUE ary, VALUE args, VALUE eobj)
 
 // Return true if the index is at or past the end of the array.
 VALUE
-rb_jit_ary_at_end(rb_execution_context_t *ec, VALUE self, VALUE index)
+rb_builtin_ary_at_end(rb_execution_context_t *ec, VALUE self, VALUE index)
 {
     return FIX2LONG(index) >= RARRAY_LEN(self) ? Qtrue : Qfalse;
 }
 
 // Return the element at the given fixnum index.
 VALUE
-rb_jit_ary_at(rb_execution_context_t *ec, VALUE self, VALUE index)
+rb_builtin_ary_at(rb_execution_context_t *ec, VALUE self, VALUE index)
 {
     return RARRAY_AREF(self, FIX2LONG(index));
 }
 
 // Increment a fixnum by 1.
 VALUE
-rb_jit_fixnum_inc(rb_execution_context_t *ec, VALUE self, VALUE num)
+rb_builtin_fixnum_inc(rb_execution_context_t *ec, VALUE self, VALUE num)
 {
     return LONG2FIX(FIX2LONG(num) + 1);
 }

--- a/array.rb
+++ b/array.rb
@@ -223,9 +223,9 @@ class Array
           return Primitive.cexpr! 'SIZED_ENUMERATOR(self, 0, 0, ary_enum_length)'
         end
         i = 0
-        until Primitive.rb_jit_ary_at_end(i)
-          yield Primitive.rb_jit_ary_at(i)
-          i = Primitive.rb_jit_fixnum_inc(i)
+        until Primitive.rb_builtin_ary_at_end(i)
+          yield Primitive.rb_builtin_ary_at(i)
+          i = Primitive.rb_builtin_fixnum_inc(i)
         end
         self
       end
@@ -243,10 +243,10 @@ class Array
 
         i = 0
         result = Primitive.ary_sized_alloc
-        until Primitive.rb_jit_ary_at_end(i)
-          value = yield(Primitive.rb_jit_ary_at(i))
+        until Primitive.rb_builtin_ary_at_end(i)
+          value = yield(Primitive.rb_builtin_ary_at(i))
           Primitive.rb_jit_ary_push(result, value)
-          i = Primitive.rb_jit_fixnum_inc(i)
+          i = Primitive.rb_builtin_fixnum_inc(i)
         end
         result
       end
@@ -269,12 +269,12 @@ class Array
 
         i = 0
         result = Primitive.ary_sized_alloc
-        until Primitive.rb_jit_ary_at_end(i)
-          value = Primitive.rb_jit_ary_at(i)
+        until Primitive.rb_builtin_ary_at_end(i)
+          value = Primitive.rb_builtin_ary_at(i)
           if yield value
             Primitive.rb_jit_ary_push(result, value)
           end
-          i = Primitive.rb_jit_fixnum_inc(i)
+          i = Primitive.rb_builtin_fixnum_inc(i)
         end
         result
       end
@@ -296,10 +296,10 @@ class Array
     #       return Primitive.cexpr! 'SIZED_ENUMERATOR(self, 0, 0, ary_enum_length)'
     #     end
     #     i = 0
-    #     until Primitive.rb_jit_ary_at_end(i)
-    #       value = Primitive.rb_jit_ary_at(i)
+    #     until Primitive.rb_builtin_ary_at_end(i)
+    #       value = Primitive.rb_builtin_ary_at(i)
     #       return value if yield(value)
-    #       i = Primitive.rb_jit_fixnum_inc(i)
+    #       i = Primitive.rb_builtin_fixnum_inc(i)
     #     end
     #     if_none_proc&.call
     #   end

--- a/zjit/src/cruby_methods.rs
+++ b/zjit/src/cruby_methods.rs
@@ -16,9 +16,9 @@ use crate::hir::{self, FieldName};
 
 // Array iteration builtin functions (defined in array.c)
 unsafe extern "C" {
-    fn rb_jit_ary_at_end(ec: EcPtr, self_: VALUE, index: VALUE) -> VALUE;
-    fn rb_jit_ary_at(ec: EcPtr, self_: VALUE, index: VALUE) -> VALUE;
-    fn rb_jit_fixnum_inc(ec: EcPtr, self_: VALUE, num: VALUE) -> VALUE;
+    fn rb_builtin_ary_at_end(ec: EcPtr, self_: VALUE, index: VALUE) -> VALUE;
+    fn rb_builtin_ary_at(ec: EcPtr, self_: VALUE, index: VALUE) -> VALUE;
+    fn rb_builtin_fixnum_inc(ec: EcPtr, self_: VALUE, num: VALUE) -> VALUE;
     fn rb_str_equal(str1: VALUE, str2: VALUE) -> VALUE;
 }
 
@@ -297,9 +297,9 @@ pub fn init() -> Annotations {
     annotate_builtin!(rb_cSymbol, "empty?", types::BoolExact);
 
     // Array iteration builtins (used in with_jit Array#each, map, select, find)
-    builtin_funcs.insert(rb_jit_fixnum_inc as *mut c_void, FnProperties { inline: inline_fixnum_inc, return_type: types::Fixnum, ..Default::default() });
-    builtin_funcs.insert(rb_jit_ary_at as *mut c_void, FnProperties { inline: inline_ary_at, ..Default::default() });
-    builtin_funcs.insert(rb_jit_ary_at_end as *mut c_void, FnProperties { inline: inline_ary_at_end, return_type: types::BoolExact, ..Default::default() });
+    builtin_funcs.insert(rb_builtin_fixnum_inc as *mut c_void, FnProperties { inline: inline_fixnum_inc, return_type: types::Fixnum, ..Default::default() });
+    builtin_funcs.insert(rb_builtin_ary_at as *mut c_void, FnProperties { inline: inline_ary_at, ..Default::default() });
+    builtin_funcs.insert(rb_builtin_ary_at_end as *mut c_void, FnProperties { inline: inline_ary_at_end, return_type: types::BoolExact, ..Default::default() });
 
     Annotations {
         cfuncs: std::mem::take(cfuncs),


### PR DESCRIPTION
This PR renames `rb_jit_`-prefixed functions in `array.c` to names with a `rb_builtin_` prefix.

To avoid confusion, I want to reserve the `rb_jit_` prefix to `jit.c` or something only called from JIT, which is not the case for these functions. They are called from the interpreter as well. These ISEQs should also stop using `with_jit` at some point, and I think `rb_builtin_` is generally a more appropriate prefix for (non-static) functions used by `invokebuiltin`.