### PR TITLE
ZJIT: Fix load-store for extended ivars

### DIFF
--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5634,7 +5634,7 @@ impl Function {
                 (self_val, true)
             },
             ShapeLayout::Extended => {
-                let fields = self.load_field(block, self_val, FieldName::as_heap, ROBJECT_OFFSET_AS_HEAP_FIELDS, types::BasicObject);
+                let fields = self.load_field(block, self_val, FieldName::as_heap, ROBJECT_OFFSET_AS_HEAP_FIELDS, types::RubyValue);
                 (fields, false)
             },
             ShapeLayout::Other | ShapeLayout::RClass => {
@@ -6916,8 +6916,8 @@ impl Function {
             | Insn::NewRange { low: left, high: right, .. }
             | Insn::CheckMatch { target: left, pattern: right, .. }
             | Insn::WriteBarrier { recv: left, val: right } => {
-                self.assert_subtype(insn_id, left, types::BasicObject)?;
-                self.assert_subtype(insn_id, right, types::BasicObject)
+                self.assert_subtype(insn_id, left, types::RubyValue)?;
+                self.assert_subtype(insn_id, right, types::RubyValue)
             }
             Insn::GetConstant { klass, allow_nil, .. } => {
                 self.assert_subtype(insn_id, klass, types::BasicObject)?;

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5515,7 +5515,7 @@ impl Function {
                     TDATA_OFFSET_FIELDS_OBJ
                 };
 
-                let fields_obj = self.load_field(block, self_val, FieldName::fields_obj, offset, types::RubyValue);
+                let fields_obj = self.load_field(block, self_val, FieldName::fields_obj, offset, types::IMemo);
                 // All fields objects are embedded
                 self.load_ivar_embedded(block, fields_obj, id, ivar_index)
             },
@@ -5634,7 +5634,7 @@ impl Function {
                 (self_val, true)
             },
             ShapeLayout::Extended => {
-                let fields = self.load_field(block, self_val, FieldName::as_heap, ROBJECT_OFFSET_AS_HEAP_FIELDS, types::RubyValue);
+                let fields = self.load_field(block, self_val, FieldName::as_heap, ROBJECT_OFFSET_AS_HEAP_FIELDS, types::IMemo);
                 (fields, false)
             },
             ShapeLayout::Other | ShapeLayout::RClass => {

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -20754,4 +20754,70 @@ mod hir_opt_tests {
           Return v59
         ");
     }
+
+    #[test]
+    fn test_elide_load_store_extended() {
+        eval(r#"
+            class C
+              def initialize
+                @foo = 1
+                100.times { |i| instance_variable_set(:"@v#{i}", i) }
+                @hclk = 1
+                @hclk_target = 2
+              end
+              def foo = 4
+              def wait_one_clock
+                @hclk += 1
+                foo if @hclk_target <= @hclk
+              end
+            end
+            O = C.new
+            O.wait_one_clock
+        "#);
+        assert_snapshot!(hir_string_proc("C.instance_method(:wait_one_clock)"), @"
+        fn wait_one_clock@<compiled>:11:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          Jump bb3(v1)
+        bb2():
+          EntryPoint JIT(0)
+          v4:BasicObject = LoadArg :self@0
+          Jump bb3(v4)
+        bb3(v6:BasicObject):
+          PatchPoint SingleRactorMode
+          v11:HeapBasicObject = GuardType v6, HeapBasicObject
+          v12:CShape = LoadField v11, :shape_id@0x1000
+          v13:CShape[0x1001] = GuardBitEquals v12, CShape(0x1001) recompile
+          v14:RubyValue = LoadField v11, :fields_obj@0x1002
+          v15:BasicObject = LoadField v14, :@hclk@0x1003
+          v17:Fixnum[1] = Const Value(1)
+          PatchPoint MethodRedefined(Integer@0x1008, +@0x1010, cme:0x1018)
+          v71:Fixnum = GuardType v15, Fixnum recompile
+          v72:Fixnum = FixnumAdd v71, v17
+          v26:BasicObject = LoadField v11, :as_heap@0x1002
+          StoreField v26, :@hclk@0x1003, v72
+          WriteBarrier v26, v72
+          PatchPoint SingleRactorMode
+          v37:BasicObject = LoadField v14, :@hclk_target@0x1040
+          v44:BasicObject = LoadField v14, :@hclk@0x1003
+          PatchPoint MethodRedefined(Integer@0x1008, <=@0x1041, cme:0x1048)
+          v75:Fixnum = GuardType v37, Fixnum recompile
+          v76:Fixnum = GuardType v44, Fixnum
+          v77:BoolExact = FixnumLe v75, v76
+          v49:CBool = Test v77
+          CondBranch v49, bb5(), bb4(v11)
+        bb5():
+          PatchPoint NoSingletonClass(C@0x1070)
+          PatchPoint MethodRedefined(C@0x1070, foo@0x1078, cme:0x1080)
+          v80:ObjectSubclass[class_exact:C] = GuardType v11, ObjectSubclass[class_exact:C] recompile
+          v81:Fixnum[4] = Const Value(4)
+          CheckInterrupts
+          Return v81
+        bb4(v60:HeapBasicObject):
+          v63:NilClass = Const Value(nil)
+          CheckInterrupts
+          Return v63
+        ");
+    }
 }

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -6929,7 +6929,7 @@ mod hir_opt_tests {
           v17:HeapBasicObject = GuardType v9, HeapBasicObject
           v18:CShape = LoadField v17, :shape_id@0x1001
           v19:CShape[0x1002] = GuardBitEquals v18, CShape(0x1002) recompile
-          v20:BasicObject = LoadField v17, :as_heap@0x1003
+          v20:RubyValue = LoadField v17, :as_heap@0x1003
           StoreField v20, :@v0@0x1003, v10
           WriteBarrier v20, v10
           CheckInterrupts
@@ -20795,16 +20795,13 @@ mod hir_opt_tests {
           PatchPoint MethodRedefined(Integer@0x1008, +@0x1010, cme:0x1018)
           v71:Fixnum = GuardType v15, Fixnum recompile
           v72:Fixnum = FixnumAdd v71, v17
-          v26:BasicObject = LoadField v11, :as_heap@0x1002
-          StoreField v26, :@hclk@0x1003, v72
-          WriteBarrier v26, v72
+          StoreField v14, :@hclk@0x1003, v72
+          WriteBarrier v14, v72
           PatchPoint SingleRactorMode
           v37:BasicObject = LoadField v14, :@hclk_target@0x1040
-          v44:BasicObject = LoadField v14, :@hclk@0x1003
           PatchPoint MethodRedefined(Integer@0x1008, <=@0x1041, cme:0x1048)
           v75:Fixnum = GuardType v37, Fixnum recompile
-          v76:Fixnum = GuardType v44, Fixnum
-          v77:BoolExact = FixnumLe v75, v76
+          v77:BoolExact = FixnumLe v75, v72
           v49:CBool = Test v77
           CondBranch v49, bb5(), bb4(v11)
         bb5():

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -6929,7 +6929,7 @@ mod hir_opt_tests {
           v17:HeapBasicObject = GuardType v9, HeapBasicObject
           v18:CShape = LoadField v17, :shape_id@0x1001
           v19:CShape[0x1002] = GuardBitEquals v18, CShape(0x1002) recompile
-          v20:RubyValue = LoadField v17, :as_heap@0x1003
+          v20:IMemo = LoadField v17, :as_heap@0x1003
           StoreField v20, :@v0@0x1003, v10
           WriteBarrier v20, v10
           CheckInterrupts
@@ -9507,7 +9507,7 @@ mod hir_opt_tests {
           v11:HeapBasicObject = GuardType v6, HeapBasicObject
           v12:CShape = LoadField v11, :shape_id@0x1000
           v13:CShape[0x1001] = GuardBitEquals v12, CShape(0x1001) recompile
-          v14:RubyValue = LoadField v11, :fields_obj@0x1002
+          v14:IMemo = LoadField v11, :fields_obj@0x1002
           v15:BasicObject = LoadField v14, :@foo@0x1003
           CheckInterrupts
           Return v15
@@ -9577,7 +9577,7 @@ mod hir_opt_tests {
           v11:HeapBasicObject = GuardType v6, HeapBasicObject
           v12:CShape = LoadField v11, :shape_id@0x1000
           v13:CShape[0x1001] = GuardBitEquals v12, CShape(0x1001) recompile
-          v14:RubyValue = LoadField v11, :fields_obj@0x1002
+          v14:IMemo = LoadField v11, :fields_obj@0x1002
           v15:BasicObject = LoadField v14, :@foo@0x1003
           CheckInterrupts
           Return v15
@@ -9640,7 +9640,7 @@ mod hir_opt_tests {
           v11:HeapBasicObject = GuardType v6, HeapBasicObject
           v12:CShape = LoadField v11, :shape_id@0x1000
           v13:CShape[0x1001] = GuardBitEquals v12, CShape(0x1001) recompile
-          v14:RubyValue = LoadField v11, :fields_obj@0x1002
+          v14:IMemo = LoadField v11, :fields_obj@0x1002
           v15:BasicObject = LoadField v14, :@a@0x1002
           CheckInterrupts
           Return v15
@@ -9675,7 +9675,7 @@ mod hir_opt_tests {
           v11:HeapBasicObject = GuardType v6, HeapBasicObject
           v12:CShape = LoadField v11, :shape_id@0x1000
           v13:CShape[0x1001] = GuardBitEquals v12, CShape(0x1001) recompile
-          v14:RubyValue = LoadField v11, :fields_obj@0x1002
+          v14:IMemo = LoadField v11, :fields_obj@0x1002
           v15:BasicObject = LoadField v14, :@a@0x1002
           CheckInterrupts
           Return v15
@@ -9817,7 +9817,7 @@ mod hir_opt_tests {
           Jump bb4(v17)
         bb6():
           v19:CShape[0x1003] = GuardBitEquals v12, CShape(0x1003) recompile
-          v21:RubyValue = LoadField v11, :fields_obj@0x1004
+          v21:IMemo = LoadField v11, :fields_obj@0x1004
           v22:BasicObject = LoadField v21, :@foo@0x1004
           Jump bb4(v22)
         bb4(v13:BasicObject):
@@ -9880,7 +9880,7 @@ mod hir_opt_tests {
           v15:CBool = IsBitEqual v12, v14
           CondBranch v15, bb5(), bb6()
         bb5():
-          v17:RubyValue = LoadField v11, :fields_obj@0x1002
+          v17:IMemo = LoadField v11, :fields_obj@0x1002
           v18:BasicObject = LoadField v17, :@foo@0x1002
           Jump bb4(v18)
         bb6():
@@ -9995,12 +9995,12 @@ mod hir_opt_tests {
           v15:CBool = IsBitEqual v12, v14
           CondBranch v15, bb5(), bb6()
         bb5():
-          v17:RubyValue = LoadField v11, :fields_obj@0x1002
+          v17:IMemo = LoadField v11, :fields_obj@0x1002
           v18:BasicObject = LoadField v17, :@a@0x1002
           Jump bb4(v18)
         bb6():
           v20:CShape[0x1003] = GuardBitEquals v12, CShape(0x1003) recompile
-          v22:RubyValue = LoadField v11, :fields_obj@0x1004
+          v22:IMemo = LoadField v11, :fields_obj@0x1004
           v23:BasicObject = LoadField v22, :@a@0x1002
           Jump bb4(v23)
         bb4(v13:BasicObject):
@@ -20789,7 +20789,7 @@ mod hir_opt_tests {
           v11:HeapBasicObject = GuardType v6, HeapBasicObject
           v12:CShape = LoadField v11, :shape_id@0x1000
           v13:CShape[0x1001] = GuardBitEquals v12, CShape(0x1001) recompile
-          v14:RubyValue = LoadField v11, :fields_obj@0x1002
+          v14:IMemo = LoadField v11, :fields_obj@0x1002
           v15:BasicObject = LoadField v14, :@hclk@0x1003
           v17:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Integer@0x1008, +@0x1010, cme:0x1018)

--- a/zjit/src/hir_type/gen_hir_type.rb
+++ b/zjit/src/hir_type/gen_hir_type.rb
@@ -47,7 +47,9 @@ end
 any = Type.new "Any"
 # Build the Ruby object universe.
 value = any.subtype "RubyValue"
+imemo = value.subtype "IMemo"
 undef_ = value.subtype "Undef"
+# TODO(max): Figure out if CME should be a subtype of IMemo
 value.subtype "CallableMethodEntry"  # rb_callable_method_entry_t*
 basic_object = value.subtype "BasicObject"
 basic_object_exact = basic_object.subtype "BasicObjectExact"

--- a/zjit/src/hir_type/hir_type.inc.rs
+++ b/zjit/src/hir_type/hir_type.inc.rs
@@ -45,40 +45,41 @@ mod bits {
   pub const HeapBasicObject: u64 = BasicObject & !Immediate;
   pub const HeapFloat: u64 = 1u64 << 28;
   pub const HeapObject: u64 = Object & !Immediate;
+  pub const IMemo: u64 = 1u64 << 29;
   pub const Immediate: u64 = FalseClass | Fixnum | Flonum | NilClass | StaticSymbol | TrueClass | Undef;
   pub const Integer: u64 = Bignum | Fixnum;
   pub const Module: u64 = Class | ModuleExact | ModuleSubclass;
-  pub const ModuleExact: u64 = 1u64 << 29;
-  pub const ModuleSubclass: u64 = 1u64 << 30;
-  pub const NilClass: u64 = 1u64 << 31;
+  pub const ModuleExact: u64 = 1u64 << 30;
+  pub const ModuleSubclass: u64 = 1u64 << 31;
+  pub const NilClass: u64 = 1u64 << 32;
   pub const NotNil: u64 = BasicObject & !NilClass;
   pub const NotString: u64 = BasicObject & !String;
   pub const Numeric: u64 = Float | Integer | NumericExact | NumericSubclass;
-  pub const NumericExact: u64 = 1u64 << 32;
-  pub const NumericSubclass: u64 = 1u64 << 33;
+  pub const NumericExact: u64 = 1u64 << 33;
+  pub const NumericSubclass: u64 = 1u64 << 34;
   pub const Object: u64 = Array | FalseClass | Hash | Module | NilClass | Numeric | ObjectExact | ObjectSubclass | Range | Regexp | Set | String | Symbol | TrueClass;
-  pub const ObjectExact: u64 = 1u64 << 34;
-  pub const ObjectSubclass: u64 = 1u64 << 35;
+  pub const ObjectExact: u64 = 1u64 << 35;
+  pub const ObjectSubclass: u64 = 1u64 << 36;
   pub const Range: u64 = RangeExact | RangeSubclass;
-  pub const RangeExact: u64 = 1u64 << 36;
-  pub const RangeSubclass: u64 = 1u64 << 37;
+  pub const RangeExact: u64 = 1u64 << 37;
+  pub const RangeSubclass: u64 = 1u64 << 38;
   pub const Regexp: u64 = RegexpExact | RegexpSubclass;
-  pub const RegexpExact: u64 = 1u64 << 38;
-  pub const RegexpSubclass: u64 = 1u64 << 39;
-  pub const RubyValue: u64 = BasicObject | CallableMethodEntry | Undef;
+  pub const RegexpExact: u64 = 1u64 << 39;
+  pub const RegexpSubclass: u64 = 1u64 << 40;
+  pub const RubyValue: u64 = BasicObject | CallableMethodEntry | IMemo | Undef;
   pub const Set: u64 = SetExact | SetSubclass;
-  pub const SetExact: u64 = 1u64 << 40;
-  pub const SetSubclass: u64 = 1u64 << 41;
-  pub const StaticSymbol: u64 = 1u64 << 42;
+  pub const SetExact: u64 = 1u64 << 41;
+  pub const SetSubclass: u64 = 1u64 << 42;
+  pub const StaticSymbol: u64 = 1u64 << 43;
   pub const String: u64 = StringExact | StringSubclass;
-  pub const StringExact: u64 = 1u64 << 43;
-  pub const StringSubclass: u64 = 1u64 << 44;
+  pub const StringExact: u64 = 1u64 << 44;
+  pub const StringSubclass: u64 = 1u64 << 45;
   pub const Subclass: u64 = ArraySubclass | BasicObjectSubclass | ClassSubclass | HashSubclass | ModuleSubclass | NumericSubclass | ObjectSubclass | RangeSubclass | RegexpSubclass | SetSubclass | StringSubclass;
   pub const Symbol: u64 = DynamicSymbol | StaticSymbol;
-  pub const TrueClass: u64 = 1u64 << 45;
+  pub const TrueClass: u64 = 1u64 << 46;
   pub const Truthy: u64 = BasicObject & !Falsy;
-  pub const Undef: u64 = 1u64 << 46;
-  pub const AllBitPatterns: [(&str, u64); 78] = [
+  pub const Undef: u64 = 1u64 << 47;
+  pub const AllBitPatterns: [(&str, u64); 79] = [
     ("Any", Any),
     ("RubyValue", RubyValue),
     ("Immediate", Immediate),
@@ -118,6 +119,7 @@ mod bits {
     ("Module", Module),
     ("ModuleSubclass", ModuleSubclass),
     ("ModuleExact", ModuleExact),
+    ("IMemo", IMemo),
     ("Float", Float),
     ("HeapFloat", HeapFloat),
     ("Hash", Hash),
@@ -158,7 +160,7 @@ mod bits {
     ("ArrayExact", ArrayExact),
     ("Empty", Empty),
   ];
-  pub const NumTypeBits: u64 = 47;
+  pub const NumTypeBits: u64 = 48;
 }
 pub mod types {
   use super::*;
@@ -207,6 +209,7 @@ pub mod types {
   pub const HeapBasicObject: Type = Type::from_bits(bits::HeapBasicObject);
   pub const HeapFloat: Type = Type::from_bits(bits::HeapFloat);
   pub const HeapObject: Type = Type::from_bits(bits::HeapObject);
+  pub const IMemo: Type = Type::from_bits(bits::IMemo);
   pub const Immediate: Type = Type::from_bits(bits::Immediate);
   pub const Integer: Type = Type::from_bits(bits::Integer);
   pub const Module: Type = Type::from_bits(bits::Module);


### PR DESCRIPTION
See individual commits. This removes 2 loads and 1 guard in optcarrot's hottest function.