### PR TITLE
[DOC] Fix the $? description of Process::Status.wait

### DIFF
--- a/process.c
+++ b/process.c
@@ -1116,20 +1116,19 @@ rb_process_status_wait(rb_pid_t pid, int flags)
  *
  *  If there are child processes,
  *  waits for a child process to exit and returns a Process::Status object
- *  containing information on that process;
- *  sets thread-local variable <tt>$?</tt>:
+ *  containing information on that process.
+ *  Unlike Process.wait, this method does not set thread-local variable
+ *  <tt>$?</tt>:
  *
  *    Process.spawn('cat /nop') # => 1155880
  *    Process::Status.wait      # => #<Process::Status: pid 1155880 exit 1>
- *    $?                        # => #<Process::Status: pid 1155508 exit 1>
+ *    $?                        # => nil # Not set.
  *
  *  If there is no child process,
  *  returns an "empty" Process::Status object
- *  that does not represent an actual process;
- *  does not set thread-local variable <tt>$?</tt>:
+ *  that does not represent an actual process:
  *
  *    Process::Status.wait # => #<Process::Status: pid -1 exit 0>
- *    $?                   # => #<Process::Status: pid 1155508 exit 1> # Unchanged.
  *
  *  May invoke the scheduler hook Fiber::Scheduler#process_wait.
  *


### PR DESCRIPTION
The documentation of `Process::Status.wait` says that it sets the thread-local
variable `$?` when there are child processes, but it never does.

`rb_process_status_wait` does not call `rb_last_status_set` — the only callers
of that function are in `rb_spawn_process`. Confirmed on 3.0.7, 3.3.12 and
4.0.6:

    $?                        # => nil
    Process.spawn('cat /nop') # => 4996
    Process::Status.wait      # => #<Process::Status: pid 4996 exit 1>
    $?                        # => nil

The existing example showed this as well: the pid displayed for `$?`
(1155508) did not match the pid of the returned status (1155880), which
contradicted the surrounding text.

Since `$?` is never set, the "does not set thread-local variable `$?`" note in
the no-child-process case became redundant, so it is folded into the general
description.

Found while writing the Japanese reference for `Process::Status` in the
rurema/doctree project (rurema/doctree#3362).
