### PR TITLE
Add missing NEWS entries for Ruby 4.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -248,6 +248,12 @@ The following APIs, which have been deprecated for many years, are removed.
 
 - The default garbage collector has been switched from a freelist allocator to a bump pointer allocator. [[PR #17201]]
 
+- The error_highlight, did_you_mean, and syntax_suggest gems are now
+  loaded lazily on the first error display instead of at interpreter
+  boot, which reduces startup time.  `Process.warmup` loads them
+  eagerly so that pre-forking servers keep their code in
+  copy-on-write shared memory.  [[Feature #21951]]
+
 ### Ractor
 
 A lot of work has gone into making Ractors more stable, performant, and usable. These improvements bring Ractor implementation closer to leaving experimental status.
@@ -266,6 +272,7 @@ A lot of work has gone into making Ractors more stable, performant, and usable. 
 [Feature #21853]: https://bugs.ruby-lang.org/issues/21853
 [Feature #21861]: https://bugs.ruby-lang.org/issues/21861
 [Feature #21932]: https://bugs.ruby-lang.org/issues/21932
+[Feature #21951]: https://bugs.ruby-lang.org/issues/21951
 [Feature #21981]: https://bugs.ruby-lang.org/issues/21981
 [Feature #22097]: https://bugs.ruby-lang.org/issues/22097
 [Feature #22135]: https://bugs.ruby-lang.org/issues/22135

--- a/NEWS.md
+++ b/NEWS.md
@@ -103,6 +103,13 @@ Note: We're only listing outstanding class updates.
 
 ## Stdlib updates
 
+* Psych
+
+    * An experimental libfyaml backend has been added.  It is only
+      enabled when psych is built with `--enable-libfyaml`, and the
+      default libyaml backend remains unchanged otherwise.  It is not
+      supported on Windows.
+
 ### The following bundled gems are added.
 
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -117,6 +117,14 @@ releases.
 * tsort 0.2.0
 * win32-registry 0.1.2
 
+### The following bundled gems are removed.
+
+* net-ftp 0.3.9
+* net-pop 0.1.2
+
+They are still available on rubygems.org and can be installed with
+`gem install`.  [[Feature #21835]]
+
 ### The following default gem is added.
 
 ### The following default gems are updated.
@@ -254,6 +262,7 @@ A lot of work has gone into making Ractors more stable, performant, and usable. 
 [Feature #21781]: https://bugs.ruby-lang.org/issues/21781
 [Feature #21785]: https://bugs.ruby-lang.org/issues/21785
 [Feature #21796]: https://bugs.ruby-lang.org/issues/21796
+[Feature #21835]: https://bugs.ruby-lang.org/issues/21835
 [Feature #21853]: https://bugs.ruby-lang.org/issues/21853
 [Feature #21861]: https://bugs.ruby-lang.org/issues/21861
 [Feature #21932]: https://bugs.ruby-lang.org/issues/21932

--- a/NEWS.md
+++ b/NEWS.md
@@ -201,6 +201,14 @@ Ruby 4.0 bundled RubyGems and Bundler version 4. see the following links for det
 
 ## Supported platforms
 
+* Support code for the following platforms has been removed.  Note
+  that all of them reached end of life many years ago and Ruby has
+  long been unbuildable on them.
+
+    * Interix (Windows Services for UNIX)
+    * SunOS 4 (Solaris, i.e. SunOS 5, is unaffected)
+    * BSD/OS (BSDi)
+
 ## Compatibility issues
 
 * `Kernel#at_exit` and `END {}` now raise `Ractor::IsolationError` when called

--- a/NEWS.md
+++ b/NEWS.md
@@ -108,7 +108,7 @@ Note: We're only listing outstanding class updates.
     * An experimental libfyaml backend has been added.  It is only
       enabled when psych is built with `--enable-libfyaml`, and the
       default libyaml backend remains unchanged otherwise.  It is not
-      supported on Windows.
+      supported on Windows.  [[GH-psych #805]]
 
 ### The following bundled gems are added.
 
@@ -296,6 +296,7 @@ A lot of work has gone into making Ractors more stable, performant, and usable. 
 [Feature #22175]: https://bugs.ruby-lang.org/issues/22175
 [Feature #22185]: https://bugs.ruby-lang.org/issues/22185
 [PR #17201]: https://github.com/ruby/ruby/pull/17201
+[GH-psych #805]: https://github.com/ruby/psych/pull/805
 [RubyGems-v4.0.4]: https://github.com/rubygems/rubygems/releases/tag/v4.0.4
 [RubyGems-v4.0.5]: https://github.com/rubygems/rubygems/releases/tag/v4.0.5
 [RubyGems-v4.0.6]: https://github.com/rubygems/rubygems/releases/tag/v4.0.6


### PR DESCRIPTION
NEWS.md was missing several user-visible changes from this development cycle. This adds entries for the removal of `net-ftp` and `net-pop` from the bundled gems (Feature #21835), the lazy loading of `error_highlight`, `did_you_mean`, and `syntax_suggest` together with their eager loading from `Process.warmup` (Feature #21951), the removal of support code for Interix, SunOS 4, and BSD/OS, which are all long past end of life, and the experimental libfyaml backend of psych behind `--enable-libfyaml` (ruby/psych#805).

The new sections were checked against `tool/update-NEWS-gemlist.rb` and `tool/update-NEWS-github-release.rb` so that the automated NEWS updates will not overwrite them.

Generated with [Claude Code](https://claude.com/claude-code)
