### PR TITLE
Avoid build-time race condition when cross-compiling from a source tarball

### DIFF
--- a/defs/gmake.mk
+++ b/defs/gmake.mk
@@ -436,15 +436,13 @@ endif
 
 ifeq ($(HAVE_GIT),yes)
 REVISION_LATEST := $(shell $(GIT_IN_SRC) rev-parse HEAD 2>/dev/null)
-else
-REVISION_LATEST := update
-endif
 REVISION_IN_HEADER := $(shell sed '/^\#define RUBY_FULL_REVISION "\(.*\)"/!d;s//\1/;q' $(wildcard $(srcdir)/revision.h revision.h) /dev/null 2>/dev/null)
 ifeq ($(REVISION_IN_HEADER),)
 REVISION_IN_HEADER := none
 endif
 ifneq ($(REVISION_IN_HEADER),$(REVISION_LATEST))
 $(REVISION_H): PHONY
+endif
 endif
 
 include $(top_srcdir)/yjit/yjit.mk


### PR DESCRIPTION
Since commit 66529eef883c ("Force to update revision.h when commits differ"), the Makefile rule for `$(REVISION_H)` is always marked as PHONY when building from a source tarball. This has no benefit, file2lastrev.rb will just print a warning and exit if we're not in a VCS checkout, but it can cause problems.

When cross-compiling, the generated file `$(arch)-fake.rb` is used by every invocation of MINIRUBY. `$(arch)-fake.rb` depends on `$(REVISION_H)`, so it is considered perpetually out-of-date and sub-make invocations will repeatedly regenerate this file.

There is no enforcement of dependencies between sub-make invocations, so one sub-make can be running MINIRUBY (and so using `$(arch)-fake.rb`) at the same time as a different sub-make is regenerating `$(arch)-fake.rb`. Truncating and re-writing `$(arch)-fake.rb` while it is mmapped by a running ruby interpreter can cause a SIGBUS error, for example:

    i686-linux-gnu-fake.rb: [BUG] Bus Error at 0x00007fee11f02765

No addition of dependencies to Makefile rules can address this. Instead, we need to stop treating `$(REVISION_H)` as PHONY when not building from a git checkout.