### PR TITLE
Add Ractor tests for the monitor list.

### DIFF
--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -2420,6 +2420,24 @@ assert_equal 'true', %q{
   port.receive == :aborted
 }
 
+assert_equal 'ok', %q{
+  long = Ractor.new { Ractor.receive }
+  Ractor.new(long) { |t| t.monitor(Ractor::Port.new) }.value
+  GC.start
+  'ok'
+}
+
+assert_equal 'ok', %q{
+  long = Ractor.new { Ractor.receive }
+  20.times do
+    Ractor.new(long) { |t| t.monitor(Ractor::Port.new) }.value
+    GC.start
+  end
+  long.send(:bye)
+  long.join
+  'ok'
+}
+
 ## Ractor#join
 
 # Ractor#join returns self when the Ractor is terminated.


### PR DESCRIPTION
This commit adds tests to ensure that the monitor list is handled correctly in advance of rlgc merging.

Because the monitor list can be mutated by multiple Ractors it's possible to engineer a situation where the list contains dangling pointers.

This test causes a SEGV under rlgc.