### PR TITLE
Fix vm_once_dispatch when multiple Ractors are racing to exec the iseq

### DIFF
--- a/test/ruby/test_ractor.rb
+++ b/test/ruby/test_ractor.rb
@@ -419,6 +419,21 @@ class TestRactor < Test::Unit::TestCase
     RUBY
   end
 
+  def test_ractor_vm_once_dispatch
+    assert_ractor(<<~'RUBY', args: ["-W0"], timeout: 30)
+      vals = 10.times.map do
+        Ractor.new {
+          a = nil
+          /#{sleep 0.1; a = "set"}/o
+          a
+        }
+      end.map(&:value)
+      vals.compact!
+      assert_equal 1, vals.size
+      assert_equal "set", vals.first
+    RUBY
+  end
+
   def assert_make_shareable(obj)
     refute Ractor.shareable?(obj), "object was already shareable"
     Ractor.make_shareable(obj)

--- a/thread.c
+++ b/thread.c
@@ -5083,6 +5083,8 @@ rb_thread_atfork_internal(rb_thread_t *th, void (*atfork)(rb_thread_t *, const r
 
     /* may be held by any thread in parent */
     rb_native_mutex_initialize(&th->interrupt_lock);
+    rb_native_mutex_initialize(&vm->once_lock);
+    rb_native_cond_initialize(&vm->once_cond);
     ccan_list_head_init(&th->interrupt_exec_tasks);
 
     vm->fork_gen++;
@@ -5755,6 +5757,8 @@ Init_Thread_Mutex(void)
     rb_thread_t *th = GET_THREAD();
 
     rb_native_mutex_initialize(&th->vm->workqueue_lock);
+    rb_native_mutex_initialize(&th->vm->once_lock);
+    rb_native_cond_initialize(&th->vm->once_cond);
     rb_native_mutex_initialize(&th->interrupt_lock);
 }
 

--- a/vm.c
+++ b/vm.c
@@ -3566,6 +3566,8 @@ ruby_vm_destruct(rb_vm_t *vm)
             rb_objspace_free(objspace);
         }
         rb_native_mutex_destroy(&vm->workqueue_lock);
+        rb_native_mutex_destroy(&vm->once_lock);
+        rb_native_cond_destroy(&vm->once_cond);
         /* after freeing objspace, you *can't* use ruby_xfree() */
         ruby_current_vm_ptr = NULL;
 

--- a/vm_core.h
+++ b/vm_core.h
@@ -802,6 +802,10 @@ typedef struct rb_vm_struct {
     struct ccan_list_head workqueue; /* <=> rb_workqueue_job.jnode */
     rb_nativethread_lock_t workqueue_lock;
 
+    /* `once` completion event (see vm_once_dispatch) */
+    rb_nativethread_lock_t once_lock;
+    rb_nativethread_cond_t once_cond;
+
     VALUE orig_progname, progname;
     VALUE coverages, me2counter;
     int coverage_mode;

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -5503,7 +5503,7 @@ static VALUE
 vm_once_clear(VALUE data)
 {
     union iseq_inline_storage_entry *is = (union iseq_inline_storage_entry *)data;
-    is->once.running_thread = NULL;
+    rbimpl_atomic_ptr_store((volatile void **)&is->once.running_thread, NULL, RBIMPL_ATOMIC_RELEASE);
     return Qnil;
 }
 
@@ -6606,33 +6606,46 @@ vm_once_dispatch(rb_execution_context_t *ec, ISEQ iseq, ISE is)
 {
     rb_thread_t *th = rb_ec_thread_ptr(ec);
     rb_thread_t *const RUNNING_THREAD_ONCE_DONE = (rb_thread_t *)(0x1);
+    rb_thread_t *running_th;
 
   again:
-    if (is->once.running_thread == RUNNING_THREAD_ONCE_DONE) {
+    running_th = rbimpl_atomic_ptr_load((void**)&is->once.running_thread, RBIMPL_ATOMIC_ACQUIRE);
+    if (running_th == RUNNING_THREAD_ONCE_DONE) {
         return is->once.value;
     }
-    else if (is->once.running_thread == NULL) {
-        VALUE val;
-        is->once.running_thread = th;
-        val = rb_ensure(vm_once_exec, (VALUE)iseq, vm_once_clear, (VALUE)is);
-        // TODO: confirm that it is shareable
+    else if (running_th == NULL) {
+        VALUE val = Qundef;
+        enum ruby_tag_type state;
+        if (rbimpl_atomic_ptr_cas((void**)&is->once.running_thread, running_th, th, RBIMPL_ATOMIC_RELEASE, RBIMPL_ATOMIC_RELAXED) != running_th) {
+            goto again;
+        }
+        EC_PUSH_TAG(ec);
+        if ((state = EC_EXEC_TAG()) == TAG_NONE) {
+            val = vm_once_exec((VALUE)iseq);
+        }
+        EC_POP_TAG();
+        if (state != TAG_NONE) {
+            vm_once_clear((VALUE)is);
+            EC_JUMP_TAG(ec, state);
+        }
 
+        // TODO: confirm that it is shareable
         if (RB_FL_ABLE(val)) {
             RB_OBJ_SET_SHAREABLE(val);
         }
 
         RB_OBJ_WRITE(CFP_ISEQ(ec->cfp), &is->once.value, val);
 
-        /* is->once.running_thread is cleared by vm_once_clear() */
-        is->once.running_thread = RUNNING_THREAD_ONCE_DONE; /* success */
+        rbimpl_atomic_ptr_store((volatile void**)&is->once.running_thread, RUNNING_THREAD_ONCE_DONE, RBIMPL_ATOMIC_RELEASE); /* success */
         return val;
     }
-    else if (is->once.running_thread == th) {
+    else if (running_th == th) {
         /* recursive once */
         return vm_once_exec((VALUE)iseq);
     }
     else {
         /* waiting for finish */
+        /* NOTE: this is not ideal if we're the only thread in the Ractor (it's a busy loop!) */
         RUBY_VM_CHECK_INTS(ec);
         rb_thread_schedule();
         goto again;

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -28,6 +28,7 @@
 #include "internal/variable.h"
 #include "internal/set_table.h"
 #include "internal/struct.h"
+#include "ruby/thread.h"
 #include "variable.h"
 
 /* finish iseq array */
@@ -5499,11 +5500,49 @@ vm_once_exec(VALUE iseq)
     return rb_proc_call_with_block(proc, 0, 0, Qnil);
 }
 
+#define RUNNING_THREAD_ONCE_DONE ((rb_thread_t *)0x1)
+
+struct vm_once_wait_arg {
+    rb_vm_t *vm;
+    union iseq_inline_storage_entry *is;
+};
+
+static void
+vm_once_broadcast(rb_vm_t *vm)
+{
+    rb_native_mutex_lock(&vm->once_lock);
+    rb_native_cond_broadcast(&vm->once_cond);
+    rb_native_mutex_unlock(&vm->once_lock);
+}
+
+static void *
+vm_once_wait_no_gvl(void *ptr)
+{
+    struct vm_once_wait_arg *arg = (struct vm_once_wait_arg *)ptr;
+    rb_vm_t *vm = arg->vm;
+    rb_thread_t *running_th;
+
+    rb_native_mutex_lock(&vm->once_lock);
+    running_th = rbimpl_atomic_ptr_load((void **)&arg->is->once.running_thread, RBIMPL_ATOMIC_ACQUIRE);
+    if (running_th != NULL && running_th != RUNNING_THREAD_ONCE_DONE) {
+        rb_native_cond_wait(&vm->once_cond, &vm->once_lock);
+    }
+    rb_native_mutex_unlock(&vm->once_lock);
+    return NULL;
+}
+
+static void
+vm_once_wait_ubf(void *ptr)
+{
+    vm_once_broadcast((rb_vm_t *)ptr);
+}
+
 static VALUE
 vm_once_clear(VALUE data)
 {
     union iseq_inline_storage_entry *is = (union iseq_inline_storage_entry *)data;
     rbimpl_atomic_ptr_store((volatile void **)&is->once.running_thread, NULL, RBIMPL_ATOMIC_RELEASE);
+    vm_once_broadcast(GET_VM());
     return Qnil;
 }
 
@@ -6605,7 +6644,6 @@ static VALUE
 vm_once_dispatch(rb_execution_context_t *ec, ISEQ iseq, ISE is)
 {
     rb_thread_t *th = rb_ec_thread_ptr(ec);
-    rb_thread_t *const RUNNING_THREAD_ONCE_DONE = (rb_thread_t *)(0x1);
     rb_thread_t *running_th;
 
   again:
@@ -6637,6 +6675,7 @@ vm_once_dispatch(rb_execution_context_t *ec, ISEQ iseq, ISE is)
         RB_OBJ_WRITE(CFP_ISEQ(ec->cfp), &is->once.value, val);
 
         rbimpl_atomic_ptr_store((volatile void**)&is->once.running_thread, RUNNING_THREAD_ONCE_DONE, RBIMPL_ATOMIC_RELEASE); /* success */
+        vm_once_broadcast(rb_ec_vm_ptr(ec));
         return val;
     }
     else if (running_th == th) {
@@ -6644,10 +6683,11 @@ vm_once_dispatch(rb_execution_context_t *ec, ISEQ iseq, ISE is)
         return vm_once_exec((VALUE)iseq);
     }
     else {
-        /* waiting for finish */
-        /* NOTE: this is not ideal if we're the only thread in the Ractor (it's a busy loop!) */
+        /* wait for the winner to finish */
+        struct vm_once_wait_arg arg = { .vm = rb_ec_vm_ptr(ec), .is = is };
+        rb_nogvl(vm_once_wait_no_gvl, &arg, vm_once_wait_ubf, arg.vm,
+                 RB_NOGVL_UBF_ASYNC_SAFE | RB_NOGVL_INTR_FAIL);
         RUBY_VM_CHECK_INTS(ec);
-        rb_thread_schedule();
         goto again;
     }
 }


### PR DESCRIPTION
The `once` insn (ex: for interpolated regexp with /o option) should only be executed once even across Ractors. The `once` value is associated with the iseq, which is shared across Ractors.

Ideally, waiting threads in other Ractors would be put in a queue and signalled when the winning thread in another Ractor wins the race and executes the iseq successfully. For now, there's potential for busy looping when Ractors wait on each other. However, the bug is fixed and the iseq will only be executed once.