### PR TITLE
Make Proc#refined's memoized iseq copy and memo shareable

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -15227,6 +15227,10 @@ rb_iseq_dup_with_independent_caches(const rb_iseq_t *src_root)
             RB_OBJ_WRITE(copy, &cb->parent_iseq, sb->parent_iseq);
             result = copy;
         }
+
+        /* Shared across Ractors through the Proc#refined memo; the duplicated
+         * subtree is self-contained, so mark each copy shareable. */
+        RB_OBJ_SET_SHAREABLE((VALUE)copy);
     }
 
     if (ISEQ_PC2BRANCHINDEX(src_root) != Qnil) {

--- a/proc.c
+++ b/proc.c
@@ -436,6 +436,9 @@ refinement_memo_store(const rb_iseq_t *src_iseq, const rb_cref_t *base_cref,
         rb_ary_push(memo, mods[i]);
     }
     OBJ_FREEZE(memo);
+    /* Every element is shareable, so mark the memo array shareable too for
+     * reuse from any Ractor. */
+    RB_OBJ_SET_SHAREABLE(memo);
 
     /* create the map outside the lock; losing the race just discards it */
     VALUE new_map = 0;


### PR DESCRIPTION
Proc#refined memoizes {copied_iseq, cref} per source iseq in a process-global map so the copy can be reused from any Ractor.  The cref's refinements table is already frozen and marked shareable for that reason, but the copied iseq and the memo array holding it are left unshareable, so the shared payload is not actually a shareable object graph.

Complete that intent: mark the copied iseq subtree shareable (it is self-contained -- nested block iseqs are copied too) and mark the frozen memo array shareable.  A copy's local_iseq/parent_iseq point at already-shareable iseqs (other copies in the subtree, or the shareable enclosing iseq), so the shareable check needs no special casing.