### PR TITLE
Return a byte count from ractor_sync_memsize()

### DIFF
--- a/ractor_sync.c
+++ b/ractor_sync.c
@@ -703,7 +703,7 @@ static size_t
 ractor_sync_memsize(const rb_ractor_t *r)
 {
     if (r->sync.ports) {
-        return st_table_size(r->sync.ports);
+        return st_memsize(r->sync.ports);
     }
     else {
         return 0;


### PR DESCRIPTION
`st_table_size()` is the number of entries, but `ractor_memsize()` adds the result to `sizeof(rb_ractor_t)` as a byte count, so a Ractor is reported as costing one byte per open port. Use `st_memsize()`, as `ractor_selector_memsize()` in this file already does for its own ports table.

```ruby
require 'objspace'
base = ObjectSpace.memsize_of(Ractor.current)
ports = 100.times.map { Ractor::Port.new }
p ObjectSpace.memsize_of(Ractor.current) - base  #=> 100 (before), 3232 (after)
```

This affects released 4.0.0, where `Ractor::Port` was introduced.