### PR TITLE
[Bug #20958] Fix test_keys_encoding on hosts without en_US.UTF-8

### DIFF
--- a/test/ruby/test_env.rb
+++ b/test/ruby/test_env.rb
@@ -197,6 +197,7 @@ class TestEnv < Test::Unit::TestCase
 
   def test_keys_encoding
     bug20958 = '[ruby-core:120277] [Bug #20958]'
+    omit "locale encoding is not UTF-8" unless ENCODING == Encoding::UTF_8
     orig = ENV.to_hash
     ENV.clear
     key = "TEST20958\u{30c6 30b9 30c8}"
@@ -206,14 +207,15 @@ class TestEnv < Test::Unit::TestCase
       omit "platform does not support UTF-8 environment variables."
     end
     EnvUtil.with_default_internal(nil) do
-      enc = RUBY_PLATFORM =~ /mswin|mingw/ ?
-         Encoding::UTF_8 : Encoding.find("locale")
-      assert_equal(enc, ENV.keys.last.encoding, bug20958)
-      assert_equal(key.encode(enc), ENV.keys.last, bug20958)
+      assert_equal(ENCODING, ENV.keys.last.encoding, bug20958)
+      assert_equal(key.encode(ENCODING), ENV.keys.last, bug20958)
     end
 
     ENV.update(orig) #required to restore ENV[RbConfig::CONFIG['LIBPATHENV']]
-    env = {key => "x", "LOCALE" => "en_US.UTF-8", "LC_ALL" => "en_US.UTF-8"}
+    env = {key => "x"}
+    # invoke_ruby forces the C locale, restore the locale of this process,
+    # which is known to be UTF-8 here.
+    EnvUtil::LANG_ENVS.each {|e| env[e] = ENV[e]}
     load_path = $LOAD_PATH.map {|v| "-I#{v}" }
     internal_enc = "Windows-31J"
     params = [env, *load_path, "-Eutf-8:#{internal_enc}"]


### PR DESCRIPTION
`TestEnv#test_keys_encoding` fails on the debian11 chkbuild host since the test was added, breaking `make test-all` there. The assertion expects the ENV key to be transcoded to the default internal encoding but gets `ASCII-8BIT`.

`EnvUtil.invoke_ruby` forces `LANG`, `LC_ALL` and `LC_CTYPE` to `C` on the child, so the test set `LC_ALL=en_US.UTF-8` to get a UTF-8 locale back. That locale is not generated on that host, `setlocale` falls back to C, and `rb_external_str_with_enc` then tags the key `ASCII-8BIT` and skips the conversion. This fix inherits the locale of the parent process, which the added guard ensures is UTF-8, so no specific locale needs to be installed. Windows is unaffected because `env_encoding()` returns UTF-8 there regardless of the locale, and the guard always passes since `ENCODING` is `Encoding::UTF_8` on Windows.

Verified in a Debian container that has only `C.utf8` and no `en_US.UTF-8`, reproducing the chkbuild condition. The current test fails there with the same `ASCII-8BIT` mismatch, and the fixed test passes. With a non-UTF-8 parent locale it omits instead of failing.

https://rubyci.s3.amazonaws.com/debian11/ruby-master/log/20260725T093003Z.fail.html.gz
