### PR TITLE
ZJIT: Reject direct block calls with too many args for LIR

### DIFF
--- a/zjit/src/codegen_tests.rs
+++ b/zjit/src/codegen_tests.rs
@@ -609,6 +609,20 @@ fn test_yield_inline_invocation_with_args() {
 }
 
 #[test]
+fn test_yield_with_too_many_args_for_lir() {
+    // Self plus six yield args don't fit in C argument registers, so the direct
+    // block invocation must be rejected instead of emitting an uncompilable CCall.
+    set_call_threshold(2);
+    eval("
+        def foo = yield(1, 2, 3, 4, 5, 6)
+        def test = foo { |a, b, c, d, e, f| a + b + c + d + e + f }
+        test
+        test
+    ");
+    assert_snapshot!(assert_compiles("test"), @"21");
+}
+
+#[test]
 fn test_yield_inline_invocation_live_stack_below_args() {
     // A live value sits on the stack below the yield args; the no-receiver-slot SP math
     // must preserve it so `x +` sees the right operand.

--- a/zjit/src/codegen_tests.rs
+++ b/zjit/src/codegen_tests.rs
@@ -610,7 +610,7 @@ fn test_yield_inline_invocation_with_args() {
 
 #[test]
 fn test_yield_with_too_many_args_for_lir() {
-    // Self plus six yield args don't fit in C argument registers, so the direct
+    // `self` + six yield args don't fit in C argument registers, so the direct
     // block invocation must be rejected instead of emitting an uncompilable CCall.
     set_call_threshold(2);
     eval("

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -2818,28 +2818,32 @@ fn block_call_inlinable(flags: u32) -> bool {
     (flags & (VM_CALL_ARGS_SPLAT | VM_CALL_KW_SPLAT | VM_CALL_KWARG | VM_CALL_ARGS_BLOCKARG)) == 0
 }
 
-/// True if `yield` with `argc` positional args can dispatch by inlining the block ISEQ
+/// Ok if `yield` with `argc` positional args can dispatch by inlining the block ISEQ
 /// frame. The block must take the simple callee-setup path (`rb_simple_iseq_p`)
 /// with an exact arity match, avoid arg0 auto-splat, and contain no `throw` (break /
-/// non-local return). Anything else falls back to the generic `invokeblock` dispatch.
-fn block_call_inlinable_iseq(iseq: IseqPtr, argc: usize) -> bool {
+/// non-local return). Anything else falls back to the generic `invokeblock` dispatch,
+/// with the returned reason attached to the fallback instruction.
+fn block_call_inlinable_iseq(iseq: IseqPtr, argc: usize) -> Result<(), SendFallbackReason> {
     if !unsafe { rb_simple_iseq_p(iseq) } {
-        return false;
+        return Err(InvokeBlockNotSpecialized);
     }
     let lead_num = unsafe { rb_get_iseq_body_param_lead_num(iseq) } as usize;
     if argc != lead_num {
-        return false;
+        return Err(InvokeBlockNotSpecialized);
     }
     if argc == 1 && !unsafe { rb_get_iseq_flags_ambiguous_param0(iseq) } {
-        return false;
+        return Err(InvokeBlockNotSpecialized);
     }
     // The JIT-to-JIT call in gen_invoke_block_iseq_direct passes captured self plus
     // each argument in C argument registers.
     // TODO: Support passing arguments on the stack in C calls
     if 1 + argc > C_ARG_OPNDS.len() {
-        return false;
+        return Err(TooManyArgsForLir);
     }
-    !crate::codegen::block_iseq_may_throw(iseq)
+    if crate::codegen::block_iseq_may_throw(iseq) {
+        return Err(InvokeBlockNotSpecialized);
+    }
+    Ok(())
 }
 
 impl Function {
@@ -9337,11 +9341,15 @@ fn add_iseq_to_hir(
 
                     // If the block handler is a known simple ISEQ block with exact arity and no
                     // non-local exit, push its frame inline instead of calling rb_vm_invokeblock.
+                    let mut fallback_reason = InvokeBlockNotSpecialized;
                     let inline_iseq = if block_call_inlinable(flags) {
                         block_handler_class.and_then(|obj| {
                             if unsafe { rb_IMEMO_TYPE_P(obj, imemo_iseq) == 1 } {
                                 let iseq = obj.as_iseq();
-                                if block_call_inlinable_iseq(iseq, args.len()) { return Some(iseq); }
+                                match block_call_inlinable_iseq(iseq, args.len()) {
+                                    Ok(()) => return Some(iseq),
+                                    Err(reason) => fallback_reason = reason,
+                                }
                             }
                             None
                         })
@@ -9355,9 +9363,14 @@ fn add_iseq_to_hir(
                             // TODO: if block iseqs become inlinable, a yield here could resolve to an ancestor frame
                             // (level > 0). To stay guard-free we'd bake in get_lvar_level(...) as the level and fetch
                             // that ancestor's blockiseq from the inline caller chain instead of bi.
-                            && get_lvar_level(exit_state.iseq) == 0
-                            && block_call_inlinable_iseq(bi, args.len()) {
-                            Some(bi)
+                            && get_lvar_level(exit_state.iseq) == 0 {
+                            match block_call_inlinable_iseq(bi, args.len()) {
+                                Ok(()) => Some(bi),
+                                Err(reason) => {
+                                    fallback_reason = reason;
+                                    None
+                                }
+                            }
                         } else { None }
                     } else { None };
 
@@ -9412,7 +9425,7 @@ fn add_iseq_to_hir(
                         block = join_block;
                         join_param
                     } else {
-                        fun.push_insn(block, Insn::InvokeBlock { cd, args, state: exit_id, reason: InvokeBlockNotSpecialized })
+                        fun.push_insn(block, Insn::InvokeBlock { cd, args, state: exit_id, reason: fallback_reason })
                     };
                     state.stack_push(result);
                 }

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -2833,6 +2833,12 @@ fn block_call_inlinable_iseq(iseq: IseqPtr, argc: usize) -> bool {
     if argc == 1 && !unsafe { rb_get_iseq_flags_ambiguous_param0(iseq) } {
         return false;
     }
+    // The JIT-to-JIT call in gen_invoke_block_iseq_direct passes captured self plus
+    // each argument in C argument registers.
+    // TODO: Support passing arguments on the stack in C calls
+    if 1 + argc > C_ARG_OPNDS.len() {
+        return false;
+    }
     !crate::codegen::block_iseq_may_throw(iseq)
 }
 

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -3977,7 +3977,7 @@ mod hir_opt_tests {
           v16:Fixnum[4] = Const Value(4)
           v18:Fixnum[5] = Const Value(5)
           v20:Fixnum[6] = Const Value(6)
-          v22:BasicObject = InvokeBlock v10, v12, v14, v16, v18, v20 # SendFallbackReason: InvokeBlock: not yet specialized
+          v22:BasicObject = InvokeBlock v10, v12, v14, v16, v18, v20 # SendFallbackReason: Too many arguments for LIR
           CheckInterrupts
           Return v22
         ");
@@ -4014,7 +4014,7 @@ mod hir_opt_tests {
           v31:Fixnum[4] = Const Value(4)
           v33:Fixnum[5] = Const Value(5)
           v35:Fixnum[6] = Const Value(6)
-          v37:BasicObject = InvokeBlock v25, v27, v29, v31, v33, v35 # SendFallbackReason: InvokeBlock: not yet specialized
+          v37:BasicObject = InvokeBlock v25, v27, v29, v31, v33, v35 # SendFallbackReason: Too many arguments for LIR
           CheckInterrupts
           PopInlineFrame
           Return v37

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -3950,6 +3950,78 @@ mod hir_opt_tests {
     }
 
     #[test]
+    fn test_yield_with_too_many_args_for_lir_falls_back() {
+        // Captured self plus six args don't fit in C argument registers, so the profiled
+        // invokeblock specialization must not emit InvokeBlockIseqDirect.
+        let result = eval("
+            def foo = yield(1, 2, 3, 4, 5, 6)
+            def test = foo { |a, b, c, d, e, f| a + b + c + d + e + f }
+            test
+            test
+        ");
+        assert_eq!(VALUE::fixnum_from_usize(21), result);
+        assert_snapshot!(hir_string("foo"), @"
+        fn foo@<compiled>:2:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          Jump bb3(v1)
+        bb2():
+          EntryPoint JIT(0)
+          v4:BasicObject = LoadArg :self@0
+          Jump bb3(v4)
+        bb3(v6:BasicObject):
+          v10:Fixnum[1] = Const Value(1)
+          v12:Fixnum[2] = Const Value(2)
+          v14:Fixnum[3] = Const Value(3)
+          v16:Fixnum[4] = Const Value(4)
+          v18:Fixnum[5] = Const Value(5)
+          v20:Fixnum[6] = Const Value(6)
+          v22:BasicObject = InvokeBlock v10, v12, v14, v16, v18, v20 # SendFallbackReason: InvokeBlock: not yet specialized
+          CheckInterrupts
+          Return v22
+        ");
+    }
+
+    #[test]
+    fn test_inlined_yield_with_too_many_args_for_lir_falls_back() {
+        // Same as test_yield_with_too_many_args_for_lir_falls_back, but for the guard-free
+        // yield dispatch inside an inlined callee whose caller passes a literal block.
+        let result = eval("
+            def foo = yield(1, 2, 3, 4, 5, 6)
+            def test = foo { |a, b, c, d, e, f| a + b + c + d + e + f }
+            test
+            test
+        ");
+        assert_eq!(VALUE::fixnum_from_usize(21), result);
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:3:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          Jump bb3(v1)
+        bb2():
+          EntryPoint JIT(0)
+          v4:BasicObject = LoadArg :self@0
+          Jump bb3(v4)
+        bb3(v6:BasicObject):
+          PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
+          v18:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
+          PushInlineFrame v18 (0x1038)
+          v25:Fixnum[1] = Const Value(1)
+          v27:Fixnum[2] = Const Value(2)
+          v29:Fixnum[3] = Const Value(3)
+          v31:Fixnum[4] = Const Value(4)
+          v33:Fixnum[5] = Const Value(5)
+          v35:Fixnum[6] = Const Value(6)
+          v37:BasicObject = InvokeBlock v25, v27, v29, v31, v33, v35 # SendFallbackReason: InvokeBlock: not yet specialized
+          CheckInterrupts
+          PopInlineFrame
+          Return v37
+        ");
+    }
+
+    #[test]
     fn test_yield_lambda_falls_back() {
         // A lambda passed via &l becomes a proc block handler (not imemo_iseq), so it never inlines invocation.
         // Compiles to Send.


### PR DESCRIPTION
Follow-up on https://github.com/ruby/ruby/pull/17653

This fixes panics on `assert!(data.opnds.len() <= C_ARG_OPNDS.len())` in `x86_split`. Similarly to https://github.com/ruby/ruby/pull/17286, we need to bail at the HIR level to deal with such cases properly.