### PR TITLE
Re-bootstrap vcpkg after updating its registry

### DIFF
--- a/.github/workflows/tarball-windows.yml
+++ b/.github/workflows/tarball-windows.yml
@@ -90,8 +90,12 @@ jobs:
           "VCPKG_BINARY_SOURCES=clear;nuget,$Env:FEED_URL,$Env:FEED_MODE" >> $Env:GITHUB_ENV
 
       - name: Install libraries with vcpkg
+        # The registry pinned by `builtin-baseline` can need a newer tool
+        # than the vcpkg.exe shipped in the runner image, so re-bootstrap
+        # it to the version the pulled registry asks for.
         run: |
           git -C "%VCPKG_INSTALLATION_ROOT%" pull --quiet
+          call "%VCPKG_INSTALLATION_ROOT%\bootstrap-vcpkg.bat"
           vcpkg install
         working-directory: ${{ inputs.archname }}
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -109,8 +109,12 @@ jobs:
           "VCPKG_BINARY_SOURCES=clear;nuget,$Env:FEED_URL,$Env:FEED_MODE" >> $Env:GITHUB_ENV
 
       - name: Install libraries with vcpkg
+        # The registry pinned by `builtin-baseline` can need a newer tool
+        # than the vcpkg.exe shipped in the runner image, so re-bootstrap
+        # it to the version the pulled registry asks for.
         run: |
           git -C "%VCPKG_INSTALLATION_ROOT%" pull --quiet
+          call "%VCPKG_INSTALLATION_ROOT%\bootstrap-vcpkg.bat"
           vcpkg install
         working-directory: src
 


### PR DESCRIPTION
Every Windows job has been failing at `vcpkg install` since microsoft/vcpkg released vcpkg-tool 2026-07-27, which bumped `scripts/vcpkg-tools.json` to schema version 2. The workflows refresh the registry with `git pull` but keep the `vcpkg.exe` that ships in the runner image, and that older tool cannot parse the new tool data file. It then cannot resolve its own git tool either, so loading `builtin-baseline` fails as well.

Bootstrapping right after the pull keeps the tool and the registry in step. `bootstrap-vcpkg.bat` installs the version pinned in `scripts/vcpkg-tool-metadata.txt` of the tree just pulled, so the skew cannot come back when upstream raises the requirement again. It picks `vcpkg-arm64.exe` on `windows-11-arm`.

I reproduced the failure locally with an old `vcpkg.exe` against a current `microsoft/vcpkg` checkout, and `vcpkg install --dry-run` resolves the baseline once the tool is re-bootstrapped.
