### PR TITLE
Re-bootstrap vcpkg after updating its registry

### DIFF
--- a/.github/workflows/tarball-windows.yml
+++ b/.github/workflows/tarball-windows.yml
@@ -90,8 +90,12 @@ jobs:
           "VCPKG_BINARY_SOURCES=clear;nuget,$Env:FEED_URL,$Env:FEED_MODE" >> $Env:GITHUB_ENV
 
       - name: Install libraries with vcpkg
+        # The registry pinned by `builtin-baseline` can need a newer tool
+        # than the vcpkg.exe shipped in the runner image, so re-bootstrap
+        # it to the version the pulled registry asks for.
         run: |
           git -C "%VCPKG_INSTALLATION_ROOT%" pull --quiet
+          call "%VCPKG_INSTALLATION_ROOT%\bootstrap-vcpkg.bat"
           vcpkg install
         working-directory: ${{ inputs.archname }}
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -108,8 +108,12 @@ jobs:
           "VCPKG_BINARY_SOURCES=clear;nuget,$Env:FEED_URL,$Env:FEED_MODE" >> $Env:GITHUB_ENV
 
       - name: Install libraries with vcpkg
+        # The registry pinned by `builtin-baseline` can need a newer tool
+        # than the vcpkg.exe shipped in the runner image, so re-bootstrap
+        # it to the version the pulled registry asks for.
         run: |
           git -C "%VCPKG_INSTALLATION_ROOT%" pull --quiet
+          call "%VCPKG_INSTALLATION_ROOT%\bootstrap-vcpkg.bat"
           vcpkg install
         working-directory: src
 


### PR DESCRIPTION
Backport of f275e95ff23f1a299b2a72fc47758de539db8dde.

Every Windows job on this branch fails at `vcpkg install`, because microsoft/vcpkg bumped `scripts/vcpkg-tools.json` to schema version 2 and the `vcpkg.exe` bundled in the runner images cannot parse it. Re-bootstrapping after the `git pull` gets the tool the pulled registry asks for. Applies cleanly to both `windows.yml` and `tarball-windows.yml`.
