### PR TITLE
Remove obsolete VM guard macros

### DIFF
--- a/internal.h
+++ b/internal.h
@@ -64,10 +64,6 @@
 /* internal/symbol.h */
 #define rb_sym_intern_ascii_cstr(...) rb_nonexistent_symbol(__VA_ARGS__)
 
-/* internal/vm.h */
-#define rb_funcallv(...) rb_nonexistent_symbol(__VA_ARGS__)
-#define rb_method_basic_definition_p(...) rb_nonexistent_symbol(__VA_ARGS__)
-
 
 /* MRI debug support */
 


### PR DESCRIPTION
These two optimization macros in `internal/vm.h` were "temporarily" removed in commit f2286925f084 for [Feature #16614].  However, since they have not been restored for over six years, the corresponding guards in `internal.h` can now be considered obsolete.