### PR TITLE
gc/default: make stress GC honor gc_allowed in TRY_WITH_GC

### DIFF
--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -8867,7 +8867,8 @@ objspace_malloc_fixup(rb_objspace_t *objspace, void *mem, size_t size, bool gc_a
             GPR_FLAG_IMMEDIATE_MARK      |                   \
             GPR_FLAG_IMMEDIATE_SWEEP     |                   \
             GPR_FLAG_MALLOC;                                 \
-        objspace_malloc_gc_stress(objspace);                 \
+        /* stress GC must also honor gc_allowed (malloc_gc_disabled) */ \
+        if (gc_allowed) objspace_malloc_gc_stress(objspace);  \
                                                              \
         if (RB_LIKELY((expr))) {                             \
             /* Success on 1st try */                         \


### PR DESCRIPTION
TRY_WITH_GC guards its retry-GC branch with gc_allowed (which reflects the current ractor's malloc_gc_disabled, set while a ractor lock is held), but called objspace_malloc_gc_stress() unconditionally.  Under GC.stress, a malloc inside a RACTOR_LOCK critical section (e.g. st_insert in ractor_add_port) therefore triggers a GC while the lock is held, which surfaces as the vm_lock_enter locked_by assertion.

Gate the stress call with gc_allowed as well, so malloc_gc_disabled suppresses every malloc-triggered GC, stress included.

Verified: a minimal repro (8x Ractor::Port.new under GC.stress) and a wave-join hang now complete; btest PASS all 2055.