### PR TITLE
ZJIT: Iterate over state in SetLocal

### DIFF
--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -1350,7 +1350,6 @@ macro_rules! for_each_operand_impl {
             | Insn::HasType { val, .. }
             | Insn::Return { val }
             | Insn::Test { val }
-            | Insn::SetLocal { val, .. }
             | Insn::BoxBool { val } => {
                 $visit_one!(*val);
             }
@@ -1366,6 +1365,7 @@ macro_rules! for_each_operand_impl {
             | Insn::ToArray { val, state }
             | Insn::IsMethodCfunc { val, state, .. }
             | Insn::ToNewArray { val, state }
+            | Insn::SetLocal { val, state, .. }
             | Insn::BoxFixnum { val, state } => {
                 $visit_one!(*val);
                 $visit_one!(*state);

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -16652,6 +16652,7 @@ mod hir_opt_tests {
           v43:BasicObject = CCallWithFrame v42, :Kernel#proc@0x1040, block=0x1048
           v22:CPtr = GetEP 0
           v23:BasicObject = LoadField v22, :blk@0x1001
+          v24:BasicObject = LoadField v22, :other_block@0x1002
           SetLocal :other_block, l0, EP@3, v43
           v30:CPtr = GetEP 0
           v31:BasicObject = LoadField v30, :other_block@0x1002
@@ -17295,6 +17296,7 @@ mod hir_opt_tests {
           v132:BasicObject = CCallWithFrame v131, :Kernel#lambda@0x1048, block=0x1050
           v89:CPtr = GetEP 0
           v90:BasicObject = LoadField v89, :list@0x1001
+          v91:BasicObject = LoadField v89, :sep@0x1002
           v92:BasicObject = LoadField v89, :iter_method@0x1005
           v93:BasicObject = LoadField v89, :kwsplat@0x1006
           SetLocal :sep, l0, EP@5, v132


### PR DESCRIPTION
We added state to `SetLocal` but didn't change `for_each_operand_impl`.
