### PR TITLE
[4.0] Fix "oneshot" tracepoints that disable themselves during the hook

### DIFF
--- a/test/ruby/test_settracefunc.rb
+++ b/test/ruby/test_settracefunc.rb
@@ -2752,6 +2752,48 @@ CODE
     tp_line.enable(target: method(:bar))
     bar
     EOS
+
+    # When another event fires at the same pc as a targeted :line hook (here,
+    # COVERAGE_LINE alongside LINE while Coverage is running), disabling the
+    # last targeted TracePoint on the iseq from inside the line hook must not
+    # leave vm_trace() dispatching the remaining event through the freed hook
+    # list.
+    assert_normal_exit(<<-'EOS', 'targeted TracePoint freed mid-dispatch')
+    require "coverage"
+    require "tempfile"
+
+    Coverage.start
+
+    file = Tempfile.new(["cov_tp", ".rb"])
+    50.times { |i| file.puts "def tracee#{i}; 1 + 1; end" }
+    file.close
+    require file.path
+
+    50.times do |i|
+      tp = TracePoint.new(:line) { tp.disable }
+      tp.enable(target: method("tracee#{i}"))
+      send("tracee#{i}")
+    end
+    EOS
+
+    # Same hazard for a bmethod's def-local hook list: a targeted :return
+    # TracePoint on the bmethod fires from vm_trace()'s special RETURN dispatch,
+    # which runs after the b_return event. A targeted :b_return hook that
+    # disables the :return TP frees that list before the special RETURN uses it.
+    assert_normal_exit(<<-'EOS', 'targeted bmethod TracePoint freed mid-dispatch')
+    50.times do
+      obj = Object.new
+      obj.define_singleton_method(:m) { 1 }
+
+      ret_tp = TracePoint.new(:return) { }
+      ret_tp.enable(target: obj.method(:m))
+
+      bret_tp = TracePoint.new(:b_return) { ret_tp.disable }
+      bret_tp.enable(target: obj.method(:m))
+
+      obj.m
+    end
+    EOS
   end
 
   def test_stat_exists

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -7245,8 +7245,13 @@ vm_trace_hook(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, const VAL
     }
 }
 
+/* Re-fetch the iseq-local hook list before each event: a hook fired by an
+ * earlier event at this pc can disable the last targeted TracePoint on this
+ * iseq, which frees local_hooks. Reload from its stable source (the ractor's
+ * targeted-hooks table) so we never dereference a dangling pointer. */
 #define VM_TRACE_HOOK(target_event, val) do { \
     if ((pc_events & (target_event)) & enabled_flags) { \
+        if (local_hooks_cnt > 0) local_hooks = rb_iseq_local_hooks(iseq, r, false); \
         vm_trace_hook(ec, reg_cfp, pc, pc_events, (target_event), global_hooks, local_hooks, (val)); \
     } \
 } while (0)
@@ -7286,6 +7291,8 @@ vm_trace(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp)
 
         rb_hook_list_t *bmethod_local_hooks = NULL;
         rb_event_flag_t bmethod_local_events = 0;
+        unsigned int bmethod_hooks_cnt = 0;
+        rb_method_definition_t *bmethod_def = NULL;
         const bool bmethod_frame = VM_FRAME_BMETHOD_P(reg_cfp);
         enabled_flags |= iseq_local_events;
 
@@ -7294,7 +7301,8 @@ vm_trace(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp)
         if (bmethod_frame) {
             const rb_callable_method_entry_t *me = rb_vm_frame_method_entry(reg_cfp);
             VM_ASSERT(me->def->type == VM_METHOD_TYPE_BMETHOD);
-            unsigned int bmethod_hooks_cnt = me->def->body.bmethod.local_hooks_cnt;
+            bmethod_def = me->def;
+            bmethod_hooks_cnt = me->def->body.bmethod.local_hooks_cnt;
             if (RB_UNLIKELY(bmethod_hooks_cnt > 0)) {
                 st_data_t val;
                 if (st_lookup(rb_ractor_targeted_hooks(r), (st_data_t)me->def, &val)) {
@@ -7352,6 +7360,9 @@ vm_trace(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp)
             VM_TRACE_HOOK(RUBY_EVENT_END | RUBY_EVENT_RETURN | RUBY_EVENT_B_RETURN, TOPN(0));
             if ((pc_events & RUBY_EVENT_B_RETURN) && bmethod_frame && (bmethod_events & RUBY_EVENT_RETURN)) {
                 /* b_return instruction running as a method. Fire return event. */
+                /* An earlier event's hook at this pc may have freed bmethod_local_hooks
+                 * (see VM_TRACE_HOOK); reload it from its stable source. */
+                if (bmethod_hooks_cnt > 0) bmethod_local_hooks = rb_method_def_local_hooks(bmethod_def, r, false);
                 vm_trace_hook(ec, reg_cfp, pc, RUBY_EVENT_RETURN, RUBY_EVENT_RETURN, global_hooks, bmethod_local_hooks, TOPN(0));
             }
         }


### PR DESCRIPTION
The debug gem uses a TP that disables itself (tp.disable) during the hook. If there are other tracepoint events afterwards on the same iseq that share the same local hooks list, this results in a UAF of the hook list.

This was fixed in a687756284187887835aa345adc89b2718054e4a but my patch for ractor-local Tracepoints (4fb537b1ee28bb37dbe551ac65c279d436c756bc) reintroduced the bug. I added some more tests to make sure this doesn't get reintroduced again in the future if someone does another rewrite/refactor.

Fixes [Bug #22217] (Backport 4.0)