### PR TITLE
Make IO objects unshareable

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -199,6 +199,11 @@ Ruby 4.0 bundled RubyGems and Bundler version 4. see the following links for det
   in a non-main Ractor.  Previously the registered handler ran in the main
   Ractor at process exit, which was confusing. [[Feature #22139]]
 
+* `Ractor.make_shareable` now raises `Ractor::Error` for an `IO` object, and
+  `Ractor.shareable?` returns `false` for it.  A frozen `IO` used to be
+  shareable, but almost all of its methods raise `FrozenError` and it can
+  still refer to unshareable objects through the members of `rb_io_t`.
+
 ## Stdlib compatibility issues
 
 ## C API updates

--- a/ractor.c
+++ b/ractor.c
@@ -1493,7 +1493,10 @@ rb_obj_traverse(VALUE obj,
 static int
 allow_frozen_shareable_p(VALUE obj)
 {
-    if (!RB_TYPE_P(obj, T_DATA)) {
+    if (RB_TYPE_P(obj, T_FILE)) {
+        return false;
+    }
+    else if (!RB_TYPE_P(obj, T_DATA)) {
         return true;
     }
     else {

--- a/ractor.c
+++ b/ractor.c
@@ -1553,10 +1553,11 @@ make_shareable_check_shareable(VALUE obj)
         return traverse_skip;
     }
     else if (!allow_frozen_shareable_p(obj)) {
-        VM_ASSERT(RB_TYPE_P(obj, T_DATA));
-        const rb_data_type_t *type = RTYPEDDATA_TYPE(obj);
-
-        if (type->flags & RUBY_TYPED_FROZEN_SHAREABLE_NO_REC) {
+        if (!RB_TYPE_P(obj, T_DATA)) {
+            rb_raise(rb_eRactorError,
+                     "can not make shareable object for %+"PRIsVALUE, obj);
+        }
+        else if (RTYPEDDATA_TYPE(obj)->flags & RUBY_TYPED_FROZEN_SHAREABLE_NO_REC) {
             if (obj_refer_only_shareables_p(obj)) {
                 make_shareable_check_shareable_freeze(obj, traverse_skip);
                 RB_OBJ_SET_SHAREABLE(obj);

--- a/test/ruby/test_ractor.rb
+++ b/test/ruby/test_ractor.rb
@@ -449,6 +449,20 @@ class TestRactor < Test::Unit::TestCase
     RUBY
   end
 
+  def test_io_is_not_shareable
+    io = File.open(IO::NULL)
+    begin
+      assert_unshareable(io, "can not make shareable object for #{io.inspect}",
+                         exception: Ractor::Error)
+      # freezing an IO does not make it shareable either
+      io.freeze
+      refute Ractor.shareable?(io)
+      assert_raise(Ractor::Error) { Ractor.make_shareable(io) }
+    ensure
+      io.close
+    end
+  end
+
   def assert_make_shareable(obj)
     refute Ractor.shareable?(obj), "object was already shareable"
     Ractor.make_shareable(obj)


### PR DESCRIPTION
A frozen `IO` currently passes `Ractor.make_shareable`, but the resulting
object is neither useful nor sound.

Not useful: almost nothing works on a frozen IO.  `read`, `gets`, `seek`,
`eof?` and `sync=` all raise `FrozenError` because they update the buffered
state in `rb_io`; practically only `fileno` and `close` remain.  So a
shareable IO can do nothing that an unshareable one cannot.

Not sound: `rb_io` keeps VALUE members (`pathv`, `tied_io_for_writing`, the
writeconv fields, `encs.ecopts`, `write_lock`, `timeout`) in a C struct that
the `make_shareable` traversal never visits, so a "shareable" IO can still
reference unshareable objects.  Maintaining the invariant properly would mean
traversing all of them, which in turn drags in freezing the tied IO and a
`Mutex` that is not shareable itself.

So this PR rejects it instead: `Ractor.make_shareable(io)` now raises
`Ractor::Error`, and `Ractor.shareable?(io)` returns `false` even for a frozen
IO.  Moving and copying an IO between ractors is unaffected.

The first commit is a prerequisite bug fix: `make_shareable_check_shareable()`
assumed `allow_frozen_shareable_p()` could only fail for `T_DATA` and
dereferenced `RTYPEDDATA_TYPE()` right after the check.  The `VM_ASSERT`
documenting that assumption is compiled out in a release build, so making any
other type non-shareable would segfault instead of raising.