### PR TITLE
CI: Build with VS 2017/2019 toolsets on Windows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -227,11 +227,126 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SIMPLER_ALERTS_URL }} # ruby-lang slack: ruby/simpler-alerts-bot
         if: ${{ failure() }}
 
+  # Check that ruby can still be built with the older supported MSVC
+  # toolsets.  The runner images no longer preinstall VS 2017/2019, so
+  # install the v141/v142 toolset into the preinstalled VS 2022 and
+  # select it with -vcvars_ver.  This only builds up to ruby.exe;
+  # extensions and tests are not covered.
+  make-old-toolset:
+    strategy:
+      matrix:
+        include:
+          - vs: 2017
+            toolset: '14.16'
+            component: Microsoft.VisualStudio.Component.VC.v141.x86.x64
+            clver: '19.16'
+          - vs: 2019
+            toolset: '14.29'
+            component: Microsoft.VisualStudio.ComponentGroup.VC.Tools.142.x86.x64
+            clver: '19.29'
+      fail-fast: false
+
+    runs-on: windows-2022
+
+    if: >-
+      ${{!(false
+      || contains(github.event.head_commit.message, '[DOC]')
+      || contains(github.event.pull_request.title, '[DOC]')
+      || contains(github.event.pull_request.labels.*.name, 'Documentation')
+      || github.event.pull_request.user.login == 'dependabot[bot]'
+      )}}
+
+    name: Windows 2022 (VS${{ matrix.vs }} toolset)
+
+    env:
+      GITPULLOPTIONS: --no-tags origin ${{ github.ref }}
+
+    steps:
+      - run: md build
+        working-directory:
+
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
+        with:
+          ruby-version: '3.1'
+          bundler: none
+          windows-toolchain: none
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          sparse-checkout-cone-mode: false
+          sparse-checkout: /.github
+
+      - uses: ./.github/actions/setup/directories
+        with:
+          srcdir: src
+          builddir: build
+          make-command: nmake
+          clean: true
+
+      - name: Install MSVC v${{ matrix.toolset }} toolset
+        shell: pwsh
+        run: |
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $installPath = & $vswhere -products '*' -latest -property installationPath
+          $setup = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\setup.exe"
+          $arguments = @('modify', '--installPath', "`"$installPath`"",
+                         '--add', '${{ matrix.component }}',
+                         '--quiet', '--norestart', '--nocache')
+          $proc = Start-Process -FilePath $setup -ArgumentList $arguments -Wait -PassThru
+          if ($proc.ExitCode -notin 0, 3010) { throw "VS installer exited with $($proc.ExitCode)" }
+        timeout-minutes: 20
+
+      - name: setup env
+        run: |
+          set > old.env
+          call ..\src\win32\vssetup.cmd -arch=amd64 -vcvars_ver=${{ matrix.toolset }}
+          nmake -f nul
+          set TMP=%RUNNER_TEMP%
+          set TEMP=%RUNNER_TEMP%
+          set MAKEFLAGS=l
+          set > new.env
+
+      - name: update env
+        shell: pwsh
+        run: |
+          $old = (Get-Content old.env); $new = (Get-Content new.env)
+          del *.env
+          Compare-Object $old $new |
+            Where-Object { $_.SideIndicator -eq '=>' } |
+            Select-Object -ExpandProperty InputObject |
+            Add-Content -Path $env:GITHUB_ENV
+
+      - name: baseruby version
+        run: ruby -v
+
+      - name: compiler version
+        run: cl 2>&1 | findstr /c:"Compiler Version ${{ matrix.clver }}"
+
+      - name: Configure
+        run: ../src/win32/configure.bat --disable-install-doc
+
+      - run: nmake incs
+
+      - run: nmake mini
+
+      - run: nmake prog
+        timeout-minutes: 50
+
+      - name: ruby version
+        run: .\ruby.exe -v --disable-gems -e "puts :ok"
+
+      - uses: ./.github/actions/slack
+        with:
+          label: Windows 2022 / VS${{ matrix.vs }} toolset
+          SLACK_WEBHOOK_URL: ${{ secrets.SIMPLER_ALERTS_URL }} # ruby-lang slack: ruby/simpler-alerts-bot
+        if: ${{ failure() }}
+
   result:
     if: ${{ always() }}
     name: ${{ github.workflow }} result
     runs-on: windows-2025-vs2026
-    needs: [make]
+    needs: [make, make-old-toolset]
     steps:
       - run: exit 1
         working-directory:

--- a/prism/prism.c
+++ b/prism/prism.c
@@ -135,7 +135,20 @@ pm_version(void) {
 #define PM_NODE_LENGTH_SET_TOKEN(parser_, node_, token_) (PM_NODE_LENGTH(node_) = PM_TOKEN_END(parser_, token_) - PM_NODE_START(node_))
 #define PM_NODE_LENGTH_SET_LOCATION(node_, location_) (PM_NODE_LENGTH(node_) = PM_LOCATION_END(location_) - PM_NODE_START(node_))
 
-#define PM_LOCATION_INIT(start_, length_) ((pm_location_t) { .start = (start_), .length = (length_) })
+/**
+ * A function instead of a compound literal: MSVC 19.16 (VS2017) miscompiles a
+ * conditional expression whose arms are both struct compound literals — it
+ * materializes both arms before testing the condition, so the token
+ * dereferences in the unselected arm of NTOK2LOC and friends fault on NULL.
+ * Function call arguments are only evaluated on the selected branch.
+ */
+static PRISM_INLINE pm_location_t
+pm_location_init(uint32_t start, uint32_t length) {
+    pm_location_t location = { .start = start, .length = length };
+    return location;
+}
+
+#define PM_LOCATION_INIT(start_, length_) pm_location_init((start_), (length_))
 #define PM_LOCATION_INIT_UNSET PM_LOCATION_INIT(0, 0)
 #define PM_LOCATION_INIT_TOKEN(parser_, token_) PM_LOCATION_INIT(PM_TOKEN_START(parser_, token_), PM_TOKEN_LENGTH(token_))
 #define PM_LOCATION_INIT_NODE(node_) UP(node_)->location
@@ -5670,12 +5683,15 @@ pm_match_write_node_create(pm_parser_t *parser, pm_call_node_t *call) {
  */
 static pm_module_node_t *
 pm_module_node_create(pm_parser_t *parser, pm_constant_id_list_t *locals, const pm_token_t *module_keyword, pm_node_t *constant_path, const pm_token_t *name, pm_node_t *body, const pm_token_t *end_keyword) {
+    pm_constant_id_list_t module_locals = { .ids = NULL, .size = 0, .capacity = 0 };
+    if (locals != NULL) module_locals = *locals;
+
     return pm_module_node_new(
         parser->arena,
         ++parser->node_id,
         0,
         PM_LOCATION_INIT_TOKENS(parser, module_keyword, end_keyword),
-        (locals == NULL ? ((pm_constant_id_list_t) { .ids = NULL, .size = 0, .capacity = 0 }) : *locals),
+        module_locals,
         TOK2LOC(parser, module_keyword),
         constant_path,
         body,
@@ -16999,10 +17015,11 @@ parse_pattern_rest(pm_parser_t *parser, pm_constant_id_list_t *captures) {
             pm_parser_local_add(parser, constant_id, parser->previous.start, parser->previous.end, 0);
         }
 
-        parse_pattern_capture(parser, captures, constant_id, &TOK2LOC(parser, &parser->previous));
+        pm_location_t previous_loc = TOK2LOC(parser, &parser->previous);
+        parse_pattern_capture(parser, captures, constant_id, &previous_loc);
         name = UP(pm_local_variable_target_node_create(
             parser,
-            &TOK2LOC(parser, &parser->previous),
+            &previous_loc,
             constant_id,
             (uint32_t) (depth == -1 ? 0 : depth)
         ));
@@ -17035,10 +17052,11 @@ parse_pattern_keyword_rest(pm_parser_t *parser, pm_constant_id_list_t *captures)
             pm_parser_local_add(parser, constant_id, parser->previous.start, parser->previous.end, 0);
         }
 
-        parse_pattern_capture(parser, captures, constant_id, &TOK2LOC(parser, &parser->previous));
+        pm_location_t previous_loc = TOK2LOC(parser, &parser->previous);
+        parse_pattern_capture(parser, captures, constant_id, &previous_loc);
         value = UP(pm_local_variable_target_node_create(
             parser,
-            &TOK2LOC(parser, &parser->previous),
+            &previous_loc,
             constant_id,
             (uint32_t) (depth == -1 ? 0 : depth)
         ));
@@ -17282,10 +17300,11 @@ parse_pattern_primitive(pm_parser_t *parser, pm_constant_id_list_t *captures, pm
                 pm_parser_local_add(parser, constant_id, parser->previous.start, parser->previous.end, 0);
             }
 
-            parse_pattern_capture(parser, captures, constant_id, &TOK2LOC(parser, &parser->previous));
+            pm_location_t previous_loc = TOK2LOC(parser, &parser->previous);
+            parse_pattern_capture(parser, captures, constant_id, &previous_loc);
             return UP(pm_local_variable_target_node_create(
                 parser,
-                &TOK2LOC(parser, &parser->previous),
+                &previous_loc,
                 constant_id,
                 (uint32_t) (depth == -1 ? 0 : depth)
             ));
@@ -17634,10 +17653,11 @@ parse_pattern_primitives(pm_parser_t *parser, pm_constant_id_list_t *captures, p
             pm_parser_local_add(parser, constant_id, parser->previous.start, parser->previous.end, 0);
         }
 
-        parse_pattern_capture(parser, captures, constant_id, &TOK2LOC(parser, &parser->previous));
+        pm_location_t previous_loc = TOK2LOC(parser, &parser->previous);
+        parse_pattern_capture(parser, captures, constant_id, &previous_loc);
         pm_local_variable_target_node_t *target = pm_local_variable_target_node_create(
             parser,
-            &TOK2LOC(parser, &parser->previous),
+            &previous_loc,
             constant_id,
             (uint32_t) (depth == -1 ? 0 : depth)
         );
@@ -21418,7 +21438,9 @@ parse_regular_expression_named_capture(pm_parser_t *parser, const pm_string_t *c
 
         // Next, create the local variable target and add it to the list of
         // targets for the match.
-        pm_node_t *target = UP(pm_local_variable_target_node_create(parser, &TOK2LOC(parser, &((pm_token_t) { .type = 0, .start = start, .end = end })), name, depth == -1 ? 0 : (uint32_t) depth));
+        pm_token_t token = { .type = 0, .start = start, .end = end };
+        pm_location_t token_loc = TOK2LOC(parser, &token);
+        pm_node_t *target = UP(pm_local_variable_target_node_create(parser, &token_loc, name, depth == -1 ? 0 : (uint32_t) depth));
         pm_node_list_append(parser->arena, &callback_data->match->targets, target);
     }
 

--- a/win32/vssetup.cmd
+++ b/win32/vssetup.cmd
@@ -28,6 +28,13 @@
         set arch=%arg:~6%
         goto :argloop
     )
+    ::- cmd.exe splits arguments on `=`, so `-vcvars_ver=14.x` arrives
+    ::- as two tokens; reassemble them for `vsdevcmd.bat`.
+    @if /i "%arg%" == "-vcvars_ver" (
+        set VSDEV_ARGS=%VSDEV_ARGS% -vcvars_ver=%1
+        shift
+        goto :argloop
+    )
 
     @set VSDEV_ARGS=%VSDEV_ARGS% %arg%
     @goto :argloop


### PR DESCRIPTION
The GitHub-hosted runner images no longer preinstall VS 2017/2019, so nothing exercises the older MSVC toolsets that ruby still supports. This adds a `make-old-toolset` job that installs the v141/v142 toolsets into the preinstalled VS 2022 with the VS installer and selects them through `win32/vssetup.cmd` with `-vcvars_ver`. The job configures without vcpkg and builds up to `ruby.exe` with `nmake incs`, `nmake mini`, and `nmake prog`. Extensions and tests are not covered.

The VS 2017 job is expected to fail at this point. cl 19.16 miscompiles conditional expressions whose arms are struct compound literals in `prism/prism.c`, which crashes `dump_ast.exe` while generating `.rbinc` files. The fix will be added to this PR after confirming the failure on CI.
