### PR TITLE
compile.c: pass the new operand ci to the write barrier, not the INSN

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -5857,7 +5857,7 @@ compile_massign_lhs(rb_iseq_t *iseq, LINK_ANCHOR *const pre, LINK_ANCHOR *const 
                 ci = ci_flag_set(iseq, ci, VM_CALL_ARGS_SPLAT_MUT);
             }
             OPERAND_AT(iobj, 0) = (VALUE)ci;
-            RB_OBJ_WRITTEN(iseq, Qundef, iobj);
+            RB_OBJ_WRITTEN(iseq, Qundef, ci);
 
             /* Given: h[*a], h[*b, 1] = ary
              *  h[*a] uses splatarray false and does not set VM_CALL_ARGS_SPLAT_MUT,


### PR DESCRIPTION
The splat rebuild in compile_massign_lhs passes the arena-allocated INSN (iobj) to RB_OBJ_WRITTEN (since f2286925f0).  iobj is not a heap object, so the barrier touches the page it happens to land on, which is undefined.  It is harmless by luck today; with a GC that records an edge for shareable iseqs, GET_HEAP_PAGE(iobj) dereferences garbage and segfaults (deterministic in btest test_insns #358/#553 under --parser=parse.y).  Pass the ci that actually became the operand, which is the edge being recorded.