### PR TITLE
Fix memory leak in MatchData

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -1456,7 +1456,7 @@ rb_gc_obj_needs_cleanup_p(VALUE obj)
         return (flags & RHASH_ST_TABLE_FLAG);
 
       case T_MATCH:
-        return !((flags & (RMATCH_ONIG | RMATCH_OFFSETS_EXTERNAL)) || USE_DEBUG_COUNTER);
+        return (flags & (RMATCH_ONIG | RMATCH_OFFSETS_EXTERNAL)) || USE_DEBUG_COUNTER;
 
       case T_BIGNUM:
         return !(flags & BIGNUM_EMBED_FLAG);


### PR DESCRIPTION
The following script leaks memory:

```ruby
10.times do
  # MatchData#offset allocates an external char_offset buffer
  100_000.times.map do
    m = /(a)(b)(c)(d)/.match("abcd")
    m.offset(0)
    m
  end

  GC.start

  puts `ps -o rss= -p #{$$}`
end
```

Before:

    49072
    56512
    66320
    72624
    80432
    89232
    96192
    105600
    111936
    121744

After:

    49328
    48928
    50864
    49312
    49248
    50160
    49264
    50816
    49296
    51216