### PR TITLE
Finish fix for cross-compilation build race condition

### DIFF
--- a/defs/gmake.mk
+++ b/defs/gmake.mk
@@ -436,12 +436,14 @@ endif
 
 ifeq ($(HAVE_GIT),yes)
 REVISION_LATEST := $(shell $(GIT_IN_SRC) rev-parse HEAD 2>/dev/null)
+ifneq ($(REVISION_LATEST),)
 REVISION_IN_HEADER := $(shell sed '/^\#define RUBY_FULL_REVISION "\(.*\)"/!d;s//\1/;q' $(wildcard $(srcdir)/revision.h revision.h) /dev/null 2>/dev/null)
 ifeq ($(REVISION_IN_HEADER),)
 REVISION_IN_HEADER := none
 endif
 ifneq ($(REVISION_IN_HEADER),$(REVISION_LATEST))
 $(REVISION_H): PHONY
+endif
 endif
 endif
 


### PR DESCRIPTION
Apologies for the extra noise here! It turns out my previous PR (https://github.com/ruby/ruby/pull/18138) was only a partial fix. Further testing showed another change was needed:

Commit bb235bddd4ce ("Avoid build-time race condition when cross-compiling from a source tarball") turned out to be only a partial fix, we also need to cover the case where git is present but we're not building from a git checkout.

We can simply check if the `git log` command returned any output, if it didn't then we're not in a git checkout.