### PR TITLE
Scale ModGC test timeouts by runner and GC

### DIFF
--- a/.github/workflows/modgc.yml
+++ b/.github/workflows/modgc.yml
@@ -137,8 +137,14 @@ jobs:
         if: ${{ matrix.test_task == 'check' && matrix.skipped_tests }}
 
       - name: Set timeout scale
-        run: echo "RUBY_TEST_TIMEOUT_SCALE=10" >> $GITHUB_ENV # subprocess assertion timeouts flake on slower/contended macOS runners, especially with the slower MMTk GC
-        if: ${{ contains(matrix.os, 'macos') }}
+        run: |
+          scale=$((os_scale * gc_scale))
+          echo "RUBY_TEST_TIMEOUT_SCALE=$scale" >> "$GITHUB_ENV"
+        env:
+          # Subprocess assertion timeouts flake on slower or contended macOS
+          # runners and with the slower MMTk GC.
+          os_scale: ${{ contains(matrix.os, 'macos') && 3 || 1 }}
+          gc_scale: ${{ matrix.gc.name == 'mmtk' && 3 || 1 }}
 
       - name: Set up Launchable
         id: launchable


### PR DESCRIPTION
## What

Apply independent timeout scale factors for the operating system and GC used by the ModGC test matrix.

|                    | Default GC | MMTk |
|--------------------|-----------:|-----:|
| Ubuntu             |          1 |    3 |
| macOS              |          3 |    9 |

## Why

`MMTk::TestOOM#test_oom` frequently exceeds the default subprocess timeout on Ubuntu runners.  The existing configuration only scales timeouts on macOS, including default-GC jobs that do not require the same tenfold allowance.

Treating macOS and MMTk as independent slowdown factors extends the Ubuntu MMTk timeout while keeping the configuration consistent across the matrix.

## Verification

- Checked all four timeout-factor combinations in the shell.
- Ran `ruby -c test/mmtk/test_oom.rb`.
- Ran `git diff --check`.
- Ran `actionlint .github/workflows/modgc.yml`; it accepted the changed expressions and reported only pre-existing optional-matrix and local action metadata diagnostics.
