### PR TITLE
ZJIT: Specialize keyword-to-positional-hash sends

### DIFF
--- a/zjit/src/codegen_tests.rs
+++ b/zjit/src/codegen_tests.rs
@@ -1091,6 +1091,46 @@ fn test_send_optional_return_default_with_argument() {
 }
 
 #[test]
+fn test_send_keyword_to_positional_hash() {
+    eval("
+        def test(arg) = arg
+        def entry = test(k: 1)
+        entry
+    ");
+    assert_snapshot!(assert_compiles("entry"), @"{k: 1}");
+}
+
+#[test]
+fn test_send_multiple_keywords_to_positional_hash() {
+    eval("
+        def test(arg) = arg
+        def entry = test(k: 1, v: 2)
+        entry
+    ");
+    assert_snapshot!(assert_compiles("entry"), @"{k: 1, v: 2}");
+}
+
+#[test]
+fn test_send_positional_and_keyword_to_positional_hash() {
+    eval("
+        def test(a, b) = [a, b]
+        def entry = test(1, k: 2)
+        entry
+    ");
+    assert_snapshot!(assert_compiles("entry"), @"[1, {k: 2}]");
+}
+
+#[test]
+fn test_send_optional_and_keyword_to_positional_hash() {
+    eval("
+        def test(a, b = 2) = [a, b]
+        def entry = test(k: 1)
+        entry
+    ");
+    assert_snapshot!(assert_compiles("entry"), @"[{k: 1}, 2]");
+}
+
+#[test]
 fn test_send_rest_arguments_with_keyword_to_positional_hash() {
     eval("
         def test(*args) = args
@@ -1098,6 +1138,61 @@ fn test_send_rest_arguments_with_keyword_to_positional_hash() {
         entry
     ");
     assert_snapshot!(assert_compiles("entry"), @"[{k: 1}]");
+}
+
+#[test]
+fn test_send_optional_and_rest_arguments_with_keyword_to_positional_hash() {
+    eval("
+        def test(a, b = 2, *rest) = [a, b, rest]
+        def entry = test(1, k: 3)
+        entry
+    ");
+    assert_snapshot!(assert_compiles("entry"), @"[1, {k: 3}, []]");
+}
+
+#[test]
+fn test_send_rest_and_post_arguments_with_keyword_to_positional_hash() {
+    eval("
+        def test(a, *rest, b) = [a, rest, b]
+        def entry = test(1, 2, k: 3)
+        entry
+    ");
+    assert_snapshot!(assert_compiles("entry"), @"[1, [2], {k: 3}]");
+}
+
+#[test]
+fn test_send_keyword_splat_to_positional_hash_fallback() {
+    eval("
+        def test(arg) = arg
+        def entry = test(**{ k: 1 })
+        entry
+    ");
+    assert_snapshot!(assert_compiles("entry"), @"{k: 1}");
+}
+
+#[test]
+fn test_send_no_kwarg_to_positional_hash_fallback() {
+    eval("
+        def test(arg, **nil) = arg
+        def entry
+          test(k: 1)
+        rescue ArgumentError
+          :argument_error
+        end
+        entry
+    ");
+    assert_snapshot!(assert_compiles("entry"), @":argument_error");
+}
+
+#[test]
+fn test_send_ruby2_keywords_to_positional_hash_fallback() {
+    eval("
+        def target(k:) = k
+        ruby2_keywords def forward(*args) = target(*args)
+        def entry = forward(k: 1)
+        entry
+    ");
+    assert_snapshot!(assert_compiles("entry"), @"1");
 }
 
 #[test]

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -2642,15 +2642,21 @@ fn can_direct_send(function: &mut Function, block: BlockId, iseq: *const rb_iseq
         return false
     }
 
-    // SendDirect only models explicit keyword slots for now, so leave this
-    // conversion to VM dispatch.
-    if keywords_as_positional_hash {
+    // Plain keyword-to-positional-hash is safe to synthesize below. Keep VM
+    // dispatch for callee modes that need keyword-sensitive handling: **nil
+    // rejection and ruby2_keywords flag preservation.
+    if keywords_as_positional_hash
+        && (params.flags.accepts_no_kwarg() != 0 || params.flags.ruby2_keywords() != 0)
+    {
         function.count(block, complex_arg_pass_keyword_to_positional_hash);
         function.set_dynamic_send_reason(send_insn, ComplexArgPass);
         return false;
     }
 
-    let keyword_ok = c_int::try_from(caller_kw_count)
+    // After keyword-to-positional-hash, SendDirect receives no keyword slots;
+    // the caller keywords are represented by one extra positional Hash.
+    let effective_keyword_count = if keywords_as_positional_hash { 0 } else { caller_kw_count };
+    let keyword_ok = c_int::try_from(effective_keyword_count)
         .as_ref()
         .map(|argc| (kw_req_num..=kw_total_num).contains(argc))
         .unwrap_or(false);
@@ -2670,7 +2676,9 @@ fn can_direct_send(function: &mut Function, block: BlockId, iseq: *const rb_iseq
     // With *rest, SendDirect receives one rest-array slot instead of each rest
     // element, so cap positional argc at required/post + filled opts + rest slot.
     let passed_opt_num = (caller_positional_i32 - min_positional).min(opt_num) as usize;
-    let send_positional_argc = if has_rest { min_positional as usize + passed_opt_num + 1 } else { caller_positional };
+    // Without *rest, use the converted positional count so the synthesized
+    // keyword Hash is included in the SendDirect argument count.
+    let send_positional_argc = if has_rest { min_positional as usize + passed_opt_num + 1 } else { effective_positional };
     let send_argc = send_positional_argc + kw_total_num as usize;
     let c_argc = 1 + send_argc + block_arg; // +1 for self
 
@@ -3605,8 +3613,7 @@ impl Function {
         iseq: IseqPtr,
         state: InsnId,
     ) -> Result<SendDirectArgs, SendFallbackReason> {
-        let kwarg = unsafe { rb_vm_ci_kwarg(ci) };
-        let (processed_args, caller_argc, kw_bits) = self.setup_keyword_arguments(block, args, kwarg, iseq)?;
+        let (processed_args, caller_argc, kw_bits) = self.setup_keyword_arguments(block, args, ci, iseq, state)?;
         let (processed_args, jit_entry_idx) = self.setup_rest_parameter(block, processed_args, iseq, state)?;
 
         // If args were reordered or synthesized, create a new snapshot with the updated stack
@@ -3639,17 +3646,49 @@ impl Function {
         &mut self,
         block: BlockId,
         args: &[InsnId],
-        kwarg: *const rb_callinfo_kwarg,
+        ci: *const rb_callinfo,
         iseq: IseqPtr,
+        state: InsnId,
     ) -> Result<(Vec<InsnId>, usize, u32), SendFallbackReason> {
+        let kwarg = unsafe { rb_vm_ci_kwarg(ci) };
         let callee_keyword = unsafe { rb_get_iseq_body_param_keyword(iseq) };
         if callee_keyword.is_null() {
-            if !kwarg.is_null() {
-                // Caller is passing kwargs but callee doesn't expect them.
+            if kwarg.is_null() {
+                // Neither caller nor callee have keywords - nothing to do
+                return Ok((args.to_vec(), args.len(), 0));
+            }
+
+            let params = unsafe { iseq.params() };
+            let ci_flags = unsafe { rb_vm_ci_flag(ci) };
+            if ci_flags & VM_CALL_KW_SPLAT != 0 {
+                // Caller **kw is one runtime Hash, not explicit keyword slots, so
+                // there is no static key/value list to repack here.
                 return Err(SendDirectKeywordMismatch);
             }
-            // Neither caller nor callee have keywords - nothing to do
-            return Ok((args.to_vec(), args.len(), 0));
+
+            if params.flags.accepts_no_kwarg() != 0 || params.flags.ruby2_keywords() != 0 {
+                // These callee modes need VM keyword setup even without a keyword table:
+                // **nil rejects keywords, and ruby2_keywords requires RHASH_PASS_AS_KEYWORDS.
+                return Err(SendDirectKeywordMismatch);
+            }
+
+            // Match vm_args.c's setup_parameters_complex via args_kw_argv_to_hash:
+            // explicit caller keywords passed to a method with no keyword table
+            // become one final positional Hash before regular parameter setup.
+            let caller_kw_count = unsafe { get_cikw_keyword_len(kwarg) } as usize;
+            let kw_args_start = args.len() - caller_kw_count;
+            let mut elements = Vec::with_capacity(caller_kw_count * 2);
+            for i in 0..caller_kw_count {
+                let keyword = unsafe { get_cikw_keywords_idx(kwarg, i as i32) };
+                let key = self.push_insn(block, Insn::Const { val: Const::Value(keyword) });
+                elements.push(key);
+                elements.push(args[kw_args_start + i]);
+            }
+
+            let hash = self.push_insn(block, Insn::NewHash { elements, state });
+            let mut processed_args = args[..kw_args_start].to_vec();
+            processed_args.push(hash);
+            return Ok((processed_args, args.len(), 0));
         }
 
         // kwarg may be null if caller passes no keywords but callee has optional keywords

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -4776,10 +4776,208 @@ mod hir_opt_tests {
     }
 
     #[test]
-    fn dont_specialize_call_to_rest_with_keyword_to_positional_hash() {
+    fn specialize_call_with_keyword_to_positional_hash() {
+        eval("
+            def foo(arg) = arg.class
+            def test = foo(k: 1)
+            test
+            test
+        ");
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:3:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          Jump bb3(v1)
+        bb2():
+          EntryPoint JIT(0)
+          v4:BasicObject = LoadArg :self@0
+          Jump bb3(v4)
+        bb3(v6:BasicObject):
+          v11:Fixnum[1] = Const Value(1)
+          v19:StaticSymbol[:k] = Const Value(VALUE(0x1000))
+          v20:HashExact = NewHash v19: v11
+          PatchPoint MethodRedefined(Object@0x1008, foo@0x1010, cme:0x1018)
+          v23:ObjectSubclass[class_exact*:Object@VALUE(0x1008)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1008)] recompile
+          PushInlineFrame v23 (0x1040), v20
+          PatchPoint NoSingletonClass(Hash@0x1068)
+          PatchPoint MethodRedefined(Hash@0x1068, class@0x1070, cme:0x1078)
+          v44:ClassSubclass[Hash@0x1068] = Const Value(VALUE(0x1068))
+          CheckInterrupts
+          PopInlineFrame
+          Return v44
+        ");
+    }
+
+    #[test]
+    fn specialize_call_with_multiple_keywords_to_positional_hash() {
+        eval("
+            def foo(arg) = arg
+            def test = foo(k: 1, v: 2)
+            test
+            test
+        ");
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:3:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          Jump bb3(v1)
+        bb2():
+          EntryPoint JIT(0)
+          v4:BasicObject = LoadArg :self@0
+          Jump bb3(v4)
+        bb3(v6:BasicObject):
+          v11:Fixnum[1] = Const Value(1)
+          v13:Fixnum[2] = Const Value(2)
+          v21:StaticSymbol[:k] = Const Value(VALUE(0x1000))
+          v22:StaticSymbol[:v] = Const Value(VALUE(0x1008))
+          v23:HashExact = NewHash v21: v11, v22: v13
+          PatchPoint MethodRedefined(Object@0x1010, foo@0x1018, cme:0x1020)
+          v26:ObjectSubclass[class_exact*:Object@VALUE(0x1010)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1010)] recompile
+          CheckInterrupts
+          Return v23
+        ");
+    }
+
+    #[test]
+    fn specialize_call_with_positional_and_keyword_to_positional_hash() {
+        eval("
+            def foo(a, b) = [a, b]
+            def test = foo(1, k: 2)
+            test
+            test
+        ");
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:3:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          Jump bb3(v1)
+        bb2():
+          EntryPoint JIT(0)
+          v4:BasicObject = LoadArg :self@0
+          Jump bb3(v4)
+        bb3(v6:BasicObject):
+          v11:Fixnum[1] = Const Value(1)
+          v13:Fixnum[2] = Const Value(2)
+          v21:StaticSymbol[:k] = Const Value(VALUE(0x1000))
+          v22:HashExact = NewHash v21: v13
+          PatchPoint MethodRedefined(Object@0x1008, foo@0x1010, cme:0x1018)
+          v25:ObjectSubclass[class_exact*:Object@VALUE(0x1008)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1008)] recompile
+          PushInlineFrame v25 (0x1040), v11, v22
+          v36:ArrayExact = NewArray v11, v22
+          CheckInterrupts
+          PopInlineFrame
+          Return v36
+        ");
+    }
+
+    #[test]
+    fn specialize_call_with_optional_and_keyword_to_positional_hash() {
+        eval("
+            def foo(a, b = 2) = [a, b]
+            def test = foo(k: 1)
+            test
+            test
+        ");
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:3:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          Jump bb3(v1)
+        bb2():
+          EntryPoint JIT(0)
+          v4:BasicObject = LoadArg :self@0
+          Jump bb3(v4)
+        bb3(v6:BasicObject):
+          v11:Fixnum[1] = Const Value(1)
+          v19:StaticSymbol[:k] = Const Value(VALUE(0x1000))
+          v20:HashExact = NewHash v19: v11
+          PatchPoint MethodRedefined(Object@0x1008, foo@0x1010, cme:0x1018)
+          v23:ObjectSubclass[class_exact*:Object@VALUE(0x1008)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1008)] recompile
+          PushInlineFrame v23 (0x1040), v20
+          v31:Fixnum[2] = Const Value(2)
+          v42:ArrayExact = NewArray v20, v31
+          CheckInterrupts
+          PopInlineFrame
+          Return v42
+        ");
+    }
+
+    #[test]
+    fn dont_specialize_keyword_splat_to_positional_hash() {
         enable_zjit_stats();
         eval("
-            def foo(*args) = args
+            def foo(arg) = arg
+            def test = foo(**{k: 1})
+            test
+            test
+        ");
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:3:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          Jump bb3(v1)
+        bb2():
+          EntryPoint JIT(0)
+          v4:BasicObject = LoadArg :self@0
+          IncrCounterPtr
+          Jump bb3(v4)
+        bb3(v7:BasicObject):
+          IncrCounter zjit_insn_count
+          IncrCounter zjit_insn_count
+          v14:HashExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          v15:HashExact = HashDup v14
+          IncrCounter zjit_insn_count
+          IncrCounter complex_arg_pass_caller_kw_splat
+          v18:BasicObject = Send v7, :foo, v15 # SendFallbackReason: Complex argument passing
+          IncrCounter zjit_insn_count
+          CheckInterrupts
+          Return v18
+        ");
+    }
+
+    #[test]
+    fn dont_specialize_no_kwarg_to_positional_hash() {
+        enable_zjit_stats();
+        eval("
+            def foo(arg, **nil) = arg
+            def test = foo(k: 1)
+            begin; test; rescue ArgumentError; end
+            begin; test; rescue ArgumentError; end
+        ");
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:3:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          Jump bb3(v1)
+        bb2():
+          EntryPoint JIT(0)
+          v4:BasicObject = LoadArg :self@0
+          IncrCounterPtr
+          Jump bb3(v4)
+        bb3(v7:BasicObject):
+          IncrCounter zjit_insn_count
+          IncrCounter zjit_insn_count
+          v14:Fixnum[1] = Const Value(1)
+          IncrCounter zjit_insn_count
+          IncrCounter complex_arg_pass_keyword_to_positional_hash
+          v17:BasicObject = Send v7, :foo, v14 # SendFallbackReason: Complex argument passing
+          IncrCounter zjit_insn_count
+          CheckInterrupts
+          Return v17
+        ");
+    }
+
+    #[test]
+    fn dont_specialize_ruby2_keywords_to_positional_hash() {
+        enable_zjit_stats();
+        eval("
+            ruby2_keywords def foo(*args) = args
             def test = foo(k: 1)
             test
             test
@@ -4809,6 +5007,107 @@ mod hir_opt_tests {
     }
 
     #[test]
+    fn specialize_call_to_rest_with_optional_and_keyword_to_positional_hash() {
+        eval("
+            def foo(a, b = 2, *rest) = [a, b, rest]
+            def test = foo(1, k: 3)
+            test
+            test
+        ");
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:3:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          Jump bb3(v1)
+        bb2():
+          EntryPoint JIT(0)
+          v4:BasicObject = LoadArg :self@0
+          Jump bb3(v4)
+        bb3(v6:BasicObject):
+          v11:Fixnum[1] = Const Value(1)
+          v13:Fixnum[3] = Const Value(3)
+          v21:StaticSymbol[:k] = Const Value(VALUE(0x1000))
+          v22:HashExact = NewHash v21: v13
+          v23:ArrayExact = NewArray
+          PatchPoint MethodRedefined(Object@0x1008, foo@0x1010, cme:0x1018)
+          v26:ObjectSubclass[class_exact*:Object@VALUE(0x1008)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1008)] recompile
+          PushInlineFrame v26 (0x1040), v11, v22, v23
+          v39:ArrayExact = NewArray v11, v22, v23
+          CheckInterrupts
+          PopInlineFrame
+          Return v39
+        ");
+    }
+
+    #[test]
+    fn specialize_call_to_rest_with_keyword_to_positional_hash() {
+        eval("
+            def foo(*args) = args
+            def test = foo(k: 1)
+            test
+            test
+        ");
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:3:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          Jump bb3(v1)
+        bb2():
+          EntryPoint JIT(0)
+          v4:BasicObject = LoadArg :self@0
+          Jump bb3(v4)
+        bb3(v6:BasicObject):
+          v11:Fixnum[1] = Const Value(1)
+          v19:StaticSymbol[:k] = Const Value(VALUE(0x1000))
+          v20:HashExact = NewHash v19: v11
+          v21:ArrayExact = NewArray v20
+          PatchPoint MethodRedefined(Object@0x1008, foo@0x1010, cme:0x1018)
+          v24:ObjectSubclass[class_exact*:Object@VALUE(0x1008)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1008)] recompile
+          PushInlineFrame v24 (0x1040), v21
+          CheckInterrupts
+          PopInlineFrame
+          Return v21
+        ");
+    }
+
+    #[test]
+    fn specialize_call_to_rest_and_post_with_keyword_to_positional_hash() {
+        eval("
+            def foo(a, *rest, b) = [a, rest, b]
+            def test = foo(1, 2, k: 3)
+            test
+            test
+        ");
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:3:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          Jump bb3(v1)
+        bb2():
+          EntryPoint JIT(0)
+          v4:BasicObject = LoadArg :self@0
+          Jump bb3(v4)
+        bb3(v6:BasicObject):
+          v11:Fixnum[1] = Const Value(1)
+          v13:Fixnum[2] = Const Value(2)
+          v15:Fixnum[3] = Const Value(3)
+          v23:StaticSymbol[:k] = Const Value(VALUE(0x1000))
+          v24:HashExact = NewHash v23: v15
+          v25:ArrayExact = NewArray v13
+          PatchPoint MethodRedefined(Object@0x1008, foo@0x1010, cme:0x1018)
+          v28:ObjectSubclass[class_exact*:Object@VALUE(0x1008)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1008)] recompile
+          PushInlineFrame v28 (0x1040), v11, v25, v24
+          v41:ArrayExact = NewArray v11, v25, v24
+          CheckInterrupts
+          PopInlineFrame
+          Return v41
+        ");
+    }
+
+    #[test]
     fn dont_classify_keyword_to_positional_hash_argc_mismatch_as_complex_arg_pass() {
         eval("
             def foo(a, b) = a
@@ -4831,6 +5130,33 @@ mod hir_opt_tests {
           v13:BasicObject = Send v6, :foo, v11 # SendFallbackReason: Argument count does not match parameter count
           CheckInterrupts
           Return v13
+        ");
+    }
+
+    #[test]
+    fn dont_classify_keyword_to_positional_hash_too_many_args_as_complex_arg_pass() {
+        eval("
+            def foo(a) = a
+            def test = foo(1, k: 2)
+            begin; test; rescue ArgumentError; end
+            begin; test; rescue ArgumentError; end
+        ");
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:3:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          Jump bb3(v1)
+        bb2():
+          EntryPoint JIT(0)
+          v4:BasicObject = LoadArg :self@0
+          Jump bb3(v4)
+        bb3(v6:BasicObject):
+          v11:Fixnum[1] = Const Value(1)
+          v13:Fixnum[2] = Const Value(2)
+          v15:BasicObject = Send v6, :foo, v11, v13 # SendFallbackReason: Argument count does not match parameter count
+          CheckInterrupts
+          Return v15
         ");
     }
 


### PR DESCRIPTION
Follow-up: https://github.com/ruby/ruby/pull/17656

Allow SendDirect to handle explicit caller keywords passed to callees with no keyword parameter table by materializing the keywords as one positional Hash.

Keep VM dispatch for keyword splat, **nil, and ruby2_keywords cases because they need keyword-sensitive setup beyond constructing a plain Hash.

## Benchmark
### erubi-rails
```diff
Top-6 popular complex argument-parameter features not optimized (100.0% of total 6,000,742):
- keyword_to_positional_hash: 1,999,826 (33.3%)
           param_forwardable: 1,749,797 (29.2%)
                caller_splat: 1,250,920 (20.8%)
             caller_blockarg:   999,884 (16.7%)
                param_kwrest:       284 ( 0.0%)
             caller_kw_splat:        31 ( 0.0%)
```

### railsbench
```diff
Top-7 popular complex argument-parameter features not optimized (100.0% of total 4,632,785):
           param_forwardable: 2,673,942 (57.7%)
             caller_kw_splat:   596,099 (12.9%)
                caller_splat:   484,444 (10.5%)
- keyword_to_positional_hash:   423,919 ( 9.2%)
                param_kwrest:   251,203 ( 5.4%)
             caller_blockarg:   201,565 ( 4.4%)
                caller_kwarg:     1,613 ( 0.0%)
```

### Performance
```
zjit-master: ruby 4.1.0dev (2026-08-04T09:16:17Z master 29d630c108) +ZJIT stats +PRISM [arm64-darwin25]
 zjit-poshash: ruby 4.1.0dev (2026-08-04T12:17:04Z zjit-specialize-se.. e88f5956c8) +ZJIT stats +PRISM [arm64-darwin25]

-----------  ----------------  ------------------  ---------------------  -------------------------
bench        zjit-master (ms)   zjit-poshash (ms)   zjit-poshash 1st itr  zjit-master/ zjit-poshash
erubi-rails      408.5 ± 3.5%        399.5 ± 1.5%                  1.210                      1.023
railsbench       580.6 ± 2.6%        562.2 ± 2.3%                  1.042                      1.033
-----------  ----------------  ------------------  ---------------------  -------------------------

Legend:
-  zjit-poshash 1st itr: ratio of zjit-master/ zjit-poshash time for the first benchmarking iteration.
- zjit-master/ zjit-poshash: ratio of zjit-master/ zjit-poshash time. Higher is better for  zjit-poshash. Above 1 represents a speedup.
```