### PR TITLE
Fix RUBY_TYPED_FROZEN_SHAREABLE_NO_REC

### DIFF
--- a/ractor.c
+++ b/ractor.c
@@ -1663,6 +1663,17 @@ shareable_p_enter(VALUE obj)
              allow_frozen_shareable_p(obj)) {
         return traverse_cont;
     }
+    else if (RB_OBJ_FROZEN_RAW(obj) &&
+             RB_TYPE_P(obj, T_DATA) &&
+             (RTYPEDDATA_TYPE(obj)->flags & RUBY_TYPED_FROZEN_SHAREABLE_NO_REC)) {
+        // Similar to RUBY_TYPED_FROZEN_SHAREABLE, but the object is only
+        // shareable if all reachable objects are already shareable (they
+        // are not made shareable recursively).
+        if (obj_refer_only_shareables_p(obj)) {
+            mark_shareable(obj);
+            return traverse_skip;
+        }
+    }
 
     return traverse_stop; // fail
 }

--- a/test/ruby/test_method.rb
+++ b/test/ruby/test_method.rb
@@ -1924,4 +1924,8 @@ class TestMethod < Test::Unit::TestCase
       assert_equal 0, err.size, err.join("\n")
     end
   end
+
+  def test_unbound_method_ractor_shareable
+    assert Ractor.shareable?(BasicObject.instance_method(:equal?).freeze)
+  end
 end


### PR DESCRIPTION
An UnboundMethod does not refer to any mutable children, so it should be shareable when frozen. The documentation for RUBY_TYPED_FROZEN_SHAREABLE_NO_REC states:

> Similar to RUBY_TYPED_FROZEN_SHAREABLE, but doesn't make shareable reachable objects from this T_DATA object on the Ractor.make_shareable.

Therefore, `Ractor.shareable?(BasicObject.instance_method(:equal?).freeze)` should return true since it doesn't refer to any shareable children. However, it doesn't do that right now so frozen UnboundMethod cannot be shared between Ractors.

cc. @ko1 