### PR TITLE
ZJIT: Require trivial inline target to end at leave

### DIFF
--- a/zjit/src/codegen_tests.rs
+++ b/zjit/src/codegen_tests.rs
@@ -1057,6 +1057,26 @@ fn test_send_optional_and_rest_arguments() {
 }
 
 #[test]
+fn test_send_optional_return_default_without_argument() {
+    eval("
+        def test(arg = nil || (return :default)) = arg
+        def entry = test
+        entry
+    ");
+    assert_snapshot!(assert_compiles("entry"), @":default");
+}
+
+#[test]
+fn test_send_optional_return_default_with_argument() {
+    eval("
+        def test(arg = nil || (return :default)) = arg
+        def entry = test(1)
+        entry
+    ");
+    assert_snapshot!(assert_compiles("entry"), @"1");
+}
+
+#[test]
 fn test_send_rest_arguments_with_keyword_to_positional_hash() {
     eval("
         def test(*args) = args

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -2736,15 +2736,23 @@ unsafe extern "C" {
     fn rb_simple_iseq_p(iseq: IseqPtr) -> bool;
 }
 
-/// Return the ISEQ's return value if it consists of one simple instruction and leave.
-fn iseq_get_return_value(iseq: IseqPtr, captured_opnd: Option<InsnId>, ci_flags: u32) -> Option<IseqReturn> {
+/// Return the ISEQ's return value from the selected JIT entry if it consists
+/// of one simple instruction and leave.
+fn iseq_get_return_value( iseq: IseqPtr, captured_opnd: Option<InsnId>, ci_flags: u32, jit_entry_idx: u16, ) -> Option<IseqReturn> {
     // Expect only two instructions and one possible operand
     // NOTE: If an ISEQ has an optional keyword parameter with a default value that requires
     // computation, the ISEQ will always have more than two instructions and won't be inlined.
 
-    // Get the first two instructions
-    let first_insn = iseq_opcode_at_idx(iseq, 0);
-    let second_insn = iseq_opcode_at_idx(iseq, insn_len(first_insn as usize));
+    // Get the first two instructions from the same optional-argument entry
+    // selected by SendDirect.
+    let first_insn_idx = unsafe { iseq.params() }
+        .opt_table_slice()
+        .get(jit_entry_idx as usize)
+        .expect("JIT entry index must be within the callee opt table")
+        .as_u32();
+    let first_insn = iseq_opcode_at_idx(iseq, first_insn_idx);
+    let second_insn_idx = first_insn_idx + insn_len(first_insn as usize);
+    let second_insn = iseq_opcode_at_idx(iseq, second_insn_idx);
 
     // Extract the return value if known
     if second_insn != YARVINSN_leave {
@@ -2766,7 +2774,7 @@ fn iseq_get_return_value(iseq: IseqPtr, captured_opnd: Option<InsnId>, ci_flags:
                 return None;
             }
 
-            let ep_offset = unsafe { *rb_iseq_pc_at_idx(iseq, 1) }.as_u32();
+            let ep_offset = unsafe { *rb_iseq_pc_at_idx(iseq, first_insn_idx + 1) }.as_u32();
             let local_idx = ep_offset_to_local_idx(iseq, ep_offset);
 
             // Only inline if the local is a parameter (not a method-defined local) as we are indexing args.
@@ -2784,13 +2792,13 @@ fn iseq_get_return_value(iseq: IseqPtr, captured_opnd: Option<InsnId>, ci_flags:
             None
         }
         YARVINSN_putnil => Some(IseqReturn::Value(Qnil)),
-        YARVINSN_putobject => Some(IseqReturn::Value(unsafe { *rb_iseq_pc_at_idx(iseq, 1) })),
+        YARVINSN_putobject => Some(IseqReturn::Value(unsafe { *rb_iseq_pc_at_idx(iseq, first_insn_idx + 1) })),
         YARVINSN_putobject_INT2FIX_0_ => Some(IseqReturn::Value(VALUE::fixnum_from_usize(0))),
         YARVINSN_putobject_INT2FIX_1_ => Some(IseqReturn::Value(VALUE::fixnum_from_usize(1))),
         // We don't support invokeblock for now. Such ISEQs are likely not used by blocks anyway.
         YARVINSN_putself if captured_opnd.is_none() => Some(IseqReturn::Receiver),
         YARVINSN_opt_invokebuiltin_delegate_leave => {
-            let pc = unsafe { rb_iseq_pc_at_idx(iseq, 0) };
+            let pc = unsafe { rb_iseq_pc_at_idx(iseq, first_insn_idx) };
             let bf: *const rb_builtin_function = get_arg(pc, 0).as_ptr();
             let argc = unsafe { (*bf).argc } as usize;
             if argc != 0 { return None; }
@@ -4020,6 +4028,7 @@ impl Function {
         let cd = data.cd;
         let state = data.state;
         let args = &data.args;
+        let jit_entry_idx = data.jit_entry_idx;
         // The trivial inliner runs first to handle simple cases (constant returns,
         // parameter returns, etc.) without frame push/pop overhead. The general
         // inliner then handles more complex methods that require full inlining.
@@ -4029,7 +4038,7 @@ impl Function {
         if ci_flags & VM_CALL_OPT_SEND != 0 {
             return self.push_insn(block, insn);
         }
-        let Some(value) = iseq_get_return_value(iseq, None, ci_flags) else {
+        let Some(value) = iseq_get_return_value(iseq, None, ci_flags, jit_entry_idx) else {
             return self.push_insn(block, insn);
         };
         match value {

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -2736,26 +2736,24 @@ unsafe extern "C" {
     fn rb_simple_iseq_p(iseq: IseqPtr) -> bool;
 }
 
-/// Return the ISEQ's return value from the selected JIT entry if it consists
-/// of one simple instruction and leave.
-fn iseq_get_return_value( iseq: IseqPtr, captured_opnd: Option<InsnId>, ci_flags: u32, jit_entry_idx: u16, ) -> Option<IseqReturn> {
+/// Return the ISEQ's return value if it consists of one simple instruction and leave.
+fn iseq_get_return_value(iseq: IseqPtr, captured_opnd: Option<InsnId>, ci_flags: u32) -> Option<IseqReturn> {
     // Expect only two instructions and one possible operand
     // NOTE: If an ISEQ has an optional keyword parameter with a default value that requires
     // computation, the ISEQ will always have more than two instructions and won't be inlined.
 
-    // Get the first two instructions from the same optional-argument entry
-    // selected by SendDirect.
-    let first_insn_idx = unsafe { iseq.params() }
-        .opt_table_slice()
-        .get(jit_entry_idx as usize)
-        .expect("JIT entry index must be within the callee opt table")
-        .as_u32();
-    let first_insn = iseq_opcode_at_idx(iseq, first_insn_idx);
-    let second_insn_idx = first_insn_idx + insn_len(first_insn as usize);
-    let second_insn = iseq_opcode_at_idx(iseq, second_insn_idx);
+    // Get the first two instructions
+    let first_insn = iseq_opcode_at_idx(iseq, 0);
+    let second_insn = iseq_opcode_at_idx(iseq, insn_len(first_insn as usize));
 
     // Extract the return value if known
     if second_insn != YARVINSN_leave {
+        return None;
+    }
+    // Make sure the leave is the final instruction. Otherwise this is a
+    // non-trivial ISEQ that should go through the general inliner.
+    let iseq_size = unsafe { get_iseq_encoded_size(iseq) };
+    if insn_len(first_insn as usize) + insn_len(second_insn as usize) != iseq_size {
         return None;
     }
     match first_insn {
@@ -2774,7 +2772,7 @@ fn iseq_get_return_value( iseq: IseqPtr, captured_opnd: Option<InsnId>, ci_flags
                 return None;
             }
 
-            let ep_offset = unsafe { *rb_iseq_pc_at_idx(iseq, first_insn_idx + 1) }.as_u32();
+            let ep_offset = unsafe { *rb_iseq_pc_at_idx(iseq, 1) }.as_u32();
             let local_idx = ep_offset_to_local_idx(iseq, ep_offset);
 
             // Only inline if the local is a parameter (not a method-defined local) as we are indexing args.
@@ -2792,13 +2790,13 @@ fn iseq_get_return_value( iseq: IseqPtr, captured_opnd: Option<InsnId>, ci_flags
             None
         }
         YARVINSN_putnil => Some(IseqReturn::Value(Qnil)),
-        YARVINSN_putobject => Some(IseqReturn::Value(unsafe { *rb_iseq_pc_at_idx(iseq, first_insn_idx + 1) })),
+        YARVINSN_putobject => Some(IseqReturn::Value(unsafe { *rb_iseq_pc_at_idx(iseq, 1) })),
         YARVINSN_putobject_INT2FIX_0_ => Some(IseqReturn::Value(VALUE::fixnum_from_usize(0))),
         YARVINSN_putobject_INT2FIX_1_ => Some(IseqReturn::Value(VALUE::fixnum_from_usize(1))),
         // We don't support invokeblock for now. Such ISEQs are likely not used by blocks anyway.
         YARVINSN_putself if captured_opnd.is_none() => Some(IseqReturn::Receiver),
         YARVINSN_opt_invokebuiltin_delegate_leave => {
-            let pc = unsafe { rb_iseq_pc_at_idx(iseq, first_insn_idx) };
+            let pc = unsafe { rb_iseq_pc_at_idx(iseq, 0) };
             let bf: *const rb_builtin_function = get_arg(pc, 0).as_ptr();
             let argc = unsafe { (*bf).argc } as usize;
             if argc != 0 { return None; }
@@ -4028,7 +4026,6 @@ impl Function {
         let cd = data.cd;
         let state = data.state;
         let args = &data.args;
-        let jit_entry_idx = data.jit_entry_idx;
         // The trivial inliner runs first to handle simple cases (constant returns,
         // parameter returns, etc.) without frame push/pop overhead. The general
         // inliner then handles more complex methods that require full inlining.
@@ -4038,7 +4035,7 @@ impl Function {
         if ci_flags & VM_CALL_OPT_SEND != 0 {
             return self.push_insn(block, insn);
         }
-        let Some(value) = iseq_get_return_value(iseq, None, ci_flags, jit_entry_idx) else {
+        let Some(value) = iseq_get_return_value(iseq, None, ci_flags) else {
             return self.push_insn(block, insn);
         };
         match value {

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -19287,6 +19287,70 @@ mod hir_opt_tests {
     }
 
     #[test]
+    fn test_inline_method_with_omitted_optional_return_default() {
+        // With the optional omitted, entry 0 runs the default expression and the
+        // trivial inliner can fold the early return.
+        eval("
+            def callee(arg = nil || (return :default))
+              arg
+            end
+            def test = callee
+            test
+            test
+        ");
+        assert_snapshot!(hir_string_with_inlining("test"), @"
+        fn test@<compiled>:5:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          Jump bb3(v1)
+        bb2():
+          EntryPoint JIT(0)
+          v4:BasicObject = LoadArg :self@0
+          Jump bb3(v4)
+        bb3(v6:BasicObject):
+          PatchPoint MethodRedefined(Object@0x1000, callee@0x1008, cme:0x1010)
+          v18:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
+          v19:StaticSymbol[:default] = Const Value(VALUE(0x1038))
+          CheckInterrupts
+          Return v19
+        ");
+    }
+
+    #[test]
+    fn test_inline_method_with_supplied_optional_return_default() {
+        // With the optional supplied, use the selected optional entry instead
+        // of entry 0 so the default-expression return is not inlined.
+        eval("
+            def callee(arg = nil || (return :default))
+              arg
+            end
+            def test = callee(3)
+            test
+            test
+        ");
+        assert_snapshot!(hir_string_with_inlining("test"), @"
+        fn test@<compiled>:5:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          Jump bb3(v1)
+        bb2():
+          EntryPoint JIT(0)
+          v4:BasicObject = LoadArg :self@0
+          Jump bb3(v4)
+        bb3(v6:BasicObject):
+          v11:Fixnum[3] = Const Value(3)
+          PatchPoint MethodRedefined(Object@0x1000, callee@0x1008, cme:0x1010)
+          v20:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
+          PushInlineFrame v20 (0x1038), v11
+          CheckInterrupts
+          PopInlineFrame
+          Return v11
+        ");
+    }
+
+    #[test]
     fn test_inline_method_with_rescue_handler() {
         eval("
             def maybe_rescue(x)

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -19288,8 +19288,8 @@ mod hir_opt_tests {
 
     #[test]
     fn test_inline_method_with_omitted_optional_return_default() {
-        // With the optional omitted, entry 0 runs the default expression and the
-        // trivial inliner can fold the early return.
+        // With the optional omitted, the general inliner enters entry 0 and
+        // runs the default expression path.
         eval("
             def callee(arg = nil || (return :default))
               arg
@@ -19311,16 +19311,20 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint MethodRedefined(Object@0x1000, callee@0x1008, cme:0x1010)
           v18:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
-          v19:StaticSymbol[:default] = Const Value(VALUE(0x1038))
+          v40:NilClass = Const Value(nil)
+          PushInlineFrame v18 (0x1038)
+          v26:StaticSymbol[:default] = Const Value(VALUE(0x1040))
           CheckInterrupts
-          Return v19
+          PopInlineFrame
+          Return v26
         ");
     }
 
     #[test]
     fn test_inline_method_with_supplied_optional_return_default() {
-        // With the optional supplied, use the selected optional entry instead
-        // of entry 0 so the default-expression return is not inlined.
+        // With the optional supplied, the general inliner uses the selected
+        // optional entry instead of entry 0, so the default-expression return
+        // is not inlined.
         eval("
             def callee(arg = nil || (return :default))
               arg


### PR DESCRIPTION
Found while working on https://github.com/ruby/ruby/pull/18061.

Limit the trivial inliner to whole-ISEQ shapes that start at bytecode index 0 and end with the second instruction's `leave`. Optional argument entries can start in the middle of the ISEQ, so keep those `SendDirect` calls for the general inliner, which handles `jit_entry_idx`.

This avoids folding default-argument initialization code when the caller actually supplied the optional positional argument.

```rb
def test(arg = nil || (return :default)) = arg
def entry = test(1)
entry # This should return 1
entry # On master, this returns :default when ZJIT is enabled
```