### PR TITLE
Optimize `&` and `|` on special constants

### DIFF
--- a/benchmark/bop_opt_and_or.yml
+++ b/benchmark/bop_opt_and_or.yml
@@ -1,0 +1,14 @@
+benchmark:
+  true_and_true:  true & true
+  true_and_false: true & false
+  true_and_nil:   true & nil
+  false_and_true: false & true
+  true_or_false:  true | false
+  false_or_true:  false | true
+  false_or_nil:   false | nil
+  nil_or_true:    nil | true
+  nil_or_nil:     nil | nil
+  integer_and:    123 & 456
+
+loop_count:
+  2000000

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -6975,7 +6975,17 @@ vm_opt_and(VALUE recv, VALUE obj)
         OP_UNREDEFINED_P(AND, INTEGER)) {
         return ret;
     }
-    else {
+    switch (recv) {
+      case Qtrue:
+        if (!OP_UNREDEFINED_P(AND, TRUE)) return Qundef;
+        return RBOOL(RTEST(obj));
+      case Qfalse:
+        if (!OP_UNREDEFINED_P(AND, FALSE)) return Qundef;
+        return Qfalse;
+      case Qnil:
+        if (!OP_UNREDEFINED_P(AND, NIL)) return Qundef;
+        return Qfalse;
+      default:
         return Qundef;
     }
 }
@@ -6987,7 +6997,17 @@ vm_opt_or(VALUE recv, VALUE obj)
         OP_UNREDEFINED_P(OR, INTEGER)) {
         return recv | obj;
     }
-    else {
+    switch (recv) {
+      case Qtrue:
+        if (!OP_UNREDEFINED_P(OR, TRUE)) return Qundef;
+        return Qtrue;
+      case Qfalse:
+        if (!OP_UNREDEFINED_P(OR, FALSE)) return Qundef;
+        return RBOOL(RTEST(obj));
+      case Qnil:
+        if (!OP_UNREDEFINED_P(OR, NIL)) return Qundef;
+        return RBOOL(RTEST(obj));
+      default:
         return Qundef;
     }
 }


### PR DESCRIPTION
Handle `TrueClass`, `FalseClass`, and `NilClass` directly in `vm_opt_and` and `vm_opt_or` when their operators are unmodified to avoid method dispatch while preserving redefined operators through the existing `Qundef` fallback.

## Benchmark

Measured on Apple Silicon with Apple Clang 21, `-O3`, and YJIT/ZJIT disabled.

| Expression | Improvement |
|:----------:|------------:|
| `true & true` | 32.6% |
| `true & false` | 32.8% |
| `true & nil` | 39.5% |
| `false & true` | 41.7% |
| `true \| false` | 39.8% |
| `false \| true` | 34.8% |
| `false \| nil` | 40.9% |
| `nil \| true` | 23.2% |
| `nil \| nil` | 20.7% |

