### PR TITLE
Implement ZJIT FPR float fast paths

### DIFF
--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -2662,6 +2662,7 @@ rb_gc_impl_zjit_new_obj_fastpath(void *objspace_ptr, size_t alloc_size, VALUE fl
     struct rb_gc_zjit_default_new_obj_fastpath default_fastpath = {
         base + offsetof(rb_ractor_newobj_heap_cache_t, cursor),
         base + offsetof(rb_ractor_newobj_heap_cache_t, cursor_end),
+        base + offsetof(rb_ractor_newobj_heap_cache_t, allocated_objects_count),
         slot_size,
         flags,
         klass

--- a/gc/default/zjit_fastpath.h
+++ b/gc/default/zjit_fastpath.h
@@ -10,6 +10,7 @@
 struct rb_gc_zjit_default_new_obj_fastpath {
     size_t cursor_offset;
     size_t cursor_end_offset;
+    size_t allocated_objects_count_offset;
     size_t slot_size;
     VALUE flags;
     VALUE klass;

--- a/jit.c
+++ b/jit.c
@@ -14,6 +14,7 @@
 #include "iseq.h"
 #include "internal/compile.h"
 #include "internal/gc.h"
+#include "internal/numeric.h"
 #include "vm_sync.h"
 #include "internal/fixnum.h"
 #include "internal/hash.h"
@@ -22,6 +23,10 @@
 #include "internal/imemo.h"
 #include "ruby/internal/core/rtypeddata.h"
 #include "zjit.h"
+
+#include <float.h>
+#include <limits.h>
+#include <math.h>
 
 #ifndef _WIN32
 #include <sys/mman.h>
@@ -819,6 +824,96 @@ VALUE
 rb_jit_fix_div_fix(VALUE recv, VALUE obj)
 {
     return rb_fix_div_fix(recv, obj);
+}
+
+static inline uint64_t
+rb_jit_f64_bits(double value)
+{
+    union { double f; uint64_t bits; } conv = { .f = value };
+    return conv.bits;
+}
+
+static inline double
+rb_jit_f64_from_bits(uint64_t bits)
+{
+    union { double f; uint64_t bits; } conv = { .bits = bits };
+    return conv.f;
+}
+
+VALUE
+rb_jit_f64_to_float(uint64_t bits)
+{
+    return DBL2NUM(rb_jit_f64_from_bits(bits));
+}
+
+uint64_t
+rb_jit_f64_sin(uint64_t bits)
+{
+    return rb_jit_f64_bits(sin(rb_jit_f64_from_bits(bits)));
+}
+
+uint64_t
+rb_jit_f64_cos(uint64_t bits)
+{
+    return rb_jit_f64_bits(cos(rb_jit_f64_from_bits(bits)));
+}
+
+uint64_t
+rb_jit_f64_pow(uint64_t left_bits, uint64_t right_bits)
+{
+    return rb_jit_f64_bits(pow(rb_jit_f64_from_bits(left_bits), rb_jit_f64_from_bits(right_bits)));
+}
+
+static VALUE
+rb_jit_fixnum_f64_cmp(VALUE fixnum, uint64_t f64_bits)
+{
+    double yd = rb_jit_f64_from_bits(f64_bits);
+    double yi, yf;
+
+    if (isnan(yd))
+        return Qnil;
+    if (isinf(yd)) {
+        if (yd > 0.0) return INT2FIX(-1);
+        else return INT2FIX(1);
+    }
+    yf = modf(yd, &yi);
+#if SIZEOF_LONG * CHAR_BIT < DBL_MANT_DIG /* assume FLT_RADIX == 2 */
+    double xd = (double)FIX2LONG(fixnum);
+    if (xd < yd)
+        return INT2FIX(-1);
+    if (xd > yd)
+        return INT2FIX(1);
+    return INT2FIX(0);
+#else
+    long xn, yn;
+    if (yi < FIXNUM_MIN)
+        return INT2FIX(1);
+    if (FIXNUM_MAX+1 <= yi)
+        return INT2FIX(-1);
+    xn = FIX2LONG(fixnum);
+    yn = (long)yi;
+    if (xn < yn)
+        return INT2FIX(-1);
+    if (xn > yn)
+        return INT2FIX(1);
+    if (yf < 0.0)
+        return INT2FIX(1);
+    if (0.0 < yf)
+        return INT2FIX(-1);
+    return INT2FIX(0);
+#endif
+}
+
+VALUE
+rb_jit_f64_fixnum_cmp(uint64_t left_bits, VALUE right)
+{
+    VALUE rel = rb_jit_fixnum_f64_cmp(right, left_bits);
+
+    if (FIXNUM_P(rel)) {
+        return LONG2FIX(-FIX2LONG(rel));
+    }
+
+    return rel;
 }
 
 // YJIT/ZJIT need this function to never allocate and never raise

--- a/vm.c
+++ b/vm.c
@@ -2928,12 +2928,33 @@ zjit_materialize_frames(const rb_execution_context_t *ec, rb_control_frame_t *cf
                         stack--;
                         *stack = ((VALUE *)cfp->jit_return)[-(ssize_t)ZJIT_STACK_MAP_VREG_INDEX(entry)];
                     }
+                    else if (ZJIT_STACK_MAP_F64_P(entry)) {
+                        stack--;
+                        *stack = Qnil;
+                    }
                     else if (ZJIT_STACK_MAP_SKIP_P(entry)) {
                         stack -= ZJIT_STACK_MAP_SKIP_SIZE(entry);
                     }
                     else {
                         stack--;
                         *stack = entry;
+                    }
+                }
+
+                stack = cfp->sp;
+                for (int32_t i = 0; i < stack_size; i++) {
+                    VALUE entry = jit_frame->stack[i];
+                    if (ZJIT_STACK_MAP_SKIP_P(entry)) {
+                        stack -= ZJIT_STACK_MAP_SKIP_SIZE(entry);
+                    }
+                    else {
+                        stack--;
+                        if (ZJIT_STACK_MAP_F64_P(entry)) {
+                            uint64_t bits = ((uint64_t *)cfp->jit_return)[-(ssize_t)ZJIT_STACK_MAP_F64_INDEX(entry)];
+                            double value;
+                            memcpy(&value, &bits, sizeof(value));
+                            *stack = rb_float_new(value);
+                        }
                     }
                 }
             }

--- a/zjit.h
+++ b/zjit.h
@@ -17,6 +17,7 @@
 // zero, so RB_SPECIAL_CONST_P is false.
 #define ZJIT_STACK_MAP_VREG_TAG 0x08
 #define ZJIT_STACK_MAP_SKIP_TAG 0x10
+#define ZJIT_STACK_MAP_F64_TAG (ZJIT_STACK_MAP_VREG_TAG | ZJIT_STACK_MAP_SKIP_TAG)
 #define ZJIT_STACK_MAP_TAG_MASK 0xff
 #define ZJIT_STACK_MAP_SHIFT 8
 
@@ -44,6 +45,18 @@ ZJIT_STACK_MAP_SKIP_SIZE(VALUE entry)
     return entry >> ZJIT_STACK_MAP_SHIFT;
 }
 
+static inline bool
+ZJIT_STACK_MAP_F64_P(VALUE entry)
+{
+    return (entry & ZJIT_STACK_MAP_TAG_MASK) == ZJIT_STACK_MAP_F64_TAG;
+}
+
+static inline size_t
+ZJIT_STACK_MAP_F64_INDEX(VALUE entry)
+{
+    return entry >> ZJIT_STACK_MAP_SHIFT;
+}
+
 // JITFrame is defined here as the single source of truth and imported into
 // Rust via bindgen. C code reads fields directly; Rust uses an impl block.
 typedef struct zjit_jit_frame {
@@ -62,8 +75,8 @@ typedef struct zjit_jit_frame {
     // Number of stack map entries in stack[].
     uint32_t stack_size;
     // Flexible array of stack map entries. Each entry is either an immediate
-    // VALUE, a tagged native-stack index from cfp->jit_return for a value
-    // kept by the JIT, or a tagged count of VM stack slots to skip.
+    // VALUE, a tagged native-stack index from cfp->jit_return for a value or
+    // raw F64 kept by the JIT, or a tagged count of VM stack slots to skip.
     VALUE stack[];
 } zjit_jit_frame_t;
 

--- a/zjit/src/asm/x86_64/mod.rs
+++ b/zjit/src/asm/x86_64/mod.rs
@@ -29,7 +29,7 @@ pub struct X86UImm
 pub enum RegType
 {
     GP,
-    //FP,
+    FP,
     //XMM,
     IP,
 }
@@ -199,6 +199,17 @@ pub const R13_REG: X86Reg = X86Reg { num_bits: 64, reg_type: RegType::GP, reg_no
 pub const R14_REG: X86Reg = X86Reg { num_bits: 64, reg_type: RegType::GP, reg_no: 14 };
 pub const R15_REG: X86Reg = X86Reg { num_bits: 64, reg_type: RegType::GP, reg_no: 15 };
 
+pub const XMM0_REG:  X86Reg = X86Reg { num_bits: 64, reg_type: RegType::FP, reg_no: 0 };
+pub const XMM1_REG:  X86Reg = X86Reg { num_bits: 64, reg_type: RegType::FP, reg_no: 1 };
+pub const XMM2_REG:  X86Reg = X86Reg { num_bits: 64, reg_type: RegType::FP, reg_no: 2 };
+pub const XMM3_REG:  X86Reg = X86Reg { num_bits: 64, reg_type: RegType::FP, reg_no: 3 };
+pub const XMM4_REG:  X86Reg = X86Reg { num_bits: 64, reg_type: RegType::FP, reg_no: 4 };
+pub const XMM5_REG:  X86Reg = X86Reg { num_bits: 64, reg_type: RegType::FP, reg_no: 5 };
+pub const XMM6_REG:  X86Reg = X86Reg { num_bits: 64, reg_type: RegType::FP, reg_no: 6 };
+pub const XMM7_REG:  X86Reg = X86Reg { num_bits: 64, reg_type: RegType::FP, reg_no: 7 };
+pub const XMM14_REG: X86Reg = X86Reg { num_bits: 64, reg_type: RegType::FP, reg_no: 14 };
+pub const XMM15_REG: X86Reg = X86Reg { num_bits: 64, reg_type: RegType::FP, reg_no: 15 };
+
 pub const RAX: X86Opnd  = X86Opnd::Reg(RAX_REG);
 pub const RCX: X86Opnd  = X86Opnd::Reg(RCX_REG);
 pub const RDX: X86Opnd  = X86Opnd::Reg(RDX_REG);
@@ -215,6 +226,10 @@ pub const R12: X86Opnd  = X86Opnd::Reg(R12_REG);
 pub const R13: X86Opnd  = X86Opnd::Reg(R13_REG);
 pub const R14: X86Opnd  = X86Opnd::Reg(R14_REG);
 pub const R15: X86Opnd  = X86Opnd::Reg(R15_REG);
+
+pub const XMM0:  X86Opnd = X86Opnd::Reg(XMM0_REG);
+pub const XMM14: X86Opnd = X86Opnd::Reg(XMM14_REG);
+pub const XMM15: X86Opnd = X86Opnd::Reg(XMM15_REG);
 
 // 32-bit GP registers
 pub const EAX: X86Opnd  = X86Opnd::Reg(X86Reg { num_bits: 32, reg_type: RegType::GP, reg_no: 0 });
@@ -742,6 +757,73 @@ pub fn cmovpe(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) { write_cmov(cb, 0
 pub fn cmovpo(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) { write_cmov(cb, 0x4b, dst, src); }
 pub fn cmovs(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) { write_cmov(cb, 0x48, dst, src); }
 pub fn cmovz(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) { write_cmov(cb, 0x44, dst, src); }
+
+fn assert_xmm_reg(opnd: X86Opnd) {
+    assert!(matches!(opnd, X86Opnd::Reg(X86Reg { reg_type: RegType::FP, num_bits: 64, .. })), "expected an XMM register, got {opnd:?}");
+}
+
+fn assert_xmm_rm(opnd: X86Opnd) {
+    assert!(
+        matches!(opnd, X86Opnd::Reg(X86Reg { reg_type: RegType::FP, num_bits: 64, .. }) | X86Opnd::Mem(X86Mem { num_bits: 64, .. })),
+        "expected an XMM register or m64, got {opnd:?}"
+    );
+}
+
+fn write_sse_f2_rm(cb: &mut CodeBlock, opcode: u8, dst: X86Opnd, src: X86Opnd) {
+    assert_xmm_reg(dst);
+    assert_xmm_rm(src);
+    cb.write_byte(0xf2);
+    write_rm(cb, false, false, dst, src, None, &[0x0f, opcode]);
+}
+
+fn write_sse_66_rm(cb: &mut CodeBlock, opcode: u8, dst: X86Opnd, src: X86Opnd) {
+    assert_xmm_reg(dst);
+    assert_xmm_rm(src);
+    cb.write_byte(0x66);
+    write_rm(cb, false, false, dst, src, None, &[0x0f, opcode]);
+}
+
+// movsd xmm, xmm/m64
+pub fn movsd_load(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) {
+    write_sse_f2_rm(cb, 0x10, dst, src);
+}
+
+// movsd xmm/m64, xmm
+pub fn movsd_store(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) {
+    assert!(matches!(dst, X86Opnd::Reg(X86Reg { reg_type: RegType::FP, num_bits: 64, .. }) | X86Opnd::Mem(X86Mem { num_bits: 64, .. })));
+    assert_xmm_reg(src);
+    cb.write_byte(0xf2);
+    write_rm(cb, false, false, src, dst, None, &[0x0f, 0x11]);
+}
+
+// movq xmm, r/m64
+pub fn movq_to_xmm(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) {
+    assert_xmm_reg(dst);
+    assert!(matches!(src, X86Opnd::Reg(X86Reg { reg_type: RegType::GP, num_bits: 64, .. }) | X86Opnd::Mem(X86Mem { num_bits: 64, .. })));
+    write_rm(cb, true, true, dst, src, None, &[0x0f, 0x6e]);
+}
+
+// movq r/m64, xmm
+pub fn movq_from_xmm(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) {
+    assert!(matches!(dst, X86Opnd::Reg(X86Reg { reg_type: RegType::GP, num_bits: 64, .. }) | X86Opnd::Mem(X86Mem { num_bits: 64, .. })));
+    assert_xmm_reg(src);
+    write_rm(cb, true, true, src, dst, None, &[0x0f, 0x7e]);
+}
+
+pub fn addsd(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) { write_sse_f2_rm(cb, 0x58, dst, src); }
+pub fn subsd(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) { write_sse_f2_rm(cb, 0x5c, dst, src); }
+pub fn mulsd(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) { write_sse_f2_rm(cb, 0x59, dst, src); }
+pub fn divsd(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) { write_sse_f2_rm(cb, 0x5e, dst, src); }
+pub fn sqrtsd(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) { write_sse_f2_rm(cb, 0x51, dst, src); }
+pub fn ucomisd(cb: &mut CodeBlock, left: X86Opnd, right: X86Opnd) { write_sse_66_rm(cb, 0x2e, left, right); }
+
+// cvtsi2sd xmm, r/m64
+pub fn cvtsi2sd(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) {
+    assert_xmm_reg(dst);
+    assert!(matches!(src, X86Opnd::Reg(X86Reg { reg_type: RegType::GP, num_bits: 64, .. }) | X86Opnd::Mem(X86Mem { num_bits: 64, .. })));
+    cb.write_byte(0xf2);
+    write_rm(cb, false, true, dst, src, None, &[0x0f, 0x2a]);
+}
 
 /// cmp - Compare and set flags
 pub fn cmp(cb: &mut CodeBlock, opnd0: X86Opnd, opnd1: X86Opnd) {

--- a/zjit/src/backend/arm64/mod.rs
+++ b/zjit/src/backend/arm64/mod.rs
@@ -191,6 +191,116 @@ fn emit_load_value(cb: &mut CodeBlock, rd: A64Opnd, value: u64) -> usize {
     }
 }
 
+fn emit_u32(cb: &mut CodeBlock, instruction: u32) {
+    cb.write_bytes(&instruction.to_le_bytes());
+}
+
+fn emit_fmov_f64_from_gp(cb: &mut CodeBlock, dst_f64_reg_no: u8, src_gp: A64Opnd) {
+    if let A64Opnd::Reg(src_gp) = src_gp {
+        assert_eq!(src_gp.num_bits, 64, "fmov dN, xN expects a 64-bit GP source");
+        assert!(dst_f64_reg_no < 32, "invalid f64 register");
+        emit_u32(cb, 0x9e67_0000 | ((src_gp.reg_no as u32) << 5) | dst_f64_reg_no as u32);
+    } else {
+        unreachable!("fmov dN, xN expects a GP register source");
+    }
+}
+
+fn emit_fmov_gp_from_f64(cb: &mut CodeBlock, dst_gp: A64Opnd, src_f64_reg_no: u8) {
+    if let A64Opnd::Reg(dst_gp) = dst_gp {
+        assert_eq!(dst_gp.num_bits, 64, "fmov xN, dN expects a 64-bit GP destination");
+        assert!(src_f64_reg_no < 32, "invalid f64 register");
+        emit_u32(cb, 0x9e66_0000 | ((src_f64_reg_no as u32) << 5) | dst_gp.reg_no as u32);
+    } else {
+        unreachable!("fmov xN, dN expects a GP register destination");
+    }
+}
+
+fn emit_f64_mem(cb: &mut CodeBlock, base: u32, f64_reg_no: u8, mem: A64Opnd) {
+    if let A64Opnd::Mem(mem) = mem {
+        assert!(f64_reg_no < 32, "invalid f64 register");
+        assert!(mem_disp_fits_bits(mem.disp), "expected displacement {} to be 9 bits or less", mem.disp);
+        let imm9 = (mem.disp as i32 as u32) & 0x1ff;
+        emit_u32(cb, base | (imm9 << 12) | ((mem.base_reg_no as u32) << 5) | f64_reg_no as u32);
+    } else {
+        unreachable!("f64 memory instruction expects a memory operand");
+    }
+}
+
+fn emit_ldur_f64(cb: &mut CodeBlock, dst_f64_reg_no: u8, mem: A64Opnd) {
+    emit_f64_mem(cb, 0xfc40_0000, dst_f64_reg_no, mem);
+}
+
+fn emit_stur_f64(cb: &mut CodeBlock, src_f64_reg_no: u8, mem: A64Opnd) {
+    emit_f64_mem(cb, 0xfc00_0000, src_f64_reg_no, mem);
+}
+
+fn emit_f64_binop(cb: &mut CodeBlock, op: F64BinOp, dst: u8, left: u8, right: u8) {
+    assert!(dst < 32 && left < 32 && right < 32, "invalid f64 register");
+    let base = match op {
+        F64BinOp::Mul => 0x1e60_0800,
+        F64BinOp::Div => 0x1e60_1800,
+        F64BinOp::Add => 0x1e60_2800,
+        F64BinOp::Sub => 0x1e60_3800,
+    };
+    emit_u32(cb, base | ((right as u32) << 16) | ((left as u32) << 5) | dst as u32);
+}
+
+fn emit_f64_raw_binop(cb: &mut CodeBlock, op: F64BinOp, left: A64Opnd, right: A64Opnd, out: A64Opnd) {
+    let left = left.unwrap_reg().reg_no;
+    let right = right.unwrap_reg().reg_no;
+    let out = out.unwrap_reg().reg_no;
+    emit_f64_binop(cb, op, out, left, right);
+}
+
+fn emit_f64_raw_sqrt(cb: &mut CodeBlock, val: A64Opnd, out: A64Opnd) {
+    let val = val.unwrap_reg().reg_no;
+    let out = out.unwrap_reg().reg_no;
+    assert!(val < 32 && out < 32, "invalid f64 register");
+    emit_u32(cb, 0x1e61_c000 | ((val as u32) << 5) | out as u32);
+}
+
+fn emit_fcmp_f64(cb: &mut CodeBlock, left: u8, right: u8) {
+    assert!(left < 32 && right < 32, "invalid f64 register");
+    emit_u32(cb, 0x1e60_2000 | ((right as u32) << 16) | ((left as u32) << 5));
+}
+
+fn emit_bool_from_condition(cb: &mut CodeBlock, out: A64Opnd, condition: u8) {
+    emit_load_value(cb, out, Qfalse.as_u64());
+    emit_load_value(cb, A64Opnd::Reg(X16_REG), Qtrue.as_u64());
+    csel(cb, out, A64Opnd::Reg(X16_REG), out, condition);
+}
+
+fn emit_f64_raw_cmp(cb: &mut CodeBlock, op: F64BoolCmpOp, left: A64Opnd, right: A64Opnd, out: A64Opnd) {
+    let left = left.unwrap_reg().reg_no;
+    let right = right.unwrap_reg().reg_no;
+    emit_fcmp_f64(cb, left, right);
+
+    let condition = match op {
+        F64BoolCmpOp::Eq => Condition::EQ,
+        // FCMP sets V for unordered. These conditions match Ruby's unordered => false semantics.
+        F64BoolCmpOp::Lt => Condition::MI,
+        F64BoolCmpOp::Le => Condition::LS,
+        F64BoolCmpOp::Gt => Condition::GT,
+        F64BoolCmpOp::Ge => Condition::GE,
+    };
+    emit_bool_from_condition(cb, out, condition);
+}
+
+fn emit_scvtf_f64_from_gp(cb: &mut CodeBlock, dst_f64_reg_no: u8, src_gp: A64Opnd) {
+    if let A64Opnd::Reg(src_gp) = src_gp {
+        assert_eq!(src_gp.num_bits, 64, "scvtf dN, xN expects a 64-bit GP source");
+        assert!(dst_f64_reg_no < 32, "invalid f64 register");
+        emit_u32(cb, 0x9e62_0000 | ((src_gp.reg_no as u32) << 5) | dst_f64_reg_no as u32);
+    } else {
+        unreachable!("scvtf dN, xN expects a GP register source");
+    }
+}
+
+fn emit_fixnum_to_f64_raw(cb: &mut CodeBlock, val: A64Opnd, out: A64Opnd) {
+    asr(cb, A64Opnd::Reg(X16_REG), val, A64Opnd::new_uimm(1));
+    emit_scvtf_f64_from_gp(cb, out.unwrap_reg().reg_no, A64Opnd::Reg(X16_REG));
+}
+
 /// List of registers that can be used for register allocation.
 /// This has the same number of registers for x86_64 and arm64.
 /// SCRATCH_OPND, SCRATCH1_OPND, and EMIT_OPND are excluded.
@@ -205,15 +315,32 @@ pub const ALLOC_REGS: &[Reg] = &[
     X12_REG,
 ];
 
+/// Floating-point registers used for F64 virtual registers.
+/// We currently use caller-saved registers only and preserve live ones around C calls explicitly.
+pub const FP_ALLOC_REGS: &[Reg] = &[
+    X0_REG,
+    X1_REG,
+    X2_REG,
+    X3_REG,
+    X4_REG,
+    X5_REG,
+    Reg { num_bits: 64, reg_no: 6 },
+    Reg { num_bits: 64, reg_no: 7 },
+];
+
 /// Special scratch registers for intermediate processing. They should be used only by
 /// [`Assembler::arm64_scratch_split`] or [`Assembler::new_with_scratch_reg`].
 const SCRATCH0_OPND: Opnd = Opnd::Reg(X15_REG);
 const SCRATCH1_OPND: Opnd = Opnd::Reg(X17_REG);
+const FP_SCRATCH0_OPND: Opnd = Opnd::Reg(Reg { num_bits: 64, reg_no: 16 });
+const FP_SCRATCH1_OPND: Opnd = Opnd::Reg(Reg { num_bits: 64, reg_no: 17 });
 
 /// A scratch register available for use by resolve_ssa to break register copy cycles.
 /// Must not overlap with ALLOC_REGS or other preserved registers.
 pub const SCRATCH_REG: Reg = X15_REG;
 const SCRATCH2_OPND: Opnd = Opnd::Reg(X14_REG);
+pub const FP_SAVE_SCRATCH_REG: Reg = X14_REG;
+pub const FP_SAVE_SCRATCH2_REG: Reg = X17_REG;
 
 impl Assembler {
     const MAX_FRAME_STACK_SLOTS: usize = 2048;
@@ -452,6 +579,20 @@ impl Assembler {
                 Insn::Sub { left, right, .. } => {
                     *left = split_load_operand(asm, *left);
                     *right = split_shifted_immediate(asm, *right);
+                    asm.push_insn(insn);
+                }
+                Insn::F64BinOpRaw { .. } |
+                Insn::F64SqrtRaw { .. } |
+                Insn::F64BoolCmpRaw { .. } => {
+                    asm.push_insn(insn);
+                }
+                Insn::BitsToF64Raw { val, .. } |
+                Insn::F64ToBitsRaw { val, .. } => {
+                    *val = split_load_operand(asm, *val);
+                    asm.push_insn(insn);
+                }
+                Insn::FixnumToF64Raw { val, .. } => {
+                    *val = split_load_operand(asm, *val);
                     asm.push_insn(insn);
                 }
                 Insn::And { left, right, .. } |
@@ -737,6 +878,34 @@ impl Assembler {
             }
         }
 
+        /// If opnd is an F64 stack spill, load it directly into an FP scratch register.
+        fn split_f64_memory_read(asm: &mut Assembler, opnd: Opnd, addr_scratch: Opnd, fp_scratch: Opnd) -> Opnd {
+            if let Opnd::Mem(_) = opnd {
+                let opnd = split_stack_membase(asm, opnd, addr_scratch);
+                asm.push_insn(Insn::LoadF64Raw { opnd, out: fp_scratch });
+                fp_scratch
+            } else {
+                opnd
+            }
+        }
+
+        /// If out is an F64 stack spill, compute into an FP scratch and return
+        /// the spill slot that needs to receive the raw bits afterwards.
+        fn split_f64_memory_write(out: &mut Opnd, fp_scratch: Opnd) -> Option<Opnd> {
+            if let Opnd::Mem(_) = out {
+                let mem_opnd = out.clone();
+                *out = fp_scratch;
+                Some(mem_opnd)
+            } else {
+                None
+            }
+        }
+
+        fn store_f64_to_memory(asm: &mut Assembler, mem_out: Opnd, fp_src: Opnd, addr_scratch: Opnd) {
+            let mem_out = split_stack_membase(asm, mem_out, addr_scratch);
+            asm.push_insn(Insn::StoreF64Raw { dest: mem_out, src: fp_src });
+        }
+
         let mut asm_local = Assembler::new_with_asm_without_blocks(&self);
         asm_local.accept_scratch_reg = true;
 
@@ -776,6 +945,41 @@ impl Assembler {
                         asm.store(mem_out, SCRATCH0_OPND);
                     }
                 }
+                Insn::F64BinOpRaw { left, right, out, .. } => {
+                    *left = split_f64_memory_read(asm, *left, SCRATCH0_OPND, FP_SCRATCH0_OPND);
+                    *right = split_f64_memory_read(asm, *right, SCRATCH1_OPND, FP_SCRATCH1_OPND);
+                    let mem_out = split_f64_memory_write(out, FP_SCRATCH0_OPND);
+                    let fp_out = *out;
+
+                    asm.push_insn(insn);
+
+                    if let Some(mem_out) = mem_out {
+                        store_f64_to_memory(asm, mem_out, fp_out, SCRATCH1_OPND);
+                    }
+                }
+                Insn::F64SqrtRaw { val, out } => {
+                    *val = split_f64_memory_read(asm, *val, SCRATCH0_OPND, FP_SCRATCH0_OPND);
+                    let mem_out = split_f64_memory_write(out, FP_SCRATCH0_OPND);
+                    let fp_out = *out;
+
+                    asm.push_insn(insn);
+
+                    if let Some(mem_out) = mem_out {
+                        store_f64_to_memory(asm, mem_out, fp_out, SCRATCH1_OPND);
+                    }
+                }
+                Insn::F64BoolCmpRaw { left, right, out, .. } => {
+                    *left = split_f64_memory_read(asm, *left, SCRATCH0_OPND, FP_SCRATCH0_OPND);
+                    *right = split_f64_memory_read(asm, *right, SCRATCH1_OPND, FP_SCRATCH1_OPND);
+                    let mem_out = split_memory_write(out, SCRATCH0_OPND);
+
+                    asm.push_insn(insn);
+
+                    if let Some(mem_out) = mem_out {
+                        let mem_out = split_stack_membase(asm, mem_out, SCRATCH1_OPND);
+                        asm.store(mem_out, SCRATCH0_OPND);
+                    }
+                }
                 Insn::Mul { left, right, out } => {
                     *left = split_memory_read(asm, *left, SCRATCH0_OPND);
                     *right = split_memory_read(asm, *right, SCRATCH1_OPND);
@@ -797,7 +1001,8 @@ impl Assembler {
                     }
                 }
                 Insn::LShift { opnd, out, .. } |
-                Insn::RShift { opnd, out, .. } => {
+                Insn::RShift { opnd, out, .. } |
+                Insn::URShift { opnd, out, .. } => {
                     *opnd = split_memory_read(asm, *opnd, SCRATCH0_OPND);
                     let mem_out = split_memory_write(out, SCRATCH0_OPND);
 
@@ -808,6 +1013,46 @@ impl Assembler {
                         asm.store(mem_out, SCRATCH0_OPND);
                     }
                 }
+                Insn::FixnumToF64Raw { val, out } |
+                Insn::BitsToF64Raw { val, out } => {
+                    *val = split_memory_read(asm, *val, SCRATCH0_OPND);
+                    let mem_out = split_f64_memory_write(out, FP_SCRATCH0_OPND);
+                    let fp_out = *out;
+
+                    asm.push_insn(insn);
+
+                    if let Some(mem_out) = mem_out {
+                        store_f64_to_memory(asm, mem_out, fp_out, SCRATCH1_OPND);
+                    }
+                }
+                Insn::F64ToBitsRaw { val, out } => {
+                    *val = split_f64_memory_read(asm, *val, SCRATCH0_OPND, FP_SCRATCH0_OPND);
+                    let mem_out = split_memory_write(out, SCRATCH0_OPND);
+
+                    asm.push_insn(insn);
+
+                    if let Some(mem_out) = mem_out {
+                        let mem_out = split_stack_membase(asm, mem_out, SCRATCH1_OPND);
+                        asm.store(mem_out, SCRATCH0_OPND);
+                    }
+                }
+                Insn::LoadF64Raw { opnd, out } => {
+                    *opnd = split_stack_membase(asm, *opnd, SCRATCH0_OPND);
+                    let mem_out = split_f64_memory_write(out, FP_SCRATCH0_OPND);
+                    let fp_out = *out;
+
+                    asm.push_insn(insn);
+
+                    if let Some(mem_out) = mem_out {
+                        store_f64_to_memory(asm, mem_out, fp_out, SCRATCH1_OPND);
+                    }
+                }
+                Insn::StoreF64Raw { dest, src } => {
+                    *dest = split_stack_membase(asm, *dest, SCRATCH0_OPND);
+                    *src = split_f64_memory_read(asm, *src, SCRATCH1_OPND, FP_SCRATCH1_OPND);
+
+                    asm.push_insn(insn);
+                }
                 Insn::Cmp { left, right } |
                 Insn::Test { left, right } => {
                     *left = split_memory_read(asm, *left, SCRATCH0_OPND);
@@ -817,7 +1062,8 @@ impl Assembler {
                 // For compile_exits, support splitting simple C arguments here
                 Insn::CCall { data } if !data.opnds.is_empty() => {
                     for (i, opnd) in data.opnds.iter().enumerate() {
-                        asm.load_into(C_ARG_OPNDS[i], *opnd);
+                        let opnd = split_stack_membase(asm, *opnd, SCRATCH0_OPND);
+                        asm.load_into(C_ARG_OPNDS[i], opnd);
                     }
                     data.opnds = vec![];
                     asm.push_insn(insn);
@@ -1244,6 +1490,30 @@ impl Assembler {
                             mul(cb, out.into(), left.into(), right.into());
                         }
                     }
+                },
+                Insn::BitsToF64Raw { val, out } => {
+                    emit_fmov_f64_from_gp(cb, A64Opnd::from(*out).unwrap_reg().reg_no, (*val).into());
+                },
+                Insn::F64ToBitsRaw { val, out } => {
+                    emit_fmov_gp_from_f64(cb, (*out).into(), A64Opnd::from(*val).unwrap_reg().reg_no);
+                },
+                Insn::LoadF64Raw { opnd, out } => {
+                    emit_ldur_f64(cb, A64Opnd::from(*out).unwrap_reg().reg_no, (*opnd).into());
+                },
+                Insn::StoreF64Raw { dest, src } => {
+                    emit_stur_f64(cb, A64Opnd::from(*src).unwrap_reg().reg_no, (*dest).into());
+                },
+                Insn::F64BinOpRaw { op, left, right, out } => {
+                    emit_f64_raw_binop(cb, *op, (*left).into(), (*right).into(), (*out).into());
+                },
+                Insn::F64SqrtRaw { val, out } => {
+                    emit_f64_raw_sqrt(cb, (*val).into(), (*out).into());
+                },
+                Insn::F64BoolCmpRaw { op, left, right, out } => {
+                    emit_f64_raw_cmp(cb, *op, (*left).into(), (*right).into(), (*out).into());
+                },
+                Insn::FixnumToF64Raw { val, out } => {
+                    emit_fixnum_to_f64_raw(cb, (*val).into(), (*out).into());
                 },
                 Insn::And { left, right, out } => {
                     and(cb, out.into(), left.into(), right.into());
@@ -1947,6 +2217,72 @@ mod tests {
         0x4: stur x0, [x2]
         ");
         assert_snapshot!(cb.hexdump(), @"000001ab400000f8");
+    }
+
+    #[test]
+    fn test_emit_f64_binop_raw() {
+        let (mut asm, mut cb) = setup_asm();
+
+        let opnd = asm.f64_binop_raw(F64BinOp::Add, Opnd::Reg(X0_REG), Opnd::Reg(X1_REG));
+        let bits = asm.f64_to_bits_raw(opnd);
+        asm.store(Opnd::mem(64, Opnd::Reg(X3_REG), 0), bits);
+        asm.compile_with_regs(&mut cb, vec![X2_REG]).unwrap();
+
+        assert_disasm_snapshot!(cb.disasm(), @"
+        0x0: fadd d0, d0, d1
+        0x4: fmov x0, d0
+        0x8: stur x0, [x3]
+        ");
+        assert_snapshot!(cb.hexdump(), @"0028611e0000669e600000f8");
+    }
+
+    #[test]
+    fn test_emit_f64_load_store_raw() {
+        let (mut asm, mut cb) = setup_asm();
+
+        asm.push_insn(Insn::LoadF64Raw {
+            opnd: Opnd::mem(64, Opnd::Reg(X1_REG), 0),
+            out: Opnd::Reg(Reg { num_bits: 64, reg_no: 0 }),
+        });
+        asm.push_insn(Insn::StoreF64Raw {
+            dest: Opnd::mem(64, Opnd::Reg(X1_REG), 0),
+            src: Opnd::Reg(Reg { num_bits: 64, reg_no: 0 }),
+        });
+        asm.push_insn(Insn::LoadF64Raw {
+            opnd: Opnd::mem(64, Opnd::Reg(X4_REG), -8),
+            out: Opnd::Reg(Reg { num_bits: 64, reg_no: 16 }),
+        });
+        asm.push_insn(Insn::StoreF64Raw {
+            dest: Opnd::mem(64, Opnd::Reg(X5_REG), 16),
+            src: Opnd::Reg(Reg { num_bits: 64, reg_no: 17 }),
+        });
+
+        asm.compile_with_num_regs(&mut cb, ALLOC_REGS.len());
+
+        assert_snapshot!(cb.hexdump(), @"200040fc200000fc90805ffcb10001fc");
+    }
+
+    #[test]
+    fn test_emit_f64_load_store_raw_from_stack_spill() {
+        let (mut asm, mut cb) = setup_asm();
+
+        let stack_mem = Opnd::Mem(Mem {
+            base: MemBase::Stack { stack_idx: 0, num_bits: 64 },
+            disp: 0,
+            num_bits: 64,
+        });
+        asm.push_insn(Insn::LoadF64Raw {
+            opnd: stack_mem,
+            out: Opnd::Reg(Reg { num_bits: 64, reg_no: 0 }),
+        });
+        asm.push_insn(Insn::StoreF64Raw {
+            dest: stack_mem,
+            src: Opnd::Reg(Reg { num_bits: 64, reg_no: 0 }),
+        });
+
+        asm.compile_with_num_regs(&mut cb, ALLOC_REGS.len());
+
+        assert!(!cb.hexdump().is_empty(), "F64 stack spill load/store should compile");
     }
 
     #[test]
@@ -2836,14 +3172,59 @@ mod tests {
         0x1c: stp xzr, x4, [sp, #-0x10]!
         0x20: mov x16, #0
         0x24: blr x16
-        0x28: ldp xzr, x4, [sp], #0x10
+        0x28: ldp x0, x4, [sp], #0x10
         0x2c: ldp x3, x2, [sp], #0x10
         0x30: ldp x1, x0, [sp], #0x10
         0x34: adds x0, x0, x1
         0x38: adds x0, x2, x3
         0x3c: adds x0, x2, x4
         ");
-        assert_snapshot!(cb.hexdump(), @"200080d2410080d2620080d2830080d2a40080d2e103bfa9e30bbfa9ff13bfa9100080d200023fd6ff13c1a8e30bc1a8e103c1a8000001ab400003ab400004ab");
+        assert_snapshot!(cb.hexdump(), @"200080d2410080d2620080d2830080d2a40080d2e103bfa9e30bbfa9ff13bfa9100080d200023fd6e013c1a8e30bc1a8e103c1a8000001ab400003ab400004ab");
+    }
+
+    #[test]
+    fn test_ccall_f64_register_preservation() {
+        let (mut asm, mut cb) = setup_asm();
+
+        let v0 = asm.bits_to_f64_raw(Opnd::Reg(X0_REG));
+        let v1 = asm.bits_to_f64_raw(Opnd::Reg(X1_REG));
+        asm.ccall(0 as _, vec![]);
+        let sum = asm.f64_binop_raw(F64BinOp::Add, v0, v1);
+        let bits = asm.f64_to_bits_raw(sum);
+        asm.mov(C_RET_OPND, bits);
+
+        asm.compile_with_num_regs(&mut cb, ALLOC_REGS.len());
+
+        assert!(!cb.hexdump().is_empty(), "FP caller-save sequence should compile");
+    }
+
+    #[test]
+    fn test_f64_spill_reload_compiles() {
+        let (mut asm, mut cb) = setup_asm();
+
+        let vals: Vec<_> = (0..9)
+            .map(|idx| {
+                let bits = asm.load((idx + 1).into());
+                asm.bits_to_f64_raw(bits)
+            })
+            .collect();
+
+        let mut acc = vals[0];
+        for val in vals.into_iter().skip(1) {
+            acc = asm.f64_binop_raw(F64BinOp::Add, acc, val);
+        }
+        let bits = asm.f64_to_bits_raw(acc);
+        asm.mov(C_RET_OPND, bits);
+
+        asm.compile_with_num_regs(&mut cb, ALLOC_REGS.len());
+
+        #[cfg(feature = "disasm")]
+        {
+            let disasm = cb.disasm();
+            assert!(disasm.contains("ldur d"), "spilled FP values should reload with LDUR D:\n{disasm}");
+            assert!(disasm.contains("stur d"), "spilled FP values should spill with STUR D:\n{disasm}");
+        }
+        assert!(!cb.hexdump().is_empty(), "spilled FP values should compile");
     }
 
     #[test]
@@ -2917,6 +3298,24 @@ mod tests {
         0xc: lsl x0, x15, #1
         ");
         assert_snapshot!(cb.hexdump(), @"300080d2b0831ff8af835ff8e0f97fd3");
+    }
+
+    #[test]
+    fn test_split_spilled_urshift() {
+        let (mut asm, mut cb) = setup_asm();
+
+        let opnd_vreg = asm.load(1.into());
+        let out_vreg = asm.urshift(opnd_vreg, Opnd::UImm(1));
+        asm.mov(C_RET_OPND, out_vreg);
+        asm.compile_with_num_regs(&mut cb, 0); // spill every VReg
+
+        assert_disasm_snapshot!(cb.disasm(), @"
+        0x0: mov x16, #1
+        0x4: stur x16, [x29, #-8]
+        0x8: ldur x15, [x29, #-8]
+        0xc: lsr x0, x15, #1
+        ");
+        assert_snapshot!(cb.hexdump(), @"300080d2b0831ff8af835ff8e0fd41d3");
     }
 
     #[test]

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -5,7 +5,8 @@ use std::mem::take;
 use std::rc::Rc;
 use crate::bitset::BitSet;
 use crate::codegen::{perf_symbol_range_start, perf_symbol_range_end, register_with_perf};
-use crate::cruby::{IseqPtr, RUBY_OFFSET_CFP_ISEQ, RUBY_OFFSET_CFP_JIT_RETURN, RUBY_OFFSET_CFP_PC, RUBY_OFFSET_CFP_SP, SIZEOF_VALUE_I32, VALUE, ZJIT_STACK_MAP_SHIFT, ZJIT_STACK_MAP_SKIP_TAG, ZJIT_STACK_MAP_VREG_TAG, vm_stack_canary, YarvInsnIdx, zjit_jit_frame, local_size_and_idx_to_ep_offset};
+use crate::cruby::{IseqPtr, RUBY_OFFSET_CFP_ISEQ, RUBY_OFFSET_CFP_JIT_RETURN, RUBY_OFFSET_CFP_PC, RUBY_OFFSET_CFP_SP, SIZEOF_VALUE_I32, VALUE, ZJIT_STACK_MAP_SHIFT, ZJIT_STACK_MAP_SKIP_TAG, ZJIT_STACK_MAP_VREG_TAG, rb_jit_f64_to_float, vm_stack_canary, YarvInsnIdx, zjit_jit_frame, local_size_and_idx_to_ep_offset};
+pub use crate::hir::{F64BinOp, F64BoolCmpOp};
 use crate::hir::{Invariant, SideExitReason};
 use crate::hir;
 use crate::options::{TraceExits, PerfMap, get_option};
@@ -15,6 +16,8 @@ use crate::virtualmem::CodePtr;
 use crate::asm::{CodeBlock, Label};
 use crate::state::{ZJITState, rb_zjit_record_exit_stack};
 use crate::cast::IntoUsize;
+
+const ZJIT_STACK_MAP_F64_TAG: usize = ZJIT_STACK_MAP_VREG_TAG as usize | ZJIT_STACK_MAP_SKIP_TAG as usize;
 
 /// LIR Block ID. Unique ID for each block, and also defined in LIR so
 /// we can differentiate it from HIR block ids.
@@ -76,6 +79,12 @@ impl std::fmt::Display for VRegId {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "v{}", self.0)
     }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Ord, PartialOrd)]
+pub enum RegClass {
+    GP,
+    FP,
 }
 
 /// Dummy HIR block ID used when creating test or invalid LIR blocks
@@ -321,7 +330,7 @@ pub enum Opnd
     Value(VALUE),
 
     /// Virtual register. Lowered to Reg or Mem during register assignment.
-    VReg{ idx: VRegId, num_bits: u8 },
+    VReg{ idx: VRegId, num_bits: u8, class: RegClass },
 
     // Low-level operands, for lowering
     Imm(i64),           // Raw signed immediate
@@ -352,7 +361,7 @@ impl Ord for Opnd {
         match (self, other) {
             (Opnd::None, Opnd::None) => std::cmp::Ordering::Equal,
             (Opnd::Value(l), Opnd::Value(r)) => l.0.cmp(&r.0),
-            (Opnd::VReg { idx: lidx, num_bits: lnum_bits }, Opnd::VReg { idx: ridx, num_bits: rnum_bits }) => (lidx, lnum_bits).cmp(&(ridx, rnum_bits)),
+            (Opnd::VReg { idx: lidx, num_bits: lnum_bits, class: lclass }, Opnd::VReg { idx: ridx, num_bits: rnum_bits, class: rclass }) => (lidx, lnum_bits, lclass).cmp(&(ridx, rnum_bits, rclass)),
             (Opnd::Imm(l), Opnd::Imm(r)) => l.cmp(&r),
             (Opnd::UImm(l), Opnd::UImm(r)) => l.cmp(&r),
             (Opnd::Mem(l), Opnd::Mem(r)) => l.cmp(&r),
@@ -371,8 +380,10 @@ impl fmt::Display for Opnd {
             None => write!(f, "None"),
             Value(VALUE(value)) if *value < 10 => write!(f, "Value({value:x})"),
             Value(VALUE(value)) => write!(f, "Value(0x{value:x})"),
-            VReg { idx, num_bits } if *num_bits == 64 => write!(f, "{idx}"),
-            VReg { idx, num_bits } => write!(f, "VReg{num_bits}({idx})"),
+            VReg { idx, num_bits, class: RegClass::GP } if *num_bits == 64 => write!(f, "{idx}"),
+            VReg { idx, num_bits, class: RegClass::GP } => write!(f, "VReg{num_bits}({idx})"),
+            VReg { idx, num_bits, class: RegClass::FP } if *num_bits == 64 => write!(f, "FReg({idx})"),
+            VReg { idx, num_bits, class: RegClass::FP } => write!(f, "FReg{num_bits}({idx})"),
             Imm(value) if value.abs() < 10 => write!(f, "Imm({value:x})"),
             Imm(value) => write!(f, "Imm(0x{value:x})"),
             UImm(value) if *value < 10 => write!(f, "{value:x}"),
@@ -389,8 +400,10 @@ impl fmt::Debug for Opnd {
         match self {
             Self::None => write!(fmt, "None"),
             Value(val) => write!(fmt, "Value({val:?})"),
-            VReg { idx, num_bits } if *num_bits == 64 => write!(fmt, "VReg({})", idx.0),
-            VReg { idx, num_bits } => write!(fmt, "VReg{num_bits}({})", idx.0),
+            VReg { idx, num_bits, class: RegClass::GP } if *num_bits == 64 => write!(fmt, "VReg({})", idx.0),
+            VReg { idx, num_bits, class: RegClass::GP } => write!(fmt, "VReg{num_bits}({})", idx.0),
+            VReg { idx, num_bits, class: RegClass::FP } if *num_bits == 64 => write!(fmt, "FReg({})", idx.0),
+            VReg { idx, num_bits, class: RegClass::FP } => write!(fmt, "FReg{num_bits}({})", idx.0),
             Imm(signed) => write!(fmt, "{signed:x}_i64"),
             UImm(unsigned) => write!(fmt, "{unsigned:x}_u64"),
             // Say Mem and Reg only once
@@ -419,7 +432,8 @@ impl Opnd
                 })
             },
 
-            Opnd::VReg{idx, num_bits: out_num_bits } => {
+            Opnd::VReg{idx, num_bits: out_num_bits, class } => {
+                assert_eq!(class, RegClass::GP, "memory operands require a GP base register");
                 assert!(num_bits <= out_num_bits);
                 Opnd::Mem(Mem {
                     base: MemBase::VReg(idx),
@@ -487,7 +501,7 @@ impl Opnd
         match *self {
             Opnd::Reg(reg) => Opnd::Reg(reg.with_num_bits(num_bits)),
             Opnd::Mem(Mem { base, disp, .. }) => Opnd::Mem(Mem { base, disp, num_bits }),
-            Opnd::VReg { idx, .. } => Opnd::VReg { idx, num_bits },
+            Opnd::VReg { idx, class, .. } => Opnd::VReg { idx, num_bits, class },
             _ => unreachable!("with_num_bits should not be used for: {self:?}"),
         }
     }
@@ -501,8 +515,8 @@ impl Opnd
     /// instructions.
     pub fn map_index(self, indices: &[usize]) -> Opnd {
         match self {
-            Opnd::VReg { idx, num_bits } => {
-                Opnd::VReg { idx: indices[idx].into(), num_bits }
+            Opnd::VReg { idx, num_bits, class } => {
+                Opnd::VReg { idx: indices[idx].into(), num_bits, class }
             }
             Opnd::Mem(Mem { base: MemBase::VReg(idx), disp, num_bits }) => {
                 Opnd::Mem(Mem { base: MemBase::VReg(indices[idx].into()), disp, num_bits })
@@ -583,8 +597,8 @@ impl From<VALUE> for Opnd {
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct SideExit {
     pub pc: Opnd,
-    pub stack: Vec<Opnd>,
-    pub locals: Vec<Opnd>,
+    pub stack: Vec<StackMapEntry>,
+    pub locals: Vec<StackMapEntry>,
     pub iseq: IseqPtr,
     /// Stack map for older inlined frames that are not written directly by this
     /// side exit. The current frame's stack and locals are still handled by
@@ -802,6 +816,30 @@ pub enum Insn {
     /// Tear down the frame stack as necessary per the architecture.
     FrameTeardown { preserved: &'static [Opnd], },
 
+    /// Perform a binary operation on raw C doubles.
+    F64BinOpRaw { op: F64BinOp, left: Opnd, right: Opnd, out: Opnd },
+
+    /// Move raw C double bits from a GP register to an F64 register.
+    BitsToF64Raw { val: Opnd, out: Opnd },
+
+    /// Move raw C double bits from an F64 register to a GP register.
+    F64ToBitsRaw { val: Opnd, out: Opnd },
+
+    /// Load a raw C double from memory into an F64 register.
+    LoadF64Raw { opnd: Opnd, out: Opnd },
+
+    /// Store a raw C double from an F64 register into memory.
+    StoreF64Raw { dest: Opnd, src: Opnd },
+
+    /// Square root of a raw C double bit pattern, returning a raw C double bit pattern.
+    F64SqrtRaw { val: Opnd, out: Opnd },
+
+    /// Compare two raw C double bit patterns, returning a Ruby boolean.
+    F64BoolCmpRaw { op: F64BoolCmpOp, left: Opnd, right: Opnd, out: Opnd },
+
+    /// Convert a Ruby Fixnum VALUE into a raw C double bit pattern.
+    FixnumToF64Raw { val: Opnd, out: Opnd },
+
     // Atomically increment a counter
     // Input: memory operand, increment value
     // Produces no output
@@ -929,11 +967,19 @@ macro_rules! target_for_each_operand_impl {
     ($self:expr, $visit_one:ident, $visit_many:ident, $reborrow:ident) => {
         match $self {
             Target::SideExit(data) => {
-                visit_many!(data.exit.stack);
-                visit_many!(data.exit.locals);
+                for entry in $reborrow!(data.exit.stack) {
+                    if let StackMapEntry::Opnd(opnd) | StackMapEntry::F64(opnd) = entry {
+                        visit_one!(opnd);
+                    }
+                }
+                for entry in $reborrow!(data.exit.locals) {
+                    if let StackMapEntry::Opnd(opnd) | StackMapEntry::F64(opnd) = entry {
+                        visit_one!(opnd);
+                    }
+                }
                 if let Some(StackMap { stack, .. }) = $reborrow!(data.exit.stack_map) {
                     for entry in stack {
-                        if let StackMapEntry::Opnd(opnd) = entry {
+                        if let StackMapEntry::Opnd(opnd) | StackMapEntry::F64(opnd) = entry {
                             visit_one!(opnd);
                         }
                     }
@@ -994,8 +1040,13 @@ macro_rules! for_each_operand_impl {
             Insn::JmpOpnd(opnd) |
             Insn::Lea { opnd, .. } |
             Insn::Load { opnd, .. } |
+            Insn::LoadF64Raw { opnd, .. } |
             Insn::LoadSExt { opnd, .. } |
-            Insn::Not { opnd, .. } => {
+            Insn::Not { opnd, .. } |
+            Insn::BitsToF64Raw { val: opnd, .. } |
+            Insn::F64ToBitsRaw { val: opnd, .. } |
+            Insn::F64SqrtRaw { val: opnd, .. } |
+            Insn::FixnumToF64Raw { val: opnd, .. } => {
                 visit_one!(opnd);
             }
             Insn::Add { left: opnd0, right: opnd1, .. } |
@@ -1011,12 +1062,15 @@ macro_rules! for_each_operand_impl {
             Insn::CSelNE { truthy: opnd0, falsy: opnd1, .. } |
             Insn::CSelNZ { truthy: opnd0, falsy: opnd1, .. } |
             Insn::CSelZ { truthy: opnd0, falsy: opnd1, .. } |
+            Insn::F64BinOpRaw { left: opnd0, right: opnd1, .. } |
+            Insn::F64BoolCmpRaw { left: opnd0, right: opnd1, .. } |
             Insn::IncrCounter { mem: opnd0, value: opnd1, .. } |
             Insn::LoadInto { dest: opnd0, opnd: opnd1 } |
             Insn::LShift { opnd: opnd0, shift: opnd1, .. } |
             Insn::Mov { dest: opnd0, src: opnd1 } |
             Insn::Or { left: opnd0, right: opnd1, .. } |
             Insn::RShift { opnd: opnd0, shift: opnd1, .. } |
+            Insn::StoreF64Raw { dest: opnd0, src: opnd1 } |
             Insn::Store { dest: opnd0, src: opnd1 } |
             Insn::Sub { left: opnd0, right: opnd1, .. } |
             Insn::Mul { left: opnd0, right: opnd1, .. } |
@@ -1033,7 +1087,7 @@ macro_rules! for_each_operand_impl {
                 // both.
                 if let Some(StackMap { stack, .. }) = $reborrow!(data.stack_map) {
                     for entry in stack {
-                        if let StackMapEntry::Opnd(opnd) = entry {
+                        if let StackMapEntry::Opnd(opnd) | StackMapEntry::F64(opnd) = entry {
                             visit_one!(opnd);
                         }
                     }
@@ -1138,6 +1192,14 @@ impl Insn {
             Insn::CSelNE { .. } => "CSelNE",
             Insn::CSelNZ { .. } => "CSelNZ",
             Insn::CSelZ { .. } => "CSelZ",
+            Insn::F64BinOpRaw { .. } => "F64BinOpRaw",
+            Insn::BitsToF64Raw { .. } => "BitsToF64Raw",
+            Insn::F64ToBitsRaw { .. } => "F64ToBitsRaw",
+            Insn::LoadF64Raw { .. } => "LoadF64Raw",
+            Insn::StoreF64Raw { .. } => "StoreF64Raw",
+            Insn::F64SqrtRaw { .. } => "F64SqrtRaw",
+            Insn::F64BoolCmpRaw { .. } => "F64BoolCmpRaw",
+            Insn::FixnumToF64Raw { .. } => "FixnumToF64Raw",
             Insn::FrameSetup { .. } => "FrameSetup",
             Insn::FrameTeardown { .. } => "FrameTeardown",
             Insn::IncrCounter { .. } => "IncrCounter",
@@ -1195,6 +1257,13 @@ impl Insn {
             Insn::CSelNE { out, .. } |
             Insn::CSelNZ { out, .. } |
             Insn::CSelZ { out, .. } |
+            Insn::F64BinOpRaw { out, .. } |
+            Insn::BitsToF64Raw { out, .. } |
+            Insn::F64ToBitsRaw { out, .. } |
+            Insn::LoadF64Raw { out, .. } |
+            Insn::F64SqrtRaw { out, .. } |
+            Insn::F64BoolCmpRaw { out, .. } |
+            Insn::FixnumToF64Raw { out, .. } |
             Insn::Lea { out, .. } |
             Insn::LeaJumpTarget { out, .. } |
             Insn::Load { out, .. } |
@@ -1227,6 +1296,13 @@ impl Insn {
             Insn::CSelNE { out, .. } |
             Insn::CSelNZ { out, .. } |
             Insn::CSelZ { out, .. } |
+            Insn::F64BinOpRaw { out, .. } |
+            Insn::BitsToF64Raw { out, .. } |
+            Insn::F64ToBitsRaw { out, .. } |
+            Insn::LoadF64Raw { out, .. } |
+            Insn::F64SqrtRaw { out, .. } |
+            Insn::F64BoolCmpRaw { out, .. } |
+            Insn::FixnumToF64Raw { out, .. } |
             Insn::Lea { out, .. } |
             Insn::LeaJumpTarget { out, .. } |
             Insn::Load { out, .. } |
@@ -1363,17 +1439,23 @@ impl LiveRange {
 pub struct Interval {
     pub range: LiveRange,
     pub id: VRegId,
+    pub class: RegClass,
 }
 
 impl Interval {
     /// Create a new Interval with no range
     pub fn new(i: VRegId) -> Self {
+        Self::new_with_class(i, RegClass::GP)
+    }
+
+    pub fn new_with_class(i: VRegId, class: RegClass) -> Self {
         Self {
             range: LiveRange {
                 start: None,
                 end: None,
             },
             id: i,
+            class,
         }
     }
 
@@ -1433,23 +1515,30 @@ pub enum Allocation {
 }
 
 impl Allocation {
-    fn assigned_reg(self) -> Option<Reg> {
-        use crate::backend::current::ALLOC_REGS;
+    fn assigned_reg(self, class: RegClass) -> Option<Reg> {
+        use crate::backend::current::{ALLOC_REGS, FP_ALLOC_REGS};
 
         match self {
-            Allocation::Reg(n) => Some(ALLOC_REGS[n]),
+            Allocation::Reg(n) => match class {
+                RegClass::GP => Some(ALLOC_REGS[n]),
+                RegClass::FP => Some(FP_ALLOC_REGS[n]),
+            },
             Allocation::Fixed(reg) => Some(reg),
             Allocation::Stack(_) => None,
         }
     }
 
-    fn alloc_pool_index(self, num_registers: usize) -> Option<usize> {
+    fn alloc_pool_index(self, class: RegClass, num_registers: usize) -> Option<usize> {
         match self {
             Allocation::Reg(n) => Some(n),
             Allocation::Fixed(reg) => {
-                use crate::backend::current::ALLOC_REGS;
+                use crate::backend::current::{ALLOC_REGS, FP_ALLOC_REGS};
+                let regs = match class {
+                    RegClass::GP => ALLOC_REGS,
+                    RegClass::FP => FP_ALLOC_REGS,
+                };
 
-                ALLOC_REGS
+                regs
                     .iter()
                     .take(num_registers)
                     .position(|candidate| candidate.reg_no == reg.reg_no)
@@ -1623,6 +1712,8 @@ impl StackMap {
 pub enum StackMapEntry {
     /// Immediate Ruby VALUE or VReg to materialize.
     Opnd(Opnd),
+    /// Raw C double bits or FP VReg to box as a Ruby Float on materialization.
+    F64(Opnd),
     /// Number of VM stack slots to skip when materializing across inlined frames.
     Skip(usize),
 }
@@ -1644,6 +1735,9 @@ pub struct Assembler {
     /// Number of VRegs allocated
     pub(super) num_vregs: usize,
 
+    /// Register class for each VReg.
+    pub(super) vreg_classes: Vec<RegClass>,
+
     /// Names of labels
     pub(super) label_names: Vec<String>,
 
@@ -1664,6 +1758,7 @@ pub struct Assembler {
     /// consumes this through Insn::CCall, after it knows whether each live VReg
     /// is in a saved register or an allocator spill slot.
     stack_map: Option<StackMap>,
+
 }
 
 impl Assembler
@@ -1678,6 +1773,7 @@ impl Assembler
             basic_blocks: Vec::default(),
             current_block_id: BlockId(0),
             num_vregs: 0,
+            vreg_classes: Vec::default(),
             idx: 0,
             stack_map: None,
         }
@@ -1720,6 +1816,7 @@ impl Assembler
         // Initialize num_vregs to match the old assembler's size
         // This allows reusing VRegs from the old assembler
         asm.num_vregs = old_asm.num_vregs;
+        asm.vreg_classes = old_asm.vreg_classes.clone();
 
         asm
     }
@@ -1976,8 +2073,18 @@ impl Assembler
 
     /// Build an Opnd::VReg
     pub fn new_vreg(&mut self, num_bits: u8) -> Opnd {
-        let vreg = Opnd::VReg { idx: self.num_vregs.into(), num_bits };
+        self.new_vreg_with_class(num_bits, RegClass::GP)
+    }
+
+    /// Build an Opnd::VReg assigned from the FP register pool.
+    pub fn new_fp_vreg(&mut self, num_bits: u8) -> Opnd {
+        self.new_vreg_with_class(num_bits, RegClass::FP)
+    }
+
+    fn new_vreg_with_class(&mut self, num_bits: u8, class: RegClass) -> Opnd {
+        let vreg = Opnd::VReg { idx: self.num_vregs.into(), num_bits, class };
         self.num_vregs += 1;
+        self.vreg_classes.push(class);
         vreg
     }
 
@@ -2111,6 +2218,10 @@ impl Assembler
         assert_eq!(preferred_registers.len(), intervals.len());
 
         let mut free_registers: BTreeSet<usize> = (0..num_registers).collect();
+        let mut free_fp_registers: BTreeSet<usize> = {
+            use crate::backend::current::FP_ALLOC_REGS;
+            (0..FP_ALLOC_REGS.len()).collect()
+        };
         let mut active: Vec<&Interval> = Vec::new(); // vreg indices sorted by increasing end point
         let mut assignment: Vec<Option<Allocation>> = vec![None; intervals.len()];
         let mut num_stack_slots: usize = 0;
@@ -2129,23 +2240,40 @@ impl Assembler
                     true
                 } else {
                     if let Some(allocation) = assignment[active_interval.id] {
-                        if let Some(reg) = allocation.alloc_pool_index(num_registers) {
-                            let was_not_there_before = free_registers.insert(reg);
+                        let class = active_interval.class;
+                        let pool_len = match class {
+                            RegClass::GP => num_registers,
+                            RegClass::FP => {
+                                use crate::backend::current::FP_ALLOC_REGS;
+                                FP_ALLOC_REGS.len()
+                            }
+                        };
+                        let free_pool = match class {
+                            RegClass::GP => &mut free_registers,
+                            RegClass::FP => &mut free_fp_registers,
+                        };
+                        if let Some(reg) = allocation.alloc_pool_index(class, pool_len) {
+                            let was_not_there_before = free_pool.insert(reg);
                             assert!(
                                 was_not_there_before,
                                 "attempted to return allocator register {:?} to the free pool more than once",
-                                allocation.assigned_reg().unwrap(),
+                                allocation.assigned_reg(class).unwrap(),
                             );
                         } else {
                             assert!(
-                                allocation.assigned_reg().is_none_or(|reg| {
-                                    crate::backend::current::ALLOC_REGS
+                                allocation.assigned_reg(class).is_none_or(|reg| {
+                                    use crate::backend::current::{ALLOC_REGS, FP_ALLOC_REGS};
+                                    let regs = match class {
+                                        RegClass::GP => ALLOC_REGS,
+                                        RegClass::FP => FP_ALLOC_REGS,
+                                    };
+                                    regs
                                         .iter()
-                                        .take(num_registers)
+                                        .take(pool_len)
                                         .all(|candidate| candidate.reg_no != reg.reg_no)
                                 }),
                                 "attempted to return non-allocatable register {:?} to the allocator pool",
-                                allocation.assigned_reg().unwrap(),
+                                allocation.assigned_reg(class).unwrap(),
                             );
                         }
                     }
@@ -2157,13 +2285,13 @@ impl Assembler
             let preferred_taken = preferred_reg.is_some_and(|reg| {
                 active.iter().any(|active_interval| {
                     assignment[active_interval.id]
-                        .and_then(|alloc| alloc.assigned_reg())
+                        .and_then(|alloc| alloc.assigned_reg(active_interval.class))
                         .is_some_and(|active_reg| active_reg.reg_no == reg.reg_no)
                 })
             });
 
-            if let Some(preferred_reg) = preferred_reg.filter(|_| !preferred_taken) {
-                if let Some(reg_idx) = Allocation::Fixed(preferred_reg).alloc_pool_index(num_registers) {
+            if let Some(preferred_reg) = preferred_reg.filter(|_| interval.class == RegClass::GP && !preferred_taken) {
+                if let Some(reg_idx) = Allocation::Fixed(preferred_reg).alloc_pool_index(RegClass::GP, num_registers) {
                     if free_registers.remove(&reg_idx) {
                         assignment[interval.id] = Some(Allocation::Fixed(preferred_reg));
                         let insert_idx = active.partition_point(|&i| i.range.end.unwrap() < interval.range.end.unwrap());
@@ -2178,13 +2306,19 @@ impl Assembler
                 }
             }
 
-            if free_registers.is_empty() {
+            let free_pool = match interval.class {
+                RegClass::GP => &mut free_registers,
+                RegClass::FP => &mut free_fp_registers,
+            };
+
+            if free_pool.is_empty() {
                 // Spill: pick the longest-lived active interval (last in sorted active)
                 // but only from the allocatable register pool. Fixed register
                 // assignments represent preferred/pinned physical registers
                 // (for example SP) and should not be selected as spill victims.
                 let spill = active.iter().rev().copied().find(|active_interval| {
-                    matches!(assignment[active_interval.id], Some(Allocation::Reg(_)))
+                    active_interval.class == interval.class &&
+                        matches!(assignment[active_interval.id], Some(Allocation::Reg(_)))
                 });
                 let slot = Allocation::Stack(num_stack_slots);
                 num_stack_slots += 1;
@@ -2204,8 +2338,8 @@ impl Assembler
                 }
             } else {
                 // Allocate lowest free register
-                let reg = *free_registers.iter().min().unwrap();
-                free_registers.remove(&reg);
+                let reg = *free_pool.iter().min().unwrap();
+                free_pool.remove(&reg);
                 assignment[interval.id] = Some(Allocation::Reg(reg));
                 // Insert into sorted active
                 let insert_idx = active.partition_point(|&i| i.range.end.unwrap() < interval.range.end.unwrap());
@@ -2222,6 +2356,88 @@ impl Assembler
     pub fn resolve_ssa(&mut self, _intervals: &[Interval], assignments: &[Option<Allocation>]) {
         use crate::backend::parcopy;
         use crate::backend::current::SCRATCH_REG;
+
+        #[derive(Clone, Copy)]
+        struct TypedCopy {
+            source: Opnd,
+            destination: Opnd,
+            source_is_fp: bool,
+            destination_is_fp: bool,
+        }
+
+        fn opnd_is_fp(opnd: Opnd) -> bool {
+            matches!(opnd, Opnd::VReg { class: RegClass::FP, .. })
+        }
+
+        fn lower_typed_copy(copy: TypedCopy) -> Vec<Insn> {
+            let scratch = Opnd::Reg(SCRATCH_REG);
+            match (copy.destination_is_fp, copy.source_is_fp, copy.destination, copy.source) {
+                (true, true, destination @ Opnd::Reg(_), source @ Opnd::Reg(_)) => vec![
+                    Insn::F64ToBitsRaw { val: source, out: scratch },
+                    Insn::BitsToF64Raw { val: scratch, out: destination },
+                ],
+                (true, true, destination @ Opnd::Reg(_), source @ Opnd::Mem(_)) => vec![
+                    Insn::LoadF64Raw { opnd: source, out: destination },
+                ],
+                (true, true, destination @ Opnd::Mem(_), source) => vec![
+                    Insn::StoreF64Raw { dest: destination, src: source },
+                ],
+                (true, false, destination @ Opnd::Reg(_), source @ Opnd::Mem(_)) => vec![
+                    Insn::LoadF64Raw { opnd: source, out: destination },
+                ],
+                (true, false, destination @ Opnd::Reg(_), source @ Opnd::Reg(_)) => vec![
+                    Insn::BitsToF64Raw { val: source, out: destination },
+                ],
+                (true, false, destination @ Opnd::Reg(_), source) => vec![
+                    Insn::LoadInto { dest: scratch, opnd: source },
+                    Insn::BitsToF64Raw { val: scratch, out: destination },
+                ],
+                (true, false, destination @ Opnd::Mem(_), source) => vec![
+                    Insn::Mov { dest: destination, src: source },
+                ],
+                (false, true, destination @ Opnd::Mem(_), source) => vec![
+                    Insn::StoreF64Raw { dest: destination, src: source },
+                ],
+                (false, true, destination, source) => vec![
+                    Insn::F64ToBitsRaw { val: source, out: destination },
+                ],
+                (false, false, destination, source @ Opnd::Value(_)) => vec![
+                    Insn::LoadInto { dest: destination, opnd: source },
+                ],
+                (false, false, destination, source) => vec![
+                    Insn::Mov { dest: destination, src: source },
+                ],
+                _ => unreachable!("unexpected typed SSA copy: {} -> {} (fp {} -> fp {})",
+                    copy.source, copy.destination, copy.source_is_fp, copy.destination_is_fp),
+            }
+        }
+
+        fn lower_copies(copies: Vec<TypedCopy>) -> Vec<Insn> {
+            let mut moves = Vec::new();
+            let mut gp_copies = Vec::new();
+
+            for copy in copies {
+                if copy.source_is_fp || copy.destination_is_fp {
+                    moves.extend(lower_typed_copy(copy));
+                } else if copy.source != copy.destination {
+                    gp_copies.push(parcopy::RegisterCopy::<Opnd> {
+                        destination: copy.destination,
+                        source: copy.source,
+                    });
+                }
+            }
+
+            let sequentialized = parcopy::sequentialize_register(&gp_copies, Opnd::Reg(SCRATCH_REG));
+            moves.extend(sequentialized.iter().flat_map(|copy| {
+                lower_typed_copy(TypedCopy {
+                    source: copy.source,
+                    destination: copy.destination,
+                    source_is_fp: false,
+                    destination_is_fp: false,
+                })
+            }));
+            moves
+        }
 
         // Count predecessors for each block
         let mut num_predecessors: HashMap<BlockId, usize> = HashMap::new();
@@ -2251,30 +2467,19 @@ impl Assembler
                 // Build the list of register-to-register copies and immediate moves.
                 // Rewrite VRegs to physical registers BEFORE sequentialization so
                 // the parcopy algorithm can see real physical register conflicts.
-                let reg_copies: Vec<parcopy::RegisterCopy<Opnd>> = edge.args
+                let copies: Vec<TypedCopy> = edge.args
                     .iter()
                     .zip(params.iter())
                     .filter(|(_arg, param)| assignments[param.vreg_idx()].is_some() )
-                    .map(|(arg, param)| parcopy::RegisterCopy::<Opnd> {
+                    .map(|(arg, param)| TypedCopy {
                         destination: Self::rewritten_opnd(*param, assignments),
                         source: Self::rewritten_opnd(*arg, assignments),
+                        destination_is_fp: opnd_is_fp(*param),
+                        source_is_fp: opnd_is_fp(*arg),
                     })
-                    .filter(|copy| copy.source != copy.destination)
                     .collect();
 
-                // Sequentialize register copies.
-                // Copies must use physical registers, not VRegs, so the
-                // parcopy algorithm can detect physical register conflicts.
-                debug_assert!(reg_copies.iter().all(|c| !c.source.is_vreg() && !c.destination.is_vreg()),
-                    "parcopy must operate on physical registers, not VRegs");
-                let sequentialized = parcopy::sequentialize_register(&reg_copies, Opnd::Reg(SCRATCH_REG));
-                let moves: Vec<Insn> = sequentialized
-                    .iter()
-                    .map(|copy| match copy.source {
-                        Opnd::Value(_) => Insn::LoadInto { dest: copy.destination, opnd: copy.source },
-                        _ => Insn::Mov { dest: copy.destination, src: copy.source },
-                    })
-                    .collect();
+                let moves = lower_copies(copies);
 
                 if moves.is_empty() {
                     continue;
@@ -2348,30 +2553,16 @@ impl Assembler
 
             // Rewrite VRegs to physical registers before sequentialization
             // so the parcopy algorithm can detect physical register conflicts.
-            let reg_copies: Vec<parcopy::RegisterCopy<Opnd>> = params.iter().enumerate()
-                .map(|(i, param)| parcopy::RegisterCopy::<Opnd> {
+            let copies: Vec<TypedCopy> = params.iter().enumerate()
+                .map(|(i, param)| TypedCopy {
                     source: C_ARG_OPNDS[i],
                     destination: Self::rewritten_opnd(*param, assignments),
+                    source_is_fp: false,
+                    destination_is_fp: opnd_is_fp(*param),
                 })
-                .filter(|copy| copy.source != copy.destination)
                 .collect();
 
-            debug_assert!(reg_copies.iter().all(|c| !c.source.is_vreg() && !c.destination.is_vreg()),
-                "parcopy must operate on physical registers, not VRegs");
-            let sequentialized = parcopy::sequentialize_register(&reg_copies, Opnd::Reg(SCRATCH_REG));
-            let moves: Vec<Insn> = sequentialized
-                .iter()
-                .map(|copy| match copy.source {
-                    Opnd::Value(_) => Insn::LoadInto {
-                        dest: copy.destination,
-                        opnd: copy.source,
-                    },
-                    _ => Insn::Mov {
-                        dest: copy.destination,
-                        src: copy.source,
-                    },
-                })
-                .collect();
+            let moves = lower_copies(copies);
 
             // Find the position after FrameSetup to insert moves
             let insert_pos = self.basic_blocks[block_id.0].insns.iter()
@@ -2409,7 +2600,10 @@ impl Assembler
         regs: &[Reg],
     ) {
         use crate::backend::parcopy;
-        use crate::backend::current::{C_RET_OPND, SCRATCH_REG, ALLOC_REGS};
+        use crate::backend::current::{
+            ALLOC_REGS, C_RET_OPND, FP_ALLOC_REGS, FP_SAVE_SCRATCH2_REG, FP_SAVE_SCRATCH_REG,
+            SCRATCH_REG,
+        };
 
         for block_id in self.block_order() {
             let block = &mut self.basic_blocks[block_id.0];
@@ -2434,7 +2628,7 @@ impl Assembler
                     // Build a set of VRegIds that can be referenced by JITFrame for materializing the VM stack
                     let stack_vreg_ids: HashSet<VRegId> = if let Some(StackMap { stack, .. }) = &stack_map {
                         stack.iter().filter_map(|entry| match entry {
-                            StackMapEntry::Opnd(Opnd::VReg { idx, .. }) => Some(*idx),
+                            StackMapEntry::Opnd(Opnd::VReg { idx, .. }) | StackMapEntry::F64(Opnd::VReg { idx, .. }) => Some(*idx),
                             _ => None,
                         }).collect()
                     } else {
@@ -2452,25 +2646,52 @@ impl Assembler
                             let survives_call = interval.has_bounds() && interval.survives(insn_number);
                             // 2) The VReg is referenced by the stack map for the CCall
                             let stack_map_reg = stack_vreg_ids.contains(&interval.id);
-                            let is_register = assignments[interval.id].and_then(|alloc| alloc.alloc_pool_index(ALLOC_REGS.len())).is_some();
+                            let pool_len = match interval.class {
+                                RegClass::GP => ALLOC_REGS.len(),
+                                RegClass::FP => FP_ALLOC_REGS.len(),
+                            };
+                            let is_register = assignments[interval.id].and_then(|alloc| alloc.alloc_pool_index(interval.class, pool_len)).is_some();
                             is_register && (survives_call || stack_map_reg)
                         })
                         .map(|interval| interval.id)
                         .collect();
 
-                    let survivor_regs: Vec<Opnd> = survivors.iter()
+                    let survivor_regs: Vec<(RegClass, Opnd)> = survivors.iter()
                         .map(|&s| match assignments[s].unwrap() {
-                            Allocation::Reg(n) => Opnd::Reg(ALLOC_REGS[n]),
-                            Allocation::Fixed(reg) => Opnd::Reg(reg),
+                            Allocation::Reg(n) => match intervals[s].class {
+                                RegClass::GP => (RegClass::GP, Opnd::Reg(ALLOC_REGS[n])),
+                                RegClass::FP => (RegClass::FP, Opnd::Reg(FP_ALLOC_REGS[n])),
+                            },
+                            Allocation::Fixed(reg) => (intervals[s].class, Opnd::Reg(reg)),
                             _ => unreachable!(),
                         })
                         .collect();
 
                     // Push all survivors on the stack, pairing adjacent pushes when possible.
+                    // FP registers are saved as their raw bits because CPushPair works on GP registers.
                     for group in survivor_regs.chunks(2) {
+                        let saved_opnd = |new_insns: &mut Vec<Insn>, new_ids: &mut Vec<Option<InsnId>>, idx: usize, class: RegClass, reg: Opnd| {
+                            match class {
+                                RegClass::GP => reg,
+                                RegClass::FP => {
+                                    let scratch = if idx == 0 { Opnd::Reg(FP_SAVE_SCRATCH_REG) } else { Opnd::Reg(FP_SAVE_SCRATCH2_REG) };
+                                    new_insns.push(Insn::F64ToBitsRaw { val: reg, out: scratch });
+                                    new_ids.push(None);
+                                    scratch
+                                }
+                            }
+                        };
+
                         match group {
-                            &[left, right] => new_insns.push(Insn::CPushPair(left, right)),
-                            &[reg]         => new_insns.push(Insn::CPushPair(reg, 0.into())),
+                            &[(left_class, left_reg), (right_class, right_reg)] => {
+                                let left = saved_opnd(&mut new_insns, &mut new_ids, 0, left_class, left_reg);
+                                let right = saved_opnd(&mut new_insns, &mut new_ids, 1, right_class, right_reg);
+                                new_insns.push(Insn::CPushPair(left, right));
+                            }
+                            &[(class, reg)] => {
+                                let reg = saved_opnd(&mut new_insns, &mut new_ids, 0, class, reg);
+                                new_insns.push(Insn::CPushPair(reg, 0.into()));
+                            }
                             _ => unreachable!(),
                         }
                         new_ids.push(None);
@@ -2496,7 +2717,7 @@ impl Assembler
                                     debug_assert!(!VALUE(encoded).special_const_p(), "encoded StackMap skip should not look like an immediate VALUE");
                                     VALUE(encoded)
                                 }
-                                StackMapEntry::Opnd(Opnd::VReg { idx: vreg, .. }) => {
+                                StackMapEntry::Opnd(Opnd::VReg { idx: vreg, .. }) | StackMapEntry::F64(Opnd::VReg { idx: vreg, .. }) => {
                                     let vreg_stack_index = match assignments[vreg].expect("StackMap VReg should have an allocation") {
                                         Allocation::Reg(_) | Allocation::Fixed(_) => {
                                             let caller_saved_reg_idx = survivors.iter().position(|&survivor_id| survivor_id == vreg).unwrap();
@@ -2509,7 +2730,11 @@ impl Assembler
                                     };
 
                                     // Encode the offset as a shifted-and-tagged integer.
-                                    let encoded = (vreg_stack_index << ZJIT_STACK_MAP_SHIFT) | ZJIT_STACK_MAP_VREG_TAG as usize;
+                                    let tag = match *stack_entry {
+                                        StackMapEntry::F64(_) => ZJIT_STACK_MAP_F64_TAG,
+                                        _ => ZJIT_STACK_MAP_VREG_TAG as usize,
+                                    };
+                                    let encoded = (vreg_stack_index << ZJIT_STACK_MAP_SHIFT) | tag;
                                     debug_assert!(!VALUE(encoded).special_const_p(), "encoded StackMap VReg should not look like an immediate VALUE");
                                     VALUE(encoded)
                                 }
@@ -2583,24 +2808,67 @@ impl Assembler
                         }
                     } else {
                         if call_result_live {
-                            // Save CCall result to scratch immediately, before pops
-                            // can clobber either C_RET or the output register.
                             new_insns.push(Insn::Mov { dest: Opnd::Reg(SCRATCH_REG), src: C_RET_OPND });
                             new_ids.push(None);
                         }
 
+                        let restore_scratch = |avoid: &[Opnd]| {
+                            [C_RET_OPND, Opnd::Reg(FP_SAVE_SCRATCH_REG), Opnd::Reg(FP_SAVE_SCRATCH2_REG), Opnd::Reg(SCRATCH_REG)]
+                                .into_iter()
+                                .find(|scratch| {
+                                    !avoid.contains(scratch) && !(call_result_live && *scratch == Opnd::Reg(SCRATCH_REG))
+                                })
+                                .expect("at least one restore scratch register should be available")
+                        };
+
                         // Restore all survivors in reverse stack order, pairing adjacent pops when possible.
                         for group in survivor_regs.chunks(2).rev() {
+                            let restore_opnd = |idx: usize, class: RegClass, reg: Opnd, avoid: &[Opnd]| {
+                                match class {
+                                    RegClass::GP => reg,
+                                    RegClass::FP => {
+                                        if idx == 0 {
+                                            Opnd::Reg(FP_SAVE_SCRATCH_REG)
+                                        } else {
+                                            restore_scratch(avoid)
+                                        }
+                                    }
+                                }
+                            };
+
                             match group {
-                                &[reg]         => new_insns.push(Insn::CPopPairInto(reg, reg)),
-                                &[left, right] => new_insns.push(Insn::CPopPairInto(right, left)),
+                                &[(class, reg)] => {
+                                    let restored = restore_opnd(0, class, reg, &[]);
+                                    let padding = restore_scratch(&[restored]);
+                                    new_insns.push(Insn::CPopPairInto(padding, restored));
+                                    new_ids.push(None);
+                                    if class == RegClass::FP {
+                                        new_insns.push(Insn::BitsToF64Raw { val: restored, out: reg });
+                                        new_ids.push(None);
+                                    }
+                                }
+                                &[(left_class, left_reg), (right_class, right_reg)] => {
+                                    let left = match left_class {
+                                        RegClass::GP => left_reg,
+                                        RegClass::FP => restore_scratch(&[right_reg]),
+                                    };
+                                    let right = restore_opnd(1, right_class, right_reg, &[left]);
+                                    new_insns.push(Insn::CPopPairInto(right, left));
+                                    new_ids.push(None);
+                                    if left_class == RegClass::FP {
+                                        new_insns.push(Insn::BitsToF64Raw { val: left, out: left_reg });
+                                        new_ids.push(None);
+                                    }
+                                    if right_class == RegClass::FP {
+                                        new_insns.push(Insn::BitsToF64Raw { val: right, out: right_reg });
+                                        new_ids.push(None);
+                                    }
+                                }
                                 _ => unreachable!(),
                             }
-                            new_ids.push(None);
                         }
 
                         if call_result_live {
-                            // Move result from scratch to output AFTER all pops.
                             let out = Self::rewritten_opnd(out, assignments);
                             new_insns.push(Insn::Mov { dest: out, src: Opnd::Reg(SCRATCH_REG) });
                             new_ids.push(None);
@@ -2641,13 +2909,13 @@ impl Assembler
         stack.iter().filter(|entry| match entry {
             StackMapEntry::Opnd(Opnd::Value(value)) => !value.special_const_p(),
             StackMapEntry::Opnd(Opnd::UImm(value)) => !VALUE(*value as usize).special_const_p(),
-            StackMapEntry::Opnd(Opnd::VReg { idx, .. }) => {
+            StackMapEntry::Opnd(Opnd::VReg { idx, .. }) | StackMapEntry::F64(Opnd::VReg { idx, .. }) => {
                 matches!(
                     assignments[idx.to_usize()].expect("StackMap VReg should have an allocation"),
                     Allocation::Reg(_) | Allocation::Fixed(_)
                 )
             }
-            StackMapEntry::Opnd(Opnd::Reg(_)) => true,
+            StackMapEntry::Opnd(Opnd::Reg(_)) | StackMapEntry::F64(Opnd::Reg(_) | Opnd::UImm(_) | Opnd::Imm(_)) => true,
             _ => false,
         }).count()
     }
@@ -2673,14 +2941,17 @@ impl Assembler
     }
 
     fn rewrite_opnd(opnd: &mut Opnd, assignments: &[Option<Allocation>]) {
-        use crate::backend::current::ALLOC_REGS;
-        let regs = &ALLOC_REGS;
+        use crate::backend::current::{ALLOC_REGS, FP_ALLOC_REGS};
 
         match opnd {
-            Opnd::VReg { idx, num_bits } => {
+            Opnd::VReg { idx, num_bits, class } => {
                 if let Some(assignment) = assignments[*idx] {
                     match assignment {
                         Allocation::Reg(n) => {
+                            let regs = match *class {
+                                RegClass::GP => ALLOC_REGS,
+                                RegClass::FP => FP_ALLOC_REGS,
+                            };
                             let mut reg = regs[n];
                             reg.num_bits = *num_bits;
                             *opnd = Opnd::Reg(reg);
@@ -2706,7 +2977,7 @@ impl Assembler
                 match assignments[*idx].unwrap() {
                     Allocation::Reg(n) => {
                         if let Opnd::Mem(mem) = opnd {
-                            mem.base = MemBase::Reg(regs[n].reg_no);
+                            mem.base = MemBase::Reg(ALLOC_REGS[n].reg_no);
                         }
                     }
                     Allocation::Fixed(reg) => {
@@ -2760,7 +3031,8 @@ impl Assembler
         self.compile_with_regs(cb, alloc_regs).unwrap()
     }
 
-    /// Compile Target::SideExit and convert it into Target::Label for all instructions.
+    /// Compile Target::SideExit after register allocation and convert it into
+    /// Target::Label for all instructions.
     /// Returns the exit code as a list of instructions to be appended after the main
     /// code is linearized and split.
     pub fn compile_exits(&mut self) -> Vec<Insn> {
@@ -2773,14 +3045,14 @@ impl Assembler
             value.special_const_p().then_some(value)
         }
 
-        fn encode_stack_map_index(asm: &Assembler, stack_idx: usize, frame_depth: usize) -> VALUE {
+        fn encode_stack_map_index(asm: &Assembler, stack_idx: usize, frame_depth: usize, tag: usize) -> VALUE {
             let vreg_stack_index = asm.stack_state.stack_map_index_for_spill(stack_idx, frame_depth);
-            let encoded = (vreg_stack_index << ZJIT_STACK_MAP_SHIFT) | ZJIT_STACK_MAP_VREG_TAG as usize;
+            let encoded = (vreg_stack_index << ZJIT_STACK_MAP_SHIFT) | tag;
             debug_assert!(!VALUE(encoded).special_const_p(), "encoded StackMap VReg should not look like an immediate VALUE");
             VALUE(encoded)
         }
 
-        fn capture_stack_map_opnd(asm: &mut Assembler, opnd: Opnd, capture_idx: &mut usize, frame_depth: usize) -> VALUE {
+        fn capture_stack_map_opnd(asm: &mut Assembler, opnd: Opnd, capture_idx: &mut usize, frame_depth: usize, tag: usize) -> VALUE {
             let stack_idx = asm.stack_state.stack_idx_for_side_exit_stack_map(*capture_idx);
             *capture_idx += 1;
             let capture_slot = Opnd::Mem(Mem {
@@ -2790,7 +3062,22 @@ impl Assembler
             });
             let opnd = if matches!(opnd, Opnd::Reg(_)) { opnd.with_num_bits(64) } else { opnd };
             asm.store(capture_slot, opnd);
-            encode_stack_map_index(asm, stack_idx, frame_depth)
+            encode_stack_map_index(asm, stack_idx, frame_depth, tag)
+        }
+
+        fn capture_stack_map_f64(asm: &mut Assembler, opnd: Opnd, capture_idx: &mut usize, frame_depth: usize) -> VALUE {
+            use crate::backend::current::FP_ALLOC_REGS;
+
+            let bits = match opnd {
+                Opnd::Reg(reg) if FP_ALLOC_REGS.contains(&reg) => {
+                    let scratch = C_ARG_OPNDS[0];
+                    asm.f64_to_bits_raw_into(scratch, opnd);
+                    scratch
+                }
+                Opnd::VReg { .. } => unreachable!("side-exit operands should be allocated before compile_exits"),
+                _ => opnd,
+            };
+            capture_stack_map_opnd(asm, bits, capture_idx, frame_depth, ZJIT_STACK_MAP_F64_TAG)
         }
 
         fn compile_exit_stack_map(asm: &mut Assembler, stack_map: &StackMap) {
@@ -2799,12 +3086,12 @@ impl Assembler
             assert_eq!(unsafe { (*jit_frame).stack_size } as usize, stack.len());
 
             let mut capture_idx = 0;
+            let mut deferred_f64_regs = Vec::new();
             for (idx, stack_entry) in stack.iter().enumerate() {
                 let entry = match *stack_entry {
-                    StackMapEntry::Opnd(Opnd::Value(_) | Opnd::UImm(_)) => {
-                        let StackMapEntry::Opnd(opnd) = *stack_entry else { unreachable!() };
+                    StackMapEntry::Opnd(opnd @ (Opnd::Value(_) | Opnd::UImm(_))) => {
                         immediate_stack_map_value(opnd)
-                            .unwrap_or_else(|| capture_stack_map_opnd(asm, opnd, &mut capture_idx, *frame_depth))
+                            .unwrap_or_else(|| capture_stack_map_opnd(asm, opnd, &mut capture_idx, *frame_depth, ZJIT_STACK_MAP_VREG_TAG as usize))
                     }
                     StackMapEntry::Skip(size) => {
                         let encoded = (size << ZJIT_STACK_MAP_SHIFT) | ZJIT_STACK_MAP_SKIP_TAG as usize;
@@ -2813,14 +3100,31 @@ impl Assembler
                     }
                     StackMapEntry::Opnd(Opnd::Mem(Mem { base: MemBase::Stack { stack_idx, .. }, disp, .. })) => {
                         assert_eq!(disp, 0, "StackMap stack slot should not have a displacement");
-                        encode_stack_map_index(asm, stack_idx.to_usize(), *frame_depth)
+                        encode_stack_map_index(asm, stack_idx.to_usize(), *frame_depth, ZJIT_STACK_MAP_VREG_TAG as usize)
                     }
-                    StackMapEntry::Opnd(Opnd::Reg(_)) => {
-                        let StackMapEntry::Opnd(opnd) = *stack_entry else { unreachable!() };
-                        capture_stack_map_opnd(asm, opnd, &mut capture_idx, *frame_depth)
+                    StackMapEntry::Opnd(opnd @ Opnd::Reg(_)) => {
+                        capture_stack_map_opnd(asm, opnd, &mut capture_idx, *frame_depth, ZJIT_STACK_MAP_VREG_TAG as usize)
+                    }
+                    StackMapEntry::F64(Opnd::Mem(Mem { base: MemBase::Stack { stack_idx, .. }, disp, .. })) => {
+                        assert_eq!(disp, 0, "StackMap F64 stack slot should not have a displacement");
+                        encode_stack_map_index(asm, stack_idx.to_usize(), *frame_depth, ZJIT_STACK_MAP_F64_TAG)
+                    }
+                    StackMapEntry::F64(opnd @ Opnd::Reg(_)) => {
+                        deferred_f64_regs.push((idx, opnd));
+                        continue;
+                    }
+                    StackMapEntry::F64(opnd) => {
+                        capture_stack_map_f64(asm, opnd, &mut capture_idx, *frame_depth)
                     }
                     _ => unreachable!("unexpected entry in SideExit StackMap: {stack_entry:?}"),
                 };
+                unsafe { (*jit_frame.cast_mut()).stack.as_mut_ptr().add(idx).write(entry); }
+            }
+
+            // F64 registers need a fixed GP temporary after register allocation. Capture
+            // them after other entries so the temporary cannot clobber a live VALUE.
+            for (idx, opnd) in deferred_f64_regs {
+                let entry = capture_stack_map_f64(asm, opnd, &mut capture_idx, *frame_depth);
                 unsafe { (*jit_frame.cast_mut()).stack.as_mut_ptr().add(idx).write(entry); }
             }
 
@@ -2832,6 +3136,8 @@ impl Assembler
 
         /// Restore VM state (cfp->pc, cfp->sp, stack, locals) for the side exit.
         fn compile_exit_save_state(asm: &mut Assembler, exit: &SideExit) {
+            use crate::backend::current::{ALLOC_REGS, FP_ALLOC_REGS};
+
             let SideExit { pc, stack, locals, iseq, stack_map, .. } = exit;
 
             // Side exit blocks are not part of the CFG at the moment,
@@ -2848,19 +3154,152 @@ impl Assembler
             asm_comment!(asm, "save cfp->iseq");
             asm.store(Opnd::mem(64, CFP, RUBY_OFFSET_CFP_ISEQ), VALUE::from(*iseq).into());
 
-            // cfp->block_code and cfp->jit_return are cleared by the materialize_exit trampoline
+            // cfp->block_code is cleared by the materialize_exit trampoline. cfp->jit_return is
+            // normally cleared there too, but F64 boxing below can call into C before then.
 
-            if !stack.is_empty() {
-                asm_comment!(asm, "write stack slots: {}", join_opnds(&stack, ", "));
-                for (idx, &opnd) in stack.iter().enumerate() {
-                    asm.store(Opnd::mem(64, SP, idx as i32 * SIZEOF_VALUE_I32), opnd);
+            let save_exit_boxing_regs = |asm: &mut Assembler| {
+                let saved_regs = ALLOC_REGS.iter()
+                    .map(|&reg| (RegClass::GP, Opnd::Reg(reg)))
+                    .chain(FP_ALLOC_REGS.iter().map(|&reg| (RegClass::FP, Opnd::Reg(reg))))
+                    .collect::<Vec<_>>();
+
+                for group in saved_regs.chunks(2) {
+                    let saved_opnd = |asm: &mut Assembler, idx: usize, class: RegClass, reg: Opnd| {
+                        match class {
+                            RegClass::GP => reg,
+                            RegClass::FP => {
+                                let scratch = C_ARG_OPNDS[idx];
+                                asm.f64_to_bits_raw_into(scratch, reg);
+                                scratch
+                            }
+                        }
+                    };
+
+                    match group {
+                        &[(left_class, left_reg), (right_class, right_reg)] => {
+                            let left = saved_opnd(asm, 0, left_class, left_reg);
+                            let right = saved_opnd(asm, 1, right_class, right_reg);
+                            asm.push_insn(Insn::CPushPair(left, right));
+                        }
+                        &[(class, reg)] => {
+                            let reg = saved_opnd(asm, 0, class, reg);
+                            asm.push_insn(Insn::CPushPair(reg, 0.into()));
+                        }
+                        _ => unreachable!(),
+                    }
                 }
-            }
 
-            if !locals.is_empty() {
-                asm_comment!(asm, "write locals: {}", join_opnds(&locals, ", "));
-                for (idx, &opnd) in locals.iter().enumerate() {
-                    asm.store(Opnd::mem(64, SP, (-local_size_and_idx_to_ep_offset(locals.len(), idx) - 1) * SIZEOF_VALUE_I32), opnd);
+                saved_regs
+            };
+
+            let restore_exit_boxing_regs = |asm: &mut Assembler, saved_regs: &[(RegClass, Opnd)]| {
+                let restore_scratch = |avoid: &[Opnd]| {
+                    C_ARG_OPNDS
+                        .into_iter()
+                        .find(|scratch| !avoid.contains(scratch))
+                        .expect("at least one restore scratch register should be available")
+                };
+
+                for group in saved_regs.chunks(2).rev() {
+                    let restore_opnd = |idx: usize, class: RegClass, reg: Opnd, avoid: &[Opnd]| {
+                        match class {
+                            RegClass::GP => reg,
+                            RegClass::FP => {
+                                if idx == 0 {
+                                    C_ARG_OPNDS[0]
+                                } else {
+                                    restore_scratch(avoid)
+                                }
+                            }
+                        }
+                    };
+
+                    match group {
+                        &[(class, reg)] => {
+                            let restored = restore_opnd(0, class, reg, &[]);
+                            let padding = restore_scratch(&[restored]);
+                            asm.push_insn(Insn::CPopPairInto(padding, restored));
+                            if class == RegClass::FP {
+                                asm.push_insn(Insn::BitsToF64Raw { val: restored, out: reg });
+                            }
+                        }
+                        &[(left_class, left_reg), (right_class, right_reg)] => {
+                            let left = match left_class {
+                                RegClass::GP => left_reg,
+                                RegClass::FP => restore_scratch(&[right_reg]),
+                            };
+                            let right = restore_opnd(1, right_class, right_reg, &[left]);
+                            asm.push_insn(Insn::CPopPairInto(right, left));
+                            if left_class == RegClass::FP {
+                                asm.push_insn(Insn::BitsToF64Raw { val: left, out: left_reg });
+                            }
+                            if right_class == RegClass::FP {
+                                asm.push_insn(Insn::BitsToF64Raw { val: right, out: right_reg });
+                            }
+                        }
+                        _ => unreachable!(),
+                    }
+                }
+            };
+
+            let write_f64_exit_entry = |asm: &mut Assembler, dest: Opnd, opnd: Opnd| {
+                let saved_regs = save_exit_boxing_regs(asm);
+
+                let bits = match opnd {
+                    Opnd::Reg(reg) if FP_ALLOC_REGS.contains(&reg) => {
+                        asm.f64_to_bits_raw_into(C_ARG_OPNDS[0], opnd);
+                        C_ARG_OPNDS[0]
+                    }
+                    Opnd::VReg { .. } => unreachable!("side-exit operands should be allocated before compile_exits"),
+                    _ => opnd,
+                };
+                asm_comment!(asm, "call rb_jit_f64_to_float");
+                asm.count_call_to("rb_jit_f64_to_float");
+                asm.ccall_into(C_RET_OPND, rb_jit_f64_to_float as *const u8, vec![bits]);
+                asm.store(dest, C_RET_OPND);
+
+                restore_exit_boxing_regs(asm, &saved_regs);
+            };
+
+            let locations = stack.iter()
+                .enumerate()
+                .map(|(idx, &entry)| (Opnd::mem(64, SP, idx as i32 * SIZEOF_VALUE_I32), entry))
+                .chain(locals.iter().enumerate().map(|(idx, &entry)| {
+                    let dest = Opnd::mem(64, SP, (-local_size_and_idx_to_ep_offset(locals.len(), idx) - 1) * SIZEOF_VALUE_I32);
+                    (dest, entry)
+                }))
+                .collect::<Vec<_>>();
+
+            let write_value_entry = |asm: &mut Assembler, dest: Opnd, entry: StackMapEntry| {
+                match entry {
+                    StackMapEntry::Opnd(opnd) => asm.store(dest, opnd),
+                    StackMapEntry::F64(_) => asm.store(dest, Opnd::UImm(crate::cruby::Qnil.as_u64())),
+                    StackMapEntry::Skip(_) => unreachable!("current-frame side exits do not use StackMap skips"),
+                }
+            };
+
+            if !stack.is_empty() || !locals.is_empty() {
+                // Write all Ruby VALUEs before boxing F64 entries. Boxing calls C
+                // and may clobber caller-saved registers referenced by other slots.
+                asm_comment!(asm, "write stack slots: {:?}", stack);
+                asm_comment!(asm, "write locals: {:?}", locals);
+                for &(dest, entry) in &locations {
+                    write_value_entry(asm, dest, entry);
+                }
+
+                if locations.iter().any(|&(_, entry)| matches!(entry, StackMapEntry::F64(_))) {
+                    // Clear cfp->jit_return before boxing F64 values. rb_jit_f64_to_float can
+                    // allocate, so GC must not see a JITFrame for this materialized frame.
+                    asm_comment!(asm, "clear cfp->jit_return");
+                    asm.store(Opnd::mem(64, CFP, RUBY_OFFSET_CFP_JIT_RETURN), 0.into());
+                }
+
+                for &(dest, entry) in &locations {
+                    match entry {
+                        StackMapEntry::F64(opnd) => write_f64_exit_entry(asm, dest, opnd),
+                        StackMapEntry::Opnd(_) => {}
+                        StackMapEntry::Skip(_) => unreachable!("current-frame side exits do not use StackMap skips"),
+                    }
                 }
             }
 
@@ -3170,8 +3609,9 @@ impl Assembler
     /// Calculate live intervals for each VReg.
     pub fn build_intervals(&self, live_in: Vec<BitSet<usize>>) -> Vec<Interval> {
         let num_vregs = self.num_vregs;
+        assert_eq!(self.vreg_classes.len(), num_vregs);
         let mut intervals: Vec<Interval> = (0..num_vregs)
-            .map(|i| Interval::new(i.into()))
+            .map(|i| Interval::new_with_class(i.into(), self.vreg_classes[i]))
             .collect();
 
         let blocks = self.block_order();
@@ -3661,6 +4101,52 @@ impl Assembler {
     pub fn add_into(&mut self, left: Opnd, right: Opnd) {
         assert!(matches!(left, Opnd::Reg(_)), "Destination of add_into must be Opnd::Reg, but got: {left:?}");
         self.push_insn(Insn::Add { left, right, out: left });
+    }
+
+    #[must_use]
+    pub fn f64_binop_raw(&mut self, op: F64BinOp, left: Opnd, right: Opnd) -> Opnd {
+        let out = self.new_fp_vreg(64);
+        self.push_insn(Insn::F64BinOpRaw { op, left, right, out });
+        out
+    }
+
+    #[must_use]
+    pub fn bits_to_f64_raw(&mut self, val: Opnd) -> Opnd {
+        let out = self.new_fp_vreg(64);
+        self.push_insn(Insn::BitsToF64Raw { val, out });
+        out
+    }
+
+    #[must_use]
+    pub fn f64_to_bits_raw(&mut self, val: Opnd) -> Opnd {
+        let out = self.new_vreg(64);
+        self.push_insn(Insn::F64ToBitsRaw { val, out });
+        out
+    }
+
+    pub fn f64_to_bits_raw_into(&mut self, out: Opnd, val: Opnd) {
+        self.push_insn(Insn::F64ToBitsRaw { val, out });
+    }
+
+    #[must_use]
+    pub fn f64_sqrt_raw(&mut self, val: Opnd) -> Opnd {
+        let out = self.new_fp_vreg(64);
+        self.push_insn(Insn::F64SqrtRaw { val, out });
+        out
+    }
+
+    #[must_use]
+    pub fn f64_bool_cmp_raw(&mut self, op: F64BoolCmpOp, left: Opnd, right: Opnd) -> Opnd {
+        let out = self.new_vreg(64);
+        self.push_insn(Insn::F64BoolCmpRaw { op, left, right, out });
+        out
+    }
+
+    #[must_use]
+    pub fn fixnum_to_f64_raw(&mut self, val: Opnd) -> Opnd {
+        let out = self.new_fp_vreg(64);
+        self.push_insn(Insn::FixnumToF64Raw { val, out });
+        out
     }
 
     #[must_use]
@@ -5002,6 +5488,28 @@ mod tests {
         if let Insn::CCall { data } = ccall {
             assert!(data.opnds.is_empty(), "CCall opnds should be empty after handle_caller_saved_regs");
         }
+
+        // Preserve the C return value across caller-saved restores, then move
+        // it to its assigned destination after restoring registers. Otherwise
+        // a restore can overwrite the result or the C return register itself.
+        let ccall_idx = insns.iter().position(|i| matches!(i, Insn::CCall { .. })).unwrap();
+        let scratch = scratch_reg();
+        let save_result_idx = insns.iter().position(|i| {
+            matches!(i, Insn::Mov { dest, src } if *dest == scratch && *src == C_RET_OPND)
+        }).expect("expected the C return register to be saved in scratch");
+        let last_pop_idx = insns.iter().rposition(|i| matches!(i, Insn::CPopPairInto(..))).unwrap();
+        let result_move_idx = insns.iter().rposition(|i| {
+            matches!(i, Insn::Mov { src, .. } if *src == scratch)
+        }).expect("expected a move from the C return register");
+        assert!(ccall_idx < save_result_idx, "CCall result should be saved after CCall");
+        assert!(save_result_idx < last_pop_idx, "CCall result should stay saved while restoring caller-saved registers");
+        assert!(last_pop_idx < result_move_idx, "CCall result must be moved after restoring caller-saved registers");
+        assert!(
+            insns[save_result_idx + 1..result_move_idx].iter().all(|insn| {
+                !matches!(insn, Insn::CPopPairInto(left, right) if *left == scratch || *right == scratch)
+            }),
+            "caller-saved restore must not clobber the saved CCall result",
+        );
 
         // v0 should be rewritten to a Stack operand
         // Find an Add that uses a Stack operand (the v0+v4 add)

--- a/zjit/src/backend/x86_64/mod.rs
+++ b/zjit/src/backend/x86_64/mod.rs
@@ -102,14 +102,29 @@ pub const ALLOC_REGS: &[Reg] = &[
     RAX_REG,
 ];
 
+pub const FP_ALLOC_REGS: &[Reg] = &[
+    XMM0_REG,
+    XMM1_REG,
+    XMM2_REG,
+    XMM3_REG,
+    XMM4_REG,
+    XMM5_REG,
+    XMM6_REG,
+    XMM7_REG,
+];
+
 /// Special scratch register for intermediate processing. It should be used only by
 /// [`Assembler::x86_scratch_split`] or [`Assembler::new_with_scratch_reg`].
 const SCRATCH0_OPND: Opnd = Opnd::Reg(R11_REG);
 const SCRATCH1_OPND: Opnd = Opnd::Reg(R10_REG);
+const FP_SCRATCH0_OPND: Opnd = Opnd::Reg(XMM14_REG);
+const FP_SCRATCH1_OPND: Opnd = Opnd::Reg(XMM15_REG);
 
 /// A scratch register available for use by resolve_ssa to break register copy cycles.
 /// Must not overlap with ALLOC_REGS or other preserved registers.
 pub const SCRATCH_REG: Reg = R11_REG;
+pub const FP_SAVE_SCRATCH_REG: Reg = R10_REG;
+pub const FP_SAVE_SCRATCH2_REG: Reg = R11_REG;
 
 impl Assembler {
     // This keeps frame growth below the +/-4096-byte displacement range we rely
@@ -185,6 +200,14 @@ impl Assembler {
                 Insn::Add { .. } |
                 Insn::Sub { .. } |
                 Insn::Mul { .. } |
+                Insn::F64BinOpRaw { .. } |
+                Insn::BitsToF64Raw { .. } |
+                Insn::F64ToBitsRaw { .. } |
+                Insn::LoadF64Raw { .. } |
+                Insn::StoreF64Raw { .. } |
+                Insn::F64SqrtRaw { .. } |
+                Insn::F64BoolCmpRaw { .. } |
+                Insn::FixnumToF64Raw { .. } |
                 Insn::And { .. } |
                 Insn::Or { .. } |
                 Insn::Xor { .. } => {
@@ -398,6 +421,32 @@ impl Assembler {
             }
         }
 
+        fn split_f64_memory_read(asm: &mut Assembler, opnd: Opnd, gp_scratch: Opnd, fp_scratch: Opnd) -> Opnd {
+            match opnd {
+                Opnd::Mem(_) => {
+                    let opnd = split_stack_membase(asm, opnd, gp_scratch);
+                    asm.push_insn(Insn::LoadF64Raw { opnd, out: fp_scratch });
+                    fp_scratch
+                }
+                _ => opnd,
+            }
+        }
+
+        fn split_f64_memory_write(opnd: &mut Opnd, scratch_opnd: Opnd) -> Option<Opnd> {
+            if let Opnd::Mem(_) = opnd {
+                let mem_opnd = *opnd;
+                *opnd = scratch_opnd;
+                Some(mem_opnd)
+            } else {
+                None
+            }
+        }
+
+        fn store_f64_to_memory(asm: &mut Assembler, mem_out: Opnd, fp_src: Opnd, gp_scratch: Opnd) {
+            let mem_out = split_stack_membase(asm, mem_out, gp_scratch);
+            asm.push_insn(Insn::StoreF64Raw { dest: mem_out, src: fp_src });
+        }
+
         fn assert_out_is_phys_reg_or_stack_mem(out: Opnd) {
             assert!(
                 matches!(out, Opnd::Reg(_) | Opnd::Mem(Mem { base: MemBase::Stack { .. }, .. })),
@@ -421,6 +470,20 @@ impl Assembler {
                 if let (Opnd::Mem(_), Opnd::Mem(_)) = (dst, src) {
                     asm.mov(scratch_opnd, src);
                     asm.mov(dst, scratch_opnd);
+                } else if let (Opnd::Mem(mem), Opnd::Imm(imm)) = (dst, src) {
+                    if mem.num_bits == 64 && imm_num_bits(imm) > 32 {
+                        asm.mov(scratch_opnd, src);
+                        asm.mov(dst, scratch_opnd);
+                    } else {
+                        asm.mov(dst, src);
+                    }
+                } else if let (Opnd::Mem(mem), Opnd::UImm(imm)) = (dst, src) {
+                    if mem.num_bits == 64 && imm_num_bits(imm as i64) > 32 {
+                        asm.mov(scratch_opnd, src);
+                        asm.mov(dst, scratch_opnd);
+                    } else {
+                        asm.mov(dst, src);
+                    }
                 } else if let (Opnd::Mem(_), Opnd::Value(value)) = (dst, src) {
                     if imm_num_bits(value.as_i64()) > 32 {
                         asm.mov(scratch_opnd, src);
@@ -528,6 +591,80 @@ impl Assembler {
                     asm.push_insn(insn);
                     asm_mov(asm, out, opnd, SCRATCH0_OPND);
                 }
+                Insn::F64BinOpRaw { left, right, out, .. } => {
+                    *left = split_f64_memory_read(asm, *left, SCRATCH0_OPND, FP_SCRATCH0_OPND);
+                    *right = split_f64_memory_read(asm, *right, SCRATCH1_OPND, FP_SCRATCH1_OPND);
+                    let mem_out = split_f64_memory_write(out, FP_SCRATCH0_OPND);
+                    let fp_out = *out;
+
+                    asm.push_insn(insn);
+
+                    if let Some(mem_out) = mem_out {
+                        store_f64_to_memory(asm, mem_out, fp_out, SCRATCH1_OPND);
+                    }
+                }
+                Insn::BitsToF64Raw { val, out } |
+                Insn::FixnumToF64Raw { val, out } => {
+                    *val = split_stack_membase(asm, *val, SCRATCH0_OPND);
+                    let mem_out = split_f64_memory_write(out, FP_SCRATCH0_OPND);
+                    let fp_out = *out;
+
+                    asm.push_insn(insn);
+
+                    if let Some(mem_out) = mem_out {
+                        store_f64_to_memory(asm, mem_out, fp_out, SCRATCH1_OPND);
+                    }
+                }
+                Insn::F64ToBitsRaw { val, out } => {
+                    *val = split_f64_memory_read(asm, *val, SCRATCH0_OPND, FP_SCRATCH0_OPND);
+                    let mem_out = split_memory_write(out, SCRATCH0_OPND);
+
+                    asm.push_insn(insn);
+
+                    if let Some(mem_out) = mem_out {
+                        let mem_out = split_stack_membase(asm, mem_out, SCRATCH1_OPND);
+                        asm.store(mem_out, SCRATCH0_OPND);
+                    }
+                }
+                Insn::LoadF64Raw { opnd, out } => {
+                    *opnd = split_stack_membase(asm, *opnd, SCRATCH0_OPND);
+                    let mem_out = split_f64_memory_write(out, FP_SCRATCH0_OPND);
+                    let fp_out = *out;
+
+                    asm.push_insn(insn);
+
+                    if let Some(mem_out) = mem_out {
+                        store_f64_to_memory(asm, mem_out, fp_out, SCRATCH1_OPND);
+                    }
+                }
+                Insn::StoreF64Raw { dest, src } => {
+                    *dest = split_stack_membase(asm, *dest, SCRATCH0_OPND);
+                    *src = split_f64_memory_read(asm, *src, SCRATCH1_OPND, FP_SCRATCH1_OPND);
+                    asm.push_insn(insn);
+                }
+                Insn::F64SqrtRaw { val, out } => {
+                    *val = split_f64_memory_read(asm, *val, SCRATCH0_OPND, FP_SCRATCH0_OPND);
+                    let mem_out = split_f64_memory_write(out, FP_SCRATCH0_OPND);
+                    let fp_out = *out;
+
+                    asm.push_insn(insn);
+
+                    if let Some(mem_out) = mem_out {
+                        store_f64_to_memory(asm, mem_out, fp_out, SCRATCH1_OPND);
+                    }
+                }
+                Insn::F64BoolCmpRaw { left, right, out, .. } => {
+                    *left = split_f64_memory_read(asm, *left, SCRATCH0_OPND, FP_SCRATCH0_OPND);
+                    *right = split_f64_memory_read(asm, *right, SCRATCH1_OPND, FP_SCRATCH1_OPND);
+                    let mem_out = split_memory_write(out, SCRATCH0_OPND);
+
+                    asm.push_insn(insn);
+
+                    if let Some(mem_out) = mem_out {
+                        let mem_out = split_stack_membase(asm, mem_out, SCRATCH1_OPND);
+                        asm.store(mem_out, SCRATCH0_OPND);
+                    }
+                }
                 Insn::Test { left, right } |
                 Insn::Cmp { left, right } => {
                     *left = split_stack_membase(asm, *left, SCRATCH1_OPND);
@@ -555,7 +692,8 @@ impl Assembler {
                 // For compile_exits, support splitting simple C arguments here
                 Insn::CCall { data } if !data.opnds.is_empty() => {
                     for (i, opnd) in data.opnds.iter().enumerate() {
-                        asm.load_into(C_ARG_OPNDS[i], *opnd);
+                        let opnd = split_stack_membase(asm, *opnd, SCRATCH0_OPND);
+                        asm.load_into(C_ARG_OPNDS[i], opnd);
                     }
                     data.opnds = vec![];
                     asm.push_insn(insn);
@@ -736,6 +874,22 @@ impl Assembler {
             }
         }
 
+        fn emit_f64_bool_compare(
+            cb: &mut CodeBlock,
+            left: Opnd,
+            right: Opnd,
+            out: Opnd,
+            cmov_fn: fn(&mut CodeBlock, X86Opnd, X86Opnd),
+        ) {
+            let scratch = if out == SCRATCH0_OPND { SCRATCH1_OPND } else { SCRATCH0_OPND };
+            ucomisd(cb, left.into(), right.into());
+            mov(cb, out.into(), Opnd::Value(Qfalse).into());
+            mov(cb, scratch.into(), Opnd::Value(Qtrue).into());
+            cmov_fn(cb, out.into(), scratch.into());
+            mov(cb, scratch.into(), Opnd::Value(Qfalse).into());
+            cmovp(cb, out.into(), scratch.into());
+        }
+
         fn emit_load_gc_value(cb: &mut CodeBlock, gc_offsets: &mut Vec<CodePtr>, dest_reg: X86Opnd, value: VALUE) {
             // Using movabs because mov might write value in 32 bits
             movabs(cb, dest_reg, value.0 as _);
@@ -828,6 +982,65 @@ impl Assembler {
                     imul(cb, left.into(), right.into());
                 },
 
+                Insn::BitsToF64Raw { val, out } => {
+                    movq_to_xmm(cb, (*out).into(), (*val).into());
+                },
+                Insn::F64ToBitsRaw { val, out } => {
+                    if let Opnd::Reg(X86Reg { reg_type: RegType::GP, .. }) = val {
+                        mov(cb, (*out).into(), (*val).into());
+                    } else {
+                        movq_from_xmm(cb, (*out).into(), (*val).into());
+                    }
+                },
+                Insn::LoadF64Raw { opnd, out } => {
+                    movsd_load(cb, (*out).into(), (*opnd).into());
+                },
+                Insn::StoreF64Raw { dest, src } => {
+                    movsd_store(cb, (*dest).into(), (*src).into());
+                },
+                Insn::F64BinOpRaw { op, left, right, out } => {
+                    let emit_op = |cb: &mut CodeBlock, dst, src| match op {
+                        F64BinOp::Add => addsd(cb, dst, src),
+                        F64BinOp::Sub => subsd(cb, dst, src),
+                        F64BinOp::Mul => mulsd(cb, dst, src),
+                        F64BinOp::Div => divsd(cb, dst, src),
+                    };
+
+                    if *out == *right && *out != *left && matches!(op, F64BinOp::Sub | F64BinOp::Div) {
+                        movsd_load(cb, FP_SCRATCH0_OPND.into(), (*left).into());
+                        emit_op(cb, FP_SCRATCH0_OPND.into(), (*right).into());
+                        movsd_load(cb, (*out).into(), FP_SCRATCH0_OPND.into());
+                    } else if *out == *right && *out != *left {
+                        emit_op(cb, (*out).into(), (*left).into());
+                    } else if *out != *left {
+                        movsd_load(cb, (*out).into(), (*left).into());
+                        emit_op(cb, (*out).into(), (*right).into());
+                    } else {
+                        emit_op(cb, (*out).into(), (*right).into());
+                    }
+                },
+                Insn::F64SqrtRaw { val, out } => {
+                    if *out != *val {
+                        movsd_load(cb, (*out).into(), (*val).into());
+                    }
+                    sqrtsd(cb, (*out).into(), (*out).into());
+                },
+                Insn::FixnumToF64Raw { val, out } => {
+                    mov(cb, R11, (*val).into());
+                    sar(cb, R11, uimm_opnd(1));
+                    cvtsi2sd(cb, (*out).into(), R11);
+                },
+                Insn::F64BoolCmpRaw { op, left, right, out } => {
+                    let cmov_fn = match op {
+                        F64BoolCmpOp::Eq => cmove,
+                        F64BoolCmpOp::Lt => cmovb,
+                        F64BoolCmpOp::Le => cmovbe,
+                        F64BoolCmpOp::Gt => cmova,
+                        F64BoolCmpOp::Ge => cmovae,
+                    };
+                    emit_f64_bool_compare(cb, *left, *right, *out, cmov_fn);
+                },
+
                 Insn::And { left, right, .. } => {
                     and(cb, left.into(), right.into());
                 },
@@ -863,6 +1076,7 @@ impl Assembler {
                         Opnd::Value(val) if val.heap_object_p() => {
                             emit_load_gc_value(cb, &mut gc_offsets, out.into(), *val);
                         }
+                        _ if *out == *opnd => {}
                         _ => mov(cb, out.into(), opnd.into())
                     }
                 },
@@ -873,7 +1087,9 @@ impl Assembler {
 
                 Insn::Store { dest, src } |
                 Insn::Mov { dest, src } => {
-                    mov(cb, dest.into(), src.into());
+                    if dest != src {
+                        mov(cb, dest.into(), src.into());
+                    }
                 },
 
                 // Load effective address
@@ -1301,6 +1517,7 @@ mod tests {
         asm.x86_scratch_split()
     }
 
+    #[cfg(feature = "disasm")]
     fn binop_mnemonic(kind: BinOpKind) -> &'static str {
         match kind {
             BinOpKind::Add => "add",
@@ -1311,6 +1528,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "disasm")]
     fn split_binop_disasm_lines(kind: BinOpKind, left: Opnd, right: Opnd, out: Opnd) -> Vec<String> {
         let mut asm = split_binop(kind, left, right, out);
         let mut cb = CodeBlock::new_dummy();
@@ -1331,6 +1549,7 @@ mod tests {
             .collect()
     }
 
+    #[cfg(feature = "disasm")]
     fn assert_split_binop_case(kind: BinOpKind, left: Opnd, right: Opnd, out: Opnd, case: &str) {
         fn reg_names(reg: Reg) -> (&'static str, &'static str) {
             const RAX_NO: u8 = RAX_REG.reg_no;
@@ -1985,19 +2204,19 @@ mod tests {
         0x20: push 0
         0x22: mov eax, 0
         0x27: call rax
-        0x29: pop r8
-        0x2b: pop r8
-        0x2d: pop rcx
-        0x2e: pop rdx
-        0x2f: pop rsi
-        0x30: pop rdi
-        0x31: add rdi, rsi
-        0x34: mov rdi, rdx
-        0x37: add rdi, rcx
-        0x3a: mov rdi, rdx
-        0x3d: add rdi, r8
+        0x29: pop rax
+        0x2a: pop r8
+        0x2c: pop rcx
+        0x2d: pop rdx
+        0x2e: pop rsi
+        0x2f: pop rdi
+        0x30: add rdi, rsi
+        0x33: mov rdi, rdx
+        0x36: add rdi, rcx
+        0x39: mov rdi, rdx
+        0x3c: add rdi, r8
         ");
-        assert_snapshot!(cb.hexdump(), @"bf01000000be02000000ba03000000b90400000041b8050000005756525141506a00b800000000ffd041584158595a5e5f4801f74889d74801cf4889d74c01c7");
+        assert_snapshot!(cb.hexdump(), @"bf01000000be02000000ba03000000b90400000041b8050000005756525141506a00b800000000ffd0584158595a5e5f4801f74889d74801cf4889d74c01c7");
     }
 
     #[test]
@@ -2192,6 +2411,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "disasm")]
     fn test_add_split_direct_mem() {
         // RAX is safe to be clobbered because it's an output
         // c_ret <- add stack[0], stack[1]
@@ -2207,6 +2427,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "disasm")]
     fn test_add_split_stack_indirect_left_uses_scratch0_for_base_and_result() {
         // stack[1] <- add stack[mem[0]], cfp
         let lines = split_binop_disasm_lines(BinOpKind::Add, stack_indirect_mem(0), CFP, stack_mem(1));
@@ -2223,6 +2444,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "disasm")]
     fn test_add_split_stack_indirect_right_uses_separate_base_scratch() {
         // mem[1] <- add cfp, mem[stack[0]]
         let lines = split_binop_disasm_lines(BinOpKind::Add, CFP, stack_indirect_mem(0), stack_mem(1));
@@ -2239,6 +2461,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "disasm")]
     fn test_add_split_two_stack_indirect_inputs_need_two_scratch_regs() {
         // stack[2] <- add [stack[0]], [stack[1]]
         let lines = split_binop_disasm_lines(BinOpKind::Add,
@@ -2260,6 +2483,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "disasm")]
     fn test_add_split_memory_output_can_compute_in_place() {
         // stack[1] <- add cfp, stack[0]
         let lines = split_binop_disasm_lines(BinOpKind::Add, CFP, stack_mem(0), stack_mem(1));
@@ -2273,6 +2497,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "disasm")]
     fn test_add_split_reg_mem_mem_when_right_equals_out() {
         // stack[1] <- add cfp, stack[1]
         //
@@ -2367,6 +2592,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "disasm")]
     fn test_add_split_output_reg_reused_as_input_memory_base_with_imm() {
         // cfp <- add 7, [cfp + 16]
         //
@@ -2388,6 +2614,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "disasm")]
     fn test_binop_split_matrix() {
         let left_cases = [
             ("reg", CFP),

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -24,7 +24,7 @@ use crate::stats::{counter_ptr, with_time_stat, trace_compile_phase, Counter, Co
 use crate::{asm::CodeBlock, cruby::*, options::debug, virtualmem::CodePtr};
 use crate::backend::lir::{self, Assembler, C_ARG_OPNDS, C_RET_OPND, CFP, EC, NATIVE_BASE_PTR, Opnd, SP, SideExit, SideExitRecompile, SideExitTarget, StackMap, StackMapEntry, Target, asm_ccall, asm_comment};
 use crate::hir::{iseq_to_hir, BlockId, Invariant, RangeType, SideExitReason::{self, *}, SpecialBackrefSymbol, SpecialObjectType};
-use crate::hir::{BlockHandler, CCallVariadicData, CCallWithFrameData, Const, FieldName, FrameState, Function, Insn, InsnId, Recompile, SendDirectData, SendFallbackReason, qualified_method_name};
+use crate::hir::{BlockHandler, CCallVariadicData, CCallWithFrameData, Const, F64BinOp, F64BoolCmpOp, FieldName, FrameState, Function, Insn, InsnId, Recompile, SendDirectData, SendFallbackReason, qualified_method_name};
 use crate::hir_type::{types, Type};
 use crate::options::{get_option, InlineDepth, PerfMap, DEFAULT_MAX_VERSIONS};
 use crate::cast::IntoUsize;
@@ -446,10 +446,15 @@ fn gen_function(cb: &mut CodeBlock, iseq: IseqPtr, version: IseqVersionRef, func
             );
 
             // Compile all parameters
-            for (idx, &insn_id) in block.params().enumerate() {
+            for &insn_id in block.params() {
                 match function.find(insn_id) {
                     Insn::Param => {
-                        jit.opnds[insn_id.0] = Some(gen_param(&mut asm, idx));
+                        let param = if function.is_raw_float_value(insn_id) {
+                            gen_param_for_type(&mut asm, types::CDouble)
+                        } else {
+                            gen_value_param(&mut asm)
+                        };
+                        jit.opnds[insn_id.0] = Some(param);
                     },
                     insn => unreachable!("Non-param insn found in block.params: {insn:?}"),
                 }
@@ -459,8 +464,8 @@ fn gen_function(cb: &mut CodeBlock, iseq: IseqPtr, version: IseqVersionRef, func
             // so that calling convention registers are reserved early, like Param.
             if function.is_entry_block(block_id) {
                 for &insn_id in block.insns() {
-                    if let Insn::LoadArg { idx, .. } = function.find(insn_id) {
-                        jit.opnds[insn_id.0] = Some(gen_param(&mut asm, idx as usize));
+                    if let Insn::LoadArg { .. } = function.find(insn_id) {
+                        jit.opnds[insn_id.0] = Some(gen_value_param(&mut asm));
                     }
                 }
             }
@@ -609,16 +614,17 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
         &Insn::Const { val: Const::CUInt16(val) } => gen_const_uint16(val),
         &Insn::Const { val: Const::CUInt32(val) } => gen_const_uint32(val),
         &Insn::Const { val: Const::CUInt64(val) } => Opnd::UImm(val),
+        &Insn::Const { val: Const::CDouble(val) } => gen_f64_opnd(asm, Opnd::UImm(val.to_bits())),
         &Insn::Const { val: Const::CAttrIndex(val) } => gen_const_attr_index_t(val),
         &Insn::Const { val: Const::CShape(val) } => {
             assert_eq!(SHAPE_ID_NUM_BITS, 32);
             gen_const_uint32(val.0)
         }
         Insn::Const { .. } => panic!("Unexpected Const in gen_insn: {insn}"),
-        Insn::NewArray { elements, state } => gen_new_array(jit, asm, opnds!(elements), &function.frame_state(*state)),
+        Insn::NewArray { elements, state } => gen_new_array(jit, asm, function, elements, &function.frame_state(*state)),
         Insn::NewHash { elements, state } => {
             let sym_keys = elements.iter().step_by(2).all(|&key| function.type_of(key).is_subtype(types::Symbol));
-            gen_new_hash(jit, asm, function, opnds!(elements), sym_keys, &function.frame_state(*state))
+            gen_new_hash(jit, asm, function, elements, sym_keys, &function.frame_state(*state))
         }
         Insn::NewRange { low, high, flag, state } => gen_new_range(jit, asm, function, opnd!(low), opnd!(high), *flag, &function.frame_state(*state)),
         Insn::NewRangeFixnum { low, high, flag, state } => gen_new_range_fixnum(jit, asm, opnd!(low), opnd!(high), *flag, &function.frame_state(*state)),
@@ -675,11 +681,19 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
         Insn::FixnumSub { left, right, state } => gen_fixnum_sub(jit, asm, function, opnd!(left), opnd!(right), &function.frame_state(*state)),
         Insn::FixnumMult { left, right, state } => gen_fixnum_mult(jit, asm, function, opnd!(left), opnd!(right), &function.frame_state(*state)),
         Insn::FixnumDiv { left, right, state } => gen_fixnum_div(jit, asm, function, opnd!(left), opnd!(right), &function.frame_state(*state)),
-        Insn::FloatAdd { recv, other, state } => gen_float_add(asm, opnd!(recv), opnd!(other), &function.frame_state(*state)),
-        Insn::FloatSub { recv, other, state } => gen_float_sub(asm, opnd!(recv), opnd!(other), &function.frame_state(*state)),
-        Insn::FloatMul { recv, other, state } => gen_float_mul(asm, opnd!(recv), opnd!(other), &function.frame_state(*state)),
-        Insn::FloatDiv { recv, other, state } => gen_float_div(asm, opnd!(recv), opnd!(other), &function.frame_state(*state)),
-        Insn::FloatToInt { recv, state } => gen_float_to_int(asm, opnd!(recv), &function.frame_state(*state)),
+        Insn::UnboxFloat { val } => gen_unbox_float(asm, opnd!(val)),
+        Insn::UnboxRubyFloat { val } => gen_unbox_ruby_float(jit, asm, opnd!(val)),
+        Insn::FixnumToF64 { val } => asm.fixnum_to_f64_raw(opnd!(val)),
+        Insn::BoxFloat { val, state } => gen_box_float(jit, asm, opnd!(val), &function.frame_state(*state)),
+        Insn::F64BinOp { op, left, right } => gen_f64_binop(asm, *op, opnd!(left), opnd!(right)),
+        Insn::F64ValueRhsOp { op, left, right, state } => gen_f64_value_rhs_op(jit, asm, function, *op, opnd!(left), opnd!(right), &function.frame_state(*state)),
+        Insn::F64Sqrt { val } => gen_f64_sqrt(asm, opnd!(val)),
+        Insn::F64Sin { val } => gen_f64_sin(asm, opnd!(val)),
+        Insn::F64Cos { val } => gen_f64_cos(asm, opnd!(val)),
+        Insn::F64Pow { left, right } => gen_f64_pow(asm, opnd!(left), opnd!(right)),
+        Insn::F64GuardNonnegative { val, state } => no_output!(gen_f64_guard_nonnegative(jit, asm, function, opnd!(val), &function.frame_state(*state))),
+        Insn::F64BoolCmp { op, left, right } => gen_f64_bool_cmp(asm, *op, opnd!(left), opnd!(right)),
+        Insn::F64FixnumBoolCmp { op, left, right } => gen_f64_fixnum_bool_cmp(asm, *op, opnd!(left), opnd!(right)),
         Insn::FixnumEq { left, right } => gen_fixnum_eq(asm, opnd!(left), opnd!(right)),
         Insn::FixnumNeq { left, right } => gen_fixnum_neq(asm, opnd!(left), opnd!(right)),
         Insn::FixnumLt { left, right } => gen_fixnum_lt(asm, opnd!(left), opnd!(right)),
@@ -777,13 +791,13 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
         &Insn::StoreField { recv, id, offset, val, num_bits } => no_output!(gen_store_field(asm, opnd!(recv), id, offset, opnd!(val), num_bits)),
         &Insn::WriteBarrier { recv, val } => no_output!(gen_write_barrier(jit, asm, opnd!(recv), opnd!(val), function.type_of(val))),
         &Insn::IsBlockGiven { block_handler } => gen_is_block_given(asm, opnd!(block_handler)),
-        Insn::ArrayInclude { elements, target, state } => gen_array_include(jit, asm, function, opnds!(elements), opnd!(target), &function.frame_state(*state)),
-        Insn::ArrayPackBuffer { elements, fmt, buffer, state } => gen_array_pack_buffer(jit, asm, function, opnds!(elements), opnd!(fmt), (*buffer).map(|buffer| opnd!(buffer)), &function.frame_state(*state)),
+        Insn::ArrayInclude { elements, target, state } => gen_array_include(jit, asm, function, elements, *target, &function.frame_state(*state)),
+        Insn::ArrayPackBuffer { elements, fmt, buffer, state } => gen_array_pack_buffer(jit, asm, function, elements, *fmt, *buffer, &function.frame_state(*state)),
         &Insn::DupArrayInclude { ary, target, state } => gen_dup_array_include(jit, asm, function, ary, opnd!(target), &function.frame_state(state)),
-        Insn::ArrayHash { elements, state } => gen_opt_newarray_hash(jit, asm, function, opnds!(elements), &function.frame_state(*state)),
+        Insn::ArrayHash { elements, state } => gen_opt_newarray_hash(jit, asm, function, elements, &function.frame_state(*state)),
         &Insn::IsA { val, class } => gen_is_a(jit, asm, opnd!(val), opnd!(class)),
-        &Insn::ArrayMax { ref elements, state } => gen_array_max(jit, asm, function, opnds!(elements), &function.frame_state(state)),
-        &Insn::ArrayMin { ref elements, state } => gen_array_min(jit, asm, function, opnds!(elements), &function.frame_state(state)),
+        &Insn::ArrayMax { ref elements, state } => gen_array_max(jit, asm, function, elements, &function.frame_state(state)),
+        &Insn::ArrayMin { ref elements, state } => gen_array_min(jit, asm, function, elements, &function.frame_state(state)),
         &Insn::Throw { state, .. } => return Err(state),
         &Insn::CondBranch { .. }
         | &Insn::Jump { .. } | Insn::Entries { .. } => unreachable!(),
@@ -1046,7 +1060,7 @@ fn gen_ccall_with_frame(
     gen_write_jit_frame(asm, state, 0);
     gen_save_sp(asm, caller_stack_size);
     gen_spill_stack(jit, asm, function, state);
-    gen_spill_locals(jit, asm, state);
+    gen_spill_locals(jit, asm, function, state);
 
     let block_handler_specval = if let Some(BlockHandler::BlockIseq(block_iseq)) = block {
         // Change cfp->block_code in the current frame. See vm_caller_setup_arg_block().
@@ -1141,7 +1155,7 @@ fn gen_ccall_variadic(
     gen_write_jit_frame(asm, state, 0);
     gen_save_sp(asm, caller_stack_size);
     gen_spill_stack(jit, asm, function, state);
-    gen_spill_locals(jit, asm, state);
+    gen_spill_locals(jit, asm, function, state);
 
     let block_handler_specval = if let Some(BlockHandler::BlockIseq(blockiseq)) = block {
         gen_block_handler_specval(asm, blockiseq)
@@ -1463,9 +1477,18 @@ fn gen_const_attr_index_t(val: attr_index_t) -> lir::Opnd {
     Opnd::UImm(val as u64)
 }
 
-/// Compile a basic block argument
-fn gen_param(asm: &mut Assembler, _idx: usize) -> lir::Opnd {
-    let vreg = asm.new_block_param(VALUE_BITS);
+/// Compile a VALUE basic block argument.
+fn gen_value_param(asm: &mut Assembler) -> lir::Opnd {
+    gen_param_for_type(asm, types::BasicObject)
+}
+
+/// Compile a typed basic block argument.
+fn gen_param_for_type(asm: &mut Assembler, ty: Type) -> lir::Opnd {
+    let vreg = if ty.is_subtype(types::CDouble) {
+        asm.new_fp_vreg(64)
+    } else {
+        asm.new_block_param(VALUE_BITS)
+    };
     asm.current_block().add_parameter(vreg);
     vreg
 }
@@ -1587,7 +1610,7 @@ fn gen_push_inline_frame(
     gen_write_jit_frame(asm, state, 0);
     gen_save_sp(asm, stack_size);
 
-    gen_spill_locals(jit, asm, state);
+    gen_spill_locals(jit, asm, function, state);
 
     // This mirrors vm_caller_setup_arg_block() for the `blockiseq != NULL` case.
     // The HIR specialization guards ensure we will only reach here for literal blocks,
@@ -1726,7 +1749,7 @@ fn gen_send_iseq_direct(
     let jit_frame = gen_write_jit_frame(asm, state, stack_map.len());
     gen_save_sp(asm, stack_size);
 
-    gen_spill_locals(jit, asm, state);
+    gen_spill_locals(jit, asm, function, state);
     asm.stack_map(stack_map, jit_frame, state.depth);
 
     // This mirrors vm_caller_setup_arg_block() in for the `blockiseq != NULL` case.
@@ -1956,7 +1979,7 @@ fn gen_invoke_block_iseq_direct(
     let jit_frame = gen_write_jit_frame(asm, state, stack_map.len());
     gen_save_sp(asm, stack_size);
 
-    gen_spill_locals(jit, asm, state);
+    gen_spill_locals(jit, asm, function, state);
     asm.stack_map(stack_map, jit_frame, state.depth);
 
     gen_push_frame(asm, args.len(), state, ControlFrame {
@@ -2166,17 +2189,29 @@ fn gen_array_dup(
 fn gen_new_array(
     jit: &mut JITState,
     asm: &mut Assembler,
-    elements: Vec<Opnd>,
+    function: &Function,
+    elements: &[InsnId],
     state: &FrameState,
 ) -> lir::Opnd {
-    gen_prepare_leaf_call_with_gc(asm, state);
-
     let num: c_long = elements.len().try_into().expect("Unable to fit length of elements into c_long");
 
     if !elements.is_empty() {
-        let argv = gen_push_opnds(jit, asm, &elements);
+        if hir_values_require_f64_boxing(jit, function, elements) {
+            gen_prepare_non_leaf_call(jit, asm, function, state);
+            let stack_bottom = state.stack().len()
+                .checked_sub(elements.len())
+                .expect("newarray elements are on the stack");
+            gen_store_hir_values_to_stack(jit, asm, function, elements, stack_bottom);
+            let argv = asm.lea(Opnd::mem(64, SP, stack_bottom as i32 * SIZEOF_VALUE_I32));
+            return asm_ccall!(asm, rb_ec_ary_new_from_values, EC, num.into(), argv);
+        }
+
+        gen_prepare_leaf_call_with_gc(asm, state);
+        let argv = gen_push_hir_values(jit, asm, function, elements);
         return asm_ccall!(asm, rb_ec_ary_new_from_values, EC, num.into(), argv);
     }
+
+    gen_prepare_leaf_call_with_gc(asm, state);
 
     let alloc_size = std::mem::size_of::<RArray>();
 
@@ -2253,7 +2288,7 @@ fn gen_opt_newarray_hash(
     jit: &JITState,
     asm: &mut Assembler,
     function: &Function,
-    elements: Vec<Opnd>,
+    elements: &[InsnId],
     state: &FrameState,
 ) -> lir::Opnd {
     // `Array#hash` will hash the elements of the array.
@@ -2261,9 +2296,8 @@ fn gen_opt_newarray_hash(
 
     let array_len: c_long = elements.len().try_into().expect("Unable to fit length of elements into c_long");
 
-    // After gen_prepare_non_leaf_call, the elements are spilled to the Ruby stack.
-    // Get a pointer to the first element on the Ruby stack.
     let stack_bottom = state.stack().len() - elements.len();
+    gen_store_hir_values_to_stack(jit, asm, function, elements, stack_bottom);
     let elements_ptr = asm.lea(Opnd::mem(64, SP, stack_bottom as i32 * SIZEOF_VALUE_I32));
 
     unsafe extern "C" {
@@ -2281,16 +2315,15 @@ fn gen_array_max(
     jit: &JITState,
     asm: &mut Assembler,
     function: &Function,
-    elements: Vec<Opnd>,
+    elements: &[InsnId],
     state: &FrameState,
 ) -> lir::Opnd {
     gen_prepare_fallback_call(jit, asm, function, state);
 
     let array_len: u32 = elements.len().try_into().expect("Unable to fit length of elements into u32");
 
-    // After gen_prepare_non_leaf_call, the elements are spilled to the Ruby stack.
-    // Get a pointer to the first element on the Ruby stack.
     let stack_bottom = state.stack().len() - elements.len();
+    gen_store_hir_values_to_stack(jit, asm, function, elements, stack_bottom);
     let elements_ptr = asm.lea(Opnd::mem(VALUE_BITS, SP, stack_bottom as i32 * SIZEOF_VALUE_I32));
 
     unsafe extern "C" {
@@ -2308,16 +2341,15 @@ fn gen_array_min(
     jit: &JITState,
     asm: &mut Assembler,
     function: &Function,
-    elements: Vec<Opnd>,
+    elements: &[InsnId],
     state: &FrameState,
 ) -> lir::Opnd {
     gen_prepare_fallback_call(jit, asm, function, state);
 
     let array_len: u32 = elements.len().try_into().expect("Unable to fit length of elements into u32");
 
-    // After gen_prepare_non_leaf_call, the elements are spilled to the Ruby stack.
-    // Get a pointer to the first element on the Ruby stack.
     let stack_bottom = state.stack().len() - elements.len();
+    gen_store_hir_values_to_stack(jit, asm, function, elements, stack_bottom);
     let elements_ptr = asm.lea(Opnd::mem(VALUE_BITS, SP, stack_bottom as i32 * SIZEOF_VALUE_I32));
 
     unsafe extern "C" {
@@ -2334,19 +2366,20 @@ fn gen_array_include(
     jit: &JITState,
     asm: &mut Assembler,
     function: &Function,
-    elements: Vec<Opnd>,
-    target: Opnd,
+    elements: &[InsnId],
+    target: InsnId,
     state: &FrameState,
 ) -> lir::Opnd {
     gen_prepare_fallback_call(jit, asm, function, state);
 
     let array_len: c_long = elements.len().try_into().expect("Unable to fit length of elements into c_long");
 
-    // After gen_prepare_non_leaf_call, the elements are spilled to the Ruby stack.
-    // The elements are at the bottom of the virtual stack, followed by the target.
-    // Get a pointer to the first element on the Ruby stack.
-    let stack_bottom = state.stack().len() - elements.len() - 1;
+    let mut values = elements.to_vec();
+    values.push(target);
+    let stack_bottom = state.stack().len() - values.len();
+    gen_store_hir_values_to_stack(jit, asm, function, &values, stack_bottom);
     let elements_ptr = asm.lea(Opnd::mem(64, SP, stack_bottom as i32 * SIZEOF_VALUE_I32));
+    let target = Opnd::mem(VALUE_BITS, SP, (stack_bottom + elements.len()) as i32 * SIZEOF_VALUE_I32);
 
     unsafe extern "C" {
         fn rb_vm_opt_newarray_include_p(ec: EcPtr, num: c_long, elts: *const VALUE, target: VALUE) -> VALUE;
@@ -2359,36 +2392,38 @@ fn gen_array_include(
 }
 
 fn gen_array_pack_buffer(
-    jit: &JITState,
+    jit: &mut JITState,
     asm: &mut Assembler,
     function: &Function,
-    elements: Vec<Opnd>,
-    fmt: Opnd,
-    buffer: Option<Opnd>,
+    elements: &[InsnId],
+    fmt: InsnId,
+    buffer: Option<InsnId>,
     state: &FrameState,
 ) -> lir::Opnd {
-    gen_prepare_fallback_call(jit, asm, function, state);
+    gen_prepare_non_leaf_call(jit, asm, function, state);
 
-    let array_len: c_long = elements.len().try_into().expect("Unable to fit length of elements into c_long");
+    let mut values = elements.to_vec();
+    values.push(fmt);
+    if let Some(buffer) = buffer {
+        values.push(buffer);
+    }
+    let stack_bottom = state.stack().len() - values.len();
+    gen_store_hir_values_to_stack(jit, asm, function, &values, stack_bottom);
 
-    // After gen_prepare_non_leaf_call, the elements are spilled to the Ruby stack.
-    // The elements are at the bottom of the virtual stack, followed by the fmt, and optionally the buffer.
-    // Get a pointer to the first element on the Ruby stack.
-    let stack_bottom = if buffer.is_some() {
-        state.stack().len() - elements.len() - 2
+    let array_len: rb_num_t = elements.len().try_into().expect("Unable to fit length of elements into rb_num_t");
+    let argv = asm.lea(Opnd::mem(64, SP, stack_bottom as i32 * SIZEOF_VALUE_I32));
+
+    let fmt = asm.load(Opnd::mem(VALUE_BITS, SP, (stack_bottom + elements.len()) as i32 * SIZEOF_VALUE_I32));
+    let buffer = if buffer.is_some() {
+        asm.load(Opnd::mem(VALUE_BITS, SP, (stack_bottom + elements.len() + 1) as i32 * SIZEOF_VALUE_I32))
     } else {
-        state.stack().len() - elements.len() - 1
+        Qundef.into()
     };
-    let elements_ptr = asm.lea(Opnd::mem(64, SP, stack_bottom as i32 * SIZEOF_VALUE_I32));
 
     unsafe extern "C" {
-        fn rb_vm_opt_newarray_pack_buffer(ec: EcPtr, num: c_long, elts: *const VALUE, fmt: VALUE, buffer: VALUE) -> VALUE;
+        fn rb_vm_opt_newarray_pack_buffer(ec: EcPtr, array_len: rb_num_t, ptr: *const VALUE, fmt: VALUE, buffer: VALUE) -> VALUE;
     }
-    asm_ccall!(
-        asm,
-        rb_vm_opt_newarray_pack_buffer,
-        EC, array_len.into(), elements_ptr, fmt, buffer.unwrap_or_else(|| Qundef.into())
-    )
+    asm_ccall!(asm, rb_vm_opt_newarray_pack_buffer, EC, array_len.into(), argv, fmt, buffer)
 }
 
 fn gen_dup_array_include(
@@ -2465,7 +2500,7 @@ fn gen_new_hash(
     jit: &mut JITState,
     asm: &mut Assembler,
     function: &Function,
-    elements: Vec<Opnd>,
+    elements: &[InsnId],
     sym_keys: bool,
     state: &FrameState,
 ) -> lir::Opnd {
@@ -2506,13 +2541,13 @@ fn gen_new_hash(
             asm_ccall!(asm, rb_hash_new_with_size, num_pairs.into())
         };
 
-        let argv = gen_push_opnds(jit, asm, &elements);
+        let argv = gen_push_hir_values(jit, asm, function, elements);
         asm_ccall!(asm, rb_hash_bulk_insert, elements.len().into(), argv, hash);
         hash
     } else {
         gen_prepare_non_leaf_call(jit, asm, function, state);
 
-        let argv = gen_push_opnds(jit, asm, &elements);
+        let argv = gen_push_hir_values(jit, asm, function, elements);
         asm_ccall!(asm, rb_hash_new_with_bulk_insert, elements.len().into(), argv)
     }
 }
@@ -2693,34 +2728,270 @@ fn gen_fixnum_div(jit: &mut JITState, asm: &mut Assembler, function: &Function, 
     asm_ccall!(asm, rb_jit_fix_div_fix, left, right)
 }
 
-/// Compile Float + Float
-fn gen_float_add(asm: &mut Assembler, recv: lir::Opnd, other: lir::Opnd, state: &FrameState) -> lir::Opnd {
-    gen_prepare_leaf_call_with_gc(asm, state);
-    asm_ccall!(asm, rb_float_plus, recv, other)
+/// Unbox a Ruby Float into a C double bit pattern.
+fn gen_unbox_float(asm: &mut Assembler, val: lir::Opnd) -> lir::Opnd {
+    let bits = gen_unbox_flonum(asm, val);
+    asm.bits_to_f64_raw(bits)
 }
 
-/// Compile Float - Float
-fn gen_float_sub(asm: &mut Assembler, recv: lir::Opnd, other: lir::Opnd, state: &FrameState) -> lir::Opnd {
-    gen_prepare_leaf_call_with_gc(asm, state);
-    asm_ccall!(asm, rb_float_minus, recv, other)
+/// Unbox any Ruby Float into a C double bit pattern.
+fn gen_unbox_ruby_float(jit: &mut JITState, asm: &mut Assembler, val: lir::Opnd) -> lir::Opnd {
+    let val = asm.load_mem(val);
+    let hir_block_id = asm.current_block().hir_block_id;
+    let rpo_idx = asm.current_block().rpo_index;
+    let flonum_block = asm.new_block(hir_block_id, false, rpo_idx);
+    let result_block = asm.new_block(hir_block_id, false, rpo_idx);
+    let flonum_edge = Target::Block(Box::new(lir::BranchEdge {
+        target: flonum_block,
+        args: vec![],
+    }));
+    let result_edge = |bits| Target::Block(Box::new(lir::BranchEdge {
+        target: result_block,
+        args: vec![bits],
+    }));
+
+    let masked = asm.and(val, lir::Opnd::UImm(RUBY_FLONUM_MASK as u64));
+    asm.cmp(masked, lir::Opnd::UImm(RUBY_FLONUM_FLAG as u64));
+    asm.je(jit, flonum_edge);
+
+    let bits = asm.load(Opnd::mem(64, val, RUBY_OFFSET_RFLOAT_VALUE));
+    asm.jmp(result_edge(bits));
+
+    asm.set_current_block(flonum_block);
+    let flonum_label = jit.get_label(asm, flonum_block, hir_block_id);
+    asm.write_label(flonum_label);
+    let bits = gen_unbox_flonum(asm, val);
+    asm.jmp(result_edge(bits));
+
+    asm.set_current_block(result_block);
+    let result_label = jit.get_label(asm, result_block, hir_block_id);
+    asm.write_label(result_label);
+    let bits = asm.new_block_param(VALUE_BITS);
+    asm.current_block().add_parameter(bits);
+    asm.bits_to_f64_raw(bits)
 }
 
-/// Compile Float * Float
-fn gen_float_mul(asm: &mut Assembler, recv: lir::Opnd, other: lir::Opnd, state: &FrameState) -> lir::Opnd {
-    gen_prepare_leaf_call_with_gc(asm, state);
-    asm_ccall!(asm, rb_float_mul, recv, other)
+unsafe extern "C" {
+    fn rb_jit_f64_sin(bits: u64) -> u64;
+    fn rb_jit_f64_cos(bits: u64) -> u64;
+    fn rb_jit_f64_pow(left_bits: u64, right_bits: u64) -> u64;
+    fn rb_jit_f64_fixnum_cmp(left_bits: u64, right: VALUE) -> VALUE;
 }
 
-/// Compile Float / Float
-fn gen_float_div(asm: &mut Assembler, recv: lir::Opnd, other: lir::Opnd, state: &FrameState) -> lir::Opnd {
-    gen_prepare_leaf_call_with_gc(asm, state);
-    asm_ccall!(asm, rb_float_div, recv, other)
+fn gen_unbox_flonum(asm: &mut Assembler, val: lir::Opnd) -> lir::Opnd {
+    let sign_bit = asm.urshift(val, lir::Opnd::UImm(63));
+    let exponent_prefix = asm.sub(lir::Opnd::UImm(2), sign_bit);
+    let payload = asm.and(val, lir::Opnd::UImm(FLONUM_CLEAR_TAG_MASK));
+    let encoded = asm.or(exponent_prefix, payload);
+    let high = asm.lshift(encoded, lir::Opnd::UImm(61));
+    let low = asm.urshift(encoded, lir::Opnd::UImm(3));
+    let decoded = asm.or(high, low);
+
+    asm.cmp(val, lir::Opnd::UImm(FLONUM_ZERO_VALUE));
+    asm.csel_e(lir::Opnd::UImm(0), decoded)
 }
 
-/// Compile Float#to_i (truncate to integer)
-fn gen_float_to_int(asm: &mut Assembler, recv: lir::Opnd, state: &FrameState) -> lir::Opnd {
+fn gen_f64_opnd(asm: &mut Assembler, opnd: lir::Opnd) -> lir::Opnd {
+    match opnd {
+        lir::Opnd::UImm(_) | lir::Opnd::Imm(_) | lir::Opnd::Value(_) => {
+            let bits = asm.load(opnd);
+            asm.bits_to_f64_raw(bits)
+        }
+        _ => opnd,
+    }
+}
+
+fn gen_f64_bits_opnd(asm: &mut Assembler, opnd: lir::Opnd) -> lir::Opnd {
+    let opnd = gen_f64_opnd(asm, opnd);
+    asm.f64_to_bits_raw(opnd)
+}
+
+/// Box a C double bit pattern into a Ruby Float.
+fn gen_box_float(jit: &mut JITState, asm: &mut Assembler, val: lir::Opnd, state: &FrameState) -> lir::Opnd {
+    let val = gen_f64_opnd(asm, val);
+    let bits = asm.f64_to_bits_raw(val);
+
+    let hir_block_id = asm.current_block().hir_block_id;
+    let rpo_idx = asm.current_block().rpo_index;
+    let fallback_block = asm.new_block(hir_block_id, false, rpo_idx);
+    let result_block = asm.new_block(hir_block_id, false, rpo_idx);
+    let fallback_edge = Target::Block(Box::new(lir::BranchEdge {
+        target: fallback_block,
+        args: vec![],
+    }));
+    let result_edge = |v| Target::Block(Box::new(lir::BranchEdge {
+        target: result_block,
+        args: vec![v],
+    }));
+
+    asm.cmp(bits, lir::Opnd::UImm(0));
+    asm.je(jit, result_edge(lir::Opnd::UImm(FLONUM_ZERO_VALUE)));
+
+    asm.cmp(bits, lir::Opnd::UImm(FLONUM_MAGIC_EXCLUDED_BITS));
+    asm.je(jit, fallback_edge.clone());
+
+    let shifted_high_bits = asm.urshift(bits, lir::Opnd::UImm(60));
+    let high_bits = asm.and(shifted_high_bits, lir::Opnd::UImm(0x7));
+    let high_bits_minus_three = asm.sub(high_bits, lir::Opnd::UImm(3));
+    let high_bits_invalid = asm.and(high_bits_minus_three, lir::Opnd::UImm(!0x1));
+    asm.cmp(high_bits_invalid, lir::Opnd::UImm(0));
+    asm.jne(jit, fallback_edge);
+
+    let encoded_high = asm.lshift(bits, lir::Opnd::UImm(3));
+    let encoded_low = asm.urshift(bits, lir::Opnd::UImm(61));
+    let encoded_rotl = asm.or(encoded_high, encoded_low);
+    let encoded_without_low_bit = asm.and(encoded_rotl, lir::Opnd::UImm(FLONUM_CLEAR_LOW_BIT_MASK));
+    let encoded = asm.or(encoded_without_low_bit, lir::Opnd::UImm(FLONUM_TAG));
+    asm.jmp(result_edge(encoded));
+
+    asm.set_current_block(fallback_block);
+    let fallback_label = jit.get_label(asm, fallback_block, hir_block_id);
+    asm.write_label(fallback_label);
     gen_prepare_leaf_call_with_gc(asm, state);
-    asm_ccall!(asm, rb_flo_to_i, recv)
+    let fallback = asm_ccall!(asm, rb_jit_f64_to_float, bits);
+    asm.jmp(result_edge(fallback));
+
+    asm.set_current_block(result_block);
+    let result_label = jit.get_label(asm, result_block, hir_block_id);
+    asm.write_label(result_label);
+    let param = asm.new_block_param(VALUE_BITS);
+    asm.current_block().add_parameter(param);
+    param
+}
+
+fn gen_f64_binop(asm: &mut Assembler, op: F64BinOp, left: lir::Opnd, right: lir::Opnd) -> lir::Opnd {
+    let left = gen_f64_opnd(asm, left);
+    let right = gen_f64_opnd(asm, right);
+
+    asm.f64_binop_raw(op, left, right)
+}
+
+fn gen_f64_value_rhs_op(
+    jit: &mut JITState,
+    asm: &mut Assembler,
+    function: &Function,
+    op: F64BinOp,
+    left: lir::Opnd,
+    right: lir::Opnd,
+    state: &FrameState,
+) -> lir::Opnd {
+    let left = gen_f64_opnd(asm, left);
+
+    let hir_block_id = asm.current_block().hir_block_id;
+    let rpo_idx = asm.current_block().rpo_index;
+    let flonum_block = asm.new_block(hir_block_id, false, rpo_idx);
+    let result_block = asm.new_block(hir_block_id, false, rpo_idx);
+    let flonum_edge = Target::Block(Box::new(lir::BranchEdge { target: flonum_block, args: vec![] }));
+    let result_edge = |v| Target::Block(Box::new(lir::BranchEdge { target: result_block, args: vec![v] }));
+
+    let masked = asm.and(right, lir::Opnd::UImm(RUBY_FLONUM_MASK as u64));
+    asm.cmp(masked, lir::Opnd::UImm(RUBY_FLONUM_FLAG as u64));
+    asm.je(jit, flonum_edge);
+
+    asm.test(right, lir::Opnd::UImm(RUBY_FIXNUM_FLAG as u64));
+    asm.jz(jit, side_exit_with_recompile(jit, function, state, GuardType(types::Flonum.union(types::Fixnum)), Some(Recompile)));
+    let right_f64 = asm.fixnum_to_f64_raw(right);
+    asm.jmp(result_edge(right_f64));
+
+    asm.set_current_block(flonum_block);
+    let flonum_label = jit.get_label(asm, flonum_block, hir_block_id);
+    asm.write_label(flonum_label);
+    let right_f64 = gen_unbox_float(asm, right);
+    asm.jmp(result_edge(right_f64));
+
+    asm.set_current_block(result_block);
+    let result_label = jit.get_label(asm, result_block, hir_block_id);
+    asm.write_label(result_label);
+    let right_f64 = asm.new_fp_vreg(64);
+    asm.current_block().add_parameter(right_f64);
+    gen_f64_binop(asm, op, left, right_f64)
+}
+
+fn gen_f64_sqrt(asm: &mut Assembler, val: lir::Opnd) -> lir::Opnd {
+    let val = gen_f64_opnd(asm, val);
+    asm.f64_sqrt_raw(val)
+}
+
+fn gen_f64_sin(asm: &mut Assembler, val: lir::Opnd) -> lir::Opnd {
+    let bits = gen_f64_bits_opnd(asm, val);
+    let result = asm_ccall!(asm, rb_jit_f64_sin, bits);
+    asm.bits_to_f64_raw(result)
+}
+
+fn gen_f64_cos(asm: &mut Assembler, val: lir::Opnd) -> lir::Opnd {
+    let bits = gen_f64_bits_opnd(asm, val);
+    let result = asm_ccall!(asm, rb_jit_f64_cos, bits);
+    asm.bits_to_f64_raw(result)
+}
+
+fn gen_f64_pow(asm: &mut Assembler, left: lir::Opnd, right: lir::Opnd) -> lir::Opnd {
+    let left = gen_f64_bits_opnd(asm, left);
+    let right = gen_f64_bits_opnd(asm, right);
+    let result = asm_ccall!(asm, rb_jit_f64_pow, left, right);
+    asm.bits_to_f64_raw(result)
+}
+
+fn gen_f64_guard_nonnegative(jit: &mut JITState, asm: &mut Assembler, function: &Function, val: lir::Opnd, state: &FrameState) {
+    let val = gen_f64_opnd(asm, val);
+    let zero = gen_f64_opnd(asm, lir::Opnd::UImm(0));
+    let negative = asm.f64_bool_cmp_raw(F64BoolCmpOp::Lt, val, zero);
+    asm.cmp(negative, Qtrue.into());
+    asm.je(jit, side_exit(jit, function, state, SideExitReason::GuardGreaterEq));
+}
+
+fn gen_equal_p(asm: &mut Assembler, left: lir::Opnd, right: lir::Opnd) -> lir::Opnd {
+    asm.cmp(left, right);
+    asm.csel_e(Qtrue.into(), Qfalse.into())
+}
+
+fn gen_f64_bool_cmp(asm: &mut Assembler, op: F64BoolCmpOp, left: lir::Opnd, right: lir::Opnd) -> lir::Opnd {
+    let left = gen_f64_opnd(asm, left);
+    let right = gen_f64_opnd(asm, right);
+
+    asm.f64_bool_cmp_raw(op, left, right)
+}
+
+fn gen_f64_fixnum_bool_cmp(asm: &mut Assembler, op: F64BoolCmpOp, left: lir::Opnd, right: lir::Opnd) -> lir::Opnd {
+    if fixnum_opnd_exact_as_f64(right) {
+        let left = gen_f64_opnd(asm, left);
+        let right = asm.fixnum_to_f64_raw(right);
+
+        return asm.f64_bool_cmp_raw(op, left, right);
+    }
+
+    let left = gen_f64_bits_opnd(asm, left);
+    let rel = asm_ccall!(asm, rb_jit_f64_fixnum_cmp, left, right);
+    let minus_one = VALUE::fixnum_from_isize(-1);
+    let zero = VALUE::fixnum_from_usize(0);
+    let one = VALUE::fixnum_from_usize(1);
+
+    match op {
+        F64BoolCmpOp::Eq => gen_equal_p(asm, rel, zero.into()),
+        F64BoolCmpOp::Lt => gen_equal_p(asm, rel, minus_one.into()),
+        F64BoolCmpOp::Le => {
+            let less = gen_equal_p(asm, rel, minus_one.into());
+            asm.cmp(rel, zero.into());
+            asm.csel_e(Qtrue.into(), less)
+        },
+        F64BoolCmpOp::Gt => gen_equal_p(asm, rel, one.into()),
+        F64BoolCmpOp::Ge => {
+            let greater = gen_equal_p(asm, rel, one.into());
+            asm.cmp(rel, zero.into());
+            asm.csel_e(Qtrue.into(), greater)
+        },
+    }
+}
+
+fn fixnum_opnd_exact_as_f64(opnd: lir::Opnd) -> bool {
+    const MAX_EXACT_I64_IN_F64: i64 = 1_i64 << 53;
+
+    let lir::Opnd::Value(value) = opnd else {
+        return false;
+    };
+    if !value.fixnum_p() {
+        return false;
+    }
+    value.as_fixnum().abs() <= MAX_EXACT_I64_IN_F64
 }
 
 /// Compile Fixnum == Fixnum
@@ -2863,7 +3134,9 @@ fn gen_test(asm: &mut Assembler, val: lir::Opnd) -> lir::Opnd {
 }
 
 fn gen_has_type(jit: &mut JITState, asm: &mut Assembler, val: lir::Opnd, val_type: Type, ty: Type) -> lir::Opnd {
-    if ty.is_subtype(types::Fixnum) {
+    if val_type.bit_equal(types::Empty) {
+        Opnd::Imm(0)
+    } else if ty.is_subtype(types::Fixnum) {
         asm.test(val, Opnd::UImm(RUBY_FIXNUM_FLAG as u64));
         asm.csel_nz(Opnd::Imm(1), Opnd::Imm(0))
     } else if ty.is_subtype(types::Flonum) {
@@ -2996,6 +3269,14 @@ fn gen_guard_type(jit: &mut JITState, asm: &mut Assembler, function: &Function, 
     } else if guard_type.is_subtype(types::NilClass) {
         asm.cmp(val, Qnil.into());
         asm.jne(jit, side_exit_with_recompile(jit, function, state, GuardType(guard_type), recompile));
+    } else if guard_type.bit_equal(types::BoolExact) {
+        let side_exit = side_exit_with_recompile(jit, function, state, GuardType(guard_type), recompile);
+        let ok = asm.new_label("guard_bool_ok");
+        asm.cmp(val, Qtrue.into());
+        asm.je(jit, ok.clone());
+        asm.cmp(val, Qfalse.into());
+        asm.jne(jit, side_exit);
+        asm.write_label(ok);
     } else if guard_type.is_subtype(types::TrueClass) {
         asm.cmp(val, Qtrue.into());
         asm.jne(jit, side_exit_with_recompile(jit, function, state, GuardType(guard_type), recompile));
@@ -3277,7 +3558,7 @@ fn gen_prepare_leaf_call_with_gc(asm: &mut Assembler, state: &FrameState) {
 /// Save the current SP on the CFP
 fn gen_save_sp(asm: &mut Assembler, stack_size: usize) {
     // Update cfp->sp which will be read by the interpreter. We also have the SP register in JIT
-    // code, and ZJIT's codegen currently assumes the SP register doesn't move, e.g. gen_param().
+    // code, and ZJIT's codegen currently assumes the SP register doesn't move, e.g. gen_value_param().
     // So we don't update the SP register here. We could update the SP register to avoid using
     // an extra register for asm.lea(), but you'll need to manage the SP offset like YJIT does.
     gen_incr_counter(asm, Counter::vm_write_sp_count);
@@ -3288,12 +3569,28 @@ fn gen_save_sp(asm: &mut Assembler, stack_size: usize) {
 }
 
 /// Spill locals onto the stack.
-fn gen_spill_locals(jit: &JITState, asm: &mut Assembler, state: &FrameState) {
+fn gen_spill_locals(jit: &JITState, asm: &mut Assembler, function: &Function, state: &FrameState) {
     // TODO: Avoid spilling locals that have been spilled before and not changed.
     gen_incr_counter(asm, Counter::vm_write_locals_count);
     asm_comment!(asm, "spill locals");
-    for (idx, &insn_id) in state.locals().enumerate() {
-        asm.mov(Opnd::mem(64, SP, (-local_idx_to_ep_offset(state.iseq, idx) - 1) * SIZEOF_VALUE_I32), jit.get_opnd(insn_id));
+    let entries = state.locals()
+        .map(|&insn_id| build_materialized_value_entry(jit, function, insn_id))
+        .collect::<Vec<_>>();
+
+    for (idx, &entry) in entries.iter().enumerate() {
+        let opnd = match entry {
+            StackMapEntry::Opnd(opnd) => opnd,
+            StackMapEntry::F64(_) => Qnil.into(),
+            StackMapEntry::Skip(_) => unreachable!("locals do not use StackMap skips"),
+        };
+        asm.mov(Opnd::mem(64, SP, (-local_idx_to_ep_offset(state.iseq, idx) - 1) * SIZEOF_VALUE_I32), opnd);
+    }
+
+    for (idx, &entry) in entries.iter().enumerate() {
+        if let StackMapEntry::F64(opnd) = entry {
+            let boxed = gen_box_stack_map_f64(asm, opnd);
+            asm.mov(Opnd::mem(64, SP, (-local_idx_to_ep_offset(state.iseq, idx) - 1) * SIZEOF_VALUE_I32), boxed);
+        }
     }
 }
 
@@ -3304,17 +3601,29 @@ fn gen_spill_stack(jit: &JITState, asm: &mut Assembler, function: &Function, sta
     gen_incr_counter(asm, Counter::vm_write_stack_count);
     asm_comment!(asm, "spill stack");
 
+    let entries = build_materialized_value_map(jit, function, state);
     let mut offset = state.stack_size() as i32;
-    for entry in build_stack_map(jit, function, state) {
+    let mut locations = Vec::new();
+    for entry in entries {
         match entry {
             StackMapEntry::Opnd(opnd) => {
                 offset -= 1;
                 asm.mov(Opnd::mem(64, SP, offset * SIZEOF_VALUE_I32), opnd);
             }
+            StackMapEntry::F64(opnd) => {
+                offset -= 1;
+                asm.mov(Opnd::mem(64, SP, offset * SIZEOF_VALUE_I32), Qnil.into());
+                locations.push((offset, opnd));
+            }
             StackMapEntry::Skip(skip) => {
                 offset -= skip as i32;
             }
         }
+    }
+
+    for (offset, opnd) in locations {
+        let boxed = gen_box_stack_map_f64(asm, opnd);
+        asm.mov(Opnd::mem(64, SP, offset * SIZEOF_VALUE_I32), boxed);
     }
 }
 
@@ -3326,7 +3635,7 @@ fn gen_spill_stack(jit: &JITState, asm: &mut Assembler, function: &Function, sta
 fn gen_prepare_fallback_call(jit: &JITState, asm: &mut Assembler, function: &Function, state: &FrameState) {
     gen_write_jit_frame(asm, state, 0);
     gen_save_sp(asm, state.stack_size());
-    gen_spill_locals(jit, asm, state);
+    gen_spill_locals(jit, asm, function, state);
     gen_spill_stack(jit, asm, function, state);
 }
 
@@ -3338,12 +3647,7 @@ fn build_stack_map(jit: &JITState, function: &Function, state: &FrameState) -> V
     let mut current_state = state.clone();
     loop {
         stack.extend(current_state.stack().rev().copied().map(|insn_id| {
-            let opnd = jit.get_opnd(insn_id);
-            assert!(
-                matches!(opnd, Opnd::Value(_) | Opnd::VReg { .. }),
-                "FrameState should only reference Opnd::Value or Opnd::VReg, but got: {opnd:?}",
-            );
-            StackMapEntry::Opnd(opnd)
+            build_stack_map_entry(jit, function, insn_id)
         }));
 
         let Some(caller) = current_state.caller() else {
@@ -3353,6 +3657,64 @@ fn build_stack_map(jit: &JITState, function: &Function, state: &FrameState) -> V
         current_state = function.frame_state(caller);
     }
     stack
+}
+
+fn build_materialized_value_map(jit: &JITState, function: &Function, state: &FrameState) -> Vec<StackMapEntry> {
+    let mut stack = Vec::new();
+    let mut current_state = state.clone();
+    loop {
+        stack.extend(current_state.stack().rev().copied().map(|insn_id| {
+            build_materialized_value_entry(jit, function, insn_id)
+        }));
+
+        let Some(caller) = current_state.caller() else {
+            break;
+        };
+        stack.push(StackMapEntry::Skip(inline_frame_stack_gap(current_state.iseq)));
+        current_state = function.frame_state(caller);
+    }
+    stack
+}
+
+fn build_materialized_value_entry(jit: &JITState, function: &Function, insn_id: InsnId) -> StackMapEntry {
+    if function.is_raw_float_value(insn_id) {
+        let opnd = jit.get_opnd(insn_id);
+        assert!(
+            matches!(opnd, Opnd::UImm(_) | Opnd::Imm(_) | Opnd::VReg { .. }),
+            "raw F64 materialization should reference CDouble bits or VReg, but got: {opnd:?}",
+        );
+        return StackMapEntry::F64(opnd);
+    }
+
+    let opnd = jit.get_opnd(insn_id);
+    assert!(
+        matches!(opnd, Opnd::Value(_) | Opnd::VReg { .. }),
+        "Ruby value materialization should only reference Opnd::Value or Opnd::VReg, but got: {opnd:?}",
+    );
+    StackMapEntry::Opnd(opnd)
+}
+
+fn build_stack_map_entry(jit: &JITState, function: &Function, insn_id: InsnId) -> StackMapEntry {
+    if function.is_raw_float_value(insn_id) {
+        let opnd = jit.get_opnd(insn_id);
+        assert!(
+            matches!(opnd, Opnd::UImm(_) | Opnd::Imm(_) | Opnd::VReg { .. }),
+            "raw F64 stack map should reference CDouble bits or VReg, but got: {opnd:?}",
+        );
+        return StackMapEntry::F64(opnd);
+    }
+
+    let opnd = jit.get_opnd(insn_id);
+    assert!(
+        matches!(opnd, Opnd::Value(_) | Opnd::VReg { .. }),
+        "FrameState should only reference Opnd::Value or Opnd::VReg, but got: {opnd:?}",
+    );
+    StackMapEntry::Opnd(opnd)
+}
+
+fn gen_box_stack_map_f64(asm: &mut Assembler, opnd: Opnd) -> Opnd {
+    let bits = gen_f64_bits_opnd(asm, opnd);
+    asm_ccall!(asm, rb_jit_f64_to_float, bits)
 }
 
 fn inline_frame_stack_gap(iseq: IseqPtr) -> usize {
@@ -3376,7 +3738,7 @@ fn gen_prepare_non_leaf_call(jit: &JITState, asm: &mut Assembler, function: &Fun
     asm.stack_map(stack_map, jit_frame, state.depth);
 
     // Spill locals in case the method looks at caller Bindings
-    gen_spill_locals(jit, asm, state);
+    gen_spill_locals(jit, asm, function, state);
 }
 
 /// Frame metadata written by gen_push_frame()
@@ -3519,12 +3881,12 @@ fn side_exit_with_recompile(jit: &JITState, function: &Function, state: &FrameSt
 fn build_side_exit(jit: &JITState, function: &Function, state: &FrameState) -> SideExit {
     let mut stack = Vec::new();
     for &insn_id in state.stack() {
-        stack.push(jit.get_opnd(insn_id));
+        stack.push(build_stack_map_entry(jit, function, insn_id));
     }
 
     let mut locals = Vec::new();
     for &insn_id in state.locals() {
-        locals.push(jit.get_opnd(insn_id));
+        locals.push(build_stack_map_entry(jit, function, insn_id));
     }
 
     SideExit{
@@ -3966,6 +4328,72 @@ fn gen_push_opnds(jit: &JITState, asm: &mut Assembler, opnds: &[Opnd]) -> lir::O
     }
 
     argv
+}
+
+fn gen_push_hir_values(jit: &JITState, asm: &mut Assembler, function: &Function, insns: &[InsnId]) -> lir::Opnd {
+    let entries = insns.iter().map(|&insn_id| {
+        build_materialized_value_entry(jit, function, insn_id)
+    }).collect::<Vec<_>>();
+
+    let argv = if !entries.is_empty() {
+        asm_comment!(asm, "allocate space on C stack for {} values", entries.len());
+        asm.alloc_stack(jit, entries.len())
+    } else {
+        asm_comment!(asm, "no opnds to allocate");
+        Opnd::UImm(0)
+    };
+
+    for (idx, &entry) in entries.iter().enumerate() {
+        let opnd = match entry {
+            StackMapEntry::Opnd(opnd) => opnd,
+            StackMapEntry::F64(_) => Qnil.into(),
+            StackMapEntry::Skip(_) => unreachable!("HIR value lists do not use StackMap skips"),
+        };
+        asm.mov(Opnd::mem(VALUE_BITS, argv, idx as i32 * SIZEOF_VALUE_I32), opnd);
+    }
+
+    for (idx, &entry) in entries.iter().enumerate() {
+        if let StackMapEntry::F64(opnd) = entry {
+            let boxed = gen_box_stack_map_f64(asm, opnd);
+            asm.mov(Opnd::mem(VALUE_BITS, argv, idx as i32 * SIZEOF_VALUE_I32), boxed);
+        }
+    }
+
+    argv
+}
+
+fn hir_values_require_f64_boxing(jit: &JITState, function: &Function, insns: &[InsnId]) -> bool {
+    insns.iter().any(|&insn_id| {
+        matches!(build_materialized_value_entry(jit, function, insn_id), StackMapEntry::F64(_))
+    })
+}
+
+fn gen_store_hir_values_to_stack(
+    jit: &JITState,
+    asm: &mut Assembler,
+    function: &Function,
+    insns: &[InsnId],
+    stack_bottom: usize,
+) {
+    let entries = insns.iter().map(|&insn_id| {
+        build_materialized_value_entry(jit, function, insn_id)
+    }).collect::<Vec<_>>();
+
+    for (idx, &entry) in entries.iter().enumerate() {
+        let opnd = match entry {
+            StackMapEntry::Opnd(opnd) => opnd,
+            StackMapEntry::F64(_) => Qnil.into(),
+            StackMapEntry::Skip(_) => unreachable!("HIR value lists do not use StackMap skips"),
+        };
+        asm.mov(Opnd::mem(VALUE_BITS, SP, (stack_bottom + idx) as i32 * SIZEOF_VALUE_I32), opnd);
+    }
+
+    for (idx, &entry) in entries.iter().enumerate() {
+        if let StackMapEntry::F64(opnd) = entry {
+            let boxed = gen_box_stack_map_f64(asm, opnd);
+            asm.mov(Opnd::mem(VALUE_BITS, SP, (stack_bottom + idx) as i32 * SIZEOF_VALUE_I32), boxed);
+        }
+    }
 }
 
 fn gen_toregexp(jit: &mut JITState, asm: &mut Assembler, function: &Function, opt: usize, values: Vec<Opnd>, state: &FrameState) -> Opnd {

--- a/zjit/src/codegen/gc_fastpath.rs
+++ b/zjit/src/codegen/gc_fastpath.rs
@@ -13,6 +13,7 @@ use super::JITState;
 struct RbGcZjitDefaultNewObjFastpath {
     cursor_offset: usize,
     cursor_end_offset: usize,
+    allocated_objects_count_offset: usize,
     slot_size: usize,
     flags: VALUE,
     klass: VALUE,
@@ -177,6 +178,7 @@ fn emit_default_new_obj_fastpath(
 ) -> Option<Opnd> {
     let cursor_offset: i32 = fastpath.cursor_offset.try_into().ok()?;
     let cursor_end_offset: i32 = fastpath.cursor_end_offset.try_into().ok()?;
+    let allocated_objects_count_offset: i32 = fastpath.allocated_objects_count_offset.try_into().ok()?;
     let slot_size: u64 = fastpath.slot_size.try_into().ok()?;
 
     let thread = asm.load(Opnd::mem(64, EC, RUBY_OFFSET_EC_THREAD_PTR as i32));
@@ -194,6 +196,12 @@ fn emit_default_new_obj_fastpath(
     asm.jl(jit, miss.clone());
 
     asm.store(Opnd::mem(64, gc_cache, cursor_offset), new_cursor);
+    let allocated_objects_count = asm.load(Opnd::mem(64, gc_cache, allocated_objects_count_offset));
+    let allocated_objects_count = asm.add(allocated_objects_count, Opnd::UImm(1));
+    asm.store(
+        Opnd::mem(64, gc_cache, allocated_objects_count_offset),
+        allocated_objects_count,
+    );
     asm.store(
         Opnd::mem(VALUE_BITS, cursor, RUBY_OFFSET_RBASIC_FLAGS),
         fastpath.flags.as_u64().into(),

--- a/zjit/src/codegen_tests.rs
+++ b/zjit/src/codegen_tests.rs
@@ -3046,6 +3046,21 @@ fn test_opt_newarray_send_pack() {
 }
 
 #[test]
+fn test_opt_newarray_send_pack_handles_raw_float_elements() {
+    eval(r#"
+        def test
+          v = 1.23
+          [v, v * 2, v * 3].pack("E*").unpack("E*") == [v, v * 2, v * 3]
+        end
+        test
+    "#);
+    assert_contains_opcode("test", YARVINSN_opt_newarray_send);
+    assert_snapshot!(assert_compiles(r#"
+        test
+    "#), @"true");
+}
+
+#[test]
 fn test_opt_newarray_send_pack_redefined() {
     eval(r#"
         class Array
@@ -3402,6 +3417,18 @@ fn test_new_hash_with_computation() {
 }
 
 #[test]
+fn test_new_hash_boxes_raw_float_elements() {
+    assert_snapshot!(inspect(r#"
+        def test
+          v = 1.23
+          {v => v * 2}
+        end
+        test
+        test
+    "#), @"{1.23 => 2.46}");
+}
+
+#[test]
 fn test_new_hash_with_user_defined_hash_method() {
     assert_snapshot!(inspect(r#"
         class CustomKey
@@ -3702,6 +3729,18 @@ fn test_new_array_order() {
         test
         test
     "), @"[3, 2, 1]");
+}
+
+#[test]
+fn test_new_array_boxes_raw_float_elements() {
+    assert_snapshot!(inspect(r#"
+        def test
+          v = 1.23
+          [v, v * 2, v * 3].pack("E*").unpack("E*") == [v, v * 2, v * 3]
+        end
+        test
+        test
+    "#), @"true");
 }
 
 #[test]
@@ -7312,10 +7351,49 @@ fn test_float_arithmetic() {
     assert_snapshot!(assert_compiles_allowing_exits("def test = 3.5 - 2.0; test"), @"1.5");
     assert_snapshot!(assert_compiles_allowing_exits("def test = 5.0 / 2.0; test"), @"2.5");
     assert_snapshot!(assert_compiles_allowing_exits("def test = 1.5 * 3; test"), @"4.5"); // Float * Fixnum
+    assert_snapshot!(assert_compiles_allowing_exits("def test = 1 + 2.5; test"), @"3.5");
+    assert_snapshot!(assert_compiles_allowing_exits("def test = 1 - 2.5; test"), @"-1.5");
+    assert_snapshot!(assert_compiles_allowing_exits("def test = 2 * 2.5; test"), @"5.0");
+    assert_snapshot!(assert_compiles_allowing_exits("def test = 5 / 2.0; test"), @"2.5");
+    assert_snapshot!(assert_compiles_allowing_exits("def test = 1 / -0.0; test"), @"-Infinity");
     assert_snapshot!(assert_compiles_allowing_exits("def test = (Float::NAN + 1.0).nan?; test"), @"true");
+    assert_snapshot!(assert_compiles_allowing_exits("def test = (0.0 / 0.0).nan?; test"), @"true");
+    assert_snapshot!(assert_compiles_allowing_exits("def test = (-0.0 / 0.0).nan?; test"), @"true");
+    assert_snapshot!(assert_compiles_allowing_exits("def test = Math.sqrt(Float::NAN).nan?; test"), @"true");
+    assert_snapshot!(assert_compiles_allowing_exits("def test(x) = x.nan?(x) rescue $!.class; test(1.0)"), @"ArgumentError");
+    assert_snapshot!(assert_compiles_allowing_exits("def test = (1.0 / 2.0).finite?; test"), @"true");
+    assert_snapshot!(assert_compiles_allowing_exits("def test = (1.0 / 0.0).infinite?; test"), @"1");
+    assert_snapshot!(assert_compiles_allowing_exits("def test = (1.0 / -0.0).infinite?; test"), @"-1");
+    assert_snapshot!(assert_compiles_allowing_exits("def test = (1.0 - 1.0).zero?; test"), @"true");
+    assert_snapshot!(assert_compiles_allowing_exits("def test = (-0.0).zero?; test"), @"true");
+    assert_snapshot!(assert_compiles_allowing_exits("def test = (-0.0).negative?; test"), @"false");
+    assert_snapshot!(assert_compiles_allowing_exits("def test = (1.0 - 2.0).positive?; test"), @"false");
+    assert_snapshot!(assert_compiles_allowing_exits("def test = (1.0 - 2.0).negative?; test"), @"true");
+    assert_snapshot!(assert_compiles_allowing_exits("def test = (1.0 + 1.5) == 2.5; test"), @"true");
+    assert_snapshot!(assert_compiles_allowing_exits("def test = (1.0 + 1.5) < 2.5; test"), @"false");
+    assert_snapshot!(assert_compiles_allowing_exits("def test = (1.0 + 1.5) <= 2.5; test"), @"true");
+    assert_snapshot!(assert_compiles_allowing_exits("def test = (1.0 + 1.5) > 2.0; test"), @"true");
+    assert_snapshot!(assert_compiles_allowing_exits("def test = (1.0 + 1.5) >= 2.6; test"), @"false");
+    assert_snapshot!(assert_compiles_allowing_exits("def test = (0.0 / 0.0) == Float::NAN; test"), @"false");
+    assert_snapshot!(assert_compiles_allowing_exits("def test = (-0.0) == 0.0; test"), @"true");
+    assert_snapshot!(assert_compiles_allowing_exits("def test = (1.0 + 1.0) == 2; test"), @"true");
+    assert_snapshot!(assert_compiles_allowing_exits("def test = (-0.0) == 0; test"), @"true");
+    assert_snapshot!(assert_compiles_allowing_exits("def test = (0.0 / 0.0) == 0; test"), @"false");
+    assert_snapshot!(assert_compiles_allowing_exits("def test = 2 == (1.0 + 1.0); test"), @"true");
+    assert_snapshot!(assert_compiles_allowing_exits("def test = 2 < (1.0 + 1.5); test"), @"true");
+    assert_snapshot!(assert_compiles_allowing_exits("def test = 3 <= (1.0 + 1.5); test"), @"false");
+    assert_snapshot!(assert_compiles_allowing_exits("def test = 3 > (1.0 + 1.5); test"), @"true");
+    assert_snapshot!(assert_compiles_allowing_exits("def test = 2 >= (1.0 + 1.5); test"), @"false");
+    assert_snapshot!(assert_compiles_allowing_exits("def test = (1.0 + 1.5) < 3; test"), @"true");
+    assert_snapshot!(assert_compiles_allowing_exits("def test = (1.0 + 1.5) <= 2; test"), @"false");
+    assert_snapshot!(assert_compiles_allowing_exits("def test = (1.0 + 1.5) > 2; test"), @"true");
+    assert_snapshot!(assert_compiles_allowing_exits("def test = (1.0 + 1.5) >= 3; test"), @"false");
+    assert_snapshot!(assert_compiles_allowing_exits("def test = (2305843009213693952.0 + 2305843009213693952.0) == 4611686018427387903; test"), @"false");
+    assert_snapshot!(assert_compiles_allowing_exits("def test = (2305843009213693952.0 + 2305843009213693952.0) > 4611686018427387903; test"), @"true");
+    assert_snapshot!(assert_compiles_allowing_exits("def test = 4611686018427387903 == (2305843009213693952.0 + 2305843009213693952.0); test"), @"false");
+    assert_snapshot!(assert_compiles_allowing_exits("def test = 4611686018427387903 < (2305843009213693952.0 + 2305843009213693952.0); test"), @"true");
     assert_snapshot!(assert_compiles_allowing_exits("def test = Float::INFINITY * 2.0; test"), @"Infinity");
-    assert_snapshot!(assert_compiles_allowing_exits("def test = 3.7.to_i; test"), @"3");
-    assert_snapshot!(assert_compiles_allowing_exits("def test = (-2.9).to_i; test"), @"-2");
+    assert_snapshot!(assert_compiles_allowing_exits(r#"def test(a, b, c) = (a + b) + c; test(1.25, 2.5, 3.75); test(1.25, 2.5, "x") rescue $!.message"#), @r#""String can't be coerced into Float""#);
 }
 
 #[test]

--- a/zjit/src/cruby.rs
+++ b/zjit/src/cruby.rs
@@ -100,6 +100,12 @@ pub type size_t = u64;
 /// shifted 1s but not explicitly an enum.
 pub type RedefinitionFlag = u32;
 
+pub const FLONUM_ZERO_VALUE: u64 = 0x8000_0000_0000_0002;
+pub const FLONUM_CLEAR_TAG_MASK: u64 = !0x3;
+pub const FLONUM_MAGIC_EXCLUDED_BITS: u64 = 0x3000_0000_0000_0000;
+pub const FLONUM_CLEAR_LOW_BIT_MASK: u64 = !0x1;
+pub const FLONUM_TAG: u64 = 0x2;
+
 #[allow(unsafe_op_in_unsafe_fn)]
 #[allow(dead_code)]
 #[allow(clippy::all)] // warning meant to help with reading; not useful for generated code
@@ -127,6 +133,7 @@ unsafe extern "C" {
     // Floats within range will be encoded without creating objects in the heap.
     // (Range is 0x3000000000000001 to 0x4fffffffffffffff (1.7272337110188893E-77 to 2.3158417847463237E+77).
     pub fn rb_float_new(d: f64) -> VALUE;
+    pub fn rb_jit_f64_to_float(bits: u64) -> VALUE;
 
     pub fn rb_hash_empty_p(hash: VALUE) -> VALUE;
     pub fn rb_ary_new_from_args(n: c_long, ...) -> VALUE;
@@ -693,6 +700,18 @@ impl VALUE {
         us
     }
 
+    pub fn as_flonum_f64(self) -> f64 {
+        assert!(self.flonum_p());
+
+        if self.0 as u64 == FLONUM_ZERO_VALUE {
+            return 0.0;
+        }
+
+        let sign_bit = (self.0 as u64) >> 63;
+        let encoded = (2 - sign_bit) | ((self.0 as u64) & FLONUM_CLEAR_TAG_MASK);
+        f64::from_bits(encoded.rotate_right(3))
+    }
+
     pub fn as_ptr<T>(self) -> *const T {
         let VALUE(us) = self;
         us as *const T
@@ -757,6 +776,19 @@ impl VALUE {
         assert!(item <= RUBY_FIXNUM_MAX);
         let k: isize = item.wrapping_add(item.wrapping_add(1));
         VALUE(k as usize)
+    }
+
+    pub fn flonum_from_f64(item: f64) -> Option<Self> {
+        let bits = item.to_bits();
+        let high_bits = (bits >> 60) & 0x7;
+
+        if bits != FLONUM_MAGIC_EXCLUDED_BITS && (high_bits.wrapping_sub(3) & FLONUM_CLEAR_LOW_BIT_MASK) == 0 {
+            Some(VALUE(((bits.rotate_left(3) & FLONUM_CLEAR_LOW_BIT_MASK) | FLONUM_TAG) as usize))
+        } else if bits == 0 {
+            Some(VALUE(FLONUM_ZERO_VALUE as usize))
+        } else {
+            None
+        }
     }
 
     /// Call the write barrier after separately writing val to self.
@@ -1208,6 +1240,7 @@ mod manual_defs {
     // redeclare all the Ruby C structs and write our own offsetof macro. For now, we use constants.
     pub const RUBY_OFFSET_RBASIC_FLAGS: i32 = 0; // struct RBasic, field "flags"
     pub const RUBY_OFFSET_RBASIC_KLASS: i32 = 8; // struct RBasic, field "klass"
+    pub const RUBY_OFFSET_RFLOAT_VALUE: i32 = 16; // struct RFloat, field "float_value"
     pub const RUBY_OFFSET_RARRAY_AS_HEAP_LEN: i32 = 16; // struct RArray, subfield "as.heap.len"
     pub const RUBY_OFFSET_RARRAY_AS_HEAP_PTR: i32 = 32; // struct RArray, subfield "as.heap.ptr"
     pub const RUBY_OFFSET_RARRAY_AS_ARY: i32 = 16; // struct RArray, subfield "as.ary"
@@ -1468,6 +1501,31 @@ pub mod test_utils {
         assert_eq!(VALUE::fixnum_from_usize(RUBY_FIXNUM_MAX as usize), VALUE(0x7fffffffffffffff));
         assert_eq!(VALUE::fixnum_from_isize(RUBY_FIXNUM_MAX), VALUE(0x7fffffffffffffff));
         assert_eq!(VALUE::fixnum_from_isize(RUBY_FIXNUM_MIN), VALUE(0x8000000000000001));
+    }
+
+    #[test]
+    fn value_from_f64_matches_cruby_flonum_encoding() {
+        with_rubyvm(|| {
+            for val in [0.0, 1.0, -1.0, 1.25, 2.5, 3.75] {
+                let expected = unsafe { rb_float_new(val) };
+                assert!(expected.flonum_p(), "{val:?} should be a flonum");
+                assert_eq!(VALUE::flonum_from_f64(val), Some(expected));
+                assert_eq!(expected.as_flonum_f64().to_bits(), val.to_bits());
+            }
+
+            for val in [
+                -0.0,
+                f64::INFINITY,
+                f64::NEG_INFINITY,
+                f64::NAN,
+                f64::MIN_POSITIVE,
+                f64::from_bits(FLONUM_MAGIC_EXCLUDED_BITS),
+            ] {
+                let expected = unsafe { rb_float_new(val) };
+                assert!(!expected.flonum_p(), "{val:?} should be a heap float");
+                assert_eq!(VALUE::flonum_from_f64(val), None);
+            }
+        });
     }
 
     #[test]

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -2026,6 +2026,7 @@ pub struct rb_gc_zjit_fastpath {
 pub struct rb_gc_zjit_default_new_obj_fastpath {
     pub cursor_offset: usize,
     pub cursor_end_offset: usize,
+    pub allocated_objects_count_offset: usize,
     pub slot_size: usize,
     pub flags: VALUE,
     pub klass: VALUE,

--- a/zjit/src/cruby_methods.rs
+++ b/zjit/src/cruby_methods.rs
@@ -14,8 +14,9 @@ use std::ffi::c_void;
 use crate::hir_type::{types, Type};
 use crate::hir::{self, FieldName};
 
-// Array iteration builtin functions (defined in array.c)
+// CRuby globals and builtin C functions referenced by annotations below.
 unsafe extern "C" {
+    static mut rb_mMath: VALUE;
     fn rb_builtin_ary_at_end(ec: EcPtr, self_: VALUE, index: VALUE) -> VALUE;
     fn rb_builtin_ary_at(ec: EcPtr, self_: VALUE, index: VALUE) -> VALUE;
     fn rb_builtin_fixnum_inc(ec: EcPtr, self_: VALUE, num: VALUE) -> VALUE;
@@ -271,21 +272,23 @@ pub fn init() -> Annotations {
     annotate!(rb_cFloat, "-", inline_float_minus);
     annotate!(rb_cFloat, "*", inline_float_mul);
     annotate!(rb_cFloat, "/", inline_float_div);
-    annotate!(rb_cFloat, "to_i", inline_float_to_i);
-    annotate!(rb_cFloat, "to_int", inline_float_to_i);
+    annotate!(rb_cFloat, "**", inline_float_pow, types::Float);
+    annotate!(rb_cFloat, "==", inline_float_eq, types::BoolExact, no_gc, leaf, elidable);
+    annotate!(rb_cFloat, ">", inline_float_gt, types::BoolExact, no_gc, leaf, elidable);
+    annotate!(rb_cFloat, ">=", inline_float_ge, types::BoolExact, no_gc, leaf, elidable);
+    annotate!(rb_cFloat, "<", inline_float_lt, types::BoolExact, no_gc, leaf, elidable);
+    annotate!(rb_cFloat, "<=", inline_float_le, types::BoolExact, no_gc, leaf, elidable);
     annotate!(rb_cString, "to_s", inline_string_to_s, types::StringExact);
-    annotate!(rb_cFloat, "nan?", types::BoolExact, no_gc, leaf, elidable);
-    annotate!(rb_cFloat, "finite?", types::BoolExact, no_gc, leaf, elidable);
-    annotate!(rb_cFloat, "infinite?", types::Fixnum.union(types::NilClass), no_gc, leaf, elidable);
+    let math_singleton = unsafe { rb_singleton_class(rb_mMath) };
+    annotate!(math_singleton, "sqrt", inline_math_sqrt, types::Float);
+    annotate!(math_singleton, "sin", inline_math_sin, types::Float);
+    annotate!(math_singleton, "cos", inline_math_cos, types::Float);
     let thread_singleton = unsafe { rb_singleton_class(rb_cThread) };
     annotate!(thread_singleton, "current", inline_thread_current, types::BasicObject, no_gc, leaf);
 
     annotate_builtin!(rb_cInteger, "zero?", types::BoolExact);
     annotate_builtin!(rb_cInteger, "even?", types::BoolExact);
     annotate_builtin!(rb_cInteger, "odd?", types::BoolExact);
-    annotate_builtin!(rb_cFloat, "zero?", types::BoolExact);
-    annotate_builtin!(rb_cFloat, "positive?", types::BoolExact);
-    annotate_builtin!(rb_cFloat, "negative?", types::BoolExact);
     annotate_builtin!(rb_mKernel, "Float", types::Float.union(types::NilClass));
     annotate_builtin!(rb_mKernel, "Integer", types::Integer.union(types::NilClass));
     annotate_builtin!(rb_mKernel, "class", inline_kernel_class, types::Class, leaf);
@@ -645,22 +648,76 @@ fn inline_integer_xor(fun: &mut hir::Function, block: hir::BlockId, recv: hir::I
     None
 }
 
-fn try_inline_float_op(fun: &mut hir::Function, block: hir::BlockId, f: &dyn Fn(hir::InsnId, hir::InsnId) -> hir::Insn, bop: u32, recv: hir::InsnId, other: hir::InsnId, state: hir::InsnId) -> Option<hir::InsnId> {
-    if !unsafe { rb_BASIC_OP_UNREDEFINED_P(bop, FLOAT_REDEFINED_OP_FLAG) } {
+fn basic_op_unredefined(bop: u32, redefined_flag: u32) -> bool {
+    unsafe { rb_BASIC_OP_UNREDEFINED_P(bop, redefined_flag) }
+}
+
+fn try_inline_float_op(fun: &mut hir::Function, block: hir::BlockId, op: hir::F64BinOp, bop: u32, recv: hir::InsnId, other: hir::InsnId, state: hir::InsnId) -> Option<hir::InsnId> {
+    if !basic_op_unredefined(bop, FLOAT_REDEFINED_OP_FLAG) {
         return None;
     }
-    // Receiver must be Flonum (cheap tag check: (val & 3) == 2).
-    // The other operand can be Flonum or Fixnum since rb_float_plus/minus/mul/div
-    // handle both via fast paths (FIXNUM_P check + cast to double).
-    // HeapFloat falls back to CCallWithFrame via the default Send path.
-    if fun.likely_a(recv, types::Flonum, state)
-        && (fun.likely_a(other, types::Flonum, state) || fun.likely_a(other, types::Fixnum, state))
+    // Receiver must be convertible to a raw C double, unless it is a
+    // still-virtual BoxFloat from a prior inlined Float operation. The other
+    // operand can also be Fixnum since we convert it to a raw C double before
+    // native arithmetic. Unknown object types fall back to CCallWithFrame via
+    // the default Send path.
+    if can_float_op_operand(fun, recv, true, state) && can_float_op_operand(fun, other, false, state)
     {
-        let recv = coerce_float_op_operand(fun, block, recv, types::Flonum, state);
-        let other_type = if fun.likely_a(other, types::Flonum, state) { types::Flonum } else { types::Fixnum };
-        let other = coerce_float_op_operand(fun, block, other, other_type, state);
-        return Some(fun.push_insn(block, f(recv, other)));
+        let recv = float_op_operand_f64(fun, block, recv, true, state)?;
+        let other = float_op_operand_f64(fun, block, other, false, state)?;
+        let result = fun.push_insn(block, hir::Insn::F64BinOp { op, left: recv, right: other });
+        return Some(box_f64_result(fun, block, result, state));
     }
+    None
+}
+
+fn try_inline_float_value_rhs_op(fun: &mut hir::Function, block: hir::BlockId, op: hir::F64BinOp, bop: u32, recv: hir::InsnId, other: hir::InsnId, state: hir::InsnId) -> Option<hir::InsnId> {
+    if !basic_op_unredefined(bop, FLOAT_REDEFINED_OP_FLAG) {
+        return None;
+    }
+    if !matches!(fun.find(other), hir::Insn::ArrayAref { .. } | hir::Insn::LoadField { .. }) {
+        return None;
+    }
+    let recv = float_op_operand_f64(fun, block, recv, true, state)?;
+    let result = fun.push_insn(block, hir::Insn::F64ValueRhsOp { op, left: recv, right: other, state });
+    Some(box_f64_result(fun, block, result, state))
+}
+
+fn box_f64_result(fun: &mut hir::Function, block: hir::BlockId, val: hir::InsnId, state: hir::InsnId) -> hir::InsnId {
+    fun.push_insn(block, hir::Insn::BoxFloat { val, state })
+}
+
+fn can_float_op_operand(fun: &hir::Function, val: hir::InsnId, is_recv: bool, state: hir::InsnId) -> bool {
+    can_float_compare_operand(fun, val, state)
+        || (!is_recv && fun.likely_a(val, types::Fixnum, state))
+}
+
+fn can_float_compare_operand(fun: &hir::Function, val: hir::InsnId, state: hir::InsnId) -> bool {
+    matches!(fun.find(val), hir::Insn::BoxFloat { .. })
+        || fun.likely_a(val, types::Flonum, state)
+        || fun.likely_a(val, types::Float, state)
+}
+
+fn float_op_operand_f64(fun: &mut hir::Function, block: hir::BlockId, val: hir::InsnId, is_recv: bool, state: hir::InsnId) -> Option<hir::InsnId> {
+    if let hir::Insn::BoxFloat { val: f64_val, .. } = fun.find(val) {
+        return Some(f64_val);
+    }
+
+    if fun.likely_a(val, types::Flonum, state) {
+        let val = coerce_float_op_operand(fun, block, val, types::Flonum, state);
+        return Some(fun.push_insn(block, hir::Insn::UnboxFloat { val }));
+    }
+
+    if !is_recv && fun.likely_a(val, types::Fixnum, state) {
+        let val = coerce_float_op_operand(fun, block, val, types::Fixnum, state);
+        return Some(fun.push_insn(block, hir::Insn::FixnumToF64 { val }));
+    }
+
+    if fun.likely_a(val, types::Float, state) {
+        let val = coerce_float_op_operand(fun, block, val, types::Float, state);
+        return Some(fun.push_insn(block, hir::Insn::UnboxRubyFloat { val }));
+    }
+
     None
 }
 
@@ -672,37 +729,178 @@ fn coerce_float_op_operand(fun: &mut hir::Function, block: hir::BlockId, val: hi
     }
 }
 
-fn inline_float_plus(fun: &mut hir::Function, block: hir::BlockId, recv: hir::InsnId, args: &[hir::InsnId], state: hir::InsnId) -> Option<hir::InsnId> {
+fn inline_float_binop(fun: &mut hir::Function, block: hir::BlockId, op: hir::F64BinOp, bop: u32, recv: hir::InsnId, args: &[hir::InsnId], state: hir::InsnId) -> Option<hir::InsnId> {
     let &[other] = args else { return None; };
-    try_inline_float_op(fun, block, &|recv, other| hir::Insn::FloatAdd { recv, other, state }, BOP_PLUS, recv, other, state)
+    try_inline_float_op(fun, block, op, bop, recv, other, state)
+        .or_else(|| try_inline_float_value_rhs_op(fun, block, op, bop, recv, other, state))
+}
+
+fn inline_float_plus(fun: &mut hir::Function, block: hir::BlockId, recv: hir::InsnId, args: &[hir::InsnId], state: hir::InsnId) -> Option<hir::InsnId> {
+    inline_float_binop(fun, block, hir::F64BinOp::Add, BOP_PLUS, recv, args, state)
 }
 
 fn inline_float_minus(fun: &mut hir::Function, block: hir::BlockId, recv: hir::InsnId, args: &[hir::InsnId], state: hir::InsnId) -> Option<hir::InsnId> {
-    let &[other] = args else { return None; };
-    try_inline_float_op(fun, block, &|recv, other| hir::Insn::FloatSub { recv, other, state }, BOP_MINUS, recv, other, state)
+    inline_float_binop(fun, block, hir::F64BinOp::Sub, BOP_MINUS, recv, args, state)
 }
 
 fn inline_float_mul(fun: &mut hir::Function, block: hir::BlockId, recv: hir::InsnId, args: &[hir::InsnId], state: hir::InsnId) -> Option<hir::InsnId> {
-    let &[other] = args else { return None; };
-    try_inline_float_op(fun, block, &|recv, other| hir::Insn::FloatMul { recv, other, state }, BOP_MULT, recv, other, state)
+    inline_float_binop(fun, block, hir::F64BinOp::Mul, BOP_MULT, recv, args, state)
 }
 
 fn inline_float_div(fun: &mut hir::Function, block: hir::BlockId, recv: hir::InsnId, args: &[hir::InsnId], state: hir::InsnId) -> Option<hir::InsnId> {
-    let &[other] = args else { return None; };
-    try_inline_float_op(fun, block, &|recv, other| hir::Insn::FloatDiv { recv, other, state }, BOP_DIV, recv, other, state)
+    inline_float_binop(fun, block, hir::F64BinOp::Div, BOP_DIV, recv, args, state)
 }
 
-fn inline_float_to_i(fun: &mut hir::Function, block: hir::BlockId, recv: hir::InsnId, args: &[hir::InsnId], state: hir::InsnId) -> Option<hir::InsnId> {
-    let &[] = args else { return None; };
-    if fun.likely_a(recv, types::Flonum, state) {
-        let recv = fun.coerce_to(block, recv, types::Flonum, state);
-        return Some(fun.push_insn(block, hir::Insn::FloatToInt { recv, state }));
+fn inline_float_pow(fun: &mut hir::Function, block: hir::BlockId, recv: hir::InsnId, args: &[hir::InsnId], state: hir::InsnId) -> Option<hir::InsnId> {
+    let &[other] = args else { return None; };
+    if !can_float_op_operand(fun, recv, true, state) || !can_float_op_operand(fun, other, false, state) {
+        return None;
     }
+
+    let recv = float_op_operand_f64(fun, block, recv, true, state)?;
+    if !is_nonnegative_f64(fun, recv, 0) {
+        return None;
+    }
+
+    let other = float_op_operand_f64(fun, block, other, false, state)?;
+    let result = fun.push_insn(block, hir::Insn::F64Pow { left: recv, right: other });
+    Some(box_f64_result(fun, block, result, state))
+}
+
+fn inline_math_sqrt(fun: &mut hir::Function, block: hir::BlockId, _recv: hir::InsnId, args: &[hir::InsnId], state: hir::InsnId) -> Option<hir::InsnId> {
+    let &[arg] = args else { return None; };
+    let arg = float_op_operand_f64(fun, block, arg, false, state)?;
+    if !is_nonnegative_f64(fun, arg, 0) {
+        fun.push_insn(block, hir::Insn::F64GuardNonnegative { val: arg, state });
+    }
+
+    let result = fun.push_insn(block, hir::Insn::F64Sqrt { val: arg });
+    Some(box_f64_result(fun, block, result, state))
+}
+
+fn inline_math_sin(fun: &mut hir::Function, block: hir::BlockId, _recv: hir::InsnId, args: &[hir::InsnId], state: hir::InsnId) -> Option<hir::InsnId> {
+    let &[arg] = args else { return None; };
+    let arg = float_op_operand_f64(fun, block, arg, false, state)?;
+    let result = fun.push_insn(block, hir::Insn::F64Sin { val: arg });
+    Some(box_f64_result(fun, block, result, state))
+}
+
+fn inline_math_cos(fun: &mut hir::Function, block: hir::BlockId, _recv: hir::InsnId, args: &[hir::InsnId], state: hir::InsnId) -> Option<hir::InsnId> {
+    let &[arg] = args else { return None; };
+    let arg = float_op_operand_f64(fun, block, arg, false, state)?;
+    let result = fun.push_insn(block, hir::Insn::F64Cos { val: arg });
+    Some(box_f64_result(fun, block, result, state))
+}
+
+fn is_nonnegative_f64(fun: &hir::Function, val: hir::InsnId, depth: usize) -> bool {
+    if depth > 8 {
+        return false;
+    }
+
+    match fun.find(val) {
+        hir::Insn::Const { val: hir::Const::CDouble(val) } => val >= 0.0 || val.is_nan(),
+        hir::Insn::Const { val: hir::Const::Value(val) } if val.flonum_p() => {
+            let val = val.as_flonum_f64();
+            val >= 0.0 || val.is_nan()
+        }
+        hir::Insn::Const { val: hir::Const::Value(val) } if val.fixnum_p() => val.as_fixnum() >= 0,
+        hir::Insn::UnboxFloat { val } | hir::Insn::UnboxRubyFloat { val } => is_nonnegative_f64(fun, val, depth + 1),
+        hir::Insn::FixnumToF64 { val } => is_nonnegative_f64(fun, val, depth + 1),
+        hir::Insn::F64BinOp { op: hir::F64BinOp::Mul, left, right } if left == right => true,
+        hir::Insn::F64BinOp { op: hir::F64BinOp::Div, left, right } => {
+            is_nonnegative_f64(fun, left, depth + 1) && is_positive_f64(fun, right, depth + 1)
+        }
+        hir::Insn::F64BinOp { op: hir::F64BinOp::Add, left, right } => {
+            is_nonnegative_f64(fun, left, depth + 1) && is_nonnegative_f64(fun, right, depth + 1)
+        }
+        _ => false,
+    }
+}
+
+fn is_positive_f64(fun: &hir::Function, val: hir::InsnId, depth: usize) -> bool {
+    if depth > 8 {
+        return false;
+    }
+
+    match fun.find(val) {
+        hir::Insn::Const { val: hir::Const::CDouble(val) } => val > 0.0 || val.is_nan(),
+        hir::Insn::Const { val: hir::Const::Value(val) } if val.flonum_p() => {
+            let val = val.as_flonum_f64();
+            val > 0.0 || val.is_nan()
+        }
+        hir::Insn::Const { val: hir::Const::Value(val) } if val.fixnum_p() => val.as_fixnum() > 0,
+        hir::Insn::UnboxFloat { val } | hir::Insn::UnboxRubyFloat { val } => is_positive_f64(fun, val, depth + 1),
+        hir::Insn::FixnumToF64 { val } => is_positive_f64(fun, val, depth + 1),
+        _ => false,
+    }
+}
+
+fn float_compare_operands(fun: &mut hir::Function, block: hir::BlockId, bop: u32, recv: hir::InsnId, other: hir::InsnId, state: hir::InsnId) -> Option<(hir::InsnId, hir::InsnId)> {
+    if !basic_op_unredefined(bop, FLOAT_REDEFINED_OP_FLAG) {
+        return None;
+    }
+
+    if can_float_compare_operand(fun, recv, state) && can_float_compare_operand(fun, other, state) {
+        let recv = float_op_operand_f64(fun, block, recv, true, state)?;
+        let other = float_op_operand_f64(fun, block, other, true, state)?;
+        return Some((recv, other));
+    }
+
     None
 }
 
+fn try_inline_float_bool_compare(fun: &mut hir::Function, block: hir::BlockId, op: hir::F64BoolCmpOp, bop: u32, recv: hir::InsnId, other: hir::InsnId, state: hir::InsnId) -> Option<hir::InsnId> {
+    let (recv, other) = float_compare_operands(fun, block, bop, recv, other, state)?;
+    Some(fun.push_insn(block, hir::Insn::F64BoolCmp { op, left: recv, right: other }))
+}
+
+fn float_fixnum_compare_operands(fun: &mut hir::Function, block: hir::BlockId, bop: u32, recv: hir::InsnId, other: hir::InsnId, state: hir::InsnId) -> Option<(hir::InsnId, hir::InsnId)> {
+    if !basic_op_unredefined(bop, FLOAT_REDEFINED_OP_FLAG) {
+        return None;
+    }
+
+    if can_float_compare_operand(fun, recv, state) && fun.likely_a(other, types::Fixnum, state) {
+        let recv = float_op_operand_f64(fun, block, recv, true, state)?;
+        let other = coerce_float_op_operand(fun, block, other, types::Fixnum, state);
+        return Some((recv, other));
+    }
+
+    None
+}
+
+fn try_inline_float_fixnum_bool_compare(fun: &mut hir::Function, block: hir::BlockId, op: hir::F64BoolCmpOp, bop: u32, recv: hir::InsnId, other: hir::InsnId, state: hir::InsnId) -> Option<hir::InsnId> {
+    let (recv, other) = float_fixnum_compare_operands(fun, block, bop, recv, other, state)?;
+    Some(fun.push_insn(block, hir::Insn::F64FixnumBoolCmp { op, left: recv, right: other }))
+}
+
+fn inline_float_bool_cmp(fun: &mut hir::Function, block: hir::BlockId, op: hir::F64BoolCmpOp, bop: u32, recv: hir::InsnId, args: &[hir::InsnId], state: hir::InsnId) -> Option<hir::InsnId> {
+    let &[other] = args else { return None; };
+    try_inline_float_fixnum_bool_compare(fun, block, op, bop, recv, other, state)
+        .or_else(|| try_inline_float_bool_compare(fun, block, op, bop, recv, other, state))
+}
+
+fn inline_float_eq(fun: &mut hir::Function, block: hir::BlockId, recv: hir::InsnId, args: &[hir::InsnId], state: hir::InsnId) -> Option<hir::InsnId> {
+    inline_float_bool_cmp(fun, block, hir::F64BoolCmpOp::Eq, BOP_EQ, recv, args, state)
+}
+
+fn inline_float_gt(fun: &mut hir::Function, block: hir::BlockId, recv: hir::InsnId, args: &[hir::InsnId], state: hir::InsnId) -> Option<hir::InsnId> {
+    inline_float_bool_cmp(fun, block, hir::F64BoolCmpOp::Gt, BOP_GT, recv, args, state)
+}
+
+fn inline_float_ge(fun: &mut hir::Function, block: hir::BlockId, recv: hir::InsnId, args: &[hir::InsnId], state: hir::InsnId) -> Option<hir::InsnId> {
+    inline_float_bool_cmp(fun, block, hir::F64BoolCmpOp::Ge, BOP_GE, recv, args, state)
+}
+
+fn inline_float_lt(fun: &mut hir::Function, block: hir::BlockId, recv: hir::InsnId, args: &[hir::InsnId], state: hir::InsnId) -> Option<hir::InsnId> {
+    inline_float_bool_cmp(fun, block, hir::F64BoolCmpOp::Lt, BOP_LT, recv, args, state)
+}
+
+fn inline_float_le(fun: &mut hir::Function, block: hir::BlockId, recv: hir::InsnId, args: &[hir::InsnId], state: hir::InsnId) -> Option<hir::InsnId> {
+    inline_float_bool_cmp(fun, block, hir::F64BoolCmpOp::Le, BOP_LE, recv, args, state)
+}
+
 fn try_inline_fixnum_op(fun: &mut hir::Function, block: hir::BlockId, f: &dyn Fn(hir::InsnId, hir::InsnId) -> hir::Insn, bop: u32, left: hir::InsnId, right: hir::InsnId, state: hir::InsnId) -> Option<hir::InsnId> {
-    if !unsafe { rb_BASIC_OP_UNREDEFINED_P(bop, INTEGER_REDEFINED_OP_FLAG) } {
+    if !basic_op_unredefined(bop, INTEGER_REDEFINED_OP_FLAG) {
         // If the basic operation is already redefined, we cannot optimize it.
         return None;
     }
@@ -719,29 +917,64 @@ fn try_inline_fixnum_op(fun: &mut hir::Function, block: hir::BlockId, f: &dyn Fn
     None
 }
 
+fn try_inline_fixnum_float_op(fun: &mut hir::Function, block: hir::BlockId, op: hir::F64BinOp, bop: u32, left: hir::InsnId, right: hir::InsnId, state: hir::InsnId) -> Option<hir::InsnId> {
+    if !basic_op_unredefined(bop, INTEGER_REDEFINED_OP_FLAG) {
+        return None;
+    }
+
+    if fun.likely_a(left, types::Fixnum, state) && can_float_compare_operand(fun, right, state) {
+        let left = fun.coerce_to(block, left, types::Fixnum, state);
+        let left = fun.push_insn(block, hir::Insn::FixnumToF64 { val: left });
+        let right = float_op_operand_f64(fun, block, right, false, state)?;
+        let result = fun.push_insn(block, hir::Insn::F64BinOp { op, left, right });
+        return Some(box_f64_result(fun, block, result, state));
+    }
+
+    None
+}
+
+fn try_inline_fixnum_float_compare(fun: &mut hir::Function, block: hir::BlockId, op: hir::F64BoolCmpOp, bop: u32, left: hir::InsnId, right: hir::InsnId, state: hir::InsnId) -> Option<hir::InsnId> {
+    if !basic_op_unredefined(bop, INTEGER_REDEFINED_OP_FLAG) {
+        return None;
+    }
+
+    if fun.likely_a(left, types::Fixnum, state) && can_float_compare_operand(fun, right, state) {
+        let left = fun.coerce_to(block, left, types::Fixnum, state);
+        let right = float_op_operand_f64(fun, block, right, false, state)?;
+        return Some(fun.push_insn(block, hir::Insn::F64FixnumBoolCmp { op, left: right, right: left }));
+    }
+
+    None
+}
+
 fn inline_integer_eq(fun: &mut hir::Function, block: hir::BlockId, recv: hir::InsnId, args: &[hir::InsnId], state: hir::InsnId) -> Option<hir::InsnId> {
     let &[other] = args else { return None; };
     try_inline_fixnum_op(fun, block, &|left, right| hir::Insn::FixnumEq { left, right }, BOP_EQ, recv, other, state)
+        .or_else(|| try_inline_fixnum_float_compare(fun, block, hir::F64BoolCmpOp::Eq, BOP_EQ, recv, other, state))
 }
 
 fn inline_integer_plus(fun: &mut hir::Function, block: hir::BlockId, recv: hir::InsnId, args: &[hir::InsnId], state: hir::InsnId) -> Option<hir::InsnId> {
     let &[other] = args else { return None; };
     try_inline_fixnum_op(fun, block, &|left, right| hir::Insn::FixnumAdd { left, right, state }, BOP_PLUS, recv, other, state)
+        .or_else(|| try_inline_fixnum_float_op(fun, block, hir::F64BinOp::Add, BOP_PLUS, recv, other, state))
 }
 
 fn inline_integer_minus(fun: &mut hir::Function, block: hir::BlockId, recv: hir::InsnId, args: &[hir::InsnId], state: hir::InsnId) -> Option<hir::InsnId> {
     let &[other] = args else { return None; };
     try_inline_fixnum_op(fun, block, &|left, right| hir::Insn::FixnumSub { left, right, state }, BOP_MINUS, recv, other, state)
+        .or_else(|| try_inline_fixnum_float_op(fun, block, hir::F64BinOp::Sub, BOP_MINUS, recv, other, state))
 }
 
 fn inline_integer_mult(fun: &mut hir::Function, block: hir::BlockId, recv: hir::InsnId, args: &[hir::InsnId], state: hir::InsnId) -> Option<hir::InsnId> {
     let &[other] = args else { return None; };
     try_inline_fixnum_op(fun, block, &|left, right| hir::Insn::FixnumMult { left, right, state }, BOP_MULT, recv, other, state)
+        .or_else(|| try_inline_fixnum_float_op(fun, block, hir::F64BinOp::Mul, BOP_MULT, recv, other, state))
 }
 
 fn inline_integer_div(fun: &mut hir::Function, block: hir::BlockId, recv: hir::InsnId, args: &[hir::InsnId], state: hir::InsnId) -> Option<hir::InsnId> {
     let &[other] = args else { return None; };
     try_inline_fixnum_op(fun, block, &|left, right| hir::Insn::FixnumDiv { left, right, state }, BOP_DIV, recv, other, state)
+        .or_else(|| try_inline_fixnum_float_op(fun, block, hir::F64BinOp::Div, BOP_DIV, recv, other, state))
 }
 
 fn inline_integer_mod(fun: &mut hir::Function, block: hir::BlockId, recv: hir::InsnId, args: &[hir::InsnId], state: hir::InsnId) -> Option<hir::InsnId> {
@@ -762,21 +995,25 @@ fn inline_integer_or(fun: &mut hir::Function, block: hir::BlockId, recv: hir::In
 fn inline_integer_gt(fun: &mut hir::Function, block: hir::BlockId, recv: hir::InsnId, args: &[hir::InsnId], state: hir::InsnId) -> Option<hir::InsnId> {
     let &[other] = args else { return None; };
     try_inline_fixnum_op(fun, block, &|left, right| hir::Insn::FixnumGt { left, right }, BOP_GT, recv, other, state)
+        .or_else(|| try_inline_fixnum_float_compare(fun, block, hir::F64BoolCmpOp::Lt, BOP_GT, recv, other, state))
 }
 
 fn inline_integer_ge(fun: &mut hir::Function, block: hir::BlockId, recv: hir::InsnId, args: &[hir::InsnId], state: hir::InsnId) -> Option<hir::InsnId> {
     let &[other] = args else { return None; };
     try_inline_fixnum_op(fun, block, &|left, right| hir::Insn::FixnumGe { left, right }, BOP_GE, recv, other, state)
+        .or_else(|| try_inline_fixnum_float_compare(fun, block, hir::F64BoolCmpOp::Le, BOP_GE, recv, other, state))
 }
 
 fn inline_integer_lt(fun: &mut hir::Function, block: hir::BlockId, recv: hir::InsnId, args: &[hir::InsnId], state: hir::InsnId) -> Option<hir::InsnId> {
     let &[other] = args else { return None; };
     try_inline_fixnum_op(fun, block, &|left, right| hir::Insn::FixnumLt { left, right }, BOP_LT, recv, other, state)
+        .or_else(|| try_inline_fixnum_float_compare(fun, block, hir::F64BoolCmpOp::Gt, BOP_LT, recv, other, state))
 }
 
 fn inline_integer_le(fun: &mut hir::Function, block: hir::BlockId, recv: hir::InsnId, args: &[hir::InsnId], state: hir::InsnId) -> Option<hir::InsnId> {
     let &[other] = args else { return None; };
     try_inline_fixnum_op(fun, block, &|left, right| hir::Insn::FixnumLe { left, right }, BOP_LE, recv, other, state)
+        .or_else(|| try_inline_fixnum_float_compare(fun, block, hir::F64BoolCmpOp::Ge, BOP_LE, recv, other, state))
 }
 
 fn inline_integer_lshift(fun: &mut hir::Function, block: hir::BlockId, recv: hir::InsnId, args: &[hir::InsnId], state: hir::InsnId) -> Option<hir::InsnId> {

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -524,6 +524,23 @@ impl PtrPrintMap {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum F64BinOp {
+    Add,
+    Sub,
+    Mul,
+    Div,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum F64BoolCmpOp {
+    Eq,
+    Lt,
+    Le,
+    Gt,
+    Ge,
+}
+
 #[derive(Debug, Clone, Copy)]
 pub enum SideExitReason {
     UnhandledNewarraySend(vm_opt_newarray_send_type),
@@ -818,6 +835,8 @@ pub enum FieldName {
     shape_id,
     as_heap,
     fields_obj,
+    rcomplex_real,
+    rcomplex_imag,
     thread_ptr,
     len,
     SelfParam,
@@ -1189,13 +1208,28 @@ pub enum Insn {
     FixnumLShift { left: InsnId, right: InsnId, state: InsnId },
     FixnumRShift { left: InsnId, right: InsnId },
 
-    /// Float arithmetic: delegates to rb_float_plus/minus/mul/div with GC preparation
-    FloatAdd  { recv: InsnId, other: InsnId, state: InsnId },
-    FloatSub  { recv: InsnId, other: InsnId, state: InsnId },
-    FloatMul  { recv: InsnId, other: InsnId, state: InsnId },
-    FloatDiv  { recv: InsnId, other: InsnId, state: InsnId },
-    /// Float#to_i: truncate float to integer via rb_jit_flo_to_i
-    FloatToInt { recv: InsnId, state: InsnId },
+    /// Convert a Flonum VALUE to an unboxed C double.
+    UnboxFloat { val: InsnId },
+    /// Convert any Ruby Float VALUE to an unboxed C double.
+    UnboxRubyFloat { val: InsnId },
+    /// Convert a Ruby Fixnum VALUE to an unboxed C double.
+    FixnumToF64 { val: InsnId },
+    /// Convert an unboxed C double to a Ruby Float VALUE.
+    BoxFloat { val: InsnId, state: InsnId },
+    /// Unboxed C double arithmetic.
+    F64BinOp { op: F64BinOp, left: InsnId, right: InsnId },
+    /// Float arithmetic with a Ruby VALUE RHS. Used when profiling proves the
+    /// RHS usually comes from memory as either Flonum or Fixnum.
+    F64ValueRhsOp { op: F64BinOp, left: InsnId, right: InsnId, state: InsnId },
+    F64Sqrt { val: InsnId },
+    F64Sin { val: InsnId },
+    F64Cos { val: InsnId },
+    F64Pow { left: InsnId, right: InsnId },
+    F64GuardNonnegative { val: InsnId, state: InsnId },
+    /// Float comparisons on unboxed C doubles.
+    F64BoolCmp { op: F64BoolCmpOp, left: InsnId, right: InsnId },
+    /// Float comparisons with a Fixnum RHS, preserving CRuby's exact integer/float ordering.
+    F64FixnumBoolCmp { op: F64BoolCmpOp, left: InsnId, right: InsnId },
 
     AnyToString { val: InsnId, state: InsnId },
 
@@ -1390,16 +1424,31 @@ macro_rules! for_each_operand_impl {
                 $visit_one!(*right);
                 $visit_one!(*state);
             }
-            Insn::FloatAdd { recv, other, state }
-            | Insn::FloatSub { recv, other, state }
-            | Insn::FloatMul { recv, other, state }
-            | Insn::FloatDiv { recv, other, state } => {
-                $visit_one!(*recv);
-                $visit_one!(*other);
+            Insn::UnboxFloat { val }
+            | Insn::UnboxRubyFloat { val }
+            | Insn::FixnumToF64 { val } => {
+                $visit_one!(*val);
+            }
+            Insn::BoxFloat { val, state }
+            | Insn::F64GuardNonnegative { val, state } => {
+                $visit_one!(*val);
                 $visit_one!(*state);
             }
-            Insn::FloatToInt { recv, state } => {
-                $visit_one!(*recv);
+            Insn::F64Sqrt { val }
+            | Insn::F64Sin { val }
+            | Insn::F64Cos { val } => {
+                $visit_one!(*val);
+            }
+            Insn::F64BinOp { left, right, .. }
+            | Insn::F64Pow { left, right }
+            | Insn::F64BoolCmp { left, right, .. }
+            | Insn::F64FixnumBoolCmp { left, right, .. } => {
+                $visit_one!(*left);
+                $visit_one!(*right);
+            }
+            Insn::F64ValueRhsOp { left, right, state, .. } => {
+                $visit_one!(*left);
+                $visit_one!(*right);
                 $visit_one!(*state);
             }
             Insn::FixnumLt { left, right }
@@ -1587,6 +1636,7 @@ impl Insn {
             | Insn::CheckInterrupts { .. } | Insn::BreakPoint | Insn::Unreachable
             | Insn::StoreField { .. } | Insn::WriteBarrier { .. } | Insn::HashAset { .. }
             | Insn::ArrayAset { .. }
+            | Insn::F64GuardNonnegative { .. }
             | Insn::PushInlineFrame { .. } | Insn::PopInlineFrame { .. } => false,
             _ => true,
         }
@@ -1606,6 +1656,26 @@ impl Insn {
             Insn::CondBranch { .. } | Insn::Jump(_) | Insn::Entries { .. } => true,
             _ => false,
         }
+    }
+
+    /// Return true if the instruction may cross a native call boundary.
+    fn is_call_boundary(&self) -> bool {
+        matches!(
+            self,
+            Insn::Send { .. }
+                | Insn::SendDirect(_)
+                | Insn::SendForward { .. }
+                | Insn::InvokeSuper { .. }
+                | Insn::InvokeSuperForward { .. }
+                | Insn::InvokeBuiltin { .. }
+                | Insn::InvokeProc { .. }
+                | Insn::InvokeBlock { .. }
+                | Insn::InvokeBlockIseqDirect { .. }
+                | Insn::InvokeBlockIfunc { .. }
+                | Insn::CCall { .. }
+                | Insn::CCallWithFrame(_)
+                | Insn::CCallVariadic(_)
+        )
     }
 
     /// Call `f` on each operand (InsnId) of this instruction.
@@ -1786,11 +1856,19 @@ impl Insn {
             Insn::FixnumMult { .. } => effects::Empty,
             Insn::FixnumDiv { .. } => effects::Any,
             Insn::FixnumMod { .. } => effects::Any,
-            Insn::FloatAdd { .. } => effects::Any,
-            Insn::FloatSub { .. } => effects::Any,
-            Insn::FloatMul { .. } => effects::Any,
-            Insn::FloatDiv { .. } => effects::Any,
-            Insn::FloatToInt { .. } => effects::Any,
+            Insn::UnboxFloat { .. }
+            | Insn::UnboxRubyFloat { .. }
+            | Insn::FixnumToF64 { .. }
+            | Insn::F64BinOp { .. }
+            | Insn::F64Sqrt { .. }
+            | Insn::F64Sin { .. }
+            | Insn::F64Cos { .. }
+            | Insn::F64Pow { .. }
+            | Insn::F64BoolCmp { .. }
+            | Insn::F64FixnumBoolCmp { .. } => effects::Empty,
+            Insn::BoxFloat { .. } => allocates,
+            Insn::F64ValueRhsOp { .. } => Effect::read_write(abstract_heaps::Empty, abstract_heaps::Control),
+            Insn::F64GuardNonnegative { .. } => Effect::read_write(abstract_heaps::Empty, abstract_heaps::Control),
             Insn::FixnumEq { .. } => effects::Empty,
             Insn::FixnumNeq { .. } => effects::Empty,
             Insn::FixnumLt { .. } => effects::Empty,
@@ -2176,11 +2254,19 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
             Insn::FixnumMult { left, right, .. } => { write!(f, "FixnumMult {left}, {right}") },
             Insn::FixnumDiv  { left, right, .. } => { write!(f, "FixnumDiv {left}, {right}") },
             Insn::FixnumMod  { left, right, .. } => { write!(f, "FixnumMod {left}, {right}") },
-            Insn::FloatAdd   { recv, other, .. } => { write!(f, "FloatAdd {recv}, {other}") },
-            Insn::FloatSub   { recv, other, .. } => { write!(f, "FloatSub {recv}, {other}") },
-            Insn::FloatMul   { recv, other, .. } => { write!(f, "FloatMul {recv}, {other}") },
-            Insn::FloatDiv   { recv, other, .. } => { write!(f, "FloatDiv {recv}, {other}") },
-            Insn::FloatToInt { recv, .. } => { write!(f, "FloatToInt {recv}") },
+            Insn::UnboxFloat { val } => { write!(f, "UnboxFloat {val}") },
+            Insn::UnboxRubyFloat { val } => { write!(f, "UnboxRubyFloat {val}") },
+            Insn::FixnumToF64 { val } => { write!(f, "FixnumToF64 {val}") },
+            Insn::BoxFloat { val, .. } => { write!(f, "BoxFloat {val}") },
+            Insn::F64BinOp { op, left, right } => { write!(f, "F64BinOp::{op:?} {left}, {right}") },
+            Insn::F64ValueRhsOp { op, left, right, .. } => { write!(f, "F64ValueRhsOp::{op:?} {left}, {right}") },
+            Insn::F64Sqrt { val } => { write!(f, "F64Sqrt {val}") },
+            Insn::F64Sin { val } => { write!(f, "F64Sin {val}") },
+            Insn::F64Cos { val } => { write!(f, "F64Cos {val}") },
+            Insn::F64Pow { left, right } => { write!(f, "F64Pow {left}, {right}") },
+            Insn::F64GuardNonnegative { val, .. } => { write!(f, "F64GuardNonnegative {val}") },
+            Insn::F64BoolCmp { op, left, right } => { write!(f, "F64BoolCmp::{op:?} {left}, {right}") },
+            Insn::F64FixnumBoolCmp { op, left, right } => { write!(f, "F64FixnumBoolCmp::{op:?} {left}, {right}") },
             Insn::FixnumEq   { left, right, .. } => { write!(f, "FixnumEq {left}, {right}") },
             Insn::FixnumNeq  { left, right, .. } => { write!(f, "FixnumNeq {left}, {right}") },
             Insn::FixnumLt   { left, right, .. } => { write!(f, "FixnumLt {left}, {right}") },
@@ -2709,6 +2795,8 @@ pub struct Function {
     /// fulfilling `(0..=opt_num)` optional parameters.
     jit_entry_blocks: Vec<BlockId>,
     profiles: Option<ProfileOracle>,
+    /// Block parameters rewritten by `unbox_loop_float_params` to carry raw F64 values.
+    raw_float_params: HashSet<InsnId>,
     /// Rough estimate for the number of (actually executable) instructions in the function. Does
     /// not count Snapshot, PatchPoint, etc.
     /// Currently updated by `infer_types` as a heuristic but that is not a guarantee.
@@ -2845,6 +2933,7 @@ impl Function {
             jit_entry_blocks: vec![],
             param_types: vec![],
             profiles: None,
+            raw_float_params: HashSet::new(),
             num_instructions: 0,
         }
     }
@@ -3174,9 +3263,41 @@ impl Function {
         self.union_find.borrow_mut().make_equal_to(insn, replacement);
     }
 
+    fn infer_type_if_any(&mut self, insn: InsnId) {
+        if !self.insns[insn.0].has_output() {
+            return;
+        }
+
+        if self.type_of(insn).bit_equal(types::Any) {
+            self.insn_types[insn.0] = self.infer_type(insn);
+        }
+    }
+
     pub fn type_of(&self, insn: InsnId) -> Type {
         assert!(self.insns[insn.0].has_output());
         self.insn_types[self.union_find.borrow_mut().find(insn).0]
+    }
+
+    fn direct_type_of(&self, insn: InsnId) -> Type {
+        assert!(self.insns[insn.0].has_output());
+        self.insn_types[insn.0]
+    }
+
+    pub fn is_raw_float_value(&self, insn: InsnId) -> bool {
+        match self.insns[insn.0] {
+            Insn::Param => self.raw_float_params.contains(&insn),
+            Insn::Const { val: Const::CDouble(_) }
+            | Insn::UnboxFloat { .. }
+            | Insn::UnboxRubyFloat { .. }
+            | Insn::FixnumToF64 { .. }
+            | Insn::F64BinOp { .. }
+            | Insn::F64ValueRhsOp { .. }
+            | Insn::F64Sqrt { .. }
+            | Insn::F64Sin { .. }
+            | Insn::F64Cos { .. }
+            | Insn::F64Pow { .. } => true,
+            _ => false,
+        }
     }
 
     /// Check if the type of `insn` is a subtype of `ty`.
@@ -3197,6 +3318,7 @@ impl Function {
             | Insn::IncrCounter(_) | Insn::IncrCounterPtr { .. }
             | Insn::CheckInterrupts { .. } | Insn::BreakPoint | Insn::Unreachable
             | Insn::StoreField { .. } | Insn::WriteBarrier { .. } | Insn::HashAset { .. } | Insn::ArrayAset { .. }
+            | Insn::F64GuardNonnegative { .. }
             | Insn::PushInlineFrame { .. } | Insn::PopInlineFrame { .. } =>
                 panic!("Cannot infer type of instruction with no output: {}. See Insn::has_output().", self.insns[insn.0]),
             Insn::Const { val: Const::Value(val) } => Type::from_value(*val),
@@ -3269,11 +3391,22 @@ impl Function {
             // Downstream Fixnum ops insert their own GuardType(Fixnum)
             Insn::FixnumDiv  { .. } => types::Integer,
             Insn::FixnumMod  { .. } => types::Fixnum,
-            Insn::FloatAdd   { .. } => types::Float,
-            Insn::FloatSub   { .. } => types::Float,
-            Insn::FloatMul   { .. } => types::Float,
-            Insn::FloatDiv   { .. } => types::Float,
-            Insn::FloatToInt { .. } => types::Integer,
+            Insn::UnboxFloat { .. }
+            | Insn::UnboxRubyFloat { .. }
+            | Insn::FixnumToF64 { .. }
+            | Insn::F64BinOp { .. }
+            | Insn::F64ValueRhsOp { .. }
+            | Insn::F64Sqrt { .. }
+            | Insn::F64Sin { .. }
+            | Insn::F64Cos { .. }
+            | Insn::F64Pow { .. } => types::CDouble,
+            Insn::BoxFloat { val, .. } => self
+                .type_of(*val)
+                .cdouble_value()
+                .and_then(VALUE::flonum_from_f64)
+                .map_or(types::Float, Type::from_value),
+            Insn::F64BoolCmp { .. } => types::BoolExact,
+            Insn::F64FixnumBoolCmp { .. } => types::BoolExact,
             Insn::FixnumEq   { .. } => types::BoolExact,
             Insn::FixnumNeq  { .. } => types::BoolExact,
             Insn::FixnumLt   { .. } => types::BoolExact,
@@ -3997,16 +4130,91 @@ impl Function {
             // Copy contents of tmp_block to block
             assert_ne!(block, tmp_block);
             let insns = std::mem::take(&mut self.blocks[tmp_block.0].insns);
+            for &insn in &insns {
+                self.infer_type_if_any(insn);
+            }
             self.blocks[block.0].insns.extend(insns);
             self.count(block, Counter::inline_cfunc_optimized_send_count);
-            if self.type_of(replacement).bit_equal(types::Any) {
-                // Not set yet; infer type
-                self.insn_types[replacement.0] = self.infer_type(replacement);
-            }
+            self.infer_type_if_any(replacement);
             self.remove_block(tmp_block);
             return replacement;
         }
         return self.push_insn(block, insn);
+    }
+
+    fn inline_invoke_builtins(&mut self) -> bool {
+        let mut changed = false;
+
+        for block in self.reverse_post_order() {
+            let old_insns = std::mem::take(&mut self.blocks[block.0].insns);
+
+            for insn_id in old_insns {
+                let insn = self.find(insn_id).clone();
+                let Insn::InvokeBuiltin { bf, recv, ref args, state, .. } = insn else {
+                    self.blocks[block.0].insns.push(insn_id);
+                    continue;
+                };
+
+                let props = ZJITState::get_method_annotations().get_builtin_properties(bf).unwrap_or_default();
+                let tmp_block = self.new_block(u32::MAX);
+                if let Some(replacement) = (props.inline)(self, tmp_block, recv, args, state) {
+                    let insns = std::mem::take(&mut self.blocks[tmp_block.0].insns);
+                    for &insn in &insns {
+                        self.infer_type_if_any(insn);
+                    }
+                    self.blocks[block.0].insns.extend(insns);
+                    self.make_equal_to(insn_id, replacement);
+                    self.infer_type_if_any(replacement);
+                    self.remove_block(tmp_block);
+                    changed = true;
+                } else {
+                    self.remove_block(tmp_block);
+                    self.blocks[block.0].insns.push(insn_id);
+                }
+            }
+        }
+
+        changed
+    }
+
+    fn inline_annotated_ccalls(&mut self) -> bool {
+        let mut changed = false;
+
+        for block in self.reverse_post_order() {
+            let old_insns = std::mem::take(&mut self.blocks[block.0].insns);
+
+            for insn_id in old_insns {
+                let insn = self.find(insn_id).clone();
+                let Insn::CCallWithFrame(data) = insn else {
+                    self.blocks[block.0].insns.push(insn_id);
+                    continue;
+                };
+
+                if data.block.is_some() {
+                    self.blocks[block.0].insns.push(insn_id);
+                    continue;
+                }
+
+                let props = ZJITState::get_method_annotations().get_cfunc_properties(data.cme).unwrap_or_default();
+                let tmp_block = self.new_block(u32::MAX);
+                if let Some(replacement) = (props.inline)(self, tmp_block, data.recv, &data.args, data.state) {
+                    let insns = std::mem::take(&mut self.blocks[tmp_block.0].insns);
+                    for &insn in &insns {
+                        self.infer_type_if_any(insn);
+                    }
+                    self.blocks[block.0].insns.extend(insns);
+                    self.make_equal_to(insn_id, replacement);
+                    self.infer_type_if_any(replacement);
+                    self.remove_block(tmp_block);
+                    changed = true;
+                } else {
+                    self.remove_block(tmp_block);
+                    self.blocks[block.0].insns.push(insn_id);
+                }
+            }
+        }
+
+        changed
     }
 
     /// Try trivially inlining the method. If we can't, emit a SendDirect instruction instead and
@@ -5417,6 +5625,9 @@ impl Function {
     }
 
     fn try_emit_optimized_getivar(&mut self, block: BlockId, self_val: InsnId, id: ID, profiled_type: ProfiledType, state: InsnId) -> Result<InsnId, Counter> {
+        if self.policy.no_side_exits {
+            return Err(Counter::getivar_fallback_no_side_exits);
+        }
         if profiled_type.flags().is_immediate() {
             // Instance variable lookups on immediate values are always nil
             return Err(Counter::getivar_fallback_immediate);
@@ -5425,13 +5636,6 @@ impl Function {
         if profiled_type.shape().is_complex() {
             // too-complex shapes can't use index access
             return Err(Counter::getivar_fallback_complex);
-        }
-        if self.policy.no_side_exits {
-            // On the final version, skip GetIvar shape specialization.
-            // iseq_to_hir already generates polymorphic branches with a
-            // GetIvar C call fallback for getinstancevariable, so we don't
-            // need to wrap it again here.
-            return Err(Counter::getivar_fallback_no_side_exits);
         }
         let self_val = self.guard_heap(block, self_val, state);
         let shape = self.load_shape(block, self_val);
@@ -5535,7 +5739,6 @@ impl Function {
 
     fn try_emit_optimized_setivar(&mut self, block: BlockId, self_val: InsnId, id: ID, val: InsnId, profiled_type: ProfiledType, state: InsnId, recompile: Option<Recompile>) -> Result<(), Counter> {
         if self.policy.no_side_exits {
-            // On the final version, don't add a shape guard without a fallback.
             return Err(Counter::setivar_fallback_no_side_exits);
         }
         let spec = self.prepare_optimized_setivar(id, profiled_type)?;
@@ -5770,6 +5973,13 @@ impl Function {
             .unwrap_or(insn_id)
     }
 
+    fn fold_f64_bop(&mut self, insn_id: InsnId, left: InsnId, right: InsnId, f: impl FnOnce(f64, f64) -> f64) -> InsnId {
+        match (self.type_of(left).cdouble_value(), self.type_of(right).cdouble_value()) {
+            (Some(left), Some(right)) => self.new_insn(Insn::Const { val: Const::CDouble(f(left, right)) }),
+            _ => insn_id,
+        }
+    }
+
     /// Block-local canonicalize: rewrite each operand through union-find and a
     /// per-block map of the most recent `Guard*` for that value. Forwards
     /// guarded values into branch-edge args (so `infer_types` narrows merge-block
@@ -5833,6 +6043,7 @@ impl Function {
         for block in self.reverse_post_order() {
             let old_insns = std::mem::take(&mut self.blocks[block.0].insns);
             let mut new_insns = vec![];
+            let mut unboxed_float_for_value: HashMap<InsnId, InsnId> = HashMap::new();
             for insn_id in old_insns {
                 let replacement_id = match self.find(insn_id) {
                     Insn::GuardType { val, guard_type, .. } if self.is_a(val, guard_type) => {
@@ -5887,6 +6098,42 @@ impl Function {
                             _ => insn_id,
                         }
                     },
+                    Insn::UnboxFloat { val } | Insn::UnboxRubyFloat { val } => {
+                        let val = self.chase_insn(val);
+                        if self.type_of(val).is_subtype(types::CDouble) {
+                            self.make_equal_to(insn_id, val);
+                            continue;
+                        } else if let Some(float_value) = self.type_of(val).ruby_object().filter(|value| value.flonum_p()) {
+                            self.new_insn(Insn::Const { val: Const::CDouble(float_value.as_flonum_f64()) })
+                        } else {
+                            let boxed_float = match self.find(val) {
+                                Insn::BoxFloat { val: float_val, .. } => Some(float_val),
+                                Insn::GuardType { val: guarded_val, .. } => match self.find(guarded_val) {
+                                    Insn::BoxFloat { val: float_val, .. } => Some(float_val),
+                                    _ => None,
+                                },
+                                _ => None,
+                            };
+
+                            if let Some(float_val) = boxed_float {
+                                self.make_equal_to(insn_id, float_val);
+                                continue;
+                            } else if let Some(cached_unbox) = unboxed_float_for_value.get(&val).copied() {
+                                self.make_equal_to(insn_id, cached_unbox);
+                                continue;
+                            } else {
+                                unboxed_float_for_value.insert(val, insn_id);
+                                insn_id
+                            }
+                        }
+                    }
+                    Insn::BoxFloat { val, .. } => {
+                        let val = self.chase_insn(val);
+                        match self.type_of(val).cdouble_value().and_then(VALUE::flonum_from_f64) {
+                            Some(float_value) => self.new_insn(Insn::Const { val: Const::Value(float_value) }),
+                            None => insn_id,
+                        }
+                    }
                     Insn::GuardGreaterEq { left, right, state, reason } => {
                         let left_num = self.type_of(left).cint64_value();
                         let right_num = self.type_of(right).cint64_value();
@@ -6019,6 +6266,18 @@ impl Function {
                             _ => None,
                         })
                     }
+                    Insn::F64BinOp { op: F64BinOp::Add, left, right } => {
+                        self.fold_f64_bop(insn_id, left, right, |left, right| left + right)
+                    }
+                    Insn::F64BinOp { op: F64BinOp::Sub, left, right } => {
+                        self.fold_f64_bop(insn_id, left, right, |left, right| left - right)
+                    }
+                    Insn::F64BinOp { op: F64BinOp::Mul, left, right } => {
+                        self.fold_f64_bop(insn_id, left, right, |left, right| left * right)
+                    }
+                    Insn::F64BinOp { op: F64BinOp::Div, left, right } => {
+                        self.fold_f64_bop(insn_id, left, right, |left, right| left / right)
+                    }
                     Insn::FixnumXor { left, right, .. } => {
                         self.fold_fixnum_bop(insn_id, left, right, |l, r| match (l, r) {
                             (Some(l), Some(r)) => Some(l ^ r),
@@ -6131,6 +6390,412 @@ impl Function {
                 }
             }
             self.blocks[block.0].insns = new_insns;
+        }
+    }
+
+    fn can_be_raw_float_arg(&self, arg: InsnId) -> bool {
+        match self.find(arg) {
+            Insn::BoxFloat { .. } => true,
+            Insn::Const { val: Const::CDouble(_) } => true,
+            Insn::Const { val: Const::Value(value) } => value.flonum_p(),
+            _ => false,
+        }
+    }
+
+    fn unbox_loop_float_params(&mut self) {
+        let rpo = self.reverse_post_order();
+        let rpo_pos: HashMap<BlockId, usize> = rpo.iter().enumerate().map(|(idx, &block)| (block, idx)).collect();
+        let mut incoming_by_target: HashMap<BlockId, Vec<(BlockId, Vec<InsnId>)>> = HashMap::new();
+        let mut uses_by_value: HashMap<InsnId, Vec<InsnId>> = HashMap::new();
+        let mut candidate_set = HashSet::new();
+        let mut candidates = Vec::new();
+
+        for &source in &rpo {
+            let Some(&terminator_id) = self.blocks[source.0].insns.last() else { continue };
+            match self.find(terminator_id) {
+                Insn::Jump(BranchEdge { target, args }) => {
+                    incoming_by_target.entry(target).or_default().push((source, args));
+                }
+                Insn::CondBranch { if_true, if_false, .. } => {
+                    for edge in [if_true, if_false] {
+                        incoming_by_target.entry(edge.target).or_default().push((source, edge.args));
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        for other_id in 0..self.insns.len() {
+            let other_id = InsnId(other_id);
+            let other = self.find(other_id);
+            other.for_each_operand(|operand| {
+                uses_by_value.entry(self.chase_insn(operand)).or_default().push(other_id);
+            });
+        }
+
+        loop {
+            let mut changed = false;
+
+            for &target in &rpo {
+                let params = self.blocks[target.0].params.clone();
+                for (idx, param) in params.into_iter().enumerate() {
+                    if candidate_set.contains(&param) {
+                        continue;
+                    }
+
+                    let mut saw_incoming = false;
+                    let mut saw_backedge = false;
+                    let mut all_incoming_raw = true;
+                    for (source, args) in incoming_by_target.get(&target).into_iter().flatten() {
+                        saw_incoming = true;
+                        saw_backedge |= rpo_pos[source] >= rpo_pos[&target];
+                        all_incoming_raw &= self.can_be_raw_float_arg(args[idx]) || candidate_set.contains(&args[idx]);
+                    }
+
+                    if !saw_incoming || !saw_backedge || !all_incoming_raw {
+                        continue;
+                    }
+
+                    let mut supported_uses = true;
+                    for &other_id in uses_by_value.get(&param).into_iter().flatten() {
+                        match self.find(other_id) {
+                            Insn::Snapshot { .. } => {}
+                            Insn::GuardType { val, guard_type, .. } if self.chase_insn(val) == param && guard_type.is_subtype(types::Flonum) => {}
+                            Insn::UnboxFloat { val } if self.chase_insn(val) == param => {}
+                            Insn::Return { val } if self.chase_insn(val) == param => {}
+                            Insn::Jump(_) | Insn::CondBranch { .. } => {}
+                            _ => supported_uses = false,
+                        }
+                    }
+
+                    if supported_uses {
+                        candidate_set.insert(param);
+                        candidates.push((target, idx, param));
+                        changed = true;
+                    }
+                }
+            }
+
+            if !changed {
+                break;
+            }
+        }
+
+        if candidates.is_empty() {
+            return;
+        }
+
+        let mut raw_params = HashMap::new();
+        for (block, idx, old_param) in candidates {
+            let raw_param = self.new_insn(Insn::Param);
+            self.blocks[block.0].params[idx] = raw_param;
+            self.raw_float_params.insert(raw_param);
+            raw_params.insert(old_param, raw_param);
+        }
+
+        for &block in &rpo {
+            let Some(term_idx) = self.blocks[block.0].insns.len().checked_sub(1) else { continue };
+            let term_id = self.blocks[block.0].insns[term_idx];
+            let mut insertions = Vec::new();
+
+            let mut terminator = self.find(term_id);
+            match &mut terminator {
+                Insn::Jump(edge) => self.rewrite_raw_float_edge(edge, &raw_params, &mut insertions),
+                Insn::CondBranch { if_true, if_false, .. } => {
+                    self.rewrite_raw_float_edge(if_true, &raw_params, &mut insertions);
+                    self.rewrite_raw_float_edge(if_false, &raw_params, &mut insertions);
+                }
+                _ => {}
+            }
+            self.blocks[block.0].insns.splice(term_idx..term_idx, insertions);
+            self.insns[term_id.0] = terminator;
+        }
+
+        for &block in &rpo {
+            let mut last_snapshot = None;
+            let old_insns = std::mem::take(&mut self.blocks[block.0].insns);
+            let mut new_insns = Vec::with_capacity(old_insns.len());
+
+            for insn_id in old_insns {
+                let replacement = match self.find(insn_id) {
+                    Insn::Snapshot { mut state } => {
+                        for val in state.stack.iter_mut().chain(state.locals.iter_mut()) {
+                            self.rewrite_raw_float_state_value(val, &raw_params);
+                        }
+                        self.insns[insn_id.0] = Insn::Snapshot { state };
+                        last_snapshot = Some(insn_id);
+                        None
+                    }
+                    Insn::GuardType { val, guard_type, .. } if guard_type.is_subtype(types::Flonum) => self.raw_float_replacement(val, &raw_params),
+                    Insn::UnboxFloat { val } => self.raw_float_replacement(val, &raw_params),
+                    Insn::Return { val } => {
+                        if let Some(raw) = self.raw_float_replacement(val, &raw_params) {
+                            let state = last_snapshot.expect("Return of raw float param should have a dominating Snapshot");
+                            let boxed = self.new_insn(Insn::BoxFloat { val: raw, state });
+                            new_insns.push(boxed);
+                            self.insns[insn_id.0] = Insn::Return { val: boxed };
+                        }
+                        None
+                    }
+                    _ => None,
+                };
+
+                if let Some(raw) = replacement {
+                    self.make_equal_to(insn_id, raw);
+                } else {
+                    new_insns.push(insn_id);
+                }
+            }
+
+            self.blocks[block.0].insns = new_insns;
+        }
+
+        self.infer_types();
+    }
+
+    fn raw_float_replacement(&self, val: InsnId, raw_params: &HashMap<InsnId, InsnId>) -> Option<InsnId> {
+        raw_params.get(&val).copied()
+            .or_else(|| raw_params.get(&self.chase_insn(val)).copied())
+            .or_else(|| match self.find(val) {
+                Insn::GuardType { val, guard_type, .. } if guard_type.is_subtype(types::Flonum) => {
+                    self.raw_float_replacement(val, raw_params)
+                }
+                Insn::RefineType { val, .. } => self.raw_float_replacement(val, raw_params),
+                _ => None,
+            })
+    }
+
+    fn rewrite_raw_float_state_value(&self, val: &mut InsnId, raw_params: &HashMap<InsnId, InsnId>) {
+        if let Some(raw) = self.raw_float_replacement(*val, raw_params) {
+            *val = raw;
+        }
+    }
+
+    fn rewrite_raw_float_edge(&mut self, edge: &mut BranchEdge, raw_params: &HashMap<InsnId, InsnId>, insertions: &mut Vec<InsnId>) {
+        for (idx, arg) in edge.args.iter_mut().enumerate() {
+            let target_param = self.blocks[edge.target.0].params[idx];
+            let target_is_raw = raw_params.values().any(|&raw| raw == target_param);
+            if let Some(&raw) = raw_params.get(arg) {
+                *arg = raw;
+                continue;
+            }
+
+            let chased_arg = self.chase_insn(*arg);
+            if let Some(&raw) = raw_params.get(&chased_arg) {
+                *arg = raw;
+                continue;
+            }
+
+            if !target_is_raw {
+                continue;
+            }
+
+            match self.find(*arg) {
+                Insn::BoxFloat { val, .. } => {
+                    *arg = val;
+                }
+                Insn::Const { val: Const::Value(value) } if value.flonum_p() => {
+                    let raw_const = self.new_insn(Insn::Const { val: Const::CDouble(value.as_flonum_f64()) });
+                    insertions.push(raw_const);
+                    *arg = raw_const;
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn box_raw_float_ruby_values(&mut self) {
+        let mut changed = false;
+        let mut boxed_raw_float_values = HashMap::new();
+
+        for block in self.reverse_post_order() {
+            let old_insns = std::mem::take(&mut self.blocks[block.0].insns);
+            let mut new_insns = Vec::with_capacity(old_insns.len());
+            let mut last_snapshot = None;
+            let mut boxed_raw_floats = Vec::new();
+            let mut raw_replacements = HashMap::new();
+
+            for insn_id in old_insns {
+                if let Insn::Snapshot { .. } = self.find(insn_id) {
+                    last_snapshot = Some(insn_id);
+                }
+
+                let box_value = |function: &mut Function, new_insns: &mut Vec<InsnId>, val: InsnId, state: InsnId| {
+                    if function.is_raw_float_value(val) {
+                        let boxed = function.new_insn(Insn::BoxFloat { val, state });
+                        new_insns.push(boxed);
+                        (boxed, true)
+                    } else {
+                        (val, false)
+                    }
+                };
+
+                if !matches!(self.find(insn_id), Insn::BoxFloat { .. } | Insn::Snapshot { .. }) {
+                    self.insns[insn_id.0].for_each_operand_mut(|operand| {
+                        if let Some(&replacement) = raw_replacements.get(operand) {
+                            *operand = replacement;
+                            changed = true;
+                        }
+                    });
+                }
+
+                let mut unbox_boxed_raw = |function: &mut Function, new_insns: &mut Vec<InsnId>, val: InsnId| {
+                    if let Some(&boxed) = boxed_raw_float_values.get(&val) {
+                        let unboxed = function.new_insn(Insn::UnboxRubyFloat { val: boxed });
+                        new_insns.push(unboxed);
+                        changed = true;
+                        unboxed
+                    } else {
+                        val
+                    }
+                };
+
+                let rewritten = match self.find(insn_id) {
+                    Insn::SetLocal { val, ep_offset, level, state } => {
+                        let (val, boxed) = box_value(self, &mut new_insns, val, state);
+                        changed |= boxed;
+                        Some(Insn::SetLocal { val, ep_offset, level, state })
+                    }
+                    Insn::SetGlobal { id, val, state } => {
+                        let (val, boxed) = box_value(self, &mut new_insns, val, state);
+                        changed |= boxed;
+                        Some(Insn::SetGlobal { id, val, state })
+                    }
+                    Insn::SetClassVar { id, val, ic, state } => {
+                        let (val, boxed) = box_value(self, &mut new_insns, val, state);
+                        changed |= boxed;
+                        Some(Insn::SetClassVar { id, val, ic, state })
+                    }
+                    Insn::SetIvar { self_val, id, val, ic, state } => {
+                        let (val, boxed) = box_value(self, &mut new_insns, val, state);
+                        changed |= boxed;
+                        Some(Insn::SetIvar { self_val, id, val, ic, state })
+                    }
+                    Insn::Return { val } => {
+                        let state = match last_snapshot {
+                            Some(state) => state,
+                            None => {
+                                new_insns.push(insn_id);
+                                continue;
+                            }
+                        };
+                        let (val, boxed) = box_value(self, &mut new_insns, val, state);
+                        changed |= boxed;
+                        Some(Insn::Return { val })
+                    }
+                    Insn::Jump(mut edge) => {
+                        let state = match last_snapshot {
+                            Some(state) => state,
+                            None => {
+                                new_insns.push(insn_id);
+                                continue;
+                            }
+                        };
+
+                        for idx in 0..edge.args.len() {
+                            let target_param = self.blocks[edge.target.0].params[idx];
+                            if self.is_raw_float_value(target_param) {
+                                continue;
+                            }
+
+                            let (arg, boxed) = box_value(self, &mut new_insns, edge.args[idx], state);
+                            edge.args[idx] = arg;
+                            changed |= boxed;
+                        }
+
+                        Some(Insn::Jump(edge))
+                    }
+                    Insn::StoreField { recv, id, offset, val, num_bits } if num_bits == types::BasicObject.num_bits() => {
+                        let state = match last_snapshot {
+                            Some(state) => state,
+                            None => {
+                                new_insns.push(insn_id);
+                                continue;
+                            }
+                        };
+                        let (val, boxed) = box_value(self, &mut new_insns, val, state);
+                        changed |= boxed;
+                        Some(Insn::StoreField { recv, id, offset, val, num_bits })
+                    }
+                    Insn::WriteBarrier { recv, val } => {
+                        let state = match last_snapshot {
+                            Some(state) => state,
+                            None => {
+                                new_insns.push(insn_id);
+                                continue;
+                            }
+                        };
+                        let (val, boxed) = box_value(self, &mut new_insns, val, state);
+                        changed |= boxed;
+                        Some(Insn::WriteBarrier { recv, val })
+                    }
+                    Insn::F64BinOp { op, left, right } => {
+                        let left = unbox_boxed_raw(self, &mut new_insns, left);
+                        let right = unbox_boxed_raw(self, &mut new_insns, right);
+                        Some(Insn::F64BinOp { op, left, right })
+                    }
+                    Insn::F64Pow { left, right } => {
+                        let left = unbox_boxed_raw(self, &mut new_insns, left);
+                        let right = unbox_boxed_raw(self, &mut new_insns, right);
+                        Some(Insn::F64Pow { left, right })
+                    }
+                    Insn::F64BoolCmp { op, left, right } => {
+                        let left = unbox_boxed_raw(self, &mut new_insns, left);
+                        let right = unbox_boxed_raw(self, &mut new_insns, right);
+                        Some(Insn::F64BoolCmp { op, left, right })
+                    }
+                    Insn::F64ValueRhsOp { op, left, right, state } => {
+                        let left = unbox_boxed_raw(self, &mut new_insns, left);
+                        Some(Insn::F64ValueRhsOp { op, left, right, state })
+                    }
+                    Insn::F64FixnumBoolCmp { op, left, right } => {
+                        let left = unbox_boxed_raw(self, &mut new_insns, left);
+                        Some(Insn::F64FixnumBoolCmp { op, left, right })
+                    }
+                    Insn::F64GuardNonnegative { val, state } => {
+                        let val = unbox_boxed_raw(self, &mut new_insns, val);
+                        Some(Insn::F64GuardNonnegative { val, state })
+                    }
+                    Insn::F64Sqrt { val } => {
+                        let val = unbox_boxed_raw(self, &mut new_insns, val);
+                        Some(Insn::F64Sqrt { val })
+                    }
+                    Insn::F64Sin { val } => {
+                        let val = unbox_boxed_raw(self, &mut new_insns, val);
+                        Some(Insn::F64Sin { val })
+                    }
+                    Insn::F64Cos { val } => {
+                        let val = unbox_boxed_raw(self, &mut new_insns, val);
+                        Some(Insn::F64Cos { val })
+                    }
+                    _ => None,
+                };
+
+                if let Some(insn) = rewritten {
+                    self.insns[insn_id.0] = insn;
+                }
+                new_insns.push(insn_id);
+
+                if let Insn::BoxFloat { val, .. } = self.find(insn_id) {
+                    boxed_raw_floats.push((val, insn_id));
+                    boxed_raw_float_values.insert(val, insn_id);
+                }
+
+                if self.find(insn_id).is_call_boundary() && !boxed_raw_floats.is_empty() {
+                    for &(raw, boxed) in &boxed_raw_floats {
+                        let unboxed = self.new_insn(Insn::UnboxRubyFloat { val: boxed });
+                        new_insns.push(unboxed);
+                        raw_replacements.insert(raw, unboxed);
+                    }
+                    changed = true;
+                }
+            }
+
+            self.blocks[block.0].insns = new_insns;
+        }
+
+        if changed {
+            self.infer_types();
         }
     }
 
@@ -6465,6 +7130,10 @@ impl Function {
             // Bucket all strength reduction together
             (type_specialize) => { Counter::compile_hir_strength_reduce_time_ns };
             (convert_no_profile_sends) => { Counter::compile_hir_strength_reduce_time_ns };
+            (inline_invoke_builtins) => { Counter::compile_hir_strength_reduce_time_ns };
+            (inline_annotated_ccalls) => { Counter::compile_hir_strength_reduce_time_ns };
+            (unbox_loop_float_params) => { Counter::compile_hir_strength_reduce_time_ns };
+            (box_raw_float_ruby_values) => { Counter::compile_hir_strength_reduce_time_ns };
             // End strength reduction bucket
             (inline_methods) => { Counter::compile_hir_inline_methods_time_ns };
             (optimize_load_store) => { Counter::compile_hir_optimize_load_store_time_ns };
@@ -6516,13 +7185,18 @@ impl Function {
             } else {
                 false
             };
+            run_pass!(inline_invoke_builtins);
             run_pass!(convert_no_profile_sends);
             run_pass!(optimize_load_store);
             run_pass!(canonicalize);
             run_pass!(fold_constants);
+            run_pass!(inline_annotated_ccalls);
+            run_pass!(fold_constants);
             run_pass!(clean_cfg);
             run_pass!(remove_redundant_patch_points);
             run_pass!(remove_duplicate_check_interrupts);
+            run_pass!(unbox_loop_float_params);
+            run_pass!(box_raw_float_ruby_values);
             run_pass!(eliminate_dead_code);
 
             if !did_inline {
@@ -6758,6 +7432,9 @@ impl Function {
             | Insn::StoreField { .. } => {
                 Ok(())
             }
+            Insn::F64GuardNonnegative { val, .. } => {
+                self.assert_subtype(insn_id, val, types::CDouble)
+            }
             // Instructions with 1 Ruby object operand
             Insn::Test { val }
             | Insn::IsMethodCfunc { val, .. }
@@ -6976,17 +7653,36 @@ impl Function {
                 self.assert_subtype(insn_id, left, types::Fixnum)?;
                 self.assert_subtype(insn_id, right, types::Fixnum)
             }
-            Insn::FloatAdd { recv, other, .. }
-            | Insn::FloatSub { recv, other, .. }
-            | Insn::FloatMul { recv, other, .. }
-            | Insn::FloatDiv { recv, other, .. }
-            => {
-                self.assert_subtype(insn_id, recv, types::Flonum)?;
-                // other can be Flonum or Fixnum (rb_float_plus etc. handle both)
-                self.assert_subtype(insn_id, other, types::Flonum.union(types::Fixnum))
+            Insn::UnboxFloat { val } => {
+                self.assert_subtype(insn_id, val, types::Flonum)
             }
-            Insn::FloatToInt { recv, .. } => {
-                self.assert_subtype(insn_id, recv, types::Flonum)
+            Insn::UnboxRubyFloat { val } => {
+                self.assert_subtype(insn_id, val, types::Float)
+            }
+            Insn::FixnumToF64 { val } => {
+                self.assert_subtype(insn_id, val, types::Fixnum)
+            }
+            Insn::BoxFloat { val, .. } => {
+                self.assert_subtype(insn_id, val, types::CDouble)
+            }
+            Insn::F64BinOp { left, right, .. }
+            | Insn::F64Pow { left, right }
+            | Insn::F64BoolCmp { left, right, .. } => {
+                self.assert_subtype(insn_id, left, types::CDouble)?;
+                self.assert_subtype(insn_id, right, types::CDouble)
+            }
+            Insn::F64ValueRhsOp { left, right, .. } => {
+                self.assert_subtype(insn_id, left, types::CDouble)?;
+                self.assert_subtype(insn_id, right, types::BasicObject)
+            }
+            Insn::F64FixnumBoolCmp { left, right, .. } => {
+                self.assert_subtype(insn_id, left, types::CDouble)?;
+                self.assert_subtype(insn_id, right, types::Fixnum)
+            }
+            Insn::F64Sqrt { val }
+            | Insn::F64Sin { val }
+            | Insn::F64Cos { val } => {
+                self.assert_subtype(insn_id, val, types::CDouble)
             }
             Insn::FixnumLShift { left, right, .. }
             | Insn::FixnumRShift { left, right, .. } => {
@@ -10587,6 +11283,32 @@ mod validation_tests {
             "optimize_load_store failed to alias two loads with different, but compatible, return types: {:?}",
             function.validate(),
         );
+    }
+
+    #[test]
+    fn raw_float_snapshot_replacement_chases_type_wrappers() {
+        let mut function = Function::new(std::ptr::null());
+        let old_param = function.new_insn(Insn::Param);
+        let raw_param = function.new_insn(Insn::Param);
+        let guard = function.new_insn(Insn::GuardType {
+            val: old_param,
+            guard_type: types::Flonum,
+            state: old_param,
+            recompile: None,
+        });
+        let refined = function.new_insn(Insn::RefineType {
+            val: guard,
+            new_type: types::Flonum,
+        });
+        let raw_params = HashMap::from([(old_param, raw_param)]);
+
+        let mut snapshot_value = refined;
+        function.rewrite_raw_float_state_value(&mut snapshot_value, &raw_params);
+
+        assert_eq!(snapshot_value, raw_param);
+        assert!(!function.is_raw_float_value(raw_param));
+        function.raw_float_params.insert(raw_param);
+        assert!(function.is_raw_float_value(raw_param));
     }
 }
 

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -18032,88 +18032,10 @@ mod hir_opt_tests {
         ");
     }
 
-    #[test]
-    fn test_float_nan_p_annotation() {
-        eval(r#"
-            def test(x) = x.nan?
-            test(1.0)
-        "#);
-        assert_snapshot!(hir_string("test"), @"
-        fn test@<compiled>:2:
-        bb1():
-          EntryPoint interpreter
-          v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          Jump bb3(v1, v3)
-        bb2():
-          EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :x@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          PatchPoint MethodRedefined(Float@0x1008, nan?@0x1010, cme:0x1018)
-          v23:Flonum = GuardType v10, Flonum recompile
-          v24:BoolExact = CCall v23, :Float#nan?@0x1040
-          CheckInterrupts
-          Return v24
-        ");
-    }
-
-    #[test]
-    fn test_float_finite_p_annotation() {
-        eval(r#"
-            def test(x) = x.finite?
-            test(1.0)
-        "#);
-        assert_snapshot!(hir_string("test"), @"
-        fn test@<compiled>:2:
-        bb1():
-          EntryPoint interpreter
-          v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          Jump bb3(v1, v3)
-        bb2():
-          EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :x@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          PatchPoint MethodRedefined(Float@0x1008, finite?@0x1010, cme:0x1018)
-          v23:Flonum = GuardType v10, Flonum recompile
-          v24:BoolExact = CCall v23, :Float#finite?@0x1040
-          CheckInterrupts
-          Return v24
-        ");
-    }
-
-    #[test]
-    fn test_float_infinite_p_annotation() {
-        eval(r#"
-            def test(x) = x.infinite?
-            test(1.0)
-        "#);
-        assert_snapshot!(hir_string("test"), @"
-        fn test@<compiled>:2:
-        bb1():
-          EntryPoint interpreter
-          v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          Jump bb3(v1, v3)
-        bb2():
-          EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :x@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          PatchPoint MethodRedefined(Float@0x1008, infinite?@0x1010, cme:0x1018)
-          v23:Flonum = GuardType v10, Flonum recompile
-          v24:NilClass|Fixnum = CCall v23, :Float#infinite?@0x1040
-          CheckInterrupts
-          Return v24
-        ");
+    fn assert_hir_contains_all(hir: &str, expected: &[&str]) {
+        for item in expected {
+            assert!(hir.contains(item), "expected {item:?} in HIR:\n{hir}");
+        }
     }
 
     #[test]
@@ -18172,239 +18094,34 @@ mod hir_opt_tests {
         ");
     }
 
-    #[test]
-    fn test_float_zero_p_annotation() {
-        eval(r#"
-            def test(x) = x.zero?
-            test(1.0)
-        "#);
-        assert_snapshot!(hir_string("test"), @"
-        fn test@<compiled>:2:
-        bb1():
-          EntryPoint interpreter
-          v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          Jump bb3(v1, v3)
-        bb2():
-          EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :x@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          PatchPoint MethodRedefined(Float@0x1008, zero?@0x1010, cme:0x1018)
-          v22:Flonum = GuardType v10, Flonum recompile
-          v23:BoolExact = InvokeBuiltin leaf <inline_expr>, v22
-          CheckInterrupts
-          Return v23
-        ");
+    fn assert_float_binop_inline(body: &str, expected_op: &str) {
+        let script = format!("def test(a, b) = {body}\ntest(1.5, 2.5)");
+        eval(&script);
+        let hir = hir_string("test");
+        assert!(hir.contains(expected_op), "{hir}");
+        assert_eq!(2, hir.matches("UnboxFloat").count(), "{hir}");
+        assert_eq!(1, hir.matches("BoxFloat").count(), "{hir}");
+        assert!(!hir.contains("CCallWithFrame"), "{hir}");
     }
 
-    #[test]
-    fn test_float_positive_p_annotation() {
-        eval(r#"
-            def test(x) = x.positive?
-            test(1.0)
-        "#);
-        assert_snapshot!(hir_string("test"), @"
-        fn test@<compiled>:2:
-        bb1():
-          EntryPoint interpreter
-          v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          Jump bb3(v1, v3)
-        bb2():
-          EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :x@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          PatchPoint MethodRedefined(Float@0x1008, positive?@0x1010, cme:0x1018)
-          v22:Flonum = GuardType v10, Flonum recompile
-          v23:BoolExact = InvokeBuiltin leaf <inline_expr>, v22
-          CheckInterrupts
-          Return v23
-        ");
-    }
-
-    #[test]
-    fn test_float_negative_p_annotation() {
-        eval(r#"
-            def test(x) = x.negative?
-            test(-1.0)
-        "#);
-        assert_snapshot!(hir_string("test"), @"
-        fn test@<compiled>:2:
-        bb1():
-          EntryPoint interpreter
-          v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          Jump bb3(v1, v3)
-        bb2():
-          EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :x@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          PatchPoint MethodRedefined(Float@0x1008, negative?@0x1010, cme:0x1018)
-          v22:Flonum = GuardType v10, Flonum recompile
-          v23:BoolExact = InvokeBuiltin leaf <inline_expr>, v22
-          CheckInterrupts
-          Return v23
-        ");
-    }
     #[test]
     fn test_float_add_inline() {
-        eval(r#"
-            def test(a, b) = a + b
-            test(1.0, 2.0)
-        "#);
-        assert_snapshot!(hir_string("test"), @"
-        fn test@<compiled>:2:
-        bb1():
-          EntryPoint interpreter
-          v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
-        bb2():
-          EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :a@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
-          PatchPoint MethodRedefined(Float@0x1008, +@0x1010, cme:0x1018)
-          v28:Flonum = GuardType v12, Flonum recompile
-          v29:Flonum = GuardType v13, Flonum recompile
-          v30:Float = FloatAdd v28, v29
-          CheckInterrupts
-          Return v30
-        ");
+        assert_float_binop_inline("a + b", "F64BinOp::Add");
     }
 
     #[test]
     fn test_float_mul_inline() {
-        eval(r#"
-            def test(a, b) = a * b
-            test(1.5, 2.5)
-        "#);
-        assert_snapshot!(hir_string("test"), @"
-        fn test@<compiled>:2:
-        bb1():
-          EntryPoint interpreter
-          v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
-        bb2():
-          EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :a@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
-          PatchPoint MethodRedefined(Float@0x1008, *@0x1010, cme:0x1018)
-          v28:Flonum = GuardType v12, Flonum recompile
-          v29:Flonum = GuardType v13, Flonum recompile
-          v30:Float = FloatMul v28, v29
-          CheckInterrupts
-          Return v30
-        ");
+        assert_float_binop_inline("a * b", "F64BinOp::Mul");
     }
 
     #[test]
     fn test_float_sub_inline() {
-        eval(r#"
-            def test(a, b) = a - b
-            test(5.0, 3.0)
-        "#);
-        assert_snapshot!(hir_string("test"), @"
-        fn test@<compiled>:2:
-        bb1():
-          EntryPoint interpreter
-          v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
-        bb2():
-          EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :a@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
-          PatchPoint MethodRedefined(Float@0x1008, -@0x1010, cme:0x1018)
-          v28:Flonum = GuardType v12, Flonum recompile
-          v29:Flonum = GuardType v13, Flonum recompile
-          v30:Float = FloatSub v28, v29
-          CheckInterrupts
-          Return v30
-        ");
+        assert_float_binop_inline("a - b", "F64BinOp::Sub");
     }
 
     #[test]
     fn test_float_div_inline() {
-        eval(r#"
-            def test(a, b) = a / b
-            test(10.0, 3.0)
-        "#);
-        assert_snapshot!(hir_string("test"), @"
-        fn test@<compiled>:2:
-        bb1():
-          EntryPoint interpreter
-          v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
-        bb2():
-          EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :a@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
-          PatchPoint MethodRedefined(Float@0x1008, /@0x1010, cme:0x1018)
-          v28:Flonum = GuardType v12, Flonum recompile
-          v29:Flonum = GuardType v13, Flonum recompile
-          v30:Float = FloatDiv v28, v29
-          CheckInterrupts
-          Return v30
-        ");
-    }
-
-    #[test]
-    fn test_float_to_i_inline() {
-        eval(r#"
-            def test(a) = a.to_i
-            test(3.7)
-        "#);
-        assert_snapshot!(hir_string("test"), @"
-        fn test@<compiled>:2:
-        bb1():
-          EntryPoint interpreter
-          v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          Jump bb3(v1, v3)
-        bb2():
-          EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :a@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          PatchPoint MethodRedefined(Float@0x1008, to_i@0x1010, cme:0x1018)
-          v23:Flonum = GuardType v10, Flonum recompile
-          v24:Integer = FloatToInt v23
-          CheckInterrupts
-          Return v24
-        ");
+        assert_float_binop_inline("a / b", "F64BinOp::Div");
     }
 
     #[test]
@@ -18413,29 +18130,111 @@ mod hir_opt_tests {
             def test(a, b) = a * b
             test(1.5, 3)
         "#);
-        assert_snapshot!(hir_string("test"), @"
-        fn test@<compiled>:2:
-        bb1():
-          EntryPoint interpreter
-          v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
-        bb2():
-          EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :a@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
-          PatchPoint MethodRedefined(Float@0x1008, *@0x1010, cme:0x1018)
-          v28:Flonum = GuardType v12, Flonum recompile
-          v29:Fixnum = GuardType v13, Fixnum recompile
-          v30:Float = FloatMul v28, v29
-          CheckInterrupts
-          Return v30
-        ");
+        let hir = hir_string("test");
+        assert_hir_contains_all(&hir, &["FixnumToF64", "F64BinOp::Mul"]);
+        assert_eq!(1, hir.matches("UnboxFloat").count(), "{hir}");
+        assert_eq!(1, hir.matches("BoxFloat").count(), "{hir}");
+        assert!(!hir.contains("CCallWithFrame"), "{hir}");
+    }
+
+    #[test]
+    fn test_float_chain_stays_unboxed_between_ops() {
+        eval(r#"
+            def test(a, b, c) = ((a + b) * c - b) / a
+            test(1.25, 2.5, 3.75)
+        "#);
+        let hir = hir_string("test");
+        assert_hir_contains_all(&hir, &["F64BinOp::Add", "F64BinOp::Mul", "F64BinOp::Sub", "F64BinOp::Div"]);
+        assert_eq!(3, hir.matches("UnboxFloat").count(), "{hir}");
+        assert_eq!(4, hir.matches("BoxFloat").count(), "{hir}");
+        assert!(!hir.contains("CCallWithFrame"), "{hir}");
+    }
+
+    #[test]
+    fn test_float_literal_chain_folds_without_boxing() {
+        eval(r#"
+            def test = (1.25 + 2.5) * 3.75
+            test
+        "#);
+        let hir = hir_string("test");
+        assert!(hir.contains("Return"), "{hir}");
+        assert!(!hir.contains("Const CDouble"), "{hir}");
+        assert!(!hir.contains("F64BinOp::Add"), "{hir}");
+        assert!(!hir.contains("F64BinOp::Mul"), "{hir}");
+        assert!(!hir.contains("UnboxFloat"), "{hir}");
+        assert!(!hir.contains("BoxFloat"), "{hir}");
+    }
+
+    #[test]
+    fn test_float_literal_division_by_zero_folds() {
+        eval(r#"
+            def test = 1.0 / 0.0
+            test
+        "#);
+        let hir = hir_string("test");
+        assert!(hir.contains("Return"), "{hir}");
+        assert!(hir.contains("Const CDouble(inf)"), "{hir}");
+        assert!(!hir.contains("F64BinOp::Div"), "{hir}");
+        assert!(!hir.contains("UnboxFloat"), "{hir}");
+    }
+
+    #[test]
+    fn test_math_sqrt_inline_with_nonnegative_guard() {
+        eval(r#"
+            def test(a) = Math.sqrt(a)
+            test(1.25)
+        "#);
+        let hir = hir_string("test");
+        assert_hir_contains_all(&hir, &["F64GuardNonnegative", "F64Sqrt"]);
+        assert!(!hir.contains("CCallWithFrame"), "{hir}");
+    }
+
+    #[test]
+    fn test_fixnum_float_rhs_uses_unboxed_float_ops() {
+        eval(r#"
+            def test(a, b) = ((a + b) * b - a) / b
+            test(1, 2.5)
+        "#);
+        let hir = hir_string("test");
+        assert_hir_contains_all(&hir, &["FixnumToF64", "F64BinOp::Add", "F64BinOp::Mul", "F64BinOp::Sub", "F64BinOp::Div"]);
+        assert_eq!(4, hir.matches("BoxFloat").count(), "{hir}");
+        assert!(!hir.contains("CCallWithFrame"), "{hir}");
+    }
+
+    #[test]
+    fn test_float_chain_comparison_avoids_boxing_result() {
+        eval(r#"
+            def test(a, b) = [(a + b) == b, (a + b) < b, (a + b) <= b, (a + b) > b, (a + b) >= b]
+            test(1.25, 2.5)
+        "#);
+        let hir = hir_string("test");
+        assert_hir_contains_all(&hir, &["F64BoolCmp::Eq", "F64BoolCmp::Lt", "F64BoolCmp::Le", "F64BoolCmp::Gt", "F64BoolCmp::Ge"]);
+        assert_eq!(5, hir.matches("BoxFloat").count(), "{hir}");
+        assert!(!hir.contains("CCallWithFrame"), "{hir}");
+    }
+
+    #[test]
+    fn test_float_chain_fixnum_comparison_uses_exact_helpers() {
+        eval(r#"
+            def test(a, b, n) = [(a + b) == n, (a + b) < n, (a + b) <= n, (a + b) > n, (a + b) >= n]
+            test(1.25, 2.5, 4)
+        "#);
+        let hir = hir_string("test");
+        assert_hir_contains_all(&hir, &["F64FixnumBoolCmp::Eq", "F64FixnumBoolCmp::Lt", "F64FixnumBoolCmp::Le", "F64FixnumBoolCmp::Gt", "F64FixnumBoolCmp::Ge"]);
+        assert_eq!(5, hir.matches("BoxFloat").count(), "{hir}");
+        assert!(!hir.contains("CCallWithFrame"), "{hir}");
+    }
+
+    #[test]
+    fn test_fixnum_float_rhs_comparison_uses_exact_helpers() {
+        eval(r#"
+            def test(n, a, b) = [n == (a + b), n < (a + b), n <= (a + b), n > (a + b), n >= (a + b)]
+            test(4, 1.25, 2.5)
+        "#);
+        let hir = hir_string("test");
+        assert_hir_contains_all(&hir, &["F64FixnumBoolCmp::Eq", "F64FixnumBoolCmp::Lt", "F64FixnumBoolCmp::Le", "F64FixnumBoolCmp::Gt", "F64FixnumBoolCmp::Ge"]);
+        assert_eq!(5, hir.matches("BoxFloat").count(), "{hir}");
+        assert!(!hir.contains("CCallWithFrame"), "{hir}");
     }
 
     #[test]
@@ -18448,7 +18247,7 @@ mod hir_opt_tests {
         "#);
 
         let intermediate_hir = hir_string("test_float_mul_recompile");
-        assert!(intermediate_hir.contains("FloatMul"), "{intermediate_hir}");
+        assert!(intermediate_hir.contains("F64BinOp::Mul"), "{intermediate_hir}");
 
         eval(r#"
             30.times { test_float_mul_recompile(1.5, -0.0) }
@@ -18456,51 +18255,7 @@ mod hir_opt_tests {
 
         let final_hir = hir_string("test_float_mul_recompile");
         assert!(final_hir.contains("CCallWithFrame"), "{final_hir}");
-        assert!(!final_hir.contains("FloatMul"), "{final_hir}");
-        assert_snapshot!(format!("{intermediate_hir}\n{final_hir}"), @"
-        fn test_float_mul_recompile@<compiled>:2:
-        bb1():
-          EntryPoint interpreter
-          v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
-        bb2():
-          EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :a@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
-          PatchPoint MethodRedefined(Float@0x1008, *@0x1010, cme:0x1018)
-          v28:Flonum = GuardType v12, Flonum recompile
-          v29:Flonum = GuardType v13, Flonum recompile
-          v30:Float = FloatMul v28, v29
-          CheckInterrupts
-          Return v30
-
-        fn test_float_mul_recompile@<compiled>:2:
-        bb1():
-          EntryPoint interpreter
-          v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
-        bb2():
-          EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :a@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
-          PatchPoint MethodRedefined(Float@0x1008, *@0x1010, cme:0x1018)
-          v28:Flonum = GuardType v12, Flonum recompile
-          v29:BasicObject = CCallWithFrame v28, :Float#*@0x1040, v13
-          CheckInterrupts
-          Return v29
-        ");
+        assert!(!final_hir.contains("F64BinOp::Mul"), "{final_hir}");
     }
 
     #[test]
@@ -18513,7 +18268,7 @@ mod hir_opt_tests {
         "#);
 
         let intermediate_hir = hir_string("test_float_mul_recompile");
-        assert!(intermediate_hir.contains("FloatMul"), "{intermediate_hir}");
+        assert!(intermediate_hir.contains("F64BinOp::Mul"), "{intermediate_hir}");
 
         eval(r#"
             30.times { test_float_mul_recompile(-0.0, 1.5) }
@@ -18521,67 +18276,7 @@ mod hir_opt_tests {
 
         let final_hir = hir_string("test_float_mul_recompile");
         assert!(final_hir.contains("CCallWithFrame"), "{final_hir}");
-        assert!(!final_hir.contains("FloatMul"), "{final_hir}");
-        assert_snapshot!(format!("{intermediate_hir}\n{final_hir}"), @"
-        fn test_float_mul_recompile@<compiled>:2:
-        bb1():
-          EntryPoint interpreter
-          v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
-        bb2():
-          EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :a@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
-          PatchPoint MethodRedefined(Float@0x1008, *@0x1010, cme:0x1018)
-          v28:Flonum = GuardType v12, Flonum recompile
-          v29:Flonum = GuardType v13, Flonum recompile
-          v30:Float = FloatMul v28, v29
-          CheckInterrupts
-          Return v30
-
-        fn test_float_mul_recompile@<compiled>:2:
-        bb1():
-          EntryPoint interpreter
-          v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
-        bb2():
-          EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :a@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
-          v21:CBool = HasType v12, HeapFloat
-          CondBranch v21, bb5(), bb6()
-        bb5():
-          v24:HeapFloat = RefineType v12, HeapFloat
-          PatchPoint MethodRedefined(Float@0x1008, *@0x1010, cme:0x1018)
-          v42:BasicObject = CCallWithFrame v24, :Float#*@0x1040, v13
-          Jump bb4(v42)
-        bb6():
-          v27:CBool = HasType v12, Flonum
-          CondBranch v27, bb7(), bb8()
-        bb7():
-          v30:Flonum = RefineType v12, Flonum
-          PatchPoint MethodRedefined(Float@0x1008, *@0x1010, cme:0x1018)
-          v45:BasicObject = CCallWithFrame v30, :Float#*@0x1040, v13
-          Jump bb4(v45)
-        bb8():
-          v33:BasicObject = Send v12, :*, v13 # SendFallbackReason: Send: polymorphic call site
-          Jump bb4(v33)
-        bb4(v20:BasicObject):
-          CheckInterrupts
-          Return v20
-        ");
+        assert!(!final_hir.contains("F64BinOp::Mul"), "{final_hir}");
     }
 
     #[test]
@@ -18782,143 +18477,14 @@ mod hir_opt_tests {
         ");
         let final_hir = hir_string_proc("C.new.method(:f)");
 
-        assert_snapshot!(format!("{intermediate_hir}\n{final_hir}"), @"
-        fn f@<compiled>:4:
-        bb1():
-          EntryPoint interpreter
-          v1:HeapBasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          v4:NilClass = Const Value(nil)
-          Jump bb3(v1, v3, v4)
-        bb2():
-          EntryPoint JIT(0)
-          v7:HeapBasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :x@1
-          v9:NilClass = Const Value(nil)
-          Jump bb3(v7, v8, v9)
-        bb3(v11:HeapBasicObject, v12:BasicObject, v13:NilClass):
-          v17:Fixnum[1] = Const Value(1)
-          PatchPoint SingleRactorMode
-          v21:CShape = LoadField v11, :shape_id@0x1001
-          v22:CShape[0x1002] = Const CShape(0x1002)
-          v23:CBool = IsBitEqual v21, v22
-          CondBranch v23, bb5(), bb6()
-        bb5():
-          StoreField v11, :@a@0x1003, v17
-          WriteBarrier v11, v17
-          Jump bb4()
-        bb6():
-          v28:CShape[0x1004] = Const CShape(0x1004)
-          v29:CBool = IsBitEqual v21, v28
-          CondBranch v29, bb7(), bb8()
-        bb7():
-          StoreField v11, :@a@0x1003, v17
-          WriteBarrier v11, v17
-          v35:CShape[0x1002] = Const CShape(0x1002)
-          StoreField v11, :shape_id@0x1001, v35
-          Jump bb4()
-        bb8():
-          SetIvar v11, :@a, v17
-          Jump bb4()
-        bb4():
-          PatchPoint NoEPEscape(f)
-          v44:Fixnum[1] = Const Value(1)
-          PatchPoint MethodRedefined(Integer@0x1008, +@0x1010, cme:0x1018)
-          v72:Fixnum = GuardType v12, Fixnum recompile
-          v73:Fixnum = FixnumAdd v72, v44
-          PatchPoint SingleRactorMode
-          v55:CShape = LoadField v11, :shape_id@0x1001
-          v56:CShape[0x1002] = Const CShape(0x1002)
-          v57:CBool = IsBitEqual v55, v56
-          CondBranch v57, bb10(), bb11()
-        bb10():
-          StoreField v11, :@a@0x1003, v73
-          WriteBarrier v11, v73
-          Jump bb9()
-        bb11():
-          SetIvar v11, :@a, v73
-          Jump bb9()
-        bb9():
-          CheckInterrupts
-          Return v73
+        assert!(intermediate_hir.contains("GuardType"), "{intermediate_hir}");
+        assert!(intermediate_hir.contains("FixnumAdd"), "{intermediate_hir}");
+        assert!(!intermediate_hir.contains("HasType"), "{intermediate_hir}");
 
-        fn f@<compiled>:4:
-        bb1():
-          EntryPoint interpreter
-          v1:HeapBasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          v4:NilClass = Const Value(nil)
-          Jump bb3(v1, v3, v4)
-        bb2():
-          EntryPoint JIT(0)
-          v7:HeapBasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :x@1
-          v9:NilClass = Const Value(nil)
-          Jump bb3(v7, v8, v9)
-        bb3(v11:HeapBasicObject, v12:BasicObject, v13:NilClass):
-          v17:Fixnum[1] = Const Value(1)
-          PatchPoint SingleRactorMode
-          v21:CShape = LoadField v11, :shape_id@0x1001
-          v22:CShape[0x1002] = Const CShape(0x1002)
-          v23:CBool = IsBitEqual v21, v22
-          CondBranch v23, bb5(), bb6()
-        bb5():
-          StoreField v11, :@a@0x1003, v17
-          WriteBarrier v11, v17
-          Jump bb4()
-        bb6():
-          v28:CShape[0x1004] = Const CShape(0x1004)
-          v29:CBool = IsBitEqual v21, v28
-          CondBranch v29, bb7(), bb8()
-        bb7():
-          StoreField v11, :@a@0x1003, v17
-          WriteBarrier v11, v17
-          v35:CShape[0x1002] = Const CShape(0x1002)
-          StoreField v11, :shape_id@0x1001, v35
-          Jump bb4()
-        bb8():
-          SetIvar v11, :@a, v17
-          Jump bb4()
-        bb4():
-          PatchPoint NoEPEscape(f)
-          v44:Fixnum[1] = Const Value(1)
-          v48:CBool = HasType v12, Fixnum
-          CondBranch v48, bb10(), bb11()
-        bb10():
-          v51:Fixnum = RefineType v12, Fixnum
-          PatchPoint MethodRedefined(Integer@0x1008, +@0x1010, cme:0x1018)
-          v86:Fixnum = FixnumAdd v51, v44
-          Jump bb9(v86)
-        bb11():
-          v54:CBool = HasType v12, Flonum
-          CondBranch v54, bb12(), bb13()
-        bb12():
-          v57:Flonum = RefineType v12, Flonum
-          PatchPoint MethodRedefined(Float@0x1040, +@0x1010, cme:0x1048)
-          v89:Float = FloatAdd v57, v44
-          Jump bb9(v89)
-        bb13():
-          v60:BasicObject = Send v12, :+, v44 # SendFallbackReason: Send: polymorphic call site
-          Jump bb9(v60)
-        bb9(v47:BasicObject):
-          PatchPoint SingleRactorMode
-          v69:CShape = LoadField v11, :shape_id@0x1001
-          v70:CShape[0x1002] = Const CShape(0x1002)
-          v71:CBool = IsBitEqual v69, v70
-          CondBranch v71, bb15(), bb16()
-        bb15():
-          StoreField v11, :@a@0x1003, v47
-          WriteBarrier v11, v47
-          Jump bb14()
-        bb16():
-          SetIvar v11, :@a, v47
-          Jump bb14()
-        bb14():
-          CheckInterrupts
-          Return v47
-        ");
+        assert!(final_hir.contains("HasType"), "{final_hir}");
+        assert!(final_hir.contains("FixnumAdd"), "{final_hir}");
+        assert!(final_hir.contains("F64BinOp::Add"), "{final_hir}");
+        assert!(final_hir.contains("SendFallbackReason: Send: polymorphic call site"), "{final_hir}");
     }
 
     // Helper that compiles with inlining enabled. Temporarily sets the inline

--- a/zjit/src/hir_type/mod.rs
+++ b/zjit/src/hir_type/mod.rs
@@ -461,6 +461,13 @@ impl Type {
         }
     }
 
+    pub fn cdouble_value(&self) -> Option<f64> {
+        match (self.is_subtype(types::CDouble), self.spec()) {
+            (true, Specialization::Double(val)) => Some(val),
+            _ => None,
+        }
+    }
+
     fn int_spec_signed(&self) -> Option<i64> {
         assert!(self.is_subtype(types::CSigned), "int_spec_signed() only makes sense for signed integer types");
         match self.spec() {


### PR DESCRIPTION
## Summary

This is a follow-up to the earlier discussion about ZJIT Float arithmetic and the cost of repeated boxing/unboxing:

https://zjit.zulipchat.com/#narrow/channel/546442-general/topic/ZJIT.20and.20Float.20arithmetic.3A.20where.20should.20we.20go.20from.20here.3F/with/593989863

The previous Float fast paths helped by replacing some sends with direct calls, but the result still had to be represented as a Ruby `Float` value. In Float-heavy loops this means downstream operations repeatedly guard, unbox, and re-box values. That overhead shows up clearly in benchmarks such as `nbody`, `mandelbrot`, and similar numeric loops.

This patch adds raw-F64 support to ZJIT so Float-heavy code can keep intermediate Float values unboxed across HIR, LIR, register allocation, backend lowering, side exits, and frame materialization.

## What changes

The patch adds:

- an FP virtual-register class in LIR,
- raw-F64 LIR operations for load/store, arithmetic, comparisons, sqrt, and bit conversion,
- arm64 and x86-64 lowering for those operations,
- F64-aware stack maps and frame materialization,
- HIR/codegen support for keeping loop-carried Float values unboxed,
- conservative inline paths for common Float-heavy operations.

Optimized operations include:

- `Float#+`, `-`, `*`, `/`, `**`
- `Float#==`, `<`, `<=`, `>`, `>=`
- `Math.sqrt`, `Math.sin`, `Math.cos`
- selected `Integer`/`Float` arithmetic and comparisons

## Why this shape

In the earlier discussion, one possible intermediate step was to keep unboxed Float values as raw `uint64_t` values in GP registers and lower operations to thin C helpers. This patch takes the more direct route and adds an FP register class instead.

The reason is that most of the performance benefit comes from avoiding boxing across loop backedges and chained Float operations. Once raw Float values are visible in HIR, the rest of the pipeline needs to preserve them through block parameters, register allocation, side exits, and frame materialization. Adding FP registers makes that representation explicit instead of treating doubles as integer payloads indefinitely.

The implementation is still intentionally conservative. It does not try to optimize every Float case, and unsupported cases continue to use the existing fallback paths.

## Semantics and safety

The optimized paths preserve existing guards and fallback behavior:

- method redefinition checks are preserved,
- unsupported operand shapes fall back to normal send/CCall paths,
- heap Float values are explicitly unboxed instead of assuming Flonum-only receivers,
- raw F64 values are boxed back to Ruby Floats for side exits and frame materialization,
- NaN, Infinity, signed zero, and large Fixnum/Float comparisons preserve CRuby behavior.

## Performance

Benchmarks were run on Ubuntu Linux x86-64 (`darwine`), AMD Ryzen 9 9950X3D, comparing this branch at `7d71720765` against Ruby master at `388ea3c3cf` built with ZJIT and YJIT. Both trees were configured with `--enable-zjit=dev` and the same base Ruby.

Ruby's vendored `benchmark-driver` used `miniruby + tool/runruby.rb`, `--repeat-count=3`, and `--run-duration=2` with the default JIT call thresholds. The machine was quiesced and CPU boost was enabled for the measurements. The first four benchmarks were run twice with reversed executable order; the table reports the mean of those two runs. `app_aobench` was run once because of its runtime.

Iterations per second, higher is better:

| benchmark | patched ZJIT | master ZJIT | master YJIT | vs master ZJIT | vs master YJIT |
|---|---:|---:|---:|---:|---:|
| `so_nbody` | 5.715 | 5.003 | 5.047 | 1.14x | 1.13x |
| `so_partial_sums` | 2.468 | 2.026 | 2.509 | 1.22x | 0.98x |
| `so_spectralnorm` | 2.669 | 2.646 | 2.820 | 1.01x | 0.95x |
| `app_mandelbrot` | 4.452 | 3.866 | 3.996 | 1.15x | 1.11x |
| `app_aobench` | 0.078 | 0.074 | 0.079 | 1.05x | 0.99x |

Across these five Float-heavy benchmarks, the geometric mean is 1.11x master ZJIT and 1.03x master YJIT. The largest gains over master ZJIT are in `so_partial_sums` (+21.9%), `app_mandelbrot` (+15.1%), and `so_nbody` (+14.2%), with no measured regression against master ZJIT in this set.

After the review fixes, I also ran a direct A/B against the pre-fix PR binary (`2923fc8196`) with the same five benchmarks, two executable orders, three repeats, and CPU boost enabled. The updated binary had a 1.009x geometric mean; individual ratios ranged from 0.988x to 1.052x, so the fixes did not introduce a material performance regression.

## Validation

Tested on two machines:

- macOS arm64, Apple M1 Max
  - `cargo check -p zjit --tests`
  - `git diff --check`
  - `make install`
  - `make btest RUN_OPTS="--zjit-call-threshold=1" BTESTS="bootstraptest/test_ractor.rb"`
    - `162 tests, 0 failures`
  - `make btest RUN_OPTS="--zjit-call-threshold=1" BTESTS="bootstraptest/test_yjit.rb"`
    - `369 tests, 0 failures`
  - ruby-bench `hexapdf` with patched ZJIT
    - average of last 10 non-warmup iterations: `1145ms`

- Ubuntu Linux x86-64 (`darwine`), AMD Ryzen 9 9950X3D 16-Core Processor, 32 hardware threads
  - patched branch built with `--enable-zjit=dev`
  - `cargo check -p zjit --tests`
  - `git diff --check`
  - `make test-all TESTS="ruby/test_range" RUN_OPTS="--zjit-disable-hir-opt --zjit-call-threshold=1"`
    - `68 tests, 396719 assertions, 0 failures, 0 errors`
  - `make test-tool RUN_OPTS="--zjit-call-threshold=1"`
    - `257 tests, 1237 assertions, 0 failures, 0 errors`
  - `make test-tool RUN_OPTS="--zjit-inline-threshold=0 --zjit-call-threshold=1"`
    - `257 tests, 1237 assertions, 0 failures, 0 errors`
  - `make zjit-test`
    - `1601 tests run: 1601 passed, 14 skipped`
  - `make -j17 check RUN_OPTS="--zjit-call-threshold=1"`
    - test-all: `36024 tests, 7773868 assertions, 0 failures, 0 errors, 153 skips`
    - Ruby specs: `3443 files, 32625 examples, 280842 expectations, 0 failures, 0 errors`
    - syntax_suggest specs: `170 examples, 0 failures`
  - `test/resolv/test_dns.rb` repeated 20 times with `--zjit-call-threshold=1`
    - every run: `25 tests, 4554 assertions, 0 failures, 0 errors, 1 skip`
  - `make test-all TESTS="rubygems/test_gem_commands_install_command.rb" RUN_OPTS="--zjit-call-threshold=1"`
    - `79 tests, 545 assertions, 0 failures, 0 errors`
  - `make btest RUN_OPTS="--zjit-disable-hir-opt --zjit-call-threshold=1" BTESTS="bootstraptest/test_yjit.rb"`
    - `369 tests, 0 failures`
  - ruby-bench `hexapdf` with patched ZJIT
    - average of last 10 non-warmup iterations: `1927ms`
  - ruby-bench `lobsters` with patched ZJIT
    - average of last 10 non-warmup iterations: `1189ms`

The final x86-64 validation completed the full parallel `test-all` run with ZJIT enabled and call threshold 1.

GitHub Actions for head `7d71720765` also completed with no failures. The ZJIT Ubuntu and ZJIT macOS aggregate jobs are green, including the default, no-inliner, and no-HIR-optimizer configurations.
