### PR TITLE
ZJIT: Remove nops for PatchPoint too close to start of LIR BB

### DIFF
--- a/zjit/src/backend/arm64/mod.rs
+++ b/zjit/src/backend/arm64/mod.rs
@@ -1068,6 +1068,15 @@ impl Assembler {
             ldr_post(cb, opnd, A64Opnd::new_mem(64, C_SP_REG, C_SP_STEP));
         }
 
+        /// Fill nops until a jump written at `last_patch_pos` can no longer reach
+        /// past the current write position.
+        fn emit_pad_after_patch_point(cb: &mut CodeBlock, last_patch_pos: Option<usize>) {
+            let Some(last_patch_pos) = last_patch_pos else { return };
+            while cb.get_write_pos().saturating_sub(last_patch_pos) < cb.jmp_ptr_bytes() && !cb.has_dropped_bytes() {
+                nop(cb);
+            }
+        }
+
         // List of GC offsets
         let mut gc_offsets: Vec<CodePtr> = Vec::new();
 
@@ -1521,13 +1530,15 @@ impl Assembler {
                 },
                 Insn::PatchPoint(..) => unreachable!("PatchPoint should have been lowered to PadPatchPoint in arm64_scratch_split"),
                 Insn::PadPatchPoint => {
-                    // If patch points are too close to each other or the end of the block, fill nop instructions
-                    if let Some(last_patch_pos) = last_patch_pos {
-                        while cb.get_write_pos().saturating_sub(last_patch_pos) < cb.jmp_ptr_bytes() && !cb.has_dropped_bytes() {
-                            nop(cb);
-                        }
-                    }
+                    emit_pad_after_patch_point(cb, last_patch_pos);
+                    // This position is itself where a jump gets written on invalidation, so it
+                    // becomes what following code has to keep its distance from.
                     last_patch_pos = Some(cb.get_write_pos());
+                },
+                Insn::BoundaryPad => {
+                    // A boundary is never patched, so it doesn't become a position to keep away
+                    // from. The last patch point stays that, and the pad just gave it its room.
+                    emit_pad_after_patch_point(cb, last_patch_pos);
                 },
                 Insn::IncrCounter { mem, value } => {
                     // Get the status register allocated by arm64_scratch_split
@@ -1803,11 +1814,10 @@ mod tests {
 
         assert_disasm_snapshot!(cb.disasm(), @"
         0x0: mov x1, #1
-        0x4: nop
-        0x8: mov x0, x1
-        0xc: ret
+        0x4: mov x0, x1
+        0x8: ret
         ");
-        assert_snapshot!(cb.hexdump(), @"210080d21f2003d5e00301aac0035fd6");
+        assert_snapshot!(cb.hexdump(), @"210080d2e00301aac0035fd6");
     }
 
     #[test]

--- a/zjit/src/backend/arm64/mod.rs
+++ b/zjit/src/backend/arm64/mod.rs
@@ -1528,8 +1528,8 @@ impl Assembler {
                 Insn::Jonz(opnd, target) => {
                     emit_cmp_zero_jump(cb, opnd.into(), false, target.clone());
                 },
-                Insn::PatchPoint(..) => unreachable!("PatchPoint should have been lowered to PadPatchPoint in arm64_scratch_split"),
-                Insn::PadPatchPoint => {
+                Insn::PatchPoint(..) => unreachable!("PatchPoint should have been lowered to PatchPointPad in arm64_scratch_split"),
+                Insn::PatchPointPad => {
                     emit_pad_after_patch_point(cb, last_patch_pos);
                     // This position is itself where a jump gets written on invalidation, so it
                     // becomes what following code has to keep its distance from.

--- a/zjit/src/backend/arm64/mod.rs
+++ b/zjit/src/backend/arm64/mod.rs
@@ -1761,6 +1761,56 @@ mod tests {
     }
 
     #[test]
+    fn test_fallthrough_to_a_patchpoint() {
+        // At one point, this generated unnecessary nop padding
+        use crate::cruby::test_utils::{compile_to_iseq, with_rubyvm};
+        use crate::hir::Invariant;
+        use crate::payload::IseqVersion;
+
+        let version = IseqVersion::new(compile_to_iseq("nil"));
+
+        // The PosMarker that split_patch_point() installs registers the patch point
+        // with ZJITState's invariant table while emitting, so the VM has to be booted.
+        let cb = with_rubyvm(|| {
+            crate::options::rb_zjit_prepare_options(); // Allow `get_option!` in Assembler
+            let mut asm = Assembler::new();
+            let mut cb = CodeBlock::new_dummy();
+
+            let bb0 = asm.new_block(crate::hir::BlockId(0), true, 0);
+            let bb1 = asm.new_block(crate::hir::BlockId(1), false, 1);
+
+            // The patch point's target only has to resolve to some address for the
+            // PosMarker that records it, so bb0 stands in for the side exit code.
+            let side_exit = asm.new_label("side_exit");
+
+            // bb0 falls through to bb1
+            asm.set_current_block(bb0);
+            let label_bb0 = asm.new_label("bb0");
+            asm.write_label(label_bb0);
+            asm.write_label(side_exit.clone());
+            asm.mov(Opnd::Reg(TEMP_REGS[0]), Opnd::UImm(1));
+            asm.push_insn(Insn::Jmp(Target::Block(Box::new(BranchEdge { target: bb1, args: vec![] }))));
+
+            asm.set_current_block(bb1);
+            let label_bb1 = asm.new_label("bb1");
+            asm.write_label(label_bb1);
+            asm.patch_point(side_exit.clone(), Invariant::SingleRactorMode, version);
+            asm.cret(Opnd::Reg(TEMP_REGS[0]));
+
+            asm.compile_with_num_regs(&mut cb, 0);
+            cb
+        });
+
+        assert_disasm_snapshot!(cb.disasm(), @"
+        0x0: mov x1, #1
+        0x4: nop
+        0x8: mov x0, x1
+        0xc: ret
+        ");
+        assert_snapshot!(cb.hexdump(), @"210080d21f2003d5e00301aac0035fd6");
+    }
+
+    #[test]
     fn test_lir_string() {
         use crate::hir::SideExitReason;
 

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -1877,9 +1877,7 @@ impl Assembler
 
         // Emit instructions with labels, expanding branch parameters
         let mut insns = Vec::with_capacity(ASSEMBLER_INSNS_CAPACITY);
-
         let block_ids = self.block_order();
-        let num_blocks = block_ids.len();
 
         for (i, block_id) in block_ids.iter().enumerate() {
             let block = &self.basic_blocks[block_id.0];
@@ -1917,14 +1915,12 @@ impl Assembler
             if let Some(marker) = block_end_pos_marker {
                 insns.push(Insn::PosMarker(marker));
             }
-
-            // Make sure we don't stomp on the next function
-            if block_id.0 == num_blocks - 1 {
-                push_insns_with_perf_symbol(&mut insns, "BoundaryPad", |insns| {
-                    insns.push(Insn::BoundaryPad);
-                });
-            }
         }
+        // Make sure we don't stomp on the next function
+        push_insns_with_perf_symbol(&mut insns, "BoundaryPad", |insns| {
+            insns.push(Insn::BoundaryPad);
+        });
+
         insns
     }
 

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -890,10 +890,26 @@ pub enum Insn {
     /// Cold fields are boxed (see `PatchPointData`) to keep `Insn` small.
     PatchPoint(Box<PatchPointData>),
 
-    /// Make sure the last PatchPoint has enough space to insert a jump.
-    /// We insert this instruction at the end of each block so that the jump
-    /// will not overwrite the next block or a side exit.
+    /// Space reserved immediately before a PatchPoint, keeping the *preceding*
+    /// patch point's invalidation jump from running over this one's address.
+    /// The position right after this pad is itself where a jump gets written on
+    /// invalidation, so whatever follows has to keep `jmp_ptr_bytes()` of
+    /// distance from it in turn.
+    ///
+    /// Zero-width whenever there is already enough room, which is the common
+    /// case.
     PadPatchPoint,
+
+    /// Space reserved at a boundary that a preceding PatchPoint's invalidation
+    /// jump must not cross: the start of a non-entry block, the start of a side
+    /// exit, or the end of the last block. Nothing is ever patched at a
+    /// boundary, so unlike [`Insn::PadPatchPoint`] this only protects what comes
+    /// after it, and it does not become something later code has to keep away
+    /// from — the first patch point of a block needs no padding in front of it.
+    ///
+    /// Zero-width whenever there is already enough room, which is the common
+    /// case.
+    BoundaryPad,
 
     // Mark a position in the generated code
     PosMarker(PosMarkerFn),
@@ -981,6 +997,7 @@ macro_rules! for_each_operand_impl {
             }
 
             Insn::BakeString(_) |
+            Insn::BoundaryPad |
             Insn::Breakpoint | Insn::Abort |
             Insn::Comment(_) |
             Insn::CPop { .. } |
@@ -1119,6 +1136,7 @@ impl Insn {
             Insn::Add { .. } => "Add",
             Insn::And { .. } => "And",
             Insn::BakeString(_) => "BakeString",
+            Insn::BoundaryPad => "BoundaryPad",
             Insn::Breakpoint => "Breakpoint",
             Insn::Abort => "Abort",
             Insn::Comment(_) => "Comment",
@@ -1868,8 +1886,8 @@ impl Assembler
             // Entry blocks shouldn't ever be preceded by something that can
             // stomp on this block.
             if !block.is_entry {
-                push_insns_with_perf_symbol(&mut insns, "PadPatchPoint", |insns| {
-                    insns.push(Insn::PadPatchPoint);
+                push_insns_with_perf_symbol(&mut insns, "BoundaryPad", |insns| {
+                    insns.push(Insn::BoundaryPad);
                 });
             }
 
@@ -1902,8 +1920,8 @@ impl Assembler
 
             // Make sure we don't stomp on the next function
             if block_id.0 == num_blocks - 1 {
-                push_insns_with_perf_symbol(&mut insns, "PadPatchPoint", |insns| {
-                    insns.push(Insn::PadPatchPoint);
+                push_insns_with_perf_symbol(&mut insns, "BoundaryPad", |insns| {
+                    insns.push(Insn::BoundaryPad);
                 });
             }
         }
@@ -2837,7 +2855,7 @@ impl Assembler
             // Side exit blocks are not part of the CFG at the moment,
             // so we need to manually ensure that patchpoints get padded
             // so that nobody stomps on us
-            asm.pad_patch_point();
+            asm.boundary_pad();
 
             asm_comment!(asm, "save cfp->pc");
             asm.store(Opnd::mem(64, CFP, RUBY_OFFSET_CFP_PC), *pc);
@@ -3958,6 +3976,10 @@ impl Assembler {
 
     pub fn pad_patch_point(&mut self) {
         self.push_insn(Insn::PadPatchPoint);
+    }
+
+    pub fn boundary_pad(&mut self) {
+        self.push_insn(Insn::BoundaryPad);
     }
 
     pub fn pos_marker(&mut self, marker_fn: impl Fn(CodePtr, &CodeBlock) + 'static) {

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -898,12 +898,12 @@ pub enum Insn {
     ///
     /// Zero-width whenever there is already enough room, which is the common
     /// case.
-    PadPatchPoint,
+    PatchPointPad,
 
     /// Space reserved at a boundary that a preceding PatchPoint's invalidation
     /// jump must not cross: the start of a non-entry block, the start of a side
     /// exit, or the end of the last block. Nothing is ever patched at a
-    /// boundary, so unlike [`Insn::PadPatchPoint`] this only protects what comes
+    /// boundary, so unlike [`Insn::PatchPointPad`] this only protects what comes
     /// after it, and it does not become something later code has to keep away
     /// from — the first patch point of a block needs no padding in front of it.
     ///
@@ -1001,7 +1001,7 @@ macro_rules! for_each_operand_impl {
             Insn::Breakpoint | Insn::Abort |
             Insn::Comment(_) |
             Insn::CPop { .. } |
-            Insn::PadPatchPoint |
+            Insn::PatchPointPad |
             Insn::PosMarker(_) |
             Insn::PosMarkerAtBlockEnd(_) => {},
 
@@ -1185,7 +1185,7 @@ impl Insn {
             Insn::Not { .. } => "Not",
             Insn::Or { .. } => "Or",
             Insn::PatchPoint(..) => "PatchPoint",
-            Insn::PadPatchPoint => "PadPatchPoint",
+            Insn::PatchPointPad => "PatchPointPad",
             Insn::PosMarker(_) => "PosMarker",
             Insn::PosMarkerAtBlockEnd(_) => "PosMarkerAtBlockEnd",
             Insn::RShift { .. } => "RShift",
@@ -3970,8 +3970,8 @@ impl Assembler {
         self.push_insn(Insn::PatchPoint(Box::new(PatchPointData { target, invariant, version })));
     }
 
-    pub fn pad_patch_point(&mut self) {
-        self.push_insn(Insn::PadPatchPoint);
+    pub fn patch_point_pad(&mut self) {
+        self.push_insn(Insn::PatchPointPad);
     }
 
     pub fn boundary_pad(&mut self) {

--- a/zjit/src/backend/x86_64/mod.rs
+++ b/zjit/src/backend/x86_64/mod.rs
@@ -1378,6 +1378,57 @@ mod tests {
     }
 
     #[test]
+    fn test_fallthrough_to_a_patchpoint() {
+        // At one point, this generated unnecessary nop padding
+        use crate::cruby::test_utils::{compile_to_iseq, with_rubyvm};
+        use crate::hir::Invariant;
+        use crate::payload::IseqVersion;
+
+        let version = IseqVersion::new(compile_to_iseq("nil"));
+
+        // The PosMarker that split_patch_point() installs registers the patch point
+        // with ZJITState's invariant table while emitting, so the VM has to be booted.
+        let cb = with_rubyvm(|| {
+            crate::options::rb_zjit_prepare_options(); // Allow `get_option!` in Assembler
+            let mut asm = Assembler::new();
+            let mut cb = CodeBlock::new_dummy();
+
+            let bb0 = asm.new_block(crate::hir::BlockId(0), true, 0);
+            let bb1 = asm.new_block(crate::hir::BlockId(1), false, 1);
+
+            // The patch point's target only has to resolve to some address for the
+            // PosMarker that records it, so bb0 stands in for the side exit code.
+            let side_exit = asm.new_label("side_exit");
+
+            // bb0 falls through to bb1
+            asm.set_current_block(bb0);
+            let label_bb0 = asm.new_label("bb0");
+            asm.write_label(label_bb0);
+            asm.write_label(side_exit.clone());
+            asm.mov(C_ARG_OPNDS[0], Opnd::UImm(1));
+            asm.push_insn(Insn::Jmp(Target::Block(Box::new(BranchEdge { target: bb1, args: vec![] }))));
+
+            asm.set_current_block(bb1);
+            let label_bb1 = asm.new_label("bb1");
+            asm.write_label(label_bb1);
+            asm.patch_point(side_exit.clone(), Invariant::SingleRactorMode, version);
+            asm.cret(C_ARG_OPNDS[0]);
+
+            asm.compile_with_num_regs(&mut cb, 0);
+            cb
+        });
+
+        assert_disasm_snapshot!(cb.disasm(), @"
+        0x0: mov edi, 1
+        0x5: nop dword ptr [rax + rax]
+        0xa: mov rax, rdi
+        0xd: ret
+        0xe: nop
+        ");
+        assert_snapshot!(cb.hexdump(), @"bf010000000f1f4400004889f8c390");
+    }
+
+    #[test]
     fn test_lir_string() {
         use crate::hir::SideExitReason;
 

--- a/zjit/src/backend/x86_64/mod.rs
+++ b/zjit/src/backend/x86_64/mod.rs
@@ -744,6 +744,16 @@ impl Assembler {
             gc_offsets.push(ptr_offset);
         }
 
+        /// Fill nops until a jump written at `last_patch_pos` can no longer reach
+        /// past the current write position.
+        fn emit_pad_after_patch_point(cb: &mut CodeBlock, last_patch_pos: Option<usize>) {
+            let Some(last_patch_pos) = last_patch_pos else { return };
+            let code_size = cb.get_write_pos().saturating_sub(last_patch_pos);
+            if code_size < cb.jmp_ptr_bytes() {
+                nop(cb, (cb.jmp_ptr_bytes() - code_size) as u32);
+            }
+        }
+
         // List of GC offsets
         let mut gc_offsets: Vec<CodePtr> = Vec::new();
 
@@ -1061,14 +1071,15 @@ impl Assembler {
 
                 Insn::PatchPoint(..) => unreachable!("PatchPoint should have been lowered to PadPatchPoint in x86_scratch_split"),
                 Insn::PadPatchPoint => {
-                    // If patch points are too close to each other or the end of the block, fill nop instructions
-                    if let Some(last_patch_pos) = last_patch_pos {
-                        let code_size = cb.get_write_pos().saturating_sub(last_patch_pos);
-                        if code_size < cb.jmp_ptr_bytes() {
-                            nop(cb, (cb.jmp_ptr_bytes() - code_size) as u32);
-                        }
-                    }
+                    emit_pad_after_patch_point(cb, last_patch_pos);
+                    // This position is itself where a jump gets written on invalidation, so it
+                    // becomes what following code has to keep its distance from.
                     last_patch_pos = Some(cb.get_write_pos());
+                },
+                Insn::BoundaryPad => {
+                    // A boundary is never patched, so it doesn't become a position to keep away
+                    // from. The last patch point stays that, and the pad just gave it its room.
+                    emit_pad_after_patch_point(cb, last_patch_pos);
                 },
 
                 // Atomically increment a counter at a given memory location
@@ -1420,12 +1431,11 @@ mod tests {
 
         assert_disasm_snapshot!(cb.disasm(), @"
         0x0: mov edi, 1
-        0x5: nop dword ptr [rax + rax]
-        0xa: mov rax, rdi
-        0xd: ret
-        0xe: nop
+        0x5: mov rax, rdi
+        0x8: ret
+        0x9: nop
         ");
-        assert_snapshot!(cb.hexdump(), @"bf010000000f1f4400004889f8c390");
+        assert_snapshot!(cb.hexdump(), @"bf010000004889f8c390");
     }
 
     #[test]

--- a/zjit/src/backend/x86_64/mod.rs
+++ b/zjit/src/backend/x86_64/mod.rs
@@ -1069,8 +1069,8 @@ impl Assembler {
 
                 Insn::Joz(..) | Insn::Jonz(..) => unreachable!("Joz/Jonz should be unused for now"),
 
-                Insn::PatchPoint(..) => unreachable!("PatchPoint should have been lowered to PadPatchPoint in x86_scratch_split"),
-                Insn::PadPatchPoint => {
+                Insn::PatchPoint(..) => unreachable!("PatchPoint should have been lowered to PatchPointPad in x86_scratch_split"),
+                Insn::PatchPointPad => {
                     emit_pad_after_patch_point(cb, last_patch_pos);
                     // This position is itself where a jump gets written on invalidation, so it
                     // becomes what following code has to keep its distance from.

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -977,7 +977,7 @@ fn gen_patch_point(jit: &mut JITState, asm: &mut Assembler, function: &Function,
     asm.patch_point(Target::SideExit(Box::new(SideExitTarget { exit, reason: PatchPoint(invariant) })), invariant, jit.version);
 }
 
-/// This is used by scratch_split to lower PatchPoint into PadPatchPoint and PosMarker.
+/// This is used by scratch_split to lower PatchPoint into PatchPointPad and PosMarker.
 /// It's called at scratch_split so that we can use the Label after side-exit deduplication in compile_exits.
 pub fn split_patch_point(asm: &mut Assembler, target: &Target, invariant: Invariant, version: IseqVersionRef) {
     let Target::Label(exit_label) = *target else {
@@ -985,7 +985,7 @@ pub fn split_patch_point(asm: &mut Assembler, target: &Target, invariant: Invari
     };
 
     // Fill nop instructions if the last patch point is too close.
-    asm.pad_patch_point();
+    asm.patch_point_pad();
 
     // Remember the current address as a patch point
     asm.pos_marker(move |code_ptr, cb| {


### PR DESCRIPTION
Previously we put a `nop` at the beginning of a block because any two
`PadPatchPoint` checked for minimum distance. The PadPatchPoint inserted
at block boundary isn't itself a patch point position, so when we had:

    PadPatchPoint
    // Enough space
    PadPatchPoint // block boundary
    // Not enough space
    PadPatchPoint

We got an unnecessary nop.

Add a new `BoundaryPad` instruction that only pads for `PatchPointPad`
preceding it.

Rename to `PatchPointPad` since "pad" first can be read as an
imperative, while most of the time these pads are zero-width.

Pull out the last iteration check for inserting the `PatchPointPad` at
end-of-function. I think there was a bug there because it checked for
block id while iterating with reverse-post order.

Note that not all padding for patchpoints are gone, as we still pad for
when two patchpoints are too close to each other. We'd need to tweak
bookkeeping in invariants.rs to support two patchpoints having the same
code address.
