### PR TITLE
C API: Expose `rb_iseq_load_from_binary`

### DIFF
--- a/ext/-test-/eval/eval.c
+++ b/ext/-test-/eval/eval.c
@@ -6,8 +6,15 @@ eval_string(VALUE self, VALUE str)
     return rb_eval_string(StringValueCStr(str));
 }
 
+static VALUE
+iseq_load_from_binary(VALUE self, VALUE str)
+{
+    return rb_iseq_load_from_binary(RSTRING_PTR(str), RSTRING_LEN(str));
+}
+
 void
 Init_eval(void)
 {
     rb_define_global_function("rb_eval_string", eval_string, 1);
+    rb_define_global_function("rb_iseq_load_from_binary", iseq_load_from_binary, 1);
 }

--- a/include/ruby/internal/eval.h
+++ b/include/ruby/internal/eval.h
@@ -400,6 +400,21 @@ RBIMPL_ATTR_NONNULL(())
  */
 VALUE rb_extract_keywords(VALUE *orighash);
 
+/**
+ *  Load an iseq object from binary format String object
+ *  created by RubyVM::InstructionSequence.to_binary.
+ *
+ * @warning     This loader does not have a verifier, so that loading broken/modified
+ *              binary causes critical problem.
+ * @warning     You should not load binary data provided by others.
+ *              You should only use binary data translated by yourself.
+ * @param[in]  ptr             A memory region of `len` bytes length.
+ * @param[in]  len             Length  of `ptr`,  in bytes,  not including  the
+ *                             optional terminating NUL character.
+ * @return     An  instance   of  RubyVM::InstructionSequence.
+ */
+VALUE rb_iseq_load_from_binary(const char *ptr, size_t len);
+
 RBIMPL_SYMBOL_EXPORT_END()
 
 #endif /* RBIMPL_EVAL_H */

--- a/iseq.c
+++ b/iseq.c
@@ -4361,12 +4361,18 @@ iseqw_to_binary(int argc, VALUE *argv, VALUE self)
  *  binary causes critical problem.
  *
  *  You should not load binary data provided by others.
- *  You should use binary data translated by yourself.
+ *  You should only use binary data translated by yourself.
  */
 static VALUE
 iseqw_s_load_from_binary(VALUE self, VALUE str)
 {
     return iseqw_new(rb_iseq_ibf_load(str));
+}
+
+VALUE
+rb_iseq_load_from_binary(const char *ptr, size_t len)
+{
+    return iseqw_new(rb_iseq_ibf_load_bytes(ptr, len));
 }
 
 /*

--- a/test/-ext-/eval/test_iseq_load.rb
+++ b/test/-ext-/eval/test_iseq_load.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: false
+require 'test/unit'
+require "-test-/eval"
+
+class IseqLoadTest < Test::Unit::TestCase
+  def test_rb_iseq_load_from_binary
+    binary = RubyVM::InstructionSequence.compile('1 + 1').to_binary
+    assert_equal 2, rb_iseq_load_from_binary(binary).eval
+  end
+end


### PR DESCRIPTION
[[Feature #22222]](https://bugs.ruby-lang.org/issues/22222)

This allows to efficiently load iseq from mmaped files and other buffers without having to copy the bytes into a Ruby string an then invoke `RubyVM::InstructionSequence.load_from_binary`.