### PR TITLE
vm_trace: Fix C event count assertion

### DIFF
--- a/vm_trace.c
+++ b/vm_trace.c
@@ -166,7 +166,7 @@ update_global_event_hooks(rb_hook_list_t *list, rb_event_flag_t prev_events, rb_
     }
     ruby_vm_iseq_events_enabled += change_iseq_events;
     if (change_c_events < 0) {
-        RUBY_ASSERT(ruby_vm_c_events_enabled >= (unsigned int)(-change_iseq_events));
+        RUBY_ASSERT(ruby_vm_c_events_enabled >= (unsigned int)(-change_c_events));
     }
     ruby_vm_c_events_enabled += change_c_events;
 


### PR DESCRIPTION
The assertion for `ruby_vm_c_events_enabled` used `change_iseq_events`, while the surrounding condition and counter update use `change_c_events`.

This PR updates the assertion to use `change_c_events` for consistency.