### PR TITLE
ZJIT: Support lifetime holes in the register allocator

### DIFF
--- a/zjit/src/backend/arm64/mod.rs
+++ b/zjit/src/backend/arm64/mod.rs
@@ -1598,9 +1598,10 @@ impl Assembler {
     }
 
     /// Optimize and compile the stored instructions
-    pub fn compile_with_regs(self, cb: &mut CodeBlock, mut regs: Vec<Reg>) -> Result<(CodePtr, Vec<CodePtr>), CompileError> {
+    pub fn compile_with_regs(self, cb: &mut CodeBlock, regs: Vec<Reg>) -> Result<(CodePtr, Vec<CodePtr>), CompileError> {
         // The backend is allowed to use scratch registers only if it has not accepted them so far.
         let use_scratch_reg = !self.accept_scratch_reg;
+        let mut regs = RegPool::new(regs);
         asm_dump!(self, init);
 
         let mut asm = trace_compile_phase("split", || self.arm64_split());
@@ -1620,9 +1621,8 @@ impl Assembler {
                 }
             }
 
-            let allocatable_regs = regs.len();
             trace_compile_phase("preferred_registers", || asm.preferred_register_assignments(&mut intervals, &mut regs));
-            let num_stack_slots = trace_compile_phase("linear_scan", || asm.linear_scan(&intervals, allocatable_regs, &regs));
+            let num_stack_slots = trace_compile_phase("linear_scan", || asm.linear_scan(&intervals, &regs));
 
             asm.stack_state.num_spill_slots = num_stack_slots;
             asm.stack_state.num_side_exit_stack_map_slots = asm.side_exit_stack_map_slots(&intervals);
@@ -1637,7 +1637,7 @@ impl Assembler {
                     for (i, interval) in intervals.iter().enumerate() {
                         if let Some(alloc) = interval.assigned.get() {
                             let alloc_str = match alloc {
-                                Allocation::Reg(n) => format!("{}", regs[n]),
+                                Allocation::Reg(n) => format!("{}", regs.reg_at(n)),
                                 Allocation::Stack(n) => format!("Stack[{}]", n),
                             };
                             println!("  v{} => {} (ranges: {})", i, alloc_str, interval.ranges_string());

--- a/zjit/src/backend/arm64/mod.rs
+++ b/zjit/src/backend/arm64/mod.rs
@@ -1622,7 +1622,7 @@ impl Assembler {
 
             let allocatable_regs = regs.len();
             trace_compile_phase("preferred_registers", || asm.preferred_register_assignments(&mut intervals, &mut regs));
-            let num_stack_slots = trace_compile_phase("linear_scan", || asm.linear_scan(&mut intervals, allocatable_regs, &regs));
+            let num_stack_slots = trace_compile_phase("linear_scan", || asm.linear_scan(&intervals, allocatable_regs, &regs));
 
             asm.stack_state.num_spill_slots = num_stack_slots;
             asm.stack_state.num_side_exit_stack_map_slots = asm.side_exit_stack_map_slots(&intervals);
@@ -1635,7 +1635,7 @@ impl Assembler {
 
                     println!("VReg assignments:");
                     for (i, interval) in intervals.iter().enumerate() {
-                        if let Some(alloc) = interval.assigned {
+                        if let Some(alloc) = interval.assigned.get() {
                             let alloc_str = match alloc {
                                 Allocation::Reg(n) => format!("{}", regs[n]),
                                 Allocation::Stack(n) => format!("Stack[{}]", n),

--- a/zjit/src/backend/arm64/mod.rs
+++ b/zjit/src/backend/arm64/mod.rs
@@ -1598,7 +1598,7 @@ impl Assembler {
     }
 
     /// Optimize and compile the stored instructions
-    pub fn compile_with_regs(self, cb: &mut CodeBlock, regs: Vec<Reg>) -> Result<(CodePtr, Vec<CodePtr>), CompileError> {
+    pub fn compile_with_regs(self, cb: &mut CodeBlock, mut regs: Vec<Reg>) -> Result<(CodePtr, Vec<CodePtr>), CompileError> {
         // The backend is allowed to use scratch registers only if it has not accepted them so far.
         let use_scratch_reg = !self.accept_scratch_reg;
         asm_dump!(self, init);
@@ -1620,8 +1620,9 @@ impl Assembler {
                 }
             }
 
-            trace_compile_phase("preferred_registers", || asm.preferred_register_assignments(&mut intervals));
-            let (assignments, num_stack_slots) = trace_compile_phase("linear_scan", || asm.linear_scan(intervals.clone(), regs.len()));
+            let allocatable_regs = regs.len();
+            trace_compile_phase("preferred_registers", || asm.preferred_register_assignments(&mut intervals, &mut regs));
+            let (assignments, num_stack_slots) = trace_compile_phase("linear_scan", || asm.linear_scan(intervals.clone(), allocatable_regs, &regs));
 
             asm.stack_state.num_spill_slots = num_stack_slots;
             asm.stack_state.num_side_exit_stack_map_slots = asm.side_exit_stack_map_slots(&assignments);
@@ -1661,8 +1662,8 @@ impl Assembler {
             });
 
             trace_compile_phase("resolve_ssa", || {
-                asm.handle_caller_saved_regs(&intervals, &assignments, &C_ARG_REGREGS);
-                asm.resolve_ssa(&intervals, &assignments);
+                asm.handle_caller_saved_regs(&intervals, &assignments, &regs, &C_ARG_REGREGS);
+                asm.resolve_ssa(&intervals, &assignments, &regs);
             });
 
             Ok(())
@@ -1920,10 +1921,10 @@ mod tests {
 
         // Assert that only 2 instructions were written.
         assert_disasm_snapshot!(cb.disasm(), @"
-        0x0: adds x0, x0, x1
-        0x4: stur x0, [x2]
+        0x0: adds x3, x0, x1
+        0x4: stur x3, [x2]
         ");
-        assert_snapshot!(cb.hexdump(), @"000001ab400000f8");
+        assert_snapshot!(cb.hexdump(), @"030001ab430000f8");
     }
 
     #[test]

--- a/zjit/src/backend/arm64/mod.rs
+++ b/zjit/src/backend/arm64/mod.rs
@@ -1611,7 +1611,7 @@ impl Assembler {
             trace_compile_phase("number_instructions", || asm.number_instructions(0));
 
             let live_in = trace_compile_phase("analyze_liveness", || asm.analyze_liveness());
-            let intervals = trace_compile_phase("build_intervals", || asm.build_intervals(live_in));
+            let mut intervals = trace_compile_phase("build_intervals", || asm.build_intervals(live_in));
 
             // Dump live intervals if requested
             if let Some(crate::options::Options { dump_lir: Some(dump_lirs), .. }) = unsafe { crate::options::OPTIONS.as_ref() } {
@@ -1620,8 +1620,8 @@ impl Assembler {
                 }
             }
 
-            let preferred_registers = trace_compile_phase("preferred_registers", || asm.preferred_register_assignments(&intervals));
-            let (assignments, num_stack_slots) = trace_compile_phase("linear_scan", || asm.linear_scan(intervals.clone(), regs.len(), &preferred_registers));
+            trace_compile_phase("preferred_registers", || asm.preferred_register_assignments(&mut intervals));
+            let (assignments, num_stack_slots) = trace_compile_phase("linear_scan", || asm.linear_scan(intervals.clone(), regs.len()));
 
             asm.stack_state.num_spill_slots = num_stack_slots;
             asm.stack_state.num_side_exit_stack_map_slots = asm.side_exit_stack_map_slots(&assignments);

--- a/zjit/src/backend/arm64/mod.rs
+++ b/zjit/src/backend/arm64/mod.rs
@@ -1625,7 +1625,7 @@ impl Assembler {
             trace_compile_phase("number_instructions", || asm.number_instructions(0));
 
             let live_in = trace_compile_phase("analyze_liveness", || asm.analyze_liveness());
-            let intervals = trace_compile_phase("build_intervals", || asm.build_intervals(live_in));
+            let mut intervals = trace_compile_phase("build_intervals", || asm.build_intervals(live_in));
 
             // Dump live intervals if requested
             if let Some(crate::options::Options { dump_lir: Some(dump_lirs), .. }) = unsafe { crate::options::OPTIONS.as_ref() } {
@@ -1634,8 +1634,8 @@ impl Assembler {
                 }
             }
 
-            let preferred_registers = trace_compile_phase("preferred_registers", || asm.preferred_register_assignments(&intervals));
-            let (assignments, num_stack_slots) = trace_compile_phase("linear_scan", || asm.linear_scan(intervals.clone(), regs.len(), &preferred_registers));
+            trace_compile_phase("preferred_registers", || asm.preferred_register_assignments(&mut intervals));
+            let (assignments, num_stack_slots) = trace_compile_phase("linear_scan", || asm.linear_scan(intervals.clone(), regs.len()));
 
             asm.stack_state.num_spill_slots = num_stack_slots;
             asm.stack_state.num_side_exit_stack_map_slots = asm.side_exit_stack_map_slots(&assignments);

--- a/zjit/src/backend/arm64/mod.rs
+++ b/zjit/src/backend/arm64/mod.rs
@@ -1654,7 +1654,7 @@ impl Assembler {
                                 Allocation::Reg(n) => format!("{}", regs[n]),
                                 Allocation::Stack(n) => format!("Stack[{}]", n),
                             };
-                            println!("  v{} => {} (range: {:?}..{:?})", i, alloc_str, interval.start(), interval.end());
+                            println!("  v{} => {} (ranges: {})", i, alloc_str, interval.ranges_string());
                         }
                     }
                 }

--- a/zjit/src/backend/arm64/mod.rs
+++ b/zjit/src/backend/arm64/mod.rs
@@ -1654,7 +1654,6 @@ impl Assembler {
                             let end = &intervals[i].end();
                             let alloc_str = match alloc {
                                 Allocation::Reg(n) => format!("{}", regs[*n]),
-                                Allocation::Fixed(reg) => format!("{}", reg),
                                 Allocation::Stack(n) => format!("Stack[{}]", n),
                             };
                             println!("  v{} => {} (range: {:?}..{:?})", i, alloc_str, start, end);

--- a/zjit/src/backend/arm64/mod.rs
+++ b/zjit/src/backend/arm64/mod.rs
@@ -1622,10 +1622,10 @@ impl Assembler {
 
             let allocatable_regs = regs.len();
             trace_compile_phase("preferred_registers", || asm.preferred_register_assignments(&mut intervals, &mut regs));
-            let (assignments, num_stack_slots) = trace_compile_phase("linear_scan", || asm.linear_scan(&mut intervals, allocatable_regs, &regs));
+            let num_stack_slots = trace_compile_phase("linear_scan", || asm.linear_scan(&mut intervals, allocatable_regs, &regs));
 
             asm.stack_state.num_spill_slots = num_stack_slots;
-            asm.stack_state.num_side_exit_stack_map_slots = asm.side_exit_stack_map_slots(&assignments);
+            asm.stack_state.num_side_exit_stack_map_slots = asm.side_exit_stack_map_slots(&intervals);
             let stack_slot_count = asm.stack_state.stack_slot_count();
 
             // Dump vreg-to-physical-register mapping if requested
@@ -1634,15 +1634,13 @@ impl Assembler {
                     println!("LIR live_intervals:\n{}", crate::backend::lir::debug_intervals(&asm, &intervals));
 
                     println!("VReg assignments:");
-                    for (i, alloc) in assignments.iter().enumerate() {
-                        if let Some(alloc) = alloc {
-                            let start = &intervals[i].start();
-                            let end = &intervals[i].end();
+                    for (i, interval) in intervals.iter().enumerate() {
+                        if let Some(alloc) = interval.assigned {
                             let alloc_str = match alloc {
-                                Allocation::Reg(n) => format!("{}", regs[*n]),
+                                Allocation::Reg(n) => format!("{}", regs[n]),
                                 Allocation::Stack(n) => format!("Stack[{}]", n),
                             };
-                            println!("  v{} => {} (range: {:?}..{:?})", i, alloc_str, start, end);
+                            println!("  v{} => {} (range: {:?}..{:?})", i, alloc_str, interval.start(), interval.end());
                         }
                     }
                 }
@@ -1661,8 +1659,8 @@ impl Assembler {
             });
 
             trace_compile_phase("resolve_ssa", || {
-                asm.handle_caller_saved_regs(&intervals, &assignments, &regs, &C_ARG_REGREGS);
-                asm.resolve_ssa(&intervals, &assignments, &regs);
+                asm.handle_caller_saved_regs(&intervals, &regs, &C_ARG_REGREGS);
+                asm.resolve_ssa(&intervals, &regs);
             });
 
             Ok(())

--- a/zjit/src/backend/arm64/mod.rs
+++ b/zjit/src/backend/arm64/mod.rs
@@ -1612,7 +1612,7 @@ impl Assembler {
     }
 
     /// Optimize and compile the stored instructions
-    pub fn compile_with_regs(self, cb: &mut CodeBlock, regs: Vec<Reg>) -> Result<(CodePtr, Vec<CodePtr>), CompileError> {
+    pub fn compile_with_regs(self, cb: &mut CodeBlock, mut regs: Vec<Reg>) -> Result<(CodePtr, Vec<CodePtr>), CompileError> {
         // The backend is allowed to use scratch registers only if it has not accepted them so far.
         let use_scratch_reg = !self.accept_scratch_reg;
         asm_dump!(self, init);
@@ -1634,8 +1634,9 @@ impl Assembler {
                 }
             }
 
-            trace_compile_phase("preferred_registers", || asm.preferred_register_assignments(&mut intervals));
-            let (assignments, num_stack_slots) = trace_compile_phase("linear_scan", || asm.linear_scan(intervals.clone(), regs.len()));
+            let allocatable_regs = regs.len();
+            trace_compile_phase("preferred_registers", || asm.preferred_register_assignments(&mut intervals, &mut regs));
+            let (assignments, num_stack_slots) = trace_compile_phase("linear_scan", || asm.linear_scan(intervals.clone(), allocatable_regs, &regs));
 
             asm.stack_state.num_spill_slots = num_stack_slots;
             asm.stack_state.num_side_exit_stack_map_slots = asm.side_exit_stack_map_slots(&assignments);
@@ -1675,8 +1676,8 @@ impl Assembler {
             });
 
             trace_compile_phase("resolve_ssa", || {
-                asm.handle_caller_saved_regs(&intervals, &assignments, &C_ARG_REGREGS);
-                asm.resolve_ssa(&intervals, &assignments);
+                asm.handle_caller_saved_regs(&intervals, &assignments, &regs, &C_ARG_REGREGS);
+                asm.resolve_ssa(&intervals, &assignments, &regs);
             });
 
             Ok(())
@@ -1983,10 +1984,10 @@ mod tests {
 
         // Assert that only 2 instructions were written.
         assert_disasm_snapshot!(cb.disasm(), @"
-        0x0: adds x0, x0, x1
-        0x4: stur x0, [x2]
+        0x0: adds x3, x0, x1
+        0x4: stur x3, [x2]
         ");
-        assert_snapshot!(cb.hexdump(), @"000001ab400000f8");
+        assert_snapshot!(cb.hexdump(), @"030001ab430000f8");
     }
 
     #[test]

--- a/zjit/src/backend/arm64/mod.rs
+++ b/zjit/src/backend/arm64/mod.rs
@@ -1622,7 +1622,7 @@ impl Assembler {
 
             let allocatable_regs = regs.len();
             trace_compile_phase("preferred_registers", || asm.preferred_register_assignments(&mut intervals, &mut regs));
-            let (assignments, num_stack_slots) = trace_compile_phase("linear_scan", || asm.linear_scan(intervals.clone(), allocatable_regs, &regs));
+            let (assignments, num_stack_slots) = trace_compile_phase("linear_scan", || asm.linear_scan(&mut intervals, allocatable_regs, &regs));
 
             asm.stack_state.num_spill_slots = num_stack_slots;
             asm.stack_state.num_side_exit_stack_map_slots = asm.side_exit_stack_map_slots(&assignments);

--- a/zjit/src/backend/arm64/mod.rs
+++ b/zjit/src/backend/arm64/mod.rs
@@ -1649,13 +1649,14 @@ impl Assembler {
                     println!("VReg assignments:");
                     for (i, alloc) in assignments.iter().enumerate() {
                         if let Some(alloc) = alloc {
-                            let range = &intervals[i].range;
+                            let start = &intervals[i].start();
+                            let end = &intervals[i].end();
                             let alloc_str = match alloc {
                                 Allocation::Reg(n) => format!("{}", regs[*n]),
                                 Allocation::Fixed(reg) => format!("{}", reg),
                                 Allocation::Stack(n) => format!("Stack[{}]", n),
                             };
-                            println!("  v{} => {} (range: {:?}..{:?})", i, alloc_str, range.start, range.end);
+                            println!("  v{} => {} (range: {:?}..{:?})", i, alloc_str, start, end);
                         }
                     }
                 }

--- a/zjit/src/backend/arm64/mod.rs
+++ b/zjit/src/backend/arm64/mod.rs
@@ -1636,7 +1636,7 @@ impl Assembler {
 
             let allocatable_regs = regs.len();
             trace_compile_phase("preferred_registers", || asm.preferred_register_assignments(&mut intervals, &mut regs));
-            let num_stack_slots = trace_compile_phase("linear_scan", || asm.linear_scan(&mut intervals, allocatable_regs, &regs));
+            let num_stack_slots = trace_compile_phase("linear_scan", || asm.linear_scan(&intervals, allocatable_regs, &regs));
 
             asm.stack_state.num_spill_slots = num_stack_slots;
             asm.stack_state.num_side_exit_stack_map_slots = asm.side_exit_stack_map_slots(&intervals);
@@ -1649,7 +1649,7 @@ impl Assembler {
 
                     println!("VReg assignments:");
                     for (i, interval) in intervals.iter().enumerate() {
-                        if let Some(alloc) = interval.assigned {
+                        if let Some(alloc) = interval.assigned.get() {
                             let alloc_str = match alloc {
                                 Allocation::Reg(n) => format!("{}", regs[n]),
                                 Allocation::Stack(n) => format!("Stack[{}]", n),

--- a/zjit/src/backend/arm64/mod.rs
+++ b/zjit/src/backend/arm64/mod.rs
@@ -1640,7 +1640,6 @@ impl Assembler {
                             let end = &intervals[i].end();
                             let alloc_str = match alloc {
                                 Allocation::Reg(n) => format!("{}", regs[*n]),
-                                Allocation::Fixed(reg) => format!("{}", reg),
                                 Allocation::Stack(n) => format!("Stack[{}]", n),
                             };
                             println!("  v{} => {} (range: {:?}..{:?})", i, alloc_str, start, end);

--- a/zjit/src/backend/arm64/mod.rs
+++ b/zjit/src/backend/arm64/mod.rs
@@ -1612,9 +1612,10 @@ impl Assembler {
     }
 
     /// Optimize and compile the stored instructions
-    pub fn compile_with_regs(self, cb: &mut CodeBlock, mut regs: Vec<Reg>) -> Result<(CodePtr, Vec<CodePtr>), CompileError> {
+    pub fn compile_with_regs(self, cb: &mut CodeBlock, regs: Vec<Reg>) -> Result<(CodePtr, Vec<CodePtr>), CompileError> {
         // The backend is allowed to use scratch registers only if it has not accepted them so far.
         let use_scratch_reg = !self.accept_scratch_reg;
+        let mut regs = RegPool::new(regs);
         asm_dump!(self, init);
 
         let mut asm = trace_compile_phase("split", || self.arm64_split());
@@ -1634,9 +1635,8 @@ impl Assembler {
                 }
             }
 
-            let allocatable_regs = regs.len();
             trace_compile_phase("preferred_registers", || asm.preferred_register_assignments(&mut intervals, &mut regs));
-            let num_stack_slots = trace_compile_phase("linear_scan", || asm.linear_scan(&intervals, allocatable_regs, &regs));
+            let num_stack_slots = trace_compile_phase("linear_scan", || asm.linear_scan(&intervals, &regs));
 
             asm.stack_state.num_spill_slots = num_stack_slots;
             asm.stack_state.num_side_exit_stack_map_slots = asm.side_exit_stack_map_slots(&intervals);
@@ -1651,7 +1651,7 @@ impl Assembler {
                     for (i, interval) in intervals.iter().enumerate() {
                         if let Some(alloc) = interval.assigned.get() {
                             let alloc_str = match alloc {
-                                Allocation::Reg(n) => format!("{}", regs[n]),
+                                Allocation::Reg(n) => format!("{}", regs.reg_at(n)),
                                 Allocation::Stack(n) => format!("Stack[{}]", n),
                             };
                             println!("  v{} => {} (ranges: {})", i, alloc_str, interval.ranges_string());

--- a/zjit/src/backend/arm64/mod.rs
+++ b/zjit/src/backend/arm64/mod.rs
@@ -1636,7 +1636,7 @@ impl Assembler {
 
             let allocatable_regs = regs.len();
             trace_compile_phase("preferred_registers", || asm.preferred_register_assignments(&mut intervals, &mut regs));
-            let (assignments, num_stack_slots) = trace_compile_phase("linear_scan", || asm.linear_scan(intervals.clone(), allocatable_regs, &regs));
+            let (assignments, num_stack_slots) = trace_compile_phase("linear_scan", || asm.linear_scan(&mut intervals, allocatable_regs, &regs));
 
             asm.stack_state.num_spill_slots = num_stack_slots;
             asm.stack_state.num_side_exit_stack_map_slots = asm.side_exit_stack_map_slots(&assignments);

--- a/zjit/src/backend/arm64/mod.rs
+++ b/zjit/src/backend/arm64/mod.rs
@@ -1640,7 +1640,7 @@ impl Assembler {
                                 Allocation::Reg(n) => format!("{}", regs[n]),
                                 Allocation::Stack(n) => format!("Stack[{}]", n),
                             };
-                            println!("  v{} => {} (range: {:?}..{:?})", i, alloc_str, interval.start(), interval.end());
+                            println!("  v{} => {} (ranges: {})", i, alloc_str, interval.ranges_string());
                         }
                     }
                 }

--- a/zjit/src/backend/arm64/mod.rs
+++ b/zjit/src/backend/arm64/mod.rs
@@ -1636,10 +1636,10 @@ impl Assembler {
 
             let allocatable_regs = regs.len();
             trace_compile_phase("preferred_registers", || asm.preferred_register_assignments(&mut intervals, &mut regs));
-            let (assignments, num_stack_slots) = trace_compile_phase("linear_scan", || asm.linear_scan(&mut intervals, allocatable_regs, &regs));
+            let num_stack_slots = trace_compile_phase("linear_scan", || asm.linear_scan(&mut intervals, allocatable_regs, &regs));
 
             asm.stack_state.num_spill_slots = num_stack_slots;
-            asm.stack_state.num_side_exit_stack_map_slots = asm.side_exit_stack_map_slots(&assignments);
+            asm.stack_state.num_side_exit_stack_map_slots = asm.side_exit_stack_map_slots(&intervals);
             let stack_slot_count = asm.stack_state.stack_slot_count();
 
             // Dump vreg-to-physical-register mapping if requested
@@ -1648,15 +1648,13 @@ impl Assembler {
                     println!("LIR live_intervals:\n{}", crate::backend::lir::debug_intervals(&asm, &intervals));
 
                     println!("VReg assignments:");
-                    for (i, alloc) in assignments.iter().enumerate() {
-                        if let Some(alloc) = alloc {
-                            let start = &intervals[i].start();
-                            let end = &intervals[i].end();
+                    for (i, interval) in intervals.iter().enumerate() {
+                        if let Some(alloc) = interval.assigned {
                             let alloc_str = match alloc {
-                                Allocation::Reg(n) => format!("{}", regs[*n]),
+                                Allocation::Reg(n) => format!("{}", regs[n]),
                                 Allocation::Stack(n) => format!("Stack[{}]", n),
                             };
-                            println!("  v{} => {} (range: {:?}..{:?})", i, alloc_str, start, end);
+                            println!("  v{} => {} (range: {:?}..{:?})", i, alloc_str, interval.start(), interval.end());
                         }
                     }
                 }
@@ -1675,8 +1673,8 @@ impl Assembler {
             });
 
             trace_compile_phase("resolve_ssa", || {
-                asm.handle_caller_saved_regs(&intervals, &assignments, &regs, &C_ARG_REGREGS);
-                asm.resolve_ssa(&intervals, &assignments, &regs);
+                asm.handle_caller_saved_regs(&intervals, &regs, &C_ARG_REGREGS);
+                asm.resolve_ssa(&intervals, &regs);
             });
 
             Ok(())

--- a/zjit/src/backend/arm64/mod.rs
+++ b/zjit/src/backend/arm64/mod.rs
@@ -1635,13 +1635,14 @@ impl Assembler {
                     println!("VReg assignments:");
                     for (i, alloc) in assignments.iter().enumerate() {
                         if let Some(alloc) = alloc {
-                            let range = &intervals[i].range;
+                            let start = &intervals[i].start();
+                            let end = &intervals[i].end();
                             let alloc_str = match alloc {
                                 Allocation::Reg(n) => format!("{}", regs[*n]),
                                 Allocation::Fixed(reg) => format!("{}", reg),
                                 Allocation::Stack(n) => format!("Stack[{}]", n),
                             };
-                            println!("  v{} => {} (range: {:?}..{:?})", i, alloc_str, range.start, range.end);
+                            println!("  v{} => {} (range: {:?}..{:?})", i, alloc_str, start, end);
                         }
                     }
                 }

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -2138,6 +2138,30 @@ impl Assembler
         preferred
     }
 
+    fn release_assignment(it: &Interval, num_registers: usize, free_registers: &mut BTreeSet<usize>) {
+        if let Some(allocation) = it.assigned {
+            if let Some(reg) = allocation.alloc_pool_index(num_registers) {
+                let was_not_there_before = free_registers.insert(reg);
+                assert!(
+                    was_not_there_before,
+                    "attempted to return allocator register {:?} to the free pool more than once",
+                    allocation.assigned_reg().unwrap(),
+                );
+            } else {
+                assert!(
+                    allocation.assigned_reg().is_none_or(|reg| {
+                        crate::backend::current::ALLOC_REGS
+                            .iter()
+                            .take(num_registers)
+                            .all(|candidate| candidate.reg_no != reg.reg_no)
+                    }),
+                    "attempted to return non-allocatable register {:?} to the allocator pool",
+                    allocation.assigned_reg().unwrap(),
+                );
+            }
+        }
+    }
+
     // TODO: We want to make the following refactoring so that we DON'T have
     // to parcopy in to entry blocks
     //
@@ -2155,9 +2179,10 @@ impl Assembler
 
         let mut free_registers: BTreeSet<usize> = (0..num_registers).collect();
         let mut active: Vec<Interval> = Vec::new(); // sorted by increasing end point
+        let mut inactive: Vec<Interval> = Vec::new(); // intervals with lifetime holes
         let mut num_stack_slots: usize = 0;
-
         let mut handled: Vec<Interval> = Vec::new();
+        let mut free_until_pos = vec![0usize; num_registers];
         let num_intervals = intervals.len();
 
         let mut sorted_intervals: Vec<Interval> = intervals.into_iter()
@@ -2169,31 +2194,12 @@ impl Assembler
 
         while let Some(mut interval) = unhandled.pop_front() {
             // Expire old intervals.
-            for it in std::mem::take(&mut active) {
+            for mut it in std::mem::take(&mut active) {
                 if it.end() > interval.start() {
                     active.push(it);
                 } else {
-                    if let Some(allocation) = it.assigned {
-                        if let Some(reg) = allocation.alloc_pool_index(num_registers) {
-                            let was_not_there_before = free_registers.insert(reg);
-                            assert!(
-                                was_not_there_before,
-                                "attempted to return allocator register {:?} to the free pool more than once",
-                                allocation.assigned_reg().unwrap(),
-                            );
-                        } else {
-                            assert!(
-                                allocation.assigned_reg().is_none_or(|reg| {
-                                    crate::backend::current::ALLOC_REGS
-                                        .iter()
-                                        .take(num_registers)
-                                        .all(|candidate| candidate.reg_no != reg.reg_no)
-                                }),
-                                "attempted to return non-allocatable register {:?} to the allocator pool",
-                                allocation.assigned_reg().unwrap(),
-                            );
-                        }
-                    }
+                    Self::release_assignment(&it, num_registers, &mut free_registers);
+                    it.state = State::Handled;
                     handled.push(it);
                 }
             }

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -1418,13 +1418,19 @@ impl Interval {
         self.ranges.last().unwrap().to
     }
 
-    /// Check if the interval is alive at position x
+    /// Check if the interval is alive at position
     /// Panics if the range is not set
-    pub fn survives(&self, x: usize) -> bool {
+    pub fn survives(&self, position: usize) -> bool {
         assert!(self.ranges.len() > 0, "survives called on interval with no range");
-        let start = self.ranges[0].from;
-        let end = self.ranges.last().unwrap().to;
-        start < x && end > x
+        for range in self.ranges.iter() {
+            if position < range.from {
+                return false;
+            }
+            if position < range.to {
+                return true;
+            }
+        }
+        return false;
     }
 
     pub fn born_at(&self, x:usize) -> bool {
@@ -1447,9 +1453,11 @@ impl Interval {
             panic!("Invalid range: {} to {}", from, to);
         }
 
-        if self.ranges.len() > 0 {
-            let last = self.ranges.last_mut().unwrap();
-            if last.from <= to {
+        // Blocks are visited in ascending order, so only the last range can
+        // overlap or abut the new one. Anything earlier is separated by a
+        // lifetime hole and must stay a distinct range.
+        if let Some(last) = self.ranges.last_mut() {
+            if from <= last.to {
                 last.from = last.from.min(from);
                 last.to = last.to.max(to);
                 return;
@@ -1459,12 +1467,9 @@ impl Interval {
         self.ranges.push(LiveRange { from, to });
     }
 
-    /// Set the start of the range
+    /// Narrow the range covering `from` so that it begins at the def.
     pub fn set_from(&mut self, from: usize) {
-        // We iterate through instructions backwards.  If an instruction
-        // has a def, but no use, then it's possible to encounter an
-        // interval that has no ranges, thus we have a None case.
-        match self.ranges.first_mut() {
+        match self.ranges.last_mut() {
             None => self.ranges.push(LiveRange { from, to: from + 1 }),
             Some(range) => range.from = from
         }
@@ -3368,18 +3373,20 @@ pub fn lir_intervals_string(asm: &Assembler, intervals: &[Interval]) -> String {
             // Print instruction ID
             output.push_str(&format!("i{:<6}: ", insn_id.0));
 
-            // For each VReg, check if it's alive at this position
+            // For each VReg, check if it's alive at this position. Each range is
+            // marked independently so lifetime holes show up as gaps.
             for vreg_idx in 0..num_vregs {
-                let is_alive = intervals[vreg_idx].has_bounds() &&
-                               intervals[vreg_idx].survives(insn_id.0);
-
-                let has_range = intervals[vreg_idx].has_bounds();
-                if has_range && intervals[vreg_idx].born_at(insn_id.0) {
-                    output.push_str("  v ");
-                } else if has_range && intervals[vreg_idx].dies_at(insn_id.0) {
-                    output.push_str("  ^ ");
-                } else if is_alive {
-                    output.push_str("  █ ");
+                let interval = &intervals[vreg_idx];
+                if interval.has_bounds() {
+                    if interval.born_at(insn_id.0) {
+                        output.push_str("  v ");
+                    } else if interval.dies_at(insn_id.0) {
+                        output.push_str("  ^ ");
+                    } else if interval.survives(insn_id.0) {
+                        output.push_str("  █ ");
+                    } else {
+                        output.push_str("  . ");
+                    }
                 } else {
                     output.push_str("  . ");
                 }

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -1,5 +1,5 @@
 use std::cell::RefCell;
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
 use std::fmt;
 use std::mem::take;
 use std::rc::Rc;
@@ -1376,11 +1376,20 @@ impl LiveRange {
     }
 }
 
+#[derive(Clone)]
+pub enum State {
+    Unhandled,
+    Active,
+    Inactive,
+    Handled,
+}
+
 /// Live Interval of a VReg
 #[derive(Clone)]
 pub struct Interval {
     pub ranges: Vec<LiveRange>,
     pub id: VRegId,
+    pub state: State,
 }
 
 impl Interval {
@@ -1389,6 +1398,7 @@ impl Interval {
         Self {
             ranges: vec![],
             id: i,
+            state: State::Unhandled,
         }
     }
 
@@ -1404,25 +1414,15 @@ impl Interval {
     /// Panics if the range is not set
     pub fn survives(&self, position: usize) -> bool {
         assert!(self.ranges.len() > 0, "survives called on interval with no range");
-        for range in self.ranges.iter() {
-            if position < range.from {
-                return false;
-            }
-            if position < range.to {
-                return true;
-            }
-        }
-        return false;
+        self.ranges.iter().any(|range| range.from < position && position < range.to)
     }
 
-    pub fn born_at(&self, x:usize) -> bool {
-        let start = self.ranges[0].from;
-        start == x
+    pub fn born_at(&self, x: usize) -> bool {
+        self.start() == x
     }
 
-    pub fn dies_at(&self, x:usize) -> bool {
-        let end = self.ranges[0].to;
-        end == x
+    pub fn dies_at(&self, x: usize) -> bool {
+        self.end() == x
     }
 
     pub fn has_bounds(&self) -> bool {
@@ -1452,9 +1452,17 @@ impl Interval {
     /// Narrow the range covering `from` so that it begins at the def.
     pub fn set_from(&mut self, from: usize) {
         match self.ranges.last_mut() {
+            // If there was no existing range, it means that we have a
+            // def with no use.  Instructions are evenly numbered, so we add
+            // 1 to indicate this is a dead interval
             None => self.ranges.push(LiveRange { from, to: from + 1 }),
             Some(range) => range.from = from
         }
+    }
+
+    /// Returns true if this interval represents a def with no use.
+    pub fn is_dead(&self) -> bool {
+        self.end() <= self.start() + 1
     }
 }
 
@@ -2144,7 +2152,7 @@ impl Assembler
         assert_eq!(preferred_registers.len(), intervals.len());
 
         let mut free_registers: BTreeSet<usize> = (0..num_registers).collect();
-        let mut active: Vec<&Interval> = Vec::new(); // vreg indices sorted by increasing end point
+        let mut active: Vec<Interval> = Vec::new(); // sorted by increasing end point
         let mut assignment: Vec<Option<Allocation>> = vec![None; intervals.len()];
         let mut num_stack_slots: usize = 0;
 
@@ -2155,9 +2163,11 @@ impl Assembler
             .collect();
         sorted_intervals.sort_by_key(|i| i.start());
 
-        for interval in &sorted_intervals {
+        let mut unhandled: VecDeque<Interval> = sorted_intervals.into();
+
+        while let Some(interval) = unhandled.pop_front() {
             // Expire old intervals
-            active.retain(|&active_interval| {
+            active.retain(|active_interval| {
                 if active_interval.end() > interval.start() {
                     true
                 } else {
@@ -2199,14 +2209,14 @@ impl Assembler
                 if let Some(reg_idx) = Allocation::Fixed(preferred_reg).alloc_pool_index(num_registers) {
                     if free_registers.remove(&reg_idx) {
                         assignment[interval.id] = Some(Allocation::Fixed(preferred_reg));
-                        let insert_idx = active.partition_point(|&i| i.end() < interval.end());
-                        active.insert(insert_idx, &interval);
+                        let insert_idx = active.partition_point(|i| i.end() < interval.end());
+                        active.insert(insert_idx, interval);
                         continue;
                     }
                 } else {
                     assignment[interval.id] = Some(Allocation::Fixed(preferred_reg));
-                    let insert_idx = active.partition_point(|&i| i.end() < interval.end());
-                    active.insert(insert_idx, &interval);
+                    let insert_idx = active.partition_point(|i| i.end() < interval.end());
+                    active.insert(insert_idx, interval);
                     continue;
                 }
             }
@@ -2216,21 +2226,25 @@ impl Assembler
                 // but only from the allocatable register pool. Fixed register
                 // assignments represent preferred/pinned physical registers
                 // (for example SP) and should not be selected as spill victims.
-                let spill = active.iter().rev().copied().find(|active_interval| {
-                    matches!(assignment[active_interval.id], Some(Allocation::Reg(_)))
-                });
+                // Take the id and end point rather than a reference, so that `active`
+                // can be mutated below.
+                let spill = active.iter().rev()
+                    .find(|active_interval| {
+                        matches!(assignment[active_interval.id], Some(Allocation::Reg(_)))
+                    })
+                    .map(|active_interval| (active_interval.id, active_interval.end()));
                 let slot = Allocation::Stack(num_stack_slots);
                 num_stack_slots += 1;
 
-                if let Some(spill) = spill.filter(|spill| spill.end() > interval.end()) {
+                if let Some((spill_id, _)) = spill.filter(|&(_, spill_end)| spill_end > interval.end()) {
                     // Spill the last active interval; give its register to current
-                    assignment[interval.id] = assignment[spill.id];
-                    assignment[spill.id] = Some(slot);
-                    let spill_idx = active.iter().position(|active_interval| active_interval.id == spill.id).unwrap();
+                    assignment[interval.id] = assignment[spill_id];
+                    assignment[spill_id] = Some(slot);
+                    let spill_idx = active.iter().position(|active_interval| active_interval.id == spill_id).unwrap();
                     active.remove(spill_idx);
                     // Insert current into sorted active
-                    let insert_idx = active.partition_point(|&i| i.end() < interval.end());
-                    active.insert(insert_idx, &interval);
+                    let insert_idx = active.partition_point(|i| i.end() < interval.end());
+                    active.insert(insert_idx, interval);
                 } else {
                     // Spill the current interval
                     assignment[interval.id] = Some(slot);
@@ -2241,8 +2255,8 @@ impl Assembler
                 free_registers.remove(&reg);
                 assignment[interval.id] = Some(Allocation::Reg(reg));
                 // Insert into sorted active
-                let insert_idx = active.partition_point(|&i| i.end() < interval.end());
-                active.insert(insert_idx, &interval);
+                let insert_idx = active.partition_point(|i| i.end() < interval.end());
+                active.insert(insert_idx, interval);
             }
         }
 
@@ -2460,7 +2474,7 @@ impl Assembler
                     // uses the result?
                     let call_result_live = out.is_vreg()
                         && intervals[out.vreg_idx()].has_bounds()
-                        && intervals[out.vreg_idx()].end() > insn_number;
+                        && !intervals[out.vreg_idx()].is_dead();
 
                     // Build a set of VRegIds that can be referenced by JITFrame for materializing the VM stack
                     let stack_vreg_ids: HashSet<VRegId> = if let Some(StackMap { stack, .. }) = &stack_map {
@@ -4484,18 +4498,62 @@ mod tests {
 
         // Add range to empty interval
         interval.add_range(5, 10);
-        assert_eq!(interval.range.start, Some(5));
-        assert_eq!(interval.range.end, Some(10));
+        assert_eq!(interval.ranges, vec![LiveRange { from: 5, to: 10 }]);
 
         // Extend range backward
         interval.add_range(3, 7);
-        assert_eq!(interval.range.start, Some(3));
-        assert_eq!(interval.range.end, Some(10));
+        assert_eq!(interval.ranges, vec![LiveRange { from: 3, to: 10 }]);
 
         // Extend range forward
         interval.add_range(8, 15);
-        assert_eq!(interval.range.start, Some(3));
-        assert_eq!(interval.range.end, Some(15));
+        assert_eq!(interval.ranges, vec![LiveRange { from: 3, to: 15 }]);
+    }
+
+    #[test]
+    fn test_interval_add_range_hole() {
+        let mut interval = Interval::new(VRegId(1));
+
+        // A range that does not reach the previous one stays separate: the gap
+        // between them is a lifetime hole.
+        interval.add_range(5, 10);
+        interval.add_range(20, 25);
+        assert_eq!(interval.ranges, vec![
+            LiveRange { from: 5, to: 10 },
+            LiveRange { from: 20, to: 25 },
+        ]);
+        // start()/end() still span the whole thing, hole included.
+        assert_eq!(interval.start(), 5);
+        assert_eq!(interval.end(), 25);
+
+        // The vreg is not live inside the hole ...
+        assert!(!interval.survives(10));
+        assert!(!interval.survives(15));
+        // ... but the interval is not over, so it must keep its register.
+        assert!(interval.end() > 15);
+        // ... and it is live again on the far side.
+        assert!(interval.survives(22));
+
+        // A range that abuts the last one merges into it.
+        interval.add_range(25, 30);
+        assert_eq!(interval.ranges, vec![
+            LiveRange { from: 5, to: 10 },
+            LiveRange { from: 20, to: 30 },
+        ]);
+    }
+
+    #[test]
+    fn test_interval_dies_at_last_range() {
+        let mut interval = Interval::new(VRegId(1));
+        interval.add_range(5, 10);
+        interval.add_range(20, 25);
+
+        // The end of the first range is only the start of a lifetime hole, not
+        // the death of the interval. Reporting otherwise lets
+        // preferred_register_assignments hand the register to something else
+        // while the vreg is still live after the hole.
+        assert!(interval.born_at(5));
+        assert!(!interval.dies_at(10));
+        assert!(interval.dies_at(25));
     }
 
     #[test]
@@ -4514,16 +4572,36 @@ mod tests {
     fn test_interval_set_from() {
         let mut interval = Interval::new(VRegId(1));
 
-        // With no range, sets both start and end
+        // With no range, records Wimmer's vacuous interval: the def occupies a
+        // register but nothing reads the value. Instructions are numbered by two,
+        // so position 11 belongs to no instruction.
         interval.set_from(10);
-        assert_eq!(interval.range.start, Some(10));
-        assert_eq!(interval.range.end, Some(10));
+        assert_eq!(interval.ranges, vec![LiveRange { from: 10, to: 11 }]);
+        assert!(!interval.survives(10));
+        assert!(interval.is_dead());
 
         // With existing range, updates start but keeps end
         interval.add_range(5, 20);
         interval.set_from(3);
-        assert_eq!(interval.range.start, Some(3));
-        assert_eq!(interval.range.end, Some(20));
+        assert_eq!(interval.ranges, vec![LiveRange { from: 3, to: 20 }]);
+        assert!(!interval.is_dead());
+    }
+
+    #[test]
+    fn test_interval_is_dead() {
+        // A def whose value is read by the next instruction is not dead.
+        let mut used = Interval::new(VRegId(1));
+        used.add_range(10, 12);
+        used.set_from(10);
+        assert!(!used.is_dead());
+
+        // A def with a lifetime hole is not dead either, even though its first
+        // range is only one position long.
+        let mut holed = Interval::new(VRegId(2));
+        holed.add_range(10, 11);
+        holed.add_range(20, 22);
+        holed.set_from(10);
+        assert!(!holed.is_dead());
     }
 
     #[test]
@@ -4563,23 +4641,26 @@ mod tests {
 
         // Assert expected ranges
         // Note: Rust CFG differs from Ruby due to conditional branches requiring two instructions (Jl + Jmp)
-        assert_eq!(intervals[r10_idx].range.start, Some(16));
-        assert_eq!(intervals[r10_idx].range.end, Some(38));
+        assert_eq!(intervals[r10_idx].ranges, vec![LiveRange { from: 16, to: 38 }]);
 
-        assert_eq!(intervals[r11_idx].range.start, Some(16));
-        assert_eq!(intervals[r11_idx].range.end, Some(20));
+        assert_eq!(intervals[r11_idx].ranges, vec![LiveRange { from: 16, to: 20 }]);
 
-        assert_eq!(intervals[r12_idx].range.start, Some(20));
-        assert_eq!(intervals[r12_idx].range.end, Some(38));
+        // r12 is live out of the first block and used again at the join, but is
+        // dead across the middle of the diamond, so 30..36 is a lifetime hole.
+        // start()/end() alone cannot see this: they still report 20..38.
+        assert_eq!(intervals[r12_idx].ranges, vec![
+            LiveRange { from: 20, to: 30 },
+            LiveRange { from: 36, to: 38 },
+        ]);
+        assert_eq!(intervals[r12_idx].start(), 20);
+        assert_eq!(intervals[r12_idx].end(), 38);
+        assert!(!intervals[r12_idx].survives(32));
 
-        assert_eq!(intervals[r13_idx].range.start, Some(20));
-        assert_eq!(intervals[r13_idx].range.end, Some(32));
+        assert_eq!(intervals[r13_idx].ranges, vec![LiveRange { from: 20, to: 32 }]);
 
-        assert_eq!(intervals[r14_idx].range.start, Some(30));
-        assert_eq!(intervals[r14_idx].range.end, Some(36));
+        assert_eq!(intervals[r14_idx].ranges, vec![LiveRange { from: 30, to: 36 }]);
 
-        assert_eq!(intervals[r15_idx].range.start, Some(32));
-        assert_eq!(intervals[r15_idx].range.end, Some(36));
+        assert_eq!(intervals[r15_idx].ranges, vec![LiveRange { from: 32, to: 36 }]);
     }
 
     #[test]

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -2259,13 +2259,17 @@ impl Assembler
                 }
             });
 
-            // Mark all registers as "free".  In other words, they aren't
-            // in use until instruction number usize::MAX.
+            // Mark all registers as "free".  Intervals that end before usize::MAX
+            // (at this point that would be all registers) are allowed to use
+            // any index from this list.
             free_registers.fill(usize::MAX);
 
-            // Mark all active intervals with assignments as "unavailable".  They are available
-            // again at instruction 0 which effectively means they can't be used (as all
-            // intervals will end after 0)
+            // Mark all active intervals with assignments as "unavailable".
+            // Intervals that want a register must find an index in the free_registers
+            // list where the value is greater than the intervals "end" (or
+            // the interval's end is _less than_ the value in the free_register list)
+            // All registers have an end that is greater than 0, so they will
+            // not pick any registers used by intervals in the active list.
             for &it in &active {
                 debug_assert!(intervals[it].state == State::Active);
                 match intervals[it].assigned.expect("should have assignment") {

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -1375,7 +1375,7 @@ impl LiveRange {
     }
 }
 
-#[derive(Clone, PartialEq)]
+#[derive(PartialEq)]
 pub enum State {
     Unhandled,
     Active,
@@ -1384,7 +1384,6 @@ pub enum State {
 }
 
 /// Live Interval of a VReg
-#[derive(Clone)]
 pub struct Interval {
     pub ranges: Vec<LiveRange>,
     pub id: VRegId,

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -2194,14 +2194,9 @@ impl Assembler
 
             let preferred_alloc = interval.preferred;
             let preferred_taken = preferred_alloc
-                .and_then(|alloc| alloc.assigned_reg(regs))
-                .is_some_and(|reg| {
-                    active.iter().any(|active_interval| {
-                        active_interval.assigned
-                            .and_then(|alloc| alloc.assigned_reg(regs))
-                            .is_some_and(|active_reg| active_reg.reg_no == reg.reg_no)
-                    })
-                });
+                .is_some_and(|alloc|
+                    active.iter().any(|active_interval| active_interval.assigned == Some(alloc))
+                );
 
             if let Some(preferred_alloc) = preferred_alloc.filter(|_| !preferred_taken) {
                 if let Some(reg_idx) = preferred_alloc.alloc_pool_index(num_registers) {
@@ -2221,14 +2216,15 @@ impl Assembler
 
             if free_registers.is_empty() {
                 // Spill: pick the longest-lived active interval (last in sorted active)
-                // but only from the allocatable register pool. Fixed register
-                // assignments represent preferred/pinned physical registers
-                // (for example SP) and should not be selected as spill victims.
+                // but only from the allocatable partition of the pool. An index
+                // at or past `num_registers` is a pinned physical register (for
+                // example SP), which is not ours to hand to someone else.
                 // Take the id and end point rather than a reference, so that `active`
                 // can be mutated below.
                 let spill = active.iter().rev()
                     .find(|active_interval| {
-                        matches!(active_interval.assigned, Some(Allocation::Reg(_)))
+                        active_interval.assigned
+                            .is_some_and(|alloc| alloc.alloc_pool_index(num_registers).is_some())
                     })
                     .map(|active_interval| (active_interval.id, active_interval.end()));
                 let slot = Allocation::Stack(num_stack_slots);
@@ -5114,11 +5110,7 @@ mod tests {
         assert!(!pushes.is_empty(), "Expected at least one saved register across CCall");
 
         // The survivor register should match v1's allocation
-        let v1_reg = match assignments[v1.vreg_idx()].unwrap() {
-            Allocation::Reg(n) => Opnd::Reg(regs[n]),
-            Allocation::Fixed(reg) => Opnd::Reg(reg),
-            _ => unreachable!(),
-        };
+        let v1_reg = Opnd::Reg(assignments[v1.vreg_idx()].unwrap().assigned_reg(&regs).unwrap());
         let pushed_v1 = pushes.iter().any(|insn| matches!(**insn, Insn::CPushPair(first, second) if first == v1_reg || second == v1_reg));
         let popped_v1 = pops.iter().any(|insn| matches!(**insn, Insn::CPopPairInto(first, second) if first == v1_reg || second == v1_reg));
         assert!(pushed_v1, "CPushPair should save v1's register");

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -1379,20 +1379,18 @@ impl fmt::Debug for Insn {
 #[derive(Clone, Debug, PartialEq)]
 pub struct LiveRange {
     /// Index of the first instruction that used the VReg
-    pub start: usize,
+    pub from: usize,
     /// Index of the last instruction that used the VReg
-    pub end: usize,
+    pub to: usize,
 }
 
 impl LiveRange {
-    /// Shorthand for self.start.unwrap()
     pub fn start(&self) -> usize {
-        self.start
+        self.from
     }
 
-    /// Shorthand for self.end.unwrap()
     pub fn end(&self) -> usize {
-        self.end
+        self.to
     }
 }
 
@@ -1413,29 +1411,29 @@ impl Interval {
     }
 
     pub fn start(&self) -> usize {
-        self.ranges[0].start
+        self.ranges[0].from
     }
 
     pub fn end(&self) -> usize {
-        self.ranges.last().unwrap().end
+        self.ranges.last().unwrap().to
     }
 
     /// Check if the interval is alive at position x
     /// Panics if the range is not set
     pub fn survives(&self, x: usize) -> bool {
         assert!(self.ranges.len() > 0, "survives called on interval with no range");
-        let start = self.ranges[0].start;
-        let end = self.ranges[0].end;
+        let start = self.ranges[0].from;
+        let end = self.ranges.last().unwrap().to;
         start < x && end > x
     }
 
     pub fn born_at(&self, x:usize) -> bool {
-        let start = self.ranges[0].start;
+        let start = self.ranges[0].from;
         start == x
     }
 
     pub fn dies_at(&self, x:usize) -> bool {
-        let end = self.ranges[0].end;
+        let end = self.ranges[0].to;
         end == x
     }
 
@@ -1449,21 +1447,26 @@ impl Interval {
             panic!("Invalid range: {} to {}", from, to);
         }
 
-        if self.ranges.len() == 0 {
-            self.ranges.push(LiveRange { start: from, end: to });
-            return;
+        if self.ranges.len() > 0 {
+            let last = self.ranges.last_mut().unwrap();
+            if last.from <= to {
+                last.from = last.from.min(from);
+                last.to = last.to.max(to);
+                return;
+            }
         }
 
-        let range = self.ranges.first_mut().unwrap();
-        range.start = range.start.min(from);
-        range.end = range.end.max(to);
+        self.ranges.push(LiveRange { from, to });
     }
 
     /// Set the start of the range
     pub fn set_from(&mut self, from: usize) {
+        // We iterate through instructions backwards.  If an instruction
+        // has a def, but no use, then it's possible to encounter an
+        // interval that has no ranges, thus we have a None case.
         match self.ranges.first_mut() {
-            None => self.ranges.push(LiveRange { start: from, end: from + 1 }),
-            Some(range) => range.start = from
+            None => self.ranges.push(LiveRange { from, to: from + 1 }),
+            Some(range) => range.from = from
         }
     }
 }

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -1458,6 +1458,13 @@ impl Interval {
         self.ranges.len() > 0
     }
 
+    pub fn ranges_string(&self) -> String {
+        self.ranges.iter()
+            .map(|range| format!("{}..{}", range.from, range.to))
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+
     /// Add a range to the interval, extending it if necessary
     pub fn add_range(&mut self, from: usize, to: usize) {
         if to <= from {

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -1379,27 +1379,27 @@ impl fmt::Debug for Insn {
 #[derive(Clone, Debug, PartialEq)]
 pub struct LiveRange {
     /// Index of the first instruction that used the VReg
-    pub start: Option<usize>,
+    pub start: usize,
     /// Index of the last instruction that used the VReg
-    pub end: Option<usize>,
+    pub end: usize,
 }
 
 impl LiveRange {
     /// Shorthand for self.start.unwrap()
     pub fn start(&self) -> usize {
-        self.start.unwrap()
+        self.start
     }
 
     /// Shorthand for self.end.unwrap()
     pub fn end(&self) -> usize {
-        self.end.unwrap()
+        self.end
     }
 }
 
 /// Live Interval of a VReg
 #[derive(Clone)]
 pub struct Interval {
-    pub range: LiveRange,
+    pub ranges: Vec<LiveRange>,
     pub id: VRegId,
 }
 
@@ -1407,35 +1407,40 @@ impl Interval {
     /// Create a new Interval with no range
     pub fn new(i: VRegId) -> Self {
         Self {
-            range: LiveRange {
-                start: None,
-                end: None,
-            },
+            ranges: vec![],
             id: i,
         }
+    }
+
+    pub fn start(&self) -> usize {
+        self.ranges[0].start
+    }
+
+    pub fn end(&self) -> usize {
+        self.ranges.last().unwrap().end
     }
 
     /// Check if the interval is alive at position x
     /// Panics if the range is not set
     pub fn survives(&self, x: usize) -> bool {
-        assert!(self.range.start.is_some() && self.range.end.is_some(), "survives called on interval with no range");
-        let start = self.range.start.unwrap();
-        let end = self.range.end.unwrap();
+        assert!(self.ranges.len() > 0, "survives called on interval with no range");
+        let start = self.ranges[0].start;
+        let end = self.ranges[0].end;
         start < x && end > x
     }
 
     pub fn born_at(&self, x:usize) -> bool {
-        let start = self.range.start.unwrap();
+        let start = self.ranges[0].start;
         start == x
     }
 
     pub fn dies_at(&self, x:usize) -> bool {
-        let end = self.range.end.unwrap();
+        let end = self.ranges[0].end;
         end == x
     }
 
     pub fn has_bounds(&self) -> bool {
-        self.range.start.is_some() && self.range.end.is_some()
+        self.ranges.len() > 0
     }
 
     /// Add a range to the interval, extending it if necessary
@@ -1444,22 +1449,22 @@ impl Interval {
             panic!("Invalid range: {} to {}", from, to);
         }
 
-        if self.range.start.is_none() {
-            self.range.start = Some(from);
-            self.range.end = Some(to);
+        if self.ranges.len() == 0 {
+            self.ranges.push(LiveRange { start: from, end: to });
             return;
         }
 
-        // Extend the range to cover both the existing range and the new range
-        self.range.start = Some(self.range.start.unwrap().min(from));
-        self.range.end = Some(self.range.end.unwrap().max(to));
+        let range = self.ranges.first_mut().unwrap();
+        range.start = range.start.min(from);
+        range.end = range.end.max(to);
     }
 
     /// Set the start of the range
     pub fn set_from(&mut self, from: usize) {
-        let end = self.range.end.unwrap_or(from);
-        self.range.start = Some(from);
-        self.range.end = Some(end);
+        match self.ranges.first_mut() {
+            None => self.ranges.push(LiveRange { start: from, end: from + 1 }),
+            Some(range) => range.start = from
+        }
     }
 }
 
@@ -2151,15 +2156,15 @@ impl Assembler
 
         // Collect vreg indices that have valid ranges, sorted by start point
         let mut sorted_intervals: Vec<Interval> = intervals.iter()
-            .filter(|i| i.range.start.is_some() && i.range.end.is_some())
+            .filter(|i| i.has_bounds())
             .cloned()
             .collect();
-        sorted_intervals.sort_by_key(|i| i.range.start.unwrap());
+        sorted_intervals.sort_by_key(|i| i.start());
 
         for interval in &sorted_intervals {
             // Expire old intervals
             active.retain(|&active_interval| {
-                if active_interval.range.end.unwrap() > interval.range.start.unwrap() {
+                if active_interval.end() > interval.start() {
                     true
                 } else {
                     if let Some(allocation) = assignment[active_interval.id] {
@@ -2200,13 +2205,13 @@ impl Assembler
                 if let Some(reg_idx) = Allocation::Fixed(preferred_reg).alloc_pool_index(num_registers) {
                     if free_registers.remove(&reg_idx) {
                         assignment[interval.id] = Some(Allocation::Fixed(preferred_reg));
-                        let insert_idx = active.partition_point(|&i| i.range.end.unwrap() < interval.range.end.unwrap());
+                        let insert_idx = active.partition_point(|&i| i.end() < interval.end());
                         active.insert(insert_idx, &interval);
                         continue;
                     }
                 } else {
                     assignment[interval.id] = Some(Allocation::Fixed(preferred_reg));
-                    let insert_idx = active.partition_point(|&i| i.range.end.unwrap() < interval.range.end.unwrap());
+                    let insert_idx = active.partition_point(|&i| i.end() < interval.end());
                     active.insert(insert_idx, &interval);
                     continue;
                 }
@@ -2223,14 +2228,14 @@ impl Assembler
                 let slot = Allocation::Stack(num_stack_slots);
                 num_stack_slots += 1;
 
-                if let Some(spill) = spill.filter(|spill| spill.range.end.unwrap() > interval.range.end.unwrap()) {
+                if let Some(spill) = spill.filter(|spill| spill.end() > interval.end()) {
                     // Spill the last active interval; give its register to current
                     assignment[interval.id] = assignment[spill.id];
                     assignment[spill.id] = Some(slot);
                     let spill_idx = active.iter().position(|active_interval| active_interval.id == spill.id).unwrap();
                     active.remove(spill_idx);
                     // Insert current into sorted active
-                    let insert_idx = active.partition_point(|&i| i.range.end.unwrap() < interval.range.end.unwrap());
+                    let insert_idx = active.partition_point(|&i| i.end() < interval.end());
                     active.insert(insert_idx, &interval);
                 } else {
                     // Spill the current interval
@@ -2242,7 +2247,7 @@ impl Assembler
                 free_registers.remove(&reg);
                 assignment[interval.id] = Some(Allocation::Reg(reg));
                 // Insert into sorted active
-                let insert_idx = active.partition_point(|&i| i.range.end.unwrap() < interval.range.end.unwrap());
+                let insert_idx = active.partition_point(|&i| i.end() < interval.end());
                 active.insert(insert_idx, &interval);
             }
         }
@@ -2460,10 +2465,8 @@ impl Assembler
                     // Do we have a case where a ccall is emitted, but nobody
                     // uses the result?
                     let call_result_live = out.is_vreg()
-                        && intervals[out.vreg_idx()]
-                            .range
-                            .end
-                            .is_some_and(|end| end > insn_number);
+                        && intervals[out.vreg_idx()].has_bounds()
+                        && intervals[out.vreg_idx()].end() > insn_number;
 
                     // Build a set of VRegIds that can be referenced by JITFrame for materializing the VM stack
                     let stack_vreg_ids: HashSet<VRegId> = if let Some(StackMap { stack, .. }) = &stack_map {
@@ -3364,11 +3367,10 @@ pub fn lir_intervals_string(asm: &Assembler, intervals: &[Interval]) -> String {
 
             // For each VReg, check if it's alive at this position
             for vreg_idx in 0..num_vregs {
-                let is_alive = intervals[vreg_idx].range.start.is_some() &&
-                               intervals[vreg_idx].range.end.is_some() &&
+                let is_alive = intervals[vreg_idx].has_bounds() &&
                                intervals[vreg_idx].survives(insn_id.0);
 
-                let has_range = intervals[vreg_idx].range.start.is_some();
+                let has_range = intervals[vreg_idx].has_bounds();
                 if has_range && intervals[vreg_idx].born_at(insn_id.0) {
                     output.push_str("  v ");
                 } else if has_range && intervals[vreg_idx].dies_at(insn_id.0) {

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -2136,7 +2136,7 @@ impl Assembler
         Some(new_moves)
     }
 
-    /// Discover vregs that should preferentially reuse a physical register,
+    /// Discover and append to `regs` vregs that should preferentially reuse a physical register,
     /// such as a newborn vreg immediately moved into a preg in the next instruction.
     pub fn preferred_register_assignments(&self, intervals: &mut [Interval], regs: &mut Vec<Reg>) {
         for block in &self.basic_blocks {

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -2256,12 +2256,10 @@ impl Assembler
         let mut inactive: Vec<&Interval> = Vec::new(); // intervals with lifetime holes
         let mut num_stack_slots: usize = 0;
 
-        let mut sorted_intervals: Vec<&Interval> = intervals.iter()
+        let mut unhandled: VecDeque<&Interval> = intervals.iter()
             .filter(|it| it.has_bounds())
             .collect();
-        sorted_intervals.sort_by_key(|it| it.start());
-
-        let mut unhandled: VecDeque<&Interval> = sorted_intervals.into();
+        unhandled.make_contiguous().sort_by_key(|it| it.start());
 
         while let Some(cur) = unhandled.pop_front() {
             let position = cur.start();
@@ -2401,11 +2399,13 @@ impl Assembler
             }
         }
 
-        // Drain active and inactive and mark everything as handled.
+        // Drain active and inactive and mark everything as handled. `state` is
+        // only ever read by the debug_asserts above, so this bookkeeping is
+        // is not necessary once assertions are compiled out.
+        #[cfg(debug_assertions)]
         for it in active.drain(..).chain(inactive.drain(..)) {
             it.state.set(IntervalState::Handled);
         }
-        debug_assert!(active.is_empty() && inactive.is_empty());
 
         num_stack_slots
     }

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -2184,43 +2184,44 @@ impl Assembler
     // support.
     pub fn linear_scan(
         &self,
-        intervals: Vec<Interval>,
+        intervals: &mut [Interval],
         num_registers: usize, // number of allocatable regs
         regs: &[Reg],         // list of all registers used, partitioned by allocatability
     ) -> (Vec<Option<Allocation>>, usize) {
         debug_assert!(num_registers <= regs.len());
 
+        // `active`, `inactive`, and `unhandled` hold indexes in to `intervals`.
+        // An interval's index is its VRegId, and it is the only identity we
+        // need: the interval data itself is mutated in place.
         let mut free_registers: Vec<usize> = vec![0; regs.len()];
-        let mut active: Vec<Interval> = Vec::new(); // sorted by increasing end point
-        let mut inactive: Vec<Interval> = Vec::new(); // intervals with lifetime holes
+        let mut active: Vec<usize> = Vec::new(); // sorted by increasing end point
+        let mut inactive: Vec<usize> = Vec::new(); // intervals with lifetime holes
         let mut num_stack_slots: usize = 0;
-        let mut handled: Vec<Interval> = Vec::new();
-        let num_intervals = intervals.len();
 
-        let mut sorted_intervals: Vec<Interval> = intervals.into_iter()
-            .filter(|i| i.has_bounds())
+        let mut sorted_intervals: Vec<usize> = (0..intervals.len())
+            .filter(|&i| intervals[i].has_bounds())
             .collect();
-        sorted_intervals.sort_by_key(|i| i.start());
+        sorted_intervals.sort_by_key(|&i| intervals[i].start());
 
-        let mut unhandled: VecDeque<Interval> = sorted_intervals.into();
+        let mut unhandled: VecDeque<usize> = sorted_intervals.into();
 
-        while let Some(mut interval) = unhandled.pop_front() {
-            let position = interval.start();
+        while let Some(cur) = unhandled.pop_front() {
+            let position = intervals[cur].start();
+            let cur_end = intervals[cur].end();
 
             // Expire old intervals.
-            active.retain_mut(|it| {
-                debug_assert!(it.state == State::Active);
+            active.retain(|&it| {
+                debug_assert!(intervals[it].state == State::Active);
                 // If the interval ends before the current position, then we're
                 // done with it and can mark it handled.
-                if it.ends_before(position) {
-                    it.state = State::Handled;
-                    handled.push(it.clone());
+                if intervals[it].ends_before(position) {
+                    intervals[it].state = State::Handled;
                     false
-                } else if !it.covers(position) {
+                } else if !intervals[it].covers(position) {
                     // If it doesn't cover the current position (there's a hole
                     // in the ranges), then move it to inactive
-                    it.state = State::Inactive;
-                    inactive.push(it.clone());
+                    intervals[it].state = State::Inactive;
+                    inactive.push(it);
                     false
                 } else {
                     // Otherwise it's still live here and stays active.
@@ -2229,20 +2230,17 @@ impl Assembler
             });
 
             // Check for intervals in inactive that are handled or active
-            inactive.retain(|it| {
-                debug_assert!(it.state == State::Inactive);
+            inactive.retain(|&it| {
+                debug_assert!(intervals[it].state == State::Inactive);
                 // If the inactive interval ends before the current position
-                if it.ends_before(position) {
+                if intervals[it].ends_before(position) {
                     // Move it to handled
-                    let mut it = it.clone();
-                    it.state = State::Handled;
-                    handled.push(it);
+                    intervals[it].state = State::Handled;
                     false
-                } else if it.covers(position) {
+                } else if intervals[it].covers(position) {
                     // If the current position falls inside one of the
                     // interval's ranges, then make it active
-                    let mut it = it.clone();
-                    it.state = State::Active;
+                    intervals[it].state = State::Active;
                     active.push(it);
                     false
                 } else {
@@ -2258,9 +2256,9 @@ impl Assembler
             // Mark all active intervals with assignments as "unavailable".  They are available
             // again at instruction 0 which effectively means they can't be used (as all
             // intervals will end after 0)
-            for it in &active {
-                debug_assert!(it.state == State::Active);
-                match it.assigned.expect("should have assignment") {
+            for &it in &active {
+                debug_assert!(intervals[it].state == State::Active);
+                match intervals[it].assigned.expect("should have assignment") {
                     Allocation::Reg(idx) => free_registers[idx] = 0,
                     _ => {},
                 }
@@ -2270,10 +2268,10 @@ impl Assembler
             // we're currently inside one of those gaps.  We'll mark in the
             // "free_registers" list when each interval will want to use its
             // assigned reg again.
-            for it in &inactive {
-                debug_assert!(it.state == State::Inactive);
-                let Some(pos) = it.next_intersection(&interval) else { continue };
-                match it.assigned.expect("should have assignment") {
+            for &it in &inactive {
+                debug_assert!(intervals[it].state == State::Inactive);
+                let Some(pos) = intervals[it].next_intersection(&intervals[cur]) else { continue };
+                match intervals[it].assigned.expect("should have assignment") {
                     Allocation::Reg(idx) => free_registers[idx] = free_registers[idx].min(pos),
                     _ => {},
                 }
@@ -2281,12 +2279,12 @@ impl Assembler
 
             // If the current interval has a preferred allocation, use it if
             // that register is available until the interval end.
-            if let Some(Allocation::Reg(idx)) = interval.preferred {
-                if free_registers[idx] >= interval.end() {
-                    interval.assigned = Some(Allocation::Reg(idx));
-                    interval.state = State::Active;
-                    let insert_idx = active.partition_point(|i| i.end() < interval.end());
-                    active.insert(insert_idx, interval);
+            if let Some(Allocation::Reg(idx)) = intervals[cur].preferred {
+                if free_registers[idx] >= cur_end {
+                    intervals[cur].assigned = Some(Allocation::Reg(idx));
+                    intervals[cur].state = State::Active;
+                    let insert_idx = active.partition_point(|&i| intervals[i].end() < cur_end);
+                    active.insert(insert_idx, cur);
                     continue;
                 }
             }
@@ -2296,66 +2294,66 @@ impl Assembler
             // we know the current interval can fit in the window this register is available.
             let best_reg = (0..num_registers).rev()
                 .max_by_key(|&reg| free_registers[reg])
-                .filter(|&reg| free_registers[reg] >= interval.end());
+                .filter(|&reg| free_registers[reg] >= cur_end);
 
-            // We couldn't find a best register, so we need to spill
-            if best_reg.is_none() {
-                // Spill: pick the longest-lived active interval (last in sorted active)
-                // but only from the allocatable partition of the pool. An index
-                // at or past `num_registers` is a pinned physical register (for
-                // example SP), which is not ours to hand to someone else.
-                let spill = active.iter().rev()
-                    .find(|active_interval| {
-                        active_interval.assigned
-                            .is_some_and(|alloc| alloc.alloc_pool_index(num_registers).is_some())
-                    })
-                    .map(|active_interval| (active_interval.id, active_interval.end()));
-                let slot = Allocation::Stack(num_stack_slots);
-                num_stack_slots += 1;
+            match best_reg {
+                // We couldn't find a best register, so we need to spill
+                None => {
+                    // Spill: pick the longest-lived active interval (last in sorted active)
+                    // but only from the allocatable partition of the pool. An index
+                    // at or past `num_registers` is a pinned physical register (for
+                    // example SP), which is not ours to hand to someone else.
+                    let spill = active.iter().rev().copied()
+                        .find(|&it| {
+                            intervals[it].assigned
+                                .is_some_and(|alloc| alloc.alloc_pool_index(num_registers).is_some())
+                        })
+                        .map(|it| (it, intervals[it].end()));
+                    let slot = Allocation::Stack(num_stack_slots);
+                    num_stack_slots += 1;
 
-                if let Some((spill_id, _)) = spill.filter(|&(_, spill_end)| spill_end > interval.end()) {
-                    // Spill the last active interval; give its register to current
-                    let spill_idx = active.iter().position(|active_interval| active_interval.id == spill_id).unwrap();
-                    let mut spilled = active.remove(spill_idx);
-                    interval.assigned = spilled.assigned;
-                    spilled.assigned = Some(slot);
-                    spilled.state = State::Handled;
-                    handled.push(spilled);
-                    // Insert current into sorted active
-                    let insert_idx = active.partition_point(|i| i.end() < interval.end());
-                    interval.state = State::Active;
-                    active.insert(insert_idx, interval);
-                } else {
-                    // Spill the current interval
-                    interval.assigned = Some(slot);
-                    interval.state = State::Handled;
-                    handled.push(interval);
+                    if let Some((spill_it, _)) = spill.filter(|&(_, spill_end)| spill_end > cur_end) {
+                        // Spill the last active interval; give its register to current
+                        let spill_idx = active.iter().position(|&i| i == spill_it).unwrap();
+                        active.remove(spill_idx);
+                        // Read the stolen allocation in to a local: reading and
+                        // writing `intervals` in one statement won't borrow check.
+                        let stolen = intervals[spill_it].assigned;
+                        intervals[spill_it].assigned = Some(slot);
+                        intervals[spill_it].state = State::Handled;
+                        intervals[cur].assigned = stolen;
+                        intervals[cur].state = State::Active;
+                        // Insert current into sorted active
+                        let insert_idx = active.partition_point(|&i| intervals[i].end() < cur_end);
+                        active.insert(insert_idx, cur);
+                    } else {
+                        // Spill the current interval
+                        intervals[cur].assigned = Some(slot);
+                        intervals[cur].state = State::Handled;
+                    }
                 }
-            } else {
-                let reg = best_reg.unwrap();
-                interval.assigned = Some(Allocation::Reg(reg));
-                interval.state = State::Active;
-                // Insert into sorted active
-                let insert_idx = active.partition_point(|i| i.end() < interval.end());
-                active.insert(insert_idx, interval);
+                Some(reg) => {
+                    intervals[cur].assigned = Some(Allocation::Reg(reg));
+                    intervals[cur].state = State::Active;
+                    // Insert into sorted active
+                    let insert_idx = active.partition_point(|&i| intervals[i].end() < cur_end);
+                    active.insert(insert_idx, cur);
+                }
             }
         }
 
         // Drain active and inactive and mark everything as handled.
-        for mut it in active.drain(..).chain(inactive.drain(..)) {
-            it.state = State::Handled;
-            handled.push(it);
+        for it in active.drain(..).chain(inactive.drain(..)) {
+            intervals[it].state = State::Handled;
         }
         debug_assert!(active.is_empty() && inactive.is_empty());
 
-        let mut assignment: Vec<Option<Allocation>> = vec![None; num_intervals];
-        for it in handled {
-            debug_assert!(it.state == State::Handled);
-            assignment[it.id] = it.assigned;
-        }
-
         // TODO: Caller should just use the mutated intervals instead of
         // using this assignment list
+        let assignment: Vec<Option<Allocation>> = intervals.iter()
+            .map(|it| it.assigned)
+            .collect();
+
         (assignment, num_stack_slots)
     }
 
@@ -4766,7 +4764,7 @@ mod tests {
         let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
         let allocatable_regs = regs.len();
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        let (assignments, num_stack_slots) = asm.linear_scan(intervals, 5.min(allocatable_regs), &regs);
+        let (assignments, num_stack_slots) = asm.linear_scan(&mut intervals, 5.min(allocatable_regs), &regs);
 
         // Extract vreg indices
         let r10_idx = if let Opnd::VReg { idx, .. } = r10 { idx } else { panic!() };
@@ -4806,7 +4804,7 @@ mod tests {
         let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
         let allocatable_regs = regs.len();
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        let (assignments, num_stack_slots) = asm.linear_scan(intervals, 3.min(allocatable_regs), &regs);
+        let (assignments, num_stack_slots) = asm.linear_scan(&mut intervals, 3.min(allocatable_regs), &regs);
 
         let r10_idx = if let Opnd::VReg { idx, .. } = r10 { idx } else { panic!() };
         let r11_idx = if let Opnd::VReg { idx, .. } = r11 { idx } else { panic!() };
@@ -4838,7 +4836,7 @@ mod tests {
         let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
         let allocatable_regs = regs.len();
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        let (assignments, num_stack_slots) = asm.linear_scan(intervals, 1.min(allocatable_regs), &regs);
+        let (assignments, num_stack_slots) = asm.linear_scan(&mut intervals, 1.min(allocatable_regs), &regs);
 
         let r10_idx = if let Opnd::VReg { idx, .. } = r10 { idx } else { panic!() };
         let r11_idx = if let Opnd::VReg { idx, .. } = r11 { idx } else { panic!() };
@@ -4884,7 +4882,7 @@ mod tests {
         // Zero allocatable registers: the only register this interval can get
         // is the pinned one appended to the pool, so the preference is what
         // makes this succeed rather than spill.
-        let (assignments, num_stack_slots) = asm.linear_scan(intervals, 0, &regs);
+        let (assignments, num_stack_slots) = asm.linear_scan(&mut intervals, 0, &regs);
         assert_eq!(num_stack_slots, 0);
         assert_eq!(assignments[vreg_idx], Some(Allocation::Reg(regno)));
         assert_eq!(assignments[vreg_idx].unwrap().assigned_reg(&regs), Some(sp.unwrap_reg()));
@@ -4919,7 +4917,7 @@ mod tests {
         let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
         let allocatable_regs = regs.len();
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        let (assignments, _) = asm.linear_scan(intervals.clone(), 5.min(allocatable_regs), &regs);
+        let (assignments, _) = asm.linear_scan(&mut intervals, 5.min(allocatable_regs), &regs);
 
         asm.resolve_ssa(&intervals, &assignments, &regs);
 
@@ -4965,7 +4963,7 @@ mod tests {
         let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
         let allocatable_regs = regs.len();
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        let (assignments, _) = asm.linear_scan(intervals.clone(), 5.min(allocatable_regs), &regs);
+        let (assignments, _) = asm.linear_scan(&mut intervals, 5.min(allocatable_regs), &regs);
 
         // Entry block b1 has parameters [v0, v1].
         // With 5 registers: v0 -> Reg(0) = regs[0], arrival = C_ARG_OPNDS[0] = regs[0] -> self-move, filtered
@@ -5014,7 +5012,7 @@ mod tests {
         let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
         let allocatable_regs = regs.len();
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        let (assignments, _) = asm.linear_scan(intervals.clone(), 5.min(allocatable_regs), &regs);
+        let (assignments, _) = asm.linear_scan(&mut intervals, 5.min(allocatable_regs), &regs);
 
         asm.resolve_ssa(&intervals, &assignments, &regs);
 
@@ -5075,7 +5073,7 @@ mod tests {
         let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
         let allocatable_regs = regs.len();
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        let (assignments, _) = asm.linear_scan(intervals.clone(), num_regs.min(allocatable_regs), &regs);
+        let (assignments, _) = asm.linear_scan(&mut intervals, num_regs.min(allocatable_regs), &regs);
 
         assert_eq!(asm.basic_blocks.len(), 3);
 
@@ -5181,7 +5179,7 @@ mod tests {
         let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
         let allocatable_regs = regs.len();
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        let (assignments, num_stack_slots) = asm.linear_scan(intervals.clone(), num_regs.min(allocatable_regs), &regs);
+        let (assignments, num_stack_slots) = asm.linear_scan(&mut intervals, num_regs.min(allocatable_regs), &regs);
         asm.stack_state.num_spill_slots = num_stack_slots;
 
         // Stand in for the C calling convention's argument registers. These

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -1387,7 +1387,7 @@ pub enum IntervalState {
 /// Live Interval of a VReg
 pub struct Interval {
     pub ranges: Vec<LiveRange>,
-    pub id: VRegId,
+    pub vreg_id: VRegId,
 
     /// Where this interval is in the linear scan lifecycle.
     /// Transitions Unhandled -> Active <-> Inactive -> Handled.
@@ -1402,7 +1402,7 @@ impl Interval {
     pub fn new(i: VRegId) -> Self {
         Self {
             ranges: vec![],
-            id: i,
+            vreg_id: i,
             state: Cell::new(IntervalState::Unhandled),
             assigned: Cell::new(None),
             preferred: None,
@@ -2586,11 +2586,11 @@ impl Assembler
                             // 1) The VReg is referenced in an instruction after the CCall
                             let survives_call = interval.has_bounds() && interval.survives(insn_number);
                             // 2) The VReg is referenced by the stack map for the CCall
-                            let stack_map_reg = stack_vreg_ids.contains(&interval.id);
+                            let stack_map_reg = stack_vreg_ids.contains(&interval.vreg_id);
                             let is_register = interval.assigned.get().and_then(|alloc| alloc.alloc_pool_index(ALLOC_REGS.len())).is_some();
                             is_register && (survives_call || stack_map_reg)
                         })
-                        .map(|interval| interval.id)
+                        .map(|interval| interval.vreg_id)
                         .collect();
 
                     let survivor_regs: Vec<Opnd> = survivors.iter()

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -2122,7 +2122,7 @@ impl Assembler
         Some(new_moves)
     }
 
-    /// Discover vregs that should preferentially reuse a physical register,
+    /// Discover and append to `regs` vregs that should preferentially reuse a physical register,
     /// such as a newborn vreg immediately moved into a preg in the next instruction.
     pub fn preferred_register_assignments(&self, intervals: &mut [Interval], regs: &mut Vec<Reg>) {
         for block in &self.basic_blocks {

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -2152,6 +2152,30 @@ impl Assembler
         preferred
     }
 
+    fn release_assignment(it: &Interval, num_registers: usize, free_registers: &mut BTreeSet<usize>) {
+        if let Some(allocation) = it.assigned {
+            if let Some(reg) = allocation.alloc_pool_index(num_registers) {
+                let was_not_there_before = free_registers.insert(reg);
+                assert!(
+                    was_not_there_before,
+                    "attempted to return allocator register {:?} to the free pool more than once",
+                    allocation.assigned_reg().unwrap(),
+                );
+            } else {
+                assert!(
+                    allocation.assigned_reg().is_none_or(|reg| {
+                        crate::backend::current::ALLOC_REGS
+                            .iter()
+                            .take(num_registers)
+                            .all(|candidate| candidate.reg_no != reg.reg_no)
+                    }),
+                    "attempted to return non-allocatable register {:?} to the allocator pool",
+                    allocation.assigned_reg().unwrap(),
+                );
+            }
+        }
+    }
+
     // TODO: We want to make the following refactoring so that we DON'T have
     // to parcopy in to entry blocks
     //
@@ -2169,9 +2193,10 @@ impl Assembler
 
         let mut free_registers: BTreeSet<usize> = (0..num_registers).collect();
         let mut active: Vec<Interval> = Vec::new(); // sorted by increasing end point
+        let mut inactive: Vec<Interval> = Vec::new(); // intervals with lifetime holes
         let mut num_stack_slots: usize = 0;
-
         let mut handled: Vec<Interval> = Vec::new();
+        let mut free_until_pos = vec![0usize; num_registers];
         let num_intervals = intervals.len();
 
         let mut sorted_intervals: Vec<Interval> = intervals.into_iter()
@@ -2183,31 +2208,12 @@ impl Assembler
 
         while let Some(mut interval) = unhandled.pop_front() {
             // Expire old intervals.
-            for it in std::mem::take(&mut active) {
+            for mut it in std::mem::take(&mut active) {
                 if it.end() > interval.start() {
                     active.push(it);
                 } else {
-                    if let Some(allocation) = it.assigned {
-                        if let Some(reg) = allocation.alloc_pool_index(num_registers) {
-                            let was_not_there_before = free_registers.insert(reg);
-                            assert!(
-                                was_not_there_before,
-                                "attempted to return allocator register {:?} to the free pool more than once",
-                                allocation.assigned_reg().unwrap(),
-                            );
-                        } else {
-                            assert!(
-                                allocation.assigned_reg().is_none_or(|reg| {
-                                    crate::backend::current::ALLOC_REGS
-                                        .iter()
-                                        .take(num_registers)
-                                        .all(|candidate| candidate.reg_no != reg.reg_no)
-                                }),
-                                "attempted to return non-allocatable register {:?} to the allocator pool",
-                                allocation.assigned_reg().unwrap(),
-                            );
-                        }
-                    }
+                    Self::release_assignment(&it, num_registers, &mut free_registers);
+                    it.state = State::Handled;
                     handled.push(it);
                 }
             }

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -2170,7 +2170,6 @@ impl Assembler
     // TODO: We want to make the following refactoring so that we DON'T have
     // to parcopy in to entry blocks
     //
-    // * Move Allocation to Interval
     // * Pre-allocate pinned regs
     // * Update linear scan to handle pinned LRs
     //

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -1408,6 +1408,7 @@ pub struct Interval {
     pub ranges: Vec<LiveRange>,
     pub id: VRegId,
     pub state: State,
+    pub assigned: Option<Allocation>,
 }
 
 impl Interval {
@@ -1417,6 +1418,7 @@ impl Interval {
             ranges: vec![],
             id: i,
             state: State::Unhandled,
+            assigned: None,
         }
     }
 
@@ -2167,25 +2169,25 @@ impl Assembler
 
         let mut free_registers: BTreeSet<usize> = (0..num_registers).collect();
         let mut active: Vec<Interval> = Vec::new(); // sorted by increasing end point
-        let mut assignment: Vec<Option<Allocation>> = vec![None; intervals.len()];
         let mut num_stack_slots: usize = 0;
 
-        // Collect vreg indices that have valid ranges, sorted by start point
-        let mut sorted_intervals: Vec<Interval> = intervals.iter()
+        let mut handled: Vec<Interval> = Vec::new();
+        let num_intervals = intervals.len();
+
+        let mut sorted_intervals: Vec<Interval> = intervals.into_iter()
             .filter(|i| i.has_bounds())
-            .cloned()
             .collect();
         sorted_intervals.sort_by_key(|i| i.start());
 
         let mut unhandled: VecDeque<Interval> = sorted_intervals.into();
 
-        while let Some(interval) = unhandled.pop_front() {
-            // Expire old intervals
-            active.retain(|active_interval| {
-                if active_interval.end() > interval.start() {
-                    true
+        while let Some(mut interval) = unhandled.pop_front() {
+            // Expire old intervals.
+            for it in std::mem::take(&mut active) {
+                if it.end() > interval.start() {
+                    active.push(it);
                 } else {
-                    if let Some(allocation) = assignment[active_interval.id] {
+                    if let Some(allocation) = it.assigned {
                         if let Some(reg) = allocation.alloc_pool_index(num_registers) {
                             let was_not_there_before = free_registers.insert(reg);
                             assert!(
@@ -2206,14 +2208,14 @@ impl Assembler
                             );
                         }
                     }
-                    false
+                    handled.push(it);
                 }
-            });
+            }
 
             let preferred_reg = preferred_registers[interval.id];
             let preferred_taken = preferred_reg.is_some_and(|reg| {
                 active.iter().any(|active_interval| {
-                    assignment[active_interval.id]
+                    active_interval.assigned
                         .and_then(|alloc| alloc.assigned_reg())
                         .is_some_and(|active_reg| active_reg.reg_no == reg.reg_no)
                 })
@@ -2222,13 +2224,13 @@ impl Assembler
             if let Some(preferred_reg) = preferred_reg.filter(|_| !preferred_taken) {
                 if let Some(reg_idx) = Allocation::Fixed(preferred_reg).alloc_pool_index(num_registers) {
                     if free_registers.remove(&reg_idx) {
-                        assignment[interval.id] = Some(Allocation::Fixed(preferred_reg));
+                        interval.assigned = Some(Allocation::Fixed(preferred_reg));
                         let insert_idx = active.partition_point(|i| i.end() < interval.end());
                         active.insert(insert_idx, interval);
                         continue;
                     }
                 } else {
-                    assignment[interval.id] = Some(Allocation::Fixed(preferred_reg));
+                    interval.assigned = Some(Allocation::Fixed(preferred_reg));
                     let insert_idx = active.partition_point(|i| i.end() < interval.end());
                     active.insert(insert_idx, interval);
                     continue;
@@ -2244,7 +2246,7 @@ impl Assembler
                 // can be mutated below.
                 let spill = active.iter().rev()
                     .find(|active_interval| {
-                        matches!(assignment[active_interval.id], Some(Allocation::Reg(_)))
+                        matches!(active_interval.assigned, Some(Allocation::Reg(_)))
                     })
                     .map(|active_interval| (active_interval.id, active_interval.end()));
                 let slot = Allocation::Stack(num_stack_slots);
@@ -2252,26 +2254,33 @@ impl Assembler
 
                 if let Some((spill_id, _)) = spill.filter(|&(_, spill_end)| spill_end > interval.end()) {
                     // Spill the last active interval; give its register to current
-                    assignment[interval.id] = assignment[spill_id];
-                    assignment[spill_id] = Some(slot);
                     let spill_idx = active.iter().position(|active_interval| active_interval.id == spill_id).unwrap();
-                    active.remove(spill_idx);
+                    let mut spilled = active.remove(spill_idx);
+                    interval.assigned = spilled.assigned;
+                    spilled.assigned = Some(slot);
+                    handled.push(spilled);
                     // Insert current into sorted active
                     let insert_idx = active.partition_point(|i| i.end() < interval.end());
                     active.insert(insert_idx, interval);
                 } else {
                     // Spill the current interval
-                    assignment[interval.id] = Some(slot);
+                    interval.assigned = Some(slot);
+                    handled.push(interval);
                 }
             } else {
                 // Allocate lowest free register
                 let reg = *free_registers.iter().min().unwrap();
                 free_registers.remove(&reg);
-                assignment[interval.id] = Some(Allocation::Reg(reg));
+                interval.assigned = Some(Allocation::Reg(reg));
                 // Insert into sorted active
                 let insert_idx = active.partition_point(|i| i.end() < interval.end());
                 active.insert(insert_idx, interval);
             }
+        }
+
+        let mut assignment: Vec<Option<Allocation>> = vec![None; num_intervals];
+        for it in active.into_iter().chain(handled) {
+            assignment[it.id] = it.assigned;
         }
 
         (assignment, num_stack_slots)

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -1365,20 +1365,21 @@ pub struct LiveRange {
     pub to: usize,
 }
 
-impl LiveRange {
-    pub fn start(&self) -> usize {
-        self.from
-    }
-
-    pub fn end(&self) -> usize {
-        self.to
-    }
-}
-
+/// Possible states for an Interval.  During linear scan, intervals
+/// start as unhandled, then transition to:
+/// * Active: we are currently handling this interval
+/// * Inactive: this interval has a hole in it, so it's not "active" for the current range
+/// * Handled: we're done dealing with this interval
+///
+/// Intervals can transition back and forth between active and inactive, but
+/// once an interval is handled, it is "done" and cannot transition out of
+/// that state.
 #[derive(Clone, Copy, PartialEq)]
-pub enum State {
+pub enum IntervalState {
     Unhandled,
+    /// Currently being handled; occupies its assigned allocation.
     Active,
+    /// In a lifetime hole — allocation is free for others right now.
     Inactive,
     Handled,
 }
@@ -1387,7 +1388,11 @@ pub enum State {
 pub struct Interval {
     pub ranges: Vec<LiveRange>,
     pub id: VRegId,
-    pub state: Cell<State>,
+
+    /// Where this interval is in the linear scan lifecycle.
+    /// Transitions Unhandled -> Active <-> Inactive -> Handled.
+    pub state: Cell<IntervalState>,
+
     pub assigned: Cell<Option<Allocation>>,
     pub preferred: Option<Allocation>,
 }
@@ -1398,7 +1403,7 @@ impl Interval {
         Self {
             ranges: vec![],
             id: i,
-            state: Cell::new(State::Unhandled),
+            state: Cell::new(IntervalState::Unhandled),
             assigned: Cell::new(None),
             preferred: None,
         }
@@ -2207,16 +2212,16 @@ impl Assembler
 
             // Expire old intervals.
             active.retain(|&it| {
-                debug_assert!(it.state.get() == State::Active);
+                debug_assert!(it.state.get() == IntervalState::Active);
                 // If the interval ends before the current position, then we're
                 // done with it and can mark it handled.
                 if it.ends_before(position) {
-                    it.state.set(State::Handled);
+                    it.state.set(IntervalState::Handled);
                     false
                 } else if !it.covers(position) {
                     // If it doesn't cover the current position (there's a hole
                     // in the ranges), then move it to inactive
-                    it.state.set(State::Inactive);
+                    it.state.set(IntervalState::Inactive);
                     inactive.push(it);
                     false
                 } else {
@@ -2227,16 +2232,16 @@ impl Assembler
 
             // Check for intervals in inactive that are handled or active
             inactive.retain(|&it| {
-                debug_assert!(it.state.get() == State::Inactive);
+                debug_assert!(it.state.get() == IntervalState::Inactive);
                 // If the inactive interval ends before the current position
                 if it.ends_before(position) {
                     // Move it to handled
-                    it.state.set(State::Handled);
+                    it.state.set(IntervalState::Handled);
                     false
                 } else if it.covers(position) {
                     // If the current position falls inside one of the
                     // interval's ranges, then make it active
-                    it.state.set(State::Active);
+                    it.state.set(IntervalState::Active);
                     active.push(it);
                     false
                 } else {
@@ -2257,7 +2262,7 @@ impl Assembler
             // All registers have an end that is greater than 0, so they will
             // not pick any registers used by intervals in the active list.
             for it in &active {
-                debug_assert!(it.state.get() == State::Active);
+                debug_assert!(it.state.get() == IntervalState::Active);
                 match it.assigned.get().expect("should have assignment") {
                     Allocation::Reg(idx) => free_registers[idx] = 0,
                     _ => {},
@@ -2269,7 +2274,7 @@ impl Assembler
             // "free_registers" list when each interval will want to use its
             // assigned reg again.
             for it in &inactive {
-                debug_assert!(it.state.get() == State::Inactive);
+                debug_assert!(it.state.get() == IntervalState::Inactive);
                 let Some(pos) = it.next_intersection(cur) else { continue };
                 match it.assigned.get().expect("should have assignment") {
                     Allocation::Reg(idx) => free_registers[idx] = free_registers[idx].min(pos),
@@ -2282,7 +2287,7 @@ impl Assembler
             if let Some(Allocation::Reg(idx)) = cur.preferred {
                 if free_registers[idx] >= cur_end {
                     cur.assigned.set(Some(Allocation::Reg(idx)));
-                    cur.state.set(State::Active);
+                    cur.state.set(IntervalState::Active);
                     let insert_idx = active.partition_point(|it| it.end() < cur_end);
                     active.insert(insert_idx, cur);
                     continue;
@@ -2315,9 +2320,9 @@ impl Assembler
                             // Spill the last active interval; give its register to current
                             let spilled = active.remove(spill_idx);
                             cur.assigned.set(spilled.assigned.get());
-                            cur.state.set(State::Active);
+                            cur.state.set(IntervalState::Active);
                             spilled.assigned.set(Some(slot));
-                            spilled.state.set(State::Handled);
+                            spilled.state.set(IntervalState::Handled);
                             // Insert current into sorted active
                             let insert_idx = active.partition_point(|it| it.end() < cur_end);
                             active.insert(insert_idx, cur);
@@ -2325,13 +2330,13 @@ impl Assembler
                         None => {
                             // Spill the current interval
                             cur.assigned.set(Some(slot));
-                            cur.state.set(State::Handled);
+                            cur.state.set(IntervalState::Handled);
                         }
                     }
                 }
                 Some(reg) => {
                     cur.assigned.set(Some(Allocation::Reg(reg)));
-                    cur.state.set(State::Active);
+                    cur.state.set(IntervalState::Active);
                     // Insert into sorted active
                     let insert_idx = active.partition_point(|it| it.end() < cur_end);
                     active.insert(insert_idx, cur);
@@ -2341,7 +2346,7 @@ impl Assembler
 
         // Drain active and inactive and mark everything as handled.
         for it in active.drain(..).chain(inactive.drain(..)) {
-            it.state.set(State::Handled);
+            it.state.set(IntervalState::Handled);
         }
         debug_assert!(active.is_empty() && inactive.is_empty());
 

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -2182,12 +2182,16 @@ impl Assembler
     // The registers in `regs` from 0 to num_registers is allocatable,
     // num_registers to the end are only allocatable via "preferred" register
     // support.
+    //
+    // Allocations are written back in to `intervals` as each interval's
+    // `assigned` field.  The return value is the number of stack slots needed
+    // for the spills.
     pub fn linear_scan(
         &self,
         intervals: &mut [Interval],
         num_registers: usize, // number of allocatable regs
         regs: &[Reg],         // list of all registers used, partitioned by allocatability
-    ) -> (Vec<Option<Allocation>>, usize) {
+    ) -> usize {
         debug_assert!(num_registers <= regs.len());
 
         // `active`, `inactive`, and `unhandled` hold indexes in to `intervals`.
@@ -2348,19 +2352,13 @@ impl Assembler
         }
         debug_assert!(active.is_empty() && inactive.is_empty());
 
-        // TODO: Caller should just use the mutated intervals instead of
-        // using this assignment list
-        let assignment: Vec<Option<Allocation>> = intervals.iter()
-            .map(|it| it.assigned)
-            .collect();
-
-        (assignment, num_stack_slots)
+        num_stack_slots
     }
 
     /// Resolve SSA block parameters by inserting sequentialized move instructions
     /// at block boundaries. This is SSA deconstruction: after linear_scan assigns
     /// registers/stack slots, we lower block parameter passing to explicit moves.
-    pub fn resolve_ssa(&mut self, _intervals: &[Interval], assignments: &[Option<Allocation>], regs: &[Reg]) {
+    pub fn resolve_ssa(&mut self, intervals: &[Interval], regs: &[Reg]) {
         use crate::backend::parcopy;
         use crate::backend::current::SCRATCH_REG;
 
@@ -2395,10 +2393,10 @@ impl Assembler
                 let reg_copies: Vec<parcopy::RegisterCopy<Opnd>> = edge.args
                     .iter()
                     .zip(params.iter())
-                    .filter(|(_arg, param)| assignments[param.vreg_idx()].is_some() )
+                    .filter(|(_arg, param)| intervals[param.vreg_idx()].assigned.is_some() )
                     .map(|(arg, param)| parcopy::RegisterCopy::<Opnd> {
-                        destination: Self::rewritten_opnd(*param, assignments, regs),
-                        source: Self::rewritten_opnd(*arg, assignments, regs),
+                        destination: Self::rewritten_opnd(*param, intervals, regs),
+                        source: Self::rewritten_opnd(*arg, intervals, regs),
                     })
                     .filter(|copy| copy.source != copy.destination)
                     .collect();
@@ -2492,7 +2490,7 @@ impl Assembler
             let reg_copies: Vec<parcopy::RegisterCopy<Opnd>> = params.iter().enumerate()
                 .map(|(i, param)| parcopy::RegisterCopy::<Opnd> {
                     source: C_ARG_OPNDS[i],
-                    destination: Self::rewritten_opnd(*param, assignments, regs),
+                    destination: Self::rewritten_opnd(*param, intervals, regs),
                 })
                 .filter(|copy| copy.source != copy.destination)
                 .collect();
@@ -2537,7 +2535,7 @@ impl Assembler
             }
         }
 
-        self.rewrite_instructions(assignments, regs);
+        self.rewrite_instructions(intervals, regs);
     }
 
     /// Handle caller-saved registers around CCall instructions.
@@ -2546,7 +2544,6 @@ impl Assembler
     pub fn handle_caller_saved_regs(
         &mut self,
         intervals: &[Interval],
-        assignments: &[Option<Allocation>],
         alloc_regs: &[Reg],
         c_arg_regs: &[Reg],
     ) {
@@ -2592,14 +2589,14 @@ impl Assembler
                             let survives_call = interval.has_bounds() && interval.survives(insn_number);
                             // 2) The VReg is referenced by the stack map for the CCall
                             let stack_map_reg = stack_vreg_ids.contains(&interval.id);
-                            let is_register = assignments[interval.id].and_then(|alloc| alloc.alloc_pool_index(ALLOC_REGS.len())).is_some();
+                            let is_register = interval.assigned.and_then(|alloc| alloc.alloc_pool_index(ALLOC_REGS.len())).is_some();
                             is_register && (survives_call || stack_map_reg)
                         })
                         .map(|interval| interval.id)
                         .collect();
 
                     let survivor_regs: Vec<Opnd> = survivors.iter()
-                        .map(|&s| Opnd::Reg(assignments[s].unwrap().assigned_reg(alloc_regs).unwrap()))
+                        .map(|&s| Opnd::Reg(intervals[s].assigned.unwrap().assigned_reg(alloc_regs).unwrap()))
                         .collect();
 
                     // Push all survivors on the stack, pairing adjacent pushes when possible.
@@ -2633,7 +2630,7 @@ impl Assembler
                                     VALUE(encoded)
                                 }
                                 StackMapEntry::Opnd(Opnd::VReg { idx: vreg, .. }) => {
-                                    let vreg_stack_index = match assignments[vreg].expect("StackMap VReg should have an allocation") {
+                                    let vreg_stack_index = match intervals[vreg].assigned.expect("StackMap VReg should have an allocation") {
                                         Allocation::Reg(_) => {
                                             let caller_saved_reg_idx = survivors.iter().position(|&survivor_id| survivor_id == vreg).unwrap();
                                             let stack_idx = self.stack_state.stack_idx_for_caller_saved_reg(caller_saved_reg_idx);
@@ -2665,7 +2662,7 @@ impl Assembler
                         .zip(c_arg_regs.iter())
                         .map(|(arg, param)| parcopy::RegisterCopy::<Opnd> {
                             destination: Opnd::Reg(*param),
-                            source: Self::rewritten_opnd(*arg, assignments, alloc_regs),
+                            source: Self::rewritten_opnd(*arg, intervals, alloc_regs),
                         })
                         .filter(|copy| copy.source != copy.destination)
                         .collect();
@@ -2713,7 +2710,7 @@ impl Assembler
                     if survivors.is_empty() {
                         if call_result_live {
                             // No survivors to restore -- move result directly to output.
-                            let out = Self::rewritten_opnd(out, assignments, alloc_regs);
+                            let out = Self::rewritten_opnd(out, intervals, alloc_regs);
                             new_insns.push(Insn::Mov { dest: out, src: C_RET_OPND });
                             new_ids.push(None);
                         }
@@ -2737,7 +2734,7 @@ impl Assembler
 
                         if call_result_live {
                             // Move result from scratch to output AFTER all pops.
-                            let out = Self::rewritten_opnd(out, assignments, alloc_regs);
+                            let out = Self::rewritten_opnd(out, intervals, alloc_regs);
                             new_insns.push(Insn::Mov { dest: out, src: Opnd::Reg(SCRATCH_REG) });
                             new_ids.push(None);
                         }
@@ -2756,17 +2753,17 @@ impl Assembler
 
     /// Return the maximum number of stack-map entries that any side exit needs
     /// to copy into reserved native stack slots.
-    pub fn side_exit_stack_map_slots(&self, assignments: &[Option<Allocation>]) -> usize {
+    pub fn side_exit_stack_map_slots(&self, intervals: &[Interval]) -> usize {
         self.block_order().into_iter().fold(0, |max_slots, block_id| {
             let block = &self.basic_blocks[block_id.0];
             block.insns.iter().fold(max_slots, |max_slots, insn| {
-                let slots = insn.target().map(|target| Self::side_exit_target_stack_map_slots(target, assignments)).unwrap_or(0);
+                let slots = insn.target().map(|target| Self::side_exit_target_stack_map_slots(target, intervals)).unwrap_or(0);
                 max_slots.max(slots)
             })
         })
     }
 
-    fn side_exit_target_stack_map_slots(target: &Target, assignments: &[Option<Allocation>]) -> usize {
+    fn side_exit_target_stack_map_slots(target: &Target, intervals: &[Interval]) -> usize {
         let Target::SideExit(data) = target else {
             return 0;
         };
@@ -2779,7 +2776,7 @@ impl Assembler
             StackMapEntry::Opnd(Opnd::UImm(value)) => !VALUE(*value as usize).special_const_p(),
             StackMapEntry::Opnd(Opnd::VReg { idx, .. }) => {
                 matches!(
-                    assignments[idx.to_usize()].expect("StackMap VReg should have an allocation"),
+                    intervals[idx.to_usize()].assigned.expect("StackMap VReg should have an allocation"),
                     Allocation::Reg(_)
                 )
             }
@@ -2789,29 +2786,29 @@ impl Assembler
     }
 
     /// Walk every instruction and replace VReg operands with the physical
-    /// register (or stack slot) from the allocation assignments.
-    fn rewrite_instructions(&mut self, assignments: &[Option<Allocation>], regs: &[Reg]) {
+    /// register (or stack slot) assigned to the VReg's interval.
+    fn rewrite_instructions(&mut self, intervals: &[Interval], regs: &[Reg]) {
         for block_id in self.block_order() {
             for insn in self.basic_blocks[block_id.0].insns.iter_mut() {
                 insn.for_each_operand_mut(|opnd| {
-                    Self::rewrite_opnd(opnd, assignments, regs);
+                    Self::rewrite_opnd(opnd, intervals, regs);
                 });
                 if let Some(out) = insn.out_opnd_mut() {
-                    Self::rewrite_opnd(out, assignments, regs);
+                    Self::rewrite_opnd(out, intervals, regs);
                 }
             }
         }
     }
 
-    fn rewritten_opnd(mut opnd: Opnd, assignments: &[Option<Allocation>], regs: &[Reg]) -> Opnd {
-        Self::rewrite_opnd(&mut opnd, assignments, regs);
+    fn rewritten_opnd(mut opnd: Opnd, intervals: &[Interval], regs: &[Reg]) -> Opnd {
+        Self::rewrite_opnd(&mut opnd, intervals, regs);
         opnd
     }
 
-    fn rewrite_opnd(opnd: &mut Opnd, assignments: &[Option<Allocation>], regs: &[Reg]) {
+    fn rewrite_opnd(opnd: &mut Opnd, intervals: &[Interval], regs: &[Reg]) {
         match opnd {
             Opnd::VReg { idx, num_bits } => {
-                if let Some(assignment) = assignments[*idx] {
+                if let Some(assignment) = intervals[*idx].assigned {
                     match assignment {
                         Allocation::Reg(n) => {
                             let mut reg = regs[n];
@@ -2832,7 +2829,7 @@ impl Assembler
                 }
             }
             Opnd::Mem(Mem { base: MemBase::VReg(idx), .. }) => {
-                match assignments[*idx].unwrap() {
+                match intervals[*idx].assigned.unwrap() {
                     Allocation::Reg(n) => {
                         if let Opnd::Mem(mem) = opnd {
                             mem.base = MemBase::Reg(regs[n].reg_no);
@@ -4764,7 +4761,7 @@ mod tests {
         let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
         let allocatable_regs = regs.len();
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        let (assignments, num_stack_slots) = asm.linear_scan(&mut intervals, 5.min(allocatable_regs), &regs);
+        let num_stack_slots = asm.linear_scan(&mut intervals, 5.min(allocatable_regs), &regs);
 
         // Extract vreg indices
         let r10_idx = if let Opnd::VReg { idx, .. } = r10 { idx } else { panic!() };
@@ -4784,12 +4781,12 @@ mod tests {
         // r13: [20,38) gets Reg(2)
         // r14: [36,42) gets Reg(1) (r12 expired, reuses its register)
         // r15: [38,42) gets Reg(2) (r13 expired, reuses its register)
-        assert_eq!(assignments[r10_idx], Some(Allocation::Reg(0)));
-        assert_eq!(assignments[r11_idx], Some(Allocation::Reg(1)));
-        assert_eq!(assignments[r12_idx], Some(Allocation::Reg(1)));
-        assert_eq!(assignments[r13_idx], Some(Allocation::Reg(2)));
-        assert_eq!(assignments[r14_idx], Some(Allocation::Reg(1)));
-        assert_eq!(assignments[r15_idx], Some(Allocation::Reg(2)));
+        assert_eq!(intervals[r10_idx].assigned, Some(Allocation::Reg(0)));
+        assert_eq!(intervals[r11_idx].assigned, Some(Allocation::Reg(1)));
+        assert_eq!(intervals[r12_idx].assigned, Some(Allocation::Reg(1)));
+        assert_eq!(intervals[r13_idx].assigned, Some(Allocation::Reg(2)));
+        assert_eq!(intervals[r14_idx].assigned, Some(Allocation::Reg(1)));
+        assert_eq!(intervals[r15_idx].assigned, Some(Allocation::Reg(2)));
     }
 
     #[test]
@@ -4804,7 +4801,7 @@ mod tests {
         let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
         let allocatable_regs = regs.len();
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        let (assignments, num_stack_slots) = asm.linear_scan(&mut intervals, 3.min(allocatable_regs), &regs);
+        let num_stack_slots = asm.linear_scan(&mut intervals, 3.min(allocatable_regs), &regs);
 
         let r10_idx = if let Opnd::VReg { idx, .. } = r10 { idx } else { panic!() };
         let r11_idx = if let Opnd::VReg { idx, .. } = r11 { idx } else { panic!() };
@@ -4816,12 +4813,12 @@ mod tests {
         // Lifetime holes make three registers enough: nothing spills, and the
         // assignment is the same one five registers produce.
         assert_eq!(num_stack_slots, 0);
-        assert_eq!(assignments[r10_idx], Some(Allocation::Reg(0)));
-        assert_eq!(assignments[r11_idx], Some(Allocation::Reg(1)));
-        assert_eq!(assignments[r12_idx], Some(Allocation::Reg(1)));
-        assert_eq!(assignments[r13_idx], Some(Allocation::Reg(2)));
-        assert_eq!(assignments[r14_idx], Some(Allocation::Reg(1)));
-        assert_eq!(assignments[r15_idx], Some(Allocation::Reg(2)));
+        assert_eq!(intervals[r10_idx].assigned, Some(Allocation::Reg(0)));
+        assert_eq!(intervals[r11_idx].assigned, Some(Allocation::Reg(1)));
+        assert_eq!(intervals[r12_idx].assigned, Some(Allocation::Reg(1)));
+        assert_eq!(intervals[r13_idx].assigned, Some(Allocation::Reg(2)));
+        assert_eq!(intervals[r14_idx].assigned, Some(Allocation::Reg(1)));
+        assert_eq!(intervals[r15_idx].assigned, Some(Allocation::Reg(2)));
     }
 
     #[test]
@@ -4836,7 +4833,7 @@ mod tests {
         let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
         let allocatable_regs = regs.len();
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        let (assignments, num_stack_slots) = asm.linear_scan(&mut intervals, 1.min(allocatable_regs), &regs);
+        let num_stack_slots = asm.linear_scan(&mut intervals, 1.min(allocatable_regs), &regs);
 
         let r10_idx = if let Opnd::VReg { idx, .. } = r10 { idx } else { panic!() };
         let r11_idx = if let Opnd::VReg { idx, .. } = r11 { idx } else { panic!() };
@@ -4846,12 +4843,12 @@ mod tests {
         let r15_idx = if let Opnd::VReg { idx, .. } = r15 { idx } else { panic!() };
 
         assert_eq!(num_stack_slots, 3);
-        assert_eq!(assignments[r10_idx], Some(Allocation::Stack(0)));
-        assert_eq!(assignments[r11_idx], Some(Allocation::Reg(0)));
-        assert_eq!(assignments[r12_idx], Some(Allocation::Stack(1)));
-        assert_eq!(assignments[r13_idx], Some(Allocation::Reg(0)));
-        assert_eq!(assignments[r14_idx], Some(Allocation::Stack(2)));
-        assert_eq!(assignments[r15_idx], Some(Allocation::Reg(0)));
+        assert_eq!(intervals[r10_idx].assigned, Some(Allocation::Stack(0)));
+        assert_eq!(intervals[r11_idx].assigned, Some(Allocation::Reg(0)));
+        assert_eq!(intervals[r12_idx].assigned, Some(Allocation::Stack(1)));
+        assert_eq!(intervals[r13_idx].assigned, Some(Allocation::Reg(0)));
+        assert_eq!(intervals[r14_idx].assigned, Some(Allocation::Stack(2)));
+        assert_eq!(intervals[r15_idx].assigned, Some(Allocation::Reg(0)));
     }
 
     #[test]
@@ -4882,10 +4879,10 @@ mod tests {
         // Zero allocatable registers: the only register this interval can get
         // is the pinned one appended to the pool, so the preference is what
         // makes this succeed rather than spill.
-        let (assignments, num_stack_slots) = asm.linear_scan(&mut intervals, 0, &regs);
+        let num_stack_slots = asm.linear_scan(&mut intervals, 0, &regs);
         assert_eq!(num_stack_slots, 0);
-        assert_eq!(assignments[vreg_idx], Some(Allocation::Reg(regno)));
-        assert_eq!(assignments[vreg_idx].unwrap().assigned_reg(&regs), Some(sp.unwrap_reg()));
+        assert_eq!(intervals[vreg_idx].assigned, Some(Allocation::Reg(regno)));
+        assert_eq!(intervals[vreg_idx].assigned.unwrap().assigned_reg(&regs), Some(sp.unwrap_reg()));
     }
 
     #[test]
@@ -4917,9 +4914,9 @@ mod tests {
         let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
         let allocatable_regs = regs.len();
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        let (assignments, _) = asm.linear_scan(&mut intervals, 5.min(allocatable_regs), &regs);
+        asm.linear_scan(&mut intervals, 5.min(allocatable_regs), &regs);
 
-        asm.resolve_ssa(&intervals, &assignments, &regs);
+        asm.resolve_ssa(&intervals, &regs);
 
         use crate::backend::current::ALLOC_REGS;
         let regs = &ALLOC_REGS[..5];
@@ -4963,7 +4960,7 @@ mod tests {
         let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
         let allocatable_regs = regs.len();
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        let (assignments, _) = asm.linear_scan(&mut intervals, 5.min(allocatable_regs), &regs);
+        asm.linear_scan(&mut intervals, 5.min(allocatable_regs), &regs);
 
         // Entry block b1 has parameters [v0, v1].
         // With 5 registers: v0 -> Reg(0) = regs[0], arrival = C_ARG_OPNDS[0] = regs[0] -> self-move, filtered
@@ -4971,7 +4968,7 @@ mod tests {
         // Before resolve_ssa, b1 has: [Label, Jmp] = 2 insns
         assert_eq!(asm.basic_blocks[b1.0].insns.len(), 2);
 
-        asm.resolve_ssa(&intervals, &assignments, &regs);
+        asm.resolve_ssa(&intervals, &regs);
 
         // After resolve_ssa, b1 should still have the same number of insns
         // (plus any edge moves, but no entry param moves since they're all self-moves).
@@ -5012,9 +5009,9 @@ mod tests {
         let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
         let allocatable_regs = regs.len();
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        let (assignments, _) = asm.linear_scan(&mut intervals, 5.min(allocatable_regs), &regs);
+        asm.linear_scan(&mut intervals, 5.min(allocatable_regs), &regs);
 
-        asm.resolve_ssa(&intervals, &assignments, &regs);
+        asm.resolve_ssa(&intervals, &regs);
 
         assert!(matches!(asm.basic_blocks[block.0].insns[1], Insn::Abort));
     }
@@ -5073,16 +5070,16 @@ mod tests {
         let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
         let allocatable_regs = regs.len();
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        let (assignments, _) = asm.linear_scan(&mut intervals, num_regs.min(allocatable_regs), &regs);
+        asm.linear_scan(&mut intervals, num_regs.min(allocatable_regs), &regs);
 
         assert_eq!(asm.basic_blocks.len(), 3);
 
         // Verify v1 and v4 have different allocations (so moves are needed)
-        let v1_alloc = assignments[v1.vreg_idx()].unwrap();
-        let v4_alloc = assignments[v4.vreg_idx()].unwrap();
+        let v1_alloc = intervals[v1.vreg_idx()].assigned.unwrap();
+        let v4_alloc = intervals[v4.vreg_idx()].assigned.unwrap();
         assert_ne!(v1_alloc, v4_alloc, "Test setup: v1 and v4 should have different allocations");
 
-        asm.resolve_ssa(&intervals, &assignments, &regs);
+        asm.resolve_ssa(&intervals, &regs);
 
         // A new interstitial block should have been created for the critical edge b1->b3
         // b1->b3 is critical because b1 has 2 successors and b3 has 2 predecessors
@@ -5114,7 +5111,7 @@ mod tests {
         assert!(has_mov, "Expected Mov in split block for v1->v4");
 
         // b2->b3 is not a critical edge (b2 has single succ), so moves go before Jmp in b2
-        let v3_alloc = assignments[v3.vreg_idx()].unwrap();
+        let v3_alloc = intervals[v3.vreg_idx()].assigned.unwrap();
         let b2_insns = &asm.basic_blocks[b2.0].insns;
         if v3_alloc != v4_alloc {
             // Check that a Mov was inserted before the Jmp in b2
@@ -5179,7 +5176,7 @@ mod tests {
         let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
         let allocatable_regs = regs.len();
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        let (assignments, num_stack_slots) = asm.linear_scan(&mut intervals, num_regs.min(allocatable_regs), &regs);
+        let num_stack_slots = asm.linear_scan(&mut intervals, num_regs.min(allocatable_regs), &regs);
         asm.stack_state.num_spill_slots = num_stack_slots;
 
         // Stand in for the C calling convention's argument registers. These
@@ -5188,15 +5185,15 @@ mod tests {
         let c_arg_regs = &ALLOC_REGS[..num_regs];
 
         // v0 should be spilled (long-lived, only 2 regs)
-        assert!(matches!(assignments[v0.vreg_idx()], Some(Allocation::Stack(_))),
+        assert!(matches!(intervals[v0.vreg_idx()].assigned, Some(Allocation::Stack(_))),
             "v0 should be spilled to stack");
         // v1 should be in a register
-        assert!(matches!(assignments[v1.vreg_idx()], Some(Allocation::Reg(_))),
+        assert!(matches!(intervals[v1.vreg_idx()].assigned, Some(Allocation::Reg(_))),
             "v1 should be in a register");
 
         // Run the pipeline: handle_caller_saved_regs then resolve_ssa
-        asm.handle_caller_saved_regs(&intervals, &assignments, &regs, c_arg_regs);
-        asm.resolve_ssa(&intervals, &assignments, &regs);
+        asm.handle_caller_saved_regs(&intervals, &regs, c_arg_regs);
+        asm.resolve_ssa(&intervals, &regs);
 
         let insns = &asm.basic_blocks[b1.0].insns;
 
@@ -5207,7 +5204,7 @@ mod tests {
         assert!(!pushes.is_empty(), "Expected at least one saved register across CCall");
 
         // The survivor register should match v1's allocation
-        let v1_reg = Opnd::Reg(assignments[v1.vreg_idx()].unwrap().assigned_reg(&regs).unwrap());
+        let v1_reg = Opnd::Reg(intervals[v1.vreg_idx()].assigned.unwrap().assigned_reg(&regs).unwrap());
         let pushed_v1 = pushes.iter().any(|insn| matches!(**insn, Insn::CPushPair(first, second) if first == v1_reg || second == v1_reg));
         let popped_v1 = pops.iter().any(|insn| matches!(**insn, Insn::CPopPairInto(first, second) if first == v1_reg || second == v1_reg));
         assert!(pushed_v1, "CPushPair should save v1's register");

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -1361,27 +1361,27 @@ impl fmt::Debug for Insn {
 #[derive(Clone, Debug, PartialEq)]
 pub struct LiveRange {
     /// Index of the first instruction that used the VReg
-    pub start: Option<usize>,
+    pub start: usize,
     /// Index of the last instruction that used the VReg
-    pub end: Option<usize>,
+    pub end: usize,
 }
 
 impl LiveRange {
     /// Shorthand for self.start.unwrap()
     pub fn start(&self) -> usize {
-        self.start.unwrap()
+        self.start
     }
 
     /// Shorthand for self.end.unwrap()
     pub fn end(&self) -> usize {
-        self.end.unwrap()
+        self.end
     }
 }
 
 /// Live Interval of a VReg
 #[derive(Clone)]
 pub struct Interval {
-    pub range: LiveRange,
+    pub ranges: Vec<LiveRange>,
     pub id: VRegId,
 }
 
@@ -1389,35 +1389,40 @@ impl Interval {
     /// Create a new Interval with no range
     pub fn new(i: VRegId) -> Self {
         Self {
-            range: LiveRange {
-                start: None,
-                end: None,
-            },
+            ranges: vec![],
             id: i,
         }
+    }
+
+    pub fn start(&self) -> usize {
+        self.ranges[0].start
+    }
+
+    pub fn end(&self) -> usize {
+        self.ranges.last().unwrap().end
     }
 
     /// Check if the interval is alive at position x
     /// Panics if the range is not set
     pub fn survives(&self, x: usize) -> bool {
-        assert!(self.range.start.is_some() && self.range.end.is_some(), "survives called on interval with no range");
-        let start = self.range.start.unwrap();
-        let end = self.range.end.unwrap();
+        assert!(self.ranges.len() > 0, "survives called on interval with no range");
+        let start = self.ranges[0].start;
+        let end = self.ranges[0].end;
         start < x && end > x
     }
 
     pub fn born_at(&self, x:usize) -> bool {
-        let start = self.range.start.unwrap();
+        let start = self.ranges[0].start;
         start == x
     }
 
     pub fn dies_at(&self, x:usize) -> bool {
-        let end = self.range.end.unwrap();
+        let end = self.ranges[0].end;
         end == x
     }
 
     pub fn has_bounds(&self) -> bool {
-        self.range.start.is_some() && self.range.end.is_some()
+        self.ranges.len() > 0
     }
 
     /// Add a range to the interval, extending it if necessary
@@ -1426,22 +1431,22 @@ impl Interval {
             panic!("Invalid range: {} to {}", from, to);
         }
 
-        if self.range.start.is_none() {
-            self.range.start = Some(from);
-            self.range.end = Some(to);
+        if self.ranges.len() == 0 {
+            self.ranges.push(LiveRange { start: from, end: to });
             return;
         }
 
-        // Extend the range to cover both the existing range and the new range
-        self.range.start = Some(self.range.start.unwrap().min(from));
-        self.range.end = Some(self.range.end.unwrap().max(to));
+        let range = self.ranges.first_mut().unwrap();
+        range.start = range.start.min(from);
+        range.end = range.end.max(to);
     }
 
     /// Set the start of the range
     pub fn set_from(&mut self, from: usize) {
-        let end = self.range.end.unwrap_or(from);
-        self.range.start = Some(from);
-        self.range.end = Some(end);
+        match self.ranges.first_mut() {
+            None => self.ranges.push(LiveRange { start: from, end: from + 1 }),
+            Some(range) => range.start = from
+        }
     }
 }
 
@@ -2137,15 +2142,15 @@ impl Assembler
 
         // Collect vreg indices that have valid ranges, sorted by start point
         let mut sorted_intervals: Vec<Interval> = intervals.iter()
-            .filter(|i| i.range.start.is_some() && i.range.end.is_some())
+            .filter(|i| i.has_bounds())
             .cloned()
             .collect();
-        sorted_intervals.sort_by_key(|i| i.range.start.unwrap());
+        sorted_intervals.sort_by_key(|i| i.start());
 
         for interval in &sorted_intervals {
             // Expire old intervals
             active.retain(|&active_interval| {
-                if active_interval.range.end.unwrap() > interval.range.start.unwrap() {
+                if active_interval.end() > interval.start() {
                     true
                 } else {
                     if let Some(allocation) = assignment[active_interval.id] {
@@ -2186,13 +2191,13 @@ impl Assembler
                 if let Some(reg_idx) = Allocation::Fixed(preferred_reg).alloc_pool_index(num_registers) {
                     if free_registers.remove(&reg_idx) {
                         assignment[interval.id] = Some(Allocation::Fixed(preferred_reg));
-                        let insert_idx = active.partition_point(|&i| i.range.end.unwrap() < interval.range.end.unwrap());
+                        let insert_idx = active.partition_point(|&i| i.end() < interval.end());
                         active.insert(insert_idx, &interval);
                         continue;
                     }
                 } else {
                     assignment[interval.id] = Some(Allocation::Fixed(preferred_reg));
-                    let insert_idx = active.partition_point(|&i| i.range.end.unwrap() < interval.range.end.unwrap());
+                    let insert_idx = active.partition_point(|&i| i.end() < interval.end());
                     active.insert(insert_idx, &interval);
                     continue;
                 }
@@ -2209,14 +2214,14 @@ impl Assembler
                 let slot = Allocation::Stack(num_stack_slots);
                 num_stack_slots += 1;
 
-                if let Some(spill) = spill.filter(|spill| spill.range.end.unwrap() > interval.range.end.unwrap()) {
+                if let Some(spill) = spill.filter(|spill| spill.end() > interval.end()) {
                     // Spill the last active interval; give its register to current
                     assignment[interval.id] = assignment[spill.id];
                     assignment[spill.id] = Some(slot);
                     let spill_idx = active.iter().position(|active_interval| active_interval.id == spill.id).unwrap();
                     active.remove(spill_idx);
                     // Insert current into sorted active
-                    let insert_idx = active.partition_point(|&i| i.range.end.unwrap() < interval.range.end.unwrap());
+                    let insert_idx = active.partition_point(|&i| i.end() < interval.end());
                     active.insert(insert_idx, &interval);
                 } else {
                     // Spill the current interval
@@ -2228,7 +2233,7 @@ impl Assembler
                 free_registers.remove(&reg);
                 assignment[interval.id] = Some(Allocation::Reg(reg));
                 // Insert into sorted active
-                let insert_idx = active.partition_point(|&i| i.range.end.unwrap() < interval.range.end.unwrap());
+                let insert_idx = active.partition_point(|&i| i.end() < interval.end());
                 active.insert(insert_idx, &interval);
             }
         }
@@ -2446,10 +2451,8 @@ impl Assembler
                     // Do we have a case where a ccall is emitted, but nobody
                     // uses the result?
                     let call_result_live = out.is_vreg()
-                        && intervals[out.vreg_idx()]
-                            .range
-                            .end
-                            .is_some_and(|end| end > insn_number);
+                        && intervals[out.vreg_idx()].has_bounds()
+                        && intervals[out.vreg_idx()].end() > insn_number;
 
                     // Build a set of VRegIds that can be referenced by JITFrame for materializing the VM stack
                     let stack_vreg_ids: HashSet<VRegId> = if let Some(StackMap { stack, .. }) = &stack_map {
@@ -3350,11 +3353,10 @@ pub fn lir_intervals_string(asm: &Assembler, intervals: &[Interval]) -> String {
 
             // For each VReg, check if it's alive at this position
             for vreg_idx in 0..num_vregs {
-                let is_alive = intervals[vreg_idx].range.start.is_some() &&
-                               intervals[vreg_idx].range.end.is_some() &&
+                let is_alive = intervals[vreg_idx].has_bounds() &&
                                intervals[vreg_idx].survives(insn_id.0);
 
-                let has_range = intervals[vreg_idx].range.start.is_some();
+                let has_range = intervals[vreg_idx].has_bounds();
                 if has_range && intervals[vreg_idx].born_at(insn_id.0) {
                     output.push_str("  v ");
                 } else if has_range && intervals[vreg_idx].dies_at(insn_id.0) {

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -2170,43 +2170,44 @@ impl Assembler
     // support.
     pub fn linear_scan(
         &self,
-        intervals: Vec<Interval>,
+        intervals: &mut [Interval],
         num_registers: usize, // number of allocatable regs
         regs: &[Reg],         // list of all registers used, partitioned by allocatability
     ) -> (Vec<Option<Allocation>>, usize) {
         debug_assert!(num_registers <= regs.len());
 
+        // `active`, `inactive`, and `unhandled` hold indexes in to `intervals`.
+        // An interval's index is its VRegId, and it is the only identity we
+        // need: the interval data itself is mutated in place.
         let mut free_registers: Vec<usize> = vec![0; regs.len()];
-        let mut active: Vec<Interval> = Vec::new(); // sorted by increasing end point
-        let mut inactive: Vec<Interval> = Vec::new(); // intervals with lifetime holes
+        let mut active: Vec<usize> = Vec::new(); // sorted by increasing end point
+        let mut inactive: Vec<usize> = Vec::new(); // intervals with lifetime holes
         let mut num_stack_slots: usize = 0;
-        let mut handled: Vec<Interval> = Vec::new();
-        let num_intervals = intervals.len();
 
-        let mut sorted_intervals: Vec<Interval> = intervals.into_iter()
-            .filter(|i| i.has_bounds())
+        let mut sorted_intervals: Vec<usize> = (0..intervals.len())
+            .filter(|&i| intervals[i].has_bounds())
             .collect();
-        sorted_intervals.sort_by_key(|i| i.start());
+        sorted_intervals.sort_by_key(|&i| intervals[i].start());
 
-        let mut unhandled: VecDeque<Interval> = sorted_intervals.into();
+        let mut unhandled: VecDeque<usize> = sorted_intervals.into();
 
-        while let Some(mut interval) = unhandled.pop_front() {
-            let position = interval.start();
+        while let Some(cur) = unhandled.pop_front() {
+            let position = intervals[cur].start();
+            let cur_end = intervals[cur].end();
 
             // Expire old intervals.
-            active.retain_mut(|it| {
-                debug_assert!(it.state == State::Active);
+            active.retain(|&it| {
+                debug_assert!(intervals[it].state == State::Active);
                 // If the interval ends before the current position, then we're
                 // done with it and can mark it handled.
-                if it.ends_before(position) {
-                    it.state = State::Handled;
-                    handled.push(it.clone());
+                if intervals[it].ends_before(position) {
+                    intervals[it].state = State::Handled;
                     false
-                } else if !it.covers(position) {
+                } else if !intervals[it].covers(position) {
                     // If it doesn't cover the current position (there's a hole
                     // in the ranges), then move it to inactive
-                    it.state = State::Inactive;
-                    inactive.push(it.clone());
+                    intervals[it].state = State::Inactive;
+                    inactive.push(it);
                     false
                 } else {
                     // Otherwise it's still live here and stays active.
@@ -2215,20 +2216,17 @@ impl Assembler
             });
 
             // Check for intervals in inactive that are handled or active
-            inactive.retain(|it| {
-                debug_assert!(it.state == State::Inactive);
+            inactive.retain(|&it| {
+                debug_assert!(intervals[it].state == State::Inactive);
                 // If the inactive interval ends before the current position
-                if it.ends_before(position) {
+                if intervals[it].ends_before(position) {
                     // Move it to handled
-                    let mut it = it.clone();
-                    it.state = State::Handled;
-                    handled.push(it);
+                    intervals[it].state = State::Handled;
                     false
-                } else if it.covers(position) {
+                } else if intervals[it].covers(position) {
                     // If the current position falls inside one of the
                     // interval's ranges, then make it active
-                    let mut it = it.clone();
-                    it.state = State::Active;
+                    intervals[it].state = State::Active;
                     active.push(it);
                     false
                 } else {
@@ -2244,9 +2242,9 @@ impl Assembler
             // Mark all active intervals with assignments as "unavailable".  They are available
             // again at instruction 0 which effectively means they can't be used (as all
             // intervals will end after 0)
-            for it in &active {
-                debug_assert!(it.state == State::Active);
-                match it.assigned.expect("should have assignment") {
+            for &it in &active {
+                debug_assert!(intervals[it].state == State::Active);
+                match intervals[it].assigned.expect("should have assignment") {
                     Allocation::Reg(idx) => free_registers[idx] = 0,
                     _ => {},
                 }
@@ -2256,10 +2254,10 @@ impl Assembler
             // we're currently inside one of those gaps.  We'll mark in the
             // "free_registers" list when each interval will want to use its
             // assigned reg again.
-            for it in &inactive {
-                debug_assert!(it.state == State::Inactive);
-                let Some(pos) = it.next_intersection(&interval) else { continue };
-                match it.assigned.expect("should have assignment") {
+            for &it in &inactive {
+                debug_assert!(intervals[it].state == State::Inactive);
+                let Some(pos) = intervals[it].next_intersection(&intervals[cur]) else { continue };
+                match intervals[it].assigned.expect("should have assignment") {
                     Allocation::Reg(idx) => free_registers[idx] = free_registers[idx].min(pos),
                     _ => {},
                 }
@@ -2267,12 +2265,12 @@ impl Assembler
 
             // If the current interval has a preferred allocation, use it if
             // that register is available until the interval end.
-            if let Some(Allocation::Reg(idx)) = interval.preferred {
-                if free_registers[idx] >= interval.end() {
-                    interval.assigned = Some(Allocation::Reg(idx));
-                    interval.state = State::Active;
-                    let insert_idx = active.partition_point(|i| i.end() < interval.end());
-                    active.insert(insert_idx, interval);
+            if let Some(Allocation::Reg(idx)) = intervals[cur].preferred {
+                if free_registers[idx] >= cur_end {
+                    intervals[cur].assigned = Some(Allocation::Reg(idx));
+                    intervals[cur].state = State::Active;
+                    let insert_idx = active.partition_point(|&i| intervals[i].end() < cur_end);
+                    active.insert(insert_idx, cur);
                     continue;
                 }
             }
@@ -2282,66 +2280,66 @@ impl Assembler
             // we know the current interval can fit in the window this register is available.
             let best_reg = (0..num_registers).rev()
                 .max_by_key(|&reg| free_registers[reg])
-                .filter(|&reg| free_registers[reg] >= interval.end());
+                .filter(|&reg| free_registers[reg] >= cur_end);
 
-            // We couldn't find a best register, so we need to spill
-            if best_reg.is_none() {
-                // Spill: pick the longest-lived active interval (last in sorted active)
-                // but only from the allocatable partition of the pool. An index
-                // at or past `num_registers` is a pinned physical register (for
-                // example SP), which is not ours to hand to someone else.
-                let spill = active.iter().rev()
-                    .find(|active_interval| {
-                        active_interval.assigned
-                            .is_some_and(|alloc| alloc.alloc_pool_index(num_registers).is_some())
-                    })
-                    .map(|active_interval| (active_interval.id, active_interval.end()));
-                let slot = Allocation::Stack(num_stack_slots);
-                num_stack_slots += 1;
+            match best_reg {
+                // We couldn't find a best register, so we need to spill
+                None => {
+                    // Spill: pick the longest-lived active interval (last in sorted active)
+                    // but only from the allocatable partition of the pool. An index
+                    // at or past `num_registers` is a pinned physical register (for
+                    // example SP), which is not ours to hand to someone else.
+                    let spill = active.iter().rev().copied()
+                        .find(|&it| {
+                            intervals[it].assigned
+                                .is_some_and(|alloc| alloc.alloc_pool_index(num_registers).is_some())
+                        })
+                        .map(|it| (it, intervals[it].end()));
+                    let slot = Allocation::Stack(num_stack_slots);
+                    num_stack_slots += 1;
 
-                if let Some((spill_id, _)) = spill.filter(|&(_, spill_end)| spill_end > interval.end()) {
-                    // Spill the last active interval; give its register to current
-                    let spill_idx = active.iter().position(|active_interval| active_interval.id == spill_id).unwrap();
-                    let mut spilled = active.remove(spill_idx);
-                    interval.assigned = spilled.assigned;
-                    spilled.assigned = Some(slot);
-                    spilled.state = State::Handled;
-                    handled.push(spilled);
-                    // Insert current into sorted active
-                    let insert_idx = active.partition_point(|i| i.end() < interval.end());
-                    interval.state = State::Active;
-                    active.insert(insert_idx, interval);
-                } else {
-                    // Spill the current interval
-                    interval.assigned = Some(slot);
-                    interval.state = State::Handled;
-                    handled.push(interval);
+                    if let Some((spill_it, _)) = spill.filter(|&(_, spill_end)| spill_end > cur_end) {
+                        // Spill the last active interval; give its register to current
+                        let spill_idx = active.iter().position(|&i| i == spill_it).unwrap();
+                        active.remove(spill_idx);
+                        // Read the stolen allocation in to a local: reading and
+                        // writing `intervals` in one statement won't borrow check.
+                        let stolen = intervals[spill_it].assigned;
+                        intervals[spill_it].assigned = Some(slot);
+                        intervals[spill_it].state = State::Handled;
+                        intervals[cur].assigned = stolen;
+                        intervals[cur].state = State::Active;
+                        // Insert current into sorted active
+                        let insert_idx = active.partition_point(|&i| intervals[i].end() < cur_end);
+                        active.insert(insert_idx, cur);
+                    } else {
+                        // Spill the current interval
+                        intervals[cur].assigned = Some(slot);
+                        intervals[cur].state = State::Handled;
+                    }
                 }
-            } else {
-                let reg = best_reg.unwrap();
-                interval.assigned = Some(Allocation::Reg(reg));
-                interval.state = State::Active;
-                // Insert into sorted active
-                let insert_idx = active.partition_point(|i| i.end() < interval.end());
-                active.insert(insert_idx, interval);
+                Some(reg) => {
+                    intervals[cur].assigned = Some(Allocation::Reg(reg));
+                    intervals[cur].state = State::Active;
+                    // Insert into sorted active
+                    let insert_idx = active.partition_point(|&i| intervals[i].end() < cur_end);
+                    active.insert(insert_idx, cur);
+                }
             }
         }
 
         // Drain active and inactive and mark everything as handled.
-        for mut it in active.drain(..).chain(inactive.drain(..)) {
-            it.state = State::Handled;
-            handled.push(it);
+        for it in active.drain(..).chain(inactive.drain(..)) {
+            intervals[it].state = State::Handled;
         }
         debug_assert!(active.is_empty() && inactive.is_empty());
 
-        let mut assignment: Vec<Option<Allocation>> = vec![None; num_intervals];
-        for it in handled {
-            debug_assert!(it.state == State::Handled);
-            assignment[it.id] = it.assigned;
-        }
-
         // TODO: Caller should just use the mutated intervals instead of
         // using this assignment list
+        let assignment: Vec<Option<Allocation>> = intervals.iter()
+            .map(|it| it.assigned)
+            .collect();
+
         (assignment, num_stack_slots)
     }
 
@@ -4748,7 +4746,7 @@ mod tests {
         let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
         let allocatable_regs = regs.len();
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        let (assignments, num_stack_slots) = asm.linear_scan(intervals, 5.min(allocatable_regs), &regs);
+        let (assignments, num_stack_slots) = asm.linear_scan(&mut intervals, 5.min(allocatable_regs), &regs);
 
         // Extract vreg indices
         let r10_idx = if let Opnd::VReg { idx, .. } = r10 { idx } else { panic!() };
@@ -4788,7 +4786,7 @@ mod tests {
         let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
         let allocatable_regs = regs.len();
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        let (assignments, num_stack_slots) = asm.linear_scan(intervals, 3.min(allocatable_regs), &regs);
+        let (assignments, num_stack_slots) = asm.linear_scan(&mut intervals, 3.min(allocatable_regs), &regs);
 
         let r10_idx = if let Opnd::VReg { idx, .. } = r10 { idx } else { panic!() };
         let r11_idx = if let Opnd::VReg { idx, .. } = r11 { idx } else { panic!() };
@@ -4820,7 +4818,7 @@ mod tests {
         let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
         let allocatable_regs = regs.len();
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        let (assignments, num_stack_slots) = asm.linear_scan(intervals, 1.min(allocatable_regs), &regs);
+        let (assignments, num_stack_slots) = asm.linear_scan(&mut intervals, 1.min(allocatable_regs), &regs);
 
         let r10_idx = if let Opnd::VReg { idx, .. } = r10 { idx } else { panic!() };
         let r11_idx = if let Opnd::VReg { idx, .. } = r11 { idx } else { panic!() };
@@ -4866,7 +4864,7 @@ mod tests {
         // Zero allocatable registers: the only register this interval can get
         // is the pinned one appended to the pool, so the preference is what
         // makes this succeed rather than spill.
-        let (assignments, num_stack_slots) = asm.linear_scan(intervals, 0, &regs);
+        let (assignments, num_stack_slots) = asm.linear_scan(&mut intervals, 0, &regs);
         assert_eq!(num_stack_slots, 0);
         assert_eq!(assignments[vreg_idx], Some(Allocation::Reg(regno)));
         assert_eq!(assignments[vreg_idx].unwrap().assigned_reg(&regs), Some(sp.unwrap_reg()));
@@ -4901,7 +4899,7 @@ mod tests {
         let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
         let allocatable_regs = regs.len();
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        let (assignments, _) = asm.linear_scan(intervals.clone(), 5.min(allocatable_regs), &regs);
+        let (assignments, _) = asm.linear_scan(&mut intervals, 5.min(allocatable_regs), &regs);
 
         asm.resolve_ssa(&intervals, &assignments, &regs);
 
@@ -4947,7 +4945,7 @@ mod tests {
         let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
         let allocatable_regs = regs.len();
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        let (assignments, _) = asm.linear_scan(intervals.clone(), 5.min(allocatable_regs), &regs);
+        let (assignments, _) = asm.linear_scan(&mut intervals, 5.min(allocatable_regs), &regs);
 
         // Entry block b1 has parameters [v0, v1].
         // With 5 registers: v0 -> Reg(0) = regs[0], arrival = C_ARG_OPNDS[0] = regs[0] -> self-move, filtered
@@ -4996,7 +4994,7 @@ mod tests {
         let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
         let allocatable_regs = regs.len();
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        let (assignments, _) = asm.linear_scan(intervals.clone(), 5.min(allocatable_regs), &regs);
+        let (assignments, _) = asm.linear_scan(&mut intervals, 5.min(allocatable_regs), &regs);
 
         asm.resolve_ssa(&intervals, &assignments, &regs);
 
@@ -5057,7 +5055,7 @@ mod tests {
         let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
         let allocatable_regs = regs.len();
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        let (assignments, _) = asm.linear_scan(intervals.clone(), num_regs.min(allocatable_regs), &regs);
+        let (assignments, _) = asm.linear_scan(&mut intervals, num_regs.min(allocatable_regs), &regs);
 
         assert_eq!(asm.basic_blocks.len(), 3);
 
@@ -5163,7 +5161,7 @@ mod tests {
         let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
         let allocatable_regs = regs.len();
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        let (assignments, num_stack_slots) = asm.linear_scan(intervals.clone(), num_regs.min(allocatable_regs), &regs);
+        let (assignments, num_stack_slots) = asm.linear_scan(&mut intervals, num_regs.min(allocatable_regs), &regs);
         asm.stack_state.num_spill_slots = num_stack_slots;
 
         // Stand in for the C calling convention's argument registers. These

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -1409,6 +1409,7 @@ pub struct Interval {
     pub id: VRegId,
     pub state: State,
     pub assigned: Option<Allocation>,
+    pub preferred: Option<Reg>,
 }
 
 impl Interval {
@@ -1419,6 +1420,7 @@ impl Interval {
             id: i,
             state: State::Unhandled,
             assigned: None,
+            preferred: None,
         }
     }
 
@@ -2116,9 +2118,7 @@ impl Assembler
 
     /// Discover vregs that should preferentially reuse a physical register,
     /// such as a newborn vreg immediately moved into a preg in the next instruction.
-    pub fn preferred_register_assignments(&self, intervals: &[Interval]) -> Vec<Option<Reg>> {
-        let mut preferred = vec![None; self.num_vregs];
-
+    pub fn preferred_register_assignments(&self, intervals: &mut [Interval]) {
         for block in &self.basic_blocks {
             let mut prev_insn: Option<(InsnId, &Insn)> = None;
 
@@ -2139,7 +2139,7 @@ impl Assembler
                                 && intervals[*idx].born_at(prev_id.0)
                                 && intervals[*idx].dies_at(insn_id.0)
                             {
-                                preferred[*idx].get_or_insert(*dest_reg);
+                                intervals[*idx].preferred.get_or_insert(*dest_reg);
                             }
                         }
                     }
@@ -2148,8 +2148,6 @@ impl Assembler
                 }
             }
         }
-
-        preferred
     }
 
     fn release_assignment(it: &Interval, num_registers: usize, free_registers: &mut BTreeSet<usize>) {
@@ -2187,10 +2185,7 @@ impl Assembler
         &self,
         intervals: Vec<Interval>,
         num_registers: usize,
-        preferred_registers: &[Option<Reg>],
     ) -> (Vec<Option<Allocation>>, usize) {
-        assert_eq!(preferred_registers.len(), intervals.len());
-
         let mut free_registers: BTreeSet<usize> = (0..num_registers).collect();
         let mut active: Vec<Interval> = Vec::new(); // sorted by increasing end point
         let mut inactive: Vec<Interval> = Vec::new(); // intervals with lifetime holes
@@ -2218,7 +2213,7 @@ impl Assembler
                 }
             }
 
-            let preferred_reg = preferred_registers[interval.id];
+            let preferred_reg = interval.preferred;
             let preferred_taken = preferred_reg.is_some_and(|reg| {
                 active.iter().any(|active_interval| {
                     active_interval.assigned
@@ -4707,12 +4702,12 @@ mod tests {
         asm.number_instructions(16);
 
         // Build intervals
-        let intervals = asm.build_intervals(live_in);
+        let mut intervals = asm.build_intervals(live_in);
 
         println!("LIR live_intervals:\n{}", crate::backend::lir::debug_intervals(&asm, &intervals));
 
-        let preferred_registers = asm.preferred_register_assignments(&intervals);
-        let (assignments, num_stack_slots) = asm.linear_scan(intervals, 5, &preferred_registers);
+        asm.preferred_register_assignments(&mut intervals);
+        let (assignments, num_stack_slots) = asm.linear_scan(intervals, 5);
 
         // Extract vreg indices
         let r10_idx = if let Opnd::VReg { idx, .. } = r10 { idx } else { panic!() };
@@ -4746,11 +4741,11 @@ mod tests {
 
         let live_in = asm.analyze_liveness();
         asm.number_instructions(16);
-        let intervals = asm.build_intervals(live_in);
+        let mut intervals = asm.build_intervals(live_in);
 
         // 3 registers -- only r10 needs to spill
-        let preferred_registers = asm.preferred_register_assignments(&intervals);
-        let (assignments, num_stack_slots) = asm.linear_scan(intervals, 3, &preferred_registers);
+        asm.preferred_register_assignments(&mut intervals);
+        let (assignments, num_stack_slots) = asm.linear_scan(intervals, 3);
 
         let r10_idx = if let Opnd::VReg { idx, .. } = r10 { idx } else { panic!() };
         let r11_idx = if let Opnd::VReg { idx, .. } = r11 { idx } else { panic!() };
@@ -4774,11 +4769,11 @@ mod tests {
 
         let live_in = asm.analyze_liveness();
         asm.number_instructions(16);
-        let intervals = asm.build_intervals(live_in);
+        let mut intervals = asm.build_intervals(live_in);
 
         // Only 1 register available -- forces spills
-        let preferred_registers = asm.preferred_register_assignments(&intervals);
-        let (assignments, num_stack_slots) = asm.linear_scan(intervals, 1, &preferred_registers);
+        asm.preferred_register_assignments(&mut intervals);
+        let (assignments, num_stack_slots) = asm.linear_scan(intervals, 1);
 
         let r10_idx = if let Opnd::VReg { idx, .. } = r10 { idx } else { panic!() };
         let r11_idx = if let Opnd::VReg { idx, .. } = r11 { idx } else { panic!() };
@@ -4811,13 +4806,13 @@ mod tests {
 
         asm.number_instructions(0);
         let live_in = asm.analyze_liveness();
-        let intervals = asm.build_intervals(live_in);
-        let preferred_registers = asm.preferred_register_assignments(&intervals);
+        let mut intervals = asm.build_intervals(live_in);
+        asm.preferred_register_assignments(&mut intervals);
 
         let vreg_idx = new_sp.vreg_idx();
-        assert_eq!(preferred_registers[vreg_idx], Some(sp.unwrap_reg()));
+        assert_eq!(intervals[vreg_idx].preferred, Some(sp.unwrap_reg()));
 
-        let (assignments, num_stack_slots) = asm.linear_scan(intervals, 0, &preferred_registers);
+        let (assignments, num_stack_slots) = asm.linear_scan(intervals, 0);
         assert_eq!(num_stack_slots, 0);
         assert_eq!(assignments[vreg_idx], Some(Allocation::Fixed(sp.unwrap_reg())));
     }
@@ -4847,9 +4842,9 @@ mod tests {
 
         let live_in = asm.analyze_liveness();
         asm.number_instructions(16);
-        let intervals = asm.build_intervals(live_in);
-        let preferred_registers = asm.preferred_register_assignments(&intervals);
-        let (assignments, _) = asm.linear_scan(intervals.clone(), 5, &preferred_registers);
+        let mut intervals = asm.build_intervals(live_in);
+        asm.preferred_register_assignments(&mut intervals);
+        let (assignments, _) = asm.linear_scan(intervals.clone(), 5);
 
         asm.resolve_ssa(&intervals, &assignments);
 
@@ -4893,9 +4888,9 @@ mod tests {
 
         let live_in = asm.analyze_liveness();
         asm.number_instructions(16);
-        let intervals = asm.build_intervals(live_in);
-        let preferred_registers = asm.preferred_register_assignments(&intervals);
-        let (assignments, _) = asm.linear_scan(intervals.clone(), 5, &preferred_registers);
+        let mut intervals = asm.build_intervals(live_in);
+        asm.preferred_register_assignments(&mut intervals);
+        let (assignments, _) = asm.linear_scan(intervals.clone(), 5);
 
         // Entry block b1 has parameters [v0, v1].
         // With 5 registers: v0 -> Reg(0) = regs[0], arrival = C_ARG_OPNDS[0] = regs[0] -> self-move, filtered
@@ -4940,9 +4935,9 @@ mod tests {
 
         let live_in = asm.analyze_liveness();
         asm.number_instructions(0);
-        let intervals = asm.build_intervals(live_in);
-        let preferred_registers = asm.preferred_register_assignments(&intervals);
-        let (assignments, _) = asm.linear_scan(intervals.clone(), 5, &preferred_registers);
+        let mut intervals = asm.build_intervals(live_in);
+        asm.preferred_register_assignments(&mut intervals);
+        let (assignments, _) = asm.linear_scan(intervals.clone(), 5);
 
         asm.resolve_ssa(&intervals, &assignments);
 
@@ -4998,10 +4993,10 @@ mod tests {
 
         let live_in = asm.analyze_liveness();
         asm.number_instructions(16);
-        let intervals = asm.build_intervals(live_in);
+        let mut intervals = asm.build_intervals(live_in);
         let num_regs = 5;
-        let preferred_registers = asm.preferred_register_assignments(&intervals);
-        let (assignments, _) = asm.linear_scan(intervals.clone(), num_regs, &preferred_registers);
+        asm.preferred_register_assignments(&mut intervals);
+        let (assignments, _) = asm.linear_scan(intervals.clone(), num_regs);
 
         assert_eq!(asm.basic_blocks.len(), 3);
 
@@ -5102,10 +5097,10 @@ mod tests {
         // Run liveness + numbering + intervals + linear scan with 2 registers
         let live_in = asm.analyze_liveness();
         asm.number_instructions(0);
-        let intervals = asm.build_intervals(live_in);
+        let mut intervals = asm.build_intervals(live_in);
         let num_regs = 2;
-        let preferred_registers = asm.preferred_register_assignments(&intervals);
-        let (assignments, num_stack_slots) = asm.linear_scan(intervals.clone(), num_regs, &preferred_registers);
+        asm.preferred_register_assignments(&mut intervals);
+        let (assignments, num_stack_slots) = asm.linear_scan(intervals.clone(), num_regs);
         asm.stack_state.num_spill_slots = num_stack_slots;
 
         let regs = &ALLOC_REGS[..num_regs];

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -1400,13 +1400,19 @@ impl Interval {
         self.ranges.last().unwrap().to
     }
 
-    /// Check if the interval is alive at position x
+    /// Check if the interval is alive at position
     /// Panics if the range is not set
-    pub fn survives(&self, x: usize) -> bool {
+    pub fn survives(&self, position: usize) -> bool {
         assert!(self.ranges.len() > 0, "survives called on interval with no range");
-        let start = self.ranges[0].from;
-        let end = self.ranges.last().unwrap().to;
-        start < x && end > x
+        for range in self.ranges.iter() {
+            if position < range.from {
+                return false;
+            }
+            if position < range.to {
+                return true;
+            }
+        }
+        return false;
     }
 
     pub fn born_at(&self, x:usize) -> bool {
@@ -1429,9 +1435,11 @@ impl Interval {
             panic!("Invalid range: {} to {}", from, to);
         }
 
-        if self.ranges.len() > 0 {
-            let last = self.ranges.last_mut().unwrap();
-            if last.from <= to {
+        // Blocks are visited in ascending order, so only the last range can
+        // overlap or abut the new one. Anything earlier is separated by a
+        // lifetime hole and must stay a distinct range.
+        if let Some(last) = self.ranges.last_mut() {
+            if from <= last.to {
                 last.from = last.from.min(from);
                 last.to = last.to.max(to);
                 return;
@@ -1441,12 +1449,9 @@ impl Interval {
         self.ranges.push(LiveRange { from, to });
     }
 
-    /// Set the start of the range
+    /// Narrow the range covering `from` so that it begins at the def.
     pub fn set_from(&mut self, from: usize) {
-        // We iterate through instructions backwards.  If an instruction
-        // has a def, but no use, then it's possible to encounter an
-        // interval that has no ranges, thus we have a None case.
-        match self.ranges.first_mut() {
+        match self.ranges.last_mut() {
             None => self.ranges.push(LiveRange { from, to: from + 1 }),
             Some(range) => range.from = from
         }
@@ -3354,18 +3359,20 @@ pub fn lir_intervals_string(asm: &Assembler, intervals: &[Interval]) -> String {
             // Print instruction ID
             output.push_str(&format!("i{:<6}: ", insn_id.0));
 
-            // For each VReg, check if it's alive at this position
+            // For each VReg, check if it's alive at this position. Each range is
+            // marked independently so lifetime holes show up as gaps.
             for vreg_idx in 0..num_vregs {
-                let is_alive = intervals[vreg_idx].has_bounds() &&
-                               intervals[vreg_idx].survives(insn_id.0);
-
-                let has_range = intervals[vreg_idx].has_bounds();
-                if has_range && intervals[vreg_idx].born_at(insn_id.0) {
-                    output.push_str("  v ");
-                } else if has_range && intervals[vreg_idx].dies_at(insn_id.0) {
-                    output.push_str("  ^ ");
-                } else if is_alive {
-                    output.push_str("  █ ");
+                let interval = &intervals[vreg_idx];
+                if interval.has_bounds() {
+                    if interval.born_at(insn_id.0) {
+                        output.push_str("  v ");
+                    } else if interval.dies_at(insn_id.0) {
+                        output.push_str("  ^ ");
+                    } else if interval.survives(insn_id.0) {
+                        output.push_str("  █ ");
+                    } else {
+                        output.push_str("  . ");
+                    }
                 } else {
                     output.push_str("  . ");
                 }

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -1393,7 +1393,7 @@ impl LiveRange {
     }
 }
 
-#[derive(Clone, PartialEq)]
+#[derive(PartialEq)]
 pub enum State {
     Unhandled,
     Active,
@@ -1402,7 +1402,6 @@ pub enum State {
 }
 
 /// Live Interval of a VReg
-#[derive(Clone)]
 pub struct Interval {
     pub ranges: Vec<LiveRange>,
     pub id: VRegId,

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -1375,7 +1375,6 @@ impl fmt::Debug for Insn {
 }
 
 /// Live range of a VReg
-/// TODO: Consider supporting lifetime holes
 #[derive(Clone, Debug, PartialEq)]
 pub struct LiveRange {
     /// Index of the first instruction that used the VReg
@@ -2160,7 +2159,8 @@ impl Assembler
                                         regs.push(*dest_reg);
                                         regs.len() - 1
                                     });
-                                intervals[*idx].preferred.get_or_insert(Allocation::Reg(regno));
+                                debug_assert!(intervals[*idx].preferred.is_none());
+                                intervals[*idx].preferred = Some(Allocation::Reg(regno));
                             }
                         }
                     }
@@ -2349,6 +2349,8 @@ impl Assembler
             assignment[it.id] = it.assigned;
         }
 
+        // TODO: Caller should just use the mutated intervals instead of
+        // using this assignment list
         (assignment, num_stack_slots)
     }
 

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -1409,7 +1409,7 @@ pub struct Interval {
     pub id: VRegId,
     pub state: State,
     pub assigned: Option<Allocation>,
-    pub preferred: Option<Reg>,
+    pub preferred: Option<Allocation>,
 }
 
 impl Interval {
@@ -1496,11 +1496,9 @@ pub enum Allocation {
 }
 
 impl Allocation {
-    fn assigned_reg(self) -> Option<Reg> {
-        use crate::backend::current::ALLOC_REGS;
-
+    fn assigned_reg(self, regs: &[Reg]) -> Option<Reg> {
         match self {
-            Allocation::Reg(n) => Some(ALLOC_REGS[n]),
+            Allocation::Reg(n) => Some(regs[n]),
             Allocation::Fixed(reg) => Some(reg),
             Allocation::Stack(_) => None,
         }
@@ -1508,7 +1506,7 @@ impl Allocation {
 
     fn alloc_pool_index(self, num_registers: usize) -> Option<usize> {
         match self {
-            Allocation::Reg(n) => Some(n),
+            Allocation::Reg(n) => (n < num_registers).then_some(n),
             Allocation::Fixed(reg) => {
                 use crate::backend::current::ALLOC_REGS;
 
@@ -2118,7 +2116,7 @@ impl Assembler
 
     /// Discover vregs that should preferentially reuse a physical register,
     /// such as a newborn vreg immediately moved into a preg in the next instruction.
-    pub fn preferred_register_assignments(&self, intervals: &mut [Interval]) {
+    pub fn preferred_register_assignments(&self, intervals: &mut [Interval], regs: &mut Vec<Reg>) {
         for block in &self.basic_blocks {
             let mut prev_insn: Option<(InsnId, &Insn)> = None;
 
@@ -2139,7 +2137,13 @@ impl Assembler
                                 && intervals[*idx].born_at(prev_id.0)
                                 && intervals[*idx].dies_at(insn_id.0)
                             {
-                                intervals[*idx].preferred.get_or_insert(*dest_reg);
+                                let regno = regs.iter()
+                                    .position(|candidate| candidate.reg_no == dest_reg.reg_no)
+                                    .unwrap_or_else(|| {
+                                        regs.push(*dest_reg);
+                                        regs.len() - 1
+                                    });
+                                intervals[*idx].preferred.get_or_insert(Allocation::Reg(regno));
                             }
                         }
                     }
@@ -2150,25 +2154,24 @@ impl Assembler
         }
     }
 
-    fn release_assignment(it: &Interval, num_registers: usize, free_registers: &mut BTreeSet<usize>) {
+    fn release_assignment(it: &Interval, num_registers: usize, regs: &[Reg], free_registers: &mut BTreeSet<usize>) {
         if let Some(allocation) = it.assigned {
             if let Some(reg) = allocation.alloc_pool_index(num_registers) {
                 let was_not_there_before = free_registers.insert(reg);
                 assert!(
                     was_not_there_before,
                     "attempted to return allocator register {:?} to the free pool more than once",
-                    allocation.assigned_reg().unwrap(),
+                    allocation.assigned_reg(regs).unwrap(),
                 );
             } else {
                 assert!(
-                    allocation.assigned_reg().is_none_or(|reg| {
-                        crate::backend::current::ALLOC_REGS
-                            .iter()
+                    allocation.assigned_reg(regs).is_none_or(|reg| {
+                        regs.iter()
                             .take(num_registers)
                             .all(|candidate| candidate.reg_no != reg.reg_no)
                     }),
                     "attempted to return non-allocatable register {:?} to the allocator pool",
-                    allocation.assigned_reg().unwrap(),
+                    allocation.assigned_reg(regs).unwrap(),
                 );
             }
         }
@@ -2185,13 +2188,13 @@ impl Assembler
         &self,
         intervals: Vec<Interval>,
         num_registers: usize,
+        regs: &[Reg],
     ) -> (Vec<Option<Allocation>>, usize) {
         let mut free_registers: BTreeSet<usize> = (0..num_registers).collect();
         let mut active: Vec<Interval> = Vec::new(); // sorted by increasing end point
         let mut inactive: Vec<Interval> = Vec::new(); // intervals with lifetime holes
         let mut num_stack_slots: usize = 0;
         let mut handled: Vec<Interval> = Vec::new();
-        let mut free_until_pos = vec![0usize; num_registers];
         let num_intervals = intervals.len();
 
         let mut sorted_intervals: Vec<Interval> = intervals.into_iter()
@@ -2207,31 +2210,33 @@ impl Assembler
                 if it.end() > interval.start() {
                     active.push(it);
                 } else {
-                    Self::release_assignment(&it, num_registers, &mut free_registers);
+                    Self::release_assignment(&it, num_registers, regs, &mut free_registers);
                     it.state = State::Handled;
                     handled.push(it);
                 }
             }
 
-            let preferred_reg = interval.preferred;
-            let preferred_taken = preferred_reg.is_some_and(|reg| {
-                active.iter().any(|active_interval| {
-                    active_interval.assigned
-                        .and_then(|alloc| alloc.assigned_reg())
-                        .is_some_and(|active_reg| active_reg.reg_no == reg.reg_no)
-                })
-            });
+            let preferred_alloc = interval.preferred;
+            let preferred_taken = preferred_alloc
+                .and_then(|alloc| alloc.assigned_reg(regs))
+                .is_some_and(|reg| {
+                    active.iter().any(|active_interval| {
+                        active_interval.assigned
+                            .and_then(|alloc| alloc.assigned_reg(regs))
+                            .is_some_and(|active_reg| active_reg.reg_no == reg.reg_no)
+                    })
+                });
 
-            if let Some(preferred_reg) = preferred_reg.filter(|_| !preferred_taken) {
-                if let Some(reg_idx) = Allocation::Fixed(preferred_reg).alloc_pool_index(num_registers) {
+            if let Some(preferred_alloc) = preferred_alloc.filter(|_| !preferred_taken) {
+                if let Some(reg_idx) = preferred_alloc.alloc_pool_index(num_registers) {
                     if free_registers.remove(&reg_idx) {
-                        interval.assigned = Some(Allocation::Fixed(preferred_reg));
+                        interval.assigned = Some(preferred_alloc);
                         let insert_idx = active.partition_point(|i| i.end() < interval.end());
                         active.insert(insert_idx, interval);
                         continue;
                     }
                 } else {
-                    interval.assigned = Some(Allocation::Fixed(preferred_reg));
+                    interval.assigned = Some(preferred_alloc);
                     let insert_idx = active.partition_point(|i| i.end() < interval.end());
                     active.insert(insert_idx, interval);
                     continue;
@@ -2290,7 +2295,7 @@ impl Assembler
     /// Resolve SSA block parameters by inserting sequentialized move instructions
     /// at block boundaries. This is SSA deconstruction: after linear_scan assigns
     /// registers/stack slots, we lower block parameter passing to explicit moves.
-    pub fn resolve_ssa(&mut self, _intervals: &[Interval], assignments: &[Option<Allocation>]) {
+    pub fn resolve_ssa(&mut self, _intervals: &[Interval], assignments: &[Option<Allocation>], regs: &[Reg]) {
         use crate::backend::parcopy;
         use crate::backend::current::SCRATCH_REG;
 
@@ -2327,8 +2332,8 @@ impl Assembler
                     .zip(params.iter())
                     .filter(|(_arg, param)| assignments[param.vreg_idx()].is_some() )
                     .map(|(arg, param)| parcopy::RegisterCopy::<Opnd> {
-                        destination: Self::rewritten_opnd(*param, assignments),
-                        source: Self::rewritten_opnd(*arg, assignments),
+                        destination: Self::rewritten_opnd(*param, assignments, regs),
+                        source: Self::rewritten_opnd(*arg, assignments, regs),
                     })
                     .filter(|copy| copy.source != copy.destination)
                     .collect();
@@ -2422,7 +2427,7 @@ impl Assembler
             let reg_copies: Vec<parcopy::RegisterCopy<Opnd>> = params.iter().enumerate()
                 .map(|(i, param)| parcopy::RegisterCopy::<Opnd> {
                     source: C_ARG_OPNDS[i],
-                    destination: Self::rewritten_opnd(*param, assignments),
+                    destination: Self::rewritten_opnd(*param, assignments, regs),
                 })
                 .filter(|copy| copy.source != copy.destination)
                 .collect();
@@ -2467,7 +2472,7 @@ impl Assembler
             }
         }
 
-        self.rewrite_instructions(assignments);
+        self.rewrite_instructions(assignments, regs);
     }
 
     /// Handle caller-saved registers around CCall instructions.
@@ -2477,7 +2482,8 @@ impl Assembler
         &mut self,
         intervals: &[Interval],
         assignments: &[Option<Allocation>],
-        regs: &[Reg],
+        alloc_regs: &[Reg],
+        c_arg_regs: &[Reg],
     ) {
         use crate::backend::parcopy;
         use crate::backend::current::{C_RET_OPND, SCRATCH_REG, ALLOC_REGS};
@@ -2528,11 +2534,7 @@ impl Assembler
                         .collect();
 
                     let survivor_regs: Vec<Opnd> = survivors.iter()
-                        .map(|&s| match assignments[s].unwrap() {
-                            Allocation::Reg(n) => Opnd::Reg(ALLOC_REGS[n]),
-                            Allocation::Fixed(reg) => Opnd::Reg(reg),
-                            _ => unreachable!(),
-                        })
+                        .map(|&s| Opnd::Reg(assignments[s].unwrap().assigned_reg(alloc_regs).unwrap()))
                         .collect();
 
                     // Push all survivors on the stack, pairing adjacent pushes when possible.
@@ -2590,15 +2592,15 @@ impl Assembler
 
                     // Extract arguments from CCall, clear opnds
 
-                    assert!(opnds.len() <= regs.len());
+                    assert!(opnds.len() <= c_arg_regs.len());
 
-                    // Sequentialize argument moves: each arg goes to regs[i]
+                    // Sequentialize argument moves: each arg goes to c_arg_regs[i]
                     let reg_copies: Vec<parcopy::RegisterCopy<Opnd>> = opnds
                         .iter()
-                        .zip(regs.iter())
+                        .zip(c_arg_regs.iter())
                         .map(|(arg, param)| parcopy::RegisterCopy::<Opnd> {
                             destination: Opnd::Reg(*param),
-                            source: Self::rewritten_opnd(*arg, assignments),
+                            source: Self::rewritten_opnd(*arg, assignments, alloc_regs),
                         })
                         .filter(|copy| copy.source != copy.destination)
                         .collect();
@@ -2646,7 +2648,7 @@ impl Assembler
                     if survivors.is_empty() {
                         if call_result_live {
                             // No survivors to restore -- move result directly to output.
-                            let out = Self::rewritten_opnd(out, assignments);
+                            let out = Self::rewritten_opnd(out, assignments, alloc_regs);
                             new_insns.push(Insn::Mov { dest: out, src: C_RET_OPND });
                             new_ids.push(None);
                         }
@@ -2670,7 +2672,7 @@ impl Assembler
 
                         if call_result_live {
                             // Move result from scratch to output AFTER all pops.
-                            let out = Self::rewritten_opnd(out, assignments);
+                            let out = Self::rewritten_opnd(out, assignments, alloc_regs);
                             new_insns.push(Insn::Mov { dest: out, src: Opnd::Reg(SCRATCH_REG) });
                             new_ids.push(None);
                         }
@@ -2723,28 +2725,25 @@ impl Assembler
 
     /// Walk every instruction and replace VReg operands with the physical
     /// register (or stack slot) from the allocation assignments.
-    fn rewrite_instructions(&mut self, assignments: &[Option<Allocation>]) {
+    fn rewrite_instructions(&mut self, assignments: &[Option<Allocation>], regs: &[Reg]) {
         for block_id in self.block_order() {
             for insn in self.basic_blocks[block_id.0].insns.iter_mut() {
                 insn.for_each_operand_mut(|opnd| {
-                    Self::rewrite_opnd(opnd, assignments);
+                    Self::rewrite_opnd(opnd, assignments, regs);
                 });
                 if let Some(out) = insn.out_opnd_mut() {
-                    Self::rewrite_opnd(out, assignments);
+                    Self::rewrite_opnd(out, assignments, regs);
                 }
             }
         }
     }
 
-    fn rewritten_opnd(mut opnd: Opnd, assignments: &[Option<Allocation>]) -> Opnd {
-        Self::rewrite_opnd(&mut opnd, assignments);
+    fn rewritten_opnd(mut opnd: Opnd, assignments: &[Option<Allocation>], regs: &[Reg]) -> Opnd {
+        Self::rewrite_opnd(&mut opnd, assignments, regs);
         opnd
     }
 
-    fn rewrite_opnd(opnd: &mut Opnd, assignments: &[Option<Allocation>]) {
-        use crate::backend::current::ALLOC_REGS;
-        let regs = &ALLOC_REGS;
-
+    fn rewrite_opnd(opnd: &mut Opnd, assignments: &[Option<Allocation>], regs: &[Reg]) {
         match opnd {
             Opnd::VReg { idx, num_bits } => {
                 if let Some(assignment) = assignments[*idx] {
@@ -4706,8 +4705,10 @@ mod tests {
 
         println!("LIR live_intervals:\n{}", crate::backend::lir::debug_intervals(&asm, &intervals));
 
-        asm.preferred_register_assignments(&mut intervals);
-        let (assignments, num_stack_slots) = asm.linear_scan(intervals, 5);
+        let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
+        let allocatable_regs = regs.len();
+        asm.preferred_register_assignments(&mut intervals, &mut regs);
+        let (assignments, num_stack_slots) = asm.linear_scan(intervals, 5.min(allocatable_regs), &regs);
 
         // Extract vreg indices
         let r10_idx = if let Opnd::VReg { idx, .. } = r10 { idx } else { panic!() };
@@ -4744,8 +4745,10 @@ mod tests {
         let mut intervals = asm.build_intervals(live_in);
 
         // 3 registers -- only r10 needs to spill
-        asm.preferred_register_assignments(&mut intervals);
-        let (assignments, num_stack_slots) = asm.linear_scan(intervals, 3);
+        let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
+        let allocatable_regs = regs.len();
+        asm.preferred_register_assignments(&mut intervals, &mut regs);
+        let (assignments, num_stack_slots) = asm.linear_scan(intervals, 3.min(allocatable_regs), &regs);
 
         let r10_idx = if let Opnd::VReg { idx, .. } = r10 { idx } else { panic!() };
         let r11_idx = if let Opnd::VReg { idx, .. } = r11 { idx } else { panic!() };
@@ -4772,8 +4775,10 @@ mod tests {
         let mut intervals = asm.build_intervals(live_in);
 
         // Only 1 register available -- forces spills
-        asm.preferred_register_assignments(&mut intervals);
-        let (assignments, num_stack_slots) = asm.linear_scan(intervals, 1);
+        let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
+        let allocatable_regs = regs.len();
+        asm.preferred_register_assignments(&mut intervals, &mut regs);
+        let (assignments, num_stack_slots) = asm.linear_scan(intervals, 1.min(allocatable_regs), &regs);
 
         let r10_idx = if let Opnd::VReg { idx, .. } = r10 { idx } else { panic!() };
         let r11_idx = if let Opnd::VReg { idx, .. } = r11 { idx } else { panic!() };
@@ -4807,14 +4812,22 @@ mod tests {
         asm.number_instructions(0);
         let live_in = asm.analyze_liveness();
         let mut intervals = asm.build_intervals(live_in);
-        asm.preferred_register_assignments(&mut intervals);
+        let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
+        asm.preferred_register_assignments(&mut intervals, &mut regs);
 
         let vreg_idx = new_sp.vreg_idx();
-        assert_eq!(intervals[vreg_idx].preferred, Some(sp.unwrap_reg()));
+        let Some(Allocation::Reg(regno)) = intervals[vreg_idx].preferred else {
+            panic!("expected a preferred register for v{vreg_idx}");
+        };
+        assert_eq!(regs[regno], sp.unwrap_reg());
 
-        let (assignments, num_stack_slots) = asm.linear_scan(intervals, 0);
+        // Zero allocatable registers: the only register this interval can get
+        // is the pinned one appended to the pool, so the preference is what
+        // makes this succeed rather than spill.
+        let (assignments, num_stack_slots) = asm.linear_scan(intervals, 0, &regs);
         assert_eq!(num_stack_slots, 0);
-        assert_eq!(assignments[vreg_idx], Some(Allocation::Fixed(sp.unwrap_reg())));
+        assert_eq!(assignments[vreg_idx], Some(Allocation::Reg(regno)));
+        assert_eq!(assignments[vreg_idx].unwrap().assigned_reg(&regs), Some(sp.unwrap_reg()));
     }
 
     #[test]
@@ -4843,10 +4856,12 @@ mod tests {
         let live_in = asm.analyze_liveness();
         asm.number_instructions(16);
         let mut intervals = asm.build_intervals(live_in);
-        asm.preferred_register_assignments(&mut intervals);
-        let (assignments, _) = asm.linear_scan(intervals.clone(), 5);
+        let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
+        let allocatable_regs = regs.len();
+        asm.preferred_register_assignments(&mut intervals, &mut regs);
+        let (assignments, _) = asm.linear_scan(intervals.clone(), 5.min(allocatable_regs), &regs);
 
-        asm.resolve_ssa(&intervals, &assignments);
+        asm.resolve_ssa(&intervals, &assignments, &regs);
 
         use crate::backend::current::ALLOC_REGS;
         let regs = &ALLOC_REGS[..5];
@@ -4889,8 +4904,10 @@ mod tests {
         let live_in = asm.analyze_liveness();
         asm.number_instructions(16);
         let mut intervals = asm.build_intervals(live_in);
-        asm.preferred_register_assignments(&mut intervals);
-        let (assignments, _) = asm.linear_scan(intervals.clone(), 5);
+        let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
+        let allocatable_regs = regs.len();
+        asm.preferred_register_assignments(&mut intervals, &mut regs);
+        let (assignments, _) = asm.linear_scan(intervals.clone(), 5.min(allocatable_regs), &regs);
 
         // Entry block b1 has parameters [v0, v1].
         // With 5 registers: v0 -> Reg(0) = regs[0], arrival = C_ARG_OPNDS[0] = regs[0] -> self-move, filtered
@@ -4898,7 +4915,7 @@ mod tests {
         // Before resolve_ssa, b1 has: [Label, Jmp] = 2 insns
         assert_eq!(asm.basic_blocks[b1.0].insns.len(), 2);
 
-        asm.resolve_ssa(&intervals, &assignments);
+        asm.resolve_ssa(&intervals, &assignments, &regs);
 
         // After resolve_ssa, b1 should still have the same number of insns
         // (plus any edge moves, but no entry param moves since they're all self-moves).
@@ -4936,10 +4953,12 @@ mod tests {
         let live_in = asm.analyze_liveness();
         asm.number_instructions(0);
         let mut intervals = asm.build_intervals(live_in);
-        asm.preferred_register_assignments(&mut intervals);
-        let (assignments, _) = asm.linear_scan(intervals.clone(), 5);
+        let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
+        let allocatable_regs = regs.len();
+        asm.preferred_register_assignments(&mut intervals, &mut regs);
+        let (assignments, _) = asm.linear_scan(intervals.clone(), 5.min(allocatable_regs), &regs);
 
-        asm.resolve_ssa(&intervals, &assignments);
+        asm.resolve_ssa(&intervals, &assignments, &regs);
 
         assert!(matches!(asm.basic_blocks[block.0].insns[1], Insn::Abort));
     }
@@ -4995,8 +5014,10 @@ mod tests {
         asm.number_instructions(16);
         let mut intervals = asm.build_intervals(live_in);
         let num_regs = 5;
-        asm.preferred_register_assignments(&mut intervals);
-        let (assignments, _) = asm.linear_scan(intervals.clone(), num_regs);
+        let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
+        let allocatable_regs = regs.len();
+        asm.preferred_register_assignments(&mut intervals, &mut regs);
+        let (assignments, _) = asm.linear_scan(intervals.clone(), num_regs.min(allocatable_regs), &regs);
 
         assert_eq!(asm.basic_blocks.len(), 3);
 
@@ -5005,7 +5026,7 @@ mod tests {
         let v4_alloc = assignments[v4.vreg_idx()].unwrap();
         assert_ne!(v1_alloc, v4_alloc, "Test setup: v1 and v4 should have different allocations");
 
-        asm.resolve_ssa(&intervals, &assignments);
+        asm.resolve_ssa(&intervals, &assignments, &regs);
 
         // A new interstitial block should have been created for the critical edge b1->b3
         // b1->b3 is critical because b1 has 2 successors and b3 has 2 predecessors
@@ -5099,11 +5120,16 @@ mod tests {
         asm.number_instructions(0);
         let mut intervals = asm.build_intervals(live_in);
         let num_regs = 2;
-        asm.preferred_register_assignments(&mut intervals);
-        let (assignments, num_stack_slots) = asm.linear_scan(intervals.clone(), num_regs);
+        let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
+        let allocatable_regs = regs.len();
+        asm.preferred_register_assignments(&mut intervals, &mut regs);
+        let (assignments, num_stack_slots) = asm.linear_scan(intervals.clone(), num_regs.min(allocatable_regs), &regs);
         asm.stack_state.num_spill_slots = num_stack_slots;
 
-        let regs = &ALLOC_REGS[..num_regs];
+        // Stand in for the C calling convention's argument registers. These
+        // deliberately overlap the allocatable pool so that arguments clobber
+        // registers the allocator handed out.
+        let c_arg_regs = &ALLOC_REGS[..num_regs];
 
         // v0 should be spilled (long-lived, only 2 regs)
         assert!(matches!(assignments[v0.vreg_idx()], Some(Allocation::Stack(_))),
@@ -5113,8 +5139,8 @@ mod tests {
             "v1 should be in a register");
 
         // Run the pipeline: handle_caller_saved_regs then resolve_ssa
-        asm.handle_caller_saved_regs(&intervals, &assignments, regs);
-        asm.resolve_ssa(&intervals, &assignments);
+        asm.handle_caller_saved_regs(&intervals, &assignments, &regs, c_arg_regs);
+        asm.resolve_ssa(&intervals, &assignments, &regs);
 
         let insns = &asm.basic_blocks[b1.0].insns;
 

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -1391,6 +1391,7 @@ pub struct Interval {
     pub id: VRegId,
     pub state: State,
     pub assigned: Option<Allocation>,
+    pub preferred: Option<Reg>,
 }
 
 impl Interval {
@@ -1401,6 +1402,7 @@ impl Interval {
             id: i,
             state: State::Unhandled,
             assigned: None,
+            preferred: None,
         }
     }
 
@@ -2102,9 +2104,7 @@ impl Assembler
 
     /// Discover vregs that should preferentially reuse a physical register,
     /// such as a newborn vreg immediately moved into a preg in the next instruction.
-    pub fn preferred_register_assignments(&self, intervals: &[Interval]) -> Vec<Option<Reg>> {
-        let mut preferred = vec![None; self.num_vregs];
-
+    pub fn preferred_register_assignments(&self, intervals: &mut [Interval]) {
         for block in &self.basic_blocks {
             let mut prev_insn: Option<(InsnId, &Insn)> = None;
 
@@ -2125,7 +2125,7 @@ impl Assembler
                                 && intervals[*idx].born_at(prev_id.0)
                                 && intervals[*idx].dies_at(insn_id.0)
                             {
-                                preferred[*idx].get_or_insert(*dest_reg);
+                                intervals[*idx].preferred.get_or_insert(*dest_reg);
                             }
                         }
                     }
@@ -2134,8 +2134,6 @@ impl Assembler
                 }
             }
         }
-
-        preferred
     }
 
     fn release_assignment(it: &Interval, num_registers: usize, free_registers: &mut BTreeSet<usize>) {
@@ -2173,10 +2171,7 @@ impl Assembler
         &self,
         intervals: Vec<Interval>,
         num_registers: usize,
-        preferred_registers: &[Option<Reg>],
     ) -> (Vec<Option<Allocation>>, usize) {
-        assert_eq!(preferred_registers.len(), intervals.len());
-
         let mut free_registers: BTreeSet<usize> = (0..num_registers).collect();
         let mut active: Vec<Interval> = Vec::new(); // sorted by increasing end point
         let mut inactive: Vec<Interval> = Vec::new(); // intervals with lifetime holes
@@ -2204,7 +2199,7 @@ impl Assembler
                 }
             }
 
-            let preferred_reg = preferred_registers[interval.id];
+            let preferred_reg = interval.preferred;
             let preferred_taken = preferred_reg.is_some_and(|reg| {
                 active.iter().any(|active_interval| {
                     active_interval.assigned
@@ -4689,12 +4684,12 @@ mod tests {
         asm.number_instructions(16);
 
         // Build intervals
-        let intervals = asm.build_intervals(live_in);
+        let mut intervals = asm.build_intervals(live_in);
 
         println!("LIR live_intervals:\n{}", crate::backend::lir::debug_intervals(&asm, &intervals));
 
-        let preferred_registers = asm.preferred_register_assignments(&intervals);
-        let (assignments, num_stack_slots) = asm.linear_scan(intervals, 5, &preferred_registers);
+        asm.preferred_register_assignments(&mut intervals);
+        let (assignments, num_stack_slots) = asm.linear_scan(intervals, 5);
 
         // Extract vreg indices
         let r10_idx = if let Opnd::VReg { idx, .. } = r10 { idx } else { panic!() };
@@ -4728,11 +4723,11 @@ mod tests {
 
         let live_in = asm.analyze_liveness();
         asm.number_instructions(16);
-        let intervals = asm.build_intervals(live_in);
+        let mut intervals = asm.build_intervals(live_in);
 
         // 3 registers -- only r10 needs to spill
-        let preferred_registers = asm.preferred_register_assignments(&intervals);
-        let (assignments, num_stack_slots) = asm.linear_scan(intervals, 3, &preferred_registers);
+        asm.preferred_register_assignments(&mut intervals);
+        let (assignments, num_stack_slots) = asm.linear_scan(intervals, 3);
 
         let r10_idx = if let Opnd::VReg { idx, .. } = r10 { idx } else { panic!() };
         let r11_idx = if let Opnd::VReg { idx, .. } = r11 { idx } else { panic!() };
@@ -4756,11 +4751,11 @@ mod tests {
 
         let live_in = asm.analyze_liveness();
         asm.number_instructions(16);
-        let intervals = asm.build_intervals(live_in);
+        let mut intervals = asm.build_intervals(live_in);
 
         // Only 1 register available -- forces spills
-        let preferred_registers = asm.preferred_register_assignments(&intervals);
-        let (assignments, num_stack_slots) = asm.linear_scan(intervals, 1, &preferred_registers);
+        asm.preferred_register_assignments(&mut intervals);
+        let (assignments, num_stack_slots) = asm.linear_scan(intervals, 1);
 
         let r10_idx = if let Opnd::VReg { idx, .. } = r10 { idx } else { panic!() };
         let r11_idx = if let Opnd::VReg { idx, .. } = r11 { idx } else { panic!() };
@@ -4793,13 +4788,13 @@ mod tests {
 
         asm.number_instructions(0);
         let live_in = asm.analyze_liveness();
-        let intervals = asm.build_intervals(live_in);
-        let preferred_registers = asm.preferred_register_assignments(&intervals);
+        let mut intervals = asm.build_intervals(live_in);
+        asm.preferred_register_assignments(&mut intervals);
 
         let vreg_idx = new_sp.vreg_idx();
-        assert_eq!(preferred_registers[vreg_idx], Some(sp.unwrap_reg()));
+        assert_eq!(intervals[vreg_idx].preferred, Some(sp.unwrap_reg()));
 
-        let (assignments, num_stack_slots) = asm.linear_scan(intervals, 0, &preferred_registers);
+        let (assignments, num_stack_slots) = asm.linear_scan(intervals, 0);
         assert_eq!(num_stack_slots, 0);
         assert_eq!(assignments[vreg_idx], Some(Allocation::Fixed(sp.unwrap_reg())));
     }
@@ -4829,9 +4824,9 @@ mod tests {
 
         let live_in = asm.analyze_liveness();
         asm.number_instructions(16);
-        let intervals = asm.build_intervals(live_in);
-        let preferred_registers = asm.preferred_register_assignments(&intervals);
-        let (assignments, _) = asm.linear_scan(intervals.clone(), 5, &preferred_registers);
+        let mut intervals = asm.build_intervals(live_in);
+        asm.preferred_register_assignments(&mut intervals);
+        let (assignments, _) = asm.linear_scan(intervals.clone(), 5);
 
         asm.resolve_ssa(&intervals, &assignments);
 
@@ -4875,9 +4870,9 @@ mod tests {
 
         let live_in = asm.analyze_liveness();
         asm.number_instructions(16);
-        let intervals = asm.build_intervals(live_in);
-        let preferred_registers = asm.preferred_register_assignments(&intervals);
-        let (assignments, _) = asm.linear_scan(intervals.clone(), 5, &preferred_registers);
+        let mut intervals = asm.build_intervals(live_in);
+        asm.preferred_register_assignments(&mut intervals);
+        let (assignments, _) = asm.linear_scan(intervals.clone(), 5);
 
         // Entry block b1 has parameters [v0, v1].
         // With 5 registers: v0 -> Reg(0) = regs[0], arrival = C_ARG_OPNDS[0] = regs[0] -> self-move, filtered
@@ -4922,9 +4917,9 @@ mod tests {
 
         let live_in = asm.analyze_liveness();
         asm.number_instructions(0);
-        let intervals = asm.build_intervals(live_in);
-        let preferred_registers = asm.preferred_register_assignments(&intervals);
-        let (assignments, _) = asm.linear_scan(intervals.clone(), 5, &preferred_registers);
+        let mut intervals = asm.build_intervals(live_in);
+        asm.preferred_register_assignments(&mut intervals);
+        let (assignments, _) = asm.linear_scan(intervals.clone(), 5);
 
         asm.resolve_ssa(&intervals, &assignments);
 
@@ -4980,10 +4975,10 @@ mod tests {
 
         let live_in = asm.analyze_liveness();
         asm.number_instructions(16);
-        let intervals = asm.build_intervals(live_in);
+        let mut intervals = asm.build_intervals(live_in);
         let num_regs = 5;
-        let preferred_registers = asm.preferred_register_assignments(&intervals);
-        let (assignments, _) = asm.linear_scan(intervals.clone(), num_regs, &preferred_registers);
+        asm.preferred_register_assignments(&mut intervals);
+        let (assignments, _) = asm.linear_scan(intervals.clone(), num_regs);
 
         assert_eq!(asm.basic_blocks.len(), 3);
 
@@ -5084,10 +5079,10 @@ mod tests {
         // Run liveness + numbering + intervals + linear scan with 2 registers
         let live_in = asm.analyze_liveness();
         asm.number_instructions(0);
-        let intervals = asm.build_intervals(live_in);
+        let mut intervals = asm.build_intervals(live_in);
         let num_regs = 2;
-        let preferred_registers = asm.preferred_register_assignments(&intervals);
-        let (assignments, num_stack_slots) = asm.linear_scan(intervals.clone(), num_regs, &preferred_registers);
+        asm.preferred_register_assignments(&mut intervals);
+        let (assignments, num_stack_slots) = asm.linear_scan(intervals.clone(), num_regs);
         asm.stack_state.num_spill_slots = num_stack_slots;
 
         let regs = &ALLOC_REGS[..num_regs];

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -2208,14 +2208,9 @@ impl Assembler
 
             let preferred_alloc = interval.preferred;
             let preferred_taken = preferred_alloc
-                .and_then(|alloc| alloc.assigned_reg(regs))
-                .is_some_and(|reg| {
-                    active.iter().any(|active_interval| {
-                        active_interval.assigned
-                            .and_then(|alloc| alloc.assigned_reg(regs))
-                            .is_some_and(|active_reg| active_reg.reg_no == reg.reg_no)
-                    })
-                });
+                .is_some_and(|alloc|
+                    active.iter().any(|active_interval| active_interval.assigned == Some(alloc))
+                );
 
             if let Some(preferred_alloc) = preferred_alloc.filter(|_| !preferred_taken) {
                 if let Some(reg_idx) = preferred_alloc.alloc_pool_index(num_registers) {
@@ -2235,14 +2230,15 @@ impl Assembler
 
             if free_registers.is_empty() {
                 // Spill: pick the longest-lived active interval (last in sorted active)
-                // but only from the allocatable register pool. Fixed register
-                // assignments represent preferred/pinned physical registers
-                // (for example SP) and should not be selected as spill victims.
+                // but only from the allocatable partition of the pool. An index
+                // at or past `num_registers` is a pinned physical register (for
+                // example SP), which is not ours to hand to someone else.
                 // Take the id and end point rather than a reference, so that `active`
                 // can be mutated below.
                 let spill = active.iter().rev()
                     .find(|active_interval| {
-                        matches!(active_interval.assigned, Some(Allocation::Reg(_)))
+                        active_interval.assigned
+                            .is_some_and(|alloc| alloc.alloc_pool_index(num_registers).is_some())
                     })
                     .map(|active_interval| (active_interval.id, active_interval.end()));
                 let slot = Allocation::Stack(num_stack_slots);
@@ -5132,11 +5128,7 @@ mod tests {
         assert!(!pushes.is_empty(), "Expected at least one saved register across CCall");
 
         // The survivor register should match v1's allocation
-        let v1_reg = match assignments[v1.vreg_idx()].unwrap() {
-            Allocation::Reg(n) => Opnd::Reg(regs[n]),
-            Allocation::Fixed(reg) => Opnd::Reg(reg),
-            _ => unreachable!(),
-        };
+        let v1_reg = Opnd::Reg(assignments[v1.vreg_idx()].unwrap().assigned_reg(&regs).unwrap());
         let pushed_v1 = pushes.iter().any(|insn| matches!(**insn, Insn::CPushPair(first, second) if first == v1_reg || second == v1_reg));
         let popped_v1 = pops.iter().any(|insn| matches!(**insn, Insn::CPopPairInto(first, second) if first == v1_reg || second == v1_reg));
         assert!(pushed_v1, "CPushPair should save v1's register");

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -1,5 +1,5 @@
 use std::cell::RefCell;
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
 use std::fmt;
 use std::mem::take;
 use std::rc::Rc;
@@ -1394,11 +1394,20 @@ impl LiveRange {
     }
 }
 
+#[derive(Clone)]
+pub enum State {
+    Unhandled,
+    Active,
+    Inactive,
+    Handled,
+}
+
 /// Live Interval of a VReg
 #[derive(Clone)]
 pub struct Interval {
     pub ranges: Vec<LiveRange>,
     pub id: VRegId,
+    pub state: State,
 }
 
 impl Interval {
@@ -1407,6 +1416,7 @@ impl Interval {
         Self {
             ranges: vec![],
             id: i,
+            state: State::Unhandled,
         }
     }
 
@@ -1422,25 +1432,15 @@ impl Interval {
     /// Panics if the range is not set
     pub fn survives(&self, position: usize) -> bool {
         assert!(self.ranges.len() > 0, "survives called on interval with no range");
-        for range in self.ranges.iter() {
-            if position < range.from {
-                return false;
-            }
-            if position < range.to {
-                return true;
-            }
-        }
-        return false;
+        self.ranges.iter().any(|range| range.from < position && position < range.to)
     }
 
-    pub fn born_at(&self, x:usize) -> bool {
-        let start = self.ranges[0].from;
-        start == x
+    pub fn born_at(&self, x: usize) -> bool {
+        self.start() == x
     }
 
-    pub fn dies_at(&self, x:usize) -> bool {
-        let end = self.ranges[0].to;
-        end == x
+    pub fn dies_at(&self, x: usize) -> bool {
+        self.end() == x
     }
 
     pub fn has_bounds(&self) -> bool {
@@ -1470,9 +1470,17 @@ impl Interval {
     /// Narrow the range covering `from` so that it begins at the def.
     pub fn set_from(&mut self, from: usize) {
         match self.ranges.last_mut() {
+            // If there was no existing range, it means that we have a
+            // def with no use.  Instructions are evenly numbered, so we add
+            // 1 to indicate this is a dead interval
             None => self.ranges.push(LiveRange { from, to: from + 1 }),
             Some(range) => range.from = from
         }
+    }
+
+    /// Returns true if this interval represents a def with no use.
+    pub fn is_dead(&self) -> bool {
+        self.end() <= self.start() + 1
     }
 }
 
@@ -2158,7 +2166,7 @@ impl Assembler
         assert_eq!(preferred_registers.len(), intervals.len());
 
         let mut free_registers: BTreeSet<usize> = (0..num_registers).collect();
-        let mut active: Vec<&Interval> = Vec::new(); // vreg indices sorted by increasing end point
+        let mut active: Vec<Interval> = Vec::new(); // sorted by increasing end point
         let mut assignment: Vec<Option<Allocation>> = vec![None; intervals.len()];
         let mut num_stack_slots: usize = 0;
 
@@ -2169,9 +2177,11 @@ impl Assembler
             .collect();
         sorted_intervals.sort_by_key(|i| i.start());
 
-        for interval in &sorted_intervals {
+        let mut unhandled: VecDeque<Interval> = sorted_intervals.into();
+
+        while let Some(interval) = unhandled.pop_front() {
             // Expire old intervals
-            active.retain(|&active_interval| {
+            active.retain(|active_interval| {
                 if active_interval.end() > interval.start() {
                     true
                 } else {
@@ -2213,14 +2223,14 @@ impl Assembler
                 if let Some(reg_idx) = Allocation::Fixed(preferred_reg).alloc_pool_index(num_registers) {
                     if free_registers.remove(&reg_idx) {
                         assignment[interval.id] = Some(Allocation::Fixed(preferred_reg));
-                        let insert_idx = active.partition_point(|&i| i.end() < interval.end());
-                        active.insert(insert_idx, &interval);
+                        let insert_idx = active.partition_point(|i| i.end() < interval.end());
+                        active.insert(insert_idx, interval);
                         continue;
                     }
                 } else {
                     assignment[interval.id] = Some(Allocation::Fixed(preferred_reg));
-                    let insert_idx = active.partition_point(|&i| i.end() < interval.end());
-                    active.insert(insert_idx, &interval);
+                    let insert_idx = active.partition_point(|i| i.end() < interval.end());
+                    active.insert(insert_idx, interval);
                     continue;
                 }
             }
@@ -2230,21 +2240,25 @@ impl Assembler
                 // but only from the allocatable register pool. Fixed register
                 // assignments represent preferred/pinned physical registers
                 // (for example SP) and should not be selected as spill victims.
-                let spill = active.iter().rev().copied().find(|active_interval| {
-                    matches!(assignment[active_interval.id], Some(Allocation::Reg(_)))
-                });
+                // Take the id and end point rather than a reference, so that `active`
+                // can be mutated below.
+                let spill = active.iter().rev()
+                    .find(|active_interval| {
+                        matches!(assignment[active_interval.id], Some(Allocation::Reg(_)))
+                    })
+                    .map(|active_interval| (active_interval.id, active_interval.end()));
                 let slot = Allocation::Stack(num_stack_slots);
                 num_stack_slots += 1;
 
-                if let Some(spill) = spill.filter(|spill| spill.end() > interval.end()) {
+                if let Some((spill_id, _)) = spill.filter(|&(_, spill_end)| spill_end > interval.end()) {
                     // Spill the last active interval; give its register to current
-                    assignment[interval.id] = assignment[spill.id];
-                    assignment[spill.id] = Some(slot);
-                    let spill_idx = active.iter().position(|active_interval| active_interval.id == spill.id).unwrap();
+                    assignment[interval.id] = assignment[spill_id];
+                    assignment[spill_id] = Some(slot);
+                    let spill_idx = active.iter().position(|active_interval| active_interval.id == spill_id).unwrap();
                     active.remove(spill_idx);
                     // Insert current into sorted active
-                    let insert_idx = active.partition_point(|&i| i.end() < interval.end());
-                    active.insert(insert_idx, &interval);
+                    let insert_idx = active.partition_point(|i| i.end() < interval.end());
+                    active.insert(insert_idx, interval);
                 } else {
                     // Spill the current interval
                     assignment[interval.id] = Some(slot);
@@ -2255,8 +2269,8 @@ impl Assembler
                 free_registers.remove(&reg);
                 assignment[interval.id] = Some(Allocation::Reg(reg));
                 // Insert into sorted active
-                let insert_idx = active.partition_point(|&i| i.end() < interval.end());
-                active.insert(insert_idx, &interval);
+                let insert_idx = active.partition_point(|i| i.end() < interval.end());
+                active.insert(insert_idx, interval);
             }
         }
 
@@ -2474,7 +2488,7 @@ impl Assembler
                     // uses the result?
                     let call_result_live = out.is_vreg()
                         && intervals[out.vreg_idx()].has_bounds()
-                        && intervals[out.vreg_idx()].end() > insn_number;
+                        && !intervals[out.vreg_idx()].is_dead();
 
                     // Build a set of VRegIds that can be referenced by JITFrame for materializing the VM stack
                     let stack_vreg_ids: HashSet<VRegId> = if let Some(StackMap { stack, .. }) = &stack_map {
@@ -4502,18 +4516,62 @@ mod tests {
 
         // Add range to empty interval
         interval.add_range(5, 10);
-        assert_eq!(interval.range.start, Some(5));
-        assert_eq!(interval.range.end, Some(10));
+        assert_eq!(interval.ranges, vec![LiveRange { from: 5, to: 10 }]);
 
         // Extend range backward
         interval.add_range(3, 7);
-        assert_eq!(interval.range.start, Some(3));
-        assert_eq!(interval.range.end, Some(10));
+        assert_eq!(interval.ranges, vec![LiveRange { from: 3, to: 10 }]);
 
         // Extend range forward
         interval.add_range(8, 15);
-        assert_eq!(interval.range.start, Some(3));
-        assert_eq!(interval.range.end, Some(15));
+        assert_eq!(interval.ranges, vec![LiveRange { from: 3, to: 15 }]);
+    }
+
+    #[test]
+    fn test_interval_add_range_hole() {
+        let mut interval = Interval::new(VRegId(1));
+
+        // A range that does not reach the previous one stays separate: the gap
+        // between them is a lifetime hole.
+        interval.add_range(5, 10);
+        interval.add_range(20, 25);
+        assert_eq!(interval.ranges, vec![
+            LiveRange { from: 5, to: 10 },
+            LiveRange { from: 20, to: 25 },
+        ]);
+        // start()/end() still span the whole thing, hole included.
+        assert_eq!(interval.start(), 5);
+        assert_eq!(interval.end(), 25);
+
+        // The vreg is not live inside the hole ...
+        assert!(!interval.survives(10));
+        assert!(!interval.survives(15));
+        // ... but the interval is not over, so it must keep its register.
+        assert!(interval.end() > 15);
+        // ... and it is live again on the far side.
+        assert!(interval.survives(22));
+
+        // A range that abuts the last one merges into it.
+        interval.add_range(25, 30);
+        assert_eq!(interval.ranges, vec![
+            LiveRange { from: 5, to: 10 },
+            LiveRange { from: 20, to: 30 },
+        ]);
+    }
+
+    #[test]
+    fn test_interval_dies_at_last_range() {
+        let mut interval = Interval::new(VRegId(1));
+        interval.add_range(5, 10);
+        interval.add_range(20, 25);
+
+        // The end of the first range is only the start of a lifetime hole, not
+        // the death of the interval. Reporting otherwise lets
+        // preferred_register_assignments hand the register to something else
+        // while the vreg is still live after the hole.
+        assert!(interval.born_at(5));
+        assert!(!interval.dies_at(10));
+        assert!(interval.dies_at(25));
     }
 
     #[test]
@@ -4532,16 +4590,36 @@ mod tests {
     fn test_interval_set_from() {
         let mut interval = Interval::new(VRegId(1));
 
-        // With no range, sets both start and end
+        // With no range, records Wimmer's vacuous interval: the def occupies a
+        // register but nothing reads the value. Instructions are numbered by two,
+        // so position 11 belongs to no instruction.
         interval.set_from(10);
-        assert_eq!(interval.range.start, Some(10));
-        assert_eq!(interval.range.end, Some(10));
+        assert_eq!(interval.ranges, vec![LiveRange { from: 10, to: 11 }]);
+        assert!(!interval.survives(10));
+        assert!(interval.is_dead());
 
         // With existing range, updates start but keeps end
         interval.add_range(5, 20);
         interval.set_from(3);
-        assert_eq!(interval.range.start, Some(3));
-        assert_eq!(interval.range.end, Some(20));
+        assert_eq!(interval.ranges, vec![LiveRange { from: 3, to: 20 }]);
+        assert!(!interval.is_dead());
+    }
+
+    #[test]
+    fn test_interval_is_dead() {
+        // A def whose value is read by the next instruction is not dead.
+        let mut used = Interval::new(VRegId(1));
+        used.add_range(10, 12);
+        used.set_from(10);
+        assert!(!used.is_dead());
+
+        // A def with a lifetime hole is not dead either, even though its first
+        // range is only one position long.
+        let mut holed = Interval::new(VRegId(2));
+        holed.add_range(10, 11);
+        holed.add_range(20, 22);
+        holed.set_from(10);
+        assert!(!holed.is_dead());
     }
 
     #[test]
@@ -4581,23 +4659,26 @@ mod tests {
 
         // Assert expected ranges
         // Note: Rust CFG differs from Ruby due to conditional branches requiring two instructions (Jl + Jmp)
-        assert_eq!(intervals[r10_idx].range.start, Some(16));
-        assert_eq!(intervals[r10_idx].range.end, Some(38));
+        assert_eq!(intervals[r10_idx].ranges, vec![LiveRange { from: 16, to: 38 }]);
 
-        assert_eq!(intervals[r11_idx].range.start, Some(16));
-        assert_eq!(intervals[r11_idx].range.end, Some(20));
+        assert_eq!(intervals[r11_idx].ranges, vec![LiveRange { from: 16, to: 20 }]);
 
-        assert_eq!(intervals[r12_idx].range.start, Some(20));
-        assert_eq!(intervals[r12_idx].range.end, Some(38));
+        // r12 is live out of the first block and used again at the join, but is
+        // dead across the middle of the diamond, so 30..36 is a lifetime hole.
+        // start()/end() alone cannot see this: they still report 20..38.
+        assert_eq!(intervals[r12_idx].ranges, vec![
+            LiveRange { from: 20, to: 30 },
+            LiveRange { from: 36, to: 38 },
+        ]);
+        assert_eq!(intervals[r12_idx].start(), 20);
+        assert_eq!(intervals[r12_idx].end(), 38);
+        assert!(!intervals[r12_idx].survives(32));
 
-        assert_eq!(intervals[r13_idx].range.start, Some(20));
-        assert_eq!(intervals[r13_idx].range.end, Some(32));
+        assert_eq!(intervals[r13_idx].ranges, vec![LiveRange { from: 20, to: 32 }]);
 
-        assert_eq!(intervals[r14_idx].range.start, Some(30));
-        assert_eq!(intervals[r14_idx].range.end, Some(36));
+        assert_eq!(intervals[r14_idx].ranges, vec![LiveRange { from: 30, to: 36 }]);
 
-        assert_eq!(intervals[r15_idx].range.start, Some(32));
-        assert_eq!(intervals[r15_idx].range.end, Some(36));
+        assert_eq!(intervals[r15_idx].ranges, vec![LiveRange { from: 32, to: 36 }]);
     }
 
     #[test]

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -1383,20 +1383,21 @@ pub struct LiveRange {
     pub to: usize,
 }
 
-impl LiveRange {
-    pub fn start(&self) -> usize {
-        self.from
-    }
-
-    pub fn end(&self) -> usize {
-        self.to
-    }
-}
-
+/// Possible states for an Interval.  During linear scan, intervals
+/// start as unhandled, then transition to:
+/// * Active: we are currently handling this interval
+/// * Inactive: this interval has a hole in it, so it's not "active" for the current range
+/// * Handled: we're done dealing with this interval
+///
+/// Intervals can transition back and forth between active and inactive, but
+/// once an interval is handled, it is "done" and cannot transition out of
+/// that state.
 #[derive(Clone, Copy, PartialEq)]
-pub enum State {
+pub enum IntervalState {
     Unhandled,
+    /// Currently being handled; occupies its assigned allocation.
     Active,
+    /// In a lifetime hole — allocation is free for others right now.
     Inactive,
     Handled,
 }
@@ -1405,7 +1406,11 @@ pub enum State {
 pub struct Interval {
     pub ranges: Vec<LiveRange>,
     pub id: VRegId,
-    pub state: Cell<State>,
+
+    /// Where this interval is in the linear scan lifecycle.
+    /// Transitions Unhandled -> Active <-> Inactive -> Handled.
+    pub state: Cell<IntervalState>,
+
     pub assigned: Cell<Option<Allocation>>,
     pub preferred: Option<Allocation>,
 }
@@ -1416,7 +1421,7 @@ impl Interval {
         Self {
             ranges: vec![],
             id: i,
-            state: Cell::new(State::Unhandled),
+            state: Cell::new(IntervalState::Unhandled),
             assigned: Cell::new(None),
             preferred: None,
         }
@@ -2221,16 +2226,16 @@ impl Assembler
 
             // Expire old intervals.
             active.retain(|&it| {
-                debug_assert!(it.state.get() == State::Active);
+                debug_assert!(it.state.get() == IntervalState::Active);
                 // If the interval ends before the current position, then we're
                 // done with it and can mark it handled.
                 if it.ends_before(position) {
-                    it.state.set(State::Handled);
+                    it.state.set(IntervalState::Handled);
                     false
                 } else if !it.covers(position) {
                     // If it doesn't cover the current position (there's a hole
                     // in the ranges), then move it to inactive
-                    it.state.set(State::Inactive);
+                    it.state.set(IntervalState::Inactive);
                     inactive.push(it);
                     false
                 } else {
@@ -2241,16 +2246,16 @@ impl Assembler
 
             // Check for intervals in inactive that are handled or active
             inactive.retain(|&it| {
-                debug_assert!(it.state.get() == State::Inactive);
+                debug_assert!(it.state.get() == IntervalState::Inactive);
                 // If the inactive interval ends before the current position
                 if it.ends_before(position) {
                     // Move it to handled
-                    it.state.set(State::Handled);
+                    it.state.set(IntervalState::Handled);
                     false
                 } else if it.covers(position) {
                     // If the current position falls inside one of the
                     // interval's ranges, then make it active
-                    it.state.set(State::Active);
+                    it.state.set(IntervalState::Active);
                     active.push(it);
                     false
                 } else {
@@ -2271,7 +2276,7 @@ impl Assembler
             // All registers have an end that is greater than 0, so they will
             // not pick any registers used by intervals in the active list.
             for it in &active {
-                debug_assert!(it.state.get() == State::Active);
+                debug_assert!(it.state.get() == IntervalState::Active);
                 match it.assigned.get().expect("should have assignment") {
                     Allocation::Reg(idx) => free_registers[idx] = 0,
                     _ => {},
@@ -2283,7 +2288,7 @@ impl Assembler
             // "free_registers" list when each interval will want to use its
             // assigned reg again.
             for it in &inactive {
-                debug_assert!(it.state.get() == State::Inactive);
+                debug_assert!(it.state.get() == IntervalState::Inactive);
                 let Some(pos) = it.next_intersection(cur) else { continue };
                 match it.assigned.get().expect("should have assignment") {
                     Allocation::Reg(idx) => free_registers[idx] = free_registers[idx].min(pos),
@@ -2296,7 +2301,7 @@ impl Assembler
             if let Some(Allocation::Reg(idx)) = cur.preferred {
                 if free_registers[idx] >= cur_end {
                     cur.assigned.set(Some(Allocation::Reg(idx)));
-                    cur.state.set(State::Active);
+                    cur.state.set(IntervalState::Active);
                     let insert_idx = active.partition_point(|it| it.end() < cur_end);
                     active.insert(insert_idx, cur);
                     continue;
@@ -2329,9 +2334,9 @@ impl Assembler
                             // Spill the last active interval; give its register to current
                             let spilled = active.remove(spill_idx);
                             cur.assigned.set(spilled.assigned.get());
-                            cur.state.set(State::Active);
+                            cur.state.set(IntervalState::Active);
                             spilled.assigned.set(Some(slot));
-                            spilled.state.set(State::Handled);
+                            spilled.state.set(IntervalState::Handled);
                             // Insert current into sorted active
                             let insert_idx = active.partition_point(|it| it.end() < cur_end);
                             active.insert(insert_idx, cur);
@@ -2339,13 +2344,13 @@ impl Assembler
                         None => {
                             // Spill the current interval
                             cur.assigned.set(Some(slot));
-                            cur.state.set(State::Handled);
+                            cur.state.set(IntervalState::Handled);
                         }
                     }
                 }
                 Some(reg) => {
                     cur.assigned.set(Some(Allocation::Reg(reg)));
-                    cur.state.set(State::Active);
+                    cur.state.set(IntervalState::Active);
                     // Insert into sorted active
                     let insert_idx = active.partition_point(|it| it.end() < cur_end);
                     active.insert(insert_idx, cur);
@@ -2355,7 +2360,7 @@ impl Assembler
 
         // Drain active and inactive and mark everything as handled.
         for it in active.drain(..).chain(inactive.drain(..)) {
-            it.state.set(State::Handled);
+            it.state.set(IntervalState::Handled);
         }
         debug_assert!(active.is_empty() && inactive.is_empty());
 

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -2208,43 +2208,48 @@ impl Assembler
             let position = interval.start();
 
             // Expire old intervals.
-            for mut it in std::mem::take(&mut active) {
+            active.retain_mut(|it| {
                 debug_assert!(it.state == State::Active);
                 // If the interval ends before the current position, then we're
                 // done with it and can mark it handled.
                 if it.ends_before(position) {
                     it.state = State::Handled;
-                    handled.push(it);
+                    handled.push(it.clone());
+                    false
                 } else if !it.covers(position) {
                     // If it doesn't cover the current position (there's a hole
                     // in the ranges), then move it to inactive
                     it.state = State::Inactive;
-                    inactive.push(it);
+                    inactive.push(it.clone());
+                    false
                 } else {
                     // Otherwise it's still live here and stays active.
-                    active.push(it);
+                    true
                 }
-            }
+            });
 
             // Check for intervals in inactive that are handled or active
-            for mut it in std::mem::take(&mut inactive) {
+            inactive.retain(|it| {
                 debug_assert!(it.state == State::Inactive);
                 // If the inactive interval ends before the current position
                 if it.ends_before(position) {
                     // Move it to handled
+                    let mut it = it.clone();
                     it.state = State::Handled;
                     handled.push(it);
-
+                    false
                 } else if it.covers(position) {
                     // If the current position falls inside one of the
                     // interval's ranges, then make it active
+                    let mut it = it.clone();
                     it.state = State::Active;
                     active.push(it);
+                    false
                 } else {
                     // It's still inactive
-                    inactive.push(it);
+                    true
                 }
-            }
+            });
 
             // Mark all registers as "free".  In other words, they aren't
             // in use until instruction number usize::MAX.

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -1,4 +1,4 @@
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::fmt;
 use std::mem::take;
@@ -1393,7 +1393,7 @@ impl LiveRange {
     }
 }
 
-#[derive(PartialEq)]
+#[derive(Clone, Copy, PartialEq)]
 pub enum State {
     Unhandled,
     Active,
@@ -1405,8 +1405,8 @@ pub enum State {
 pub struct Interval {
     pub ranges: Vec<LiveRange>,
     pub id: VRegId,
-    pub state: State,
-    pub assigned: Option<Allocation>,
+    pub state: Cell<State>,
+    pub assigned: Cell<Option<Allocation>>,
     pub preferred: Option<Allocation>,
 }
 
@@ -1416,8 +1416,8 @@ impl Interval {
         Self {
             ranges: vec![],
             id: i,
-            state: State::Unhandled,
-            assigned: None,
+            state: Cell::new(State::Unhandled),
+            assigned: Cell::new(None),
             preferred: None,
         }
     }
@@ -2194,43 +2194,43 @@ impl Assembler
     // for the spills.
     pub fn linear_scan(
         &self,
-        intervals: &mut [Interval],
+        intervals: &[Interval],
         num_registers: usize, // number of allocatable regs
         regs: &[Reg],         // list of all registers used, partitioned by allocatability
     ) -> usize {
         debug_assert!(num_registers <= regs.len());
 
-        // `active`, `inactive`, and `unhandled` hold indexes in to `intervals`.
-        // An interval's index is its VRegId, and it is the only identity we
-        // need: the interval data itself is mutated in place.
+        // `active`, `inactive`, and `unhandled` borrow the intervals they hold.
+        // Allocation results are written through the Cell fields, so a shared
+        // reference is all the identity and access this needs.
         let mut free_registers: Vec<usize> = vec![0; regs.len()];
-        let mut active: Vec<usize> = Vec::new(); // sorted by increasing end point
-        let mut inactive: Vec<usize> = Vec::new(); // intervals with lifetime holes
+        let mut active: Vec<&Interval> = Vec::new(); // sorted by increasing end point
+        let mut inactive: Vec<&Interval> = Vec::new(); // intervals with lifetime holes
         let mut num_stack_slots: usize = 0;
 
-        let mut sorted_intervals: Vec<usize> = (0..intervals.len())
-            .filter(|&i| intervals[i].has_bounds())
+        let mut sorted_intervals: Vec<&Interval> = intervals.iter()
+            .filter(|it| it.has_bounds())
             .collect();
-        sorted_intervals.sort_by_key(|&i| intervals[i].start());
+        sorted_intervals.sort_by_key(|it| it.start());
 
-        let mut unhandled: VecDeque<usize> = sorted_intervals.into();
+        let mut unhandled: VecDeque<&Interval> = sorted_intervals.into();
 
         while let Some(cur) = unhandled.pop_front() {
-            let position = intervals[cur].start();
-            let cur_end = intervals[cur].end();
+            let position = cur.start();
+            let cur_end = cur.end();
 
             // Expire old intervals.
             active.retain(|&it| {
-                debug_assert!(intervals[it].state == State::Active);
+                debug_assert!(it.state.get() == State::Active);
                 // If the interval ends before the current position, then we're
                 // done with it and can mark it handled.
-                if intervals[it].ends_before(position) {
-                    intervals[it].state = State::Handled;
+                if it.ends_before(position) {
+                    it.state.set(State::Handled);
                     false
-                } else if !intervals[it].covers(position) {
+                } else if !it.covers(position) {
                     // If it doesn't cover the current position (there's a hole
                     // in the ranges), then move it to inactive
-                    intervals[it].state = State::Inactive;
+                    it.state.set(State::Inactive);
                     inactive.push(it);
                     false
                 } else {
@@ -2241,16 +2241,16 @@ impl Assembler
 
             // Check for intervals in inactive that are handled or active
             inactive.retain(|&it| {
-                debug_assert!(intervals[it].state == State::Inactive);
+                debug_assert!(it.state.get() == State::Inactive);
                 // If the inactive interval ends before the current position
-                if intervals[it].ends_before(position) {
+                if it.ends_before(position) {
                     // Move it to handled
-                    intervals[it].state = State::Handled;
+                    it.state.set(State::Handled);
                     false
-                } else if intervals[it].covers(position) {
+                } else if it.covers(position) {
                     // If the current position falls inside one of the
                     // interval's ranges, then make it active
-                    intervals[it].state = State::Active;
+                    it.state.set(State::Active);
                     active.push(it);
                     false
                 } else {
@@ -2270,9 +2270,9 @@ impl Assembler
             // the interval's end is _less than_ the value in the free_register list)
             // All registers have an end that is greater than 0, so they will
             // not pick any registers used by intervals in the active list.
-            for &it in &active {
-                debug_assert!(intervals[it].state == State::Active);
-                match intervals[it].assigned.expect("should have assignment") {
+            for it in &active {
+                debug_assert!(it.state.get() == State::Active);
+                match it.assigned.get().expect("should have assignment") {
                     Allocation::Reg(idx) => free_registers[idx] = 0,
                     _ => {},
                 }
@@ -2282,10 +2282,10 @@ impl Assembler
             // we're currently inside one of those gaps.  We'll mark in the
             // "free_registers" list when each interval will want to use its
             // assigned reg again.
-            for &it in &inactive {
-                debug_assert!(intervals[it].state == State::Inactive);
-                let Some(pos) = intervals[it].next_intersection(&intervals[cur]) else { continue };
-                match intervals[it].assigned.expect("should have assignment") {
+            for it in &inactive {
+                debug_assert!(it.state.get() == State::Inactive);
+                let Some(pos) = it.next_intersection(cur) else { continue };
+                match it.assigned.get().expect("should have assignment") {
                     Allocation::Reg(idx) => free_registers[idx] = free_registers[idx].min(pos),
                     _ => {},
                 }
@@ -2293,11 +2293,11 @@ impl Assembler
 
             // If the current interval has a preferred allocation, use it if
             // that register is available until the interval end.
-            if let Some(Allocation::Reg(idx)) = intervals[cur].preferred {
+            if let Some(Allocation::Reg(idx)) = cur.preferred {
                 if free_registers[idx] >= cur_end {
-                    intervals[cur].assigned = Some(Allocation::Reg(idx));
-                    intervals[cur].state = State::Active;
-                    let insert_idx = active.partition_point(|&i| intervals[i].end() < cur_end);
+                    cur.assigned.set(Some(Allocation::Reg(idx)));
+                    cur.state.set(State::Active);
+                    let insert_idx = active.partition_point(|it| it.end() < cur_end);
                     active.insert(insert_idx, cur);
                     continue;
                 }
@@ -2317,40 +2317,37 @@ impl Assembler
                     // but only from the allocatable partition of the pool. An index
                     // at or past `num_registers` is a pinned physical register (for
                     // example SP), which is not ours to hand to someone else.
-                    let spill = active.iter().rev().copied()
-                        .find(|&it| {
-                            intervals[it].assigned
-                                .is_some_and(|alloc| alloc.alloc_pool_index(num_registers).is_some())
-                        })
-                        .map(|it| (it, intervals[it].end()));
+                    let spill_idx = active.iter().rposition(|it| {
+                        it.assigned.get()
+                            .is_some_and(|alloc| alloc.alloc_pool_index(num_registers).is_some())
+                    });
                     let slot = Allocation::Stack(num_stack_slots);
                     num_stack_slots += 1;
 
-                    if let Some((spill_it, _)) = spill.filter(|&(_, spill_end)| spill_end > cur_end) {
-                        // Spill the last active interval; give its register to current
-                        let spill_idx = active.iter().position(|&i| i == spill_it).unwrap();
-                        active.remove(spill_idx);
-                        // Read the stolen allocation in to a local: reading and
-                        // writing `intervals` in one statement won't borrow check.
-                        let stolen = intervals[spill_it].assigned;
-                        intervals[spill_it].assigned = Some(slot);
-                        intervals[spill_it].state = State::Handled;
-                        intervals[cur].assigned = stolen;
-                        intervals[cur].state = State::Active;
-                        // Insert current into sorted active
-                        let insert_idx = active.partition_point(|&i| intervals[i].end() < cur_end);
-                        active.insert(insert_idx, cur);
-                    } else {
-                        // Spill the current interval
-                        intervals[cur].assigned = Some(slot);
-                        intervals[cur].state = State::Handled;
+                    match spill_idx.filter(|&idx| active[idx].end() > cur_end) {
+                        Some(spill_idx) => {
+                            // Spill the last active interval; give its register to current
+                            let spilled = active.remove(spill_idx);
+                            cur.assigned.set(spilled.assigned.get());
+                            cur.state.set(State::Active);
+                            spilled.assigned.set(Some(slot));
+                            spilled.state.set(State::Handled);
+                            // Insert current into sorted active
+                            let insert_idx = active.partition_point(|it| it.end() < cur_end);
+                            active.insert(insert_idx, cur);
+                        }
+                        None => {
+                            // Spill the current interval
+                            cur.assigned.set(Some(slot));
+                            cur.state.set(State::Handled);
+                        }
                     }
                 }
                 Some(reg) => {
-                    intervals[cur].assigned = Some(Allocation::Reg(reg));
-                    intervals[cur].state = State::Active;
+                    cur.assigned.set(Some(Allocation::Reg(reg)));
+                    cur.state.set(State::Active);
                     // Insert into sorted active
-                    let insert_idx = active.partition_point(|&i| intervals[i].end() < cur_end);
+                    let insert_idx = active.partition_point(|it| it.end() < cur_end);
                     active.insert(insert_idx, cur);
                 }
             }
@@ -2358,7 +2355,7 @@ impl Assembler
 
         // Drain active and inactive and mark everything as handled.
         for it in active.drain(..).chain(inactive.drain(..)) {
-            intervals[it].state = State::Handled;
+            it.state.set(State::Handled);
         }
         debug_assert!(active.is_empty() && inactive.is_empty());
 
@@ -2403,7 +2400,7 @@ impl Assembler
                 let reg_copies: Vec<parcopy::RegisterCopy<Opnd>> = edge.args
                     .iter()
                     .zip(params.iter())
-                    .filter(|(_arg, param)| intervals[param.vreg_idx()].assigned.is_some() )
+                    .filter(|(_arg, param)| intervals[param.vreg_idx()].assigned.get().is_some() )
                     .map(|(arg, param)| parcopy::RegisterCopy::<Opnd> {
                         destination: Self::rewritten_opnd(*param, intervals, regs),
                         source: Self::rewritten_opnd(*arg, intervals, regs),
@@ -2599,14 +2596,14 @@ impl Assembler
                             let survives_call = interval.has_bounds() && interval.survives(insn_number);
                             // 2) The VReg is referenced by the stack map for the CCall
                             let stack_map_reg = stack_vreg_ids.contains(&interval.id);
-                            let is_register = interval.assigned.and_then(|alloc| alloc.alloc_pool_index(ALLOC_REGS.len())).is_some();
+                            let is_register = interval.assigned.get().and_then(|alloc| alloc.alloc_pool_index(ALLOC_REGS.len())).is_some();
                             is_register && (survives_call || stack_map_reg)
                         })
                         .map(|interval| interval.id)
                         .collect();
 
                     let survivor_regs: Vec<Opnd> = survivors.iter()
-                        .map(|&s| Opnd::Reg(intervals[s].assigned.unwrap().assigned_reg(alloc_regs).unwrap()))
+                        .map(|&s| Opnd::Reg(intervals[s].assigned.get().unwrap().assigned_reg(alloc_regs).unwrap()))
                         .collect();
 
                     // Push all survivors on the stack, pairing adjacent pushes when possible.
@@ -2640,7 +2637,7 @@ impl Assembler
                                     VALUE(encoded)
                                 }
                                 StackMapEntry::Opnd(Opnd::VReg { idx: vreg, .. }) => {
-                                    let vreg_stack_index = match intervals[vreg].assigned.expect("StackMap VReg should have an allocation") {
+                                    let vreg_stack_index = match intervals[vreg].assigned.get().expect("StackMap VReg should have an allocation") {
                                         Allocation::Reg(_) => {
                                             let caller_saved_reg_idx = survivors.iter().position(|&survivor_id| survivor_id == vreg).unwrap();
                                             let stack_idx = self.stack_state.stack_idx_for_caller_saved_reg(caller_saved_reg_idx);
@@ -2786,7 +2783,7 @@ impl Assembler
             StackMapEntry::Opnd(Opnd::UImm(value)) => !VALUE(*value as usize).special_const_p(),
             StackMapEntry::Opnd(Opnd::VReg { idx, .. }) => {
                 matches!(
-                    intervals[idx.to_usize()].assigned.expect("StackMap VReg should have an allocation"),
+                    intervals[idx.to_usize()].assigned.get().expect("StackMap VReg should have an allocation"),
                     Allocation::Reg(_)
                 )
             }
@@ -2818,7 +2815,7 @@ impl Assembler
     fn rewrite_opnd(opnd: &mut Opnd, intervals: &[Interval], regs: &[Reg]) {
         match opnd {
             Opnd::VReg { idx, num_bits } => {
-                if let Some(assignment) = intervals[*idx].assigned {
+                if let Some(assignment) = intervals[*idx].assigned.get() {
                     match assignment {
                         Allocation::Reg(n) => {
                             let mut reg = regs[n];
@@ -2839,7 +2836,7 @@ impl Assembler
                 }
             }
             Opnd::Mem(Mem { base: MemBase::VReg(idx), .. }) => {
-                match intervals[*idx].assigned.unwrap() {
+                match intervals[*idx].assigned.get().unwrap() {
                     Allocation::Reg(n) => {
                         if let Opnd::Mem(mem) = opnd {
                             mem.base = MemBase::Reg(regs[n].reg_no);
@@ -4771,7 +4768,7 @@ mod tests {
         let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
         let allocatable_regs = regs.len();
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        let num_stack_slots = asm.linear_scan(&mut intervals, 5.min(allocatable_regs), &regs);
+        let num_stack_slots = asm.linear_scan(&intervals, 5.min(allocatable_regs), &regs);
 
         // Extract vreg indices
         let r10_idx = if let Opnd::VReg { idx, .. } = r10 { idx } else { panic!() };
@@ -4791,12 +4788,12 @@ mod tests {
         // r13: [20,38) gets Reg(2)
         // r14: [36,42) gets Reg(1) (r12 expired, reuses its register)
         // r15: [38,42) gets Reg(2) (r13 expired, reuses its register)
-        assert_eq!(intervals[r10_idx].assigned, Some(Allocation::Reg(0)));
-        assert_eq!(intervals[r11_idx].assigned, Some(Allocation::Reg(1)));
-        assert_eq!(intervals[r12_idx].assigned, Some(Allocation::Reg(1)));
-        assert_eq!(intervals[r13_idx].assigned, Some(Allocation::Reg(2)));
-        assert_eq!(intervals[r14_idx].assigned, Some(Allocation::Reg(1)));
-        assert_eq!(intervals[r15_idx].assigned, Some(Allocation::Reg(2)));
+        assert_eq!(intervals[r10_idx].assigned.get(), Some(Allocation::Reg(0)));
+        assert_eq!(intervals[r11_idx].assigned.get(), Some(Allocation::Reg(1)));
+        assert_eq!(intervals[r12_idx].assigned.get(), Some(Allocation::Reg(1)));
+        assert_eq!(intervals[r13_idx].assigned.get(), Some(Allocation::Reg(2)));
+        assert_eq!(intervals[r14_idx].assigned.get(), Some(Allocation::Reg(1)));
+        assert_eq!(intervals[r15_idx].assigned.get(), Some(Allocation::Reg(2)));
     }
 
     #[test]
@@ -4811,7 +4808,7 @@ mod tests {
         let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
         let allocatable_regs = regs.len();
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        let num_stack_slots = asm.linear_scan(&mut intervals, 3.min(allocatable_regs), &regs);
+        let num_stack_slots = asm.linear_scan(&intervals, 3.min(allocatable_regs), &regs);
 
         let r10_idx = if let Opnd::VReg { idx, .. } = r10 { idx } else { panic!() };
         let r11_idx = if let Opnd::VReg { idx, .. } = r11 { idx } else { panic!() };
@@ -4823,12 +4820,12 @@ mod tests {
         // Lifetime holes make three registers enough: nothing spills, and the
         // assignment is the same one five registers produce.
         assert_eq!(num_stack_slots, 0);
-        assert_eq!(intervals[r10_idx].assigned, Some(Allocation::Reg(0)));
-        assert_eq!(intervals[r11_idx].assigned, Some(Allocation::Reg(1)));
-        assert_eq!(intervals[r12_idx].assigned, Some(Allocation::Reg(1)));
-        assert_eq!(intervals[r13_idx].assigned, Some(Allocation::Reg(2)));
-        assert_eq!(intervals[r14_idx].assigned, Some(Allocation::Reg(1)));
-        assert_eq!(intervals[r15_idx].assigned, Some(Allocation::Reg(2)));
+        assert_eq!(intervals[r10_idx].assigned.get(), Some(Allocation::Reg(0)));
+        assert_eq!(intervals[r11_idx].assigned.get(), Some(Allocation::Reg(1)));
+        assert_eq!(intervals[r12_idx].assigned.get(), Some(Allocation::Reg(1)));
+        assert_eq!(intervals[r13_idx].assigned.get(), Some(Allocation::Reg(2)));
+        assert_eq!(intervals[r14_idx].assigned.get(), Some(Allocation::Reg(1)));
+        assert_eq!(intervals[r15_idx].assigned.get(), Some(Allocation::Reg(2)));
     }
 
     #[test]
@@ -4843,7 +4840,7 @@ mod tests {
         let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
         let allocatable_regs = regs.len();
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        let num_stack_slots = asm.linear_scan(&mut intervals, 1.min(allocatable_regs), &regs);
+        let num_stack_slots = asm.linear_scan(&intervals, 1.min(allocatable_regs), &regs);
 
         let r10_idx = if let Opnd::VReg { idx, .. } = r10 { idx } else { panic!() };
         let r11_idx = if let Opnd::VReg { idx, .. } = r11 { idx } else { panic!() };
@@ -4853,12 +4850,12 @@ mod tests {
         let r15_idx = if let Opnd::VReg { idx, .. } = r15 { idx } else { panic!() };
 
         assert_eq!(num_stack_slots, 3);
-        assert_eq!(intervals[r10_idx].assigned, Some(Allocation::Stack(0)));
-        assert_eq!(intervals[r11_idx].assigned, Some(Allocation::Reg(0)));
-        assert_eq!(intervals[r12_idx].assigned, Some(Allocation::Stack(1)));
-        assert_eq!(intervals[r13_idx].assigned, Some(Allocation::Reg(0)));
-        assert_eq!(intervals[r14_idx].assigned, Some(Allocation::Stack(2)));
-        assert_eq!(intervals[r15_idx].assigned, Some(Allocation::Reg(0)));
+        assert_eq!(intervals[r10_idx].assigned.get(), Some(Allocation::Stack(0)));
+        assert_eq!(intervals[r11_idx].assigned.get(), Some(Allocation::Reg(0)));
+        assert_eq!(intervals[r12_idx].assigned.get(), Some(Allocation::Stack(1)));
+        assert_eq!(intervals[r13_idx].assigned.get(), Some(Allocation::Reg(0)));
+        assert_eq!(intervals[r14_idx].assigned.get(), Some(Allocation::Stack(2)));
+        assert_eq!(intervals[r15_idx].assigned.get(), Some(Allocation::Reg(0)));
     }
 
     #[test]
@@ -4889,10 +4886,10 @@ mod tests {
         // Zero allocatable registers: the only register this interval can get
         // is the pinned one appended to the pool, so the preference is what
         // makes this succeed rather than spill.
-        let num_stack_slots = asm.linear_scan(&mut intervals, 0, &regs);
+        let num_stack_slots = asm.linear_scan(&intervals, 0, &regs);
         assert_eq!(num_stack_slots, 0);
-        assert_eq!(intervals[vreg_idx].assigned, Some(Allocation::Reg(regno)));
-        assert_eq!(intervals[vreg_idx].assigned.unwrap().assigned_reg(&regs), Some(sp.unwrap_reg()));
+        assert_eq!(intervals[vreg_idx].assigned.get(), Some(Allocation::Reg(regno)));
+        assert_eq!(intervals[vreg_idx].assigned.get().unwrap().assigned_reg(&regs), Some(sp.unwrap_reg()));
     }
 
     #[test]
@@ -4924,7 +4921,7 @@ mod tests {
         let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
         let allocatable_regs = regs.len();
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        asm.linear_scan(&mut intervals, 5.min(allocatable_regs), &regs);
+        asm.linear_scan(&intervals, 5.min(allocatable_regs), &regs);
 
         asm.resolve_ssa(&intervals, &regs);
 
@@ -4970,7 +4967,7 @@ mod tests {
         let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
         let allocatable_regs = regs.len();
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        asm.linear_scan(&mut intervals, 5.min(allocatable_regs), &regs);
+        asm.linear_scan(&intervals, 5.min(allocatable_regs), &regs);
 
         // Entry block b1 has parameters [v0, v1].
         // With 5 registers: v0 -> Reg(0) = regs[0], arrival = C_ARG_OPNDS[0] = regs[0] -> self-move, filtered
@@ -5019,7 +5016,7 @@ mod tests {
         let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
         let allocatable_regs = regs.len();
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        asm.linear_scan(&mut intervals, 5.min(allocatable_regs), &regs);
+        asm.linear_scan(&intervals, 5.min(allocatable_regs), &regs);
 
         asm.resolve_ssa(&intervals, &regs);
 
@@ -5080,13 +5077,13 @@ mod tests {
         let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
         let allocatable_regs = regs.len();
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        asm.linear_scan(&mut intervals, num_regs.min(allocatable_regs), &regs);
+        asm.linear_scan(&intervals, num_regs.min(allocatable_regs), &regs);
 
         assert_eq!(asm.basic_blocks.len(), 3);
 
         // Verify v1 and v4 have different allocations (so moves are needed)
-        let v1_alloc = intervals[v1.vreg_idx()].assigned.unwrap();
-        let v4_alloc = intervals[v4.vreg_idx()].assigned.unwrap();
+        let v1_alloc = intervals[v1.vreg_idx()].assigned.get().unwrap();
+        let v4_alloc = intervals[v4.vreg_idx()].assigned.get().unwrap();
         assert_ne!(v1_alloc, v4_alloc, "Test setup: v1 and v4 should have different allocations");
 
         asm.resolve_ssa(&intervals, &regs);
@@ -5121,7 +5118,7 @@ mod tests {
         assert!(has_mov, "Expected Mov in split block for v1->v4");
 
         // b2->b3 is not a critical edge (b2 has single succ), so moves go before Jmp in b2
-        let v3_alloc = intervals[v3.vreg_idx()].assigned.unwrap();
+        let v3_alloc = intervals[v3.vreg_idx()].assigned.get().unwrap();
         let b2_insns = &asm.basic_blocks[b2.0].insns;
         if v3_alloc != v4_alloc {
             // Check that a Mov was inserted before the Jmp in b2
@@ -5186,7 +5183,7 @@ mod tests {
         let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
         let allocatable_regs = regs.len();
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        let num_stack_slots = asm.linear_scan(&mut intervals, num_regs.min(allocatable_regs), &regs);
+        let num_stack_slots = asm.linear_scan(&intervals, num_regs.min(allocatable_regs), &regs);
         asm.stack_state.num_spill_slots = num_stack_slots;
 
         // Stand in for the C calling convention's argument registers. These
@@ -5195,10 +5192,10 @@ mod tests {
         let c_arg_regs = &ALLOC_REGS[..num_regs];
 
         // v0 should be spilled (long-lived, only 2 regs)
-        assert!(matches!(intervals[v0.vreg_idx()].assigned, Some(Allocation::Stack(_))),
+        assert!(matches!(intervals[v0.vreg_idx()].assigned.get(), Some(Allocation::Stack(_))),
             "v0 should be spilled to stack");
         // v1 should be in a register
-        assert!(matches!(intervals[v1.vreg_idx()].assigned, Some(Allocation::Reg(_))),
+        assert!(matches!(intervals[v1.vreg_idx()].assigned.get(), Some(Allocation::Reg(_))),
             "v1 should be in a register");
 
         // Run the pipeline: handle_caller_saved_regs then resolve_ssa
@@ -5214,7 +5211,7 @@ mod tests {
         assert!(!pushes.is_empty(), "Expected at least one saved register across CCall");
 
         // The survivor register should match v1's allocation
-        let v1_reg = Opnd::Reg(intervals[v1.vreg_idx()].assigned.unwrap().assigned_reg(&regs).unwrap());
+        let v1_reg = Opnd::Reg(intervals[v1.vreg_idx()].assigned.get().unwrap().assigned_reg(&regs).unwrap());
         let pushed_v1 = pushes.iter().any(|insn| matches!(**insn, Insn::CPushPair(first, second) if first == v1_reg || second == v1_reg));
         let popped_v1 = pops.iter().any(|insn| matches!(**insn, Insn::CPopPairInto(first, second) if first == v1_reg || second == v1_reg));
         assert!(pushed_v1, "CPushPair should save v1's register");

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -1390,6 +1390,7 @@ pub struct Interval {
     pub ranges: Vec<LiveRange>,
     pub id: VRegId,
     pub state: State,
+    pub assigned: Option<Allocation>,
 }
 
 impl Interval {
@@ -1399,6 +1400,7 @@ impl Interval {
             ranges: vec![],
             id: i,
             state: State::Unhandled,
+            assigned: None,
         }
     }
 
@@ -2153,25 +2155,25 @@ impl Assembler
 
         let mut free_registers: BTreeSet<usize> = (0..num_registers).collect();
         let mut active: Vec<Interval> = Vec::new(); // sorted by increasing end point
-        let mut assignment: Vec<Option<Allocation>> = vec![None; intervals.len()];
         let mut num_stack_slots: usize = 0;
 
-        // Collect vreg indices that have valid ranges, sorted by start point
-        let mut sorted_intervals: Vec<Interval> = intervals.iter()
+        let mut handled: Vec<Interval> = Vec::new();
+        let num_intervals = intervals.len();
+
+        let mut sorted_intervals: Vec<Interval> = intervals.into_iter()
             .filter(|i| i.has_bounds())
-            .cloned()
             .collect();
         sorted_intervals.sort_by_key(|i| i.start());
 
         let mut unhandled: VecDeque<Interval> = sorted_intervals.into();
 
-        while let Some(interval) = unhandled.pop_front() {
-            // Expire old intervals
-            active.retain(|active_interval| {
-                if active_interval.end() > interval.start() {
-                    true
+        while let Some(mut interval) = unhandled.pop_front() {
+            // Expire old intervals.
+            for it in std::mem::take(&mut active) {
+                if it.end() > interval.start() {
+                    active.push(it);
                 } else {
-                    if let Some(allocation) = assignment[active_interval.id] {
+                    if let Some(allocation) = it.assigned {
                         if let Some(reg) = allocation.alloc_pool_index(num_registers) {
                             let was_not_there_before = free_registers.insert(reg);
                             assert!(
@@ -2192,14 +2194,14 @@ impl Assembler
                             );
                         }
                     }
-                    false
+                    handled.push(it);
                 }
-            });
+            }
 
             let preferred_reg = preferred_registers[interval.id];
             let preferred_taken = preferred_reg.is_some_and(|reg| {
                 active.iter().any(|active_interval| {
-                    assignment[active_interval.id]
+                    active_interval.assigned
                         .and_then(|alloc| alloc.assigned_reg())
                         .is_some_and(|active_reg| active_reg.reg_no == reg.reg_no)
                 })
@@ -2208,13 +2210,13 @@ impl Assembler
             if let Some(preferred_reg) = preferred_reg.filter(|_| !preferred_taken) {
                 if let Some(reg_idx) = Allocation::Fixed(preferred_reg).alloc_pool_index(num_registers) {
                     if free_registers.remove(&reg_idx) {
-                        assignment[interval.id] = Some(Allocation::Fixed(preferred_reg));
+                        interval.assigned = Some(Allocation::Fixed(preferred_reg));
                         let insert_idx = active.partition_point(|i| i.end() < interval.end());
                         active.insert(insert_idx, interval);
                         continue;
                     }
                 } else {
-                    assignment[interval.id] = Some(Allocation::Fixed(preferred_reg));
+                    interval.assigned = Some(Allocation::Fixed(preferred_reg));
                     let insert_idx = active.partition_point(|i| i.end() < interval.end());
                     active.insert(insert_idx, interval);
                     continue;
@@ -2230,7 +2232,7 @@ impl Assembler
                 // can be mutated below.
                 let spill = active.iter().rev()
                     .find(|active_interval| {
-                        matches!(assignment[active_interval.id], Some(Allocation::Reg(_)))
+                        matches!(active_interval.assigned, Some(Allocation::Reg(_)))
                     })
                     .map(|active_interval| (active_interval.id, active_interval.end()));
                 let slot = Allocation::Stack(num_stack_slots);
@@ -2238,26 +2240,33 @@ impl Assembler
 
                 if let Some((spill_id, _)) = spill.filter(|&(_, spill_end)| spill_end > interval.end()) {
                     // Spill the last active interval; give its register to current
-                    assignment[interval.id] = assignment[spill_id];
-                    assignment[spill_id] = Some(slot);
                     let spill_idx = active.iter().position(|active_interval| active_interval.id == spill_id).unwrap();
-                    active.remove(spill_idx);
+                    let mut spilled = active.remove(spill_idx);
+                    interval.assigned = spilled.assigned;
+                    spilled.assigned = Some(slot);
+                    handled.push(spilled);
                     // Insert current into sorted active
                     let insert_idx = active.partition_point(|i| i.end() < interval.end());
                     active.insert(insert_idx, interval);
                 } else {
                     // Spill the current interval
-                    assignment[interval.id] = Some(slot);
+                    interval.assigned = Some(slot);
+                    handled.push(interval);
                 }
             } else {
                 // Allocate lowest free register
                 let reg = *free_registers.iter().min().unwrap();
                 free_registers.remove(&reg);
-                assignment[interval.id] = Some(Allocation::Reg(reg));
+                interval.assigned = Some(Allocation::Reg(reg));
                 // Insert into sorted active
                 let insert_idx = active.partition_point(|i| i.end() < interval.end());
                 active.insert(insert_idx, interval);
             }
+        }
+
+        let mut assignment: Vec<Option<Allocation>> = vec![None; num_intervals];
+        for it in active.into_iter().chain(handled) {
+            assignment[it.id] = it.assigned;
         }
 
         (assignment, num_stack_slots)

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -1476,6 +1476,13 @@ impl Interval {
         self.ranges.len() > 0
     }
 
+    pub fn ranges_string(&self) -> String {
+        self.ranges.iter()
+            .map(|range| format!("{}..{}", range.from, range.to))
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+
     /// Add a range to the interval, extending it if necessary
     pub fn add_range(&mut self, from: usize, to: usize) {
         if to <= from {

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -2245,13 +2245,17 @@ impl Assembler
                 }
             });
 
-            // Mark all registers as "free".  In other words, they aren't
-            // in use until instruction number usize::MAX.
+            // Mark all registers as "free".  Intervals that end before usize::MAX
+            // (at this point that would be all registers) are allowed to use
+            // any index from this list.
             free_registers.fill(usize::MAX);
 
-            // Mark all active intervals with assignments as "unavailable".  They are available
-            // again at instruction 0 which effectively means they can't be used (as all
-            // intervals will end after 0)
+            // Mark all active intervals with assignments as "unavailable".
+            // Intervals that want a register must find an index in the free_registers
+            // list where the value is greater than the intervals "end" (or
+            // the interval's end is _less than_ the value in the free_register list)
+            // All registers have an end that is greater than 0, so they will
+            // not pick any registers used by intervals in the active list.
             for &it in &active {
                 debug_assert!(intervals[it].state == State::Active);
                 match intervals[it].assigned.expect("should have assignment") {

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -1532,18 +1532,73 @@ pub enum Allocation {
 }
 
 impl Allocation {
-    fn assigned_reg(self, regs: &[Reg]) -> Option<Reg> {
+    fn assigned_reg(self, regs: &RegPool) -> Option<Reg> {
         match self {
-            Allocation::Reg(n) => Some(regs[n]),
+            Allocation::Reg(n) => Some(regs.reg_at(n)),
             Allocation::Stack(_) => None,
         }
     }
 
-    fn alloc_pool_index(self, num_registers: usize) -> Option<usize> {
+    fn alloc_pool_index(self, regs: &RegPool) -> Option<usize> {
         match self {
-            Allocation::Reg(n) => (n < num_registers).then_some(n),
+            Allocation::Reg(n) => (n < regs.num_allocatable()).then_some(n),
             Allocation::Stack(_) => None,
         }
+    }
+}
+
+/// The physical registers the register allocator hands out, partitioned by
+/// allocatability. The registers at indexes `0..num_allocatable()` are the ones
+/// linear_scan() is free to assign to any interval. The rest are pinned
+/// registers (NATIVE_STACK_PTR, for example) that an interval can only end up
+/// in through its `preferred` allocation.
+///
+/// The list and the boundary travel together so that consumers can't disagree
+/// about where the partition is, and so pinning a register can't move it.
+#[derive(Debug)]
+pub struct RegPool {
+    regs: Vec<Reg>,
+    allocatable: usize,
+}
+
+impl RegPool {
+    /// Build a pool in which every register is allocatable.
+    pub fn new(regs: Vec<Reg>) -> Self {
+        let allocatable = regs.len();
+        Self { regs, allocatable }
+    }
+
+    #[cfg(test)]
+    pub fn with_allocatable(regs: Vec<Reg>, allocatable: usize) -> Self {
+        assert!(allocatable <= regs.len());
+        Self { regs, allocatable }
+    }
+
+    /// The number of registers linear_scan() is free to allocate.
+    pub fn num_allocatable(&self) -> usize {
+        self.allocatable
+    }
+
+    /// The total number of registers in the pool.
+    pub fn len(&self) -> usize {
+        self.regs.len()
+    }
+
+    /// The register at `index`, in either partition.
+    pub fn reg_at(&self, index: usize) -> Reg {
+        self.regs[index]
+    }
+
+    /// Find the index of `reg` in the pool.  If the pool doesn't have the
+    /// reg, add it to the pool, but place it outside of the "allocatable"
+    /// register range.
+    pub fn find_or_add_index(&mut self, reg: Reg) -> usize {
+        self.regs.iter()
+            .position(|candidate| candidate.reg_no == reg.reg_no)
+            .unwrap_or_else(|| {
+                self.regs.push(reg);
+                self.regs.len() - 1
+            })
     }
 }
 
@@ -2141,9 +2196,9 @@ impl Assembler
         Some(new_moves)
     }
 
-    /// Discover and append to `regs` vregs that should preferentially reuse a physical register,
-    /// such as a newborn vreg immediately moved into a preg in the next instruction.
-    pub fn preferred_register_assignments(&self, intervals: &mut [Interval], regs: &mut Vec<Reg>) {
+    /// Record a preferred physical register on vregs that should reuse one, such as a
+    /// newborn vreg immediately moved into a preg in the next instruction.
+    pub fn preferred_register_assignments(&self, intervals: &mut [Interval], regs: &mut RegPool) {
         for block in &self.basic_blocks {
             let mut prev_insn: Option<(InsnId, &Insn)> = None;
 
@@ -2164,12 +2219,7 @@ impl Assembler
                                 && intervals[*idx].born_at(prev_id.0)
                                 && intervals[*idx].dies_at(insn_id.0)
                             {
-                                let regno = regs.iter()
-                                    .position(|candidate| candidate.reg_no == dest_reg.reg_no)
-                                    .unwrap_or_else(|| {
-                                        regs.push(*dest_reg);
-                                        regs.len() - 1
-                                    });
+                                let regno = regs.find_or_add_index(*dest_reg);
                                 debug_assert!(intervals[*idx].preferred.is_none());
                                 intervals[*idx].preferred = Some(Allocation::Reg(regno));
                             }
@@ -2188,22 +2238,15 @@ impl Assembler
     // * Pre-allocate pinned regs
     // * Update linear scan to handle pinned LRs
     //
-    // num_registers is the number of allocatable registers.  `regs` is a
-    // list of _all_ registers partitioned by allocatable and non-allocatable.
-    // The registers in `regs` from 0 to num_registers is allocatable,
-    // num_registers to the end are only allocatable via "preferred" register
-    // support.
+    // `regs` is the pool of _all_ registers, partitioned by allocatability.
+    // The registers below `regs.num_allocatable()` are allocatable here, the
+    // rest are only reachable via "preferred" register support.
     //
     // Allocations are written back in to `intervals` as each interval's
     // `assigned` field.  The return value is the number of stack slots needed
     // for the spills.
-    pub fn linear_scan(
-        &self,
-        intervals: &[Interval],
-        num_registers: usize, // number of allocatable regs
-        regs: &[Reg],         // list of all registers used, partitioned by allocatability
-    ) -> usize {
-        debug_assert!(num_registers <= regs.len());
+    pub fn linear_scan(&self, intervals: &[Interval], regs: &RegPool) -> usize {
+        let num_registers = regs.num_allocatable();
 
         // `active`, `inactive`, and `unhandled` borrow the intervals they hold.
         // Allocation results are written through the Cell fields, so a shared
@@ -2320,11 +2363,11 @@ impl Assembler
                 None => {
                     // Spill: pick the longest-lived active interval (last in sorted active)
                     // but only from the allocatable partition of the pool. An index
-                    // at or past `num_registers` is a pinned physical register (for
-                    // example SP), which is not ours to hand to someone else.
+                    // at or past the pool's allocatable boundary is a pinned physical
+                    // register (for example SP), which is not ours to hand to someone else.
                     let spill_idx = active.iter().rposition(|it| {
                         it.assigned.get()
-                            .is_some_and(|alloc| alloc.alloc_pool_index(num_registers).is_some())
+                            .is_some_and(|alloc| alloc.alloc_pool_index(regs).is_some())
                     });
                     let slot = Allocation::Stack(num_stack_slots);
                     num_stack_slots += 1;
@@ -2370,7 +2413,7 @@ impl Assembler
     /// Resolve SSA block parameters by inserting sequentialized move instructions
     /// at block boundaries. This is SSA deconstruction: after linear_scan assigns
     /// registers/stack slots, we lower block parameter passing to explicit moves.
-    pub fn resolve_ssa(&mut self, intervals: &[Interval], regs: &[Reg]) {
+    pub fn resolve_ssa(&mut self, intervals: &[Interval], regs: &RegPool) {
         use crate::backend::parcopy;
         use crate::backend::current::SCRATCH_REG;
 
@@ -2556,11 +2599,11 @@ impl Assembler
     pub fn handle_caller_saved_regs(
         &mut self,
         intervals: &[Interval],
-        alloc_regs: &[Reg],
+        alloc_regs: &RegPool,
         c_arg_regs: &[Reg],
     ) {
         use crate::backend::parcopy;
-        use crate::backend::current::{C_RET_OPND, SCRATCH_REG, ALLOC_REGS};
+        use crate::backend::current::{C_RET_OPND, SCRATCH_REG};
 
         for block_id in self.block_order() {
             let block = &mut self.basic_blocks[block_id.0];
@@ -2601,7 +2644,7 @@ impl Assembler
                             let survives_call = interval.has_bounds() && interval.survives(insn_number);
                             // 2) The VReg is referenced by the stack map for the CCall
                             let stack_map_reg = stack_vreg_ids.contains(&interval.vreg_id);
-                            let is_register = interval.assigned.get().and_then(|alloc| alloc.alloc_pool_index(ALLOC_REGS.len())).is_some();
+                            let is_register = interval.assigned.get().and_then(|alloc| alloc.alloc_pool_index(alloc_regs)).is_some();
                             is_register && (survives_call || stack_map_reg)
                         })
                         .map(|interval| interval.vreg_id)
@@ -2799,7 +2842,7 @@ impl Assembler
 
     /// Walk every instruction and replace VReg operands with the physical
     /// register (or stack slot) assigned to the VReg's interval.
-    fn rewrite_instructions(&mut self, intervals: &[Interval], regs: &[Reg]) {
+    fn rewrite_instructions(&mut self, intervals: &[Interval], regs: &RegPool) {
         for block_id in self.block_order() {
             for insn in self.basic_blocks[block_id.0].insns.iter_mut() {
                 insn.for_each_operand_mut(|opnd| {
@@ -2812,18 +2855,18 @@ impl Assembler
         }
     }
 
-    fn rewritten_opnd(mut opnd: Opnd, intervals: &[Interval], regs: &[Reg]) -> Opnd {
+    fn rewritten_opnd(mut opnd: Opnd, intervals: &[Interval], regs: &RegPool) -> Opnd {
         Self::rewrite_opnd(&mut opnd, intervals, regs);
         opnd
     }
 
-    fn rewrite_opnd(opnd: &mut Opnd, intervals: &[Interval], regs: &[Reg]) {
+    fn rewrite_opnd(opnd: &mut Opnd, intervals: &[Interval], regs: &RegPool) {
         match opnd {
             Opnd::VReg { idx, num_bits } => {
                 if let Some(assignment) = intervals[*idx].assigned.get() {
                     match assignment {
                         Allocation::Reg(n) => {
-                            let mut reg = regs[n];
+                            let mut reg = regs.reg_at(n);
                             reg.num_bits = *num_bits;
                             *opnd = Opnd::Reg(reg);
                         }
@@ -2844,7 +2887,7 @@ impl Assembler
                 match intervals[*idx].assigned.get().unwrap() {
                     Allocation::Reg(n) => {
                         if let Opnd::Mem(mem) = opnd {
-                            mem.base = MemBase::Reg(regs[n].reg_no);
+                            mem.base = MemBase::Reg(regs.reg_at(n).reg_no);
                         }
                     }
                     Allocation::Stack(n) => {
@@ -4263,6 +4306,12 @@ mod tests {
         Assembler::new_with_scratch_reg().1
     }
 
+    fn alloc_reg_pool(num_allocatable: usize) -> RegPool {
+        let regs = crate::backend::current::ALLOC_REGS.to_vec();
+        let num_allocatable = num_allocatable.min(regs.len());
+        RegPool::with_allocatable(regs, num_allocatable)
+    }
+
     #[test]
     fn test_size_of_insn() {
         // PatchPoint (PatchPointData), CCall (CCallData), and Target (Block/SideExit
@@ -4770,10 +4819,9 @@ mod tests {
 
         println!("LIR live_intervals:\n{}", crate::backend::lir::debug_intervals(&asm, &intervals));
 
-        let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
-        let allocatable_regs = regs.len();
+        let mut regs = alloc_reg_pool(5);
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        let num_stack_slots = asm.linear_scan(&intervals, 5.min(allocatable_regs), &regs);
+        let num_stack_slots = asm.linear_scan(&intervals, &regs);
 
         // Extract vreg indices
         let r10_idx = if let Opnd::VReg { idx, .. } = r10 { idx } else { panic!() };
@@ -4810,10 +4858,9 @@ mod tests {
         let mut intervals = asm.build_intervals(live_in);
 
         // 3 registers -- enough for every interval once holes are reused
-        let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
-        let allocatable_regs = regs.len();
+        let mut regs = alloc_reg_pool(3);
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        let num_stack_slots = asm.linear_scan(&intervals, 3.min(allocatable_regs), &regs);
+        let num_stack_slots = asm.linear_scan(&intervals, &regs);
 
         let r10_idx = if let Opnd::VReg { idx, .. } = r10 { idx } else { panic!() };
         let r11_idx = if let Opnd::VReg { idx, .. } = r11 { idx } else { panic!() };
@@ -4842,10 +4889,9 @@ mod tests {
         let mut intervals = asm.build_intervals(live_in);
 
         // Only 1 register available -- forces spills
-        let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
-        let allocatable_regs = regs.len();
+        let mut regs = alloc_reg_pool(1);
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        let num_stack_slots = asm.linear_scan(&intervals, 1.min(allocatable_regs), &regs);
+        let num_stack_slots = asm.linear_scan(&intervals, &regs);
 
         let r10_idx = if let Opnd::VReg { idx, .. } = r10 { idx } else { panic!() };
         let r11_idx = if let Opnd::VReg { idx, .. } = r11 { idx } else { panic!() };
@@ -4879,19 +4925,19 @@ mod tests {
         asm.number_instructions(0);
         let live_in = asm.analyze_liveness();
         let mut intervals = asm.build_intervals(live_in);
-        let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
+        // Zero allocatable registers: the only register this interval can get
+        // is the pinned one appended to the pool, so the preference is what
+        // makes this succeed rather than spill.
+        let mut regs = alloc_reg_pool(0);
         asm.preferred_register_assignments(&mut intervals, &mut regs);
 
         let vreg_idx = new_sp.vreg_idx();
         let Some(Allocation::Reg(regno)) = intervals[vreg_idx].preferred else {
             panic!("expected a preferred register for v{vreg_idx}");
         };
-        assert_eq!(regs[regno], sp.unwrap_reg());
+        assert_eq!(regs.reg_at(regno), sp.unwrap_reg());
 
-        // Zero allocatable registers: the only register this interval can get
-        // is the pinned one appended to the pool, so the preference is what
-        // makes this succeed rather than spill.
-        let num_stack_slots = asm.linear_scan(&intervals, 0, &regs);
+        let num_stack_slots = asm.linear_scan(&intervals, &regs);
         assert_eq!(num_stack_slots, 0);
         assert_eq!(intervals[vreg_idx].assigned.get(), Some(Allocation::Reg(regno)));
         assert_eq!(intervals[vreg_idx].assigned.get().unwrap().assigned_reg(&regs), Some(sp.unwrap_reg()));
@@ -4923,10 +4969,9 @@ mod tests {
         let live_in = asm.analyze_liveness();
         asm.number_instructions(16);
         let mut intervals = asm.build_intervals(live_in);
-        let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
-        let allocatable_regs = regs.len();
+        let mut regs = alloc_reg_pool(5);
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        asm.linear_scan(&intervals, 5.min(allocatable_regs), &regs);
+        asm.linear_scan(&intervals, &regs);
 
         asm.resolve_ssa(&intervals, &regs);
 
@@ -4969,10 +5014,9 @@ mod tests {
         let live_in = asm.analyze_liveness();
         asm.number_instructions(16);
         let mut intervals = asm.build_intervals(live_in);
-        let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
-        let allocatable_regs = regs.len();
+        let mut regs = alloc_reg_pool(5);
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        asm.linear_scan(&intervals, 5.min(allocatable_regs), &regs);
+        asm.linear_scan(&intervals, &regs);
 
         // Entry block b1 has parameters [v0, v1].
         // With 5 registers: v0 -> Reg(0) = regs[0], arrival = C_ARG_OPNDS[0] = regs[0] -> self-move, filtered
@@ -5018,10 +5062,9 @@ mod tests {
         let live_in = asm.analyze_liveness();
         asm.number_instructions(0);
         let mut intervals = asm.build_intervals(live_in);
-        let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
-        let allocatable_regs = regs.len();
+        let mut regs = alloc_reg_pool(5);
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        asm.linear_scan(&intervals, 5.min(allocatable_regs), &regs);
+        asm.linear_scan(&intervals, &regs);
 
         asm.resolve_ssa(&intervals, &regs);
 
@@ -5078,11 +5121,9 @@ mod tests {
         let live_in = asm.analyze_liveness();
         asm.number_instructions(16);
         let mut intervals = asm.build_intervals(live_in);
-        let num_regs = 5;
-        let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
-        let allocatable_regs = regs.len();
+        let mut regs = alloc_reg_pool(5);
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        asm.linear_scan(&intervals, num_regs.min(allocatable_regs), &regs);
+        asm.linear_scan(&intervals, &regs);
 
         assert_eq!(asm.basic_blocks.len(), 3);
 
@@ -5185,10 +5226,9 @@ mod tests {
         asm.number_instructions(0);
         let mut intervals = asm.build_intervals(live_in);
         let num_regs = 2;
-        let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
-        let allocatable_regs = regs.len();
+        let mut regs = alloc_reg_pool(num_regs);
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        let num_stack_slots = asm.linear_scan(&intervals, num_regs.min(allocatable_regs), &regs);
+        let num_stack_slots = asm.linear_scan(&intervals, &regs);
         asm.stack_state.num_spill_slots = num_stack_slots;
 
         // Stand in for the C calling convention's argument registers. These

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -1,5 +1,5 @@
 use std::cell::RefCell;
-use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::fmt;
 use std::mem::take;
 use std::rc::Rc;
@@ -1394,7 +1394,7 @@ impl LiveRange {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub enum State {
     Unhandled,
     Active,
@@ -1432,11 +1432,38 @@ impl Interval {
         self.ranges.last().unwrap().to
     }
 
+    pub fn next_intersection(&self, other: &Interval) -> Option<usize> {
+        let (mut i, mut j) = (0, 0);
+
+        // Both range lists are sorted and disjoint, so advancing whichever
+        // range ends first can never skip past an overlap. That makes the
+        // first overlap found the earliest one.
+        while let (Some(a), Some(b)) = (self.ranges.get(i), other.ranges.get(j)) {
+            let lo = a.from.max(b.from);
+            if lo < a.to.min(b.to) {
+                return Some(lo);
+            }
+            if a.to < b.to { i += 1; } else { j += 1; }
+        }
+
+        None
+    }
+
+    pub fn ends_before(&self, pos: usize) -> bool {
+        self.end() <= pos
+    }
+
     /// Check if the interval is alive at position
     /// Panics if the range is not set
     pub fn survives(&self, position: usize) -> bool {
         assert!(self.ranges.len() > 0, "survives called on interval with no range");
         self.ranges.iter().any(|range| range.from < position && position < range.to)
+    }
+
+    /// Returns true if position falls inside one of the ranges in this
+    /// interval.
+    pub fn covers(&self, position: usize) -> bool {
+        self.ranges.iter().any(|range| range.from <= position && position < range.to)
     }
 
     pub fn born_at(&self, x: usize) -> bool {
@@ -2144,42 +2171,26 @@ impl Assembler
         }
     }
 
-    fn release_assignment(it: &Interval, num_registers: usize, regs: &[Reg], free_registers: &mut BTreeSet<usize>) {
-        if let Some(allocation) = it.assigned {
-            if let Some(reg) = allocation.alloc_pool_index(num_registers) {
-                let was_not_there_before = free_registers.insert(reg);
-                assert!(
-                    was_not_there_before,
-                    "attempted to return allocator register {:?} to the free pool more than once",
-                    allocation.assigned_reg(regs).unwrap(),
-                );
-            } else {
-                assert!(
-                    allocation.assigned_reg(regs).is_none_or(|reg| {
-                        regs.iter()
-                            .take(num_registers)
-                            .all(|candidate| candidate.reg_no != reg.reg_no)
-                    }),
-                    "attempted to return non-allocatable register {:?} to the allocator pool",
-                    allocation.assigned_reg(regs).unwrap(),
-                );
-            }
-        }
-    }
-
     // TODO: We want to make the following refactoring so that we DON'T have
     // to parcopy in to entry blocks
     //
     // * Pre-allocate pinned regs
     // * Update linear scan to handle pinned LRs
     //
+    // num_registers is the number of allocatable registers.  `regs` is a
+    // list of _all_ registers partitioned by allocatable and non-allocatable.
+    // The registers in `regs` from 0 to num_registers is allocatable,
+    // num_registers to the end are only allocatable via "preferred" register
+    // support.
     pub fn linear_scan(
         &self,
         intervals: Vec<Interval>,
-        num_registers: usize,
-        regs: &[Reg],
+        num_registers: usize, // number of allocatable regs
+        regs: &[Reg],         // list of all registers used, partitioned by allocatability
     ) -> (Vec<Option<Allocation>>, usize) {
-        let mut free_registers: BTreeSet<usize> = (0..num_registers).collect();
+        debug_assert!(num_registers <= regs.len());
+
+        let mut free_registers: Vec<usize> = vec![0; regs.len()];
         let mut active: Vec<Interval> = Vec::new(); // sorted by increasing end point
         let mut inactive: Vec<Interval> = Vec::new(); // intervals with lifetime holes
         let mut num_stack_slots: usize = 0;
@@ -2194,46 +2205,100 @@ impl Assembler
         let mut unhandled: VecDeque<Interval> = sorted_intervals.into();
 
         while let Some(mut interval) = unhandled.pop_front() {
+            let position = interval.start();
+
             // Expire old intervals.
             for mut it in std::mem::take(&mut active) {
-                if it.end() > interval.start() {
-                    active.push(it);
-                } else {
-                    Self::release_assignment(&it, num_registers, regs, &mut free_registers);
+                assert!(it.state == State::Active);
+                // If the interval ends before the current position, then we're
+                // done with it and can mark it handled.
+                if it.ends_before(position) {
                     it.state = State::Handled;
                     handled.push(it);
+                } else if !it.covers(position) {
+                    // If it doesn't cover the current position (there's a hole
+                    // in the ranges), then move it to inactive
+                    it.state = State::Inactive;
+                    inactive.push(it);
+                } else {
+                    // Otherwise it's still live here and stays active.
+                    active.push(it);
                 }
             }
 
-            let preferred_alloc = interval.preferred;
-            let preferred_taken = preferred_alloc
-                .is_some_and(|alloc|
-                    active.iter().any(|active_interval| active_interval.assigned == Some(alloc))
-                );
+            // Check for intervals in inactive that are handled or active
+            for mut it in std::mem::take(&mut inactive) {
+                assert!(it.state == State::Inactive);
+                // If the inactive interval ends before the current position
+                if it.ends_before(position) {
+                    // Move it to handled
+                    it.state = State::Handled;
+                    handled.push(it);
 
-            if let Some(preferred_alloc) = preferred_alloc.filter(|_| !preferred_taken) {
-                if let Some(reg_idx) = preferred_alloc.alloc_pool_index(num_registers) {
-                    if free_registers.remove(&reg_idx) {
-                        interval.assigned = Some(preferred_alloc);
-                        let insert_idx = active.partition_point(|i| i.end() < interval.end());
-                        active.insert(insert_idx, interval);
-                        continue;
-                    }
+                } else if it.covers(position) {
+                    // If the current position falls inside one of the
+                    // interval's ranges, then make it active
+                    it.state = State::Active;
+                    active.push(it);
                 } else {
-                    interval.assigned = Some(preferred_alloc);
+                    // It's still inactive
+                    inactive.push(it);
+                }
+            }
+
+            // Mark all registers as "free".  In other words, they aren't
+            // in use until instruction number usize::MAX.
+            free_registers.fill(usize::MAX);
+
+            // Mark all active intervals with assignments as "unavailable".  They are available
+            // again at instruction 0 which effectively means they can't be used (as all
+            // intervals will end after 0)
+            for it in &active {
+                debug_assert!(it.state == State::Active);
+                match it.assigned.expect("should have assignment") {
+                    Allocation::Reg(idx) => free_registers[idx] = 0,
+                    _ => {},
+                }
+            }
+
+            // Inactive intervals are intervals that have gaps in them, and
+            // we're currently inside one of those gaps.  We'll mark in the
+            // "free_registers" list when each interval will want to use its
+            // assigned reg again.
+            for it in &inactive {
+                debug_assert!(it.state == State::Inactive);
+                let Some(pos) = it.next_intersection(&interval) else { continue };
+                match it.assigned.expect("should have assignment") {
+                    Allocation::Reg(idx) => free_registers[idx] = free_registers[idx].min(pos),
+                    _ => {},
+                }
+            }
+
+            // If the current interval has a preferred allocation, use it if
+            // that register is available until the interval end.
+            if let Some(Allocation::Reg(idx)) = interval.preferred {
+                if free_registers[idx] >= interval.end() {
+                    interval.assigned = Some(Allocation::Reg(idx));
+                    interval.state = State::Active;
                     let insert_idx = active.partition_point(|i| i.end() < interval.end());
                     active.insert(insert_idx, interval);
                     continue;
                 }
             }
 
-            if free_registers.is_empty() {
+            // Find a reg with the highest "free until use" point, then check if that "free until
+            // use" point is greater than or eq to than the current interval's end.  If it is, then
+            // we know the current interval can fit in the window this register is available.
+            let best_reg = (0..num_registers).rev()
+                .max_by_key(|&reg| free_registers[reg])
+                .filter(|&reg| free_registers[reg] >= interval.end());
+
+            // We couldn't find a best register, so we need to spill
+            if best_reg.is_none() {
                 // Spill: pick the longest-lived active interval (last in sorted active)
                 // but only from the allocatable partition of the pool. An index
                 // at or past `num_registers` is a pinned physical register (for
                 // example SP), which is not ours to hand to someone else.
-                // Take the id and end point rather than a reference, so that `active`
-                // can be mutated below.
                 let spill = active.iter().rev()
                     .find(|active_interval| {
                         active_interval.assigned
@@ -2249,28 +2314,38 @@ impl Assembler
                     let mut spilled = active.remove(spill_idx);
                     interval.assigned = spilled.assigned;
                     spilled.assigned = Some(slot);
+                    spilled.state = State::Handled;
                     handled.push(spilled);
                     // Insert current into sorted active
                     let insert_idx = active.partition_point(|i| i.end() < interval.end());
+                    interval.state = State::Active;
                     active.insert(insert_idx, interval);
                 } else {
                     // Spill the current interval
                     interval.assigned = Some(slot);
+                    interval.state = State::Handled;
                     handled.push(interval);
                 }
             } else {
-                // Allocate lowest free register
-                let reg = *free_registers.iter().min().unwrap();
-                free_registers.remove(&reg);
+                let reg = best_reg.unwrap();
                 interval.assigned = Some(Allocation::Reg(reg));
+                interval.state = State::Active;
                 // Insert into sorted active
                 let insert_idx = active.partition_point(|i| i.end() < interval.end());
                 active.insert(insert_idx, interval);
             }
         }
 
+        // Drain active and inactive and mark everything as handled.
+        for mut it in active.drain(..).chain(inactive.drain(..)) {
+            it.state = State::Handled;
+            handled.push(it);
+        }
+        debug_assert!(active.is_empty() && inactive.is_empty());
+
         let mut assignment: Vec<Option<Allocation>> = vec![None; num_intervals];
-        for it in active.into_iter().chain(handled) {
+        for it in handled {
+            debug_assert!(it.state == State::Handled);
             assignment[it.id] = it.assigned;
         }
 
@@ -3362,7 +3437,7 @@ pub fn lir_intervals_string(asm: &Assembler, intervals: &[Interval]) -> String {
                 }
                 output.push_str(&format!("{param}"));
             }
-            output.push_str("):\n");
+            output.push_str("):\n"); // :)
         }
 
         for (insn, insn_id) in block.insns.iter().zip(&block.insn_ids) {
@@ -3381,7 +3456,7 @@ pub fn lir_intervals_string(asm: &Assembler, intervals: &[Interval]) -> String {
                         output.push_str("  v ");
                     } else if interval.dies_at(insn_id.0) {
                         output.push_str("  ^ ");
-                    } else if interval.survives(insn_id.0) {
+                    } else if interval.covers(insn_id.0) {
                         output.push_str("  █ ");
                     } else {
                         output.push_str("  . ");
@@ -4708,7 +4783,7 @@ mod tests {
         assert_eq!(assignments[r11_idx], Some(Allocation::Reg(1)));
         assert_eq!(assignments[r12_idx], Some(Allocation::Reg(1)));
         assert_eq!(assignments[r13_idx], Some(Allocation::Reg(2)));
-        assert_eq!(assignments[r14_idx], Some(Allocation::Reg(3)));
+        assert_eq!(assignments[r14_idx], Some(Allocation::Reg(1)));
         assert_eq!(assignments[r15_idx], Some(Allocation::Reg(2)));
     }
 
@@ -4720,7 +4795,7 @@ mod tests {
         asm.number_instructions(16);
         let mut intervals = asm.build_intervals(live_in);
 
-        // 3 registers -- only r10 needs to spill
+        // 3 registers -- enough for every interval once holes are reused
         let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
         let allocatable_regs = regs.len();
         asm.preferred_register_assignments(&mut intervals, &mut regs);
@@ -4733,12 +4808,14 @@ mod tests {
         let r14_idx = if let Opnd::VReg { idx, .. } = r14 { idx } else { panic!() };
         let r15_idx = if let Opnd::VReg { idx, .. } = r15 { idx } else { panic!() };
 
-        assert_eq!(num_stack_slots, 1);
-        assert_eq!(assignments[r10_idx], Some(Allocation::Stack(0)));
+        // Lifetime holes make three registers enough: nothing spills, and the
+        // assignment is the same one five registers produce.
+        assert_eq!(num_stack_slots, 0);
+        assert_eq!(assignments[r10_idx], Some(Allocation::Reg(0)));
         assert_eq!(assignments[r11_idx], Some(Allocation::Reg(1)));
         assert_eq!(assignments[r12_idx], Some(Allocation::Reg(1)));
         assert_eq!(assignments[r13_idx], Some(Allocation::Reg(2)));
-        assert_eq!(assignments[r14_idx], Some(Allocation::Reg(0)));
+        assert_eq!(assignments[r14_idx], Some(Allocation::Reg(1)));
         assert_eq!(assignments[r15_idx], Some(Allocation::Reg(2)));
     }
 
@@ -4855,20 +4932,18 @@ mod tests {
             if *dest == Opnd::Reg(regs[1]) && *src == Opnd::UImm(1)));
 
         // Edge b3->b2 (single succ): args=[v4, v5], params=[v2, v3]
-        // v4->Reg(3), v5->Reg(2), v2->Reg(1), v3->Reg(2)
-        // Reg copy: Reg(3)->Reg(1) -> Mov(regs[1], regs[3])
-        // Reg(2)->Reg(2) is self-move, filtered
-        // Inserted in b3 before Jmp: [Label, Mul, Sub, Mov, Jmp]
+        // v4->Reg(1), v5->Reg(2), v2->Reg(1), v3->Reg(2)
+        // Reg(1)->Reg(1) and Reg(2)->Reg(2) are both self-moves, filtered, so
+        // this edge needs no moves at all: [Label, Mul, Sub, Jmp]
         let b3_insns = &asm.basic_blocks[b3.0].insns;
-        assert_eq!(b3_insns.len(), 5);
-        assert!(matches!(&b3_insns[3], Insn::Mov { dest, src }
-            if *dest == Opnd::Reg(regs[1]) && *src == Opnd::Reg(regs[3])));
+        assert_eq!(b3_insns.len(), 4);
+        assert!(matches!(&b3_insns[3], Insn::Jmp(..)));
 
         // Verify original instructions in b3 are rewritten to physical registers.
         // b3: Mul { left: r12, right: r13, out: r14 }, Sub { left: r13, right: UImm(1), out: r15 }
-        // r12->Reg(1), r13->Reg(2), r14->Reg(3), r15->Reg(2)
+        // r12->Reg(1), r13->Reg(2), r14->Reg(1), r15->Reg(2)
         assert!(matches!(&b3_insns[1], Insn::Mul { left, right, out }
-            if *left == Opnd::Reg(regs[1]) && *right == Opnd::Reg(regs[2]) && *out == Opnd::Reg(regs[3])));
+            if *left == Opnd::Reg(regs[1]) && *right == Opnd::Reg(regs[2]) && *out == Opnd::Reg(regs[1])));
         assert!(matches!(&b3_insns[2], Insn::Sub { left, right, out }
             if *left == Opnd::Reg(regs[2]) && *right == Opnd::UImm(1) && *out == Opnd::Reg(regs[2])));
     }

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -1,4 +1,4 @@
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::fmt;
 use std::mem::take;
@@ -1375,7 +1375,7 @@ impl LiveRange {
     }
 }
 
-#[derive(PartialEq)]
+#[derive(Clone, Copy, PartialEq)]
 pub enum State {
     Unhandled,
     Active,
@@ -1387,8 +1387,8 @@ pub enum State {
 pub struct Interval {
     pub ranges: Vec<LiveRange>,
     pub id: VRegId,
-    pub state: State,
-    pub assigned: Option<Allocation>,
+    pub state: Cell<State>,
+    pub assigned: Cell<Option<Allocation>>,
     pub preferred: Option<Allocation>,
 }
 
@@ -1398,8 +1398,8 @@ impl Interval {
         Self {
             ranges: vec![],
             id: i,
-            state: State::Unhandled,
-            assigned: None,
+            state: Cell::new(State::Unhandled),
+            assigned: Cell::new(None),
             preferred: None,
         }
     }
@@ -2180,43 +2180,43 @@ impl Assembler
     // for the spills.
     pub fn linear_scan(
         &self,
-        intervals: &mut [Interval],
+        intervals: &[Interval],
         num_registers: usize, // number of allocatable regs
         regs: &[Reg],         // list of all registers used, partitioned by allocatability
     ) -> usize {
         debug_assert!(num_registers <= regs.len());
 
-        // `active`, `inactive`, and `unhandled` hold indexes in to `intervals`.
-        // An interval's index is its VRegId, and it is the only identity we
-        // need: the interval data itself is mutated in place.
+        // `active`, `inactive`, and `unhandled` borrow the intervals they hold.
+        // Allocation results are written through the Cell fields, so a shared
+        // reference is all the identity and access this needs.
         let mut free_registers: Vec<usize> = vec![0; regs.len()];
-        let mut active: Vec<usize> = Vec::new(); // sorted by increasing end point
-        let mut inactive: Vec<usize> = Vec::new(); // intervals with lifetime holes
+        let mut active: Vec<&Interval> = Vec::new(); // sorted by increasing end point
+        let mut inactive: Vec<&Interval> = Vec::new(); // intervals with lifetime holes
         let mut num_stack_slots: usize = 0;
 
-        let mut sorted_intervals: Vec<usize> = (0..intervals.len())
-            .filter(|&i| intervals[i].has_bounds())
+        let mut sorted_intervals: Vec<&Interval> = intervals.iter()
+            .filter(|it| it.has_bounds())
             .collect();
-        sorted_intervals.sort_by_key(|&i| intervals[i].start());
+        sorted_intervals.sort_by_key(|it| it.start());
 
-        let mut unhandled: VecDeque<usize> = sorted_intervals.into();
+        let mut unhandled: VecDeque<&Interval> = sorted_intervals.into();
 
         while let Some(cur) = unhandled.pop_front() {
-            let position = intervals[cur].start();
-            let cur_end = intervals[cur].end();
+            let position = cur.start();
+            let cur_end = cur.end();
 
             // Expire old intervals.
             active.retain(|&it| {
-                debug_assert!(intervals[it].state == State::Active);
+                debug_assert!(it.state.get() == State::Active);
                 // If the interval ends before the current position, then we're
                 // done with it and can mark it handled.
-                if intervals[it].ends_before(position) {
-                    intervals[it].state = State::Handled;
+                if it.ends_before(position) {
+                    it.state.set(State::Handled);
                     false
-                } else if !intervals[it].covers(position) {
+                } else if !it.covers(position) {
                     // If it doesn't cover the current position (there's a hole
                     // in the ranges), then move it to inactive
-                    intervals[it].state = State::Inactive;
+                    it.state.set(State::Inactive);
                     inactive.push(it);
                     false
                 } else {
@@ -2227,16 +2227,16 @@ impl Assembler
 
             // Check for intervals in inactive that are handled or active
             inactive.retain(|&it| {
-                debug_assert!(intervals[it].state == State::Inactive);
+                debug_assert!(it.state.get() == State::Inactive);
                 // If the inactive interval ends before the current position
-                if intervals[it].ends_before(position) {
+                if it.ends_before(position) {
                     // Move it to handled
-                    intervals[it].state = State::Handled;
+                    it.state.set(State::Handled);
                     false
-                } else if intervals[it].covers(position) {
+                } else if it.covers(position) {
                     // If the current position falls inside one of the
                     // interval's ranges, then make it active
-                    intervals[it].state = State::Active;
+                    it.state.set(State::Active);
                     active.push(it);
                     false
                 } else {
@@ -2256,9 +2256,9 @@ impl Assembler
             // the interval's end is _less than_ the value in the free_register list)
             // All registers have an end that is greater than 0, so they will
             // not pick any registers used by intervals in the active list.
-            for &it in &active {
-                debug_assert!(intervals[it].state == State::Active);
-                match intervals[it].assigned.expect("should have assignment") {
+            for it in &active {
+                debug_assert!(it.state.get() == State::Active);
+                match it.assigned.get().expect("should have assignment") {
                     Allocation::Reg(idx) => free_registers[idx] = 0,
                     _ => {},
                 }
@@ -2268,10 +2268,10 @@ impl Assembler
             // we're currently inside one of those gaps.  We'll mark in the
             // "free_registers" list when each interval will want to use its
             // assigned reg again.
-            for &it in &inactive {
-                debug_assert!(intervals[it].state == State::Inactive);
-                let Some(pos) = intervals[it].next_intersection(&intervals[cur]) else { continue };
-                match intervals[it].assigned.expect("should have assignment") {
+            for it in &inactive {
+                debug_assert!(it.state.get() == State::Inactive);
+                let Some(pos) = it.next_intersection(cur) else { continue };
+                match it.assigned.get().expect("should have assignment") {
                     Allocation::Reg(idx) => free_registers[idx] = free_registers[idx].min(pos),
                     _ => {},
                 }
@@ -2279,11 +2279,11 @@ impl Assembler
 
             // If the current interval has a preferred allocation, use it if
             // that register is available until the interval end.
-            if let Some(Allocation::Reg(idx)) = intervals[cur].preferred {
+            if let Some(Allocation::Reg(idx)) = cur.preferred {
                 if free_registers[idx] >= cur_end {
-                    intervals[cur].assigned = Some(Allocation::Reg(idx));
-                    intervals[cur].state = State::Active;
-                    let insert_idx = active.partition_point(|&i| intervals[i].end() < cur_end);
+                    cur.assigned.set(Some(Allocation::Reg(idx)));
+                    cur.state.set(State::Active);
+                    let insert_idx = active.partition_point(|it| it.end() < cur_end);
                     active.insert(insert_idx, cur);
                     continue;
                 }
@@ -2303,40 +2303,37 @@ impl Assembler
                     // but only from the allocatable partition of the pool. An index
                     // at or past `num_registers` is a pinned physical register (for
                     // example SP), which is not ours to hand to someone else.
-                    let spill = active.iter().rev().copied()
-                        .find(|&it| {
-                            intervals[it].assigned
-                                .is_some_and(|alloc| alloc.alloc_pool_index(num_registers).is_some())
-                        })
-                        .map(|it| (it, intervals[it].end()));
+                    let spill_idx = active.iter().rposition(|it| {
+                        it.assigned.get()
+                            .is_some_and(|alloc| alloc.alloc_pool_index(num_registers).is_some())
+                    });
                     let slot = Allocation::Stack(num_stack_slots);
                     num_stack_slots += 1;
 
-                    if let Some((spill_it, _)) = spill.filter(|&(_, spill_end)| spill_end > cur_end) {
-                        // Spill the last active interval; give its register to current
-                        let spill_idx = active.iter().position(|&i| i == spill_it).unwrap();
-                        active.remove(spill_idx);
-                        // Read the stolen allocation in to a local: reading and
-                        // writing `intervals` in one statement won't borrow check.
-                        let stolen = intervals[spill_it].assigned;
-                        intervals[spill_it].assigned = Some(slot);
-                        intervals[spill_it].state = State::Handled;
-                        intervals[cur].assigned = stolen;
-                        intervals[cur].state = State::Active;
-                        // Insert current into sorted active
-                        let insert_idx = active.partition_point(|&i| intervals[i].end() < cur_end);
-                        active.insert(insert_idx, cur);
-                    } else {
-                        // Spill the current interval
-                        intervals[cur].assigned = Some(slot);
-                        intervals[cur].state = State::Handled;
+                    match spill_idx.filter(|&idx| active[idx].end() > cur_end) {
+                        Some(spill_idx) => {
+                            // Spill the last active interval; give its register to current
+                            let spilled = active.remove(spill_idx);
+                            cur.assigned.set(spilled.assigned.get());
+                            cur.state.set(State::Active);
+                            spilled.assigned.set(Some(slot));
+                            spilled.state.set(State::Handled);
+                            // Insert current into sorted active
+                            let insert_idx = active.partition_point(|it| it.end() < cur_end);
+                            active.insert(insert_idx, cur);
+                        }
+                        None => {
+                            // Spill the current interval
+                            cur.assigned.set(Some(slot));
+                            cur.state.set(State::Handled);
+                        }
                     }
                 }
                 Some(reg) => {
-                    intervals[cur].assigned = Some(Allocation::Reg(reg));
-                    intervals[cur].state = State::Active;
+                    cur.assigned.set(Some(Allocation::Reg(reg)));
+                    cur.state.set(State::Active);
                     // Insert into sorted active
-                    let insert_idx = active.partition_point(|&i| intervals[i].end() < cur_end);
+                    let insert_idx = active.partition_point(|it| it.end() < cur_end);
                     active.insert(insert_idx, cur);
                 }
             }
@@ -2344,7 +2341,7 @@ impl Assembler
 
         // Drain active and inactive and mark everything as handled.
         for it in active.drain(..).chain(inactive.drain(..)) {
-            intervals[it].state = State::Handled;
+            it.state.set(State::Handled);
         }
         debug_assert!(active.is_empty() && inactive.is_empty());
 
@@ -2389,7 +2386,7 @@ impl Assembler
                 let reg_copies: Vec<parcopy::RegisterCopy<Opnd>> = edge.args
                     .iter()
                     .zip(params.iter())
-                    .filter(|(_arg, param)| intervals[param.vreg_idx()].assigned.is_some() )
+                    .filter(|(_arg, param)| intervals[param.vreg_idx()].assigned.get().is_some() )
                     .map(|(arg, param)| parcopy::RegisterCopy::<Opnd> {
                         destination: Self::rewritten_opnd(*param, intervals, regs),
                         source: Self::rewritten_opnd(*arg, intervals, regs),
@@ -2585,14 +2582,14 @@ impl Assembler
                             let survives_call = interval.has_bounds() && interval.survives(insn_number);
                             // 2) The VReg is referenced by the stack map for the CCall
                             let stack_map_reg = stack_vreg_ids.contains(&interval.id);
-                            let is_register = interval.assigned.and_then(|alloc| alloc.alloc_pool_index(ALLOC_REGS.len())).is_some();
+                            let is_register = interval.assigned.get().and_then(|alloc| alloc.alloc_pool_index(ALLOC_REGS.len())).is_some();
                             is_register && (survives_call || stack_map_reg)
                         })
                         .map(|interval| interval.id)
                         .collect();
 
                     let survivor_regs: Vec<Opnd> = survivors.iter()
-                        .map(|&s| Opnd::Reg(intervals[s].assigned.unwrap().assigned_reg(alloc_regs).unwrap()))
+                        .map(|&s| Opnd::Reg(intervals[s].assigned.get().unwrap().assigned_reg(alloc_regs).unwrap()))
                         .collect();
 
                     // Push all survivors on the stack, pairing adjacent pushes when possible.
@@ -2626,7 +2623,7 @@ impl Assembler
                                     VALUE(encoded)
                                 }
                                 StackMapEntry::Opnd(Opnd::VReg { idx: vreg, .. }) => {
-                                    let vreg_stack_index = match intervals[vreg].assigned.expect("StackMap VReg should have an allocation") {
+                                    let vreg_stack_index = match intervals[vreg].assigned.get().expect("StackMap VReg should have an allocation") {
                                         Allocation::Reg(_) => {
                                             let caller_saved_reg_idx = survivors.iter().position(|&survivor_id| survivor_id == vreg).unwrap();
                                             let stack_idx = self.stack_state.stack_idx_for_caller_saved_reg(caller_saved_reg_idx);
@@ -2772,7 +2769,7 @@ impl Assembler
             StackMapEntry::Opnd(Opnd::UImm(value)) => !VALUE(*value as usize).special_const_p(),
             StackMapEntry::Opnd(Opnd::VReg { idx, .. }) => {
                 matches!(
-                    intervals[idx.to_usize()].assigned.expect("StackMap VReg should have an allocation"),
+                    intervals[idx.to_usize()].assigned.get().expect("StackMap VReg should have an allocation"),
                     Allocation::Reg(_)
                 )
             }
@@ -2804,7 +2801,7 @@ impl Assembler
     fn rewrite_opnd(opnd: &mut Opnd, intervals: &[Interval], regs: &[Reg]) {
         match opnd {
             Opnd::VReg { idx, num_bits } => {
-                if let Some(assignment) = intervals[*idx].assigned {
+                if let Some(assignment) = intervals[*idx].assigned.get() {
                     match assignment {
                         Allocation::Reg(n) => {
                             let mut reg = regs[n];
@@ -2825,7 +2822,7 @@ impl Assembler
                 }
             }
             Opnd::Mem(Mem { base: MemBase::VReg(idx), .. }) => {
-                match intervals[*idx].assigned.unwrap() {
+                match intervals[*idx].assigned.get().unwrap() {
                     Allocation::Reg(n) => {
                         if let Opnd::Mem(mem) = opnd {
                             mem.base = MemBase::Reg(regs[n].reg_no);
@@ -4753,7 +4750,7 @@ mod tests {
         let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
         let allocatable_regs = regs.len();
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        let num_stack_slots = asm.linear_scan(&mut intervals, 5.min(allocatable_regs), &regs);
+        let num_stack_slots = asm.linear_scan(&intervals, 5.min(allocatable_regs), &regs);
 
         // Extract vreg indices
         let r10_idx = if let Opnd::VReg { idx, .. } = r10 { idx } else { panic!() };
@@ -4773,12 +4770,12 @@ mod tests {
         // r13: [20,38) gets Reg(2)
         // r14: [36,42) gets Reg(1) (r12 expired, reuses its register)
         // r15: [38,42) gets Reg(2) (r13 expired, reuses its register)
-        assert_eq!(intervals[r10_idx].assigned, Some(Allocation::Reg(0)));
-        assert_eq!(intervals[r11_idx].assigned, Some(Allocation::Reg(1)));
-        assert_eq!(intervals[r12_idx].assigned, Some(Allocation::Reg(1)));
-        assert_eq!(intervals[r13_idx].assigned, Some(Allocation::Reg(2)));
-        assert_eq!(intervals[r14_idx].assigned, Some(Allocation::Reg(1)));
-        assert_eq!(intervals[r15_idx].assigned, Some(Allocation::Reg(2)));
+        assert_eq!(intervals[r10_idx].assigned.get(), Some(Allocation::Reg(0)));
+        assert_eq!(intervals[r11_idx].assigned.get(), Some(Allocation::Reg(1)));
+        assert_eq!(intervals[r12_idx].assigned.get(), Some(Allocation::Reg(1)));
+        assert_eq!(intervals[r13_idx].assigned.get(), Some(Allocation::Reg(2)));
+        assert_eq!(intervals[r14_idx].assigned.get(), Some(Allocation::Reg(1)));
+        assert_eq!(intervals[r15_idx].assigned.get(), Some(Allocation::Reg(2)));
     }
 
     #[test]
@@ -4793,7 +4790,7 @@ mod tests {
         let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
         let allocatable_regs = regs.len();
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        let num_stack_slots = asm.linear_scan(&mut intervals, 3.min(allocatable_regs), &regs);
+        let num_stack_slots = asm.linear_scan(&intervals, 3.min(allocatable_regs), &regs);
 
         let r10_idx = if let Opnd::VReg { idx, .. } = r10 { idx } else { panic!() };
         let r11_idx = if let Opnd::VReg { idx, .. } = r11 { idx } else { panic!() };
@@ -4805,12 +4802,12 @@ mod tests {
         // Lifetime holes make three registers enough: nothing spills, and the
         // assignment is the same one five registers produce.
         assert_eq!(num_stack_slots, 0);
-        assert_eq!(intervals[r10_idx].assigned, Some(Allocation::Reg(0)));
-        assert_eq!(intervals[r11_idx].assigned, Some(Allocation::Reg(1)));
-        assert_eq!(intervals[r12_idx].assigned, Some(Allocation::Reg(1)));
-        assert_eq!(intervals[r13_idx].assigned, Some(Allocation::Reg(2)));
-        assert_eq!(intervals[r14_idx].assigned, Some(Allocation::Reg(1)));
-        assert_eq!(intervals[r15_idx].assigned, Some(Allocation::Reg(2)));
+        assert_eq!(intervals[r10_idx].assigned.get(), Some(Allocation::Reg(0)));
+        assert_eq!(intervals[r11_idx].assigned.get(), Some(Allocation::Reg(1)));
+        assert_eq!(intervals[r12_idx].assigned.get(), Some(Allocation::Reg(1)));
+        assert_eq!(intervals[r13_idx].assigned.get(), Some(Allocation::Reg(2)));
+        assert_eq!(intervals[r14_idx].assigned.get(), Some(Allocation::Reg(1)));
+        assert_eq!(intervals[r15_idx].assigned.get(), Some(Allocation::Reg(2)));
     }
 
     #[test]
@@ -4825,7 +4822,7 @@ mod tests {
         let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
         let allocatable_regs = regs.len();
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        let num_stack_slots = asm.linear_scan(&mut intervals, 1.min(allocatable_regs), &regs);
+        let num_stack_slots = asm.linear_scan(&intervals, 1.min(allocatable_regs), &regs);
 
         let r10_idx = if let Opnd::VReg { idx, .. } = r10 { idx } else { panic!() };
         let r11_idx = if let Opnd::VReg { idx, .. } = r11 { idx } else { panic!() };
@@ -4835,12 +4832,12 @@ mod tests {
         let r15_idx = if let Opnd::VReg { idx, .. } = r15 { idx } else { panic!() };
 
         assert_eq!(num_stack_slots, 3);
-        assert_eq!(intervals[r10_idx].assigned, Some(Allocation::Stack(0)));
-        assert_eq!(intervals[r11_idx].assigned, Some(Allocation::Reg(0)));
-        assert_eq!(intervals[r12_idx].assigned, Some(Allocation::Stack(1)));
-        assert_eq!(intervals[r13_idx].assigned, Some(Allocation::Reg(0)));
-        assert_eq!(intervals[r14_idx].assigned, Some(Allocation::Stack(2)));
-        assert_eq!(intervals[r15_idx].assigned, Some(Allocation::Reg(0)));
+        assert_eq!(intervals[r10_idx].assigned.get(), Some(Allocation::Stack(0)));
+        assert_eq!(intervals[r11_idx].assigned.get(), Some(Allocation::Reg(0)));
+        assert_eq!(intervals[r12_idx].assigned.get(), Some(Allocation::Stack(1)));
+        assert_eq!(intervals[r13_idx].assigned.get(), Some(Allocation::Reg(0)));
+        assert_eq!(intervals[r14_idx].assigned.get(), Some(Allocation::Stack(2)));
+        assert_eq!(intervals[r15_idx].assigned.get(), Some(Allocation::Reg(0)));
     }
 
     #[test]
@@ -4871,10 +4868,10 @@ mod tests {
         // Zero allocatable registers: the only register this interval can get
         // is the pinned one appended to the pool, so the preference is what
         // makes this succeed rather than spill.
-        let num_stack_slots = asm.linear_scan(&mut intervals, 0, &regs);
+        let num_stack_slots = asm.linear_scan(&intervals, 0, &regs);
         assert_eq!(num_stack_slots, 0);
-        assert_eq!(intervals[vreg_idx].assigned, Some(Allocation::Reg(regno)));
-        assert_eq!(intervals[vreg_idx].assigned.unwrap().assigned_reg(&regs), Some(sp.unwrap_reg()));
+        assert_eq!(intervals[vreg_idx].assigned.get(), Some(Allocation::Reg(regno)));
+        assert_eq!(intervals[vreg_idx].assigned.get().unwrap().assigned_reg(&regs), Some(sp.unwrap_reg()));
     }
 
     #[test]
@@ -4906,7 +4903,7 @@ mod tests {
         let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
         let allocatable_regs = regs.len();
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        asm.linear_scan(&mut intervals, 5.min(allocatable_regs), &regs);
+        asm.linear_scan(&intervals, 5.min(allocatable_regs), &regs);
 
         asm.resolve_ssa(&intervals, &regs);
 
@@ -4952,7 +4949,7 @@ mod tests {
         let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
         let allocatable_regs = regs.len();
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        asm.linear_scan(&mut intervals, 5.min(allocatable_regs), &regs);
+        asm.linear_scan(&intervals, 5.min(allocatable_regs), &regs);
 
         // Entry block b1 has parameters [v0, v1].
         // With 5 registers: v0 -> Reg(0) = regs[0], arrival = C_ARG_OPNDS[0] = regs[0] -> self-move, filtered
@@ -5001,7 +4998,7 @@ mod tests {
         let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
         let allocatable_regs = regs.len();
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        asm.linear_scan(&mut intervals, 5.min(allocatable_regs), &regs);
+        asm.linear_scan(&intervals, 5.min(allocatable_regs), &regs);
 
         asm.resolve_ssa(&intervals, &regs);
 
@@ -5062,13 +5059,13 @@ mod tests {
         let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
         let allocatable_regs = regs.len();
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        asm.linear_scan(&mut intervals, num_regs.min(allocatable_regs), &regs);
+        asm.linear_scan(&intervals, num_regs.min(allocatable_regs), &regs);
 
         assert_eq!(asm.basic_blocks.len(), 3);
 
         // Verify v1 and v4 have different allocations (so moves are needed)
-        let v1_alloc = intervals[v1.vreg_idx()].assigned.unwrap();
-        let v4_alloc = intervals[v4.vreg_idx()].assigned.unwrap();
+        let v1_alloc = intervals[v1.vreg_idx()].assigned.get().unwrap();
+        let v4_alloc = intervals[v4.vreg_idx()].assigned.get().unwrap();
         assert_ne!(v1_alloc, v4_alloc, "Test setup: v1 and v4 should have different allocations");
 
         asm.resolve_ssa(&intervals, &regs);
@@ -5103,7 +5100,7 @@ mod tests {
         assert!(has_mov, "Expected Mov in split block for v1->v4");
 
         // b2->b3 is not a critical edge (b2 has single succ), so moves go before Jmp in b2
-        let v3_alloc = intervals[v3.vreg_idx()].assigned.unwrap();
+        let v3_alloc = intervals[v3.vreg_idx()].assigned.get().unwrap();
         let b2_insns = &asm.basic_blocks[b2.0].insns;
         if v3_alloc != v4_alloc {
             // Check that a Mov was inserted before the Jmp in b2
@@ -5168,7 +5165,7 @@ mod tests {
         let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
         let allocatable_regs = regs.len();
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        let num_stack_slots = asm.linear_scan(&mut intervals, num_regs.min(allocatable_regs), &regs);
+        let num_stack_slots = asm.linear_scan(&intervals, num_regs.min(allocatable_regs), &regs);
         asm.stack_state.num_spill_slots = num_stack_slots;
 
         // Stand in for the C calling convention's argument registers. These
@@ -5177,10 +5174,10 @@ mod tests {
         let c_arg_regs = &ALLOC_REGS[..num_regs];
 
         // v0 should be spilled (long-lived, only 2 regs)
-        assert!(matches!(intervals[v0.vreg_idx()].assigned, Some(Allocation::Stack(_))),
+        assert!(matches!(intervals[v0.vreg_idx()].assigned.get(), Some(Allocation::Stack(_))),
             "v0 should be spilled to stack");
         // v1 should be in a register
-        assert!(matches!(intervals[v1.vreg_idx()].assigned, Some(Allocation::Reg(_))),
+        assert!(matches!(intervals[v1.vreg_idx()].assigned.get(), Some(Allocation::Reg(_))),
             "v1 should be in a register");
 
         // Run the pipeline: handle_caller_saved_regs then resolve_ssa
@@ -5196,7 +5193,7 @@ mod tests {
         assert!(!pushes.is_empty(), "Expected at least one saved register across CCall");
 
         // The survivor register should match v1's allocation
-        let v1_reg = Opnd::Reg(intervals[v1.vreg_idx()].assigned.unwrap().assigned_reg(&regs).unwrap());
+        let v1_reg = Opnd::Reg(intervals[v1.vreg_idx()].assigned.get().unwrap().assigned_reg(&regs).unwrap());
         let pushed_v1 = pushes.iter().any(|insn| matches!(**insn, Insn::CPushPair(first, second) if first == v1_reg || second == v1_reg));
         let popped_v1 = pops.iter().any(|insn| matches!(**insn, Insn::CPopPairInto(first, second) if first == v1_reg || second == v1_reg));
         assert!(pushed_v1, "CPushPair should save v1's register");

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -1,5 +1,5 @@
 use std::cell::RefCell;
-use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::fmt;
 use std::mem::take;
 use std::rc::Rc;
@@ -1376,7 +1376,7 @@ impl LiveRange {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub enum State {
     Unhandled,
     Active,
@@ -1414,11 +1414,38 @@ impl Interval {
         self.ranges.last().unwrap().to
     }
 
+    pub fn next_intersection(&self, other: &Interval) -> Option<usize> {
+        let (mut i, mut j) = (0, 0);
+
+        // Both range lists are sorted and disjoint, so advancing whichever
+        // range ends first can never skip past an overlap. That makes the
+        // first overlap found the earliest one.
+        while let (Some(a), Some(b)) = (self.ranges.get(i), other.ranges.get(j)) {
+            let lo = a.from.max(b.from);
+            if lo < a.to.min(b.to) {
+                return Some(lo);
+            }
+            if a.to < b.to { i += 1; } else { j += 1; }
+        }
+
+        None
+    }
+
+    pub fn ends_before(&self, pos: usize) -> bool {
+        self.end() <= pos
+    }
+
     /// Check if the interval is alive at position
     /// Panics if the range is not set
     pub fn survives(&self, position: usize) -> bool {
         assert!(self.ranges.len() > 0, "survives called on interval with no range");
         self.ranges.iter().any(|range| range.from < position && position < range.to)
+    }
+
+    /// Returns true if position falls inside one of the ranges in this
+    /// interval.
+    pub fn covers(&self, position: usize) -> bool {
+        self.ranges.iter().any(|range| range.from <= position && position < range.to)
     }
 
     pub fn born_at(&self, x: usize) -> bool {
@@ -2130,42 +2157,26 @@ impl Assembler
         }
     }
 
-    fn release_assignment(it: &Interval, num_registers: usize, regs: &[Reg], free_registers: &mut BTreeSet<usize>) {
-        if let Some(allocation) = it.assigned {
-            if let Some(reg) = allocation.alloc_pool_index(num_registers) {
-                let was_not_there_before = free_registers.insert(reg);
-                assert!(
-                    was_not_there_before,
-                    "attempted to return allocator register {:?} to the free pool more than once",
-                    allocation.assigned_reg(regs).unwrap(),
-                );
-            } else {
-                assert!(
-                    allocation.assigned_reg(regs).is_none_or(|reg| {
-                        regs.iter()
-                            .take(num_registers)
-                            .all(|candidate| candidate.reg_no != reg.reg_no)
-                    }),
-                    "attempted to return non-allocatable register {:?} to the allocator pool",
-                    allocation.assigned_reg(regs).unwrap(),
-                );
-            }
-        }
-    }
-
     // TODO: We want to make the following refactoring so that we DON'T have
     // to parcopy in to entry blocks
     //
     // * Pre-allocate pinned regs
     // * Update linear scan to handle pinned LRs
     //
+    // num_registers is the number of allocatable registers.  `regs` is a
+    // list of _all_ registers partitioned by allocatable and non-allocatable.
+    // The registers in `regs` from 0 to num_registers is allocatable,
+    // num_registers to the end are only allocatable via "preferred" register
+    // support.
     pub fn linear_scan(
         &self,
         intervals: Vec<Interval>,
-        num_registers: usize,
-        regs: &[Reg],
+        num_registers: usize, // number of allocatable regs
+        regs: &[Reg],         // list of all registers used, partitioned by allocatability
     ) -> (Vec<Option<Allocation>>, usize) {
-        let mut free_registers: BTreeSet<usize> = (0..num_registers).collect();
+        debug_assert!(num_registers <= regs.len());
+
+        let mut free_registers: Vec<usize> = vec![0; regs.len()];
         let mut active: Vec<Interval> = Vec::new(); // sorted by increasing end point
         let mut inactive: Vec<Interval> = Vec::new(); // intervals with lifetime holes
         let mut num_stack_slots: usize = 0;
@@ -2180,46 +2191,100 @@ impl Assembler
         let mut unhandled: VecDeque<Interval> = sorted_intervals.into();
 
         while let Some(mut interval) = unhandled.pop_front() {
+            let position = interval.start();
+
             // Expire old intervals.
             for mut it in std::mem::take(&mut active) {
-                if it.end() > interval.start() {
-                    active.push(it);
-                } else {
-                    Self::release_assignment(&it, num_registers, regs, &mut free_registers);
+                assert!(it.state == State::Active);
+                // If the interval ends before the current position, then we're
+                // done with it and can mark it handled.
+                if it.ends_before(position) {
                     it.state = State::Handled;
                     handled.push(it);
+                } else if !it.covers(position) {
+                    // If it doesn't cover the current position (there's a hole
+                    // in the ranges), then move it to inactive
+                    it.state = State::Inactive;
+                    inactive.push(it);
+                } else {
+                    // Otherwise it's still live here and stays active.
+                    active.push(it);
                 }
             }
 
-            let preferred_alloc = interval.preferred;
-            let preferred_taken = preferred_alloc
-                .is_some_and(|alloc|
-                    active.iter().any(|active_interval| active_interval.assigned == Some(alloc))
-                );
+            // Check for intervals in inactive that are handled or active
+            for mut it in std::mem::take(&mut inactive) {
+                assert!(it.state == State::Inactive);
+                // If the inactive interval ends before the current position
+                if it.ends_before(position) {
+                    // Move it to handled
+                    it.state = State::Handled;
+                    handled.push(it);
 
-            if let Some(preferred_alloc) = preferred_alloc.filter(|_| !preferred_taken) {
-                if let Some(reg_idx) = preferred_alloc.alloc_pool_index(num_registers) {
-                    if free_registers.remove(&reg_idx) {
-                        interval.assigned = Some(preferred_alloc);
-                        let insert_idx = active.partition_point(|i| i.end() < interval.end());
-                        active.insert(insert_idx, interval);
-                        continue;
-                    }
+                } else if it.covers(position) {
+                    // If the current position falls inside one of the
+                    // interval's ranges, then make it active
+                    it.state = State::Active;
+                    active.push(it);
                 } else {
-                    interval.assigned = Some(preferred_alloc);
+                    // It's still inactive
+                    inactive.push(it);
+                }
+            }
+
+            // Mark all registers as "free".  In other words, they aren't
+            // in use until instruction number usize::MAX.
+            free_registers.fill(usize::MAX);
+
+            // Mark all active intervals with assignments as "unavailable".  They are available
+            // again at instruction 0 which effectively means they can't be used (as all
+            // intervals will end after 0)
+            for it in &active {
+                debug_assert!(it.state == State::Active);
+                match it.assigned.expect("should have assignment") {
+                    Allocation::Reg(idx) => free_registers[idx] = 0,
+                    _ => {},
+                }
+            }
+
+            // Inactive intervals are intervals that have gaps in them, and
+            // we're currently inside one of those gaps.  We'll mark in the
+            // "free_registers" list when each interval will want to use its
+            // assigned reg again.
+            for it in &inactive {
+                debug_assert!(it.state == State::Inactive);
+                let Some(pos) = it.next_intersection(&interval) else { continue };
+                match it.assigned.expect("should have assignment") {
+                    Allocation::Reg(idx) => free_registers[idx] = free_registers[idx].min(pos),
+                    _ => {},
+                }
+            }
+
+            // If the current interval has a preferred allocation, use it if
+            // that register is available until the interval end.
+            if let Some(Allocation::Reg(idx)) = interval.preferred {
+                if free_registers[idx] >= interval.end() {
+                    interval.assigned = Some(Allocation::Reg(idx));
+                    interval.state = State::Active;
                     let insert_idx = active.partition_point(|i| i.end() < interval.end());
                     active.insert(insert_idx, interval);
                     continue;
                 }
             }
 
-            if free_registers.is_empty() {
+            // Find a reg with the highest "free until use" point, then check if that "free until
+            // use" point is greater than or eq to than the current interval's end.  If it is, then
+            // we know the current interval can fit in the window this register is available.
+            let best_reg = (0..num_registers).rev()
+                .max_by_key(|&reg| free_registers[reg])
+                .filter(|&reg| free_registers[reg] >= interval.end());
+
+            // We couldn't find a best register, so we need to spill
+            if best_reg.is_none() {
                 // Spill: pick the longest-lived active interval (last in sorted active)
                 // but only from the allocatable partition of the pool. An index
                 // at or past `num_registers` is a pinned physical register (for
                 // example SP), which is not ours to hand to someone else.
-                // Take the id and end point rather than a reference, so that `active`
-                // can be mutated below.
                 let spill = active.iter().rev()
                     .find(|active_interval| {
                         active_interval.assigned
@@ -2235,28 +2300,38 @@ impl Assembler
                     let mut spilled = active.remove(spill_idx);
                     interval.assigned = spilled.assigned;
                     spilled.assigned = Some(slot);
+                    spilled.state = State::Handled;
                     handled.push(spilled);
                     // Insert current into sorted active
                     let insert_idx = active.partition_point(|i| i.end() < interval.end());
+                    interval.state = State::Active;
                     active.insert(insert_idx, interval);
                 } else {
                     // Spill the current interval
                     interval.assigned = Some(slot);
+                    interval.state = State::Handled;
                     handled.push(interval);
                 }
             } else {
-                // Allocate lowest free register
-                let reg = *free_registers.iter().min().unwrap();
-                free_registers.remove(&reg);
+                let reg = best_reg.unwrap();
                 interval.assigned = Some(Allocation::Reg(reg));
+                interval.state = State::Active;
                 // Insert into sorted active
                 let insert_idx = active.partition_point(|i| i.end() < interval.end());
                 active.insert(insert_idx, interval);
             }
         }
 
+        // Drain active and inactive and mark everything as handled.
+        for mut it in active.drain(..).chain(inactive.drain(..)) {
+            it.state = State::Handled;
+            handled.push(it);
+        }
+        debug_assert!(active.is_empty() && inactive.is_empty());
+
         let mut assignment: Vec<Option<Allocation>> = vec![None; num_intervals];
-        for it in active.into_iter().chain(handled) {
+        for it in handled {
+            debug_assert!(it.state == State::Handled);
             assignment[it.id] = it.assigned;
         }
 
@@ -3348,7 +3423,7 @@ pub fn lir_intervals_string(asm: &Assembler, intervals: &[Interval]) -> String {
                 }
                 output.push_str(&format!("{param}"));
             }
-            output.push_str("):\n");
+            output.push_str("):\n"); // :)
         }
 
         for (insn, insn_id) in block.insns.iter().zip(&block.insn_ids) {
@@ -3367,7 +3442,7 @@ pub fn lir_intervals_string(asm: &Assembler, intervals: &[Interval]) -> String {
                         output.push_str("  v ");
                     } else if interval.dies_at(insn_id.0) {
                         output.push_str("  ^ ");
-                    } else if interval.survives(insn_id.0) {
+                    } else if interval.covers(insn_id.0) {
                         output.push_str("  █ ");
                     } else {
                         output.push_str("  . ");
@@ -4690,7 +4765,7 @@ mod tests {
         assert_eq!(assignments[r11_idx], Some(Allocation::Reg(1)));
         assert_eq!(assignments[r12_idx], Some(Allocation::Reg(1)));
         assert_eq!(assignments[r13_idx], Some(Allocation::Reg(2)));
-        assert_eq!(assignments[r14_idx], Some(Allocation::Reg(3)));
+        assert_eq!(assignments[r14_idx], Some(Allocation::Reg(1)));
         assert_eq!(assignments[r15_idx], Some(Allocation::Reg(2)));
     }
 
@@ -4702,7 +4777,7 @@ mod tests {
         asm.number_instructions(16);
         let mut intervals = asm.build_intervals(live_in);
 
-        // 3 registers -- only r10 needs to spill
+        // 3 registers -- enough for every interval once holes are reused
         let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
         let allocatable_regs = regs.len();
         asm.preferred_register_assignments(&mut intervals, &mut regs);
@@ -4715,12 +4790,14 @@ mod tests {
         let r14_idx = if let Opnd::VReg { idx, .. } = r14 { idx } else { panic!() };
         let r15_idx = if let Opnd::VReg { idx, .. } = r15 { idx } else { panic!() };
 
-        assert_eq!(num_stack_slots, 1);
-        assert_eq!(assignments[r10_idx], Some(Allocation::Stack(0)));
+        // Lifetime holes make three registers enough: nothing spills, and the
+        // assignment is the same one five registers produce.
+        assert_eq!(num_stack_slots, 0);
+        assert_eq!(assignments[r10_idx], Some(Allocation::Reg(0)));
         assert_eq!(assignments[r11_idx], Some(Allocation::Reg(1)));
         assert_eq!(assignments[r12_idx], Some(Allocation::Reg(1)));
         assert_eq!(assignments[r13_idx], Some(Allocation::Reg(2)));
-        assert_eq!(assignments[r14_idx], Some(Allocation::Reg(0)));
+        assert_eq!(assignments[r14_idx], Some(Allocation::Reg(1)));
         assert_eq!(assignments[r15_idx], Some(Allocation::Reg(2)));
     }
 
@@ -4837,20 +4914,18 @@ mod tests {
             if *dest == Opnd::Reg(regs[1]) && *src == Opnd::UImm(1)));
 
         // Edge b3->b2 (single succ): args=[v4, v5], params=[v2, v3]
-        // v4->Reg(3), v5->Reg(2), v2->Reg(1), v3->Reg(2)
-        // Reg copy: Reg(3)->Reg(1) -> Mov(regs[1], regs[3])
-        // Reg(2)->Reg(2) is self-move, filtered
-        // Inserted in b3 before Jmp: [Label, Mul, Sub, Mov, Jmp]
+        // v4->Reg(1), v5->Reg(2), v2->Reg(1), v3->Reg(2)
+        // Reg(1)->Reg(1) and Reg(2)->Reg(2) are both self-moves, filtered, so
+        // this edge needs no moves at all: [Label, Mul, Sub, Jmp]
         let b3_insns = &asm.basic_blocks[b3.0].insns;
-        assert_eq!(b3_insns.len(), 5);
-        assert!(matches!(&b3_insns[3], Insn::Mov { dest, src }
-            if *dest == Opnd::Reg(regs[1]) && *src == Opnd::Reg(regs[3])));
+        assert_eq!(b3_insns.len(), 4);
+        assert!(matches!(&b3_insns[3], Insn::Jmp(..)));
 
         // Verify original instructions in b3 are rewritten to physical registers.
         // b3: Mul { left: r12, right: r13, out: r14 }, Sub { left: r13, right: UImm(1), out: r15 }
-        // r12->Reg(1), r13->Reg(2), r14->Reg(3), r15->Reg(2)
+        // r12->Reg(1), r13->Reg(2), r14->Reg(1), r15->Reg(2)
         assert!(matches!(&b3_insns[1], Insn::Mul { left, right, out }
-            if *left == Opnd::Reg(regs[1]) && *right == Opnd::Reg(regs[2]) && *out == Opnd::Reg(regs[3])));
+            if *left == Opnd::Reg(regs[1]) && *right == Opnd::Reg(regs[2]) && *out == Opnd::Reg(regs[1])));
         assert!(matches!(&b3_insns[2], Insn::Sub { left, right, out }
             if *left == Opnd::Reg(regs[2]) && *right == Opnd::UImm(1) && *out == Opnd::Reg(regs[2])));
     }

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -2168,12 +2168,16 @@ impl Assembler
     // The registers in `regs` from 0 to num_registers is allocatable,
     // num_registers to the end are only allocatable via "preferred" register
     // support.
+    //
+    // Allocations are written back in to `intervals` as each interval's
+    // `assigned` field.  The return value is the number of stack slots needed
+    // for the spills.
     pub fn linear_scan(
         &self,
         intervals: &mut [Interval],
         num_registers: usize, // number of allocatable regs
         regs: &[Reg],         // list of all registers used, partitioned by allocatability
-    ) -> (Vec<Option<Allocation>>, usize) {
+    ) -> usize {
         debug_assert!(num_registers <= regs.len());
 
         // `active`, `inactive`, and `unhandled` hold indexes in to `intervals`.
@@ -2334,19 +2338,13 @@ impl Assembler
         }
         debug_assert!(active.is_empty() && inactive.is_empty());
 
-        // TODO: Caller should just use the mutated intervals instead of
-        // using this assignment list
-        let assignment: Vec<Option<Allocation>> = intervals.iter()
-            .map(|it| it.assigned)
-            .collect();
-
-        (assignment, num_stack_slots)
+        num_stack_slots
     }
 
     /// Resolve SSA block parameters by inserting sequentialized move instructions
     /// at block boundaries. This is SSA deconstruction: after linear_scan assigns
     /// registers/stack slots, we lower block parameter passing to explicit moves.
-    pub fn resolve_ssa(&mut self, _intervals: &[Interval], assignments: &[Option<Allocation>], regs: &[Reg]) {
+    pub fn resolve_ssa(&mut self, intervals: &[Interval], regs: &[Reg]) {
         use crate::backend::parcopy;
         use crate::backend::current::SCRATCH_REG;
 
@@ -2381,10 +2379,10 @@ impl Assembler
                 let reg_copies: Vec<parcopy::RegisterCopy<Opnd>> = edge.args
                     .iter()
                     .zip(params.iter())
-                    .filter(|(_arg, param)| assignments[param.vreg_idx()].is_some() )
+                    .filter(|(_arg, param)| intervals[param.vreg_idx()].assigned.is_some() )
                     .map(|(arg, param)| parcopy::RegisterCopy::<Opnd> {
-                        destination: Self::rewritten_opnd(*param, assignments, regs),
-                        source: Self::rewritten_opnd(*arg, assignments, regs),
+                        destination: Self::rewritten_opnd(*param, intervals, regs),
+                        source: Self::rewritten_opnd(*arg, intervals, regs),
                     })
                     .filter(|copy| copy.source != copy.destination)
                     .collect();
@@ -2478,7 +2476,7 @@ impl Assembler
             let reg_copies: Vec<parcopy::RegisterCopy<Opnd>> = params.iter().enumerate()
                 .map(|(i, param)| parcopy::RegisterCopy::<Opnd> {
                     source: C_ARG_OPNDS[i],
-                    destination: Self::rewritten_opnd(*param, assignments, regs),
+                    destination: Self::rewritten_opnd(*param, intervals, regs),
                 })
                 .filter(|copy| copy.source != copy.destination)
                 .collect();
@@ -2523,7 +2521,7 @@ impl Assembler
             }
         }
 
-        self.rewrite_instructions(assignments, regs);
+        self.rewrite_instructions(intervals, regs);
     }
 
     /// Handle caller-saved registers around CCall instructions.
@@ -2532,7 +2530,6 @@ impl Assembler
     pub fn handle_caller_saved_regs(
         &mut self,
         intervals: &[Interval],
-        assignments: &[Option<Allocation>],
         alloc_regs: &[Reg],
         c_arg_regs: &[Reg],
     ) {
@@ -2578,14 +2575,14 @@ impl Assembler
                             let survives_call = interval.has_bounds() && interval.survives(insn_number);
                             // 2) The VReg is referenced by the stack map for the CCall
                             let stack_map_reg = stack_vreg_ids.contains(&interval.id);
-                            let is_register = assignments[interval.id].and_then(|alloc| alloc.alloc_pool_index(ALLOC_REGS.len())).is_some();
+                            let is_register = interval.assigned.and_then(|alloc| alloc.alloc_pool_index(ALLOC_REGS.len())).is_some();
                             is_register && (survives_call || stack_map_reg)
                         })
                         .map(|interval| interval.id)
                         .collect();
 
                     let survivor_regs: Vec<Opnd> = survivors.iter()
-                        .map(|&s| Opnd::Reg(assignments[s].unwrap().assigned_reg(alloc_regs).unwrap()))
+                        .map(|&s| Opnd::Reg(intervals[s].assigned.unwrap().assigned_reg(alloc_regs).unwrap()))
                         .collect();
 
                     // Push all survivors on the stack, pairing adjacent pushes when possible.
@@ -2619,7 +2616,7 @@ impl Assembler
                                     VALUE(encoded)
                                 }
                                 StackMapEntry::Opnd(Opnd::VReg { idx: vreg, .. }) => {
-                                    let vreg_stack_index = match assignments[vreg].expect("StackMap VReg should have an allocation") {
+                                    let vreg_stack_index = match intervals[vreg].assigned.expect("StackMap VReg should have an allocation") {
                                         Allocation::Reg(_) => {
                                             let caller_saved_reg_idx = survivors.iter().position(|&survivor_id| survivor_id == vreg).unwrap();
                                             let stack_idx = self.stack_state.stack_idx_for_caller_saved_reg(caller_saved_reg_idx);
@@ -2651,7 +2648,7 @@ impl Assembler
                         .zip(c_arg_regs.iter())
                         .map(|(arg, param)| parcopy::RegisterCopy::<Opnd> {
                             destination: Opnd::Reg(*param),
-                            source: Self::rewritten_opnd(*arg, assignments, alloc_regs),
+                            source: Self::rewritten_opnd(*arg, intervals, alloc_regs),
                         })
                         .filter(|copy| copy.source != copy.destination)
                         .collect();
@@ -2699,7 +2696,7 @@ impl Assembler
                     if survivors.is_empty() {
                         if call_result_live {
                             // No survivors to restore -- move result directly to output.
-                            let out = Self::rewritten_opnd(out, assignments, alloc_regs);
+                            let out = Self::rewritten_opnd(out, intervals, alloc_regs);
                             new_insns.push(Insn::Mov { dest: out, src: C_RET_OPND });
                             new_ids.push(None);
                         }
@@ -2723,7 +2720,7 @@ impl Assembler
 
                         if call_result_live {
                             // Move result from scratch to output AFTER all pops.
-                            let out = Self::rewritten_opnd(out, assignments, alloc_regs);
+                            let out = Self::rewritten_opnd(out, intervals, alloc_regs);
                             new_insns.push(Insn::Mov { dest: out, src: Opnd::Reg(SCRATCH_REG) });
                             new_ids.push(None);
                         }
@@ -2742,17 +2739,17 @@ impl Assembler
 
     /// Return the maximum number of stack-map entries that any side exit needs
     /// to copy into reserved native stack slots.
-    pub fn side_exit_stack_map_slots(&self, assignments: &[Option<Allocation>]) -> usize {
+    pub fn side_exit_stack_map_slots(&self, intervals: &[Interval]) -> usize {
         self.block_order().into_iter().fold(0, |max_slots, block_id| {
             let block = &self.basic_blocks[block_id.0];
             block.insns.iter().fold(max_slots, |max_slots, insn| {
-                let slots = insn.target().map(|target| Self::side_exit_target_stack_map_slots(target, assignments)).unwrap_or(0);
+                let slots = insn.target().map(|target| Self::side_exit_target_stack_map_slots(target, intervals)).unwrap_or(0);
                 max_slots.max(slots)
             })
         })
     }
 
-    fn side_exit_target_stack_map_slots(target: &Target, assignments: &[Option<Allocation>]) -> usize {
+    fn side_exit_target_stack_map_slots(target: &Target, intervals: &[Interval]) -> usize {
         let Target::SideExit(data) = target else {
             return 0;
         };
@@ -2765,7 +2762,7 @@ impl Assembler
             StackMapEntry::Opnd(Opnd::UImm(value)) => !VALUE(*value as usize).special_const_p(),
             StackMapEntry::Opnd(Opnd::VReg { idx, .. }) => {
                 matches!(
-                    assignments[idx.to_usize()].expect("StackMap VReg should have an allocation"),
+                    intervals[idx.to_usize()].assigned.expect("StackMap VReg should have an allocation"),
                     Allocation::Reg(_)
                 )
             }
@@ -2775,29 +2772,29 @@ impl Assembler
     }
 
     /// Walk every instruction and replace VReg operands with the physical
-    /// register (or stack slot) from the allocation assignments.
-    fn rewrite_instructions(&mut self, assignments: &[Option<Allocation>], regs: &[Reg]) {
+    /// register (or stack slot) assigned to the VReg's interval.
+    fn rewrite_instructions(&mut self, intervals: &[Interval], regs: &[Reg]) {
         for block_id in self.block_order() {
             for insn in self.basic_blocks[block_id.0].insns.iter_mut() {
                 insn.for_each_operand_mut(|opnd| {
-                    Self::rewrite_opnd(opnd, assignments, regs);
+                    Self::rewrite_opnd(opnd, intervals, regs);
                 });
                 if let Some(out) = insn.out_opnd_mut() {
-                    Self::rewrite_opnd(out, assignments, regs);
+                    Self::rewrite_opnd(out, intervals, regs);
                 }
             }
         }
     }
 
-    fn rewritten_opnd(mut opnd: Opnd, assignments: &[Option<Allocation>], regs: &[Reg]) -> Opnd {
-        Self::rewrite_opnd(&mut opnd, assignments, regs);
+    fn rewritten_opnd(mut opnd: Opnd, intervals: &[Interval], regs: &[Reg]) -> Opnd {
+        Self::rewrite_opnd(&mut opnd, intervals, regs);
         opnd
     }
 
-    fn rewrite_opnd(opnd: &mut Opnd, assignments: &[Option<Allocation>], regs: &[Reg]) {
+    fn rewrite_opnd(opnd: &mut Opnd, intervals: &[Interval], regs: &[Reg]) {
         match opnd {
             Opnd::VReg { idx, num_bits } => {
-                if let Some(assignment) = assignments[*idx] {
+                if let Some(assignment) = intervals[*idx].assigned {
                     match assignment {
                         Allocation::Reg(n) => {
                             let mut reg = regs[n];
@@ -2818,7 +2815,7 @@ impl Assembler
                 }
             }
             Opnd::Mem(Mem { base: MemBase::VReg(idx), .. }) => {
-                match assignments[*idx].unwrap() {
+                match intervals[*idx].assigned.unwrap() {
                     Allocation::Reg(n) => {
                         if let Opnd::Mem(mem) = opnd {
                             mem.base = MemBase::Reg(regs[n].reg_no);
@@ -4746,7 +4743,7 @@ mod tests {
         let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
         let allocatable_regs = regs.len();
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        let (assignments, num_stack_slots) = asm.linear_scan(&mut intervals, 5.min(allocatable_regs), &regs);
+        let num_stack_slots = asm.linear_scan(&mut intervals, 5.min(allocatable_regs), &regs);
 
         // Extract vreg indices
         let r10_idx = if let Opnd::VReg { idx, .. } = r10 { idx } else { panic!() };
@@ -4766,12 +4763,12 @@ mod tests {
         // r13: [20,38) gets Reg(2)
         // r14: [36,42) gets Reg(1) (r12 expired, reuses its register)
         // r15: [38,42) gets Reg(2) (r13 expired, reuses its register)
-        assert_eq!(assignments[r10_idx], Some(Allocation::Reg(0)));
-        assert_eq!(assignments[r11_idx], Some(Allocation::Reg(1)));
-        assert_eq!(assignments[r12_idx], Some(Allocation::Reg(1)));
-        assert_eq!(assignments[r13_idx], Some(Allocation::Reg(2)));
-        assert_eq!(assignments[r14_idx], Some(Allocation::Reg(1)));
-        assert_eq!(assignments[r15_idx], Some(Allocation::Reg(2)));
+        assert_eq!(intervals[r10_idx].assigned, Some(Allocation::Reg(0)));
+        assert_eq!(intervals[r11_idx].assigned, Some(Allocation::Reg(1)));
+        assert_eq!(intervals[r12_idx].assigned, Some(Allocation::Reg(1)));
+        assert_eq!(intervals[r13_idx].assigned, Some(Allocation::Reg(2)));
+        assert_eq!(intervals[r14_idx].assigned, Some(Allocation::Reg(1)));
+        assert_eq!(intervals[r15_idx].assigned, Some(Allocation::Reg(2)));
     }
 
     #[test]
@@ -4786,7 +4783,7 @@ mod tests {
         let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
         let allocatable_regs = regs.len();
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        let (assignments, num_stack_slots) = asm.linear_scan(&mut intervals, 3.min(allocatable_regs), &regs);
+        let num_stack_slots = asm.linear_scan(&mut intervals, 3.min(allocatable_regs), &regs);
 
         let r10_idx = if let Opnd::VReg { idx, .. } = r10 { idx } else { panic!() };
         let r11_idx = if let Opnd::VReg { idx, .. } = r11 { idx } else { panic!() };
@@ -4798,12 +4795,12 @@ mod tests {
         // Lifetime holes make three registers enough: nothing spills, and the
         // assignment is the same one five registers produce.
         assert_eq!(num_stack_slots, 0);
-        assert_eq!(assignments[r10_idx], Some(Allocation::Reg(0)));
-        assert_eq!(assignments[r11_idx], Some(Allocation::Reg(1)));
-        assert_eq!(assignments[r12_idx], Some(Allocation::Reg(1)));
-        assert_eq!(assignments[r13_idx], Some(Allocation::Reg(2)));
-        assert_eq!(assignments[r14_idx], Some(Allocation::Reg(1)));
-        assert_eq!(assignments[r15_idx], Some(Allocation::Reg(2)));
+        assert_eq!(intervals[r10_idx].assigned, Some(Allocation::Reg(0)));
+        assert_eq!(intervals[r11_idx].assigned, Some(Allocation::Reg(1)));
+        assert_eq!(intervals[r12_idx].assigned, Some(Allocation::Reg(1)));
+        assert_eq!(intervals[r13_idx].assigned, Some(Allocation::Reg(2)));
+        assert_eq!(intervals[r14_idx].assigned, Some(Allocation::Reg(1)));
+        assert_eq!(intervals[r15_idx].assigned, Some(Allocation::Reg(2)));
     }
 
     #[test]
@@ -4818,7 +4815,7 @@ mod tests {
         let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
         let allocatable_regs = regs.len();
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        let (assignments, num_stack_slots) = asm.linear_scan(&mut intervals, 1.min(allocatable_regs), &regs);
+        let num_stack_slots = asm.linear_scan(&mut intervals, 1.min(allocatable_regs), &regs);
 
         let r10_idx = if let Opnd::VReg { idx, .. } = r10 { idx } else { panic!() };
         let r11_idx = if let Opnd::VReg { idx, .. } = r11 { idx } else { panic!() };
@@ -4828,12 +4825,12 @@ mod tests {
         let r15_idx = if let Opnd::VReg { idx, .. } = r15 { idx } else { panic!() };
 
         assert_eq!(num_stack_slots, 3);
-        assert_eq!(assignments[r10_idx], Some(Allocation::Stack(0)));
-        assert_eq!(assignments[r11_idx], Some(Allocation::Reg(0)));
-        assert_eq!(assignments[r12_idx], Some(Allocation::Stack(1)));
-        assert_eq!(assignments[r13_idx], Some(Allocation::Reg(0)));
-        assert_eq!(assignments[r14_idx], Some(Allocation::Stack(2)));
-        assert_eq!(assignments[r15_idx], Some(Allocation::Reg(0)));
+        assert_eq!(intervals[r10_idx].assigned, Some(Allocation::Stack(0)));
+        assert_eq!(intervals[r11_idx].assigned, Some(Allocation::Reg(0)));
+        assert_eq!(intervals[r12_idx].assigned, Some(Allocation::Stack(1)));
+        assert_eq!(intervals[r13_idx].assigned, Some(Allocation::Reg(0)));
+        assert_eq!(intervals[r14_idx].assigned, Some(Allocation::Stack(2)));
+        assert_eq!(intervals[r15_idx].assigned, Some(Allocation::Reg(0)));
     }
 
     #[test]
@@ -4864,10 +4861,10 @@ mod tests {
         // Zero allocatable registers: the only register this interval can get
         // is the pinned one appended to the pool, so the preference is what
         // makes this succeed rather than spill.
-        let (assignments, num_stack_slots) = asm.linear_scan(&mut intervals, 0, &regs);
+        let num_stack_slots = asm.linear_scan(&mut intervals, 0, &regs);
         assert_eq!(num_stack_slots, 0);
-        assert_eq!(assignments[vreg_idx], Some(Allocation::Reg(regno)));
-        assert_eq!(assignments[vreg_idx].unwrap().assigned_reg(&regs), Some(sp.unwrap_reg()));
+        assert_eq!(intervals[vreg_idx].assigned, Some(Allocation::Reg(regno)));
+        assert_eq!(intervals[vreg_idx].assigned.unwrap().assigned_reg(&regs), Some(sp.unwrap_reg()));
     }
 
     #[test]
@@ -4899,9 +4896,9 @@ mod tests {
         let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
         let allocatable_regs = regs.len();
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        let (assignments, _) = asm.linear_scan(&mut intervals, 5.min(allocatable_regs), &regs);
+        asm.linear_scan(&mut intervals, 5.min(allocatable_regs), &regs);
 
-        asm.resolve_ssa(&intervals, &assignments, &regs);
+        asm.resolve_ssa(&intervals, &regs);
 
         use crate::backend::current::ALLOC_REGS;
         let regs = &ALLOC_REGS[..5];
@@ -4945,7 +4942,7 @@ mod tests {
         let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
         let allocatable_regs = regs.len();
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        let (assignments, _) = asm.linear_scan(&mut intervals, 5.min(allocatable_regs), &regs);
+        asm.linear_scan(&mut intervals, 5.min(allocatable_regs), &regs);
 
         // Entry block b1 has parameters [v0, v1].
         // With 5 registers: v0 -> Reg(0) = regs[0], arrival = C_ARG_OPNDS[0] = regs[0] -> self-move, filtered
@@ -4953,7 +4950,7 @@ mod tests {
         // Before resolve_ssa, b1 has: [Label, Jmp] = 2 insns
         assert_eq!(asm.basic_blocks[b1.0].insns.len(), 2);
 
-        asm.resolve_ssa(&intervals, &assignments, &regs);
+        asm.resolve_ssa(&intervals, &regs);
 
         // After resolve_ssa, b1 should still have the same number of insns
         // (plus any edge moves, but no entry param moves since they're all self-moves).
@@ -4994,9 +4991,9 @@ mod tests {
         let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
         let allocatable_regs = regs.len();
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        let (assignments, _) = asm.linear_scan(&mut intervals, 5.min(allocatable_regs), &regs);
+        asm.linear_scan(&mut intervals, 5.min(allocatable_regs), &regs);
 
-        asm.resolve_ssa(&intervals, &assignments, &regs);
+        asm.resolve_ssa(&intervals, &regs);
 
         assert!(matches!(asm.basic_blocks[block.0].insns[1], Insn::Abort));
     }
@@ -5055,16 +5052,16 @@ mod tests {
         let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
         let allocatable_regs = regs.len();
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        let (assignments, _) = asm.linear_scan(&mut intervals, num_regs.min(allocatable_regs), &regs);
+        asm.linear_scan(&mut intervals, num_regs.min(allocatable_regs), &regs);
 
         assert_eq!(asm.basic_blocks.len(), 3);
 
         // Verify v1 and v4 have different allocations (so moves are needed)
-        let v1_alloc = assignments[v1.vreg_idx()].unwrap();
-        let v4_alloc = assignments[v4.vreg_idx()].unwrap();
+        let v1_alloc = intervals[v1.vreg_idx()].assigned.unwrap();
+        let v4_alloc = intervals[v4.vreg_idx()].assigned.unwrap();
         assert_ne!(v1_alloc, v4_alloc, "Test setup: v1 and v4 should have different allocations");
 
-        asm.resolve_ssa(&intervals, &assignments, &regs);
+        asm.resolve_ssa(&intervals, &regs);
 
         // A new interstitial block should have been created for the critical edge b1->b3
         // b1->b3 is critical because b1 has 2 successors and b3 has 2 predecessors
@@ -5096,7 +5093,7 @@ mod tests {
         assert!(has_mov, "Expected Mov in split block for v1->v4");
 
         // b2->b3 is not a critical edge (b2 has single succ), so moves go before Jmp in b2
-        let v3_alloc = assignments[v3.vreg_idx()].unwrap();
+        let v3_alloc = intervals[v3.vreg_idx()].assigned.unwrap();
         let b2_insns = &asm.basic_blocks[b2.0].insns;
         if v3_alloc != v4_alloc {
             // Check that a Mov was inserted before the Jmp in b2
@@ -5161,7 +5158,7 @@ mod tests {
         let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
         let allocatable_regs = regs.len();
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        let (assignments, num_stack_slots) = asm.linear_scan(&mut intervals, num_regs.min(allocatable_regs), &regs);
+        let num_stack_slots = asm.linear_scan(&mut intervals, num_regs.min(allocatable_regs), &regs);
         asm.stack_state.num_spill_slots = num_stack_slots;
 
         // Stand in for the C calling convention's argument registers. These
@@ -5170,15 +5167,15 @@ mod tests {
         let c_arg_regs = &ALLOC_REGS[..num_regs];
 
         // v0 should be spilled (long-lived, only 2 regs)
-        assert!(matches!(assignments[v0.vreg_idx()], Some(Allocation::Stack(_))),
+        assert!(matches!(intervals[v0.vreg_idx()].assigned, Some(Allocation::Stack(_))),
             "v0 should be spilled to stack");
         // v1 should be in a register
-        assert!(matches!(assignments[v1.vreg_idx()], Some(Allocation::Reg(_))),
+        assert!(matches!(intervals[v1.vreg_idx()].assigned, Some(Allocation::Reg(_))),
             "v1 should be in a register");
 
         // Run the pipeline: handle_caller_saved_regs then resolve_ssa
-        asm.handle_caller_saved_regs(&intervals, &assignments, &regs, c_arg_regs);
-        asm.resolve_ssa(&intervals, &assignments, &regs);
+        asm.handle_caller_saved_regs(&intervals, &regs, c_arg_regs);
+        asm.resolve_ssa(&intervals, &regs);
 
         let insns = &asm.basic_blocks[b1.0].insns;
 
@@ -5189,7 +5186,7 @@ mod tests {
         assert!(!pushes.is_empty(), "Expected at least one saved register across CCall");
 
         // The survivor register should match v1's allocation
-        let v1_reg = Opnd::Reg(assignments[v1.vreg_idx()].unwrap().assigned_reg(&regs).unwrap());
+        let v1_reg = Opnd::Reg(intervals[v1.vreg_idx()].assigned.unwrap().assigned_reg(&regs).unwrap());
         let pushed_v1 = pushes.iter().any(|insn| matches!(**insn, Insn::CPushPair(first, second) if first == v1_reg || second == v1_reg));
         let popped_v1 = pops.iter().any(|insn| matches!(**insn, Insn::CPopPairInto(first, second) if first == v1_reg || second == v1_reg));
         assert!(pushed_v1, "CPushPair should save v1's register");

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -1491,7 +1491,6 @@ impl Interval {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Allocation {
     Reg(usize),
-    Fixed(Reg),
     Stack(usize),
 }
 
@@ -1499,7 +1498,6 @@ impl Allocation {
     fn assigned_reg(self, regs: &[Reg]) -> Option<Reg> {
         match self {
             Allocation::Reg(n) => Some(regs[n]),
-            Allocation::Fixed(reg) => Some(reg),
             Allocation::Stack(_) => None,
         }
     }
@@ -1507,14 +1505,6 @@ impl Allocation {
     fn alloc_pool_index(self, num_registers: usize) -> Option<usize> {
         match self {
             Allocation::Reg(n) => (n < num_registers).then_some(n),
-            Allocation::Fixed(reg) => {
-                use crate::backend::current::ALLOC_REGS;
-
-                ALLOC_REGS
-                    .iter()
-                    .take(num_registers)
-                    .position(|candidate| candidate.reg_no == reg.reg_no)
-            }
             Allocation::Stack(_) => None,
         }
     }
@@ -2569,7 +2559,7 @@ impl Assembler
                                 }
                                 StackMapEntry::Opnd(Opnd::VReg { idx: vreg, .. }) => {
                                     let vreg_stack_index = match assignments[vreg].expect("StackMap VReg should have an allocation") {
-                                        Allocation::Reg(_) | Allocation::Fixed(_) => {
+                                        Allocation::Reg(_) => {
                                             let caller_saved_reg_idx = survivors.iter().position(|&survivor_id| survivor_id == vreg).unwrap();
                                             let stack_idx = self.stack_state.stack_idx_for_caller_saved_reg(caller_saved_reg_idx);
                                             self.stack_state.stack_map_index_for_spill(stack_idx, frame_depth)
@@ -2715,7 +2705,7 @@ impl Assembler
             StackMapEntry::Opnd(Opnd::VReg { idx, .. }) => {
                 matches!(
                     assignments[idx.to_usize()].expect("StackMap VReg should have an allocation"),
-                    Allocation::Reg(_) | Allocation::Fixed(_)
+                    Allocation::Reg(_)
                 )
             }
             StackMapEntry::Opnd(Opnd::Reg(_)) => true,
@@ -2753,10 +2743,6 @@ impl Assembler
                             reg.num_bits = *num_bits;
                             *opnd = Opnd::Reg(reg);
                         }
-                        Allocation::Fixed(mut reg) => {
-                            reg.num_bits = *num_bits;
-                            *opnd = Opnd::Reg(reg);
-                        }
                         Allocation::Stack(n) => {
                             let num_bits = *num_bits;
                             *opnd = Opnd::Mem(Mem {
@@ -2775,11 +2761,6 @@ impl Assembler
                     Allocation::Reg(n) => {
                         if let Opnd::Mem(mem) = opnd {
                             mem.base = MemBase::Reg(regs[n].reg_no);
-                        }
-                    }
-                    Allocation::Fixed(reg) => {
-                        if let Opnd::Mem(mem) = opnd {
-                            mem.base = MemBase::Reg(reg.reg_no);
                         }
                     }
                     Allocation::Stack(n) => {

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -1361,20 +1361,18 @@ impl fmt::Debug for Insn {
 #[derive(Clone, Debug, PartialEq)]
 pub struct LiveRange {
     /// Index of the first instruction that used the VReg
-    pub start: usize,
+    pub from: usize,
     /// Index of the last instruction that used the VReg
-    pub end: usize,
+    pub to: usize,
 }
 
 impl LiveRange {
-    /// Shorthand for self.start.unwrap()
     pub fn start(&self) -> usize {
-        self.start
+        self.from
     }
 
-    /// Shorthand for self.end.unwrap()
     pub fn end(&self) -> usize {
-        self.end
+        self.to
     }
 }
 
@@ -1395,29 +1393,29 @@ impl Interval {
     }
 
     pub fn start(&self) -> usize {
-        self.ranges[0].start
+        self.ranges[0].from
     }
 
     pub fn end(&self) -> usize {
-        self.ranges.last().unwrap().end
+        self.ranges.last().unwrap().to
     }
 
     /// Check if the interval is alive at position x
     /// Panics if the range is not set
     pub fn survives(&self, x: usize) -> bool {
         assert!(self.ranges.len() > 0, "survives called on interval with no range");
-        let start = self.ranges[0].start;
-        let end = self.ranges[0].end;
+        let start = self.ranges[0].from;
+        let end = self.ranges.last().unwrap().to;
         start < x && end > x
     }
 
     pub fn born_at(&self, x:usize) -> bool {
-        let start = self.ranges[0].start;
+        let start = self.ranges[0].from;
         start == x
     }
 
     pub fn dies_at(&self, x:usize) -> bool {
-        let end = self.ranges[0].end;
+        let end = self.ranges[0].to;
         end == x
     }
 
@@ -1431,21 +1429,26 @@ impl Interval {
             panic!("Invalid range: {} to {}", from, to);
         }
 
-        if self.ranges.len() == 0 {
-            self.ranges.push(LiveRange { start: from, end: to });
-            return;
+        if self.ranges.len() > 0 {
+            let last = self.ranges.last_mut().unwrap();
+            if last.from <= to {
+                last.from = last.from.min(from);
+                last.to = last.to.max(to);
+                return;
+            }
         }
 
-        let range = self.ranges.first_mut().unwrap();
-        range.start = range.start.min(from);
-        range.end = range.end.max(to);
+        self.ranges.push(LiveRange { from, to });
     }
 
     /// Set the start of the range
     pub fn set_from(&mut self, from: usize) {
+        // We iterate through instructions backwards.  If an instruction
+        // has a def, but no use, then it's possible to encounter an
+        // interval that has no ranges, thus we have a None case.
         match self.ranges.first_mut() {
-            None => self.ranges.push(LiveRange { start: from, end: from + 1 }),
-            Some(range) => range.start = from
+            None => self.ranges.push(LiveRange { from, to: from + 1 }),
+            Some(range) => range.from = from
         }
     }
 }

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -2195,7 +2195,7 @@ impl Assembler
 
             // Expire old intervals.
             for mut it in std::mem::take(&mut active) {
-                assert!(it.state == State::Active);
+                debug_assert!(it.state == State::Active);
                 // If the interval ends before the current position, then we're
                 // done with it and can mark it handled.
                 if it.ends_before(position) {
@@ -2214,7 +2214,7 @@ impl Assembler
 
             // Check for intervals in inactive that are handled or active
             for mut it in std::mem::take(&mut inactive) {
-                assert!(it.state == State::Inactive);
+                debug_assert!(it.state == State::Inactive);
                 // If the inactive interval ends before the current position
                 if it.ends_before(position) {
                     // Move it to handled

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -1357,7 +1357,6 @@ impl fmt::Debug for Insn {
 }
 
 /// Live range of a VReg
-/// TODO: Consider supporting lifetime holes
 #[derive(Clone, Debug, PartialEq)]
 pub struct LiveRange {
     /// Index of the first instruction that used the VReg
@@ -2146,7 +2145,8 @@ impl Assembler
                                         regs.push(*dest_reg);
                                         regs.len() - 1
                                     });
-                                intervals[*idx].preferred.get_or_insert(Allocation::Reg(regno));
+                                debug_assert!(intervals[*idx].preferred.is_none());
+                                intervals[*idx].preferred = Some(Allocation::Reg(regno));
                             }
                         }
                     }
@@ -2335,6 +2335,8 @@ impl Assembler
             assignment[it.id] = it.assigned;
         }
 
+        // TODO: Caller should just use the mutated intervals instead of
+        // using this assignment list
         (assignment, num_stack_slots)
     }
 

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -2209,7 +2209,7 @@ impl Assembler
 
             // Expire old intervals.
             for mut it in std::mem::take(&mut active) {
-                assert!(it.state == State::Active);
+                debug_assert!(it.state == State::Active);
                 // If the interval ends before the current position, then we're
                 // done with it and can mark it handled.
                 if it.ends_before(position) {
@@ -2228,7 +2228,7 @@ impl Assembler
 
             // Check for intervals in inactive that are handled or active
             for mut it in std::mem::take(&mut inactive) {
-                assert!(it.state == State::Inactive);
+                debug_assert!(it.state == State::Inactive);
                 // If the inactive interval ends before the current position
                 if it.ends_before(position) {
                     // Move it to handled

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -1473,7 +1473,6 @@ impl Interval {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Allocation {
     Reg(usize),
-    Fixed(Reg),
     Stack(usize),
 }
 
@@ -1481,7 +1480,6 @@ impl Allocation {
     fn assigned_reg(self, regs: &[Reg]) -> Option<Reg> {
         match self {
             Allocation::Reg(n) => Some(regs[n]),
-            Allocation::Fixed(reg) => Some(reg),
             Allocation::Stack(_) => None,
         }
     }
@@ -1489,14 +1487,6 @@ impl Allocation {
     fn alloc_pool_index(self, num_registers: usize) -> Option<usize> {
         match self {
             Allocation::Reg(n) => (n < num_registers).then_some(n),
-            Allocation::Fixed(reg) => {
-                use crate::backend::current::ALLOC_REGS;
-
-                ALLOC_REGS
-                    .iter()
-                    .take(num_registers)
-                    .position(|candidate| candidate.reg_no == reg.reg_no)
-            }
             Allocation::Stack(_) => None,
         }
     }
@@ -2555,7 +2545,7 @@ impl Assembler
                                 }
                                 StackMapEntry::Opnd(Opnd::VReg { idx: vreg, .. }) => {
                                     let vreg_stack_index = match assignments[vreg].expect("StackMap VReg should have an allocation") {
-                                        Allocation::Reg(_) | Allocation::Fixed(_) => {
+                                        Allocation::Reg(_) => {
                                             let caller_saved_reg_idx = survivors.iter().position(|&survivor_id| survivor_id == vreg).unwrap();
                                             let stack_idx = self.stack_state.stack_idx_for_caller_saved_reg(caller_saved_reg_idx);
                                             self.stack_state.stack_map_index_for_spill(stack_idx, frame_depth)
@@ -2701,7 +2691,7 @@ impl Assembler
             StackMapEntry::Opnd(Opnd::VReg { idx, .. }) => {
                 matches!(
                     assignments[idx.to_usize()].expect("StackMap VReg should have an allocation"),
-                    Allocation::Reg(_) | Allocation::Fixed(_)
+                    Allocation::Reg(_)
                 )
             }
             StackMapEntry::Opnd(Opnd::Reg(_)) => true,
@@ -2739,10 +2729,6 @@ impl Assembler
                             reg.num_bits = *num_bits;
                             *opnd = Opnd::Reg(reg);
                         }
-                        Allocation::Fixed(mut reg) => {
-                            reg.num_bits = *num_bits;
-                            *opnd = Opnd::Reg(reg);
-                        }
                         Allocation::Stack(n) => {
                             let num_bits = *num_bits;
                             *opnd = Opnd::Mem(Mem {
@@ -2761,11 +2747,6 @@ impl Assembler
                     Allocation::Reg(n) => {
                         if let Opnd::Mem(mem) = opnd {
                             mem.base = MemBase::Reg(regs[n].reg_no);
-                        }
-                    }
-                    Allocation::Fixed(reg) => {
-                        if let Opnd::Mem(mem) = opnd {
-                            mem.base = MemBase::Reg(reg.reg_no);
                         }
                     }
                     Allocation::Stack(n) => {

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -1405,7 +1405,7 @@ pub enum IntervalState {
 /// Live Interval of a VReg
 pub struct Interval {
     pub ranges: Vec<LiveRange>,
-    pub id: VRegId,
+    pub vreg_id: VRegId,
 
     /// Where this interval is in the linear scan lifecycle.
     /// Transitions Unhandled -> Active <-> Inactive -> Handled.
@@ -1420,7 +1420,7 @@ impl Interval {
     pub fn new(i: VRegId) -> Self {
         Self {
             ranges: vec![],
-            id: i,
+            vreg_id: i,
             state: Cell::new(IntervalState::Unhandled),
             assigned: Cell::new(None),
             preferred: None,
@@ -2600,11 +2600,11 @@ impl Assembler
                             // 1) The VReg is referenced in an instruction after the CCall
                             let survives_call = interval.has_bounds() && interval.survives(insn_number);
                             // 2) The VReg is referenced by the stack map for the CCall
-                            let stack_map_reg = stack_vreg_ids.contains(&interval.id);
+                            let stack_map_reg = stack_vreg_ids.contains(&interval.vreg_id);
                             let is_register = interval.assigned.get().and_then(|alloc| alloc.alloc_pool_index(ALLOC_REGS.len())).is_some();
                             is_register && (survives_call || stack_map_reg)
                         })
-                        .map(|interval| interval.id)
+                        .map(|interval| interval.vreg_id)
                         .collect();
 
                     let survivor_regs: Vec<Opnd> = survivors.iter()

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -1391,7 +1391,7 @@ pub struct Interval {
     pub id: VRegId,
     pub state: State,
     pub assigned: Option<Allocation>,
-    pub preferred: Option<Reg>,
+    pub preferred: Option<Allocation>,
 }
 
 impl Interval {
@@ -1478,11 +1478,9 @@ pub enum Allocation {
 }
 
 impl Allocation {
-    fn assigned_reg(self) -> Option<Reg> {
-        use crate::backend::current::ALLOC_REGS;
-
+    fn assigned_reg(self, regs: &[Reg]) -> Option<Reg> {
         match self {
-            Allocation::Reg(n) => Some(ALLOC_REGS[n]),
+            Allocation::Reg(n) => Some(regs[n]),
             Allocation::Fixed(reg) => Some(reg),
             Allocation::Stack(_) => None,
         }
@@ -1490,7 +1488,7 @@ impl Allocation {
 
     fn alloc_pool_index(self, num_registers: usize) -> Option<usize> {
         match self {
-            Allocation::Reg(n) => Some(n),
+            Allocation::Reg(n) => (n < num_registers).then_some(n),
             Allocation::Fixed(reg) => {
                 use crate::backend::current::ALLOC_REGS;
 
@@ -2104,7 +2102,7 @@ impl Assembler
 
     /// Discover vregs that should preferentially reuse a physical register,
     /// such as a newborn vreg immediately moved into a preg in the next instruction.
-    pub fn preferred_register_assignments(&self, intervals: &mut [Interval]) {
+    pub fn preferred_register_assignments(&self, intervals: &mut [Interval], regs: &mut Vec<Reg>) {
         for block in &self.basic_blocks {
             let mut prev_insn: Option<(InsnId, &Insn)> = None;
 
@@ -2125,7 +2123,13 @@ impl Assembler
                                 && intervals[*idx].born_at(prev_id.0)
                                 && intervals[*idx].dies_at(insn_id.0)
                             {
-                                intervals[*idx].preferred.get_or_insert(*dest_reg);
+                                let regno = regs.iter()
+                                    .position(|candidate| candidate.reg_no == dest_reg.reg_no)
+                                    .unwrap_or_else(|| {
+                                        regs.push(*dest_reg);
+                                        regs.len() - 1
+                                    });
+                                intervals[*idx].preferred.get_or_insert(Allocation::Reg(regno));
                             }
                         }
                     }
@@ -2136,25 +2140,24 @@ impl Assembler
         }
     }
 
-    fn release_assignment(it: &Interval, num_registers: usize, free_registers: &mut BTreeSet<usize>) {
+    fn release_assignment(it: &Interval, num_registers: usize, regs: &[Reg], free_registers: &mut BTreeSet<usize>) {
         if let Some(allocation) = it.assigned {
             if let Some(reg) = allocation.alloc_pool_index(num_registers) {
                 let was_not_there_before = free_registers.insert(reg);
                 assert!(
                     was_not_there_before,
                     "attempted to return allocator register {:?} to the free pool more than once",
-                    allocation.assigned_reg().unwrap(),
+                    allocation.assigned_reg(regs).unwrap(),
                 );
             } else {
                 assert!(
-                    allocation.assigned_reg().is_none_or(|reg| {
-                        crate::backend::current::ALLOC_REGS
-                            .iter()
+                    allocation.assigned_reg(regs).is_none_or(|reg| {
+                        regs.iter()
                             .take(num_registers)
                             .all(|candidate| candidate.reg_no != reg.reg_no)
                     }),
                     "attempted to return non-allocatable register {:?} to the allocator pool",
-                    allocation.assigned_reg().unwrap(),
+                    allocation.assigned_reg(regs).unwrap(),
                 );
             }
         }
@@ -2171,13 +2174,13 @@ impl Assembler
         &self,
         intervals: Vec<Interval>,
         num_registers: usize,
+        regs: &[Reg],
     ) -> (Vec<Option<Allocation>>, usize) {
         let mut free_registers: BTreeSet<usize> = (0..num_registers).collect();
         let mut active: Vec<Interval> = Vec::new(); // sorted by increasing end point
         let mut inactive: Vec<Interval> = Vec::new(); // intervals with lifetime holes
         let mut num_stack_slots: usize = 0;
         let mut handled: Vec<Interval> = Vec::new();
-        let mut free_until_pos = vec![0usize; num_registers];
         let num_intervals = intervals.len();
 
         let mut sorted_intervals: Vec<Interval> = intervals.into_iter()
@@ -2193,31 +2196,33 @@ impl Assembler
                 if it.end() > interval.start() {
                     active.push(it);
                 } else {
-                    Self::release_assignment(&it, num_registers, &mut free_registers);
+                    Self::release_assignment(&it, num_registers, regs, &mut free_registers);
                     it.state = State::Handled;
                     handled.push(it);
                 }
             }
 
-            let preferred_reg = interval.preferred;
-            let preferred_taken = preferred_reg.is_some_and(|reg| {
-                active.iter().any(|active_interval| {
-                    active_interval.assigned
-                        .and_then(|alloc| alloc.assigned_reg())
-                        .is_some_and(|active_reg| active_reg.reg_no == reg.reg_no)
-                })
-            });
+            let preferred_alloc = interval.preferred;
+            let preferred_taken = preferred_alloc
+                .and_then(|alloc| alloc.assigned_reg(regs))
+                .is_some_and(|reg| {
+                    active.iter().any(|active_interval| {
+                        active_interval.assigned
+                            .and_then(|alloc| alloc.assigned_reg(regs))
+                            .is_some_and(|active_reg| active_reg.reg_no == reg.reg_no)
+                    })
+                });
 
-            if let Some(preferred_reg) = preferred_reg.filter(|_| !preferred_taken) {
-                if let Some(reg_idx) = Allocation::Fixed(preferred_reg).alloc_pool_index(num_registers) {
+            if let Some(preferred_alloc) = preferred_alloc.filter(|_| !preferred_taken) {
+                if let Some(reg_idx) = preferred_alloc.alloc_pool_index(num_registers) {
                     if free_registers.remove(&reg_idx) {
-                        interval.assigned = Some(Allocation::Fixed(preferred_reg));
+                        interval.assigned = Some(preferred_alloc);
                         let insert_idx = active.partition_point(|i| i.end() < interval.end());
                         active.insert(insert_idx, interval);
                         continue;
                     }
                 } else {
-                    interval.assigned = Some(Allocation::Fixed(preferred_reg));
+                    interval.assigned = Some(preferred_alloc);
                     let insert_idx = active.partition_point(|i| i.end() < interval.end());
                     active.insert(insert_idx, interval);
                     continue;
@@ -2276,7 +2281,7 @@ impl Assembler
     /// Resolve SSA block parameters by inserting sequentialized move instructions
     /// at block boundaries. This is SSA deconstruction: after linear_scan assigns
     /// registers/stack slots, we lower block parameter passing to explicit moves.
-    pub fn resolve_ssa(&mut self, _intervals: &[Interval], assignments: &[Option<Allocation>]) {
+    pub fn resolve_ssa(&mut self, _intervals: &[Interval], assignments: &[Option<Allocation>], regs: &[Reg]) {
         use crate::backend::parcopy;
         use crate::backend::current::SCRATCH_REG;
 
@@ -2313,8 +2318,8 @@ impl Assembler
                     .zip(params.iter())
                     .filter(|(_arg, param)| assignments[param.vreg_idx()].is_some() )
                     .map(|(arg, param)| parcopy::RegisterCopy::<Opnd> {
-                        destination: Self::rewritten_opnd(*param, assignments),
-                        source: Self::rewritten_opnd(*arg, assignments),
+                        destination: Self::rewritten_opnd(*param, assignments, regs),
+                        source: Self::rewritten_opnd(*arg, assignments, regs),
                     })
                     .filter(|copy| copy.source != copy.destination)
                     .collect();
@@ -2408,7 +2413,7 @@ impl Assembler
             let reg_copies: Vec<parcopy::RegisterCopy<Opnd>> = params.iter().enumerate()
                 .map(|(i, param)| parcopy::RegisterCopy::<Opnd> {
                     source: C_ARG_OPNDS[i],
-                    destination: Self::rewritten_opnd(*param, assignments),
+                    destination: Self::rewritten_opnd(*param, assignments, regs),
                 })
                 .filter(|copy| copy.source != copy.destination)
                 .collect();
@@ -2453,7 +2458,7 @@ impl Assembler
             }
         }
 
-        self.rewrite_instructions(assignments);
+        self.rewrite_instructions(assignments, regs);
     }
 
     /// Handle caller-saved registers around CCall instructions.
@@ -2463,7 +2468,8 @@ impl Assembler
         &mut self,
         intervals: &[Interval],
         assignments: &[Option<Allocation>],
-        regs: &[Reg],
+        alloc_regs: &[Reg],
+        c_arg_regs: &[Reg],
     ) {
         use crate::backend::parcopy;
         use crate::backend::current::{C_RET_OPND, SCRATCH_REG, ALLOC_REGS};
@@ -2514,11 +2520,7 @@ impl Assembler
                         .collect();
 
                     let survivor_regs: Vec<Opnd> = survivors.iter()
-                        .map(|&s| match assignments[s].unwrap() {
-                            Allocation::Reg(n) => Opnd::Reg(ALLOC_REGS[n]),
-                            Allocation::Fixed(reg) => Opnd::Reg(reg),
-                            _ => unreachable!(),
-                        })
+                        .map(|&s| Opnd::Reg(assignments[s].unwrap().assigned_reg(alloc_regs).unwrap()))
                         .collect();
 
                     // Push all survivors on the stack, pairing adjacent pushes when possible.
@@ -2576,15 +2578,15 @@ impl Assembler
 
                     // Extract arguments from CCall, clear opnds
 
-                    assert!(opnds.len() <= regs.len());
+                    assert!(opnds.len() <= c_arg_regs.len());
 
-                    // Sequentialize argument moves: each arg goes to regs[i]
+                    // Sequentialize argument moves: each arg goes to c_arg_regs[i]
                     let reg_copies: Vec<parcopy::RegisterCopy<Opnd>> = opnds
                         .iter()
-                        .zip(regs.iter())
+                        .zip(c_arg_regs.iter())
                         .map(|(arg, param)| parcopy::RegisterCopy::<Opnd> {
                             destination: Opnd::Reg(*param),
-                            source: Self::rewritten_opnd(*arg, assignments),
+                            source: Self::rewritten_opnd(*arg, assignments, alloc_regs),
                         })
                         .filter(|copy| copy.source != copy.destination)
                         .collect();
@@ -2632,7 +2634,7 @@ impl Assembler
                     if survivors.is_empty() {
                         if call_result_live {
                             // No survivors to restore -- move result directly to output.
-                            let out = Self::rewritten_opnd(out, assignments);
+                            let out = Self::rewritten_opnd(out, assignments, alloc_regs);
                             new_insns.push(Insn::Mov { dest: out, src: C_RET_OPND });
                             new_ids.push(None);
                         }
@@ -2656,7 +2658,7 @@ impl Assembler
 
                         if call_result_live {
                             // Move result from scratch to output AFTER all pops.
-                            let out = Self::rewritten_opnd(out, assignments);
+                            let out = Self::rewritten_opnd(out, assignments, alloc_regs);
                             new_insns.push(Insn::Mov { dest: out, src: Opnd::Reg(SCRATCH_REG) });
                             new_ids.push(None);
                         }
@@ -2709,28 +2711,25 @@ impl Assembler
 
     /// Walk every instruction and replace VReg operands with the physical
     /// register (or stack slot) from the allocation assignments.
-    fn rewrite_instructions(&mut self, assignments: &[Option<Allocation>]) {
+    fn rewrite_instructions(&mut self, assignments: &[Option<Allocation>], regs: &[Reg]) {
         for block_id in self.block_order() {
             for insn in self.basic_blocks[block_id.0].insns.iter_mut() {
                 insn.for_each_operand_mut(|opnd| {
-                    Self::rewrite_opnd(opnd, assignments);
+                    Self::rewrite_opnd(opnd, assignments, regs);
                 });
                 if let Some(out) = insn.out_opnd_mut() {
-                    Self::rewrite_opnd(out, assignments);
+                    Self::rewrite_opnd(out, assignments, regs);
                 }
             }
         }
     }
 
-    fn rewritten_opnd(mut opnd: Opnd, assignments: &[Option<Allocation>]) -> Opnd {
-        Self::rewrite_opnd(&mut opnd, assignments);
+    fn rewritten_opnd(mut opnd: Opnd, assignments: &[Option<Allocation>], regs: &[Reg]) -> Opnd {
+        Self::rewrite_opnd(&mut opnd, assignments, regs);
         opnd
     }
 
-    fn rewrite_opnd(opnd: &mut Opnd, assignments: &[Option<Allocation>]) {
-        use crate::backend::current::ALLOC_REGS;
-        let regs = &ALLOC_REGS;
-
+    fn rewrite_opnd(opnd: &mut Opnd, assignments: &[Option<Allocation>], regs: &[Reg]) {
         match opnd {
             Opnd::VReg { idx, num_bits } => {
                 if let Some(assignment) = assignments[*idx] {
@@ -4688,8 +4687,10 @@ mod tests {
 
         println!("LIR live_intervals:\n{}", crate::backend::lir::debug_intervals(&asm, &intervals));
 
-        asm.preferred_register_assignments(&mut intervals);
-        let (assignments, num_stack_slots) = asm.linear_scan(intervals, 5);
+        let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
+        let allocatable_regs = regs.len();
+        asm.preferred_register_assignments(&mut intervals, &mut regs);
+        let (assignments, num_stack_slots) = asm.linear_scan(intervals, 5.min(allocatable_regs), &regs);
 
         // Extract vreg indices
         let r10_idx = if let Opnd::VReg { idx, .. } = r10 { idx } else { panic!() };
@@ -4726,8 +4727,10 @@ mod tests {
         let mut intervals = asm.build_intervals(live_in);
 
         // 3 registers -- only r10 needs to spill
-        asm.preferred_register_assignments(&mut intervals);
-        let (assignments, num_stack_slots) = asm.linear_scan(intervals, 3);
+        let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
+        let allocatable_regs = regs.len();
+        asm.preferred_register_assignments(&mut intervals, &mut regs);
+        let (assignments, num_stack_slots) = asm.linear_scan(intervals, 3.min(allocatable_regs), &regs);
 
         let r10_idx = if let Opnd::VReg { idx, .. } = r10 { idx } else { panic!() };
         let r11_idx = if let Opnd::VReg { idx, .. } = r11 { idx } else { panic!() };
@@ -4754,8 +4757,10 @@ mod tests {
         let mut intervals = asm.build_intervals(live_in);
 
         // Only 1 register available -- forces spills
-        asm.preferred_register_assignments(&mut intervals);
-        let (assignments, num_stack_slots) = asm.linear_scan(intervals, 1);
+        let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
+        let allocatable_regs = regs.len();
+        asm.preferred_register_assignments(&mut intervals, &mut regs);
+        let (assignments, num_stack_slots) = asm.linear_scan(intervals, 1.min(allocatable_regs), &regs);
 
         let r10_idx = if let Opnd::VReg { idx, .. } = r10 { idx } else { panic!() };
         let r11_idx = if let Opnd::VReg { idx, .. } = r11 { idx } else { panic!() };
@@ -4789,14 +4794,22 @@ mod tests {
         asm.number_instructions(0);
         let live_in = asm.analyze_liveness();
         let mut intervals = asm.build_intervals(live_in);
-        asm.preferred_register_assignments(&mut intervals);
+        let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
+        asm.preferred_register_assignments(&mut intervals, &mut regs);
 
         let vreg_idx = new_sp.vreg_idx();
-        assert_eq!(intervals[vreg_idx].preferred, Some(sp.unwrap_reg()));
+        let Some(Allocation::Reg(regno)) = intervals[vreg_idx].preferred else {
+            panic!("expected a preferred register for v{vreg_idx}");
+        };
+        assert_eq!(regs[regno], sp.unwrap_reg());
 
-        let (assignments, num_stack_slots) = asm.linear_scan(intervals, 0);
+        // Zero allocatable registers: the only register this interval can get
+        // is the pinned one appended to the pool, so the preference is what
+        // makes this succeed rather than spill.
+        let (assignments, num_stack_slots) = asm.linear_scan(intervals, 0, &regs);
         assert_eq!(num_stack_slots, 0);
-        assert_eq!(assignments[vreg_idx], Some(Allocation::Fixed(sp.unwrap_reg())));
+        assert_eq!(assignments[vreg_idx], Some(Allocation::Reg(regno)));
+        assert_eq!(assignments[vreg_idx].unwrap().assigned_reg(&regs), Some(sp.unwrap_reg()));
     }
 
     #[test]
@@ -4825,10 +4838,12 @@ mod tests {
         let live_in = asm.analyze_liveness();
         asm.number_instructions(16);
         let mut intervals = asm.build_intervals(live_in);
-        asm.preferred_register_assignments(&mut intervals);
-        let (assignments, _) = asm.linear_scan(intervals.clone(), 5);
+        let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
+        let allocatable_regs = regs.len();
+        asm.preferred_register_assignments(&mut intervals, &mut regs);
+        let (assignments, _) = asm.linear_scan(intervals.clone(), 5.min(allocatable_regs), &regs);
 
-        asm.resolve_ssa(&intervals, &assignments);
+        asm.resolve_ssa(&intervals, &assignments, &regs);
 
         use crate::backend::current::ALLOC_REGS;
         let regs = &ALLOC_REGS[..5];
@@ -4871,8 +4886,10 @@ mod tests {
         let live_in = asm.analyze_liveness();
         asm.number_instructions(16);
         let mut intervals = asm.build_intervals(live_in);
-        asm.preferred_register_assignments(&mut intervals);
-        let (assignments, _) = asm.linear_scan(intervals.clone(), 5);
+        let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
+        let allocatable_regs = regs.len();
+        asm.preferred_register_assignments(&mut intervals, &mut regs);
+        let (assignments, _) = asm.linear_scan(intervals.clone(), 5.min(allocatable_regs), &regs);
 
         // Entry block b1 has parameters [v0, v1].
         // With 5 registers: v0 -> Reg(0) = regs[0], arrival = C_ARG_OPNDS[0] = regs[0] -> self-move, filtered
@@ -4880,7 +4897,7 @@ mod tests {
         // Before resolve_ssa, b1 has: [Label, Jmp] = 2 insns
         assert_eq!(asm.basic_blocks[b1.0].insns.len(), 2);
 
-        asm.resolve_ssa(&intervals, &assignments);
+        asm.resolve_ssa(&intervals, &assignments, &regs);
 
         // After resolve_ssa, b1 should still have the same number of insns
         // (plus any edge moves, but no entry param moves since they're all self-moves).
@@ -4918,10 +4935,12 @@ mod tests {
         let live_in = asm.analyze_liveness();
         asm.number_instructions(0);
         let mut intervals = asm.build_intervals(live_in);
-        asm.preferred_register_assignments(&mut intervals);
-        let (assignments, _) = asm.linear_scan(intervals.clone(), 5);
+        let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
+        let allocatable_regs = regs.len();
+        asm.preferred_register_assignments(&mut intervals, &mut regs);
+        let (assignments, _) = asm.linear_scan(intervals.clone(), 5.min(allocatable_regs), &regs);
 
-        asm.resolve_ssa(&intervals, &assignments);
+        asm.resolve_ssa(&intervals, &assignments, &regs);
 
         assert!(matches!(asm.basic_blocks[block.0].insns[1], Insn::Abort));
     }
@@ -4977,8 +4996,10 @@ mod tests {
         asm.number_instructions(16);
         let mut intervals = asm.build_intervals(live_in);
         let num_regs = 5;
-        asm.preferred_register_assignments(&mut intervals);
-        let (assignments, _) = asm.linear_scan(intervals.clone(), num_regs);
+        let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
+        let allocatable_regs = regs.len();
+        asm.preferred_register_assignments(&mut intervals, &mut regs);
+        let (assignments, _) = asm.linear_scan(intervals.clone(), num_regs.min(allocatable_regs), &regs);
 
         assert_eq!(asm.basic_blocks.len(), 3);
 
@@ -4987,7 +5008,7 @@ mod tests {
         let v4_alloc = assignments[v4.vreg_idx()].unwrap();
         assert_ne!(v1_alloc, v4_alloc, "Test setup: v1 and v4 should have different allocations");
 
-        asm.resolve_ssa(&intervals, &assignments);
+        asm.resolve_ssa(&intervals, &assignments, &regs);
 
         // A new interstitial block should have been created for the critical edge b1->b3
         // b1->b3 is critical because b1 has 2 successors and b3 has 2 predecessors
@@ -5081,11 +5102,16 @@ mod tests {
         asm.number_instructions(0);
         let mut intervals = asm.build_intervals(live_in);
         let num_regs = 2;
-        asm.preferred_register_assignments(&mut intervals);
-        let (assignments, num_stack_slots) = asm.linear_scan(intervals.clone(), num_regs);
+        let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
+        let allocatable_regs = regs.len();
+        asm.preferred_register_assignments(&mut intervals, &mut regs);
+        let (assignments, num_stack_slots) = asm.linear_scan(intervals.clone(), num_regs.min(allocatable_regs), &regs);
         asm.stack_state.num_spill_slots = num_stack_slots;
 
-        let regs = &ALLOC_REGS[..num_regs];
+        // Stand in for the C calling convention's argument registers. These
+        // deliberately overlap the allocatable pool so that arguments clobber
+        // registers the allocator handed out.
+        let c_arg_regs = &ALLOC_REGS[..num_regs];
 
         // v0 should be spilled (long-lived, only 2 regs)
         assert!(matches!(assignments[v0.vreg_idx()], Some(Allocation::Stack(_))),
@@ -5095,8 +5121,8 @@ mod tests {
             "v1 should be in a register");
 
         // Run the pipeline: handle_caller_saved_regs then resolve_ssa
-        asm.handle_caller_saved_regs(&intervals, &assignments, regs);
-        asm.resolve_ssa(&intervals, &assignments);
+        asm.handle_caller_saved_regs(&intervals, &assignments, &regs, c_arg_regs);
+        asm.resolve_ssa(&intervals, &assignments, &regs);
 
         let insns = &asm.basic_blocks[b1.0].insns;
 

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -1514,18 +1514,73 @@ pub enum Allocation {
 }
 
 impl Allocation {
-    fn assigned_reg(self, regs: &[Reg]) -> Option<Reg> {
+    fn assigned_reg(self, regs: &RegPool) -> Option<Reg> {
         match self {
-            Allocation::Reg(n) => Some(regs[n]),
+            Allocation::Reg(n) => Some(regs.reg_at(n)),
             Allocation::Stack(_) => None,
         }
     }
 
-    fn alloc_pool_index(self, num_registers: usize) -> Option<usize> {
+    fn alloc_pool_index(self, regs: &RegPool) -> Option<usize> {
         match self {
-            Allocation::Reg(n) => (n < num_registers).then_some(n),
+            Allocation::Reg(n) => (n < regs.num_allocatable()).then_some(n),
             Allocation::Stack(_) => None,
         }
+    }
+}
+
+/// The physical registers the register allocator hands out, partitioned by
+/// allocatability. The registers at indexes `0..num_allocatable()` are the ones
+/// linear_scan() is free to assign to any interval. The rest are pinned
+/// registers (NATIVE_STACK_PTR, for example) that an interval can only end up
+/// in through its `preferred` allocation.
+///
+/// The list and the boundary travel together so that consumers can't disagree
+/// about where the partition is, and so pinning a register can't move it.
+#[derive(Debug)]
+pub struct RegPool {
+    regs: Vec<Reg>,
+    allocatable: usize,
+}
+
+impl RegPool {
+    /// Build a pool in which every register is allocatable.
+    pub fn new(regs: Vec<Reg>) -> Self {
+        let allocatable = regs.len();
+        Self { regs, allocatable }
+    }
+
+    #[cfg(test)]
+    pub fn with_allocatable(regs: Vec<Reg>, allocatable: usize) -> Self {
+        assert!(allocatable <= regs.len());
+        Self { regs, allocatable }
+    }
+
+    /// The number of registers linear_scan() is free to allocate.
+    pub fn num_allocatable(&self) -> usize {
+        self.allocatable
+    }
+
+    /// The total number of registers in the pool.
+    pub fn len(&self) -> usize {
+        self.regs.len()
+    }
+
+    /// The register at `index`, in either partition.
+    pub fn reg_at(&self, index: usize) -> Reg {
+        self.regs[index]
+    }
+
+    /// Find the index of `reg` in the pool.  If the pool doesn't have the
+    /// reg, add it to the pool, but place it outside of the "allocatable"
+    /// register range.
+    pub fn find_or_add_index(&mut self, reg: Reg) -> usize {
+        self.regs.iter()
+            .position(|candidate| candidate.reg_no == reg.reg_no)
+            .unwrap_or_else(|| {
+                self.regs.push(reg);
+                self.regs.len() - 1
+            })
     }
 }
 
@@ -2127,9 +2182,9 @@ impl Assembler
         Some(new_moves)
     }
 
-    /// Discover and append to `regs` vregs that should preferentially reuse a physical register,
-    /// such as a newborn vreg immediately moved into a preg in the next instruction.
-    pub fn preferred_register_assignments(&self, intervals: &mut [Interval], regs: &mut Vec<Reg>) {
+    /// Record a preferred physical register on vregs that should reuse one, such as a
+    /// newborn vreg immediately moved into a preg in the next instruction.
+    pub fn preferred_register_assignments(&self, intervals: &mut [Interval], regs: &mut RegPool) {
         for block in &self.basic_blocks {
             let mut prev_insn: Option<(InsnId, &Insn)> = None;
 
@@ -2150,12 +2205,7 @@ impl Assembler
                                 && intervals[*idx].born_at(prev_id.0)
                                 && intervals[*idx].dies_at(insn_id.0)
                             {
-                                let regno = regs.iter()
-                                    .position(|candidate| candidate.reg_no == dest_reg.reg_no)
-                                    .unwrap_or_else(|| {
-                                        regs.push(*dest_reg);
-                                        regs.len() - 1
-                                    });
+                                let regno = regs.find_or_add_index(*dest_reg);
                                 debug_assert!(intervals[*idx].preferred.is_none());
                                 intervals[*idx].preferred = Some(Allocation::Reg(regno));
                             }
@@ -2174,22 +2224,15 @@ impl Assembler
     // * Pre-allocate pinned regs
     // * Update linear scan to handle pinned LRs
     //
-    // num_registers is the number of allocatable registers.  `regs` is a
-    // list of _all_ registers partitioned by allocatable and non-allocatable.
-    // The registers in `regs` from 0 to num_registers is allocatable,
-    // num_registers to the end are only allocatable via "preferred" register
-    // support.
+    // `regs` is the pool of _all_ registers, partitioned by allocatability.
+    // The registers below `regs.num_allocatable()` are allocatable here, the
+    // rest are only reachable via "preferred" register support.
     //
     // Allocations are written back in to `intervals` as each interval's
     // `assigned` field.  The return value is the number of stack slots needed
     // for the spills.
-    pub fn linear_scan(
-        &self,
-        intervals: &[Interval],
-        num_registers: usize, // number of allocatable regs
-        regs: &[Reg],         // list of all registers used, partitioned by allocatability
-    ) -> usize {
-        debug_assert!(num_registers <= regs.len());
+    pub fn linear_scan(&self, intervals: &[Interval], regs: &RegPool) -> usize {
+        let num_registers = regs.num_allocatable();
 
         // `active`, `inactive`, and `unhandled` borrow the intervals they hold.
         // Allocation results are written through the Cell fields, so a shared
@@ -2306,11 +2349,11 @@ impl Assembler
                 None => {
                     // Spill: pick the longest-lived active interval (last in sorted active)
                     // but only from the allocatable partition of the pool. An index
-                    // at or past `num_registers` is a pinned physical register (for
-                    // example SP), which is not ours to hand to someone else.
+                    // at or past the pool's allocatable boundary is a pinned physical
+                    // register (for example SP), which is not ours to hand to someone else.
                     let spill_idx = active.iter().rposition(|it| {
                         it.assigned.get()
-                            .is_some_and(|alloc| alloc.alloc_pool_index(num_registers).is_some())
+                            .is_some_and(|alloc| alloc.alloc_pool_index(regs).is_some())
                     });
                     let slot = Allocation::Stack(num_stack_slots);
                     num_stack_slots += 1;
@@ -2356,7 +2399,7 @@ impl Assembler
     /// Resolve SSA block parameters by inserting sequentialized move instructions
     /// at block boundaries. This is SSA deconstruction: after linear_scan assigns
     /// registers/stack slots, we lower block parameter passing to explicit moves.
-    pub fn resolve_ssa(&mut self, intervals: &[Interval], regs: &[Reg]) {
+    pub fn resolve_ssa(&mut self, intervals: &[Interval], regs: &RegPool) {
         use crate::backend::parcopy;
         use crate::backend::current::SCRATCH_REG;
 
@@ -2542,11 +2585,11 @@ impl Assembler
     pub fn handle_caller_saved_regs(
         &mut self,
         intervals: &[Interval],
-        alloc_regs: &[Reg],
+        alloc_regs: &RegPool,
         c_arg_regs: &[Reg],
     ) {
         use crate::backend::parcopy;
-        use crate::backend::current::{C_RET_OPND, SCRATCH_REG, ALLOC_REGS};
+        use crate::backend::current::{C_RET_OPND, SCRATCH_REG};
 
         for block_id in self.block_order() {
             let block = &mut self.basic_blocks[block_id.0];
@@ -2587,7 +2630,7 @@ impl Assembler
                             let survives_call = interval.has_bounds() && interval.survives(insn_number);
                             // 2) The VReg is referenced by the stack map for the CCall
                             let stack_map_reg = stack_vreg_ids.contains(&interval.vreg_id);
-                            let is_register = interval.assigned.get().and_then(|alloc| alloc.alloc_pool_index(ALLOC_REGS.len())).is_some();
+                            let is_register = interval.assigned.get().and_then(|alloc| alloc.alloc_pool_index(alloc_regs)).is_some();
                             is_register && (survives_call || stack_map_reg)
                         })
                         .map(|interval| interval.vreg_id)
@@ -2785,7 +2828,7 @@ impl Assembler
 
     /// Walk every instruction and replace VReg operands with the physical
     /// register (or stack slot) assigned to the VReg's interval.
-    fn rewrite_instructions(&mut self, intervals: &[Interval], regs: &[Reg]) {
+    fn rewrite_instructions(&mut self, intervals: &[Interval], regs: &RegPool) {
         for block_id in self.block_order() {
             for insn in self.basic_blocks[block_id.0].insns.iter_mut() {
                 insn.for_each_operand_mut(|opnd| {
@@ -2798,18 +2841,18 @@ impl Assembler
         }
     }
 
-    fn rewritten_opnd(mut opnd: Opnd, intervals: &[Interval], regs: &[Reg]) -> Opnd {
+    fn rewritten_opnd(mut opnd: Opnd, intervals: &[Interval], regs: &RegPool) -> Opnd {
         Self::rewrite_opnd(&mut opnd, intervals, regs);
         opnd
     }
 
-    fn rewrite_opnd(opnd: &mut Opnd, intervals: &[Interval], regs: &[Reg]) {
+    fn rewrite_opnd(opnd: &mut Opnd, intervals: &[Interval], regs: &RegPool) {
         match opnd {
             Opnd::VReg { idx, num_bits } => {
                 if let Some(assignment) = intervals[*idx].assigned.get() {
                     match assignment {
                         Allocation::Reg(n) => {
-                            let mut reg = regs[n];
+                            let mut reg = regs.reg_at(n);
                             reg.num_bits = *num_bits;
                             *opnd = Opnd::Reg(reg);
                         }
@@ -2830,7 +2873,7 @@ impl Assembler
                 match intervals[*idx].assigned.get().unwrap() {
                     Allocation::Reg(n) => {
                         if let Opnd::Mem(mem) = opnd {
-                            mem.base = MemBase::Reg(regs[n].reg_no);
+                            mem.base = MemBase::Reg(regs.reg_at(n).reg_no);
                         }
                     }
                     Allocation::Stack(n) => {
@@ -4245,6 +4288,12 @@ mod tests {
         Assembler::new_with_scratch_reg().1
     }
 
+    fn alloc_reg_pool(num_allocatable: usize) -> RegPool {
+        let regs = crate::backend::current::ALLOC_REGS.to_vec();
+        let num_allocatable = num_allocatable.min(regs.len());
+        RegPool::with_allocatable(regs, num_allocatable)
+    }
+
     #[test]
     fn test_size_of_insn() {
         // PatchPoint (PatchPointData), CCall (CCallData), and Target (Block/SideExit
@@ -4752,10 +4801,9 @@ mod tests {
 
         println!("LIR live_intervals:\n{}", crate::backend::lir::debug_intervals(&asm, &intervals));
 
-        let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
-        let allocatable_regs = regs.len();
+        let mut regs = alloc_reg_pool(5);
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        let num_stack_slots = asm.linear_scan(&intervals, 5.min(allocatable_regs), &regs);
+        let num_stack_slots = asm.linear_scan(&intervals, &regs);
 
         // Extract vreg indices
         let r10_idx = if let Opnd::VReg { idx, .. } = r10 { idx } else { panic!() };
@@ -4792,10 +4840,9 @@ mod tests {
         let mut intervals = asm.build_intervals(live_in);
 
         // 3 registers -- enough for every interval once holes are reused
-        let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
-        let allocatable_regs = regs.len();
+        let mut regs = alloc_reg_pool(3);
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        let num_stack_slots = asm.linear_scan(&intervals, 3.min(allocatable_regs), &regs);
+        let num_stack_slots = asm.linear_scan(&intervals, &regs);
 
         let r10_idx = if let Opnd::VReg { idx, .. } = r10 { idx } else { panic!() };
         let r11_idx = if let Opnd::VReg { idx, .. } = r11 { idx } else { panic!() };
@@ -4824,10 +4871,9 @@ mod tests {
         let mut intervals = asm.build_intervals(live_in);
 
         // Only 1 register available -- forces spills
-        let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
-        let allocatable_regs = regs.len();
+        let mut regs = alloc_reg_pool(1);
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        let num_stack_slots = asm.linear_scan(&intervals, 1.min(allocatable_regs), &regs);
+        let num_stack_slots = asm.linear_scan(&intervals, &regs);
 
         let r10_idx = if let Opnd::VReg { idx, .. } = r10 { idx } else { panic!() };
         let r11_idx = if let Opnd::VReg { idx, .. } = r11 { idx } else { panic!() };
@@ -4861,19 +4907,19 @@ mod tests {
         asm.number_instructions(0);
         let live_in = asm.analyze_liveness();
         let mut intervals = asm.build_intervals(live_in);
-        let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
+        // Zero allocatable registers: the only register this interval can get
+        // is the pinned one appended to the pool, so the preference is what
+        // makes this succeed rather than spill.
+        let mut regs = alloc_reg_pool(0);
         asm.preferred_register_assignments(&mut intervals, &mut regs);
 
         let vreg_idx = new_sp.vreg_idx();
         let Some(Allocation::Reg(regno)) = intervals[vreg_idx].preferred else {
             panic!("expected a preferred register for v{vreg_idx}");
         };
-        assert_eq!(regs[regno], sp.unwrap_reg());
+        assert_eq!(regs.reg_at(regno), sp.unwrap_reg());
 
-        // Zero allocatable registers: the only register this interval can get
-        // is the pinned one appended to the pool, so the preference is what
-        // makes this succeed rather than spill.
-        let num_stack_slots = asm.linear_scan(&intervals, 0, &regs);
+        let num_stack_slots = asm.linear_scan(&intervals, &regs);
         assert_eq!(num_stack_slots, 0);
         assert_eq!(intervals[vreg_idx].assigned.get(), Some(Allocation::Reg(regno)));
         assert_eq!(intervals[vreg_idx].assigned.get().unwrap().assigned_reg(&regs), Some(sp.unwrap_reg()));
@@ -4905,10 +4951,9 @@ mod tests {
         let live_in = asm.analyze_liveness();
         asm.number_instructions(16);
         let mut intervals = asm.build_intervals(live_in);
-        let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
-        let allocatable_regs = regs.len();
+        let mut regs = alloc_reg_pool(5);
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        asm.linear_scan(&intervals, 5.min(allocatable_regs), &regs);
+        asm.linear_scan(&intervals, &regs);
 
         asm.resolve_ssa(&intervals, &regs);
 
@@ -4951,10 +4996,9 @@ mod tests {
         let live_in = asm.analyze_liveness();
         asm.number_instructions(16);
         let mut intervals = asm.build_intervals(live_in);
-        let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
-        let allocatable_regs = regs.len();
+        let mut regs = alloc_reg_pool(5);
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        asm.linear_scan(&intervals, 5.min(allocatable_regs), &regs);
+        asm.linear_scan(&intervals, &regs);
 
         // Entry block b1 has parameters [v0, v1].
         // With 5 registers: v0 -> Reg(0) = regs[0], arrival = C_ARG_OPNDS[0] = regs[0] -> self-move, filtered
@@ -5000,10 +5044,9 @@ mod tests {
         let live_in = asm.analyze_liveness();
         asm.number_instructions(0);
         let mut intervals = asm.build_intervals(live_in);
-        let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
-        let allocatable_regs = regs.len();
+        let mut regs = alloc_reg_pool(5);
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        asm.linear_scan(&intervals, 5.min(allocatable_regs), &regs);
+        asm.linear_scan(&intervals, &regs);
 
         asm.resolve_ssa(&intervals, &regs);
 
@@ -5060,11 +5103,9 @@ mod tests {
         let live_in = asm.analyze_liveness();
         asm.number_instructions(16);
         let mut intervals = asm.build_intervals(live_in);
-        let num_regs = 5;
-        let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
-        let allocatable_regs = regs.len();
+        let mut regs = alloc_reg_pool(5);
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        asm.linear_scan(&intervals, num_regs.min(allocatable_regs), &regs);
+        asm.linear_scan(&intervals, &regs);
 
         assert_eq!(asm.basic_blocks.len(), 3);
 
@@ -5167,10 +5208,9 @@ mod tests {
         asm.number_instructions(0);
         let mut intervals = asm.build_intervals(live_in);
         let num_regs = 2;
-        let mut regs = crate::backend::current::ALLOC_REGS.to_vec();
-        let allocatable_regs = regs.len();
+        let mut regs = alloc_reg_pool(num_regs);
         asm.preferred_register_assignments(&mut intervals, &mut regs);
-        let num_stack_slots = asm.linear_scan(&intervals, num_regs.min(allocatable_regs), &regs);
+        let num_stack_slots = asm.linear_scan(&intervals, &regs);
         asm.stack_state.num_spill_slots = num_stack_slots;
 
         // Stand in for the C calling convention's argument registers. These

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -2194,43 +2194,48 @@ impl Assembler
             let position = interval.start();
 
             // Expire old intervals.
-            for mut it in std::mem::take(&mut active) {
+            active.retain_mut(|it| {
                 debug_assert!(it.state == State::Active);
                 // If the interval ends before the current position, then we're
                 // done with it and can mark it handled.
                 if it.ends_before(position) {
                     it.state = State::Handled;
-                    handled.push(it);
+                    handled.push(it.clone());
+                    false
                 } else if !it.covers(position) {
                     // If it doesn't cover the current position (there's a hole
                     // in the ranges), then move it to inactive
                     it.state = State::Inactive;
-                    inactive.push(it);
+                    inactive.push(it.clone());
+                    false
                 } else {
                     // Otherwise it's still live here and stays active.
-                    active.push(it);
+                    true
                 }
-            }
+            });
 
             // Check for intervals in inactive that are handled or active
-            for mut it in std::mem::take(&mut inactive) {
+            inactive.retain(|it| {
                 debug_assert!(it.state == State::Inactive);
                 // If the inactive interval ends before the current position
                 if it.ends_before(position) {
                     // Move it to handled
+                    let mut it = it.clone();
                     it.state = State::Handled;
                     handled.push(it);
-
+                    false
                 } else if it.covers(position) {
                     // If the current position falls inside one of the
                     // interval's ranges, then make it active
+                    let mut it = it.clone();
                     it.state = State::Active;
                     active.push(it);
+                    false
                 } else {
                     // It's still inactive
-                    inactive.push(it);
+                    true
                 }
-            }
+            });
 
             // Mark all registers as "free".  In other words, they aren't
             // in use until instruction number usize::MAX.

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -2156,7 +2156,6 @@ impl Assembler
     // TODO: We want to make the following refactoring so that we DON'T have
     // to parcopy in to entry blocks
     //
-    // * Move Allocation to Interval
     // * Pre-allocate pinned regs
     // * Update linear scan to handle pinned LRs
     //

--- a/zjit/src/backend/x86_64/mod.rs
+++ b/zjit/src/backend/x86_64/mod.rs
@@ -1167,7 +1167,7 @@ impl Assembler {
             // this index is a register the allocator must not hand out.
             let allocatable_regs = regs.len();
             trace_compile_phase("preferred_registers", || asm.preferred_register_assignments(&mut intervals, &mut regs));
-            let (assignments, num_stack_slots) = trace_compile_phase("linear_scan", || asm.linear_scan(intervals.clone(), allocatable_regs, &regs));
+            let (assignments, num_stack_slots) = trace_compile_phase("linear_scan", || asm.linear_scan(&mut intervals, allocatable_regs, &regs));
 
             asm.stack_state.num_spill_slots = num_stack_slots;
             asm.stack_state.num_side_exit_stack_map_slots = asm.side_exit_stack_map_slots(&assignments);

--- a/zjit/src/backend/x86_64/mod.rs
+++ b/zjit/src/backend/x86_64/mod.rs
@@ -1176,7 +1176,6 @@ impl Assembler {
                             let range = &intervals[i].range;
                             let alloc_str = match alloc {
                                 Allocation::Reg(n) => format!("{}", regs[*n]),
-                                Allocation::Fixed(reg) => format!("{}", reg),
                                 Allocation::Stack(n) => format!("Stack[{}]", n),
                             };
                             println!("  v{} => {} (range: {:?}..{:?})", i, alloc_str, range.start, range.end);

--- a/zjit/src/backend/x86_64/mod.rs
+++ b/zjit/src/backend/x86_64/mod.rs
@@ -1156,7 +1156,7 @@ impl Assembler {
             // this index is a register the allocator must not hand out.
             let allocatable_regs = regs.len();
             trace_compile_phase("preferred_registers", || asm.preferred_register_assignments(&mut intervals, &mut regs));
-            let (assignments, num_stack_slots) = trace_compile_phase("linear_scan", || asm.linear_scan(intervals.clone(), allocatable_regs, &regs));
+            let (assignments, num_stack_slots) = trace_compile_phase("linear_scan", || asm.linear_scan(&mut intervals, allocatable_regs, &regs));
 
             asm.stack_state.num_spill_slots = num_stack_slots;
             asm.stack_state.num_side_exit_stack_map_slots = asm.side_exit_stack_map_slots(&assignments);

--- a/zjit/src/backend/x86_64/mod.rs
+++ b/zjit/src/backend/x86_64/mod.rs
@@ -1187,7 +1187,6 @@ impl Assembler {
                             let range = &intervals[i].range;
                             let alloc_str = match alloc {
                                 Allocation::Reg(n) => format!("{}", regs[*n]),
-                                Allocation::Fixed(reg) => format!("{}", reg),
                                 Allocation::Stack(n) => format!("Stack[{}]", n),
                             };
                             println!("  v{} => {} (range: {:?}..{:?})", i, alloc_str, range.start, range.end);

--- a/zjit/src/backend/x86_64/mod.rs
+++ b/zjit/src/backend/x86_64/mod.rs
@@ -1188,7 +1188,7 @@ impl Assembler {
                                 Allocation::Reg(n) => format!("{}", regs[n]),
                                 Allocation::Stack(n) => format!("Stack[{}]", n),
                             };
-                            println!("  v{} => {} (range: {:?}..{:?})", i, alloc_str, interval.start(), interval.end());
+                            println!("  v{} => {} (ranges: {})", i, alloc_str, interval.ranges_string());
                         }
                     }
                 }

--- a/zjit/src/backend/x86_64/mod.rs
+++ b/zjit/src/backend/x86_64/mod.rs
@@ -1129,7 +1129,7 @@ impl Assembler {
     }
 
     /// Optimize and compile the stored instructions
-    pub fn compile_with_regs(self, cb: &mut CodeBlock, regs: Vec<Reg>) -> Result<(CodePtr, Vec<CodePtr>), CompileError> {
+    pub fn compile_with_regs(self, cb: &mut CodeBlock, mut regs: Vec<Reg>) -> Result<(CodePtr, Vec<CodePtr>), CompileError> {
         // The backend is allowed to use scratch registers only if it has not accepted them so far.
         let use_scratch_regs = !self.accept_scratch_reg;
         asm_dump!(self, init);
@@ -1151,8 +1151,12 @@ impl Assembler {
                 }
             }
 
-            trace_compile_phase("preferred_registers", || asm.preferred_register_assignments(&mut intervals));
-            let (assignments, num_stack_slots) = trace_compile_phase("linear_scan", || asm.linear_scan(intervals.clone(), regs.len()));
+            // Capture the allocatable count before preferred_register_assignments
+            // appends any pinned registers to the pool. Everything at or past
+            // this index is a register the allocator must not hand out.
+            let allocatable_regs = regs.len();
+            trace_compile_phase("preferred_registers", || asm.preferred_register_assignments(&mut intervals, &mut regs));
+            let (assignments, num_stack_slots) = trace_compile_phase("linear_scan", || asm.linear_scan(intervals.clone(), allocatable_regs, &regs));
 
             asm.stack_state.num_spill_slots = num_stack_slots;
             asm.stack_state.num_side_exit_stack_map_slots = asm.side_exit_stack_map_slots(&assignments);
@@ -1194,8 +1198,8 @@ impl Assembler {
             });
 
             trace_compile_phase("resolve_ssa", || {
-                asm.handle_caller_saved_regs(&intervals, &assignments, &C_ARG_REGREGS);
-                asm.resolve_ssa(&intervals, &assignments);
+                asm.handle_caller_saved_regs(&intervals, &assignments, &regs, &C_ARG_REGREGS);
+                asm.resolve_ssa(&intervals, &assignments, &regs);
             });
 
             Ok(())

--- a/zjit/src/backend/x86_64/mod.rs
+++ b/zjit/src/backend/x86_64/mod.rs
@@ -1184,12 +1184,13 @@ impl Assembler {
                     println!("VReg assignments:");
                     for (i, alloc) in assignments.iter().enumerate() {
                         if let Some(alloc) = alloc {
-                            let range = &intervals[i].range;
+                            let start = &intervals[i].start();
+                            let end = &intervals[i].end();
                             let alloc_str = match alloc {
                                 Allocation::Reg(n) => format!("{}", regs[*n]),
                                 Allocation::Stack(n) => format!("Stack[{}]", n),
                             };
-                            println!("  v{} => {} (range: {:?}..{:?})", i, alloc_str, range.start, range.end);
+                            println!("  v{} => {} (range: {:?}..{:?})", i, alloc_str, start, end);
                         }
                     }
                 }

--- a/zjit/src/backend/x86_64/mod.rs
+++ b/zjit/src/backend/x86_64/mod.rs
@@ -1142,7 +1142,7 @@ impl Assembler {
             trace_compile_phase("number_instructions", || asm.number_instructions(0));
 
             let live_in = trace_compile_phase("analyze_liveness", || asm.analyze_liveness());
-            let intervals = trace_compile_phase("build_intervals", || asm.build_intervals(live_in));
+            let mut intervals = trace_compile_phase("build_intervals", || asm.build_intervals(live_in));
 
             // Dump live intervals if requested
             if let Some(crate::options::Options { dump_lir: Some(dump_lirs), .. }) = unsafe { crate::options::OPTIONS.as_ref() } {
@@ -1151,8 +1151,8 @@ impl Assembler {
                 }
             }
 
-            let preferred_registers = trace_compile_phase("preferred_registers", || asm.preferred_register_assignments(&intervals));
-            let (assignments, num_stack_slots) = trace_compile_phase("linear_scan", || asm.linear_scan(intervals.clone(), regs.len(), &preferred_registers));
+            trace_compile_phase("preferred_registers", || asm.preferred_register_assignments(&mut intervals));
+            let (assignments, num_stack_slots) = trace_compile_phase("linear_scan", || asm.linear_scan(intervals.clone(), regs.len()));
 
             asm.stack_state.num_spill_slots = num_stack_slots;
             asm.stack_state.num_side_exit_stack_map_slots = asm.side_exit_stack_map_slots(&assignments);

--- a/zjit/src/backend/x86_64/mod.rs
+++ b/zjit/src/backend/x86_64/mod.rs
@@ -1156,7 +1156,7 @@ impl Assembler {
             // this index is a register the allocator must not hand out.
             let allocatable_regs = regs.len();
             trace_compile_phase("preferred_registers", || asm.preferred_register_assignments(&mut intervals, &mut regs));
-            let num_stack_slots = trace_compile_phase("linear_scan", || asm.linear_scan(&mut intervals, allocatable_regs, &regs));
+            let num_stack_slots = trace_compile_phase("linear_scan", || asm.linear_scan(&intervals, allocatable_regs, &regs));
 
             asm.stack_state.num_spill_slots = num_stack_slots;
             asm.stack_state.num_side_exit_stack_map_slots = asm.side_exit_stack_map_slots(&intervals);
@@ -1172,7 +1172,7 @@ impl Assembler {
 
                     println!("VReg assignments:");
                     for (i, interval) in intervals.iter().enumerate() {
-                        if let Some(alloc) = interval.assigned {
+                        if let Some(alloc) = interval.assigned.get() {
                             let alloc_str = match alloc {
                                 Allocation::Reg(n) => format!("{}", regs[n]),
                                 Allocation::Stack(n) => format!("Stack[{}]", n),

--- a/zjit/src/backend/x86_64/mod.rs
+++ b/zjit/src/backend/x86_64/mod.rs
@@ -1140,7 +1140,7 @@ impl Assembler {
     }
 
     /// Optimize and compile the stored instructions
-    pub fn compile_with_regs(self, cb: &mut CodeBlock, regs: Vec<Reg>) -> Result<(CodePtr, Vec<CodePtr>), CompileError> {
+    pub fn compile_with_regs(self, cb: &mut CodeBlock, mut regs: Vec<Reg>) -> Result<(CodePtr, Vec<CodePtr>), CompileError> {
         // The backend is allowed to use scratch registers only if it has not accepted them so far.
         let use_scratch_regs = !self.accept_scratch_reg;
         asm_dump!(self, init);
@@ -1162,8 +1162,12 @@ impl Assembler {
                 }
             }
 
-            trace_compile_phase("preferred_registers", || asm.preferred_register_assignments(&mut intervals));
-            let (assignments, num_stack_slots) = trace_compile_phase("linear_scan", || asm.linear_scan(intervals.clone(), regs.len()));
+            // Capture the allocatable count before preferred_register_assignments
+            // appends any pinned registers to the pool. Everything at or past
+            // this index is a register the allocator must not hand out.
+            let allocatable_regs = regs.len();
+            trace_compile_phase("preferred_registers", || asm.preferred_register_assignments(&mut intervals, &mut regs));
+            let (assignments, num_stack_slots) = trace_compile_phase("linear_scan", || asm.linear_scan(intervals.clone(), allocatable_regs, &regs));
 
             asm.stack_state.num_spill_slots = num_stack_slots;
             asm.stack_state.num_side_exit_stack_map_slots = asm.side_exit_stack_map_slots(&assignments);
@@ -1205,8 +1209,8 @@ impl Assembler {
             });
 
             trace_compile_phase("resolve_ssa", || {
-                asm.handle_caller_saved_regs(&intervals, &assignments, &C_ARG_REGREGS);
-                asm.resolve_ssa(&intervals, &assignments);
+                asm.handle_caller_saved_regs(&intervals, &assignments, &regs, &C_ARG_REGREGS);
+                asm.resolve_ssa(&intervals, &assignments, &regs);
             });
 
             Ok(())

--- a/zjit/src/backend/x86_64/mod.rs
+++ b/zjit/src/backend/x86_64/mod.rs
@@ -1140,9 +1140,10 @@ impl Assembler {
     }
 
     /// Optimize and compile the stored instructions
-    pub fn compile_with_regs(self, cb: &mut CodeBlock, mut regs: Vec<Reg>) -> Result<(CodePtr, Vec<CodePtr>), CompileError> {
+    pub fn compile_with_regs(self, cb: &mut CodeBlock, regs: Vec<Reg>) -> Result<(CodePtr, Vec<CodePtr>), CompileError> {
         // The backend is allowed to use scratch registers only if it has not accepted them so far.
         let use_scratch_regs = !self.accept_scratch_reg;
+        let mut regs = RegPool::new(regs);
         asm_dump!(self, init);
 
         let mut asm = trace_compile_phase("split", || self.x86_split());
@@ -1162,9 +1163,8 @@ impl Assembler {
                 }
             }
 
-            let allocatable_regs = regs.len();
             trace_compile_phase("preferred_registers", || asm.preferred_register_assignments(&mut intervals, &mut regs));
-            let num_stack_slots = trace_compile_phase("linear_scan", || asm.linear_scan(&intervals, allocatable_regs, &regs));
+            let num_stack_slots = trace_compile_phase("linear_scan", || asm.linear_scan(&intervals, &regs));
 
             asm.stack_state.num_spill_slots = num_stack_slots;
             asm.stack_state.num_side_exit_stack_map_slots = asm.side_exit_stack_map_slots(&intervals);
@@ -1182,7 +1182,7 @@ impl Assembler {
                     for (i, interval) in intervals.iter().enumerate() {
                         if let Some(alloc) = interval.assigned.get() {
                             let alloc_str = match alloc {
-                                Allocation::Reg(n) => format!("{}", regs[n]),
+                                Allocation::Reg(n) => format!("{}", regs.reg_at(n)),
                                 Allocation::Stack(n) => format!("Stack[{}]", n),
                             };
                             println!("  v{} => {} (ranges: {})", i, alloc_str, interval.ranges_string());

--- a/zjit/src/backend/x86_64/mod.rs
+++ b/zjit/src/backend/x86_64/mod.rs
@@ -1151,9 +1151,6 @@ impl Assembler {
                 }
             }
 
-            // Capture the allocatable count before preferred_register_assignments
-            // appends any pinned registers to the pool. Everything at or past
-            // this index is a register the allocator must not hand out.
             let allocatable_regs = regs.len();
             trace_compile_phase("preferred_registers", || asm.preferred_register_assignments(&mut intervals, &mut regs));
             let num_stack_slots = trace_compile_phase("linear_scan", || asm.linear_scan(&intervals, allocatable_regs, &regs));

--- a/zjit/src/backend/x86_64/mod.rs
+++ b/zjit/src/backend/x86_64/mod.rs
@@ -1177,7 +1177,7 @@ impl Assembler {
                                 Allocation::Reg(n) => format!("{}", regs[n]),
                                 Allocation::Stack(n) => format!("Stack[{}]", n),
                             };
-                            println!("  v{} => {} (range: {:?}..{:?})", i, alloc_str, interval.start(), interval.end());
+                            println!("  v{} => {} (ranges: {})", i, alloc_str, interval.ranges_string());
                         }
                     }
                 }

--- a/zjit/src/backend/x86_64/mod.rs
+++ b/zjit/src/backend/x86_64/mod.rs
@@ -1153,7 +1153,7 @@ impl Assembler {
             trace_compile_phase("number_instructions", || asm.number_instructions(0));
 
             let live_in = trace_compile_phase("analyze_liveness", || asm.analyze_liveness());
-            let intervals = trace_compile_phase("build_intervals", || asm.build_intervals(live_in));
+            let mut intervals = trace_compile_phase("build_intervals", || asm.build_intervals(live_in));
 
             // Dump live intervals if requested
             if let Some(crate::options::Options { dump_lir: Some(dump_lirs), .. }) = unsafe { crate::options::OPTIONS.as_ref() } {
@@ -1162,8 +1162,8 @@ impl Assembler {
                 }
             }
 
-            let preferred_registers = trace_compile_phase("preferred_registers", || asm.preferred_register_assignments(&intervals));
-            let (assignments, num_stack_slots) = trace_compile_phase("linear_scan", || asm.linear_scan(intervals.clone(), regs.len(), &preferred_registers));
+            trace_compile_phase("preferred_registers", || asm.preferred_register_assignments(&mut intervals));
+            let (assignments, num_stack_slots) = trace_compile_phase("linear_scan", || asm.linear_scan(intervals.clone(), regs.len()));
 
             asm.stack_state.num_spill_slots = num_stack_slots;
             asm.stack_state.num_side_exit_stack_map_slots = asm.side_exit_stack_map_slots(&assignments);

--- a/zjit/src/backend/x86_64/mod.rs
+++ b/zjit/src/backend/x86_64/mod.rs
@@ -1156,10 +1156,10 @@ impl Assembler {
             // this index is a register the allocator must not hand out.
             let allocatable_regs = regs.len();
             trace_compile_phase("preferred_registers", || asm.preferred_register_assignments(&mut intervals, &mut regs));
-            let (assignments, num_stack_slots) = trace_compile_phase("linear_scan", || asm.linear_scan(&mut intervals, allocatable_regs, &regs));
+            let num_stack_slots = trace_compile_phase("linear_scan", || asm.linear_scan(&mut intervals, allocatable_regs, &regs));
 
             asm.stack_state.num_spill_slots = num_stack_slots;
-            asm.stack_state.num_side_exit_stack_map_slots = asm.side_exit_stack_map_slots(&assignments);
+            asm.stack_state.num_side_exit_stack_map_slots = asm.side_exit_stack_map_slots(&intervals);
             let stack_slot_count = asm.stack_state.stack_slot_count();
             if stack_slot_count > Self::MAX_FRAME_STACK_SLOTS {
                 return Err(CompileError::NativeStackTooLarge);
@@ -1171,15 +1171,13 @@ impl Assembler {
                     println!("LIR live_intervals:\n{}", crate::backend::lir::debug_intervals(&asm, &intervals));
 
                     println!("VReg assignments:");
-                    for (i, alloc) in assignments.iter().enumerate() {
-                        if let Some(alloc) = alloc {
-                            let start = &intervals[i].start();
-                            let end = &intervals[i].end();
+                    for (i, interval) in intervals.iter().enumerate() {
+                        if let Some(alloc) = interval.assigned {
                             let alloc_str = match alloc {
-                                Allocation::Reg(n) => format!("{}", regs[*n]),
+                                Allocation::Reg(n) => format!("{}", regs[n]),
                                 Allocation::Stack(n) => format!("Stack[{}]", n),
                             };
-                            println!("  v{} => {} (range: {:?}..{:?})", i, alloc_str, start, end);
+                            println!("  v{} => {} (range: {:?}..{:?})", i, alloc_str, interval.start(), interval.end());
                         }
                     }
                 }
@@ -1198,8 +1196,8 @@ impl Assembler {
             });
 
             trace_compile_phase("resolve_ssa", || {
-                asm.handle_caller_saved_regs(&intervals, &assignments, &regs, &C_ARG_REGREGS);
-                asm.resolve_ssa(&intervals, &assignments, &regs);
+                asm.handle_caller_saved_regs(&intervals, &regs, &C_ARG_REGREGS);
+                asm.resolve_ssa(&intervals, &regs);
             });
 
             Ok(())

--- a/zjit/src/backend/x86_64/mod.rs
+++ b/zjit/src/backend/x86_64/mod.rs
@@ -1162,9 +1162,6 @@ impl Assembler {
                 }
             }
 
-            // Capture the allocatable count before preferred_register_assignments
-            // appends any pinned registers to the pool. Everything at or past
-            // this index is a register the allocator must not hand out.
             let allocatable_regs = regs.len();
             trace_compile_phase("preferred_registers", || asm.preferred_register_assignments(&mut intervals, &mut regs));
             let num_stack_slots = trace_compile_phase("linear_scan", || asm.linear_scan(&intervals, allocatable_regs, &regs));

--- a/zjit/src/backend/x86_64/mod.rs
+++ b/zjit/src/backend/x86_64/mod.rs
@@ -1167,10 +1167,10 @@ impl Assembler {
             // this index is a register the allocator must not hand out.
             let allocatable_regs = regs.len();
             trace_compile_phase("preferred_registers", || asm.preferred_register_assignments(&mut intervals, &mut regs));
-            let (assignments, num_stack_slots) = trace_compile_phase("linear_scan", || asm.linear_scan(&mut intervals, allocatable_regs, &regs));
+            let num_stack_slots = trace_compile_phase("linear_scan", || asm.linear_scan(&mut intervals, allocatable_regs, &regs));
 
             asm.stack_state.num_spill_slots = num_stack_slots;
-            asm.stack_state.num_side_exit_stack_map_slots = asm.side_exit_stack_map_slots(&assignments);
+            asm.stack_state.num_side_exit_stack_map_slots = asm.side_exit_stack_map_slots(&intervals);
             let stack_slot_count = asm.stack_state.stack_slot_count();
             if stack_slot_count > Self::MAX_FRAME_STACK_SLOTS {
                 return Err(CompileError::NativeStackTooLarge);
@@ -1182,15 +1182,13 @@ impl Assembler {
                     println!("LIR live_intervals:\n{}", crate::backend::lir::debug_intervals(&asm, &intervals));
 
                     println!("VReg assignments:");
-                    for (i, alloc) in assignments.iter().enumerate() {
-                        if let Some(alloc) = alloc {
-                            let start = &intervals[i].start();
-                            let end = &intervals[i].end();
+                    for (i, interval) in intervals.iter().enumerate() {
+                        if let Some(alloc) = interval.assigned {
                             let alloc_str = match alloc {
-                                Allocation::Reg(n) => format!("{}", regs[*n]),
+                                Allocation::Reg(n) => format!("{}", regs[n]),
                                 Allocation::Stack(n) => format!("Stack[{}]", n),
                             };
-                            println!("  v{} => {} (range: {:?}..{:?})", i, alloc_str, start, end);
+                            println!("  v{} => {} (range: {:?}..{:?})", i, alloc_str, interval.start(), interval.end());
                         }
                     }
                 }
@@ -1209,8 +1207,8 @@ impl Assembler {
             });
 
             trace_compile_phase("resolve_ssa", || {
-                asm.handle_caller_saved_regs(&intervals, &assignments, &regs, &C_ARG_REGREGS);
-                asm.resolve_ssa(&intervals, &assignments, &regs);
+                asm.handle_caller_saved_regs(&intervals, &regs, &C_ARG_REGREGS);
+                asm.resolve_ssa(&intervals, &regs);
             });
 
             Ok(())

--- a/zjit/src/backend/x86_64/mod.rs
+++ b/zjit/src/backend/x86_64/mod.rs
@@ -1129,9 +1129,10 @@ impl Assembler {
     }
 
     /// Optimize and compile the stored instructions
-    pub fn compile_with_regs(self, cb: &mut CodeBlock, mut regs: Vec<Reg>) -> Result<(CodePtr, Vec<CodePtr>), CompileError> {
+    pub fn compile_with_regs(self, cb: &mut CodeBlock, regs: Vec<Reg>) -> Result<(CodePtr, Vec<CodePtr>), CompileError> {
         // The backend is allowed to use scratch registers only if it has not accepted them so far.
         let use_scratch_regs = !self.accept_scratch_reg;
+        let mut regs = RegPool::new(regs);
         asm_dump!(self, init);
 
         let mut asm = trace_compile_phase("split", || self.x86_split());
@@ -1151,9 +1152,8 @@ impl Assembler {
                 }
             }
 
-            let allocatable_regs = regs.len();
             trace_compile_phase("preferred_registers", || asm.preferred_register_assignments(&mut intervals, &mut regs));
-            let num_stack_slots = trace_compile_phase("linear_scan", || asm.linear_scan(&intervals, allocatable_regs, &regs));
+            let num_stack_slots = trace_compile_phase("linear_scan", || asm.linear_scan(&intervals, &regs));
 
             asm.stack_state.num_spill_slots = num_stack_slots;
             asm.stack_state.num_side_exit_stack_map_slots = asm.side_exit_stack_map_slots(&intervals);
@@ -1171,7 +1171,7 @@ impl Assembler {
                     for (i, interval) in intervals.iter().enumerate() {
                         if let Some(alloc) = interval.assigned.get() {
                             let alloc_str = match alloc {
-                                Allocation::Reg(n) => format!("{}", regs[n]),
+                                Allocation::Reg(n) => format!("{}", regs.reg_at(n)),
                                 Allocation::Stack(n) => format!("Stack[{}]", n),
                             };
                             println!("  v{} => {} (ranges: {})", i, alloc_str, interval.ranges_string());

--- a/zjit/src/backend/x86_64/mod.rs
+++ b/zjit/src/backend/x86_64/mod.rs
@@ -1167,7 +1167,7 @@ impl Assembler {
             // this index is a register the allocator must not hand out.
             let allocatable_regs = regs.len();
             trace_compile_phase("preferred_registers", || asm.preferred_register_assignments(&mut intervals, &mut regs));
-            let num_stack_slots = trace_compile_phase("linear_scan", || asm.linear_scan(&mut intervals, allocatable_regs, &regs));
+            let num_stack_slots = trace_compile_phase("linear_scan", || asm.linear_scan(&intervals, allocatable_regs, &regs));
 
             asm.stack_state.num_spill_slots = num_stack_slots;
             asm.stack_state.num_side_exit_stack_map_slots = asm.side_exit_stack_map_slots(&intervals);
@@ -1183,7 +1183,7 @@ impl Assembler {
 
                     println!("VReg assignments:");
                     for (i, interval) in intervals.iter().enumerate() {
-                        if let Some(alloc) = interval.assigned {
+                        if let Some(alloc) = interval.assigned.get() {
                             let alloc_str = match alloc {
                                 Allocation::Reg(n) => format!("{}", regs[n]),
                                 Allocation::Stack(n) => format!("Stack[{}]", n),

--- a/zjit/src/backend/x86_64/mod.rs
+++ b/zjit/src/backend/x86_64/mod.rs
@@ -1173,12 +1173,13 @@ impl Assembler {
                     println!("VReg assignments:");
                     for (i, alloc) in assignments.iter().enumerate() {
                         if let Some(alloc) = alloc {
-                            let range = &intervals[i].range;
+                            let start = &intervals[i].start();
+                            let end = &intervals[i].end();
                             let alloc_str = match alloc {
                                 Allocation::Reg(n) => format!("{}", regs[*n]),
                                 Allocation::Stack(n) => format!("Stack[{}]", n),
                             };
-                            println!("  v{} => {} (range: {:?}..{:?})", i, alloc_str, range.start, range.end);
+                            println!("  v{} => {} (range: {:?}..{:?})", i, alloc_str, start, end);
                         }
                     }
                 }


### PR DESCRIPTION
This PR implements lifetime holes in our register allocator.  It's based on algorithms from Wimmer's 2005 and 2010 papers.  I didn't change the spill heuristics, nor did I add splitting (those papers include techniques for spill heuristics and interval splitting, but I didn't want to implement them because it's a lot of work that we can do later).

I refactored some of the structs in order to make the lifetime holes changes easier.

Here are some stats from ruby-bench, protoboeuf seems to benefit the most:

```
master: ruby 4.1.0dev (2026-07-31T13:38:41Z master 805d510ebd) +ZJIT +PRISM [x86_64-linux]
holes: ruby 4.1.0dev (2026-07-31T20:06:14Z lifetime-holes 1f087bab81) +ZJIT +PRISM [x86_64-linux]

harness:
---------------------  -------------  -------------  -------------  ------------
bench                    master (ms)     holes (ms)  holes 1st itr  master/holes
activerecord            168.7 ± 1.8%   168.9 ± 1.8%          0.987         0.999
chunky-png              618.0 ± 0.5%   622.4 ± 0.2%          0.983         0.993
erubi-rails             869.5 ± 0.6%   865.2 ± 0.4%          0.992         1.005
hexapdf                2092.8 ± 1.1%  2067.6 ± 1.5%          0.999         1.012
liquid-c                 62.3 ± 6.8%    62.7 ± 8.0%          0.972         0.995
liquid-compile          47.4 ± 10.0%    47.0 ± 9.0%          0.973         1.010
liquid-il               236.0 ± 1.3%   234.7 ± 1.2%          0.994         1.006
liquid-render           116.4 ± 4.0%   115.4 ± 4.0%          0.975         1.009
lobsters               1120.6 ± 1.6%  1116.9 ± 2.0%          1.002         1.003
mail                    148.0 ± 3.2%   149.3 ± 4.3%          0.959         0.992
psych-load             1975.2 ± 0.6%  2036.5 ± 1.8%          1.000         0.970
railsbench             2131.0 ± 1.3%  2141.1 ± 1.3%          0.987         0.995
rubocop                205.4 ± 12.0%  205.4 ± 10.5%          0.969         1.000
ruby-lsp                146.2 ± 5.3%   143.7 ± 4.5%          0.991         1.018
sequel                   63.7 ± 5.7%    64.1 ± 5.4%          1.002         0.993
shipit                 1836.1 ± 0.6%  1834.9 ± 1.5%          1.011         1.001
addressable-equality    524.3 ± 0.4%   524.4 ± 0.3%          1.005         1.000
addressable-getters     135.3 ± 0.9%   134.3 ± 1.4%          1.017         1.007
addressable-join        278.8 ± 1.7%   273.4 ± 1.7%          1.013         1.020
addressable-merge       119.5 ± 1.2%   120.5 ± 0.6%          1.023         0.992
addressable-new          57.7 ± 1.2%    57.5 ± 1.3%          0.992         1.004
addressable-normalize   295.9 ± 1.0%   292.6 ± 0.3%          1.045         1.011
addressable-parse       211.2 ± 0.3%   212.3 ± 0.7%          0.977         0.995
addressable-setters     107.8 ± 1.4%   107.7 ± 1.1%          1.044         1.000
addressable-to-s        135.5 ± 0.8%   136.4 ± 1.3%          0.998         0.993
binarytrees             310.3 ± 0.9%   302.3 ± 1.7%          1.021         1.026
blurhash                204.3 ± 0.6%   209.3 ± 2.1%          0.999         0.976
erubi                   193.8 ± 1.0%   194.6 ± 0.9%          1.009         0.996
etanni                  331.7 ± 0.9%   324.4 ± 1.0%          1.043         1.022
fannkuchredux           596.9 ± 0.3%   587.8 ± 0.2%          1.013         1.015
fluentd                 520.3 ± 1.5%   518.0 ± 1.8%          1.004         1.004
graphql                  42.8 ± 4.1%    43.0 ± 5.4%          0.972         0.994
graphql-native          351.3 ± 0.5%   360.3 ± 2.6%          0.984         0.975
knucleotide             256.4 ± 1.1%   257.2 ± 1.0%          1.002         0.997
lee                     380.2 ± 0.3%   381.9 ± 0.5%          1.004         0.996
matmul                  251.7 ± 1.0%   251.8 ± 0.5%          1.001         1.000
nbody                    49.5 ± 0.6%    49.7 ± 0.7%          0.991         0.997
nqueens                  74.4 ± 0.8%    71.5 ± 0.5%          1.018         1.040
optcarrot              1682.1 ± 1.2%  1655.7 ± 1.3%          1.021         1.016
protoboeuf               67.6 ± 1.9%    58.9 ± 1.9%          0.985         1.149
protoboeuf-encode        52.0 ± 3.8%    50.1 ± 4.3%          0.954         1.038
rack                     53.4 ± 7.2%    52.8 ± 4.2%          0.990         1.012
ruby-json               222.3 ± 0.9%   227.6 ± 1.4%          0.983         0.977
rubyboy                3335.8 ± 0.2%  3344.6 ± 0.3%          0.990         0.997
rubykon                 672.4 ± 1.1%   667.3 ± 1.7%          1.012         1.008
splay                  130.1 ± 84.6%  134.6 ± 89.2%          1.017         0.966
sudoku                  220.9 ± 1.5%   218.3 ± 0.9%          1.002         1.012
tinygql                 321.8 ± 1.2%   319.3 ± 0.6%          1.005         1.008
30k_ifelse              162.7 ± 1.8%   156.0 ± 2.9%          0.977         1.043
30k_methods              36.0 ± 2.9%    36.5 ± 2.6%          0.969         0.986
attr_accessor          16.3 ± 203.9%  14.7 ± 211.8%          1.022         1.108
cfunc_itself             3.7 ± 35.6%    3.7 ± 35.1%          0.997         0.986
fib                      44.4 ± 1.8%    40.9 ± 1.7%          1.051         1.085
getivar                12.2 ± 112.5%  12.5 ± 111.9%          0.996         0.978
getivar-module         44.6 ± 160.9%  43.0 ± 165.3%          0.953         1.038
keyword_args            26.5 ± 11.3%   26.5 ± 11.5%          0.989         1.000
loops-times             809.2 ± 0.6%   809.5 ± 0.2%          0.999         1.000
object-new              11.8 ± 75.9%   11.9 ± 74.2%          1.015         0.991
object-new-initialize   24.1 ± 24.3%   24.1 ± 24.5%          0.987         0.998
object-new-no-escape    41.5 ± 18.3%   41.4 ± 18.3%          0.975         1.003
respond_to               9.3 ± 23.1%    9.1 ± 23.3%          1.011         1.024
ruby-xor                 29.6 ± 1.5%    29.7 ± 1.5%          1.001         0.994
send_bmethod             4.0 ± 34.0%    4.0 ± 33.8%          1.013         1.005
send_cfunc_block        108.5 ± 7.2%   104.3 ± 7.3%          1.032         1.040
send_rubyfunc_block     30.7 ± 10.7%   30.8 ± 11.2%          0.971         0.997
send_rubyfunc_inline     75.9 ± 0.8%    77.5 ± 2.4%          0.948         0.979
setivar                 3.0 ± 259.6%   3.0 ± 255.7%          1.055         0.975
setivar_object          53.6 ± 54.7%   53.6 ± 54.4%          1.005         0.999
setivar_young           53.8 ± 54.8%   53.6 ± 54.5%          1.047         1.002
str_concat               42.2 ± 7.6%    42.6 ± 7.9%          1.000         0.991
structaref             16.2 ± 202.9%  15.8 ± 195.7%          1.034         1.025
structaset              6.4 ± 259.1%   6.4 ± 251.2%          1.014         0.991
throw                    34.2 ± 1.6%    34.0 ± 1.8%          0.999         1.005
---------------------  -------------  -------------  -------------  ------------

harness-gc:
----------------------  ------------  ------------  -------------  ------------
bench                    master (ms)    holes (ms)  holes 1st itr  master/holes
gcbench                 503.9 ± 5.0%  538.0 ± 0.5%          1.047         0.937
string_malloc_pressure  792.3 ± 4.4%  789.4 ± 4.5%          0.999         1.004
----------------------  ------------  ------------  -------------  ------------

GC summary (harness-gc):
----------------------  ---------------  ----------------  -------------  --------------  -------------  ---------------  -------------
bench                   mark/iter ratio  sweep/iter ratio  mark/GC ratio  sweep/GC ratio     major/iter       minor/iter     minor GC %
gcbench                           0.794             1.005          0.549           0.695   0.4  →   1.0    83.5  →  57.0  100%  →   98%
string_malloc_pressure            0.980             1.000          1.001           1.022  22.6  →  23.1  106.2  →  108.5   82%  →   82%
----------------------  ---------------  ----------------  -------------  --------------  -------------  ---------------  -------------

Legend:
- holes 1st itr: ratio of master/holes time for the first benchmarking iteration.
- master/holes: ratio of master/holes time. Higher is better for holes. Above 1 represents a speedup.
- GC summary compares master → comparison. Ratio columns are master/comparison; above 1 means the comparison spent less GC time.
- mark/iter ratio and sweep/iter ratio compare total GC phase time per benchmark iteration, so they include both per-GC cost and GC frequency changes.
- mark/GC ratio and sweep/GC ratio compare average phase time per GC, isolating whether each GC became cheaper or more expensive.
- major/iter, minor/iter, and minor GC % show master → comparison values, not ratios. Rows with no GC activity are omitted.

Output:
/home/aaron/git/ruby-bench/data/output_006.json
+ sudo -S sh -c 'echo 0 > /sys/devices/system/cpu/intel_pstate/no_turbo'
```

Here is stack usage across the headline benchmarks:

```
master: ruby 4.1.0dev (2026-07-29T19:20:24Z master 8ebf16fa73) +ZJIT +PRISM [arm64-darwin25]
holes: ruby 4.1.0dev (2026-07-31T17:40:10Z lifetime-holes a01056eadc) +ZJIT +PRISM [arm64-darwin25]

--------------  -------------  ------------------------  -------------  ------------------------  -------------  ------------
bench             master (ms)  total_native_stack_bytes     holes (ms)  total_native_stack_bytes  holes 1st itr  master/holes
activerecord     241.0 ± 5.8%                   358,400   229.8 ± 2.2%                   288,320          0.955         1.049
chunky-png      1404.8 ± 2.4%                    52,352  1451.0 ± 1.9%                    38,976          1.120         0.968
erubi-rails      702.6 ± 0.2%                   369,344   704.8 ± 0.2%                   275,200          1.094         0.997
hexapdf         1775.1 ± 0.9%                   369,216  1822.2 ± 0.4%                   274,112          0.980         0.974
liquid-c          32.1 ± 6.1%                   125,696    31.9 ± 6.0%                    95,936          0.989         1.006
liquid-compile    32.3 ± 6.3%                    97,856    31.8 ± 2.2%                    68,416          0.978         1.015
liquid-il        360.3 ± 0.9%                   182,720   372.0 ± 1.7%                   156,544          0.999         0.969
liquid-render     99.8 ± 1.8%                   159,040   100.8 ± 2.0%                   112,768          0.970         0.991
lobsters         487.8 ± 2.9%                 2,093,952   480.0 ± 2.8%                 1,655,232          0.982         1.016
mail              65.6 ± 3.0%                   761,088    67.4 ± 6.6%                   723,968          0.960         0.974
psych-load      1859.7 ± 0.5%                    60,416  1865.8 ± 0.1%                    44,032          0.994         0.997
railsbench       773.0 ± 1.1%                   871,360   771.6 ± 1.8%                   691,072          0.973         1.002
rubocop         133.2 ± 11.3%                 1,696,000  133.0 ± 10.1%                 1,488,512          0.980         1.001
ruby-lsp         125.8 ± 1.6%                   219,648   129.0 ± 4.9%                   177,984          0.860         0.975
sequel            32.8 ± 3.4%                   103,488    33.2 ± 6.4%                    82,432          1.024         0.988
shipit           770.6 ± 1.1%                 1,659,200   768.0 ± 2.8%                 1,340,608          1.036         1.003
--------------  -------------  ------------------------  -------------  ------------------------  -------------  ------------
```

I ran the above like this:

```
ruby run_benchmarks.rb --headline \
                                              --zjit-stats=total_native_stack_bytes \
                                              -e "master::/Users/aaron/.rubies/arm64/master/bin/ruby --zjit --zjit-stats-quiet" \
                                              -e "holes::/Users/aaron/.rubies/arm64/lifetime-holes/bin/ruby --zjit --zjit-stats-quiet"
```