### PR TITLE
Fix potential memory leak in Onigmo's expand_case_fold_string().

### DIFF
--- a/regcomp.c
+++ b/regcomp.c
@@ -3664,7 +3664,11 @@ expand_case_fold_string(Node* node, regex_t* reg, int state)
       }
 
       r = onig_node_str_cat(snode, p, p + len);
-      if (r != 0) goto err;
+      if (r != 0) {
+        if (IS_NULL(root))
+          onig_node_free(snode);
+        goto err;
+      }
     }
     else {
       alt_num *= (n + 1);


### PR DESCRIPTION
Free snode when onig_node_str_cat() fails and the node has not yet been linked into the root tree.

When `root` is `NULL_NODE`, `snode` is not linked into the node tree. If `onig_node_str_cat()` fails here, `snode` leaks because `err:` only frees `top_root`.

Found by coverity scan on recent Ruby 3.3 rebase, seems present in other branches as well.

The leak situation is presumably rare as the `onig_node_str_cat()` fails mainly in OOM cases when `realloc` returns `NULL` and does not free original memory.

Contributed to Onigmo as well: https://github.com/k-takata/Onigmo/pull/178