### PR TITLE
Preserve line events across jump optimization

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -3677,30 +3677,22 @@ iseq_peephole_optimize(rb_iseq_t *iseq, LINK_ELEMENT *list, const int do_tailcal
          */
         INSN *nobj = (INSN *)get_destination_insn(iobj);
 
-        /* This is super nasty hack!!!
-         *
-         * This jump-jump optimization may ignore event flags of the jump
-         * instruction being skipped.  Actually, Line 2 TracePoint event
-         * is never fired in the following code:
+        /* This jump-jump optimization may ignore line events on the jump
+         * instruction being skipped.  For example, the Line 2 TracePoint
+         * event would otherwise never fire in the following code:
          *
          *   1: raise if 1 == 2
          *   2: while true
          *   3:   break
          *   4: end
          *
-         * This is critical for coverage measurement.  [Bug #15980]
-         *
-         * This is a stopgap measure: stop the jump-jump optimization if
-         * coverage measurement is enabled and if the skipped instruction
-         * has any event flag.
-         *
-         * Note that, still, TracePoint Line event does not occur on Line 2.
-         * This should be fixed in future.
+         * Do not skip a jump that carries a line event.  This applies even
+         * when coverage is disabled because TracePoint consumes the same
+         * event.  [Bug #15980]
          */
         int stop_optimization =
-            ISEQ_COVERAGE(iseq) && ISEQ_LINE_COVERAGE(iseq) &&
             nobj->link.type == ISEQ_ELEMENT_INSN &&
-            nobj->insn_info.events;
+            (nobj->insn_info.events & (RUBY_EVENT_LINE | RUBY_EVENT_COVERAGE_LINE));
         if (!stop_optimization) {
             INSN *pobj = (INSN *)iobj->link.prev;
             int prev_dup = 0;

--- a/test/ruby/test_settracefunc.rb
+++ b/test/ruby/test_settracefunc.rb
@@ -2808,6 +2808,62 @@ CODE
     assert_equal [__LINE__ - 5, __LINE__ - 4, __LINE__ - 3], lines, 'Bug #17868'
   end
 
+  def test_line_event_after_guard_before_while
+    lines = []
+    while_line = body_line = nil
+
+    TracePoint.new(:line) {|tp|
+      next unless target_thread?
+      lines << tp.lineno
+    }.enable {
+      raise if 1 == 2
+      while_line = __LINE__ + 1
+      while true
+        body_line = __LINE__ + 1
+        break
+      end
+    }
+
+    assert_includes lines, while_line
+    assert_includes lines, body_line
+    assert_operator lines.index(while_line), :<, lines.index(body_line)
+  end
+
+  def test_line_event_after_guard_before_while_predicate
+    parent = Class.new do
+      def read
+        @values.shift
+      end
+    end
+
+    child = Class.new(parent) do
+      def initialize
+        @values = ["chunk", nil]
+      end
+    end
+
+    start_line = __LINE__ + 2
+    while_line = start_line + 2
+    child.class_eval <<~RUBY, __FILE__, start_line
+      def read
+        return if @finished
+        while chunk = super
+          chunk.upcase
+        end
+      end
+    RUBY
+
+    lines = []
+    TracePoint.new(:line) {|tp|
+      next unless target_thread?
+      lines << tp.lineno
+    }.enable {
+      child.new.read
+    }
+
+    assert_includes lines, while_line
+  end
+
   def test_allow_reentry
     event_lines = []
     _l1 = _l2 = _l3 = _l4 = nil


### PR DESCRIPTION
`TracePoint.new(:line)` can miss the line event for an executed loop condition when jump-to-jump peephole optimization retargets a conditional branch past the jump carrying the event.

For example, this reports lines 1 and 3 but not line 2:

```ruby
raise if 1 == 2
while true
  break
end
```

The same shape occurs with a real predicate, such as a guard followed by `while chunk = super`.

## Fix

Do not perform this specific jump-to-jump retargeting when the skipped jump carries a line event.

Ruby already stops this optimization for event-bearing jumps when line coverage is enabled. This change applies that guard to `RUBY_EVENT_LINE` and `RUBY_EVENT_COVERAGE_LINE` regardless of whether coverage is active, allowing regular line TracePoint to observe the executed line too.

This is a smaller alternative to #17825 following @ko1's feedback. It changes only `compile.c` and the regression tests; it does not add edge metadata or new VM/JIT handling.

## Performance

The cost is one additional YARV `jump` dispatch whenever execution takes an affected edge. Other jump-to-jump folding is unchanged.

This is an intentional interpreter/JIT tradeoff: keep event-correct bytecode in the interpreter and let the JITs remove the control-flow overhead for performance-sensitive execution. YJIT's `gen_direct_jump` emits no machine jump when it can place the target block next, and ZJIT's `clean_cfg` absorbs single-predecessor jump chains. The benchmarks below confirm that both recover the interpreter loss in steady state.

I compared Ruby built immediately before and after this patch on an Apple M4 Pro. Each result is the median of 9 or 11 samples after 3 warmups.

| Targeted benchmark | Baseline | Patched | Change |
|---|---:|---:|---:|
| Hot affected edge, interpreter | 46.20 M iter/s | 45.74 M iter/s | -1.0% |
| Minimal `return if ...; while next_chunk` reader, interpreter | 30.95 M calls/s | 30.13 M calls/s | -2.7% |
| Minimal reader, YJIT | 272.56 M calls/s | 272.56 M calls/s | 0.0% |
| Minimal reader, ZJIT | 435.34 M calls/s | 436.89 M calls/s | +0.4% |

For the synthetic hot-edge benchmark, ZJIT differed by +0.04%. Two long YJIT runs in opposite order varied between -0.5% and +0.4%, so there was no repeatable YJIT regression. The interpreter results are included to quantify the tradeoff, but are not the optimization target. They describe deliberately concentrated upper-bound cases: ordinary code only pays when it traverses this particular event-bearing jump.

JIT runs used `--yjit --yjit-call-threshold=1` or `--zjit --zjit-call-threshold=1 --zjit-num-profiles=1` to measure steady-state generated code.

## Tests

Added line TracePoint regressions for:

- a guard before `while true`
- a guard before `while chunk = super`

Verified with:

```sh
make test-all TESTS='test/ruby/test_settracefunc.rb test/coverage/test_coverage.rb'
make test
```

The targeted suites report 145 tests and 1,324 assertions with no failures. The bootstrap suite reports all 2,053 tests passing.

Related: [Bug #15980](https://bugs.ruby-lang.org/issues/15980)
Supersedes: #17825

https://bugs.ruby-lang.org/issues/22218