### PR TITLE
[Win32] Define warnflags in RbConfig::CONFIG

### DIFF
--- a/win32/Makefile.sub
+++ b/win32/Makefile.sub
@@ -940,6 +940,7 @@ s,@SHELL@,$$(COMSPEC),;t t
 s,@BUILD_FILE_SEPARATOR@,\,;t t
 s,@PATH_SEPARATOR@,;,;t t
 s,@CFLAGS@,$(CFLAGS),;t t
+s,@warnflags@,$(WARNFLAGS),;t t
 s,@WERRORFLAG@,$(WERRORFLAG),;t t
 s,@DEFS@,$(DEFS),;t t
 s,@CPPFLAGS@,$(CPPFLAGS),;t t


### PR DESCRIPTION
On mswin, `config.status` generated by `win32/Makefile.sub` did not define `warnflags`, so `RbConfig::CONFIG["warnflags"]` returned nil. Extensions that modify `warnflags` in `extconf.rb`, such as oj and ox, crashed with NoMethodError and could not be installed. Define it from the existing `WARNFLAGS` macro as on the autoconf platforms.

Verified with a full mswin build. The generated `rbconfig.rb` now contains the key, and `extconf.rb` of oj 3.17.4 and ox 2.14.28 runs past `CONFIG['warnflags'].slice!` and creates a Makefile. btest and test-mkmf pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
