### PR TITLE
Add NativeSorbet VM hooks for native type-checking

### DIFF
--- a/insns.def
+++ b/insns.def
@@ -1191,6 +1191,12 @@ leave
         }
     }
 
+    /* NativeSorbet: targeted return type-check. `leave` runs only on normal
+     * return, so exception unwinding never reaches here (no masking). */
+    if (UNLIKELY(ISEQ_BODY(GET_ISEQ())->typecheck != NULL)) {
+        rb_native_tc_return(ec, GET_CFP(), ISEQ_BODY(GET_ISEQ())->typecheck, val);
+    }
+
     if (vm_pop_frame(ec, GET_CFP(), GET_EP())) {
 #if OPT_CALL_THREADED_CODE
         rb_ec_thread_ptr(ec)->retval = val;

--- a/iseq.c
+++ b/iseq.c
@@ -2047,6 +2047,37 @@ rb_iseqw_to_iseq(VALUE iseqw)
     return iseqw_check(iseqw);
 }
 
+/* ---- NativeSorbet: targeted native type-check callbacks ---- */
+static void
+tc_noop_entry(rb_execution_context_t *ec, rb_control_frame_t *cfp, void *data)
+{
+    (void)ec; (void)cfp; (void)data;
+}
+static void
+tc_noop_return(rb_execution_context_t *ec, rb_control_frame_t *cfp, void *data, VALUE retval)
+{
+    (void)ec; (void)cfp; (void)data; (void)retval;
+}
+
+rb_native_tc_entry_func_t rb_native_tc_entry = tc_noop_entry;
+rb_native_tc_return_func_t rb_native_tc_return = tc_noop_return;
+
+void
+rb_native_tc_set_hooks(rb_native_tc_entry_func_t entry, rb_native_tc_return_func_t ret)
+{
+    rb_native_tc_entry = entry ? entry : tc_noop_entry;
+    rb_native_tc_return = ret ? ret : tc_noop_return;
+}
+
+/* Attach (or clear, if data == NULL) precomputed type-check metadata to the
+ * iseq underlying an InstructionSequence wrapper (RubyVM::InstructionSequence.of). */
+void
+rb_native_tc_attach(VALUE iseqw, void *data)
+{
+    const rb_iseq_t *iseq = rb_iseqw_to_iseq(iseqw);
+    ((struct rb_iseq_constant_body *)ISEQ_BODY(iseq))->typecheck = data;
+}
+
 /*
  *  call-seq:
  *     iseq.eval -> obj

--- a/vm_core.h
+++ b/vm_core.h
@@ -574,6 +574,13 @@ struct rb_iseq_constant_body {
     // ZJIT stores some data on each iseq.
     void *zjit_payload;
 #endif
+
+    /* NativeSorbet: optional pointer to precomputed native type-check metadata
+     * for this method. NULL (the ZALLOC default) for every method without a
+     * registered signature, so the per-call cost is a single load + predicted-
+     * not-taken branch. Set via rb_native_tc_attach(). Placed last so adding it
+     * does not shift any existing field offset. */
+    void *typecheck;
 };
 
 /* T_IMEMO/iseq */
@@ -1127,6 +1134,20 @@ struct rb_execution_context_struct {
 typedef struct rb_execution_context_struct rb_execution_context_t;
 #define rb_execution_context_t rb_execution_context_t
 #endif
+
+/* NativeSorbet: targeted native type-check callbacks. When an iseq's
+ * `body->typecheck` is non-NULL, the VM invokes these at method entry and on
+ * normal return (`leave`). Registered by an extension via rb_native_tc_set_hooks. */
+typedef void (*rb_native_tc_entry_func_t)(rb_execution_context_t *ec, rb_control_frame_t *cfp, void *data);
+typedef void (*rb_native_tc_return_func_t)(rb_execution_context_t *ec, rb_control_frame_t *cfp, void *data, VALUE retval);
+RUBY_EXTERN rb_native_tc_entry_func_t rb_native_tc_entry;
+RUBY_EXTERN rb_native_tc_return_func_t rb_native_tc_return;
+/* Exported so a native extension can resolve them at dlopen time (ruby is not
+ * linked -rdynamic; only RUBY_SYMBOL_EXPORT-marked symbols land in .dynsym). */
+RUBY_SYMBOL_EXPORT_BEGIN
+void rb_native_tc_set_hooks(rb_native_tc_entry_func_t entry, rb_native_tc_return_func_t ret);
+void rb_native_tc_attach(VALUE iseqw, void *data);
+RUBY_SYMBOL_EXPORT_END
 
 // for builtin.h
 #define VM_CORE_H_EC_DEFINED 1

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -3415,6 +3415,12 @@ vm_call_iseq_setup_normal(rb_execution_context_t *ec, rb_control_frame_t *cfp, s
                   ISEQ_BODY(iseq)->iseq_encoded + opt_pc, sp,
                   local_size - param_size,
                   ISEQ_BODY(iseq)->stack_max);
+
+    /* NativeSorbet: targeted argument type-check. Common case is a single
+     * predicted-not-taken branch; the callback reads args off ec->cfp->ep. */
+    if (UNLIKELY(ISEQ_BODY(iseq)->typecheck != NULL)) {
+        rb_native_tc_entry(ec, ec->cfp, ISEQ_BODY(iseq)->typecheck);
+    }
     return Qundef;
 }
 


### PR DESCRIPTION
Adds rb_native_tc_attach / rb_native_tc_set_hooks / rb_native_tc_entry / rb_native_tc_return to enable a native extension to perform Sorbet runtime type checks directly from C, without Ruby-level method wrappers.

A `void *typecheck` field is added to rb_iseq_constant_body (NULL by default). When non-NULL, the VM calls the registered entry hook after pushing the frame in vm_call_iseq_setup_normal, and the return hook from the `leave` instruction. Cost for un-sig'd methods: one load + predicted-not-taken branch.

Extracted from stripe-internal/mint branch fable/USE_NATIVE_SORBET-sorbetoptimize.


Committed-By-Agent: claude