### PR TITLE
Fix operand in the update_global_event_hooks assertion

### DIFF
--- a/vm_trace.c
+++ b/vm_trace.c
@@ -166,7 +166,7 @@ update_global_event_hooks(rb_hook_list_t *list, rb_event_flag_t prev_events, rb_
     }
     ruby_vm_iseq_events_enabled += change_iseq_events;
     if (change_c_events < 0) {
-        RUBY_ASSERT(ruby_vm_c_events_enabled >= (unsigned int)(-change_iseq_events));
+        RUBY_ASSERT(ruby_vm_c_events_enabled >= (unsigned int)(-change_c_events));
     }
     ruby_vm_c_events_enabled += change_c_events;
 


### PR DESCRIPTION
The assertion for change_c_events < 0 compares ruby_vm_c_events_enabled against -change_iseq_events instead of -change_c_events, so it fires on a normal case where the iseq-event decrement happens to exceed the number of enabled C events.  It trips flakily in irb's tracer test on RUBY_DEBUG builds.  Use -change_c_events, mirroring the first assertion.