### PR TITLE
win32/rm.bat: report removal failures via exit code

### DIFF
--- a/win32/rm.bat
+++ b/win32/rm.bat
@@ -14,7 +14,7 @@ if "%1" == "-n" (shift & set "dryrun=%1" & goto :optloop)
 if "%1" == "-r" (shift & set "recursive=%1" & goto :optloop)
 if "%1" == "--debug" (shift & set "debug=%1" & set PROMPT=$E[34m+$E[m$S & echo on & goto :optloop)
 :begin
-if "%1" == "" goto :EOF
+if "%1" == "" exit /b %error%
   set p=%1
   shift
   set p=%p:/=\%
@@ -58,7 +58,7 @@ goto :remove_end
     rd /q "%p%" 2> nul && goto :remove_end
 
     ::- If matching files and directory exist, remove the files only first.
-    del /q "%p%" 2> nul
+    del /f /q "%p%" 2> nul
 
     ::- `del` exits with 0 even when nothing matched, so its result cannot
     ::- tell whether directories remain; check if matching entries still
@@ -73,7 +73,14 @@ goto :remove_end
 
     ::- Remove remained directories recursively.
     for /D %%I in (%p%) do (
-        rd /s /q %%I 2> nul || call set error=%%ERRORLEVEL%%
+        rd /s /q %%I 2> nul
     )
+
+    ::- `rd /s` does not set ERRORLEVEL on failure; check what remains
+    ::- instead.  `if exist "dir\*"` is true even for an empty directory,
+    ::- so check remaining files and directories separately.
+    if not exist "%p%" goto :remove_end
+    for %%I in (%p%) do if not exist "%%I\" set error=1
+    for /D %%I in (%p%) do if exist "%%I\" set error=1
 :remove_end
 endlocal & set "error=%error%" & goto :EOF


### PR DESCRIPTION
On mswin, a removal failure such as a DLL locked by another process leaves `nmake clean` green while stale artifacts remain and poison the next build. `rm.bat` sets its internal `error` flag on failure but never propagates it to the exit code, and with `-r` the failure is not even detected because `rd /s /q` does not set `ERRORLEVEL`.

Exit with `error` at the end, detect `rd /s` failures by checking the entries remaining afterwards, and pass `/f` to `del` so read-only files are removed as `rm -f` does. Since `if exist "dir\*"` is true even for an empty directory, remaining files and directories are checked separately with plain `for` and `for /D`.

Before this change a locked file exits 0 both with and without `-r` while the file remains. After it both cases exit 1. Verified with a 15-case matrix covering locked files, multiple arguments, wildcards, intermediate-wildcard recursion, trailing slashes, directory symlinks, dry-run, and read-only files.
