### PR TITLE
mswin: Fix dependencies to build ruby.exe in a single nmake run

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -326,10 +326,6 @@ jobs:
       - name: Configure
         run: ../src/win32/configure.bat --disable-install-doc
 
-      - run: nmake incs
-
-      - run: nmake mini
-
       - run: nmake prog
         timeout-minutes: 50
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -326,7 +326,7 @@ jobs:
       - name: Configure
         run: ../src/win32/configure.bat --disable-install-doc
 
-      - run: nmake prog
+      - run: nmake ruby
         timeout-minutes: 50
 
       - name: ruby version

--- a/win32/Makefile.sub
+++ b/win32/Makefile.sub
@@ -657,6 +657,10 @@ config: config.status
 
 config.status: $(CONFIG_H)
 
+# {$(VPATH)}config.h prerequisites in common.mk resolve to this bare
+# name until $(RUBY_CONFIG_H) is generated.
+config.h: $(CONFIG_H)
+
 BANG = !
 
 !if !exist(config.status)
@@ -1123,9 +1127,9 @@ s,@ruby_pc@,$(ruby_pc),;t t
 s,@PKG_CONFIG@,$(PKG_CONFIG),;t t
 <<KEEP
 
-!if "$(HAVE_BASERUBY)" != "yes" || "$(CROSS_COMPILING)" == "yes"
+# BOOTSTRAPRUBY is $(MINIRUBY) here even with BASERUBY, so rbconfig.rb
+# generation always needs $(PREP).
 $(RBCONFIG): $(PREP)
-!endif
 
 miniruby: miniruby$(EXEEXT)
 


### PR DESCRIPTION
In a clean mswin build directory, `nmake ruby.exe` stops with `U1073: don't know how to make 'config.h'` because the `{$(VPATH)}config.h` prerequisites in `common.mk` fall back to the bare name before `.ext/include/*/ruby/config.h` is generated. With BASERUBY available, rules reached via `verconf.h` also run `.\miniruby.exe` before it is linked, since `$(RBCONFIG)` depended on `$(PREP)` only when BASERUBY was absent while `BOOTSTRAPRUBY` is always `$(MINIRUBY)` in `win32/Makefile.sub`. This is why the VS2017/2019 jobs added in #18187 needed the `nmake incs`, `nmake mini`, `nmake prog` sequence. With both dependencies fixed, a single `nmake ruby` works from a clean directory, so the `make-old-toolset` jobs are reduced to one step. Verified with VS2017 BuildTools that `nmake ruby` and `nmake prog` each build from a fresh `configure.bat --disable-install-doc` directory and the resulting `ruby.exe` runs.
