### PR TITLE
id_table.c: keep managed id table live across foreach/dup callbacks

### DIFF
--- a/id_table.c
+++ b/id_table.c
@@ -397,6 +397,9 @@ rb_managed_id_table_dup(VALUE old_table)
     struct rb_id_table *old_tbl = managed_id_table_ptr(old_table);
     rb_id_table_init(new_tbl, old_tbl->num + 1);
     rb_id_table_foreach(old_tbl, managed_id_table_dup_i, new_tbl);
+    /* The table body is embedded (RUBY_TYPED_EMBEDDABLE), so old_tbl is an
+     * interior pointer.  Keep old_table live in case dup_i triggers a GC. */
+    RB_GC_GUARD(old_table);
     return obj;
 }
 
@@ -422,12 +425,16 @@ void
 rb_managed_id_table_foreach(VALUE table, rb_id_table_foreach_func_t *func, void *data)
 {
     rb_id_table_foreach(managed_id_table_ptr(table), func, data);
+    /* The table body is embedded (RUBY_TYPED_EMBEDDABLE), so the pointer above
+     * is interior.  Keep table live in case func triggers a GC. */
+    RB_GC_GUARD(table);
 }
 
 void
 rb_managed_id_table_foreach_values(VALUE table, rb_id_table_foreach_values_func_t *func, void *data)
 {
     rb_id_table_foreach_values(managed_id_table_ptr(table), func, data);
+    RB_GC_GUARD(table);
 }
 
 int


### PR DESCRIPTION
rb_managed_id_table stores its rb_id_table body as embedded data (RUBY_TYPED_EMBEDDABLE), so managed_id_table_ptr returns a pointer interior to the wrapper object.  rb_managed_id_table_foreach, _foreach_values, and _dup hand that interior pointer to a callback that may allocate and trigger a GC.  If the compiler stops keeping the wrapper VALUE live once the interior pointer is taken, the table can be reclaimed while it is still being iterated.  Add RB_GC_GUARD on the wrapper across these calls.