### PR TITLE
[DOC] Fix the buffer size in the IO::Buffer#& example

### DIFF
--- a/io_buffer.c
+++ b/io_buffer.c
@@ -3540,7 +3540,7 @@ memory_and(unsigned char * restrict output, const unsigned char * restrict base,
  *
  *    IO::Buffer.for("1234567890") & IO::Buffer.for("\xFF\x00\x00\xFF")
  *    # =>
- *    # #<IO::Buffer 0x00005589b2758480+4 INTERNAL>
+ *    # #<IO::Buffer 0x00005589b2758480+10 INTERNAL>
  *    # 0x00000000  31 00 00 34 35 00 00 38 39 00                   1..45..89.
  */
 static VALUE


### PR DESCRIPTION
The example for `IO::Buffer#&` shows the result as `+4`:

```
 *    IO::Buffer.for("1234567890") & IO::Buffer.for("\xFF\x00\x00\xFF")
 *    # =>
 *    # #<IO::Buffer 0x00005589b2758480+4 INTERNAL>
 *    # 0x00000000  31 00 00 34 35 00 00 38 39 00                   1..45..89.
```

but the operation returns a buffer of the same size as the source, which is
10 bytes here:

```console
$ ruby -e 'Warning[:experimental] = false; p((IO::Buffer.for("1234567890") & IO::Buffer.for("\xFF\x00\x00\xFF")).size)'
10
```

The actual output (address masked) is:

```
#<IO::Buffer 0xADDR+10 INTERNAL>
0x00000000  31 00 00 34 35 00 00 38 39 00                   1..45..89.
```

The rest of the example is already correct: the hex dump and the ASCII column
show all 10 bytes. The description right above the example also says
"Generate a new buffer **the same size as the source**", so the `+4` contradicts
both the description and the rest of its own example. The size of the mask is 4,
which is likely where the number came from.

The neighbouring examples for `#|`, `#^` and `#~` all show `+10` and need no
change. Checked with 3.2.11, 3.4.10 and 4.0.6; all three produce `+10`.

Documentation only; no behavior change.
