### PR TITLE
[Bug #22214] Raise TypeError for uninitialized Ractor::Port

### DIFF
--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -2715,3 +2715,40 @@ assert_equal 'ok', %q{
   r.send(nil)
   r.value
 }
+
+# Ractor::Port.allocate leaves the owner Ractor NULL, so every method reachable
+# from Ruby must reject such a port instead of dereferencing it. [Bug #22214]
+assert_equal 'ok', %q{
+  port = Ractor::Port.allocate
+
+  messages = [
+    -> { port.send(1) },
+    -> { port << 1 },
+    -> { port.receive },
+    -> { port.close },
+    -> { port.closed? },
+    -> { port.inspect },
+    -> { Ractor::Port.new.__send__(:initialize_copy, port) },
+    -> { Ractor.new { :x }.monitor(port) },
+    -> { Ractor.new { :x }.unmonitor(port) },
+    -> { Ractor.select(port) },
+  ].map do |blk|
+    begin
+      blk.call
+      'not raised'
+    rescue TypeError => e
+      e.message
+    end
+  end
+
+  messages.uniq == ['uninitialized Ractor::Port'] ? :ok : messages
+}
+
+assert_equal 'uninitialized MyPort', %q{
+  class MyPort < Ractor::Port; end
+  begin
+    MyPort.allocate.closed?
+  rescue TypeError => e
+    e.message
+  end
+}

--- a/ractor.rb
+++ b/ractor.rb
@@ -825,7 +825,6 @@ class Ractor
     #
     # Returns whether or not the port is closed.
     def closed?
-      Primitive.attr! :leaf
       __builtin_cexpr! %q{
         ractor_port_closed_p(ec, self);
       }
@@ -836,7 +835,7 @@ class Ractor
     #    port.inspect -> string
     def inspect
       "#<Ractor::Port to:\##{
-        __builtin_cexpr! "SIZET2NUM(rb_ractor_id((RACTOR_PORT_PTR(self)->r)))"
+        __builtin_cexpr! "SIZET2NUM(rb_ractor_id(ractor_port_ptr_check(self)->r))"
       } id:#{
         __builtin_cexpr! "SIZET2NUM(ractor_port_id(RACTOR_PORT_PTR(self)))"
       }>"

--- a/ractor_sync.c
+++ b/ractor_sync.c
@@ -53,6 +53,19 @@ RACTOR_PORT_PTR(VALUE self)
     return RTYPEDDATA_GET_DATA(self);
 }
 
+// r is NULL between Ractor::Port.allocate and ractor_port_init()
+static struct ractor_port *
+ractor_port_ptr_check(VALUE self)
+{
+    struct ractor_port *rp = RACTOR_PORT_PTR(self);
+
+    if (UNLIKELY(rp->r == NULL)) {
+        rb_raise(rb_eTypeError, "uninitialized %"PRIsVALUE, rb_obj_class(self));
+    }
+
+    return rp;
+}
+
 static VALUE
 ractor_port_alloc(VALUE klass)
 {
@@ -94,8 +107,8 @@ ractor_port_initialize(VALUE self)
 static VALUE
 ractor_port_initialize_copy(VALUE self, VALUE orig)
 {
-    struct ractor_port *dst = RACTOR_PORT_PTR(self);
-    struct ractor_port *src = RACTOR_PORT_PTR(orig);
+    struct ractor_port *dst = RACTOR_PORT_PTR(self); // uninitialized by definition
+    struct ractor_port *src = ractor_port_ptr_check(orig);
     dst->r = src->r;
     RB_OBJ_WRITTEN(self, Qundef, dst->r->pub.self);
     dst->id_ = ractor_port_id(src);
@@ -120,7 +133,7 @@ ractor_port_p(VALUE self)
 static VALUE
 ractor_port_receive(rb_execution_context_t *ec, VALUE self)
 {
-    const struct ractor_port *rp = RACTOR_PORT_PTR(self);
+    const struct ractor_port *rp = ractor_port_ptr_check(self);
 
     if (rp->r != rb_ec_ractor_ptr(ec)) {
         rb_raise(rb_eRactorError, "only allowed from the creator Ractor of this port");
@@ -134,7 +147,7 @@ ractor_port_receive(rb_execution_context_t *ec, VALUE self)
 static VALUE
 ractor_port_send(rb_execution_context_t *ec, VALUE self, VALUE obj, VALUE move)
 {
-    const struct ractor_port *rp = RACTOR_PORT_PTR(self);
+    const struct ractor_port *rp = ractor_port_ptr_check(self);
     ractor_send(ec, rp, obj, RTEST(move));
     RB_GC_GUARD(self);
     return self;
@@ -146,7 +159,7 @@ static bool ractor_close_port(rb_execution_context_t *ec, rb_ractor_t *r, const 
 static VALUE
 ractor_port_closed_p(rb_execution_context_t *ec, VALUE self)
 {
-    const struct ractor_port *rp = RACTOR_PORT_PTR(self);
+    const struct ractor_port *rp = ractor_port_ptr_check(self);
     rb_ractor_t *r = rp->r;
     bool closed;
 
@@ -173,7 +186,7 @@ ractor_port_closed_p(rb_execution_context_t *ec, VALUE self)
 static VALUE
 ractor_port_close(rb_execution_context_t *ec, VALUE self)
 {
-    const struct ractor_port *rp = RACTOR_PORT_PTR(self);
+    const struct ractor_port *rp = ractor_port_ptr_check(self);
     rb_ractor_t *cr = rb_ec_ractor_ptr(ec);
 
     if (cr != rp->r) {
@@ -560,7 +573,7 @@ ractor_monitor(rb_execution_context_t *ec, VALUE self, VALUE port)
 {
     rb_ractor_t *r = RACTOR_PTR(self);
     bool terminated = false;
-    const struct ractor_port *rp = RACTOR_PORT_PTR(port);
+    const struct ractor_port *rp = ractor_port_ptr_check(port);
     struct ractor_monitor *rm = ALLOC(struct ractor_monitor);
     rm->port = *rp; // copy port information
 
@@ -592,7 +605,7 @@ static VALUE
 ractor_unmonitor(rb_execution_context_t *ec, VALUE self, VALUE port)
 {
     rb_ractor_t *r = RACTOR_PTR(self);
-    const struct ractor_port *rp = RACTOR_PORT_PTR(port);
+    const struct ractor_port *rp = ractor_port_ptr_check(port);
 
     RACTOR_LOCK(r);
     {
@@ -1310,7 +1323,7 @@ ractor_selector_add(VALUE selv, VALUE rpv)
     }
 
     struct ractor_selector *s = RACTOR_SELECTOR_PTR(selv);
-    const struct ractor_port *rp = RACTOR_PORT_PTR(rpv);
+    const struct ractor_port *rp = ractor_port_ptr_check(rpv);
 
     if (st_lookup(s->ports, (st_data_t)rpv, NULL)) {
         rb_raise(rb_eArgError, "already added");


### PR DESCRIPTION
`Ractor::Port.allocate` returns a port whose owner Ractor is NULL, and the methods dereferenced it unchecked:

```ruby
Ractor::Port.allocate.closed?  # [BUG] Segmentation fault at 0x60
```

Route the paths reachable from Ruby through `ractor_port_ptr_check()`, which raises `TypeError` as other uninitialized typed data objects do.

`Ractor.select` is included: it does not crash, but such a port has id 0 and takes messages from the current Ractor's default port, which has the same id.

`Port#closed?` also loses `Primitive.attr! :leaf`. It can raise now, and it was not a leaf before either, since the foreign Ractor path takes `RACTOR_LOCK()`.