### PR TITLE
[DOC] Deprecate ruby2_keywords in documentation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -39,6 +39,11 @@ Note: We're only listing outstanding class updates.
       given names, raising `KeyError` for missing names unless a block is
       given. [[Feature #21781]]
 
+* Hash
+
+    * `Hash.ruby2_keywords_hash?` and `Hash.ruby2_keywords_hash` are
+      deprecated and will be removed in Ruby 4.5. [[Feature #22205]]
+
 * Integer
 
     * `Integer#bit_count` is added. It returns the number of `1` bits in the
@@ -59,6 +64,11 @@ Note: We're only listing outstanding class updates.
     * `MatchData#integer_at` is added.  It converts the matched substring to
       integer and return the result.  [[Feature #21932]]
 
+* Module
+
+    * `Module#ruby2_keywords` and top-level `ruby2_keywords` are
+      deprecated and will be removed in Ruby 4.4. [[Feature #22205]]
+
 * ObjectSpace
 
     * `ObjectSpace._id2ref` was removed.  [[Feature #22135]]
@@ -69,6 +79,8 @@ Note: We're only listing outstanding class updates.
       receiver but with the refinements activated by the given modules
       in effect inside its body, without affecting the original `Proc`.
       [[Feature #22097]]
+    * `Proc#ruby2_keywords` is deprecated and will be removed in Ruby 4.4.
+      [[Feature #22205]]
 
 * Range
 
@@ -264,6 +276,7 @@ A lot of work has gone into making Ractors more stable, performant, and usable. 
 [Feature #22139]: https://bugs.ruby-lang.org/issues/22139
 [Feature #22175]: https://bugs.ruby-lang.org/issues/22175
 [Feature #22185]: https://bugs.ruby-lang.org/issues/22185
+[Feature #22205]: https://bugs.ruby-lang.org/issues/22205
 [PR #17201]: https://github.com/ruby/ruby/pull/17201
 [RubyGems-v4.0.4]: https://github.com/rubygems/rubygems/releases/tag/v4.0.4
 [RubyGems-v4.0.5]: https://github.com/rubygems/rubygems/releases/tag/v4.0.5

--- a/hash.c
+++ b/hash.c
@@ -1917,6 +1917,10 @@ rb_hash_s_try_convert(VALUE dummy, VALUE hash)
  *  call-seq:
  *     Hash.ruby2_keywords_hash?(hash) -> true or false
  *
+ *  Deprecated: will be removed in Ruby 4.5, one version after the
+ *  removal of the ruby2_keywords mechanism.  See
+ *  https://bugs.ruby-lang.org/issues/22205 for the schedule.
+ *
  *  Checks if a given hash is flagged by Module#ruby2_keywords (or
  *  Proc#ruby2_keywords).
  *  This method is not for casual use; debugging, researching, and
@@ -1938,6 +1942,10 @@ rb_hash_s_ruby2_keywords_hash_p(VALUE dummy, VALUE hash)
 /*
  *  call-seq:
  *     Hash.ruby2_keywords_hash(hash) -> hash
+ *
+ *  Deprecated: will be removed in Ruby 4.5, one version after the
+ *  removal of the ruby2_keywords mechanism.  See
+ *  https://bugs.ruby-lang.org/issues/22205 for the schedule.
  *
  *  Duplicates a given hash and adds a ruby2_keywords flag.
  *  This method is not for casual use; debugging, researching, and

--- a/proc.c
+++ b/proc.c
@@ -4641,6 +4641,11 @@ rb_method_compose_to_right(VALUE self, VALUE g)
  *  call-seq:
  *     proc.ruby2_keywords -> proc
  *
+ *  Deprecated: will be removed in Ruby 4.4.  Use explicit delegation
+ *  (<tt>*args, **kwargs</tt>) instead; it works correctly on Ruby 3.0
+ *  and later.  See https://bugs.ruby-lang.org/issues/22205 for the
+ *  schedule.
+ *
  *  Marks the proc as passing keywords through a normal argument splat.
  *  This should only be called on procs that accept an argument splat
  *  (<tt>*args</tt>) but not explicit keywords or a keyword splat.  It
@@ -4654,19 +4659,6 @@ rb_method_compose_to_right(VALUE self, VALUE g)
  *  This should only be used for procs that delegate keywords to another
  *  method, and only for backwards compatibility with Ruby versions before
  *  2.7.
- *
- *  This method will probably be removed at some point, as it exists only
- *  for backwards compatibility. As it does not exist in Ruby versions
- *  before 2.7, check that the proc responds to this method before calling
- *  it. Also, be aware that if this method is removed, the behavior of the
- *  proc will change so that it does not pass through keywords.
- *
- *    module Mod
- *      foo = ->(meth, *args, &block) do
- *        send(:"do_#{meth}", *args, &block)
- *      end
- *      foo.ruby2_keywords if foo.respond_to?(:ruby2_keywords)
- *    end
  */
 
 static VALUE

--- a/vm_method.c
+++ b/vm_method.c
@@ -3115,6 +3115,12 @@ rb_mod_private(int argc, VALUE *argv, VALUE module)
  *  call-seq:
  *     ruby2_keywords(method_name, ...)    -> nil
  *
+ *  Deprecated: will be removed in Ruby 4.4.  Use <tt>...</tt>
+ *  {argument forwarding}[rdoc-ref:syntax/methods.rdoc@Argument+Forwarding]
+ *  or other delegation styles instead; they work correctly on Ruby 3.0
+ *  and later.  See https://bugs.ruby-lang.org/issues/22205 for the
+ *  schedule.
+ *
  *  For the given method names, marks the method as passing keywords through
  *  a normal argument splat.  This should only be called on methods that
  *  accept an argument splat (<tt>*args</tt>) but not explicit keywords or
@@ -3130,21 +3136,6 @@ rb_mod_private(int argc, VALUE *argv, VALUE module)
  *  method, and only for backwards compatibility with Ruby versions before 3.0.
  *  See https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/
  *  for details on why +ruby2_keywords+ exists and when and how to use it.
- *
- *  This method will probably be removed at some point, as it exists only
- *  for backwards compatibility. As it does not exist in Ruby versions before
- *  2.7, check that the module responds to this method before calling it:
- *
- *    module Mod
- *      def foo(meth, *args, &block)
- *        send(:"do_#{meth}", *args, &block)
- *      end
- *      ruby2_keywords(:foo) if respond_to?(:ruby2_keywords, true)
- *    end
- *
- *  However, be aware that if the +ruby2_keywords+ method is removed, the
- *  behavior of the +foo+ method using the above approach will change so that
- *  the method does not pass through keywords.
  */
 
 static VALUE
@@ -3316,6 +3307,12 @@ top_private(int argc, VALUE *argv, VALUE _)
 /*
  *  call-seq:
  *     ruby2_keywords(method_name, ...) -> self
+ *
+ *  Deprecated: will be removed in Ruby 4.4.  Use <tt>...</tt>
+ *  {argument forwarding}[rdoc-ref:syntax/methods.rdoc@Argument+Forwarding]
+ *  or other delegation styles instead; they work correctly on Ruby 3.0
+ *  and later.  See https://bugs.ruby-lang.org/issues/22205 for the
+ *  schedule.
  *
  *  For the given method names, marks the method as passing keywords through
  *  a normal argument splat.  See Module#ruby2_keywords in detail.


### PR DESCRIPTION
Add documentation-only deprecation notices to Module#ruby2_keywords, main.ruby2_keywords, Proc#ruby2_keywords, Hash.ruby2_keywords_hash?, and Hash.ruby2_keywords_hash, as the first phase of the schedule proposed at https://bugs.ruby-lang.org/issues/22205.