### PR TITLE
Silence debugger availability probes in EnvUtil

### DIFF
--- a/tool/lib/envutil.rb
+++ b/tool/lib/envutil.rb
@@ -130,7 +130,7 @@ module EnvUtil
 
     register("gdb") do
       class << self
-        def usable?; system(*%w[gdb --batch --quiet --nx -ex exit]); end
+        def usable?; system(*%w[gdb --batch --quiet --nx -ex exit], out: IO::NULL, err: IO::NULL); end
         def start(pid, *args, **opts)
           spawn(*%W[gdb --batch --quiet --pid #{pid}], *args, **opts)
         end
@@ -140,7 +140,7 @@ module EnvUtil
 
     register("lldb") do
       class << self
-        def usable?; system(*%w[lldb -Q --no-lldbinit -o exit]); end
+        def usable?; system(*%w[lldb -Q --no-lldbinit -o exit], out: IO::NULL, err: IO::NULL); end
         def start(pid, *args, **opts)
           spawn(*%W[lldb --batch -Q --attach-pid #{pid}], *args, **opts)
         end
@@ -149,7 +149,10 @@ module EnvUtil
     end
 
     def self.search
-      @debugger ||= @list.find(&:usable?)
+      # Cache the result even when no debugger is available, not to probe
+      # unusable debuggers repeatedly.
+      return @debugger if defined?(@debugger)
+      @debugger = @list.find(&:usable?)
     end
   end
 


### PR DESCRIPTION
`EnvUtil::Debugger.search` decides which debugger to use by actually running each one, and the probe output is not redirected anywhere. On Windows the `lldb.exe` shipped with Visual Studio BuildTools fails to load its dependencies and prints an LLVM crash report, which lands in the middle of the test progress output.

It shows up while running `TestThread#test_thread_interrupt_for_killed_thread`, where the timeout path reaches `Debugger.search` before sending `ABRT`.

```
TestThread#test_thread_interrupt_for_killed_threaderror: unable to find 'python311.dll'.
PLEASE submit a bug report to https://github.com/llvm/llvm-project/issues/ and include the crash backtrace.
Stack dump:
0.      Program arguments: lldb -Q --no-lldbinit -o exit
```

Send the probe output to `IO::NULL`, and cache a `nil` result as well so that a failing probe does not run again on every later timeout.
