### PR TITLE
Shrink `st_table` from 48B down to 40B

### DIFF
--- a/include/ruby/st.h
+++ b/include/ruby/st.h
@@ -78,7 +78,7 @@ struct st_table_entry; /* defined in st.c */
 
 struct st_table {
     /* Cached features of the table -- see st.c for more details.  */
-    unsigned char entry_power, bin_power, size_ind;
+    unsigned char entry_power, bin_power, size_ind, entries_start;
     /* How many times the table was rebuilt.  */
     unsigned int rebuilds_num;
     const struct st_hash_type *type;
@@ -87,7 +87,7 @@ struct st_table {
     /* Start and bound index of entries in array entries.
        entries_starts and entries_bound are in interval
        [0,allocated_entries].  */
-    st_index_t entries_start, entries_bound;
+    st_index_t entries_bound;
     /* Array of size 2^entry_power.
        Optionally followed by an array of bins used for access by keys.  */
     st_table_entry *entries;

--- a/internal/set_table.h
+++ b/internal/set_table.h
@@ -9,7 +9,7 @@ typedef struct set_table_entry set_table_entry;
 
 struct set_table {
     /* Cached features of the table -- see st.c for more details.  */
-    unsigned char entry_power, bin_power, size_ind;
+    unsigned char entry_power, bin_power, size_ind, entries_start;
     /* How many times the table was rebuilt.  */
     unsigned int rebuilds_num;
     const struct st_hash_type *type;
@@ -19,7 +19,7 @@ struct set_table {
     /* Start and bound index of entries in array entries.
        entries_starts and entries_bound are in interval
        [0,allocated_entries].  */
-    st_index_t entries_start, entries_bound;
+    st_index_t entries_bound;
 
     /**
      * Array of size 2^entry_power.

--- a/st.c
+++ b/st.c
@@ -131,6 +131,8 @@
 #define ATTRIBUTE_UNUSED
 #endif
 
+#define MAX_ENTRIES_START ((unsigned char)-1)
+
 /* The type of hashes.  */
 typedef st_index_t st_hash_t;
 
@@ -1187,12 +1189,13 @@ st_get_key(st_table *tab, st_data_t key, st_data_t *result)
 
 /* Check the table and rebuild it if it is necessary.  */
 static inline void
-rebuild_table_if_necessary (st_table *tab)
+rebuild_table_if_necessary(st_table *tab)
 {
     st_index_t bound = tab->entries_bound;
 
-    if (bound == get_allocated_entries(tab))
+    if (bound == get_allocated_entries(tab) || tab->entries_start == MAX_ENTRIES_START) {
         rebuild_table(tab);
+    }
 }
 
 /* Insert (KEY, VALUE) into table TAB and return zero.  If there is
@@ -1301,7 +1304,7 @@ st_insert2(st_table *tab, st_data_t key, st_data_t value,
 
     hash_value = do_hash(key, tab);
  retry:
-    rebuild_table_if_necessary (tab);
+    rebuild_table_if_necessary(tab);
     if (!st_has_bins(tab)) {
         bin = find_entry(tab, hash_value, key);
         if (EXPECT(bin == REBUILT_TABLE_ENTRY_IND, 0))
@@ -1384,6 +1387,9 @@ update_range_for_deleted(st_table *tab, st_index_t n)
         st_index_t bound = tab->entries_bound;
         st_table_entry *entries = tab->entries;
         while (start < bound && DELETED_ENTRY_P(&entries[start])) start++;
+        if (start > MAX_ENTRIES_START) {
+            start = MAX_ENTRIES_START;
+        }
         tab->entries_start = start;
     }
 }
@@ -2989,12 +2995,13 @@ set_table_lookup(set_table *tab, st_data_t key)
 
 /* Check the table and rebuild it if it is necessary.  */
 static inline void
-set_rebuild_table_if_necessary (set_table *tab)
+set_rebuild_table_if_necessary(set_table *tab)
 {
     st_index_t bound = tab->entries_bound;
 
-    if (bound == set_get_allocated_entries(tab))
+    if (bound == set_get_allocated_entries(tab) || tab->entries_start == MAX_ENTRIES_START) {
         set_rebuild_table(tab);
+    }
 }
 
 /* Insert KEY into table TAB and return zero.  If there is
@@ -3079,6 +3086,9 @@ set_update_range_for_deleted(set_table *tab, st_index_t n)
         st_index_t bound = tab->entries_bound;
         set_table_entry *entries = tab->entries;
         while (start < bound && DELETED_ENTRY_P(&entries[start])) start++;
+        if (start > MAX_ENTRIES_START) {
+            start = MAX_ENTRIES_START;
+        }
         tab->entries_start = start;
     }
 }


### PR DESCRIPTION
This allows `st_table + RHash` to fit in a `64B` slot.

It is achieved by turning `entries_start` from pointer size down to a single byte.

This means it can now overflow, if you delete the first element 255 times, but in such case we can rebuild the table entirely, which is an acceptable tradeoff.