### PR TITLE
ZJIT: clear cfp->block_code in the materialize_exit trampoline

### DIFF
--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -3968,6 +3968,10 @@ pub fn gen_materialize_exit_trampoline(cb: &mut CodeBlock, exit_trampoline: Code
 
     asm_comment!(asm, "clear JITFrame materialized by exit code");
     asm.store(Opnd::mem(64, CFP, RUBY_OFFSET_CFP_JIT_RETURN), 0.into());
+    // zjit_materialize_frames() identifies a JIT frame by a non-NULL jit_return, so
+    // it skips this frame and never runs its materialize_block_code branch.  Clear
+    // block_code here, as compile_exit_save_state() already documents we do.
+    asm.store(Opnd::mem(64, CFP, RUBY_OFFSET_CFP_BLOCK_CODE), 0.into());
 
     asm_comment!(asm, "materialize ZJIT frames");
     asm_ccall!(asm, rb_zjit_materialize_frames, EC, CFP);

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -3968,9 +3968,9 @@ pub fn gen_materialize_exit_trampoline(cb: &mut CodeBlock, exit_trampoline: Code
 
     asm_comment!(asm, "clear JITFrame materialized by exit code");
     asm.store(Opnd::mem(64, CFP, RUBY_OFFSET_CFP_JIT_RETURN), 0.into());
-    // zjit_materialize_frames() identifies a JIT frame by a non-NULL jit_return, so
-    // it skips this frame and never runs its materialize_block_code branch.  Clear
-    // block_code here, as compile_exit_save_state() already documents we do.
+    // Clear cfp->block_code since it may have been left uninitialized by JITFrame mechanisms.
+    // Zero is the right value because we're dealing with the top most frame.
+    // Non-zero values are only set before pushing a frame.
     asm.store(Opnd::mem(64, CFP, RUBY_OFFSET_CFP_BLOCK_CODE), 0.into());
 
     asm_comment!(asm, "materialize ZJIT frames");


### PR DESCRIPTION
gen_materialize_exit_trampoline clears cfp->jit_return and then calls rb_zjit_materialize_frames.  CFP_ZJIT_FRAME_P() is exactly cfp->jit_return != NULL, so by then the exiting frame no longer looks like a JIT frame and zjit_materialize_frames() skips its whole per-frame body, including the branch that clears block_code:

    if (jit_frame->materialize_block_code) {
        cfp->block_code = NULL;
    }

Nothing else clears it.  compile_exit_save_state() does not write block_code, and its comment in zjit/src/backend/lir.rs already states that this trampoline clears both fields, which it never did.  The exiting frame therefore keeps the block_code ZJIT wrote for it, and rb_execution_context_mark() marks cfp->block_code; once that iseq is collected, marking it is "[BUG] try to mark T_NONE".

An instrumented build counts how often the exiting frame reaches zjit_materialize_frames() with a non-NULL block_code: 5 times in the first 162 trampoline calls of a single btest process on master, 0 with this change.

Clearing jit_return after materializing instead would be wrong: skipping the exiting frame is deliberate, since compile_exit_save_state() has already written its state and the stack-map restore would overwrite it.