### PR TITLE
[DOC] Fix the return value of IO::Buffer#set_value in its example

### DIFF
--- a/io_buffer.c
+++ b/io_buffer.c
@@ -2537,7 +2537,8 @@ struct io_buffer_set_value_arguments {
  *  call-seq: set_value(type, offset, value) -> offset
  *
  *  Write to a buffer a +value+ of +type+ at +offset+. +type+ should be one of
- *  symbols described in #get_value.
+ *  symbols described in #get_value. Returns the offset just after the written
+ *  value.
  *
  *    buffer = IO::Buffer.new(8)
  *    # =>
@@ -2545,7 +2546,7 @@ struct io_buffer_set_value_arguments {
  *    # 0x00000000  00 00 00 00 00 00 00 00
  *
  *    buffer.set_value(:U8, 1, 111)
- *    # => 1
+ *    # => 2
  *
  *    buffer
  *    # =>
@@ -2577,10 +2578,12 @@ io_buffer_set_value(VALUE self, VALUE type, VALUE _offset, VALUE value)
  *
  *  Write +values+ of +buffer_types+ at +offset+ to the buffer. +buffer_types+
  *  should be an array of symbols as described in #get_value. +values+ should
- *  be an array of values to write.
+ *  be an array of values to write. Returns the offset just after the last
+ *  written value.
  *
  *    buffer = IO::Buffer.new(8)
  *    buffer.set_values([:U8, :U16], 0, [1, 2])
+ *    # => 3
  *    buffer
  *    # =>
  *    # #<IO::Buffer 0x696f717561746978+8 INTERNAL>


### PR DESCRIPTION
The documentation for `IO::Buffer#set_value` shows:

```ruby
buffer.set_value(:U8, 1, 111)
# => 1
```

but it actually returns `2`, the offset just after the written value:

```console
$ ruby -e 'p IO::Buffer.new(8).set_value(:U8, 1, 111)'
2
```

`io_buffer_set_value` passes `&offset` to `rb_io_buffer_set_value`, which
advances it by the size of the written value, and then returns the advanced
offset:

```c
static VALUE
io_buffer_set_value(VALUE self, VALUE type, VALUE _offset, VALUE value)
{
    struct rb_io_buffer *buffer = get_io_buffer_for_writing(self);
    size_t offset = io_buffer_extract_offset(_offset);
    rb_io_buffer_set_value(buffer, type, &offset, value);
    return SIZET2NUM(offset);
}
```

This changed in 025b8701c09813c40339bd8fa1c75e0e5eaf7120 (#6434, released in
3.2.0); before that the method returned the given offset, so the example was
correct when it was written. Checked with all-ruby:

```
3.1.6  => 1
3.2.11 => 2
3.3.12 => 2
3.4.10 => 2
4.0.6  => 2
```

I also stated the return value explicitly for both `set_value` and
`set_values`. The call-seq says `-> offset`, which reads as if the given offset
were returned. `set_values` returns the offset after the last written value in
the same way (`3` for the example in its documentation), so I added that to its
example too.

Documentation only; no behavior change.
