### PR TITLE
Fix memory leak when sweeping hashes with st_table

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -1453,7 +1453,7 @@ rb_gc_obj_needs_cleanup_p(VALUE obj)
         return !(flags & RARRAY_EMBED_FLAG);
 
       case T_HASH:
-        return !(flags & RHASH_ST_TABLE_FLAG);
+        return (flags & RHASH_ST_TABLE_FLAG);
 
       case T_MATCH:
         return !((flags & (RMATCH_ONIG | RMATCH_OFFSETS_EXTERNAL)) || USE_DEBUG_COUNTER);


### PR DESCRIPTION
The GC sweep fast path had an inverted condition for hashes in rb_gc_obj_needs_cleanup_p. Hashes with an st_table needs to be freed.

The following script leaks memory:
```ruby
10.times do
  100_000.times do
    # Hashes with more than 8 elements use st_table with a malloc'd
    # entries array
    h = {}
    9.times { |i| h[i] = i }
  end

  GC.start

  puts `ps -o rss= -p #{$$}`
end
```

Before:

     58816
     97056
    135296
    173584
    211840
    250096
    288336
    326608
    364848
    403088

After:

    27696
    27696
    27696
    27696
    27696
    27696
    27696
    27696
    27696
    27696