### PR TITLE
Enable long path names on Windows without the registry value

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -229,9 +229,10 @@ Ruby 4.0 bundled RubyGems and Bundler version 4. see the following links for det
     * BSD/OS (BSDi)
 
 * Windows 10 1703 or later no longer needs the `LongPathsEnabled` registry
-  value to use paths longer than 260 characters.  Each path component is still
-  limited to 255 characters, and a child process still starts with the
-  `MAX_PATH` limited current directory. [[Bug #18947]]
+  value to use paths longer than 260 characters.  This applies to any process
+  running the interpreter, including a program which embeds libruby.  Each path
+  component is still limited to 255 characters, and a child process still
+  starts with the `MAX_PATH` limited current directory. [[Bug #18947]]
 
 ## Compatibility issues
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -244,6 +244,11 @@ Ruby 4.0 bundled RubyGems and Bundler version 4. see the following links for det
     * SunOS 4 (Solaris, i.e. SunOS 5, is unaffected)
     * BSD/OS (BSDi)
 
+* Windows 10 1703 or later no longer needs the `LongPathsEnabled` registry
+  value to use paths longer than 260 characters.  Each path component is still
+  limited to 255 characters, and a child process still starts with the
+  `MAX_PATH` limited current directory. [[Bug #18947]]
+
 ## Compatibility issues
 
 * `Kernel#at_exit` and `END {}` now raise `Ractor::IsolationError` when called
@@ -327,6 +332,7 @@ A lot of work has gone into making Ractors more stable, performant, and usable. 
 
 ## JIT
 
+[Bug #18947]: https://bugs.ruby-lang.org/issues/18947
 [Feature #8948]: https://bugs.ruby-lang.org/issues/8948
 [Feature #9779]: https://bugs.ruby-lang.org/issues/9779
 [Feature #15330]: https://bugs.ruby-lang.org/issues/15330

--- a/NEWS.md
+++ b/NEWS.md
@@ -245,9 +245,10 @@ Ruby 4.0 bundled RubyGems and Bundler version 4. see the following links for det
     * BSD/OS (BSDi)
 
 * Windows 10 1703 or later no longer needs the `LongPathsEnabled` registry
-  value to use paths longer than 260 characters.  Each path component is still
-  limited to 255 characters, and a child process still starts with the
-  `MAX_PATH` limited current directory. [[Bug #18947]]
+  value to use paths longer than 260 characters.  This applies to any process
+  running the interpreter, including a program which embeds libruby.  Each path
+  component is still limited to 255 characters, and a child process still
+  starts with the `MAX_PATH` limited current directory. [[Bug #18947]]
 
 ## Compatibility issues
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -228,6 +228,11 @@ Ruby 4.0 bundled RubyGems and Bundler version 4. see the following links for det
     * SunOS 4 (Solaris, i.e. SunOS 5, is unaffected)
     * BSD/OS (BSDi)
 
+* Windows 10 1703 or later no longer needs the `LongPathsEnabled` registry
+  value to use paths longer than 260 characters.  Each path component is still
+  limited to 255 characters, and a child process still starts with the
+  `MAX_PATH` limited current directory. [[Bug #18947]]
+
 ## Compatibility issues
 
 * `Kernel#at_exit` and `END {}` now raise `Ractor::IsolationError` when called
@@ -292,6 +297,7 @@ A lot of work has gone into making Ractors more stable, performant, and usable. 
 
 ## JIT
 
+[Bug #18947]: https://bugs.ruby-lang.org/issues/18947
 [Feature #8948]: https://bugs.ruby-lang.org/issues/8948
 [Feature #15330]: https://bugs.ruby-lang.org/issues/15330
 [Feature #20163]: https://bugs.ruby-lang.org/issues/20163

--- a/eval.c
+++ b/eval.c
@@ -77,6 +77,9 @@ ruby_setup(void)
 #if defined(__linux__) && defined(PR_SET_THP_DISABLE)
     prctl(PR_SET_THP_DISABLE, 1, 0, 0, 0);
 #endif
+#if defined(_WIN32)
+    rb_w32_init_long_paths();
+#endif
     Init_BareVM();
     rb_vm_encoded_insn_data_table_init();
     Init_enable_box();

--- a/internal.h
+++ b/internal.h
@@ -64,6 +64,11 @@
 /* internal/symbol.h */
 #define rb_sym_intern_ascii_cstr(...) rb_nonexistent_symbol(__VA_ARGS__)
 
+#ifdef _WIN32
+/* win32/win32.c */
+void rb_w32_init_long_paths(void);
+#endif
+
 
 /* MRI debug support */
 

--- a/test/ruby/test_dir.rb
+++ b/test/ruby/test_dir.rb
@@ -590,6 +590,22 @@ class TestDir < Test::Unit::TestCase
       assert_empty(entries - Dir.glob("#{wild}/Common*", File::FNM_SHORTNAME), bug10819)
     end
 
+    def test_glob_long_path
+      bug18923 = '[Bug #18923]'
+      # the whole path is longer than MAX_PATH, while each component is
+      # within the 255 chars limit of NTFS
+      deep = File.join(@root, "a" * 200, "b" * 200)
+      begin
+        FileUtils.mkdir_p(deep)
+      rescue SystemCallError
+        omit "long path names are not available"
+      end
+      file = File.join(deep, "c.txt")
+      File.write(file, "")
+      assert_equal([file], Dir.glob(File.join(@root, "**", "*.txt")), bug18923)
+      assert_equal(["c.txt"], Dir.children(deep), bug18923)
+    end
+
     def test_home_windows
       setup_envs(%w[HOME USERPROFILE HOMEDRIVE HOMEPATH])
 

--- a/win32/win32.c
+++ b/win32/win32.c
@@ -843,6 +843,44 @@ static int w32_cmdvector(const WCHAR *, char ***, UINT, rb_encoding *);
 //
 // Initialization stuff
 //
+
+/* License: Ruby's */
+/* Enable long path names for this process, whatever the registry value
+ * HKLM\SYSTEM\CurrentControlSet\Control\FileSystem\LongPathsEnabled is.  The
+ * loader sets the same PEB bit for longPathAware in the manifest, but only
+ * when that registry value is set, so the manifest alone is not enough on a
+ * stock machine.  Undocumented, and taken from initLongPathSupport in Go's
+ * runtime <https://go.dev/src/runtime/os_windows.go>, whose maintainers have
+ * proposed to drop it <https://github.com/golang/go/issues/66560>. */
+static void
+init_long_path_support(void)
+{
+    /* PEB.BitField, and the IsLongPathAwareProcess bit in it */
+    enum {peb_bit_field_offset = 3, is_long_path_aware_process = 0x80};
+    typedef long (WINAPI version_func)(OSVERSIONINFOW *);
+    typedef void *(WINAPI peb_func)(void);
+    version_func *pRtlGetVersion;
+    peb_func *pRtlGetCurrentPeb;
+    OSVERSIONINFOW osvi;
+    BYTE *bit_field;
+
+    pRtlGetVersion = (version_func *)get_proc_address("ntdll.dll", "RtlGetVersion", NULL);
+    if (!pRtlGetVersion) return;
+    memset(&osvi, 0, sizeof(osvi));
+    osvi.dwOSVersionInfoSize = sizeof(osvi);
+    if (pRtlGetVersion(&osvi)) return;
+
+    /* the PEB bit is honored since Windows 10 1703 (10.0.15063) */
+    if (osvi.dwMajorVersion < 10) return;
+    if (osvi.dwMajorVersion == 10 && osvi.dwMinorVersion == 0 &&
+        osvi.dwBuildNumber < 15063) return;
+
+    pRtlGetCurrentPeb = (peb_func *)get_proc_address("ntdll.dll", "RtlGetCurrentPeb", NULL);
+    if (!pRtlGetCurrentPeb) return;
+    bit_field = (BYTE *)pRtlGetCurrentPeb() + peb_bit_field_offset;
+    *bit_field |= is_long_path_aware_process;
+}
+
 /* License: Ruby's */
 void
 rb_w32_sysinit(int *argc, char ***argv)
@@ -854,6 +892,7 @@ rb_w32_sysinit(int *argc, char ***argv)
     SetErrorMode(SEM_FAILCRITICALERRORS|SEM_NOGPFAULTERRORBOX);
 
     get_version();
+    init_long_path_support();
 
     //
     // subvert cmd.exe's feeble attempt at command line parsing

--- a/win32/win32.c
+++ b/win32/win32.c
@@ -851,18 +851,26 @@ static int w32_cmdvector(const WCHAR *, char ***, UINT, rb_encoding *);
  * when that registry value is set, so the manifest alone is not enough on a
  * stock machine.  Undocumented, and taken from initLongPathSupport in Go's
  * runtime <https://go.dev/src/runtime/os_windows.go>, whose maintainers have
- * proposed to drop it <https://github.com/golang/go/issues/66560>. */
-static void
-init_long_path_support(void)
+ * proposed to drop it <https://github.com/golang/go/issues/66560>.
+ *
+ * Called from rb_w32_sysinit, which runs before the VM exists, and from
+ * ruby_setup, so that a program which embeds libruby without calling
+ * ruby_sysinit gets it as well. */
+void
+rb_w32_init_long_paths(void)
 {
     /* PEB.BitField, and the IsLongPathAwareProcess bit in it */
     enum {peb_bit_field_offset = 3, is_long_path_aware_process = 0x80};
     typedef long (WINAPI version_func)(OSVERSIONINFOW *);
     typedef void *(WINAPI peb_func)(void);
+    static int done = 0;
     version_func *pRtlGetVersion;
     peb_func *pRtlGetCurrentPeb;
     OSVERSIONINFOW osvi;
     BYTE *bit_field;
+
+    if (done) return;
+    done = 1;
 
     pRtlGetVersion = (version_func *)get_proc_address("ntdll.dll", "RtlGetVersion", NULL);
     if (!pRtlGetVersion) return;
@@ -892,7 +900,7 @@ rb_w32_sysinit(int *argc, char ***argv)
     SetErrorMode(SEM_FAILCRITICALERRORS|SEM_NOGPFAULTERRORBOX);
 
     get_version();
-    init_long_path_support();
+    rb_w32_init_long_paths();
 
     //
     // subvert cmd.exe's feeble attempt at command line parsing

--- a/win32/win32.c
+++ b/win32/win32.c
@@ -853,9 +853,8 @@ static int w32_cmdvector(const WCHAR *, char ***, UINT, rb_encoding *);
  * runtime <https://go.dev/src/runtime/os_windows.go>, whose maintainers have
  * proposed to drop it <https://github.com/golang/go/issues/66560>.
  *
- * Called from rb_w32_sysinit, which runs before the VM exists, and from
- * ruby_setup, so that a program which embeds libruby without calling
- * ruby_sysinit gets it as well. */
+ * Called from ruby_setup, not from rb_w32_sysinit, which a program that
+ * embeds libruby is not expected to call. */
 void
 rb_w32_init_long_paths(void)
 {
@@ -863,14 +862,10 @@ rb_w32_init_long_paths(void)
     enum {peb_bit_field_offset = 3, is_long_path_aware_process = 0x80};
     typedef long (WINAPI version_func)(OSVERSIONINFOW *);
     typedef void *(WINAPI peb_func)(void);
-    static int done = 0;
     version_func *pRtlGetVersion;
     peb_func *pRtlGetCurrentPeb;
     OSVERSIONINFOW osvi;
     BYTE *bit_field;
-
-    if (done) return;
-    done = 1;
 
     pRtlGetVersion = (version_func *)get_proc_address("ntdll.dll", "RtlGetVersion", NULL);
     if (!pRtlGetVersion) return;
@@ -900,7 +895,6 @@ rb_w32_sysinit(int *argc, char ***argv)
     SetErrorMode(SEM_FAILCRITICALERRORS|SEM_NOGPFAULTERRORBOX);
 
     get_version();
-    rb_w32_init_long_paths();
 
     //
     // subvert cmd.exe's feeble attempt at command line parsing


### PR DESCRIPTION
Ruby ships `win32/ruby.manifest` with `longPathAware`, but Windows honors it only when the registry value `LongPathsEnabled` is set, which is 0 by default. On a stock machine `Pathname#children` and `Dir.glob` still fail on a directory `FileUtils.mkpath` just created.

`rb_w32_sysinit` now sets the undocumented `IsLongPathAwareProcess` bit in the PEB, the same bit the loader sets from the manifest and the one `RtlAreLongPathsEnabled` reads. Go's runtime has done this since 1.23, so I followed it, including the `RtlGetVersion` gate for Windows 10 1703 and later. Microsoft's Go maintainers have proposed removing it in golang/go#66560.

Verified on 10.0.26200 with `LongPathsEnabled` at 0. A 420 character path works for `File`, `Dir`, `Dir.glob`, `require`, and `Dir.chdir`, where master fails. A component over 255 characters still raises `Errno::EINVAL`, and spawning from a long current directory still fails.

The added test asserts the asymmetry the reports describe rather than long path support itself, since a runner with the registry enabled passes either way.
