### PR TITLE
[ruby/spec] Use ENVSpecs.encoding for ENV key encoding specs

### DIFF
--- a/spec/ruby/core/env/each_key_spec.rb
+++ b/spec/ruby/core/env/each_key_spec.rb
@@ -1,5 +1,6 @@
 require_relative '../../spec_helper'
 require_relative '../enumerable/shared/enumeratorized'
+require_relative 'fixtures/common'
 
 describe "ENV.each_key" do
 
@@ -26,7 +27,7 @@ describe "ENV.each_key" do
 
   it "returns keys in the locale encoding" do
     ENV.each_key do |key|
-      key.encoding.should == Encoding.find('locale')
+      key.encoding.should == ENVSpecs.encoding
     end
   end
 

--- a/spec/ruby/core/env/keys_spec.rb
+++ b/spec/ruby/core/env/keys_spec.rb
@@ -1,4 +1,5 @@
 require_relative '../../spec_helper'
+require_relative 'fixtures/common'
 
 describe "ENV.keys" do
 
@@ -8,7 +9,7 @@ describe "ENV.keys" do
 
   it "returns the keys in the locale encoding" do
     ENV.keys.each do |key|
-      key.encoding.should == Encoding.find('locale')
+      key.encoding.should == ENVSpecs.encoding
     end
   end
 end


### PR DESCRIPTION
`ENV.keys` and `ENV.each_key` specs compared the key encoding against `Encoding.find('locale')`, which fails on Windows. `env_encoding()` in `hash.c` returns UTF-8 unconditionally there, while `Encoding.find('locale')` follows `GetConsoleCP()`, so `make test-spec` reports two failures under a Japanese console code page.

The other ENV specs already go through `ENVSpecs.encoding` in `spec/ruby/core/env/fixtures/common.rb`, which maps Windows to UTF-8. These two now do the same.

Verified with an mswin build under both code pages. `spec/ruby/core/env` gives 200 examples and 0 failures at chcp 932 and at chcp 65001, where it previously failed twice at 932.
