### PR TITLE
[Feature #22215] Introduce narrow internal interfaces for bundled extensions

### DIFF
--- a/bignum.c
+++ b/bignum.c
@@ -45,6 +45,7 @@
 #include "ruby/thread.h"
 #include "ruby/util.h"
 #include "ruby_assert.h"
+#include "vm_core.h"            /* for GET_EC() */
 
 #if USE_GMP
 RBIMPL_WARNING_PUSH()

--- a/compile.c
+++ b/compile.c
@@ -21,6 +21,7 @@
 #include "internal.h"
 #include "internal/array.h"
 #include "internal/compile.h"
+#include "internal/coverage.h"
 #include "internal/complex.h"
 #include "internal/encoding.h"
 #include "internal/error.h"

--- a/ext/coverage/coverage.c
+++ b/ext/coverage/coverage.c
@@ -8,12 +8,9 @@
 
 ************************************************/
 
-#include "internal/gc.h"
+#include "internal/coverage.h"
 #include "internal/hash.h"
-#include "internal/thread.h"
-#include "internal/sanitizers.h"
 #include "ruby.h"
-#include "vm_core.h"
 
 static enum {
     IDLE,
@@ -42,13 +39,13 @@ rb_coverage_supported(VALUE self, VALUE _mode)
 {
     ID mode = RB_SYM2ID(_mode);
 
-    return RBOOL(
+    return (
         mode == rb_intern("lines") ||
         mode == rb_intern("oneshot_lines") ||
         mode == rb_intern("branches") ||
         mode == rb_intern("methods") ||
         mode == rb_intern("eval")
-    );
+    ) ? Qtrue : Qfalse;
 }
 
 /*
@@ -242,60 +239,30 @@ branch_coverage(VALUE branches)
     return b.result;
 }
 
-/*
- * Fold a single method entry's contribution into the method coverage result.
- * `add` is the number of calls to attribute to it (0 is used to make sure a
- * defined-but-uncalled method shows up). Entries that resolve elsewhere (e.g.
- * aliases) are skipped: their calls are attributed to the original definition
- * via the [owner, mid, location] key, exactly like the old heap-walk did.
- */
 static void
-method_coverage_add(const rb_method_entry_t *me, long add, VALUE ncoverages)
+method_coverage_i(const struct rb_coverage_method_data *method, void *data)
 {
-    VALUE data[5];
-    const rb_method_entry_t *me2 = rb_resolve_me_location(me, data);
-    if (me != me2) return;
+    VALUE ncoverages = *(VALUE *)data;
+    VALUE ncoverage = rb_hash_aref(ncoverages, method->path);
 
-    VALUE klass = me->owner;
-    if (RB_TYPE_P(klass, T_ICLASS)) return;
+    if (!NIL_P(ncoverage)) {
+        VALUE methods = rb_hash_aref(ncoverage, ID2SYM(rb_intern("methods")));
+        VALUE key = rb_ary_new_from_args(6, method->owner, method->method_id,
+                                         method->first_lineno, method->first_column,
+                                         method->last_lineno, method->last_column);
+        VALUE rcount = method->count;
+        VALUE previous = rb_hash_aref(methods, key);
 
-    VALUE first_lineno = data[1];
-    if (FIX2LONG(first_lineno) <= 0) return;
-
-    VALUE path = data[0];
-    VALUE ncoverage = rb_hash_aref(ncoverages, path);
-    if (NIL_P(ncoverage)) return;
-
-    VALUE methods = rb_hash_aref(ncoverage, ID2SYM(rb_intern("methods")));
-    VALUE method_id = ID2SYM(me->def->original_id);
-    VALUE key = rb_ary_new_from_args(6, klass, method_id, data[1], data[2], data[3], data[4]);
-
-    VALUE rcount = rb_hash_aref(methods, key);
-    long count = NIL_P(rcount) ? 0 : FIX2LONG(rcount);
-    if (!POSFIXABLE(count + add)) {
-        count = FIXNUM_MAX;
+        if (NIL_P(rcount)) rcount = LONG2FIX(0);
+        if (NIL_P(previous)) previous = LONG2FIX(0);
+        if (!POSFIXABLE(FIX2LONG(rcount) + FIX2LONG(previous))) {
+            rcount = LONG2FIX(FIXNUM_MAX);
+        }
+        else {
+            rcount = LONG2FIX(FIX2LONG(rcount) + FIX2LONG(previous));
+        }
+        rb_hash_aset(methods, key, rcount);
     }
-    else {
-        count += add;
-    }
-    rb_hash_aset(methods, key, LONG2FIX(count));
-}
-
-/* me_set entries: every defined method, so uncalled ones appear with count 0. */
-static int
-method_coverage_me_i(VALUE key, VALUE value, VALUE ncoverages)
-{
-    method_coverage_add((const rb_method_entry_t *)key, 0, ncoverages);
-    return ST_CONTINUE;
-}
-
-/* cme2counter entries: call counts, attributed to the definition's key. */
-static int
-method_coverage_count_i(VALUE key, VALUE value, VALUE ncoverages)
-{
-    long add = FIXNUM_P(value) ? FIX2LONG(value) : 0;
-    method_coverage_add((const rb_method_entry_t *)key, add, ncoverages);
-    return ST_CONTINUE;
 }
 
 static int
@@ -361,8 +328,7 @@ rb_coverage_peek_result(VALUE klass)
     rb_hash_foreach(coverages, coverage_peek_result_i, ncoverages);
 
     if (current_mode & COVERAGE_TARGET_METHODS) {
-        if (RTEST(me_set)) rb_hash_foreach(me_set, method_coverage_me_i, ncoverages);
-        if (RTEST(cme2counter)) rb_hash_foreach(cme2counter, method_coverage_count_i, ncoverages);
+        rb_coverage_each_method(method_coverage_i, &ncoverages);
     }
 
     rb_hash_freeze(ncoverages);

--- a/ext/objspace/object_tracing.c
+++ b/ext/objspace/object_tracing.c
@@ -13,7 +13,6 @@
 
 **********************************************************************/
 
-#include "internal.h"
 #include "internal/gc.h"
 #include "ruby/debug.h"
 #include "objspace.h"

--- a/ext/objspace/objspace.c
+++ b/ext/objspace/objspace.c
@@ -13,20 +13,16 @@
 **********************************************************************/
 
 #include "internal.h"
-#include "internal/class.h"
-#include "internal/compilers.h"
 #include "internal/gc.h"
 #include "internal/hash.h"
 #include "internal/imemo.h"
+#include "internal/objspace.h"
 #include "internal/sanitizers.h"
 #include "ruby/io.h"
 #include "ruby/re.h"
 #include "ruby/st.h"
 #include "symbol.h"
-
-#undef rb_funcall
-
-#include "ruby/ruby.h"
+#include "objspace.h"
 
 /*
  *  call-seq:

--- a/ext/objspace/objspace_dump.c
+++ b/ext/objspace/objspace_dump.c
@@ -14,24 +14,18 @@
 
 #include "id_table.h"
 #include "internal.h"
-#include "internal/array.h"
-#include "internal/class.h"
-#include "internal/gc.h"
 #include "internal/hash.h"
+#include "internal/imemo.h"
 #include "internal/io.h"
+#include "internal/objspace.h"
 #include "internal/string.h"
 #include "internal/sanitizers.h"
 #include "symbol.h"
 #include "shape.h"
-#include "node.h"
 #include "objspace.h"
 #include "ruby/debug.h"
 #include "ruby/util.h"
 #include "ruby/io.h"
-#include "vm_callinfo.h"
-#include "vm_sync.h"
-
-RUBY_EXTERN const char ruby_hexdigits[];
 
 #define BUFFER_CAPACITY 4096
 
@@ -443,7 +437,7 @@ dump_object(VALUE obj, struct dump_config *dc)
 
         switch (imemo_type(obj)) {
           case imemo_callinfo:
-            mid = vm_ci_mid((const struct rb_callinfo *)obj);
+            mid = rb_imemo_callinfo_mid(obj);
             if (mid != 0) {
                 dump_append(dc, ", \"mid\":");
                 dump_append_id(dc, mid);
@@ -452,9 +446,10 @@ dump_object(VALUE obj, struct dump_config *dc)
 
           case imemo_callcache:
             {
-                VALUE klass = ((const struct rb_callcache *)obj)->klass;
-                if (klass != Qundef) {
-                    mid = vm_cc_cme((const struct rb_callcache *)obj)->called_id;
+                struct rb_imemo_callcache_data data;
+                if (rb_imemo_callcache_get_data(obj, &data)) {
+                    VALUE klass = data.klass;
+                    mid = data.called_id;
                     if (mid != 0) {
                         dump_append(dc, ", \"called_id\":");
                         dump_append_id(dc, mid);

--- a/ext/socket/raddrinfo.c
+++ b/ext/socket/raddrinfo.c
@@ -9,6 +9,7 @@
 ************************************************/
 
 #include "rubysocket.h"
+#include <signal.h>
 
 // GETADDRINFO_IMPL == 0 : call getaddrinfo/getnameinfo directly
 // GETADDRINFO_IMPL == 1 : call getaddrinfo/getnameinfo without gvl (but uncancellable)

--- a/imemo.c
+++ b/imemo.c
@@ -11,6 +11,27 @@ size_t rb_iseq_memsize(const rb_iseq_t *iseq);
 void rb_iseq_mark_and_move(rb_iseq_t *iseq, bool reference_updating);
 void rb_iseq_free(const rb_iseq_t *iseq);
 
+ID
+rb_imemo_callinfo_mid(VALUE obj)
+{
+    RUBY_ASSERT(imemo_type(obj) == imemo_callinfo);
+    return vm_ci_mid((const struct rb_callinfo *)obj);
+}
+
+bool
+rb_imemo_callcache_get_data(VALUE obj, struct rb_imemo_callcache_data *data)
+{
+    const struct rb_callcache *cc = (const struct rb_callcache *)obj;
+
+    RUBY_ASSERT(imemo_type(obj) == imemo_callcache);
+
+    if (cc->klass == Qundef) return false;
+
+    data->klass = cc->klass;
+    data->called_id = vm_cc_cme(cc)->called_id;
+    return true;
+}
+
 const char *
 rb_imemo_name(enum imemo_type type)
 {

--- a/internal/box.h
+++ b/internal/box.h
@@ -94,4 +94,8 @@ void rb_box_cleanup_local_extension(VALUE cleanup);
 void rb_initialize_mandatory_boxes(void);
 void rb_box_init_done(void);
 void rb_box_set_gem_flags(rb_box_gem_flags_t *);
+
+/* variable.c */
+void rb_autoload_copy_table_for_box(st_table *, const rb_box_t *);
+
 #endif /* INTERNAL_BOX_H */

--- a/internal/coverage.h
+++ b/internal/coverage.h
@@ -1,0 +1,50 @@
+#ifndef INTERNAL_COVERAGE_H                         /*-*-C-*-vi:se ft=c:*/
+#define INTERNAL_COVERAGE_H
+/**
+ * @author     Ruby developers <ruby-core@ruby-lang.org>
+ * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
+ *             Permission  is hereby  granted,  to  either redistribute  and/or
+ *             modify this file, provided that  the conditions mentioned in the
+ *             file COPYING are met.  Consult the file for details.
+ * @brief      Internal header for Coverage.
+ */
+#include "ruby/ruby.h"
+
+#define COVERAGE_INDEX_LINES    0
+#define COVERAGE_INDEX_BRANCHES 1
+
+#define COVERAGE_TARGET_LINES         1
+#define COVERAGE_TARGET_BRANCHES      2
+#define COVERAGE_TARGET_METHODS       4
+#define COVERAGE_TARGET_ONESHOT_LINES 8
+#define COVERAGE_TARGET_EVAL          16
+
+struct rb_coverage_method_data {
+    VALUE owner;
+    VALUE method_id;
+    VALUE path;
+    VALUE first_lineno;
+    VALUE first_column;
+    VALUE last_lineno;
+    VALUE last_column;
+    VALUE count;
+};
+
+typedef void rb_coverage_method_callback(const struct rb_coverage_method_data *, void *);
+
+RUBY_SYMBOL_EXPORT_BEGIN
+
+VALUE rb_get_coverages(void);
+void rb_set_coverages(VALUE coverages, int mode, VALUE cme2counter, VALUE me_set);
+void rb_clear_coverages(void);
+void rb_reset_coverages(void);
+void rb_resume_coverages(void);
+void rb_suspend_coverages(void);
+void rb_coverage_each_method(rb_coverage_method_callback callback, void *data);
+
+RUBY_SYMBOL_EXPORT_END
+
+int rb_get_coverage_mode(void);
+VALUE rb_default_coverage(int n);
+
+#endif /* INTERNAL_COVERAGE_H */

--- a/internal/gc.h
+++ b/internal/gc.h
@@ -14,7 +14,7 @@
 
 #include "internal/compilers.h" /* for __has_attribute */
 #include "ruby/ruby.h"          /* for rb_event_flag_t */
-#include "vm_core.h"            /* for GET_EC() */
+#include "ruby_atomic.h"        /* for RUBY_ATOMIC_VALUE_SET */
 
 struct rb_gc_zjit_fastpath;
 
@@ -121,6 +121,7 @@ const char *rb_raw_obj_info(char *const buff, const size_t buff_size, VALUE obj)
 
 struct rb_execution_context_struct; /* in vm_core.h */
 struct rb_objspace; /* in vm_core.h */
+struct rb_ractor_struct; /* in vm_core.h */
 
 #define EC_NEWOBJ_OF(var, T, c, f, s, ec)  \
     T *(var) = (T *)rb_ec_newobj_of((ec), (c), (f), s)
@@ -200,9 +201,10 @@ void *rb_xrealloc_mul_add(const void *, size_t, size_t, size_t);
 RUBY_ATTR_MALLOC void *rb_xmalloc_mul_add_mul(size_t, size_t, size_t, size_t);
 RUBY_ATTR_MALLOC void *rb_xcalloc_mul_add_mul(size_t, size_t, size_t, size_t);
 void rb_gc_register_pinning_obj(VALUE obj);
-rb_execution_context_t *rb_gc_get_ec(void);
+struct rb_execution_context_struct *rb_gc_get_ec(void);
+VALUE rb_newobj_of_unprotected(VALUE klass, VALUE flags, size_t size);
 
-void *rb_gc_ractor_cache_alloc(rb_ractor_t *ractor);
+void *rb_gc_ractor_cache_alloc(struct rb_ractor_struct *ractor);
 void rb_gc_ractor_cache_free(void *cache);
 bool rb_gc_zjit_new_obj_fastpath(size_t alloc_size, VALUE flags, VALUE klass, struct rb_gc_zjit_fastpath *fastpath);
 

--- a/internal/imemo.h
+++ b/internal/imemo.h
@@ -160,6 +160,12 @@ void rb_imemo_free(VALUE obj);
 
 RUBY_SYMBOL_EXPORT_BEGIN
 const char *rb_imemo_name(enum imemo_type type);
+ID rb_imemo_callinfo_mid(VALUE obj);
+struct rb_imemo_callcache_data {
+    VALUE klass;
+    ID called_id;
+};
+bool rb_imemo_callcache_get_data(VALUE obj, struct rb_imemo_callcache_data *data);
 RUBY_SYMBOL_EXPORT_END
 
 static inline enum imemo_type

--- a/internal/objspace.h
+++ b/internal/objspace.h
@@ -1,0 +1,24 @@
+#ifndef INTERNAL_OBJSPACE_H                         /*-*-C-*-vi:se ft=c:*/
+#define INTERNAL_OBJSPACE_H
+/**
+ * @author     Ruby developers <ruby-core@ruby-lang.org>
+ * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
+ *             Permission  is hereby  granted,  to  either redistribute  and/or
+ *             modify this file, provided that  the conditions mentioned in the
+ *             file COPYING are met.  Consult the file for details.
+ * @brief      Internal header for Objspace.
+ */
+
+RUBY_SYMBOL_EXPORT_BEGIN
+
+/* from intern/class.h */
+RUBY_EXTERN VALUE rb_class_super_of(VALUE klass);
+RUBY_EXTERN VALUE rb_class_singleton_p(VALUE klass);
+RUBY_EXTERN unsigned char rb_class_variation_count(VALUE klass);
+
+/* from vm_sync.h */
+RUBY_EXTERN VALUE rb_vm_lock_with_barrier(VALUE (*func)(void *args), void *args);
+
+RUBY_SYMBOL_EXPORT_END
+
+#endif /* INTERNAL_OBJSPACE_H */

--- a/internal/thread.h
+++ b/internal/thread.h
@@ -23,15 +23,6 @@ struct rb_io;
         SET_MACHINE_STACK_END(&(th)->ec->machine.stack_end);	\
     } while (0)
 
-/* thread.c */
-#define COVERAGE_INDEX_LINES    0
-#define COVERAGE_INDEX_BRANCHES 1
-#define COVERAGE_TARGET_LINES    1
-#define COVERAGE_TARGET_BRANCHES 2
-#define COVERAGE_TARGET_METHODS  4
-#define COVERAGE_TARGET_ONESHOT_LINES 8
-#define COVERAGE_TARGET_EVAL 16
-
 #define RUBY_FATAL_THREAD_KILLED INT2FIX(0)
 #define RUBY_FATAL_THREAD_TERMINATED INT2FIX(1)
 #define RUBY_FATAL_FIBER_KILLED RB_INT2FIX(2)
@@ -39,9 +30,6 @@ struct rb_io;
 VALUE rb_obj_is_mutex(VALUE obj);
 VALUE rb_suppress_tracing(VALUE (*func)(VALUE), VALUE arg);
 void rb_thread_execute_interrupts(VALUE th);
-VALUE rb_get_coverages(void);
-int rb_get_coverage_mode(void);
-VALUE rb_default_coverage(int);
 VALUE rb_thread_shield_new(void);
 bool rb_thread_shield_owned(VALUE self);
 VALUE rb_thread_shield_wait(VALUE self);

--- a/internal/thread.h
+++ b/internal/thread.h
@@ -12,6 +12,7 @@
 #include "ruby/intern.h"        /* for rb_blocking_function_t */
 #include "ccan/list/list.h"     /* for list in rb_io_close_wait_list */
 
+struct rb_execution_context_struct; /* in vm_core.h */
 struct rb_thread_struct;        /* in vm_core.h */
 struct rb_io;
 

--- a/iseq.c
+++ b/iseq.c
@@ -25,6 +25,7 @@
 #include "internal/bits.h"
 #include "internal/class.h"
 #include "internal/compile.h"
+#include "internal/coverage.h"
 #include "internal/error.h"
 #include "internal/file.h"
 #include "internal/gc.h"

--- a/iseq.h
+++ b/iseq.h
@@ -10,6 +10,7 @@
   Copyright (C) 2004-2008 Koichi Sasada
 
 **********************************************************************/
+#include "internal/coverage.h"
 #include "internal/gc.h"
 #include "shape.h"
 #include "vm_core.h"

--- a/memory_view.c
+++ b/memory_view.c
@@ -9,6 +9,7 @@
 #include "internal.h"
 #include "internal/hash.h"
 #include "internal/variable.h"
+#include "internal/vm.h"
 #include "ruby/memory_view.h"
 #include "ruby/util.h"
 #include "vm_sync.h"

--- a/node.c
+++ b/node.c
@@ -11,11 +11,12 @@
 
 #ifdef UNIVERSAL_PARSER
 #include <stddef.h>
-#include "node.h"
 #include "rubyparser.h"
 #endif
 
+#include "internal.h"
 #include "internal/variable.h"
+#include "node.h"
 
 #define NODE_BUF_DEFAULT_SIZE (sizeof(struct RNode) * 16)
 

--- a/numeric.c
+++ b/numeric.c
@@ -39,6 +39,7 @@
 #include "internal/string.h"
 #include "internal/util.h"
 #include "internal/variable.h"
+#include "vm_core.h"
 #include "ruby/encoding.h"
 #include "ruby/util.h"
 #include "builtin.h"

--- a/parse.y
+++ b/parse.y
@@ -24,6 +24,7 @@
 #endif
 
 #include "ruby/internal/config.h"
+#include "internal/thread.h"
 
 #include <errno.h>
 
@@ -41,11 +42,13 @@
 #else
 
 #include "internal.h"
+#include "internal/array.h"
 #include "internal/compile.h"
 #include "internal/compilers.h"
 #include "internal/complex.h"
 #include "internal/encoding.h"
 #include "internal/error.h"
+#include "internal/gc.h"
 #include "internal/hash.h"
 #include "internal/io.h"
 #include "internal/numeric.h"
@@ -55,7 +58,6 @@
 #include "internal/ruby_parser.h"
 #include "internal/symbol.h"
 #include "internal/thread.h"
-#include "internal/variable.h"
 #include "node.h"
 #include "parser_node.h"
 #include "probes.h"

--- a/rational.c
+++ b/rational.c
@@ -33,6 +33,7 @@
 #include "internal/object.h"
 #include "internal/rational.h"
 #include "ruby_assert.h"
+#include "vm_core.h"            /* for GET_EC() */
 
 #if USE_GMP
 RBIMPL_WARNING_PUSH()

--- a/ruby.c
+++ b/ruby.c
@@ -45,6 +45,7 @@
 #include "internal.h"
 #include "internal/cmdlineopt.h"
 #include "internal/cont.h"
+#include "internal/coverage.h"
 #include "internal/error.h"
 #include "internal/file.h"
 #include "internal/inits.h"

--- a/shape.h
+++ b/shape.h
@@ -2,6 +2,7 @@
 #define RUBY_SHAPE_H
 
 #include "internal/gc.h"
+#include "internal/imemo.h"
 
 typedef uint8_t attr_index_t;
 typedef uint32_t shape_id_t;

--- a/string.c
+++ b/string.c
@@ -48,6 +48,7 @@
 #include "ruby/ractor.h"
 #include "ruby_assert.h"
 #include "shape.h"
+#include "vm_core.h"
 #include "vm_sync.h"
 #include "zjit.h"
 #include "ruby/internal/attr/nonstring.h"

--- a/symbol.c
+++ b/symbol.c
@@ -24,6 +24,7 @@
 #include "ruby/ractor.h"
 #include "ruby/st.h"
 #include "symbol.h"
+#include "vm_core.h"
 #include "vm_sync.h"
 #include "builtin.h"
 #include "ruby/internal/attr/nonstring.h"

--- a/thread.c
+++ b/thread.c
@@ -77,6 +77,7 @@
 #include "internal.h"
 #include "internal/class.h"
 #include "internal/cont.h"
+#include "internal/coverage.h"
 #include "internal/error.h"
 #include "internal/eval.h"
 #include "internal/gc.h"
@@ -6097,6 +6098,66 @@ rb_resolve_me_location(const rb_method_entry_t *me, VALUE resolved_location[5])
         resolved_location[4] = end_pos_column;
     }
     return me;
+}
+
+struct method_coverage_arg {
+    rb_coverage_method_callback *callback;
+    void *data;
+};
+
+static void
+method_coverage_call(const rb_method_entry_t *me, VALUE count,
+                     struct method_coverage_arg *arg)
+{
+    VALUE location[5];
+    const rb_method_entry_t *resolved_me = rb_resolve_me_location(me, location);
+
+    if (me != resolved_me || RB_TYPE_P(me->owner, T_ICLASS) ||
+        FIX2LONG(location[1]) <= 0) return;
+
+    struct rb_coverage_method_data method = {
+        .owner = me->owner,
+        .method_id = ID2SYM(me->def->original_id),
+        .path = location[0],
+        .first_lineno = location[1],
+        .first_column = location[2],
+        .last_lineno = location[3],
+        .last_column = location[4],
+        .count = count,
+    };
+    arg->callback(&method, arg->data);
+}
+
+static int
+method_coverage_me_i(VALUE me, VALUE value, VALUE data)
+{
+    method_coverage_call((const rb_method_entry_t *)me, INT2FIX(0),
+                         (struct method_coverage_arg *)data);
+    return ST_CONTINUE;
+}
+
+static int
+method_coverage_count_i(VALUE me, VALUE count, VALUE data)
+{
+    if (!FIXNUM_P(count)) count = INT2FIX(0);
+    method_coverage_call((const rb_method_entry_t *)me, count,
+                         (struct method_coverage_arg *)data);
+    return ST_CONTINUE;
+}
+
+void
+rb_coverage_each_method(rb_coverage_method_callback callback, void *data)
+{
+    struct method_coverage_arg arg = {callback, data};
+    VALUE me_set = GET_VM()->me_set;
+    VALUE cme2counter = GET_VM()->cme2counter;
+
+    if (RTEST(me_set)) {
+        rb_hash_foreach(me_set, method_coverage_me_i, (VALUE)&arg);
+    }
+    if (RTEST(cme2counter)) {
+        rb_hash_foreach(cme2counter, method_coverage_count_i, (VALUE)&arg);
+    }
 }
 
 static void

--- a/vm_core.h
+++ b/vm_core.h
@@ -2437,13 +2437,6 @@ int rb_thread_check_trap_pending(void);
 #define RUBY_EVENT_COVERAGE_LINE                0x010000
 #define RUBY_EVENT_COVERAGE_BRANCH              0x020000
 
-extern VALUE rb_get_coverages(void);
-extern void rb_set_coverages(VALUE, int, VALUE, VALUE);
-extern void rb_clear_coverages(void);
-extern void rb_reset_coverages(void);
-extern void rb_resume_coverages(void);
-extern void rb_suspend_coverages(void);
-
 void rb_postponed_job_flush(rb_vm_t *vm);
 void rb_postponed_job_trigger_for_ractor(unsigned int h, VALUE running_ractor);
 

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -153,6 +153,7 @@ impl<T> ::std::cmp::PartialEq for __BindgenUnionField<T> {
     }
 }
 impl<T> ::std::cmp::Eq for __BindgenUnionField<T> {}
+pub const SHAPE_ID_NUM_BITS: u32 = 32;
 pub const INTEGER_REDEFINED_OP_FLAG: u32 = 1;
 pub const FLOAT_REDEFINED_OP_FLAG: u32 = 2;
 pub const STRING_REDEFINED_OP_FLAG: u32 = 4;
@@ -171,7 +172,6 @@ pub const VM_ENV_DATA_INDEX_ME_CREF: i32 = -2;
 pub const VM_ENV_DATA_INDEX_SPECVAL: i32 = -1;
 pub const VM_ENV_DATA_INDEX_FLAGS: u32 = 0;
 pub const VM_BLOCK_HANDLER_NONE: u32 = 0;
-pub const SHAPE_ID_NUM_BITS: u32 = 32;
 pub type ID = ::std::os::raw::c_ulong;
 pub type rb_alloc_func_t = ::std::option::Option<unsafe extern "C" fn(klass: VALUE) -> VALUE>;
 pub const RUBY_Qfalse: ruby_special_consts = 0;
@@ -300,6 +300,42 @@ pub const RUBY_ENCINDEX_EUC_JP: ruby_preserved_encindex = 10;
 pub const RUBY_ENCINDEX_Windows_31J: ruby_preserved_encindex = 11;
 pub const RUBY_ENCINDEX_BUILTIN_MAX: ruby_preserved_encindex = 12;
 pub type ruby_preserved_encindex = u32;
+pub type rb_atomic_t = ::std::os::raw::c_uint;
+pub const imemo_env: imemo_type = 0;
+pub const imemo_cref: imemo_type = 1;
+pub const imemo_svar: imemo_type = 2;
+pub const imemo_throw_data: imemo_type = 3;
+pub const imemo_ifunc: imemo_type = 4;
+pub const imemo_memo: imemo_type = 5;
+pub const imemo_ment: imemo_type = 6;
+pub const imemo_iseq: imemo_type = 7;
+pub const imemo_tmpbuf: imemo_type = 8;
+pub const imemo_cvar_entry: imemo_type = 9;
+pub const imemo_callinfo: imemo_type = 10;
+pub const imemo_callcache: imemo_type = 11;
+pub const imemo_constcache: imemo_type = 12;
+pub const imemo_fields: imemo_type = 13;
+pub const imemo_subclasses: imemo_type = 14;
+pub const imemo_cdhash: imemo_type = 15;
+pub type imemo_type = u32;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vm_ifunc_argc {
+    pub min: ::std::os::raw::c_int,
+    pub max: ::std::os::raw::c_int,
+}
+#[repr(C)]
+pub struct vm_ifunc {
+    pub flags: VALUE,
+    pub svar_lep: *mut VALUE,
+    pub func: rb_block_call_func_t,
+    pub data: *const ::std::os::raw::c_void,
+    pub argc: vm_ifunc_argc,
+}
+pub type attr_index_t = u8;
+pub type shape_id_t = u32;
+pub const SHAPE_ID_HAS_IVAR_MASK: shape_id_mask = 67633150;
+pub type shape_id_mask = u32;
 pub const BOP_PLUS: ruby_basic_operators = 0;
 pub const BOP_MINUS: ruby_basic_operators = 1;
 pub const BOP_MULT: ruby_basic_operators = 2;
@@ -339,38 +375,6 @@ pub const BOP_YIELD: ruby_basic_operators = 35;
 pub const BOP_LAST_: ruby_basic_operators = 36;
 pub type ruby_basic_operators = u32;
 pub type rb_serial_t = ::std::os::raw::c_ulonglong;
-pub const imemo_env: imemo_type = 0;
-pub const imemo_cref: imemo_type = 1;
-pub const imemo_svar: imemo_type = 2;
-pub const imemo_throw_data: imemo_type = 3;
-pub const imemo_ifunc: imemo_type = 4;
-pub const imemo_memo: imemo_type = 5;
-pub const imemo_ment: imemo_type = 6;
-pub const imemo_iseq: imemo_type = 7;
-pub const imemo_tmpbuf: imemo_type = 8;
-pub const imemo_cvar_entry: imemo_type = 9;
-pub const imemo_callinfo: imemo_type = 10;
-pub const imemo_callcache: imemo_type = 11;
-pub const imemo_constcache: imemo_type = 12;
-pub const imemo_fields: imemo_type = 13;
-pub const imemo_subclasses: imemo_type = 14;
-pub const imemo_cdhash: imemo_type = 15;
-pub type imemo_type = u32;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct vm_ifunc_argc {
-    pub min: ::std::os::raw::c_int,
-    pub max: ::std::os::raw::c_int,
-}
-#[repr(C)]
-pub struct vm_ifunc {
-    pub flags: VALUE,
-    pub svar_lep: *mut VALUE,
-    pub func: rb_block_call_func_t,
-    pub data: *const ::std::os::raw::c_void,
-    pub argc: vm_ifunc_argc,
-}
-pub type rb_atomic_t = ::std::os::raw::c_uint;
 pub const METHOD_VISI_UNDEF: rb_method_visibility_t = 0;
 pub const METHOD_VISI_PUBLIC: rb_method_visibility_t = 1;
 pub const METHOD_VISI_PRIVATE: rb_method_visibility_t = 2;
@@ -645,10 +649,6 @@ pub const VM_ENV_FLAG_ESCAPED: vm_frame_env_flags = 4;
 pub const VM_ENV_FLAG_WB_REQUIRED: vm_frame_env_flags = 8;
 pub const VM_ENV_FLAG_ISOLATED: vm_frame_env_flags = 16;
 pub type vm_frame_env_flags = u32;
-pub type attr_index_t = u8;
-pub type shape_id_t = u32;
-pub const SHAPE_ID_HAS_IVAR_MASK: shape_id_mask = 67633150;
-pub type shape_id_mask = u32;
 #[repr(C)]
 pub struct rb_cvar_class_tbl_entry {
     pub imemo_flags: VALUE,
@@ -1098,6 +1098,8 @@ extern "C" {
         elements: *const VALUE,
         opt: ::std::os::raw::c_int,
     ) -> VALUE;
+    pub fn rb_obj_info(obj: VALUE) -> *const ::std::os::raw::c_char;
+    pub fn rb_ec_stack_check(ec: *mut rb_execution_context_struct) -> ::std::os::raw::c_int;
     pub fn rb_ary_tmp_new_from_values(
         arg1: VALUE,
         arg2: ::std::os::raw::c_long,
@@ -1108,6 +1110,14 @@ extern "C" {
         n: ::std::os::raw::c_long,
         elts: *const VALUE,
     ) -> VALUE;
+    pub fn rb_shape_id_offset() -> i32;
+    pub fn rb_obj_shape_id(obj: VALUE) -> shape_id_t;
+    pub fn rb_shape_get_iv_index(shape_id: shape_id_t, id: ID, value: *mut attr_index_t) -> bool;
+    pub fn rb_shape_transition_add_ivar_no_warnings(
+        shape_id: shape_id_t,
+        id: ID,
+        klass: VALUE,
+    ) -> shape_id_t;
     pub fn rb_vm_top_self() -> VALUE;
     pub static mut rb_vm_insn_count: u64;
     pub fn rb_method_entry_at(obj: VALUE, id: ID) -> *const rb_method_entry_t;
@@ -1126,16 +1136,6 @@ extern "C" {
     pub fn rb_vm_frame_method_entry(
         cfp: *const rb_control_frame_t,
     ) -> *const rb_callable_method_entry_t;
-    pub fn rb_obj_info(obj: VALUE) -> *const ::std::os::raw::c_char;
-    pub fn rb_ec_stack_check(ec: *mut rb_execution_context_struct) -> ::std::os::raw::c_int;
-    pub fn rb_shape_id_offset() -> i32;
-    pub fn rb_obj_shape_id(obj: VALUE) -> shape_id_t;
-    pub fn rb_shape_get_iv_index(shape_id: shape_id_t, id: ID, value: *mut attr_index_t) -> bool;
-    pub fn rb_shape_transition_add_ivar_no_warnings(
-        shape_id: shape_id_t,
-        id: ID,
-        klass: VALUE,
-    ) -> shape_id_t;
     pub fn rb_ivar_get_at(obj: VALUE, index: attr_index_t, id: ID) -> VALUE;
     pub fn rb_ivar_get_at_no_ractor_check(obj: VALUE, index: attr_index_t) -> VALUE;
     pub fn rb_gvar_get(arg1: ID) -> VALUE;

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -215,6 +215,7 @@ pub const ONIG_OPTION_EXTEND: u32 = 2;
 pub const ONIG_OPTION_MULTILINE: u32 = 4;
 pub const ARG_ENCODING_FIXED: u32 = 16;
 pub const ARG_ENCODING_NONE: u32 = 32;
+pub const SHAPE_ID_NUM_BITS: u32 = 32;
 pub const INTEGER_REDEFINED_OP_FLAG: u32 = 1;
 pub const FLOAT_REDEFINED_OP_FLAG: u32 = 2;
 pub const STRING_REDEFINED_OP_FLAG: u32 = 4;
@@ -233,7 +234,6 @@ pub const VM_ENV_DATA_INDEX_ME_CREF: i32 = -2;
 pub const VM_ENV_DATA_INDEX_SPECVAL: i32 = -1;
 pub const VM_ENV_DATA_INDEX_FLAGS: u32 = 0;
 pub const VM_BLOCK_HANDLER_NONE: u32 = 0;
-pub const SHAPE_ID_NUM_BITS: u32 = 32;
 pub const ZJIT_STACK_MAP_VREG_TAG: u32 = 8;
 pub const ZJIT_STACK_MAP_SKIP_TAG: u32 = 16;
 pub const ZJIT_STACK_MAP_SHIFT: u32 = 8;
@@ -403,6 +403,60 @@ pub const RUBY_ENCINDEX_EUC_JP: ruby_preserved_encindex = 10;
 pub const RUBY_ENCINDEX_Windows_31J: ruby_preserved_encindex = 11;
 pub const RUBY_ENCINDEX_BUILTIN_MAX: ruby_preserved_encindex = 12;
 pub type ruby_preserved_encindex = u32;
+pub type rb_atomic_t = ::std::os::raw::c_uint;
+#[repr(C)]
+#[repr(align(8))]
+#[derive(Debug, Copy, Clone)]
+pub struct rb_id_table {
+    pub _bindgen_opaque_blob: [u64; 3usize],
+}
+pub const imemo_env: imemo_type = 0;
+pub const imemo_cref: imemo_type = 1;
+pub const imemo_svar: imemo_type = 2;
+pub const imemo_throw_data: imemo_type = 3;
+pub const imemo_ifunc: imemo_type = 4;
+pub const imemo_memo: imemo_type = 5;
+pub const imemo_ment: imemo_type = 6;
+pub const imemo_iseq: imemo_type = 7;
+pub const imemo_tmpbuf: imemo_type = 8;
+pub const imemo_cvar_entry: imemo_type = 9;
+pub const imemo_callinfo: imemo_type = 10;
+pub const imemo_callcache: imemo_type = 11;
+pub const imemo_constcache: imemo_type = 12;
+pub const imemo_fields: imemo_type = 13;
+pub const imemo_subclasses: imemo_type = 14;
+pub const imemo_cdhash: imemo_type = 15;
+pub type imemo_type = u32;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vm_ifunc_argc {
+    pub min: ::std::os::raw::c_int,
+    pub max: ::std::os::raw::c_int,
+}
+#[repr(C)]
+pub struct vm_ifunc {
+    pub flags: VALUE,
+    pub svar_lep: *mut VALUE,
+    pub func: rb_block_call_func_t,
+    pub data: *const ::std::os::raw::c_void,
+    pub argc: vm_ifunc_argc,
+}
+pub type attr_index_t = u8;
+pub type shape_id_t = u32;
+pub const SHAPE_ID_CAPACITY_MASK: shape_id_fl_type = 66584576;
+pub const SHAPE_ID_FL_COMPLEX: shape_id_fl_type = 67108864;
+pub const SHAPE_ID_FL_FROZEN: shape_id_fl_type = 134217728;
+pub const SHAPE_ID_FL_HAS_OBJECT_ID: shape_id_fl_type = 268435456;
+pub const SHAPE_ID_LAYOUT_ROBJECT: shape_id_fl_type = 0;
+pub const SHAPE_ID_LAYOUT_RCLASS: shape_id_fl_type = 536870912;
+pub const SHAPE_ID_LAYOUT_EXTENDED: shape_id_fl_type = 1073741824;
+pub const SHAPE_ID_LAYOUT_RDATA: shape_id_fl_type = 1073741824;
+pub const SHAPE_ID_LAYOUT_OTHER: shape_id_fl_type = 1610612736;
+pub const SHAPE_ID_LAYOUT_MASK: shape_id_fl_type = 1610612736;
+pub const SHAPE_ID_FL_NON_CANONICAL_MASK: shape_id_fl_type = 402653184;
+pub const SHAPE_ID_FLAGS_MASK: shape_id_fl_type = 2146959360;
+pub const SHAPE_ID_FL_PRIVATE_MASK: shape_id_fl_type = 1677197312;
+pub type shape_id_fl_type = u32;
 pub const BOP_PLUS: ruby_basic_operators = 0;
 pub const BOP_MINUS: ruby_basic_operators = 1;
 pub const BOP_MULT: ruby_basic_operators = 2;
@@ -442,44 +496,6 @@ pub const BOP_YIELD: ruby_basic_operators = 35;
 pub const BOP_LAST_: ruby_basic_operators = 36;
 pub type ruby_basic_operators = u32;
 pub type rb_serial_t = ::std::os::raw::c_ulonglong;
-#[repr(C)]
-#[repr(align(8))]
-#[derive(Debug, Copy, Clone)]
-pub struct rb_id_table {
-    pub _bindgen_opaque_blob: [u64; 3usize],
-}
-pub const imemo_env: imemo_type = 0;
-pub const imemo_cref: imemo_type = 1;
-pub const imemo_svar: imemo_type = 2;
-pub const imemo_throw_data: imemo_type = 3;
-pub const imemo_ifunc: imemo_type = 4;
-pub const imemo_memo: imemo_type = 5;
-pub const imemo_ment: imemo_type = 6;
-pub const imemo_iseq: imemo_type = 7;
-pub const imemo_tmpbuf: imemo_type = 8;
-pub const imemo_cvar_entry: imemo_type = 9;
-pub const imemo_callinfo: imemo_type = 10;
-pub const imemo_callcache: imemo_type = 11;
-pub const imemo_constcache: imemo_type = 12;
-pub const imemo_fields: imemo_type = 13;
-pub const imemo_subclasses: imemo_type = 14;
-pub const imemo_cdhash: imemo_type = 15;
-pub type imemo_type = u32;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct vm_ifunc_argc {
-    pub min: ::std::os::raw::c_int,
-    pub max: ::std::os::raw::c_int,
-}
-#[repr(C)]
-pub struct vm_ifunc {
-    pub flags: VALUE,
-    pub svar_lep: *mut VALUE,
-    pub func: rb_block_call_func_t,
-    pub data: *const ::std::os::raw::c_void,
-    pub argc: vm_ifunc_argc,
-}
-pub type rb_atomic_t = ::std::os::raw::c_uint;
 pub const METHOD_VISI_UNDEF: rb_method_visibility_t = 0;
 pub const METHOD_VISI_PUBLIC: rb_method_visibility_t = 1;
 pub const METHOD_VISI_PRIVATE: rb_method_visibility_t = 2;
@@ -1541,22 +1557,6 @@ pub const VM_ENV_FLAG_ESCAPED: vm_frame_env_flags = 4;
 pub const VM_ENV_FLAG_WB_REQUIRED: vm_frame_env_flags = 8;
 pub const VM_ENV_FLAG_ISOLATED: vm_frame_env_flags = 16;
 pub type vm_frame_env_flags = u32;
-pub type attr_index_t = u8;
-pub type shape_id_t = u32;
-pub const SHAPE_ID_CAPACITY_MASK: shape_id_fl_type = 66584576;
-pub const SHAPE_ID_FL_COMPLEX: shape_id_fl_type = 67108864;
-pub const SHAPE_ID_FL_FROZEN: shape_id_fl_type = 134217728;
-pub const SHAPE_ID_FL_HAS_OBJECT_ID: shape_id_fl_type = 268435456;
-pub const SHAPE_ID_LAYOUT_ROBJECT: shape_id_fl_type = 0;
-pub const SHAPE_ID_LAYOUT_RCLASS: shape_id_fl_type = 536870912;
-pub const SHAPE_ID_LAYOUT_EXTENDED: shape_id_fl_type = 1073741824;
-pub const SHAPE_ID_LAYOUT_RDATA: shape_id_fl_type = 1073741824;
-pub const SHAPE_ID_LAYOUT_OTHER: shape_id_fl_type = 1610612736;
-pub const SHAPE_ID_LAYOUT_MASK: shape_id_fl_type = 1610612736;
-pub const SHAPE_ID_FL_NON_CANONICAL_MASK: shape_id_fl_type = 402653184;
-pub const SHAPE_ID_FLAGS_MASK: shape_id_fl_type = 2146959360;
-pub const SHAPE_ID_FL_PRIVATE_MASK: shape_id_fl_type = 1677197312;
-pub type shape_id_fl_type = u32;
 pub const CONST_DEPRECATED: rb_const_flag_t = 256;
 pub const CONST_VISIBILITY_MASK: rb_const_flag_t = 255;
 pub const CONST_PUBLIC: rb_const_flag_t = 0;
@@ -2176,6 +2176,19 @@ unsafe extern "C" {
         elements: *const VALUE,
         opt: ::std::os::raw::c_int,
     ) -> VALUE;
+    pub fn rb_obj_info(obj: VALUE) -> *const ::std::os::raw::c_char;
+    pub fn rb_raw_obj_info(
+        buff: *mut ::std::os::raw::c_char,
+        buff_size: usize,
+        obj: VALUE,
+    ) -> *const ::std::os::raw::c_char;
+    pub fn rb_ec_stack_check(ec: *mut rb_execution_context_struct) -> ::std::os::raw::c_int;
+    pub fn rb_gc_writebarrier_remember(obj: VALUE);
+    pub fn rb_id_table_lookup(
+        tbl: *mut rb_id_table,
+        id: ID,
+        valp: *mut VALUE,
+    ) -> ::std::os::raw::c_int;
     pub fn rb_ary_tmp_new_from_values(
         arg1: VALUE,
         arg2: ::std::os::raw::c_long,
@@ -2186,13 +2199,16 @@ unsafe extern "C" {
         n: ::std::os::raw::c_long,
         elts: *const VALUE,
     ) -> VALUE;
+    pub fn rb_shape_id_offset() -> i32;
+    pub fn rb_obj_shape_id(obj: VALUE) -> shape_id_t;
+    pub fn rb_shape_get_iv_index(shape_id: shape_id_t, id: ID, value: *mut attr_index_t) -> bool;
+    pub fn rb_shape_transition_add_ivar_no_warnings(
+        shape_id: shape_id_t,
+        id: ID,
+        klass: VALUE,
+    ) -> shape_id_t;
     pub fn rb_vm_top_self() -> VALUE;
     pub static mut rb_vm_insn_count: u64;
-    pub fn rb_id_table_lookup(
-        tbl: *mut rb_id_table,
-        id: ID,
-        valp: *mut VALUE,
-    ) -> ::std::os::raw::c_int;
     pub fn rb_method_entry_at(obj: VALUE, id: ID) -> *const rb_method_entry_t;
     pub fn rb_callable_method_entry(klass: VALUE, id: ID) -> *const rb_callable_method_entry_t;
     pub fn rb_callable_method_entry_or_negative(
@@ -2210,22 +2226,6 @@ unsafe extern "C" {
     pub fn rb_vm_frame_method_entry(
         cfp: *const rb_control_frame_t,
     ) -> *const rb_callable_method_entry_t;
-    pub fn rb_obj_info(obj: VALUE) -> *const ::std::os::raw::c_char;
-    pub fn rb_raw_obj_info(
-        buff: *mut ::std::os::raw::c_char,
-        buff_size: usize,
-        obj: VALUE,
-    ) -> *const ::std::os::raw::c_char;
-    pub fn rb_ec_stack_check(ec: *mut rb_execution_context_struct) -> ::std::os::raw::c_int;
-    pub fn rb_gc_writebarrier_remember(obj: VALUE);
-    pub fn rb_shape_id_offset() -> i32;
-    pub fn rb_obj_shape_id(obj: VALUE) -> shape_id_t;
-    pub fn rb_shape_get_iv_index(shape_id: shape_id_t, id: ID, value: *mut attr_index_t) -> bool;
-    pub fn rb_shape_transition_add_ivar_no_warnings(
-        shape_id: shape_id_t,
-        id: ID,
-        klass: VALUE,
-    ) -> shape_id_t;
     pub fn rb_const_lookup(klass: VALUE, id: ID) -> *mut rb_const_entry_t;
     pub fn rb_ivar_get_at_no_ractor_check(obj: VALUE, index: attr_index_t) -> VALUE;
     pub fn rb_gvar_get(arg1: ID) -> VALUE;


### PR DESCRIPTION
Add narrow internal interfaces for the bundled extensions:

* Collect coverage constants and declarations in `internal/coverage.h`.
* Perform method-entry traversal in the core and pass normalized method coverage data to `ext/coverage` through `rb_coverage_each_method`.
* Add `rb_imemo_callinfo_mid` and `rb_imemo_callcache_get_data` for the information required by `ext/objspace`.
* Keep these declarations in `internal/` headers rather than public `ruby/` headers.
* Remove the transitive inclusion of `vm_core.h` from `internal/gc.h`.

The new interfaces are exported for bundled extensions and are not intended to be stable APIs for third-party extensions.

Generated dependencies confirm that extensions under `ext` no longer depend on `vm_core.h` or `thread_pthread.[ch]`.