### PR TITLE
Make svars method-and-fiber-local

### DIFF
--- a/cont.c
+++ b/cont.c
@@ -2661,6 +2661,7 @@ rb_fiber_start(rb_fiber_t *fiber_arg)
         th->ec->errinfo = Qnil;
         th->ec->root_lep = rb_vm_proc_local_ep(fiber->first_proc);
         th->ec->root_svar = Qfalse;
+        th->ec->svar_table = Qnil;
 
         EXEC_EVENT_HOOK(th->ec, RUBY_EVENT_FIBER_SWITCH, th->self, 0, 0, 0, Qnil);
         cont->value = rb_vm_invoke_proc(th->ec, proc, argc, argv, cont->kw_splat, VM_BLOCK_HANDLER_NONE, cref);
@@ -2750,6 +2751,8 @@ rb_threadptr_root_fiber_terminate(rb_thread_t *th)
     rb_fiber_t *fiber = th->ec->fiber_ptr;
 
     fiber->status = FIBER_TERMINATED;
+
+    th->ec->svar_table = Qnil;
 
     // The vm_stack is `alloca`ed on the thread stack, so it's gone too:
     rb_ec_clear_vm_stack(th->ec);

--- a/internal/imemo.h
+++ b/internal/imemo.h
@@ -12,6 +12,7 @@
 #include <stddef.h>             /* for size_t */
 #include "id_table.h"
 #include "internal/array.h"     /* for rb_ary_hidden_new_fill */
+#include "internal/serial.h"    /* for rb_serial_t */
 #include "ruby/internal/stdbool.h"     /* for bool */
 #include "ruby/ruby.h"          /* for rb_block_call_func_t */
 
@@ -55,7 +56,13 @@ struct vm_svar {
     const VALUE lastline;
     const VALUE backref;
     const VALUE others;
+    /*! serial of the fiber that owns this svar at ep[-2], SVAR_UNOWNED if
+     * none. Not a VALUE, so that the svar does not keep that fiber alive. */
+    rb_serial_t owner_ec_serial;
 };
+#define SVAR_UNOWNED ((rb_serial_t)0)
+/*! Bare shareable svar (owned by no fiber) for ep[-2] of an isolated env. */
+VALUE rb_svar_new_bare_shareable(VALUE cref_or_me);
 
 /*! THROW_DATA */
 struct vm_throw_data {

--- a/thread.c
+++ b/thread.c
@@ -606,6 +606,7 @@ thread_do_start_proc(rb_thread_t *th)
     th->ec->errinfo = Qnil;
     th->ec->root_lep = rb_vm_proc_local_ep(procval);
     th->ec->root_svar = Qfalse;
+    th->ec->svar_table = Qnil;
 
     vm_check_ints_blocking(th->ec);
 

--- a/vm.c
+++ b/vm.c
@@ -1465,12 +1465,20 @@ env_copy(const VALUE *src_ep, VALUE read_only_variables)
             svar_val = Qfalse;
         }
     }
-    RB_OBJ_WRITE(copied_env, &ep[VM_ENV_DATA_INDEX_ME_CREF], svar_val);
-
     ep[VM_ENV_DATA_INDEX_FLAGS] = src_ep[VM_ENV_DATA_INDEX_FLAGS] | VM_ENV_FLAG_ISOLATED;
     if (!VM_ENV_LOCAL_P(src_ep)) {
         VM_ENV_FLAGS_SET(ep, VM_ENV_FLAG_LOCAL);
     }
+
+    VALUE ep_me_cref;
+    if (VM_ENV_LOCAL_P(src_ep)) {
+        // Bare shareable svar so each fiber uses its ec->svar_table, not ep[-2].
+        ep_me_cref = rb_svar_new_bare_shareable(svar_val);
+    }
+    else {
+        ep_me_cref = svar_val;
+    }
+    RB_OBJ_WRITE((VALUE)copied_env, &ep[VM_ENV_DATA_INDEX_ME_CREF], ep_me_cref);
 
     if (read_only_variables) {
         for (int i=RARRAY_LENINT(read_only_variables)-1; i>=0; i--) {
@@ -2028,13 +2036,29 @@ rb_vm_invoke_proc_with_self(rb_execution_context_t *ec, rb_proc_t *proc, VALUE s
 
 /* special variable */
 
+/* The ep an ifunc captured may have escaped to the heap since, which leaves the
+ * env in ep[0] (see vm_make_env_each), so follow it to the env's own ep. */
+static VALUE *
+vm_ifunc_svar_lep(struct vm_ifunc *ifunc)
+{
+    if (ifunc->svar_lep) {
+        VALUE ep0 = ifunc->svar_lep[0];
+
+        if (RB_TYPE_P(ep0, T_IMEMO) && imemo_type_p(ep0, imemo_env)) {
+            ifunc->svar_lep = (VALUE *)((const rb_env_t *)ep0)->ep;
+        }
+    }
+
+    return ifunc->svar_lep;
+}
+
 VALUE *
 rb_vm_svar_lep(const rb_execution_context_t *ec, const rb_control_frame_t *cfp)
 {
     while (!CFP_PC(cfp) || !CFP_ISEQ(cfp)) {
         if (VM_FRAME_TYPE(cfp) == VM_FRAME_MAGIC_IFUNC) {
             struct vm_ifunc *ifunc = (struct vm_ifunc *)CFP_ISEQ(cfp);
-            return ifunc->svar_lep;
+            return vm_ifunc_svar_lep(ifunc);
         }
         else {
             cfp = RUBY_VM_PREVIOUS_CONTROL_FRAME(cfp);
@@ -3891,6 +3915,7 @@ rb_execution_context_mark(const rb_execution_context_t *ec)
 
     rb_gc_mark(ec->errinfo);
     rb_gc_mark(ec->root_svar);
+    rb_gc_mark(ec->svar_table);
     if (ec->local_storage) {
         rb_id_table_foreach_values(ec->local_storage, mark_local_storage_i, NULL);
     }
@@ -4078,6 +4103,7 @@ rb_ec_close(rb_execution_context_t *ec)
 {
     // Fiber storage is not accessible from outside the running fiber, so it is safe to clear it here.
     ec->storage = Qnil;
+    ec->svar_table = Qnil;
 }
 
 static void
@@ -4124,6 +4150,7 @@ th_init(rb_thread_t *th, VALUE self, rb_vm_t *vm)
 
     th->ec->errinfo = Qnil;
     th->ec->root_svar = Qfalse;
+    th->ec->svar_table = Qnil;
     th->ec->local_storage_recursive_hash = Qnil;
     th->ec->local_storage_recursive_hash_for_trace = Qnil;
 

--- a/vm_core.h
+++ b/vm_core.h
@@ -1094,6 +1094,7 @@ struct rb_execution_context_struct {
     /* eval env */
     const VALUE *root_lep;
     VALUE root_svar;
+    VALUE svar_table; /* WeakKeyMap: escaped env → this fiber's vm_svar; Qnil until needed */
 
     /* trace information */
     struct rb_trace_arg_struct *trace_arg;
@@ -2096,7 +2097,7 @@ RUBY_EXTERN unsigned int ruby_vm_c_events_enabled;
 #define GET_EC()     rb_current_execution_context(true)
 
 static inline rb_serial_t
-rb_ec_serial(struct rb_execution_context_struct *ec)
+rb_ec_serial(const struct rb_execution_context_struct *ec)
 {
     VM_ASSERT(ec->serial >= 1);
     return ec->serial;

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -582,6 +582,166 @@ vm_svar_valid_p(VALUE svar)
 }
 #endif
 
+/* Table mapping an escaped env to the svar this execution context uses for it,
+ * so that $~ and $_ are not shared between the fibers running a block. The
+ * keys are weak, the values are strong. */
+
+struct svar_table {
+    st_table *table;
+};
+
+static int
+svar_table_mark_i(st_data_t key, st_data_t val, st_data_t arg)
+{
+    rb_gc_mark_movable((VALUE)val);
+
+    return ST_CONTINUE;
+}
+
+static void
+svar_table_mark(void *ptr)
+{
+    struct svar_table *t = ptr;
+
+    /* The keys are weak references, so only the values are marked. */
+    st_foreach(t->table, svar_table_mark_i, (st_data_t)0);
+}
+
+static void
+svar_table_free(void *ptr)
+{
+    struct svar_table *t = ptr;
+
+    st_free_table(t->table);
+}
+
+static size_t
+svar_table_memsize(const void *ptr)
+{
+    const struct svar_table *t = ptr;
+
+    return st_memsize(t->table);
+}
+
+static int
+svar_table_compact_i(st_data_t key, st_data_t val, st_data_t arg, int error)
+{
+    /* The keys are hashed by address, so a moved key must be reinserted. */
+    if ((VALUE)key != rb_gc_location((VALUE)key)) {
+        st_insert((st_table *)arg, (st_data_t)rb_gc_location((VALUE)key), (st_data_t)rb_gc_location((VALUE)val));
+
+        return ST_DELETE;
+    }
+    else if ((VALUE)val != rb_gc_location((VALUE)val)) {
+        return ST_REPLACE;
+    }
+    else {
+        return ST_CONTINUE;
+    }
+}
+
+static int
+svar_table_compact_replace_i(st_data_t *key, st_data_t *val, st_data_t arg, int existing)
+{
+    *val = (st_data_t)rb_gc_location((VALUE)*val);
+
+    return ST_CONTINUE;
+}
+
+static void
+svar_table_compact(void *ptr)
+{
+    struct svar_table *t = ptr;
+
+    DURING_GC_COULD_MALLOC_REGION_START();
+    {
+        st_foreach_with_replace(t->table, svar_table_compact_i, svar_table_compact_replace_i, (st_data_t)t->table);
+    }
+    DURING_GC_COULD_MALLOC_REGION_END();
+}
+
+static int
+svar_table_handle_weak_references_i(st_data_t key, st_data_t val, st_data_t arg)
+{
+    return rb_gc_handle_weak_references_alive_p((VALUE)key) ? ST_CONTINUE : ST_DELETE;
+}
+
+static void
+svar_table_handle_weak_references(void *ptr)
+{
+    struct svar_table *t = ptr;
+
+    st_foreach(t->table, svar_table_handle_weak_references_i, (st_data_t)0);
+}
+
+static const rb_data_type_t svar_table_data_type = {
+    "VM/svar_table",
+    {
+        svar_table_mark,
+        svar_table_free,
+        svar_table_memsize,
+        svar_table_compact,
+        svar_table_handle_weak_references,
+    },
+    0, 0, RUBY_TYPED_THREAD_SAFE_FREE | RUBY_TYPED_WB_PROTECTED | RUBY_TYPED_EMBEDDABLE
+};
+
+static VALUE
+svar_table_new(void)
+{
+    struct svar_table *t;
+    VALUE obj = TypedData_Make_Struct(0, struct svar_table, &svar_table_data_type, t);
+
+    t->table = st_init_numtable();
+
+    rb_gc_declare_weak_references(obj);
+
+    return obj;
+}
+
+static inline struct vm_svar *
+ec_svar_table_lookup(const rb_execution_context_t *ec, const VALUE *lep)
+{
+    if (!RTEST(ec->svar_table)) return NULL;
+
+    struct svar_table *t = RTYPEDDATA_GET_DATA(ec->svar_table);
+    st_data_t svar;
+
+    if (!st_lookup(t->table, (st_data_t)VM_ENV_ENVVAL(lep), &svar)) return NULL;
+
+    return (struct vm_svar *)svar;
+}
+
+static inline void
+ec_svar_table_insert(rb_execution_context_t *ec, const VALUE *lep, const struct vm_svar *svar)
+{
+    if (!RTEST(ec->svar_table)) {
+        RB_OBJ_WRITE(rb_ec_thread_ptr(ec)->self, &ec->svar_table, svar_table_new());
+    }
+
+    struct svar_table *t = RTYPEDDATA_GET_DATA(ec->svar_table);
+    VALUE env = VM_ENV_ENVVAL(lep);
+
+    st_insert(t->table, (st_data_t)env, (st_data_t)svar);
+
+    /* The key is remembered as well, not to keep the env alive, but so that a
+     * minor GC which could collect it also runs the weak reference handler. */
+    RB_OBJ_WRITTEN(ec->svar_table, Qundef, env);
+    RB_OBJ_WRITTEN(ec->svar_table, Qundef, (VALUE)svar);
+}
+
+static inline struct vm_svar *
+lep_svar_owned(const rb_execution_context_t *ec, VALUE svar_val)
+{
+    if (svar_val != Qfalse && imemo_type_p(svar_val, imemo_svar)) {
+        struct vm_svar *sv = (struct vm_svar *)svar_val;
+        if (sv->owner_ec_serial == rb_ec_serial(ec)) {
+            return sv;
+        }
+    }
+    return NULL;
+}
+
 static inline struct vm_svar *
 lep_svar(const rb_execution_context_t *ec, const VALUE *lep)
 {
@@ -615,9 +775,21 @@ lep_svar_write(const rb_execution_context_t *ec, const VALUE *lep, const struct 
 static VALUE
 lep_svar_get(const rb_execution_context_t *ec, const VALUE *lep, rb_num_t key)
 {
-    const struct vm_svar *svar = lep_svar(ec, lep);
+    const struct vm_svar *svar;
 
-    if ((VALUE)svar == Qfalse || imemo_type((VALUE)svar) != imemo_svar) return Qnil;
+    if (lep && ec && ec->root_lep != lep && VM_ENV_ESCAPED_P(lep)) {
+        VALUE ep_val = lep[VM_ENV_DATA_INDEX_ME_CREF];
+
+        svar = lep_svar_owned(ec, ep_val);
+        if (ep_val != Qfalse && !svar) {
+            svar = ec_svar_table_lookup(ec, lep);
+        }
+        if (!svar) return Qnil;
+    }
+    else {
+        svar = lep_svar(ec, lep);
+        if ((VALUE)svar == Qfalse || imemo_type((VALUE)svar) != imemo_svar) return Qnil;
+    }
 
     switch (key) {
       case VM_SVAR_LASTLINE:
@@ -638,23 +810,60 @@ lep_svar_get(const rb_execution_context_t *ec, const VALUE *lep, rb_num_t key)
 }
 
 static struct vm_svar *
-svar_new(VALUE obj)
+svar_new(VALUE obj, rb_serial_t owner_ec_serial)
 {
     struct vm_svar *svar = IMEMO_NEW(struct vm_svar, imemo_svar, obj);
     *((VALUE *)&svar->lastline) = Qnil;
     *((VALUE *)&svar->backref) = Qnil;
     *((VALUE *)&svar->others) = Qnil;
+    svar->owner_ec_serial = owner_ec_serial;
 
     return svar;
+}
+/* Construct a bare, immutable Ractor-shareable svar that wraps +cref_or_me+ and is
+ * owned by no fiber. Installed at ep[-2] of an isolated/shareable env so that every
+ * fiber which runs it uses its own svar in ec->svar_table */
+VALUE
+rb_svar_new_bare_shareable(VALUE cref_or_me)
+{
+    struct vm_svar *svar = svar_new(cref_or_me, SVAR_UNOWNED);
+    RB_OBJ_SET_SHAREABLE((VALUE)svar);
+    return (VALUE)svar;
 }
 
 static void
 lep_svar_set(const rb_execution_context_t *ec, const VALUE *lep, rb_num_t key, VALUE val)
 {
-    struct vm_svar *svar = lep_svar(ec, lep);
+    struct vm_svar *svar;
+    rb_serial_t this_ec = rb_ec_serial(ec);
 
-    if ((VALUE)svar == Qfalse || imemo_type((VALUE)svar) != imemo_svar) {
-        lep_svar_write(ec, lep, svar = svar_new((VALUE)svar));
+    if (lep && ec && ec->root_lep != lep && VM_ENV_ESCAPED_P(lep)) {
+        VALUE ep_val = lep[VM_ENV_DATA_INDEX_ME_CREF];
+
+        svar = lep_svar_owned(ec, ep_val);
+        if (ep_val != Qfalse && !svar) svar = ec_svar_table_lookup(ec, lep);
+
+        if (svar) {
+            rb_ractor_confirm_belonging((VALUE)svar);
+        }
+        else {
+            if (ep_val != Qfalse && imemo_type_p(ep_val, imemo_svar)) {
+                /* Another fiber owns the svar in the env, so keep ours in the
+                 * table of this execution context. */
+                svar = svar_new(((struct vm_svar *)ep_val)->cref_or_me, this_ec);
+                ec_svar_table_insert((rb_execution_context_t *)ec, lep, svar);
+            }
+            else {
+                svar = svar_new(ep_val, this_ec);
+                lep_svar_write(ec, lep, svar);
+            }
+        }
+    }
+    else {
+        svar = lep_svar(ec, lep);
+        if ((VALUE)svar == Qfalse || imemo_type((VALUE)svar) != imemo_svar) {
+            lep_svar_write(ec, lep, svar = svar_new((VALUE)svar, this_ec));
+        }
     }
 
     switch (key) {


### PR DESCRIPTION
This stores an owner EC (via serial) on all imemo_svar. Other threads/fibers/ractors accessing special variables (which have been set on another thread) must go through a table on the EC to get a fiber-local imemo_svar instead.

Alternative to #18135, where we did the same but made them thread-local.