### PR TITLE
ZJIT: Don't do incremental mark/sweep in profiling

### DIFF
--- a/zjit/bindgen/src/main.rs
+++ b/zjit/bindgen/src/main.rs
@@ -163,7 +163,7 @@ fn main() {
         .allowlist_function("rb_singleton_class")
         .allowlist_function("rb_define_class")
         .allowlist_function("rb_class_get_superclass")
-        .allowlist_function("rb_gc_disable")
+        .allowlist_function("rb_gc_disable_no_rest")
         .allowlist_function("rb_gc_enable")
         .allowlist_function("rb_gc_mark")
         .allowlist_function("rb_gc_mark_movable")

--- a/zjit/src/cruby.rs
+++ b/zjit/src/cruby.rs
@@ -1087,7 +1087,7 @@ where
     //   2. If we yield to the GC while compiling, it re-enters our mark and update functions.
     //      This breaks `&mut` exclusivity since mark functions derive fresh `&mut` from statics
     //      while there is a stack frame below it that has an overlapping `&mut`. That's UB.
-    let gc_disabled_pre_call = unsafe { rb_gc_disable() }.test();
+    let gc_disabled_pre_call = unsafe { rb_gc_disable_no_rest() }.test();
 
     let ret = match catch_unwind(func) {
         Ok(result) => result,

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -2069,7 +2069,6 @@ unsafe extern "C" {
     pub fn rb_gc_mark_movable(obj: VALUE);
     pub fn rb_gc_location(obj: VALUE) -> VALUE;
     pub fn rb_gc_enable() -> VALUE;
-    pub fn rb_gc_disable() -> VALUE;
     pub fn rb_gc_register_mark_object(object: VALUE);
     pub fn rb_gc_writebarrier(old: VALUE, young: VALUE);
     pub fn rb_class_get_superclass(klass: VALUE) -> VALUE;
@@ -2216,6 +2215,7 @@ unsafe extern "C" {
         buff_size: usize,
         obj: VALUE,
     ) -> *const ::std::os::raw::c_char;
+    pub fn rb_gc_disable_no_rest() -> VALUE;
     pub fn rb_ec_stack_check(ec: *mut rb_execution_context_struct) -> ::std::os::raw::c_int;
     pub fn rb_gc_writebarrier_remember(obj: VALUE);
     pub fn rb_shape_id_offset() -> i32;


### PR DESCRIPTION
We just want to disable the GC, nothing more. Brings GC disable time from ~20% of profiling time to ~0.5%.

Before:
<img width="1286" height="492" alt="Screenshot 2026-07-29 at 2 51 27 PM" src="https://github.com/user-attachments/assets/ece1f480-3380-4063-b0f0-f92acd4c1688" />

After:
<img width="1287" height="348" alt="Screenshot 2026-07-29 at 2 51 32 PM" src="https://github.com/user-attachments/assets/5b45d7f1-b216-479d-8a4a-a62a40338fdf" />
