### PR TITLE
[DOC] Clarify when IO::Buffer#readonly? is true

### DIFF
--- a/io_buffer.c
+++ b/io_buffer.c
@@ -1490,7 +1490,8 @@ rb_io_buffer_readonly_p(VALUE self)
  *  If the buffer is <i>read only</i>, meaning the buffer cannot be modified using
  *  #set_value, #set_string or #copy and similar.
  *
- *  Frozen strings and read-only files create read-only buffers.
+ *  A buffer created by IO::Buffer.for without a block is read-only, as is one
+ *  backed by a frozen string or a read-only file.
  */
 static VALUE
 io_buffer_readonly_p(VALUE self)


### PR DESCRIPTION
The documentation for `IO::Buffer#readonly?` says:

> Frozen strings and read-only files create read-only buffers.

This omits the most common case: a buffer created by `IO::Buffer.for`
**without a block is always read-only, even when the source string is not
frozen**.

```console
$ ruby -e 'p IO::Buffer.for("test").readonly?'
true
```

The string `"test"` is not frozen, yet the resulting buffer is read-only.
This is because the no-block form of `IO::Buffer.for` uses an internal frozen
copy of the string as the buffer source (`rb_io_buffer_type_for` passes
`RB_IO_BUFFER_READONLY` unconditionally in that path), and its call-seq is
already documented as `IO::Buffer.for(string) -> readonly io_buffer`.

The block form, on the other hand, is writable unless the source string is
frozen:

```console
$ ruby -e 'p IO::Buffer.for("test") { |b| b.readonly? }'
false
$ ruby -e 'p IO::Buffer.for("test".freeze) { |b| b.readonly? }'
true
$ ruby -e 'p IO::Buffer.new(4).readonly?'
false
```

So the current wording is misleading in that it implies a frozen string (or a
read-only file) is required, when in fact the plain `IO::Buffer.for(string)`
form is the usual way a read-only buffer is produced.

```diff
- *  Frozen strings and read-only files create read-only buffers.
+ *  A buffer created by IO::Buffer.for without a block is read-only, as is one
+ *  backed by a frozen string or a read-only file.
```

I found this while adding Japanese documentation for `IO::Buffer#readonly?`
to the reference manual (rurema/doctree): rurema/doctree#3305
