### PR TITLE
Add C API specs for new Ruby 4.1 APIs

### DIFF
--- a/spec/ruby/optional/capi/ext/integer_spec.c
+++ b/spec/ruby/optional/capi/ext/integer_spec.c
@@ -18,6 +18,21 @@ static VALUE integer_spec_rb_int_positive_pow(VALUE self, VALUE a, VALUE b) {
   return rb_int_positive_pow(FIX2INT(a), FIX2INT(b));
 }
 
+#ifdef RUBY_VERSION_IS_4_1
+static VALUE integer_spec_rb_int_parse_cstr(VALUE self, VALUE str, VALUE len, VALUE base, VALUE flags) {
+  const char *s = RSTRING_PTR(str);
+  ssize_t n = NIL_P(len) ? RSTRING_LEN(str) : NUM2SSIZET(len);
+  int b = NUM2INT(base), f = NUM2INT(flags);
+  char *end = NULL;
+  size_t ndigits = 0;
+  VALUE result[3];
+  result[0] = rb_int_parse_cstr(s, n, &end, &ndigits, b, f);
+  result[1] = SIZET2NUM(end - s);
+  result[2] = SIZET2NUM(ndigits);
+  return rb_ary_new_from_values(3, result);
+}
+#endif
+
 void Init_integer_spec(void) {
   VALUE cls = rb_define_class("CApiIntegerSpecs", rb_cObject);
   rb_define_const(cls, "MSWORD", INT2NUM(INTEGER_PACK_MSWORD_FIRST));
@@ -30,9 +45,19 @@ void Init_integer_spec(void) {
   rb_define_const(cls, "BIG_ENDIAN", INT2NUM(INTEGER_PACK_BIG_ENDIAN));
   rb_define_const(cls, "FORCE_BIGNUM", INT2NUM(INTEGER_PACK_FORCE_BIGNUM));
   rb_define_const(cls, "NEGATIVE", INT2NUM(INTEGER_PACK_NEGATIVE));
+#ifdef RUBY_VERSION_IS_4_1
+  rb_define_const(cls, "RB_INT_PARSE_SIGN", INT2NUM(RB_INT_PARSE_SIGN));
+  rb_define_const(cls, "RB_INT_PARSE_UNDERSCORE", INT2NUM(RB_INT_PARSE_UNDERSCORE));
+  rb_define_const(cls, "RB_INT_PARSE_PREFIX", INT2NUM(RB_INT_PARSE_PREFIX));
+  rb_define_const(cls, "RB_INT_PARSE_ALL", INT2NUM(RB_INT_PARSE_ALL));
+  rb_define_const(cls, "RB_INT_PARSE_DEFAULT", INT2NUM(RB_INT_PARSE_DEFAULT));
+#endif
 
   rb_define_method(cls, "rb_integer_pack", integer_spec_rb_integer_pack, 6);
   rb_define_method(cls, "rb_int_positive_pow", integer_spec_rb_int_positive_pow, 2);
+#ifdef RUBY_VERSION_IS_4_1
+  rb_define_method(cls, "rb_int_parse_cstr", integer_spec_rb_int_parse_cstr, 4);
+#endif
 }
 
 #ifdef __cplusplus

--- a/spec/ruby/optional/capi/ext/integer_spec.c
+++ b/spec/ruby/optional/capi/ext/integer_spec.c
@@ -12,8 +12,6 @@ static VALUE integer_spec_rb_integer_pack(VALUE self, VALUE value,
   return INT2FIX(result);
 }
 
-RUBY_EXTERN VALUE rb_int_positive_pow(long x, unsigned long y); /* internal.h, used in ripper */
-
 static VALUE integer_spec_rb_int_positive_pow(VALUE self, VALUE a, VALUE b) {
   return rb_int_positive_pow(FIX2INT(a), FIX2INT(b));
 }

--- a/spec/ruby/optional/capi/ext/process_spec.c
+++ b/spec/ruby/optional/capi/ext/process_spec.c
@@ -1,0 +1,26 @@
+#include "ruby.h"
+#include "rubyspec.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef RUBY_VERSION_IS_4_1
+static VALUE process_spec_rb_process_status_for(VALUE self, VALUE pid,
+    VALUE status, VALUE error) {
+  return rb_process_status_for(NUM2PIDT(pid), NUM2INT(status), NUM2INT(error));
+}
+#endif
+
+void Init_process_spec(void) {
+  VALUE cls = rb_define_class("CApiProcessSpecs", rb_cObject);
+
+#ifdef RUBY_VERSION_IS_4_1
+  rb_define_method(cls, "rb_process_status_for",
+      process_spec_rb_process_status_for, 3);
+#endif
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/spec/ruby/optional/capi/integer_spec.rb
+++ b/spec/ruby/optional/capi/integer_spec.rb
@@ -304,4 +304,12 @@ describe "CApiIntegerSpecs" do
       @s.rb_int_positive_pow(8, 23).should == 590295810358705651712
     end
   end
+
+  ruby_version_is "4.1" do
+    describe "rb_int_parse_cstr" do
+      it "returns the parsed integer, end position, and digit count" do
+        @s.rb_int_parse_cstr("123x", nil, 10, 0).should == [123, 3, 3]
+      end
+    end
+  end
 end

--- a/spec/ruby/optional/capi/process_spec.rb
+++ b/spec/ruby/optional/capi/process_spec.rb
@@ -1,0 +1,19 @@
+require_relative 'spec_helper'
+
+load_extension("process")
+
+describe "CApiProcessSpecs" do
+  ruby_version_is "4.1" do
+    describe "rb_process_status_for" do
+      it "returns a frozen Process::Status for the given process result" do
+        raw_status = 42 << 8
+        status = CApiProcessSpecs.new.rb_process_status_for(123, raw_status, 0)
+
+        status.should.is_a?(Process::Status)
+        status.pid.should == 123
+        status.to_i.should == raw_status
+        status.should.frozen?
+      end
+    end
+  end
+end

--- a/spec/ruby/spec_helper.rb
+++ b/spec/ruby/spec_helper.rb
@@ -28,8 +28,8 @@ unless ENV['MSPEC_RUNNER'] # Running directly with ruby some_spec.rb
 end
 
 # Compare with SpecVersion directly here so it works even with --unguarded
-if VersionGuard::FULL_RUBY_VERSION < SpecVersion.new('2.7')
-  abort "This version of ruby/spec requires Ruby 2.7+"
+if VersionGuard::FULL_RUBY_VERSION < SpecVersion.new('3.3')
+  abort "This version of ruby/spec requires Ruby 3.3+"
 end
 
 unless ENV['MSPEC_RUNNER'] # Running directly with ruby some_spec.rb


### PR DESCRIPTION
- Add C API specs for Ruby 4.1 APIs `rb_int_parse_cstr` and
  `rb_process_status_for`.
- Require Ruby 3.3 or later when running ruby/spec directly.
- Remove the redundant declaration of `rb_int_positive_pow`.