### PR TITLE
Drop MMTK_HEAP_MAX in test_oom

### DIFF
--- a/test/mmtk/test_oom.rb
+++ b/test/mmtk/test_oom.rb
@@ -5,7 +5,7 @@ require_relative "helper"
 module MMTk
   class TestOOM < TestCase
     def test_oom
-      assert_in_out_err([{ "MMTK_HEAP_MAX" => "64MiB" }], <<~RUBY, [], /failed to allocate memory/)
+      assert_in_out_err([{ "MMTK_HEAP_MAX" => "4MiB" }], <<~RUBY, [], /failed to allocate memory/)
         10_000_000.times.map do
           Object.new
         end


### PR DESCRIPTION
Sync ruby/mmtk@11ea3a437f788fb085a61d1c7d931a9527dc13ba.