### PR TITLE
[Bug #22219] Raise FrozenError from IO::Buffer#free and IO::Buffer#resize on a frozen buffer

### DIFF
--- a/io_buffer.c
+++ b/io_buffer.c
@@ -230,7 +230,7 @@ io_buffer_initialize(VALUE self, struct rb_io_buffer *buffer, void *base, size_t
 }
 
 static void
-io_buffer_free(struct rb_io_buffer *buffer)
+io_buffer_release(struct rb_io_buffer *buffer)
 {
     if (buffer->base) {
         if (buffer->flags & RB_IO_BUFFER_INTERNAL) {
@@ -265,9 +265,9 @@ io_buffer_free(struct rb_io_buffer *buffer)
 
 #if defined(_WIN32)
     if (buffer->mapping) {
-        if (RB_IO_BUFFER_DEBUG) fprintf(stderr, "io_buffer_free:CloseHandle -> %p\n", buffer->mapping);
+        if (RB_IO_BUFFER_DEBUG) fprintf(stderr, "io_buffer_release:CloseHandle -> %p\n", buffer->mapping);
         if (!CloseHandle(buffer->mapping)) {
-            fprintf(stderr, "io_buffer_free:GetLastError -> %lu\n", GetLastError());
+            fprintf(stderr, "io_buffer_release:GetLastError -> %lu\n", GetLastError());
         }
         buffer->mapping = NULL;
     }
@@ -308,7 +308,7 @@ rb_io_buffer_type_free(void *_buffer)
 {
     struct rb_io_buffer *buffer = _buffer;
 
-    io_buffer_free(buffer);
+    io_buffer_release(buffer);
 }
 
 static size_t
@@ -1615,6 +1615,20 @@ rb_io_buffer_locked(VALUE self)
     return rb_ensure(rb_yield, self, rb_io_buffer_locked_ensure, self);
 }
 
+VALUE
+rb_io_buffer_free(VALUE self)
+{
+    struct rb_io_buffer *buffer = get_io_buffer(self);
+
+    if (buffer->flags & RB_IO_BUFFER_LOCKED) {
+        rb_raise(rb_eIOBufferLockedError, "Buffer is locked!");
+    }
+
+    io_buffer_release(buffer);
+
+    return self;
+}
+
 /*
  *  call-seq: free -> self
  *
@@ -1639,19 +1653,20 @@ rb_io_buffer_locked(VALUE self)
  *
  *    buffer.null?
  *    # => true
+ *
+ *  A frozen buffer cannot be freed, as that would release the memory its
+ *  contents live in:
+ *
+ *    buffer = IO::Buffer.for('test').freeze
+ *    buffer.free
+ *    # in `free': can't modify frozen IO::Buffer (FrozenError)
  */
-VALUE
-rb_io_buffer_free(VALUE self)
+static VALUE
+io_buffer_free(VALUE self)
 {
-    struct rb_io_buffer *buffer = get_io_buffer(self);
+    rb_check_frozen(self);
 
-    if (buffer->flags & RB_IO_BUFFER_LOCKED) {
-        rb_raise(rb_eIOBufferLockedError, "Buffer is locked!");
-    }
-
-    io_buffer_free(buffer);
-
-    return self;
+    return rb_io_buffer_free(self);
 }
 
 VALUE rb_io_buffer_free_locked(VALUE self)
@@ -1659,7 +1674,7 @@ VALUE rb_io_buffer_free_locked(VALUE self)
     struct rb_io_buffer *buffer = get_io_buffer(self);
 
     io_buffer_unlock(buffer);
-    io_buffer_free(buffer);
+    io_buffer_release(buffer);
 
     return self;
 }
@@ -1873,7 +1888,7 @@ io_buffer_resize_copy(VALUE self, struct rb_io_buffer *buffer, size_t size)
         io_buffer_resize_clear(buffer, resized.base, size);
     }
 
-    io_buffer_free(buffer);
+    io_buffer_release(buffer);
     *buffer = resized;
 }
 
@@ -1916,7 +1931,7 @@ rb_io_buffer_resize(VALUE self, size_t size)
 
     if (buffer->flags & RB_IO_BUFFER_INTERNAL) {
         if (size == 0) {
-            io_buffer_free(buffer);
+            io_buffer_release(buffer);
             return;
         }
 
@@ -1952,12 +1967,14 @@ rb_io_buffer_resize(VALUE self, size_t size)
  *    # #<IO::Buffer 0x0000555f5d1a1630+8 INTERNAL>
  *    # 0x00000000  74 65 73 74 00 00 00 00                         test....
  *
- *  External buffer (created with ::for), and locked buffer
+ *  External buffer (created with ::for), locked buffer, and frozen buffer
  *  can not be resized.
  */
 static VALUE
 io_buffer_resize(VALUE self, VALUE size)
 {
+    rb_check_frozen(self);
+
     rb_io_buffer_resize(self, io_buffer_extract_size(size));
 
     return self;
@@ -4154,7 +4171,7 @@ Init_IO_Buffer(void)
     rb_define_method(rb_cIOBuffer, "<=>", rb_io_buffer_compare, 1);
     rb_define_method(rb_cIOBuffer, "resize", io_buffer_resize, 1);
     rb_define_method(rb_cIOBuffer, "clear", io_buffer_clear, -1);
-    rb_define_method(rb_cIOBuffer, "free", rb_io_buffer_free, 0);
+    rb_define_method(rb_cIOBuffer, "free", io_buffer_free, 0);
 
     rb_include_module(rb_cIOBuffer, rb_mComparable);
 

--- a/test/ruby/test_io_buffer.rb
+++ b/test/ruby/test_io_buffer.rb
@@ -327,6 +327,79 @@ class TestIOBuffer < Test::Unit::TestCase
     end
   end
 
+  def test_resize_after_free
+    buffer = IO::Buffer.new(4)
+    buffer.set_string("test")
+    buffer.free
+    assert_predicate buffer, :null?
+
+    buffer.resize(8)
+    assert_equal 8, buffer.size
+    refute_predicate buffer, :null?
+  end
+
+  def test_free_frozen
+    buffer = IO::Buffer.new(4)
+    buffer.set_string("test")
+    buffer.freeze
+
+    assert_raise(FrozenError) do
+      buffer.free
+    end
+
+    refute_predicate buffer, :null?
+    assert_equal "test", buffer.get_string
+  end
+
+  def test_free_frozen_external
+    string = "Hello World".freeze
+    buffer = IO::Buffer.for(string)
+    buffer.freeze
+
+    assert_raise(FrozenError) do
+      buffer.free
+    end
+
+    refute_predicate buffer, :null?
+    assert_equal string, buffer.get_string
+  end
+
+  def test_free_frozen_in_block
+    string = +"Hello World"
+
+    buffer = IO::Buffer.for(string, &:freeze)
+    assert_predicate buffer, :null?
+
+    # The string is no longer locked by the buffer:
+    assert_equal "Hello World!", string << "!"
+  end
+
+  def test_resize_frozen
+    buffer = IO::Buffer.new(4)
+    buffer.set_string("test")
+    buffer.freeze
+
+    assert_raise(FrozenError) do
+      buffer.resize(8)
+    end
+
+    assert_equal 4, buffer.size
+    assert_equal "test", buffer.get_string
+  end
+
+  def test_resize_frozen_external
+    string = "Hello World".freeze
+    buffer = IO::Buffer.for(string)
+    buffer.freeze
+
+    assert_raise(FrozenError) do
+      buffer.resize(8)
+    end
+
+    assert_equal string.bytesize, buffer.size
+    assert_equal string, buffer.get_string
+  end
+
   def test_compare_same_size
     buffer1 = IO::Buffer.new(1)
     assert_equal buffer1, buffer1


### PR DESCRIPTION
The check is added in method-level wrappers, leaving the public C API unchanged. `#resize` already had such a wrapper. `#free` did not, so this adds one, and the struct-level helper `io_buffer_free()` is renamed to `io_buffer_release()` to free the name.