### PR TITLE
ZJIT: Shrink hir::Insn from 80 to 72 bytes

### DIFF
--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -24,7 +24,7 @@ use crate::stats::{counter_ptr, with_time_stat, trace_compile_phase, Counter, Co
 use crate::{asm::CodeBlock, cruby::*, options::debug, virtualmem::CodePtr};
 use crate::backend::lir::{self, Assembler, C_ARG_OPNDS, C_RET_OPND, CFP, EC, NATIVE_BASE_PTR, Opnd, SP, SideExit, SideExitRecompile, SideExitTarget, StackMap, StackMapEntry, Target, asm_ccall, asm_comment};
 use crate::hir::{self, iseq_to_hir, BlockId, Invariant, RangeType, SideExitReason::{self, *}, SpecialBackrefSymbol, SpecialObjectType};
-use crate::hir::{BlockHandler, CCallVariadicData, CCallWithFrameData, Const, FieldName, FrameState, Function, Insn, InsnId, Recompile, SendData, SendDirectData, PushInlineFrameData, SendFallbackReason, qualified_method_name};
+use crate::hir::{BlockHandler, CCallData, CCallVariadicData, CCallWithFrameData, Const, FieldName, FrameState, Function, Insn, InsnId, Recompile, SendData, SendDirectData, PushInlineFrameData, SendFallbackReason, qualified_method_name};
 use crate::hir_type::{types, Type};
 use crate::options::{get_option, InlineDepth, PerfMap, DEFAULT_MAX_VERSIONS};
 use crate::cast::IntoUsize;
@@ -735,7 +735,10 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
         &Insn::GuardLess { left, right, ref reason, state } => gen_guard_less(jit, asm, function, opnd!(left), opnd!(right), **reason, &function.frame_state(state)),
         &Insn::GuardGreaterEq { left, right, state, .. } => gen_guard_greater_eq(jit, asm, function, opnd!(left), opnd!(right), &function.frame_state(state)),
         Insn::PatchPoint { invariant, state } => no_output!(gen_patch_point(jit, asm, function, invariant, &function.frame_state(*state))),
-        Insn::CCall { cfunc, recv, args, name, owner, return_type: _, elidable: _ } => gen_ccall(asm, *cfunc, *name, *owner, opnd!(recv), opnds!(args)),
+        Insn::CCall(insn) => {
+            let CCallData { cfunc, recv, args, name, owner, return_type: _, elidable: _ } = &**insn;
+            gen_ccall(asm, *cfunc, *name, *owner, opnd!(recv), opnds!(args))
+        }
         Insn::CCallWithFrame(insn) => {
             let CCallWithFrameData { cfunc, recv, name, args, cme, state, block, .. } = &**insn;
             gen_ccall_with_frame(jit, asm, function, *cfunc, *name, opnd!(recv), opnds!(args), *cme, *block, &function.frame_state(*state))

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -24,7 +24,7 @@ use crate::stats::{counter_ptr, with_time_stat, trace_compile_phase, Counter, Co
 use crate::{asm::CodeBlock, cruby::*, options::debug, virtualmem::CodePtr};
 use crate::backend::lir::{self, Assembler, C_ARG_OPNDS, C_RET_OPND, CFP, EC, NATIVE_BASE_PTR, Opnd, SP, SideExit, SideExitRecompile, SideExitTarget, StackMap, StackMapEntry, Target, asm_ccall, asm_comment};
 use crate::hir::{self, iseq_to_hir, BlockId, Invariant, RangeType, SideExitReason::{self, *}, SpecialBackrefSymbol, SpecialObjectType};
-use crate::hir::{BlockHandler, CCallVariadicData, CCallWithFrameData, Const, FieldName, FrameState, Function, Insn, InsnId, Recompile, SendData, SendDirectData, SendFallbackReason, qualified_method_name};
+use crate::hir::{BlockHandler, CCallVariadicData, CCallWithFrameData, Const, FieldName, FrameState, Function, Insn, InsnId, Recompile, SendData, SendDirectData, PushInlineFrameData, SendFallbackReason, qualified_method_name};
 use crate::hir_type::{types, Type};
 use crate::options::{get_option, InlineDepth, PerfMap, DEFAULT_MAX_VERSIONS};
 use crate::cast::IntoUsize;
@@ -662,8 +662,9 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
                 function, *cme, *iseq, opnd!(recv), opnds!(args),
                 *kw_bits, *jit_entry_idx, &function.frame_state(*state), *block,
             )
-        }
-        Insn::PushInlineFrame { cme, iseq, recv, args, blockiseq, state, .. } => {
+        },
+        Insn::PushInlineFrame(insn) => {
+            let PushInlineFrameData { iseq, cme, recv, args, blockiseq, state, .. } = &**insn;
             no_output!(gen_push_inline_frame(jit, asm, function, *cme, *iseq, opnd!(recv), opnds!(args), &function.frame_state(*state), *blockiseq))
         },
         Insn::PopInlineFrame { iseq, argc, state } => {

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -24,7 +24,7 @@ use crate::stats::{counter_ptr, with_time_stat, trace_compile_phase, Counter, Co
 use crate::{asm::CodeBlock, cruby::*, options::debug, virtualmem::CodePtr};
 use crate::backend::lir::{self, Assembler, C_ARG_OPNDS, C_RET_OPND, CFP, EC, NATIVE_BASE_PTR, Opnd, SP, SideExit, SideExitRecompile, SideExitTarget, StackMap, StackMapEntry, Target, asm_ccall, asm_comment};
 use crate::hir::{self, iseq_to_hir, BlockId, Invariant, RangeType, SideExitReason::{self, *}, SpecialBackrefSymbol, SpecialObjectType};
-use crate::hir::{BlockHandler, CCallVariadicData, CCallWithFrameData, Const, FieldName, FrameState, Function, Insn, InsnId, Recompile, SendDirectData, SendFallbackReason, qualified_method_name};
+use crate::hir::{BlockHandler, CCallVariadicData, CCallWithFrameData, Const, FieldName, FrameState, Function, Insn, InsnId, Recompile, SendData, SendDirectData, SendFallbackReason, qualified_method_name};
 use crate::hir_type::{types, Type};
 use crate::options::{get_option, InlineDepth, PerfMap, DEFAULT_MAX_VERSIONS};
 use crate::cast::IntoUsize;
@@ -647,9 +647,13 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
         Insn::Param => unreachable!("block.insns should not have Insn::Param"),
         Insn::LoadArg { .. } => return Ok(()), // compiled in the LoadArg pre-pass above
         Insn::Snapshot { .. } => return Ok(()), // we don't need to do anything for this instruction at the moment
-        &Insn::Send { cd, block: None, state, reason, .. } => gen_send_without_block(jit, asm, function, cd, &function.frame_state(state), reason),
-        &Insn::Send { cd, block: Some(BlockHandler::BlockIseq(blockiseq)), state, reason, .. } => gen_send(jit, asm, function, cd, blockiseq, &function.frame_state(state), reason),
-        &Insn::Send { cd, block: Some(BlockHandler::BlockArg), state, reason, .. } => gen_send(jit, asm, function, cd, std::ptr::null(), &function.frame_state(state), reason),
+        Insn::Send(send_insn) => {
+            match &**send_insn {
+                SendData { cd, block: None, state, reason, .. } => gen_send_without_block(jit, asm, function, cd.clone(), &function.frame_state(*state), *reason),
+                SendData { cd, block: Some(BlockHandler::BlockIseq(blockiseq)), state, reason, .. } => gen_send(jit, asm, function, cd.clone(), blockiseq.clone(), &function.frame_state(*state), *reason),
+                SendData { cd, block: Some(BlockHandler::BlockArg), state, reason, .. } => gen_send(jit, asm, function, cd.clone(), std::ptr::null(), &function.frame_state(*state), *reason),
+            }
+        }
         &Insn::SendForward { cd, blockiseq, state, reason, .. } => gen_send_forward(jit, asm, function, cd, blockiseq, &function.frame_state(state), reason),
         Insn::SendDirect(insn) => {
             let SendDirectData { cme, iseq, recv, args, kw_bits, jit_entry_idx, block, state, .. } = &**insn;

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -475,19 +475,19 @@ fn gen_function(cb: &mut CodeBlock, iseq: IseqPtr, version: IseqVersionRef, func
                 let perf_symbol = hir_perf_symbol_range_start(&mut asm, &insn);
 
                 let result = match &insn {
-                    Insn::CondBranch { val, if_true, if_false } => {
-                        let val_opnd = jit.get_opnd(*val);
-                        let true_target = hir_to_lir[if_true.target.0].unwrap();
-                        let false_target = hir_to_lir[if_false.target.0].unwrap();
+                    Insn::CondBranch(cb_insn) => {
+                        let val_opnd = jit.get_opnd(cb_insn.val);
+                        let true_target = hir_to_lir[cb_insn.if_true.target.0].unwrap();
+                        let false_target = hir_to_lir[cb_insn.if_false.target.0].unwrap();
 
                         let true_branch = lir::BranchEdge {
                             target: true_target,
-                            args: if_true.args.iter().map(|insn_id| jit.get_opnd(*insn_id)).collect()
+                            args: cb_insn.if_true.args.iter().map(|insn_id| jit.get_opnd(*insn_id)).collect()
                         };
 
                         let false_branch = lir::BranchEdge {
                             target: false_target,
-                            args: if_false.args.iter().map(|insn_id| jit.get_opnd(*insn_id)).collect()
+                            args: cb_insn.if_false.args.iter().map(|insn_id| jit.get_opnd(*insn_id)).collect()
                         };
 
                         asm.test(val_opnd, val_opnd);
@@ -788,8 +788,7 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
         &Insn::ArrayMax { ref elements, state } => gen_array_max(jit, asm, function, opnds!(elements), &function.frame_state(state)),
         &Insn::ArrayMin { ref elements, state } => gen_array_min(jit, asm, function, opnds!(elements), &function.frame_state(state)),
         &Insn::Throw { state, .. } => no_output!(gen_throw(jit, asm, function, &function.frame_state(state))),
-        &Insn::CondBranch { .. }
-        | &Insn::Jump { .. } | Insn::Entries { .. } => unreachable!(),
+        &Insn::CondBranch(_) | &Insn::Jump(_) | Insn::Entries { .. } => unreachable!(),
     };
 
     assert!(insn.has_output(), "Cannot write LIR output of HIR instruction with no output: {insn}");

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -915,6 +915,14 @@ pub struct SendDirectData {
     pub state: InsnId,
 }
 
+/// Payload of [`Insn::CondBranch`]. Boxed in the enum to keep `Insn` small.
+#[derive(Debug, Clone)]
+pub struct CondBranchData {
+    pub val: InsnId,
+    pub if_true: BranchEdge,
+    pub if_false: BranchEdge,
+}
+
 /// Payload of [`Insn::CCallVariadic`]. Boxed in the enum to keep `Insn` small.
 #[derive(Debug, Clone)]
 pub struct CCallVariadicData {
@@ -1095,7 +1103,7 @@ pub enum Insn {
     Jump(BranchEdge),
 
     /// Conditional branch
-    CondBranch { val: InsnId, if_true: BranchEdge, if_false: BranchEdge },
+    CondBranch(Box<CondBranchData>),
 
     /// Call a C function without pushing a frame
     /// `name` and `owner` are for printing purposes only
@@ -1466,10 +1474,10 @@ macro_rules! for_each_operand_impl {
             Insn::Jump(BranchEdge { args, .. }) => {
                 $visit_many!(args);
             }
-            Insn::CondBranch { val, if_true: BranchEdge { args: true_args, .. }, if_false: BranchEdge { args: false_args, .. } } => {
-                $visit_one!(*val);
-                $visit_many!(true_args);
-                $visit_many!(false_args);
+            Insn::CondBranch(insn) => {
+                $visit_one!(insn.val);
+                $visit_many!(insn.if_true.args);
+                $visit_many!(insn.if_false.args);
             }
             Insn::ArrayDup { val, state }
             | Insn::Throw { val, state, .. }
@@ -1624,7 +1632,7 @@ impl Insn {
             Insn::Comment { .. }
             | Insn::Jump(_)
             | Insn::Entries { .. }
-            | Insn::CondBranch { .. } | Insn::EntryPoint { .. } | Insn::Return { .. }
+            | Insn::CondBranch(_) | Insn::EntryPoint { .. } | Insn::Return { .. }
             | Insn::PatchPoint { .. } | Insn::SetIvar { .. } | Insn::SetClassVar { .. } | Insn::ArrayExtend { .. }
             | Insn::ArrayPush { .. } | Insn::SideExit { .. } | Insn::SetGlobal { .. }
             | Insn::SetLocal { .. } | Insn::Throw { .. } | Insn::IncrCounter(_) | Insn::IncrCounterPtr { .. }
@@ -1639,7 +1647,7 @@ impl Insn {
     /// Return true if the instruction ends a basic block and false otherwise.
     pub fn is_terminator(&self) -> bool {
         match self {
-            Insn::Unreachable | Insn::CondBranch { .. } | Insn::Jump(_) | Insn::Entries { .. } | Insn::Return { .. } | Insn::SideExit { .. } | Insn::Throw { .. } => true,
+            Insn::Unreachable | Insn::CondBranch(_) | Insn::Jump(_) | Insn::Entries { .. } | Insn::Return { .. } | Insn::SideExit { .. } | Insn::Throw { .. } => true,
             _ => false,
         }
     }
@@ -1647,7 +1655,7 @@ impl Insn {
     /// Return true if the instruction is a jump (has successor blocks in the CFG).
     pub fn is_jump(&self) -> bool {
         match self {
-            Insn::CondBranch { .. } | Insn::Jump(_) | Insn::Entries { .. } => true,
+            Insn::CondBranch(_) | Insn::Jump(_) | Insn::Entries { .. } => true,
             _ => false,
         }
     }
@@ -1773,7 +1781,7 @@ impl Insn {
             Insn::GetBlockParam { .. } => effects::Any,
             Insn::Snapshot { .. } => effects::Empty,
             Insn::Jump(_) => effects::Any,
-            Insn::CondBranch { .. } => effects::Any,
+            Insn::CondBranch(_) => effects::Any,
             Insn::CCall { elidable, .. } => {
                 if *elidable {
                     Effect::write(abstract_heaps::Allocator)
@@ -2125,7 +2133,9 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
             Insn::UnboxFixnum { val } => write!(f, "UnboxFixnum {val}"),
             Insn::FixnumAref { recv, index } => write!(f, "FixnumAref {recv}, {index}"),
             Insn::Jump(target) => { write!(f, "Jump {target}") }
-            Insn::CondBranch { val, if_true, if_false } => { write!(f, "CondBranch {val}, {if_true}, {if_false}") },
+            Insn::CondBranch(insn) => {
+                write!(f, "CondBranch {}, {}, {}", insn.val, insn.if_true, insn.if_false)
+            },
             Insn::SendDirect(insn) => {
                 let SendDirectData { recv, cme, iseq, args, block, jit_entry_idx, .. } = &**insn;
                 let blockiseq = block.map(|bh| match bh { BlockHandler::BlockIseq(iseq) => iseq, BlockHandler::BlockArg => unreachable!() });
@@ -3099,7 +3109,7 @@ impl Function {
         let terminator = &self.insns[self.blocks[block.0].insns.last().unwrap().0];
 
         let (first, second, rest): (Option<BlockId>, Option<BlockId>, &[BlockId]) = match terminator {
-            Insn::CondBranch { if_true, if_false, .. } => (Some(if_true.target), Some(if_false.target), &[]),
+            Insn::CondBranch(insn) => (Some(insn.if_true.target), Some(insn.if_false.target), &[]),
             Insn::Jump(edge) => (Some(edge.target), None, &[]),
             Insn::Entries { targets } => (None, None, targets.as_slice()),
 
@@ -3299,7 +3309,7 @@ impl Function {
             Insn::LoadArg { val_type, .. } => *val_type,
             Insn::SetGlobal { .. } | Insn::Jump(_) | Insn::Entries { .. } | Insn::EntryPoint { .. }
             | Insn::Comment { .. }
-            | Insn::CondBranch { .. } | Insn::Return { .. } | Insn::Throw { .. }
+            | Insn::CondBranch(_) | Insn::Return { .. } | Insn::Throw { .. }
             | Insn::PatchPoint { .. } | Insn::SetIvar { .. } | Insn::SetClassVar { .. } | Insn::ArrayExtend { .. }
             | Insn::ArrayPush { .. } | Insn::SideExit { .. } | Insn::SetLocal { .. }
             | Insn::IncrCounter(_) | Insn::IncrCounterPtr { .. }
@@ -3519,24 +3529,24 @@ impl Function {
                     // Instructions without output, including branch instructions, can't be targets
                     // of make_equal_to, so we don't need find() here.
                     let insn_type = match &self.insns[insn_id.0] {
-                        Insn::CondBranch { val, if_true, if_false } => {
-                            assert!(!self.type_of(*val).bit_equal(types::Empty));
-                            if self.type_of(*val).could_be(Type::from_cbool(true)) {
-                                reachable.insert(if_true.target);
+                        Insn::CondBranch(insn) => {
+                            assert!(!self.type_of(insn.val).bit_equal(types::Empty));
+                            if self.type_of(insn.val).could_be(Type::from_cbool(true)) {
+                                reachable.insert(insn.if_true.target);
                                 // Snapshot arg types before any param updates so phi-style
                                 // updates happen in parallel (the args of a self-loop may name
                                 // params of `target` itself).
-                                let arg_types: Vec<Type> = if_true.args.iter().map(|a| self.type_of(*a)).collect();
+                                let arg_types: Vec<Type> = insn.if_true.args.iter().map(|a| self.type_of(*a)).collect();
                                 for (idx, arg_type) in arg_types.into_iter().enumerate() {
-                                    let param = self.blocks[if_true.target.0].params[idx];
+                                    let param = self.blocks[insn.if_true.target.0].params[idx];
                                     changed |= set_type!(param, self.type_of(param).union(arg_type));
                                 }
                             }
-                            if self.type_of(*val).could_be(Type::from_cbool(false)) {
-                                reachable.insert(if_false.target);
-                                let arg_types: Vec<Type> = if_false.args.iter().map(|a| self.type_of(*a)).collect();
+                            if self.type_of(insn.val).could_be(Type::from_cbool(false)) {
+                                reachable.insert(insn.if_false.target);
+                                let arg_types: Vec<Type> = insn.if_false.args.iter().map(|a| self.type_of(*a)).collect();
                                 for (idx, arg_type) in arg_types.into_iter().enumerate() {
-                                    let param = self.blocks[if_false.target.0].params[idx];
+                                    let param = self.blocks[insn.if_false.target.0].params[idx];
                                     changed |= set_type!(param, self.type_of(param).union(arg_type));
                                 }
                             }
@@ -6235,11 +6245,11 @@ impl Function {
                             insn_id
                         }
                     }
-                    &Insn::CondBranch { val, ref if_true, .. } if self.is_a(val, Type::from_cbool(true)) => {
-                        self.new_insn(Insn::Jump(if_true.clone()))
+                    Insn::CondBranch(insn) if self.is_a(insn.val, Type::from_cbool(true)) => {
+                        self.new_insn(Insn::Jump(insn.if_true.clone()))
                     }
-                    &Insn::CondBranch { val, ref if_false, .. } if self.is_a(val, Type::from_cbool(false)) => {
-                        self.new_insn(Insn::Jump(if_false.clone()))
+                    Insn::CondBranch(insn) if self.is_a(insn.val, Type::from_cbool(false)) => {
+                        self.new_insn(Insn::Jump(insn.if_false.clone()))
                     }
                     _ => insn_id,
                 };
@@ -6729,9 +6739,9 @@ impl Function {
                     Insn::Jump(edge) => {
                         check_edge(block_id, edge)?;
                     }
-                    Insn::CondBranch { if_true, if_false, .. } => {
-                        check_edge(block_id, if_true)?;
-                        check_edge(block_id, if_false)?;
+                    Insn::CondBranch(insn) => {
+                        check_edge(block_id, &insn.if_true)?;
+                        check_edge(block_id, &insn.if_false)?;
                     }
                     _ => {}
                 }
@@ -6794,9 +6804,9 @@ impl Function {
                 };
                 match insn {
                     Insn::Jump(edge) => propagate(edge.target)?,
-                    Insn::CondBranch { if_true, if_false, .. } => {
-                        propagate(if_true.target)?;
-                        propagate(if_false.target)?;
+                    Insn::CondBranch(insn) => {
+                        propagate(insn.if_true.target)?;
+                        propagate(insn.if_false.target)?;
                     }
                     Insn::Entries { ref targets } => {
                         for &target in targets {
@@ -7078,9 +7088,11 @@ impl Function {
                     self.assert_subtype(insn_id, right, all_ints)
                 }
             }
-            Insn::BoxBool { val }
-            | Insn::CondBranch { val, .. } => {
+            Insn::BoxBool { val } => {
                 self.assert_subtype(insn_id, val, types::CBool)
+            }
+            Insn::CondBranch(insn) => {
+                self.assert_subtype(insn_id, insn.val, types::CBool)
             }
             Insn::BoxFixnum { val, .. } => self.assert_subtype(insn_id, val, types::CInt64),
             Insn::UnboxFixnum { val } => {
@@ -7252,7 +7264,7 @@ impl Function {
 
         // Otherwise, make HIR blocks to handle different shapes or a fallback, and let them jump to join_block.
         let edge = |target: BlockId| BranchEdge { target, args: vec![] };
-        let branch = |cond: InsnId, if_true: BlockId, if_false: BlockId| Insn::CondBranch { val: cond, if_true: edge(if_true), if_false: edge(if_false) };
+        let branch = |cond: InsnId, if_true: BlockId, if_false: BlockId| Insn::CondBranch(Box::new(CondBranchData { val: cond, if_true: edge(if_true), if_false: edge(if_false) } ));
         let result_edge = |target: BlockId, result: Option<InsnId>| {
             assert_eq!(has_result, result.is_some());
             BranchEdge { target, args: result.into_iter().collect() }
@@ -8429,10 +8441,10 @@ fn add_iseq_to_hir(
                             let target = BranchEdge { target: iftrue_block, args: vec![] };
                             let fall_through = fun.new_block(insn_idx);
 
-                            fun.push_insn(block, Insn::CondBranch { val: has_shape,
+                            fun.push_insn(block, Insn::CondBranch(Box::new(CondBranchData { val: has_shape,
                                 if_true: target,
                                 if_false: BranchEdge { target: fall_through, args: vec![] }
-                            });
+                            })));
 
                             block = fall_through;
                             let mut ivar_index: attr_index_t = 0;
@@ -8562,11 +8574,11 @@ fn add_iseq_to_hir(
                     iffalse_state.replace(val, nil_false);
                     let fall_through = fun.new_block(insn_idx);
 
-                    fun.push_insn(block, Insn::CondBranch {
+                    fun.push_insn(block, Insn::CondBranch(Box::new(CondBranchData {
                         val: test_id,
                         if_true: BranchEdge { target: fall_through, args: vec![] },
                         if_false: BranchEdge { target, args: iffalse_state.as_args(self_param) }
-                    });
+                    })));
 
                     block = fall_through;
 
@@ -8591,11 +8603,11 @@ fn add_iseq_to_hir(
 
                     let fall_through = fun.new_block(insn_idx);
 
-                    fun.push_insn(block, Insn::CondBranch {
+                    fun.push_insn(block, Insn::CondBranch(Box::new(CondBranchData {
                         val: test_id,
                         if_true: BranchEdge { target, args: iftrue_state.as_args(self_param) },
                         if_false: BranchEdge { target: fall_through, args: vec![] }
-                    });
+                    })));
 
                     block = fall_through;
 
@@ -8619,11 +8631,11 @@ fn add_iseq_to_hir(
 
                     let fall_through = fun.new_block(insn_idx);
 
-                    fun.push_insn(block, Insn::CondBranch {
+                    fun.push_insn(block, Insn::CondBranch(Box::new(CondBranchData {
                         val: test_id,
                         if_true: BranchEdge { target, args: iftrue_state.as_args(self_param) },
                         if_false: BranchEdge { target: fall_through, args: vec![] }
-                    });
+                    })));
 
                     block = fall_through;
                     let new_type = types::NotNil;
@@ -8655,11 +8667,11 @@ fn add_iseq_to_hir(
                     let target_idx = insn_idx_at_offset(insn_idx, dst);
                     let target = insn_idx_to_block[&target_idx];
                     let fall_through = fun.new_block(insn_idx);
-                    fun.push_insn(block, Insn::CondBranch {
+                    fun.push_insn(block, Insn::CondBranch(Box::new(CondBranchData {
                         val: test_id,
                         if_true: BranchEdge { target: fall_through, args: vec![] },
                         if_false: BranchEdge { target, args: state.as_args(self_param) }
-                    });
+                    })));
                     block = fall_through;
                     queue.push_back((state.clone(), target, target_idx, local_inval));
 
@@ -8817,11 +8829,11 @@ fn add_iseq_to_hir(
                     let flags = fun.load_ep_flags(block, ep);
                     let is_modified = fun.push_insn(block, Insn::IsBlockParamModified { flags });
 
-                    fun.push_insn(block, Insn::CondBranch {
+                    fun.push_insn(block, Insn::CondBranch(Box::new(CondBranchData {
                         val: is_modified,
                         if_true: BranchEdge { target: modified_block, args: vec![] },
                         if_false: BranchEdge { target: unmodified_block, args: vec![] }
-                    });
+                    })));
 
                     // Push modified block: load the block local via EP.
                     let modified_val = fun.get_local_from_ep(modified_block, iseq, ep, ep_offset, level, types::BasicObject);
@@ -8948,11 +8960,11 @@ fn add_iseq_to_hir(
 
                                         let next_block = fun.new_block(branch_insn_idx);
 
-                                        fun.push_insn(current_block, Insn::CondBranch {
+                                        fun.push_insn(current_block, Insn::CondBranch(Box::new(CondBranchData {
                                             val: is_none,
                                             if_true: BranchEdge { target: profiled_block, args: vec![] },
                                             if_false: BranchEdge { target: next_block, args: vec![] },
-                                        });
+                                        })));
 
                                         current_block = next_block;
 
@@ -8978,11 +8990,11 @@ fn add_iseq_to_hir(
                                             right: tag_mask,
                                         });
                                         let next_block = fun.new_block(branch_insn_idx);
-                                        fun.push_insn(current_block, Insn::CondBranch {
+                                        fun.push_insn(current_block, Insn::CondBranch(Box::new(CondBranchData {
                                             val: is_iseq_or_ifunc,
                                             if_true: BranchEdge { target: profiled_block, args: vec![] },
                                             if_false: BranchEdge { target: next_block, args: vec![] },
-                                        });
+                                        })));
                                         current_block = next_block;
 
                                         // TODO(Shopify/ruby#753): GC root, so we should be able to avoid unnecessary GC tracing
@@ -9008,11 +9020,11 @@ fn add_iseq_to_hir(
                                         });
                                         let true_val = fun.push_insn(proc_check_block, Insn::Const { val: Const::Value(Qtrue) });
                                         let is_proc = fun.push_insn(proc_check_block, Insn::IsBitEqual { left: proc_result, right: true_val });
-                                        fun.push_insn(proc_check_block, Insn::CondBranch {
+                                        fun.push_insn(proc_check_block, Insn::CondBranch(Box::new(CondBranchData {
                                             val: is_proc,
                                             if_true: BranchEdge { target: profiled_block, args: vec![] },
                                             if_false: BranchEdge { target: next_block, args: vec![] },
-                                        });
+                                        })));
                                         current_block = next_block;
 
                                         let mut args = vec![proc_val];
@@ -9050,11 +9062,11 @@ fn add_iseq_to_hir(
                     let flags = fun.load_ep_flags(block, ep);
                     let is_modified = fun.push_insn(block, Insn::IsBlockParamModified { flags });
 
-                    fun.push_insn(block, Insn::CondBranch {
+                    fun.push_insn(block, Insn::CondBranch(Box::new(CondBranchData {
                         val: is_modified,
                         if_true: BranchEdge { target: modified_block, args: vec![] },
                         if_false: BranchEdge { target: unmodified_block, args: vec![] }
-                    });
+                    })));
 
                     // Push modified block: read Proc from EP.
                     let modified_val = fun.get_local_from_ep(modified_block, iseq, ep, ep_offset, level, types::BasicObject);
@@ -9272,11 +9284,11 @@ fn add_iseq_to_hir(
                             let has_type = fun.push_insn(block, Insn::HasType { val: recv, expected });
                             let iftrue_block = fun.new_block(insn_idx);
                             let fall_through = fun.new_block(insn_idx);
-                            fun.push_insn(block, Insn::CondBranch {
+                            fun.push_insn(block, Insn::CondBranch(Box::new(CondBranchData {
                                 val: has_type,
                                 if_true: BranchEdge { target: iftrue_block, args: vec![] },
                                 if_false: BranchEdge { target: fall_through, args: vec![] }
-                            });
+                            })));
                             block = fall_through;
                             // Take a fresh Snapshot rather than
                             // reusing exit_id so type specialization resolves the receiver from
@@ -9515,11 +9527,11 @@ fn add_iseq_to_hir(
                         let ifunc_block = fun.new_block(insn_idx);
                         let fall_through = fun.new_block(insn_idx);
 
-                        fun.push_insn(block, Insn::CondBranch {
+                        fun.push_insn(block, Insn::CondBranch(Box::new(CondBranchData {
                             val: is_ifunc_match,
                             if_true: BranchEdge { target: ifunc_block, args: vec![] },
                             if_false: BranchEdge { target: fall_through, args: vec![] },
-                        });
+                        })));
 
                         block = fall_through;
 
@@ -9779,11 +9791,11 @@ fn add_iseq_to_hir(
                         let iftrue_block = fun.new_block(insn_idx);
                         let iffalse_block = fun.new_block(insn_idx);
                         let join_block = fun.new_block(insn_idx);
-                        fun.push_insn(block, Insn::CondBranch {
+                        fun.push_insn(block, Insn::CondBranch(Box::new(CondBranchData {
                             val: has_type,
                             if_true: BranchEdge { target: iftrue_block, args: vec![] },
                             if_false: BranchEdge { target: iffalse_block, args: vec![] }
-                        });
+                        })));
                         // true block
                         let refined = fun.push_insn(iftrue_block, Insn::RefineType { val: recv, new_type: types::String });
                         fun.push_insn(iftrue_block, Insn::Jump(BranchEdge { target: join_block, args: vec![refined] }));
@@ -9806,11 +9818,11 @@ fn add_iseq_to_hir(
                     let iftrue_block = fun.new_block(insn_idx);
                     let iffalse_block = fun.new_block(insn_idx);
                     let join_block = fun.new_block(insn_idx);
-                    fun.push_insn(block, Insn::CondBranch {
+                    fun.push_insn(block, Insn::CondBranch(Box::new(CondBranchData {
                         val: has_type,
                         if_true: BranchEdge { target: iftrue_block, args: vec![] },
                         if_false: BranchEdge { target: iffalse_block, args: vec![] }
-                    });
+                    })));
                     // true block
                     let refined = fun.push_insn(iftrue_block, Insn::RefineType { val: str, new_type: types::String });
                     fun.push_insn(iftrue_block, Insn::Jump(BranchEdge { target: join_block, args: vec![refined] }));
@@ -9932,11 +9944,11 @@ fn compile_entry_block(fun: &mut Function, jit_entry_insns: &[u32], insn_idx_to_
         let next_insn_idx = **iter.peek().expect("last entry is skipped so there is always a next");
         let fall_through = fun.new_block(next_insn_idx);
 
-        fun.push_insn(entry_block, Insn::CondBranch {
+        fun.push_insn(entry_block, Insn::CondBranch(Box::new(CondBranchData {
             val: test_id,
             if_true: BranchEdge { target: target_block, args: entry_state.as_args(self_param) },
             if_false: BranchEdge { target: fall_through, args: vec![] }
-        });
+        })));
         entry_block = fall_through;
     }
 
@@ -10435,11 +10447,11 @@ mod rpo_tests {
         let exit = function.new_block(0);
         function.push_insn(side, Insn::Jump(BranchEdge { target: exit, args: vec![] }));
         let val = function.push_insn(entry, Insn::Const { val: Const::Value(Qnil) });
-        function.push_insn(entry, Insn::CondBranch {
+        function.push_insn(entry, Insn::CondBranch(Box::new(CondBranchData {
             val,
             if_true: BranchEdge { target: side, args: vec![] },
             if_false: BranchEdge { target: exit, args: vec![] }
-        });
+        })));
         let val = function.push_insn(exit, Insn::Const { val: Const::Value(Qnil) });
         function.push_insn(exit, Insn::Return { val });
         function.seal_entries();
@@ -10455,11 +10467,11 @@ mod rpo_tests {
         let exit = function.new_block(0);
         function.push_insn(side, Insn::Jump(BranchEdge { target: exit, args: vec![] }));
         let val = function.push_insn(entry, Insn::Const { val: Const::Value(Qnil) });
-        function.push_insn(entry, Insn::CondBranch {
+        function.push_insn(entry, Insn::CondBranch(Box::new(CondBranchData {
             val,
             if_true: BranchEdge { target: exit, args: vec![] },
             if_false: BranchEdge { target: side, args: vec![] },
-        });
+        })));
         let val = function.push_insn(exit, Insn::Const { val: Const::Value(Qnil) });
         function.push_insn(exit, Insn::Return { val });
         function.seal_entries();
@@ -10521,11 +10533,11 @@ mod validation_tests {
         let fall_through = function.new_block(1);
         function.push_insn(fall_through, Insn::Unreachable);
         function.push_insn(side, Insn::Unreachable);
-        function.push_insn(entry, Insn::CondBranch {
+        function.push_insn(entry, Insn::CondBranch(Box::new(CondBranchData {
             val,
             if_true: BranchEdge { target: side, args: vec![val, val, val] },
             if_false: BranchEdge { target: fall_through, args: vec![] }
-        });
+        })));
         function.seal_entries();
         assert_matches_err(function.validate(), ValidationError::MismatchedBlockArity(entry, 0, 3));
     }
@@ -10539,11 +10551,11 @@ mod validation_tests {
         let fall_through = function.new_block(1);
         function.push_insn(fall_through, Insn::Unreachable);
         function.push_insn(side, Insn::Unreachable);
-        function.push_insn(entry, Insn::CondBranch {
+        function.push_insn(entry, Insn::CondBranch(Box::new(CondBranchData {
             val,
             if_true: BranchEdge { target: fall_through, args: vec![] },
             if_false: BranchEdge { target: side, args: vec![val, val, val] },
-        });
+        })));
         function.seal_entries();
         assert_matches_err(function.validate(), ValidationError::MismatchedBlockArity(entry, 0, 3));
     }
@@ -10595,11 +10607,11 @@ mod validation_tests {
         let v0 = function.push_insn(side, Insn::Const { val: Const::Value(VALUE::fixnum_from_usize(3)) });
         function.push_insn(side, Insn::Jump(BranchEdge { target: exit, args: vec![] }));
         let val1 = function.push_insn(entry, Insn::Const { val: Const::CBool(false) });
-        function.push_insn(entry, Insn::CondBranch {
+        function.push_insn(entry, Insn::CondBranch(Box::new(CondBranchData {
             val: val1,
             if_true: BranchEdge { target: exit, args: vec![] },
             if_false: BranchEdge { target: side, args: vec![] },
-        });
+        })));
         let val2 = function.push_insn(exit, Insn::ArrayDup { val: v0, state: v0 });
         let const_ = function.push_insn(exit, Insn::Const{val: Const::CBool(true)});
         function.push_insn(exit, Insn::Return { val: const_ });
@@ -10621,11 +10633,11 @@ mod validation_tests {
         let v0 = function.push_insn(entry, Insn::Const { val: Const::Value(VALUE::fixnum_from_usize(3)) });
         function.push_insn(side, Insn::Jump(BranchEdge { target: exit, args: vec![] }));
         let val = function.push_insn(entry, Insn::Const { val: Const::CBool(false) });
-        function.push_insn(entry, Insn::CondBranch {
+        function.push_insn(entry, Insn::CondBranch(Box::new(CondBranchData {
             val,
             if_true: BranchEdge { target: exit, args: vec![] },
             if_false: BranchEdge { target: side, args: vec![] }
-        });
+        })));
         let _val = function.push_insn(exit, Insn::ArrayDup { val: v0, state: v0 });
         let const_ = function.push_insn(exit, Insn::Const{val: Const::CBool(true)});
         function.push_insn(exit, Insn::Return { val: const_ });
@@ -10820,11 +10832,11 @@ mod infer_tests {
         function.push_insn(side, Insn::Jump(BranchEdge { target: exit, args: vec![v0] }));
         let val = function.push_insn(entry, Insn::Const { val: Const::CBool(false) });
         let v1 = function.push_insn(entry, Insn::Const { val: Const::Value(VALUE::fixnum_from_usize(4)) });
-        function.push_insn(entry, Insn::CondBranch {
+        function.push_insn(entry, Insn::CondBranch(Box::new(CondBranchData {
             val,
             if_true: BranchEdge { target: exit, args: vec![v1] },
             if_false: BranchEdge { target: side, args: vec![] },
-        });
+        })));
         let param = function.push_insn(exit, Insn::Param);
         function.push_insn(exit, Insn::Unreachable);
         function.seal_entries();
@@ -10891,11 +10903,11 @@ mod infer_tests {
         function.push_insn(side, Insn::Jump(BranchEdge { target: exit, args: vec![v0] }));
         let val = function.push_insn(entry, Insn::Const { val: Const::CBool(false) });
         let v1 = function.push_insn(entry, Insn::Const { val: Const::Value(Qfalse) });
-        function.push_insn(entry, Insn::CondBranch {
+        function.push_insn(entry, Insn::CondBranch(Box::new(CondBranchData {
             val,
             if_true: BranchEdge { target: exit, args: vec![v1] },
             if_false: BranchEdge { target: side, args: vec![] },
-        });
+        })));
         let param = function.push_insn(exit, Insn::Param);
         function.push_insn(exit, Insn::Unreachable);
         function.seal_entries();

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -926,6 +926,17 @@ pub struct SendDirectData {
     pub state: InsnId,
 }
 
+/// Payload of [`Insn::PushInlineFrame`]. Boxed in the enum to keep `Insn` small.
+#[derive(Debug, Clone)]
+pub struct PushInlineFrameData {
+    pub iseq: IseqPtr,
+    pub cme: *const rb_callable_method_entry_t,
+    pub recv: InsnId,
+    pub args: Vec<InsnId>,
+    pub blockiseq: Option<IseqPtr>,
+    pub state: InsnId,
+}
+
 /// Payload of [`Insn::CondBranch`]. Boxed in the enum to keep `Insn` small.
 #[derive(Debug, Clone)]
 pub struct CondBranchData {
@@ -1192,14 +1203,7 @@ pub enum Insn {
     SendDirect(Box<SendDirectData>),
 
     /// Push a lighter weight frame used for inlined methods.
-    PushInlineFrame {
-        iseq: IseqPtr,
-        cme: *const rb_callable_method_entry_t,
-        recv: InsnId,
-        args: Vec<InsnId>,
-        blockiseq: Option<IseqPtr>,
-        state: InsnId,
-    },
+    PushInlineFrame(Box<PushInlineFrameData>),
 
     /// Pop a lighter weight frame used for inlined methods.
     PopInlineFrame {
@@ -1521,7 +1525,6 @@ macro_rules! for_each_operand_impl {
                 $visit_one!(*state);
             }
             | Insn::SendForward { recv, args, state, .. }
-            | Insn::PushInlineFrame { recv, args, state, .. }
             | Insn::InvokeBuiltin { recv, args, state, .. }
             | Insn::InvokeSuper { recv, args, state, .. }
             | Insn::InvokeSuperForward { recv, args, state, .. }
@@ -1539,6 +1542,11 @@ macro_rules! for_each_operand_impl {
                 $visit_one!(insn.state);
             }
             Insn::SendDirect(insn) => {
+                $visit_one!(insn.recv);
+                $visit_many!(insn.args);
+                $visit_one!(insn.state);
+            }
+            Insn::PushInlineFrame(insn) => {
                 $visit_one!(insn.recv);
                 $visit_many!(insn.args);
                 $visit_one!(insn.state);
@@ -2156,7 +2164,8 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
                 write_separated!(f, ", ", ", ", args);
                 Ok(())
             }
-            Insn::PushInlineFrame { recv, iseq, args, .. } => {
+            Insn::PushInlineFrame(insn) => {
+                let PushInlineFrameData { iseq, recv, args, .. } = &**insn;
                 write!(f, "PushInlineFrame {recv} ({:?})", self.ptr_map.map_ptr(*iseq))?;
                 write_separated!(f, ", ", ", ", args);
                 Ok(())
@@ -5439,9 +5448,10 @@ impl Function {
                 self.push_insn_id(block, post_send_caller);
 
                 // Insert PushLightweightFrame and jump to callee body entry.
-                self.push_insn(block, Insn::PushInlineFrame {
+                let data = PushInlineFrameData {
                     iseq, cme, recv, args: args.clone(), blockiseq, state,
-                });
+                };
+                self.push_insn(block, Insn::PushInlineFrame(Box::new(data)));
                 self.count(block, Counter::inline_iseq_optimized_send_count);
                 self.push_insn(block, Insn::Jump(BranchEdge {
                     target: callee_entry_body_block,
@@ -6955,8 +6965,7 @@ impl Function {
                 Ok(())
             }
             // Instructions with recv and a Vec of Ruby objects
-            Insn::PushInlineFrame { recv, ref args, .. }
-            | Insn::SendForward { recv, ref args, .. }
+            Insn::SendForward { recv, ref args, .. }
             | Insn::InvokeSuper { recv, ref args, .. }
             | Insn::InvokeSuperForward { recv, ref args, .. }
             | Insn::InvokeBuiltin { recv, ref args, .. }
@@ -6969,6 +6978,13 @@ impl Function {
                 Ok(())
             }
             Insn::SendDirect(insn) => {
+                self.assert_subtype(insn_id, insn.recv, types::BasicObject)?;
+                for &arg in &insn.args {
+                    self.assert_subtype(insn_id, arg, types::BasicObject)?;
+                }
+                Ok(())
+            }
+            Insn::PushInlineFrame(insn) => {
                 self.assert_subtype(insn_id, insn.recv, types::BasicObject)?;
                 for &arg in &insn.args {
                     self.assert_subtype(insn_id, arg, types::BasicObject)?;

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -901,6 +901,17 @@ pub struct CCallWithFrameData {
     pub block: Option<BlockHandler>,
 }
 
+/// Payload of [`Insn::Send`]. Boxed in the enum to keep `Insn` small.
+#[derive(Debug, Clone)]
+pub struct SendData {
+    pub recv: InsnId,
+    pub cd: *const rb_call_data,
+    pub block: Option<BlockHandler>,
+    pub args: Vec<InsnId>,
+    pub state: InsnId,
+    pub reason: SendFallbackReason,
+}
+
 /// Payload of [`Insn::SendDirect`]. Boxed in the enum to keep `Insn` small.
 #[derive(Debug, Clone)]
 pub struct SendDirectData {
@@ -1118,14 +1129,7 @@ pub enum Insn {
 
     /// Un-optimized fallback implementation (dynamic dispatch) for send-ish instructions
     /// Ignoring keyword arguments etc for now
-    Send {
-        recv: InsnId,
-        cd: *const rb_call_data,
-        block: Option<BlockHandler>,
-        args: Vec<InsnId>,
-        state: InsnId,
-        reason: SendFallbackReason,
-    },
+    Send(Box<SendData>),
     SendForward {
         recv: InsnId,
         cd: *const rb_call_data,
@@ -1516,7 +1520,6 @@ macro_rules! for_each_operand_impl {
                 $visit_one!(*val);
                 $visit_one!(*state);
             }
-            Insn::Send { recv, args, state, .. }
             | Insn::SendForward { recv, args, state, .. }
             | Insn::PushInlineFrame { recv, args, state, .. }
             | Insn::InvokeBuiltin { recv, args, state, .. }
@@ -1527,9 +1530,14 @@ macro_rules! for_each_operand_impl {
                 $visit_many!(args);
                 $visit_one!(*state);
             }
-            // SendDirect/CCallWithFrame/CCallVariadic carry their operands behind a Box,
+            // Send/SendDirect/CCallWithFrame/CCallVariadic carry their operands behind a Box,
             // which stable Rust can't destructure in a pattern. visit_one takes a place, so
             // a box field works the same as the deref'd bindings used by other arms.
+            Insn::Send(insn) => {
+                $visit_one!(insn.recv);
+                $visit_many!(insn.args);
+                $visit_one!(insn.state);
+            }
             Insn::SendDirect(insn) => {
                 $visit_one!(insn.recv);
                 $visit_many!(insn.args);
@@ -2156,7 +2164,8 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
             Insn::PopInlineFrame { .. } => {
                 write!(f, "PopInlineFrame")
             }
-            Insn::Send { recv, cd, args, block, reason, .. } => {
+            Insn::Send(insn) => {
+                let SendData { recv, cd, block, args, state: _, reason } = insn.as_ref();
                 // For tests, we want to check HIR snippets textually. Addresses change
                 // between runs, making tests fail. Instead, pick an arbitrary hex value to
                 // use as a "pointer" so we can check the rest of the HIR.
@@ -3272,8 +3281,8 @@ impl Function {
         // Always set the reason: convert_no_profile_sends depends on it to identify
         // sends that should be converted to side exits for exit-based recompilation.
         match self.insns.get_mut(insn_id.0).unwrap() {
-            Send { reason, .. }
-            | SendForward { reason, .. }
+            Send(insn) => insn.reason = dynamic_send_reason,
+            SendForward { reason, .. }
             | InvokeSuper { reason, .. }
             | InvokeSuperForward { reason, .. }
             | InvokeBlock { reason, .. }
@@ -4205,13 +4214,14 @@ impl Function {
             assert!(self.blocks[block.0].insns.is_empty());
             for insn_id in old_insns {
                 match self.find(insn_id) {
-                    Insn::Send { recv, block: None, args, state, cd, .. } if ruby_call_method_id(cd) == ID!(freeze) && args.is_empty() =>
-                        self.try_rewrite_freeze(block, insn_id, recv, state),
-                    Insn::Send { recv, block: None, args, state, cd, .. } if ruby_call_method_id(cd) == ID!(minusat) && args.is_empty() =>
-                        self.try_rewrite_uminus(block, insn_id, recv, state),
-                    ref send@Insn::Send { mut recv, cd, state, block: send_block, ref args, .. } => {
+                    Insn::Send(insn) if insn.block.is_none() && ruby_call_method_id(insn.cd) == ID!(freeze) && insn.args.is_empty() =>
+                        self.try_rewrite_freeze(block, insn_id, insn.recv, insn.state),
+                    Insn::Send(insn) if insn.block.is_none() && ruby_call_method_id(insn.cd) == ID!(minusat) && insn.args.is_empty() =>
+                        self.try_rewrite_uminus(block, insn_id, insn.recv, insn.state),
+                    ref send@Insn::Send(ref insn) => {
+                        let SendData { mut recv, cd, block: send_block, args, state, reason: _ } = insn.as_ref().clone();
                         let mut has_block = send_block.is_some();
-                        let (klass, profiled_type) = match self.resolve_receiver_type(recv, self.type_of(recv), state) {
+                        let (klass, profiled_type) = match self.resolve_receiver_type(insn.recv, self.type_of(insn.recv), insn.state) {
                             ReceiverTypeResolution::StaticallyKnown { class } => (class, None),
                             ReceiverTypeResolution::Monomorphic { profiled_type }
                             | ReceiverTypeResolution::SkewedPolymorphic { profiled_type } => (profiled_type.class(), Some(profiled_type)),
@@ -4232,7 +4242,7 @@ impl Function {
                                 continue;
                             }
                         };
-                        let ci = unsafe { (*cd).ci }; // info about the call site
+                        let ci = unsafe { (*insn.cd).ci }; // info about the call site
 
                         let flags = unsafe { rb_vm_ci_flag(ci) };
 
@@ -4555,9 +4565,10 @@ impl Function {
                                 profiled_type: Option<ProfiledType>,
                                 cme: *const rb_callable_method_entry_struct,
                             ) -> Result<(), ()> {
-                                let Insn::Send { mut recv, cd, block: send_block, args, state, .. } = send else {
+                                let Insn::Send(insn) = send else {
                                     return Err(());
                                 };
+                                let SendData { mut recv, cd, block: send_block, args, state, .. } = *insn;
 
                                 let call_info = unsafe { (*cd).ci };
                                 let argc = unsafe { vm_ci_argc(call_info) };
@@ -5803,8 +5814,8 @@ impl Function {
             assert!(self.blocks[block.0].insns.is_empty());
             for insn_id in old_insns {
                 match self.resolve(insn_id).insn(self) {
-                    &Insn::Send { state, reason: SendFallbackReason::SendNoProfiles, .. } => {
-                        self.push_insn(block, Insn::SideExit { state, reason: Box::new(SideExitReason::NoProfileSend), recompile: Some(Recompile) });
+                    Insn::Send(insn) if matches!(insn.reason, SendFallbackReason::SendNoProfiles) => {
+                        self.push_insn(block, Insn::SideExit { state: insn.state, reason: Box::new(SideExitReason::NoProfileSend), recompile: Some(Recompile) });
                         // SideExit is a terminator; don't add remaining instructions
                         break;
                     }
@@ -6936,9 +6947,15 @@ impl Function {
             Insn::AnyToString { val, .. } => {
                 self.assert_subtype(insn_id, val, types::BasicObject)
             }
+            Insn::Send(insn) => {
+                self.assert_subtype(insn_id, insn.recv, types::BasicObject)?;
+                for &arg in &insn.args {
+                    self.assert_subtype(insn_id, arg, types::BasicObject)?;
+                }
+                Ok(())
+            }
             // Instructions with recv and a Vec of Ruby objects
             Insn::PushInlineFrame { recv, ref args, .. }
-            | Insn::Send { recv, ref args, .. }
             | Insn::SendForward { recv, ref args, .. }
             | Insn::InvokeSuper { recv, ref args, .. }
             | Insn::InvokeSuperForward { recv, ref args, .. }
@@ -9140,7 +9157,8 @@ fn add_iseq_to_hir(
                     }
                     let args = state.stack_pop_n(argc as usize)?;
                     let recv = state.stack_pop()?;
-                    let send = fun.push_insn(block, Insn::Send { recv, cd, block: None, args, state: exit_id, reason: Uncategorized(opcode) });
+                    let send_data = SendData { recv, cd, block: None, args, state: exit_id, reason: Uncategorized(opcode) };
+                    let send = fun.push_insn(block, Insn::Send(Box::new(send_data)));
                     state.stack_push(send);
                 }
                 YARVINSN_opt_hash_freeze => {
@@ -9296,19 +9314,22 @@ fn add_iseq_to_hir(
                             // keyed at exit_id.
                             let snapshot = fun.push_insn(iftrue_block, Insn::Snapshot { state: Box::new(exit_state.clone()) });
                             let refined_recv = fun.push_insn(iftrue_block, Insn::RefineType { val: recv, new_type: expected });
-                            let send = fun.push_insn(iftrue_block, Insn::Send { recv: refined_recv, cd, block: None, args: args.clone(), state: snapshot, reason: Uncategorized(opcode) });
+                            let send_data = SendData { recv: refined_recv, cd, block: None, args: args.clone(), state: snapshot, reason: Uncategorized(opcode) };
+                            let send = fun.push_insn(iftrue_block, Insn::Send(Box::new(send_data)));
                             fun.push_insn(iftrue_block, Insn::Jump(BranchEdge { target: join_block, args: vec![send] }));
                         }
                         // In the fallthrough case, do a generic interpreter send and then join.
                         let reason = SendPolymorphicFallback;
-                        let send = fun.push_insn(block, Insn::Send { recv, cd, block: None, args, state: exit_id, reason });
+                        let send_data = SendData { recv, cd, block: None, args, state: exit_id, reason };
+                        let send = fun.push_insn(block, Insn::Send(Box::new(send_data)));
                         fun.push_insn(block, Insn::Jump(BranchEdge { target: join_block, args: vec![send] }));
                         state.stack_push(join_param);
                         // Continue compilation from the join block at the next instruction.
                         block = join_block;
                     } else {
                         // Maybe monomorphic; handled in type_specialize
-                        let send = fun.push_insn(block, Insn::Send { recv, cd, block: None, args, state: exit_id, reason: Uncategorized(opcode) });
+                        let send_data = SendData { recv, cd, block: None, args, state: exit_id, reason: Uncategorized(opcode) };
+                        let send = fun.push_insn(block, Insn::Send(Box::new(send_data)));
                         state.stack_push(send);
                     }
                 }
@@ -9338,7 +9359,8 @@ fn add_iseq_to_hir(
                     } else {
                         None
                     };
-                    let send = fun.push_insn(block, Insn::Send { recv, cd, block: block_handler, args, state: exit_id, reason: Uncategorized(opcode) });
+                    let send_data = SendData { recv, cd, block: block_handler, args, state: exit_id, reason: Uncategorized(opcode) };
+                    let send = fun.push_insn(block, Insn::Send(Box::new(send_data)));
                     state.stack_push(send);
 
                     if let Some(BlockHandler::BlockIseq(blockiseq)) = block_handler {
@@ -9784,7 +9806,8 @@ fn add_iseq_to_hir(
                             fun.push_insn(block, Insn::GuardType { val: recv, guard_type: types::String, state: exit_id, recompile: None })
                         } else {
                             let recv = fun.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state: exit_id, recompile: None });
-                            fun.push_insn(block, Insn::Send { recv, cd, block: None, args: vec![], state: exit_id, reason: ObjToStringNotString })
+                            let send_data = SendData { recv, cd, block: None, args: vec![], state: exit_id, reason: ObjToStringNotString };
+                            fun.push_insn(block, Insn::Send(Box::new(send_data)))
                         }
                     } else {
                         let has_type = fun.push_insn(block, Insn::HasType { val: recv, expected: types::String });
@@ -9801,7 +9824,8 @@ fn add_iseq_to_hir(
                         fun.push_insn(iftrue_block, Insn::Jump(BranchEdge { target: join_block, args: vec![refined] }));
                         // false block
                         let refined = fun.push_insn(iffalse_block, Insn::RefineType { val: recv, new_type: types::NotString });
-                        let send = fun.push_insn(iffalse_block, Insn::Send { recv: refined, cd, block: None, args: vec![], state: exit_id, reason: ObjToStringNotString });
+                        let send_data = SendData { recv: refined, cd, block: None, args: vec![], state: exit_id, reason: ObjToStringNotString };
+                        let send = fun.push_insn(iffalse_block, Insn::Send(Box::new(send_data)));
                         fun.push_insn(iffalse_block, Insn::Jump(BranchEdge { target: join_block, args: vec![send] }));
                         // join block
                         block = join_block;

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -945,6 +945,18 @@ pub struct CondBranchData {
     pub if_false: BranchEdge,
 }
 
+/// Payload of [`Insn::CCall`]. Boxed in the enum to keep `Insn` small.
+#[derive(Debug, Clone)]
+pub struct CCallData {
+    pub cfunc: *const u8,
+    pub recv: InsnId,
+    pub args: Vec<InsnId>,
+    pub name: ID,
+    pub owner: VALUE,
+    pub return_type: Type,
+    pub elidable: bool,
+}
+
 /// Payload of [`Insn::CCallVariadic`]. Boxed in the enum to keep `Insn` small.
 #[derive(Debug, Clone)]
 pub struct CCallVariadicData {
@@ -1129,7 +1141,7 @@ pub enum Insn {
 
     /// Call a C function without pushing a frame
     /// `name` and `owner` are for printing purposes only
-    CCall { cfunc: *const u8, recv: InsnId, args: Vec<InsnId>, name: ID, owner: VALUE, return_type: Type, elidable: bool },
+    CCall(Box<CCallData>),
 
     /// Call a C function that pushes a frame
     CCallWithFrame(Box<CCallWithFrameData>),
@@ -1575,9 +1587,9 @@ macro_rules! for_each_operand_impl {
                 $visit_many!(args);
                 $visit_one!(*state);
             }
-            Insn::CCall { recv, args, .. } => {
-                $visit_one!(*recv);
-                $visit_many!(args);
+            Insn::CCall(insn) => {
+                $visit_one!(insn.recv);
+                $visit_many!(insn.args);
             }
             Insn::GetIvar { self_val, state, .. }
             | Insn::DefinedIvar { self_val, state, .. } => {
@@ -1798,8 +1810,8 @@ impl Insn {
             Insn::Snapshot { .. } => effects::Empty,
             Insn::Jump(_) => effects::Any,
             Insn::CondBranch(_) => effects::Any,
-            Insn::CCall { elidable, .. } => {
-                if *elidable {
+            Insn::CCall(insn) => {
+                if insn.elidable {
                     Effect::write(abstract_heaps::Allocator)
                 }
                 else {
@@ -2309,7 +2321,8 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
             Insn::GetConstantPath { ic, .. } => { write!(f, "GetConstantPath {:p}", self.ptr_map.map_ptr(*ic)) },
             Insn::IsBlockGiven { block_handler } => { write!(f, "IsBlockGiven {block_handler}") },
             Insn::FixnumBitCheck {val, index} => { write!(f, "FixnumBitCheck {val}, {index}") },
-            Insn::CCall { cfunc, recv, args, name, owner, return_type: _, elidable: _ } => {
+            Insn::CCall(insn) => {
+                let CCallData { cfunc, recv, args, name, owner, return_type: _, elidable: _ } = &**insn;
                 let display_name = if *owner == Qnil { name.contents_lossy().to_string() } else { qualified_method_name(*owner, *name) };
                 write!(f, "CCall {recv}, :{}@{:p}", display_name, self.ptr_map.map_ptr(*cfunc))?;
                 write_separated!(f, ", ", ", ", args);
@@ -3385,7 +3398,7 @@ impl Function {
             Insn::ObjectAlloc { .. } => types::HeapBasicObject,
             Insn::ObjectAllocClass { class, .. } => Type::from_class(*class),
             Insn::CCallWithFrame(insn) => insn.return_type,
-            Insn::CCall { return_type, .. } => *return_type,
+            Insn::CCall(insn) => insn.return_type,
             Insn::CCallVariadic(insn) => insn.return_type,
             Insn::CheckMatch { .. } => types::BasicObject,
             Insn::GuardType { val, guard_type, .. } => self.type_of(*val).intersection(*guard_type),
@@ -4672,7 +4685,15 @@ impl Function {
                                             if props.leaf && props.no_gc {
                                                 fun.count(block, Counter::inline_cfunc_optimized_send_count);
                                                 let owner = unsafe { (*cme).owner };
-                                                let ccall = fun.push_insn(block, Insn::CCall { cfunc: cfunc_ptr, recv, args, name, owner, return_type, elidable });
+                                                let ccall = fun.push_insn(block, Insn::CCall(Box::new(CCallData {
+                                                    cfunc: cfunc_ptr,
+                                                    recv,
+                                                    args,
+                                                    name,
+                                                    owner,
+                                                    return_type,
+                                                    elidable
+                                                })));
                                                 fun.insn_types[ccall.0] = fun.infer_type(ccall);
                                                 fun.make_equal_to(send_insn_id, ccall);
                                                 return Ok(());
@@ -4739,7 +4760,15 @@ impl Function {
                                             if props.leaf && props.no_gc {
                                                 fun.count(block, Counter::inline_cfunc_optimized_send_count);
                                                 let owner = unsafe { (*cme).owner };
-                                                let ccall = fun.push_insn(block, Insn::CCall { cfunc: cfunc_ptr, recv, args, name, owner, return_type, elidable });
+                                                let ccall = fun.push_insn(block, Insn::CCall(Box::new(CCallData {
+                                                    cfunc: cfunc_ptr,
+                                                    recv,
+                                                    args,
+                                                    name,
+                                                    owner,
+                                                    return_type,
+                                                    elidable
+                                                })));
                                                 fun.insn_types[ccall.0] = fun.infer_type(ccall);
                                                 fun.make_equal_to(send_insn_id, ccall);
                                                 return Ok(());
@@ -5021,7 +5050,15 @@ impl Function {
                                     // Filter for a leaf and GC free function
                                     let ccall = if props.leaf && props.no_gc {
                                         self.count(block, Counter::inline_cfunc_optimized_send_count);
-                                        self.push_insn(block, Insn::CCall { cfunc: cfunc_ptr, recv, args, name, owner, return_type, elidable })
+                                        self.push_insn(block, Insn::CCall(Box::new(CCallData {
+                                            cfunc: cfunc_ptr,
+                                            recv,
+                                            args,
+                                            name,
+                                            owner,
+                                            return_type,
+                                            elidable
+                                        })))
                                     } else {
                                         if get_option!(stats) {
                                             self.count_not_inlined_cfunc(block, super_cme);
@@ -5071,7 +5108,7 @@ impl Function {
                                     // Filter for a leaf and GC free function
                                     let ccall = if props.leaf && props.no_gc {
                                         self.count(block, Counter::inline_cfunc_optimized_send_count);
-                                        self.push_insn(block, Insn::CCall { cfunc: cfunc_ptr, recv, args, name, owner, return_type, elidable })
+                                        self.push_insn(block, Insn::CCall(Box::new(CCallData { cfunc: cfunc_ptr, recv, args, name, owner, return_type, elidable })))
                                     } else {
                                         if get_option!(stats) {
                                             self.count_not_inlined_cfunc(block, super_cme);
@@ -5502,14 +5539,14 @@ impl Function {
         // NOTE: it's fine to use rb_ivar_get_at_no_ractor_check because
         // getinstancevariable does assume_single_ractor_mode()
         let ivar_index_insn = self.push_insn(block, Insn::Const { val: Const::CAttrIndex(ivar_index) });
-        self.push_insn(block, Insn::CCall {
+        self.push_insn(block, Insn::CCall(Box::new(CCallData {
             cfunc: rb_ivar_get_at_no_ractor_check as *const u8,
             recv,
             args: vec![ivar_index_insn],
             name: ID!(rb_ivar_get_at_no_ractor_check),
             owner: Qnil,
             return_type: types::BasicObject,
-            elidable: true })
+            elidable: true })))
     }
 
     fn load_ivar_embedded(&mut self, block: BlockId, recv: InsnId, id: ID, ivar_index: attr_index_t) -> InsnId {
@@ -6937,10 +6974,12 @@ impl Function {
             | Insn::ObjectAlloc { val, .. }
             | Insn::DupArrayInclude { target: val, .. }
             | Insn::GetIvar { self_val: val, .. }
-            | Insn::CCall { recv: val, .. }
             | Insn::FixnumBitCheck { val, .. } // TODO (https://github.com/Shopify/ruby/issues/859) this should check Fixnum, but then test_checkkeyword_tests_fixnum_bit fails
             | Insn::DefinedIvar { self_val: val, .. } => {
                 self.assert_subtype(insn_id, val, types::BasicObject)
+            }
+            Insn::CCall(insn) => {
+                self.assert_subtype(insn_id, insn.recv, types::BasicObject)
             }
             // Instructions with 2 Ruby object operands
             Insn::SetIvar { self_val: left, val: right, .. }
@@ -8954,7 +8993,7 @@ fn add_iseq_to_hir(
                             }
                             ProfiledBlockHandlerFamily::Proc => {
                                 let proc_val = fun.load_ep_env_field(unmodified_block, ep, FieldName::VM_ENV_DATA_INDEX_SPECVAL, VM_ENV_DATA_INDEX_SPECVAL, types::BasicObject);
-                                let is_proc = fun.push_insn(unmodified_block, Insn::CCall {
+                                let is_proc = fun.push_insn(unmodified_block, Insn::CCall(Box::new(CCallData {
                                     cfunc: rb_obj_is_proc as *const u8,
                                     recv: proc_val,
                                     args: vec![],
@@ -8962,7 +9001,7 @@ fn add_iseq_to_hir(
                                     owner: Qnil,
                                     return_type: types::BasicObject,
                                     elidable: true,
-                                });
+                                })));
                                 fun.push_insn(unmodified_block, Insn::GuardBitEquals { val: is_proc, expected: Const::Value(Qtrue), reason: Box::new(SideExitReason::BlockParamProxyNotProc), state: exit_id, recompile: Some(Recompile) });
                                 let mut args = vec![proc_val];
                                 if let Some(local) = original_local {
@@ -9042,7 +9081,7 @@ fn add_iseq_to_hir(
                                         fun.push_insn(current_block, Insn::Jump(BranchEdge { target: proc_check_block, args: vec![] }));
 
                                         let proc_val = fun.load_ep_env_field(proc_check_block, ep, FieldName::VM_ENV_DATA_INDEX_SPECVAL, VM_ENV_DATA_INDEX_SPECVAL, types::BasicObject);
-                                        let proc_result = fun.push_insn(proc_check_block, Insn::CCall {
+                                        let proc_result = fun.push_insn(proc_check_block, Insn::CCall(Box::new(CCallData {
                                             cfunc: rb_obj_is_proc as *const u8,
                                             recv: proc_val,
                                             args: vec![],
@@ -9050,7 +9089,7 @@ fn add_iseq_to_hir(
                                             owner: Qnil,
                                             return_type: types::BasicObject,
                                             elidable: true,
-                                        });
+                                        })));
                                         let true_val = fun.push_insn(proc_check_block, Insn::Const { val: Const::Value(Qtrue) });
                                         let is_proc = fun.push_insn(proc_check_block, Insn::IsBitEqual { left: proc_result, right: true_val });
                                         fun.push_insn(proc_check_block, Insn::CondBranch(Box::new(CondBranchData {

--- a/zjit/src/hir/tests.rs
+++ b/zjit/src/hir/tests.rs
@@ -7,7 +7,7 @@ mod size_tests {
 
     #[test]
     fn test_size_of_insn() {
-        assert_eq!(std::mem::size_of::<Insn>(), 80);
+        assert_eq!(std::mem::size_of::<Insn>(), 72);
     }
 
     #[test]
@@ -38,7 +38,7 @@ mod printer_tests {
             let cme = unsafe { rb_callable_method_entry(rb_cInteger, name) };
             assert!(!cme.is_null());
 
-            let ccall = print_same_cfunc_twice(|| Insn::CCall {
+            let ccall = print_same_cfunc_twice(|| Insn::CCall(Box::new(CCallData {
                 cfunc,
                 recv: InsnId(0),
                 args: vec![],
@@ -46,7 +46,7 @@ mod printer_tests {
                 owner: Qnil,
                 return_type: types::Any,
                 elidable: false,
-            });
+            })));
             let ccall_with_frame = print_same_cfunc_twice(|| {
                 Insn::CCallWithFrame(Box::new(CCallWithFrameData {
                     cd: std::ptr::null(),

--- a/zjit/src/hir/tests.rs
+++ b/zjit/src/hir/tests.rs
@@ -6311,7 +6311,7 @@ pub(crate) mod hir_build_tests {
         let bb3 = function.new_block(0);
 
         let v1 = function.push_insn(bb0, Insn::Const { val: Const::Value(Qfalse) });
-        let _ = function.push_insn(bb0, Insn::CondBranch { val: v1, if_true: edge(bb2), if_false: edge(bb1) });
+        let _ = function.push_insn(bb0, Insn::CondBranch(Box::new(CondBranchData { val: v1, if_true: edge(bb2), if_false: edge(bb1) })));
         function.push_insn(bb1, Insn::Jump(edge(bb3)));
         function.push_insn(bb2, Insn::Jump(edge(bb3)));
 
@@ -6337,7 +6337,7 @@ pub(crate) mod hir_build_tests {
 
          // Construct two separate jump instructions.
          let v1 = function.push_insn(bb0, Insn::Const { val: Const::Value(Qfalse) });
-         let _ = function.push_insn(bb0, Insn::CondBranch { val: v1, if_true: edge(bb1), if_false: edge(bb1)});
+         let _ = function.push_insn(bb0, Insn::CondBranch(Box::new(CondBranchData { val: v1, if_true: edge(bb1), if_false: edge(bb1)})));
 
          let retval = function.push_insn(bb1, Insn::Const { val: Const::CBool(true) });
          function.push_insn(bb1, Insn::Return { val: retval });
@@ -6417,7 +6417,7 @@ pub(crate) mod hir_build_tests {
         let bb3 = function.new_block(0);
 
         let val = function.push_insn(bb0, Insn::Const { val: Const::Value(Qfalse) });
-        let _ = function.push_insn(bb0, Insn::CondBranch { val, if_true: edge(bb1), if_false: edge(bb2) });
+        let _ = function.push_insn(bb0, Insn::CondBranch(Box::new(CondBranchData { val, if_true: edge(bb1), if_false: edge(bb2) })));
 
         function.push_insn(bb2, Insn::Jump(edge(bb3)));
         function.push_insn(bb1, Insn::Jump(edge(bb3)));
@@ -6465,12 +6465,12 @@ pub(crate) mod hir_build_tests {
         function.push_insn(bb0, Insn::Jump(edge(bb1)));
 
         let v0 = function.push_insn(bb1, Insn::Const { val: Const::Value(Qfalse) });
-        let _ = function.push_insn(bb1, Insn::CondBranch { val: v0, if_true: edge(bb2), if_false: edge(bb4) });
+        let _ = function.push_insn(bb1, Insn::CondBranch(Box::new(CondBranchData { val: v0, if_true: edge(bb2), if_false: edge(bb4) })));
 
         function.push_insn(bb2, Insn::Jump(edge(bb3)));
 
         let v1 = function.push_insn(bb3, Insn::Const { val: Const::Value(Qfalse) });
-        let _ = function.push_insn(bb3, Insn::CondBranch { val: v1, if_true: edge(bb5), if_false: edge(bb7) });
+        let _ = function.push_insn(bb3, Insn::CondBranch(Box::new(CondBranchData { val: v1, if_true: edge(bb5), if_false: edge(bb7) })));
 
         function.push_insn(bb4, Insn::Jump(edge(bb5)));
 
@@ -6530,17 +6530,17 @@ pub(crate) mod hir_build_tests {
         let bb5 = function.new_block(0);
 
         let v0 = function.push_insn(bb0, Insn::Const { val: Const::Value(Qfalse) });
-        let _ = function.push_insn(bb0, Insn::CondBranch { val: v0, if_true: edge(bb1), if_false: edge(bb4) });
+        let _ = function.push_insn(bb0, Insn::CondBranch(Box::new(CondBranchData { val: v0, if_true: edge(bb1), if_false: edge(bb4) })));
 
         let v1 = function.push_insn(bb1, Insn::Const { val: Const::Value(Qfalse) });
-        let _ = function.push_insn(bb1, Insn::CondBranch { val: v1, if_true: edge(bb2), if_false: edge(bb3) });
+        let _ = function.push_insn(bb1, Insn::CondBranch(Box::new(CondBranchData { val: v1, if_true: edge(bb2), if_false: edge(bb3) })));
 
         function.push_insn(bb2, Insn::Jump(edge(bb3)));
 
         function.push_insn(bb4, Insn::Jump(edge(bb5)));
 
         let v2 = function.push_insn(bb5, Insn::Const { val: Const::Value(Qfalse) });
-        let _ = function.push_insn(bb5, Insn::CondBranch { val: v2, if_true: edge(bb3), if_false: edge(bb4) });
+        let _ = function.push_insn(bb5, Insn::CondBranch(Box::new(CondBranchData { val: v2, if_true: edge(bb3), if_false: edge(bb4) })));
 
         let retval = function.push_insn(bb3, Insn::Const { val: Const::CBool(true) });
         function.push_insn(bb3, Insn::Return { val: retval });
@@ -6650,7 +6650,7 @@ mod loop_info_tests {
         function.push_insn(bb0, Insn::Jump(edge(bb2)));
 
         let val = function.push_insn(bb2, Insn::Const { val: Const::Value(Qfalse) });
-        let _ = function.push_insn(bb2, Insn::CondBranch { val, if_true: edge(bb1), if_false: edge(bb3) });
+        let _ = function.push_insn(bb2, Insn::CondBranch(Box::new(CondBranchData { val, if_true: edge(bb1), if_false: edge(bb3) })));
         let retval = function.push_insn(bb3, Insn::Const { val: Const::CBool(true) });
         let _ = function.push_insn(bb3, Insn::Return { val: retval });
 
@@ -6714,10 +6714,10 @@ mod loop_info_tests {
         function.push_insn(bb1, Insn::Jump(edge(bb2)));
 
         let cond = function.push_insn(bb2, Insn::Const { val: Const::Value(Qfalse) });
-        let _ = function.push_insn(bb2, Insn::CondBranch { val: cond, if_true: edge(bb1), if_false: edge(bb3) });
+        let _ = function.push_insn(bb2, Insn::CondBranch(Box::new(CondBranchData { val: cond, if_true: edge(bb1), if_false: edge(bb3) })));
 
         let cond = function.push_insn(bb3, Insn::Const { val: Const::Value(Qtrue) });
-        let _ = function.push_insn(bb3, Insn::CondBranch { val: cond, if_true: edge(bb0), if_false: edge(bb4) });
+        let _ = function.push_insn(bb3, Insn::CondBranch(Box::new(CondBranchData { val: cond, if_true: edge(bb0), if_false: edge(bb4) })));
 
         let retval = function.push_insn(bb4, Insn::Const { val: Const::CBool(true) });
         let _ = function.push_insn(bb4, Insn::Return { val: retval });
@@ -6789,17 +6789,17 @@ mod loop_info_tests {
         let bb6 = function.new_block(0);
 
         let cond = function.push_insn(bb0, Insn::Const { val: Const::Value(Qfalse) });
-        let _ = function.push_insn(bb0, Insn::CondBranch { val: cond, if_true: edge(bb1), if_false: edge(bb3) });
+        let _ = function.push_insn(bb0, Insn::CondBranch(Box::new(CondBranchData { val: cond, if_true: edge(bb1), if_false: edge(bb3) })));
 
         function.push_insn(bb1, Insn::Jump(edge(bb2)));
 
-        let _ = function.push_insn(bb2, Insn::CondBranch { val: cond, if_true: edge(bb1), if_false: edge(bb5) });
+        let _ = function.push_insn(bb2, Insn::CondBranch(Box::new(CondBranchData { val: cond, if_true: edge(bb1), if_false: edge(bb5) })));
 
         function.push_insn(bb3, Insn::Jump(edge(bb4)));
 
-        let _ = function.push_insn(bb4, Insn::CondBranch { val: cond, if_true: edge(bb3), if_false: edge(bb5) });
+        let _ = function.push_insn(bb4, Insn::CondBranch(Box::new(CondBranchData { val: cond, if_true: edge(bb3), if_false: edge(bb5) })));
 
-        let _ = function.push_insn(bb5, Insn::CondBranch { val: cond, if_true: edge(bb0), if_false: edge(bb6) });
+        let _ = function.push_insn(bb5, Insn::CondBranch(Box::new(CondBranchData { val: cond, if_true: edge(bb0), if_false: edge(bb6) })));
 
         let retval = function.push_insn(bb6, Insn::Const { val: Const::CBool(true) });
         let _ = function.push_insn(bb6, Insn::Return { val: retval });
@@ -6943,9 +6943,9 @@ mod loop_info_tests {
         let _ = function.push_insn(bb0, Insn::Jump(edge(bb1)));
         let _ = function.push_insn(bb1, Insn::Jump(edge(bb2)));
         let _ = function.push_insn(bb2, Insn::Jump(edge(bb3)));
-        let _ = function.push_insn(bb3, Insn::CondBranch {val: cond, if_true: edge(bb2), if_false: edge(bb4) });
-        let _ = function.push_insn(bb4, Insn::CondBranch {val: cond, if_true: edge(bb1), if_false: edge(bb5) });
-        let _ = function.push_insn(bb5, Insn::CondBranch {val: cond, if_true: edge(bb0), if_false: edge(bb6) });
+        let _ = function.push_insn(bb3, Insn::CondBranch(Box::new(CondBranchData {val: cond, if_true: edge(bb2), if_false: edge(bb4) })));
+        let _ = function.push_insn(bb4, Insn::CondBranch(Box::new(CondBranchData {val: cond, if_true: edge(bb1), if_false: edge(bb5) })));
+        let _ = function.push_insn(bb5, Insn::CondBranch(Box::new(CondBranchData {val: cond, if_true: edge(bb0), if_false: edge(bb6) })));
         function.push_insn(bb6, Insn::Unreachable);
 
         function.seal_entries();
@@ -7055,7 +7055,7 @@ mod iongraph_tests {
         let bb2 = function.new_block(0);
 
         let cond = function.push_insn(bb0, Insn::Const { val: Const::CBool(true) });
-        function.push_insn(bb0, Insn::CondBranch { val: cond, if_true: edge(bb1), if_false: edge(bb2) });
+        function.push_insn(bb0, Insn::CondBranch(Box::new(CondBranchData { val: cond, if_true: edge(bb1), if_false: edge(bb2) })));
 
         let retval1 = function.push_insn(bb2, Insn::Const { val: Const::CBool(false) });
         function.push_insn(bb2, Insn::Return { val: retval1 });
@@ -7080,7 +7080,7 @@ mod iongraph_tests {
         function.push_insn(bb0, Insn::Jump(edge(bb2)));
 
         let val = function.push_insn(bb2, Insn::Const { val: Const::Value(Qfalse) });
-        let _ = function.push_insn(bb2, Insn::CondBranch { val, if_true: edge(bb1), if_false: edge(bb3) });
+        let _ = function.push_insn(bb2, Insn::CondBranch(Box::new(CondBranchData { val, if_true: edge(bb1), if_false: edge(bb3) })));
         let retval = function.push_insn(bb3, Insn::Const { val: Const::CBool(true) });
         let _ = function.push_insn(bb3, Insn::Return { val: retval });
 
@@ -7099,7 +7099,7 @@ mod iongraph_tests {
         let bb2 = function.new_block(0);
 
         let cond = function.push_insn(bb0, Insn::Const { val: Const::CBool(true) });
-        function.push_insn(bb0, Insn::CondBranch { val: cond, if_true: edge(bb1), if_false: edge(bb2) });
+        function.push_insn(bb0, Insn::CondBranch(Box::new(CondBranchData { val: cond, if_true: edge(bb1), if_false: edge(bb2) })));
 
         let retval1 = function.push_insn(bb1, Insn::Const { val: Const::CBool(true) });
         function.push_insn(bb1, Insn::Return { val: retval1 });


### PR DESCRIPTION
Similar to #17719.
Part of https://github.com/Shopify/ruby/issues/986.

Boxes CondBranch, Send, PushInlineFrame, and CCall instructions to reduce the size of hir::Insn from 80 to 72 bytes.

I'm new to Rust so keen for any feedback.