### PR TITLE
Only clear $~ once when #match "fails"

### DIFF
--- a/re.c
+++ b/re.c
@@ -3830,6 +3830,7 @@ reg_match_pos(VALUE re, VALUE *strp, long pos, VALUE* set_match)
             VALUE l = rb_str_length(str);
             pos += NUM2INT(l);
             if (pos < 0) {
+                rb_backref_set(Qnil);
                 return pos;
             }
         }
@@ -4024,7 +4025,6 @@ rb_reg_match_m(int argc, VALUE *argv, VALUE re)
 
     pos = reg_match_pos(re, &str, pos, &result);
     if (pos < 0) {
-        rb_backref_set(Qnil);
         return Qnil;
     }
     rb_match_busy(result);


### PR DESCRIPTION
```
$ ips --ruby ruby-dev --ruby ruby-master -e '"".match?(/a/)' -e '"".match(/a/)'
ruby 4.1.0dev (2026-07-28T19:56:48Z master 120c8fa88c) +PRISM [arm64-darwin25]
      "".match?(/a/):    40.578M i/s (± 1.4%)
       "".match(/a/):    23.439M i/s (± 1.7%)

ruby 4.1.0dev (2026-07-28T19:56:48Z master 120c8fa88c) +PRISM [arm64-darwin25]
      "".match?(/a/):    40.357M i/s (± 1.7%)
       "".match(/a/):    20.285M i/s (± 1.5%)

Summary
  "".match?(/a/) (ruby ruby-dev) ran
    1.01 ± 0.02 times faster than "".match?(/a/) (ruby ruby-master)
    1.73 ± 0.04 times faster than "".match(/a/) (ruby ruby-dev)
    2.00 ± 0.04 times faster than "".match(/a/) (ruby ruby-master)
```

Previously, `reg_match_pos` cleared `$~` in every case where it returned a negative offset except one: when a negative `pos` argument underflows the start of the string. `rb_reg_match_m` had to account for this by clearing `$~` for _any_ negative return, so every failed `Regexp#match` (and `String#match`) which doesn't underflow ended up calling `rb_backref_set` twice.

This commit moves the clear into the branch that was missing it, so `reg_match_pos` maintains `$~` on all of its negative returns and its callers no longer have to.