### PR TITLE
Fix bignum power_cache across Ractors (used by big2str/str2big)

### DIFF
--- a/bignum.c
+++ b/bignum.c
@@ -41,6 +41,7 @@
 #include "internal/sanitizers.h"
 #include "internal/variable.h"
 #include "internal/warnings.h"
+#include "ruby/atomic.h"
 #include "ruby/thread.h"
 #include "ruby/util.h"
 #include "ruby_assert.h"
@@ -4762,7 +4763,7 @@ power_cache_get_power(int base, int power_level, size_t *numdigits_ret)
     if (MAX_BASE36_POWER_TABLE_ENTRIES <= power_level)
         rb_bug("too big power number requested: maxpow_in_bdigit_dbl(%d)**(2**%d)", base, power_level);
 
-    VALUE power = base36_power_cache[base - 2][power_level];
+    VALUE power = rbimpl_atomic_value_load(&base36_power_cache[base - 2][power_level], RBIMPL_ATOMIC_ACQUIRE);
     if (!power) {
         size_t numdigits;
         if (power_level == 0) {
@@ -4777,9 +4778,16 @@ power_cache_get_power(int base, int power_level, size_t *numdigits_ret)
             numdigits *= 2;
         }
         rb_obj_hide(power);
-        base36_power_cache[base - 2][power_level] = power;
-        base36_numdigits_cache[base - 2][power_level] = numdigits;
-        rb_vm_register_global_object(power);
+        base36_numdigits_cache[base - 2][power_level] = numdigits; // benign race
+        /* Ractors can race this fill */
+        VALUE old = rbimpl_atomic_value_cas(&base36_power_cache[base - 2][power_level], 0, power,
+                                            RBIMPL_ATOMIC_RELEASE, RBIMPL_ATOMIC_ACQUIRE);
+        if (old) {
+            power = old;
+        }
+        else {
+            rb_vm_register_global_object(power);
+        }
     }
     if (numdigits_ret)
         *numdigits_ret = base36_numdigits_cache[base - 2][power_level];

--- a/test/ruby/test_ractor.rb
+++ b/test/ruby/test_ractor.rb
@@ -434,6 +434,21 @@ class TestRactor < Test::Unit::TestCase
     RUBY
   end
 
+  def test_bignum_to_s
+    assert_ractor(<<~'RUBY')
+      8.times.map do
+        Ractor.new do
+          1_000.times do |i|
+            v = (2**96 - 1) + i
+            s = v.to_s
+            # round-trip through str2big (uses the same cache)
+            raise "bad to_s: #{s.inspect}" unless Integer(s) == v
+          end
+        end
+      end.each(&:join)
+    RUBY
+  end
+
   def assert_make_shareable(obj)
     refute Ractor.shareable?(obj), "object was already shareable"
     Ractor.make_shareable(obj)


### PR DESCRIPTION
This global cache was unsynchronized and across Ractors that is racy and leads to undefined behavior. The repro code included as a regression test was crashing with SEGV or producing bad results from bignum#to_s before this fix.