### PR TITLE
Fix unused variable warning in test_thread_timer_and_interrupt

### DIFF
--- a/test/ruby/test_thread.rb
+++ b/test/ruby/test_thread.rb
@@ -1016,7 +1016,7 @@ _eom
     cmd = 'Signal.trap(:INT, "DEFAULT"); pipe=IO.pipe; Thread.start {Thread.pass until Thread.main.stop?; puts; STDOUT.flush}; pipe[0].read'
     opt = {}
     opt[:new_pgroup] = true if /mswin|mingw/ =~ RUBY_PLATFORM
-    s, err = EnvUtil.invoke_ruby(['-e', cmd], "", true, true, **opt) do |in_p, out_p, err_p, cpid|
+    s, _err = EnvUtil.invoke_ruby(['-e', cmd], "", true, true, **opt) do |in_p, out_p, err_p, cpid|
       assert IO.select([out_p], nil, nil, 10), 'subprocess not ready'
       out_p.gets
       pid = cpid


### PR DESCRIPTION
`err` became unused when commit c05f55416f1 removed the flaky timing assertion, so `test/ruby/test_thread.rb` now emits `warning: assigned but unused variable - err` on every rubyci build. This shows up as the `1W` marker on nearly all servers. Renaming it back to `_err` silences the warning.
