### PR TITLE
common.mk: fix prerequisites ignored by nmake

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -1052,8 +1052,8 @@ $(ENC_MK): $(srcdir)/enc/make_encmake.rb $(srcdir)/enc/Makefile.in $(srcdir)/enc
 
 PHONY:
 
-{$(VPATH)}parse.c: {$(VPATH)}parse.y {$(VPATH)}id.h
-{$(VPATH)}parse.h: {$(VPATH)}parse.c
+parse.c: {$(VPATH)}parse.y {$(VPATH)}id.h
+parse.h: {$(VPATH)}parse.c
 
 {$(srcdir)}.y.c:
 	$(ECHO) generating $@
@@ -1311,9 +1311,7 @@ $(MAINOBJ): $(srcdir)/$(MAINSRC)
 	$(ECHO) compiling $(srcdir)/$(MAINSRC)
 	$(Q) $(CC) $(MAINCPPFLAGS) $(CFLAGS) $(XCFLAGS) $(CPPFLAGS) $(COUTFLAG)$@ -c $(CSRCFLAG)$(srcdir)/$(MAINSRC)
 
-{$(VPATH)}probes.dmyh: {$(srcdir)}probes.d $(tooldir)/gen_dummy_probes.rb
-
-probes.dmyh:
+probes.dmyh: {$(srcdir)}probes.d $(tooldir)/gen_dummy_probes.rb
 	$(BASERUBY) $(tooldir)/gen_dummy_probes.rb $(srcdir)/probes.d > $@
 
 probes.h: {$(VPATH)}probes.$(DTRACE_EXT) $(srcdir)/vm_opts.h


### PR DESCRIPTION
nmake does not join a `{$(VPATH)}target` dependency line and a bare `target` command line into a single node, so the prerequisites declared on the braced lines never fired. In an out-of-place mswin build, `probes.dmyh` was never regenerated after the initial build. When 89e7b08a9f added the `gc__xcalloc` and related probes to `probes.d`, an incremental `nmake` failed to compile `gc.c` with `RUBY_DTRACE_GC_XCALLOC` undefined until the stale `probes.dmyh` was removed by hand. The `id.h` prerequisite of `parse.c` had the same problem, while its `parse.y` prerequisite still worked through the `{$(srcdir)}.y.c` inference rule.

Declaring the prerequisites on the bare targets fixes both. GNU make is unaffected because `tool/prereq.status` strips the braces when generating `uncommon.mk`, which already merged the two lines into one rule.
