### PR TITLE
Honor RUBY_DUMP_AST environment variable if set

### DIFF
--- a/.github/actions/setup/baseruby/action.yml
+++ b/.github/actions/setup/baseruby/action.yml
@@ -45,7 +45,7 @@ runs:
         ln -sr "$srcdir" "$builddir/.src"
         pushd "$builddir"
         .src/configure "--prefix=${installdir}" --disable-install-doc
-        CONFIGURE_ARGS=--with-out-ext=-test- make install
+        CONFIGURE_ARGS=--with-out-ext=-test- make install dump_ast
         install dump_ast "${installdir}/bin"
         {
           echo "${installdir}/bin/dump_ast"

--- a/.github/actions/setup/directories/action.yml
+++ b/.github/actions/setup/directories/action.yml
@@ -162,6 +162,7 @@ runs:
           sed -f tool/prereq.status template/$mk.in > $mk
         done
         make up
+        echo RUBY_DUMP_AST=true >> "$GITHUB_ENV"
 
     # Cleanup, runs even on failure
     - if: always() && inputs.makeup

--- a/configure.ac
+++ b/configure.ac
@@ -119,12 +119,16 @@ AC_SUBST(X_BUILD_EXEEXT)
 AC_ARG_WITH(dump-ast,
 	AS_HELP_STRING([--with-dump-ast=DUMP_AST], [use DUMP_AST as dump_ast; for cross-compiling with a host-built dump_ast]),
 	[DUMP_AST=$withval DUMP_AST_TARGET='$(empty)'],
-	[AS_IF([test "$cross_compiling" = yes], [
+	[AS_IF([test ${RUBY_DUMP_AST+set}], [
+	    DUMP_AST="${RUBY_DUMP_AST}"
+	    DUMP_AST_TARGET='$(empty)'
+	], [test "$cross_compiling" = yes], [
 	    DUMP_AST='build-tool/dump_ast$(BUILD_EXEEXT)'
+	    DUMP_AST_TARGET='$(DUMP_AST)'
 	], [
 	    DUMP_AST='./dump_ast$(BUILD_EXEEXT)'
-	])
-	DUMP_AST_TARGET='$(DUMP_AST)'])
+	    DUMP_AST_TARGET='$(DUMP_AST)'
+	])])
 dnl Without baseruby, .rbinc files cannot be regenerated, so clear the
 dnl dependency on dump_ast to avoid rebuilding pre-generated .rbinc files.
 AS_IF([test "$HAVE_BASERUBY" = no], [DUMP_AST_TARGET='$(empty)'])

--- a/win32/Makefile.sub
+++ b/win32/Makefile.sub
@@ -567,6 +567,12 @@ ABI_VERSION_HDR = $(hdrdir)/ruby/internal/abi.h
 
 !if defined(DUMP_AST)
 DUMP_AST_TARGET = $(empty)
+!else if defined(RUBY_DUMP_AST)
+DUMP_AST = $(RUBY_DUMP_AST)
+DUMP_AST_TARGET = $(empty)
+!else if "$(CROSS_COMPILING)" == "yes"
+DUMP_AST = ruby-dump_ast$(BUILD_EXEEXT)
+DUMP_AST_TARGET = $(DUMP_AST)
 !else
 DUMP_AST = dump_ast$(BUILD_EXEEXT)
 DUMP_AST_TARGET = $(DUMP_AST)


### PR DESCRIPTION
It is assumed that this variable points to the `dump_ast` command for the build host that has already been installed.