### PR TITLE
Ractor: keep the elements a moved array still shares

### DIFF
--- a/array.c
+++ b/array.c
@@ -228,6 +228,15 @@ rb_ary_embeddable_p(VALUE ary)
     return !(ARY_SHARED_ROOT_P(ary) || OBJ_FROZEN(ary) || ARY_SHARED_P(ary));
 }
 
+/* True when other arrays may read this array's elements out of its own slot, so the
+ * slot contents must stay valid for as long as the object does.  A frozen array is
+ * handed out as a shared root as it is, without the shared root flag. */
+bool
+rb_ary_embedded_shared_root_p(VALUE ary)
+{
+    return ARY_EMBED_P(ary) && OBJ_FROZEN(ary);
+}
+
 size_t
 rb_ary_size_as_embedded(VALUE ary)
 {

--- a/gc.c
+++ b/gc.c
@@ -3220,7 +3220,15 @@ rb_gc_mark_children(void *objspace, VALUE obj)
       case T_ARRAY:
         if (ARY_SHARED_P(obj)) {
             VALUE root = ARY_SHARED_ROOT(obj);
-            gc_mark_internal(root);
+            if (RB_TYPE_P(root, T_ARRAY)) {
+                gc_mark_internal(root);
+            }
+            else {
+                /* Ractor#send(move: true) hollowed the root out in place.  If it was
+                 * embedded our elements are still in its slot, and nothing says so any
+                 * more, so it must not move (gc_ref_update_array cannot re-point us). */
+                gc_mark_and_pin_internal(root);
+            }
         }
         else {
             long len = RARRAY_LEN(obj);
@@ -3624,8 +3632,10 @@ gc_ref_update_array(void *objspace, VALUE v)
         UPDATE_IF_MOVED(objspace, RARRAY(v)->as.heap.aux.shared_root);
 
         VALUE new_root = RARRAY(v)->as.heap.aux.shared_root;
+        // A root hollowed out by a move is no longer an array, and it is pinned rather
+        // than re-pointed (see the marking of a shared root).
         // If the root is embedded and its location has changed
-        if (ARY_EMBED_P(new_root) && new_root != old_root) {
+        if (RB_TYPE_P(new_root, T_ARRAY) && ARY_EMBED_P(new_root) && new_root != old_root) {
             size_t offset = (size_t)(RARRAY(v)->as.heap.ptr - RARRAY(old_root)->as.ary);
             GC_ASSERT(RARRAY(v)->as.heap.ptr >= RARRAY(old_root)->as.ary);
             RARRAY(v)->as.heap.ptr = RARRAY(new_root)->as.ary + offset;

--- a/internal/array.h
+++ b/internal/array.h
@@ -37,6 +37,7 @@ void rb_ary_cancel_sharing(VALUE ary);
 size_t rb_ary_size_as_embedded(VALUE ary);
 void rb_ary_make_embedded(VALUE ary);
 bool rb_ary_embeddable_p(VALUE ary);
+bool rb_ary_embedded_shared_root_p(VALUE ary);
 VALUE rb_ary_diff(VALUE ary1, VALUE ary2);
 VALUE rb_ary_compact_bang(VALUE ary);
 VALUE rb_ary_modify_expand(VALUE ary, long expand);

--- a/ractor.c
+++ b/ractor.c
@@ -8,6 +8,7 @@
 #include "vm_core.h"
 #include "vm_sync.h"
 #include "ractor_core.h"
+#include "internal/array.h"
 #include "internal/complex.h"
 #include "internal/error.h"
 #include "internal/gc.h"
@@ -2125,10 +2126,20 @@ move_leave(VALUE obj, struct obj_traverse_replace_data *data)
     VALUE flags = T_OBJECT | FL_FREEZE | (RBASIC(obj)->flags & FL_PROMOTED);
     shape_id_t shape_id = (RBASIC_SHAPE_ID(obj) & SHAPE_ID_CAPACITY_MASK) | ROOT_SHAPE_ID | SHAPE_ID_LAYOUT_ROBJECT | SHAPE_ID_FL_FROZEN;
 
-    // A copy-on-write sharer reads its bytes straight out of an embedded root's slot
-    // (String#dup of a frozen string), and it outlives the move, so that body has to
-    // survive as it is.
-    bool wipe_body = !(RB_TYPE_P(obj, T_STRING) && rb_str_embedded_shared_root_p(obj));
+    // A copy-on-write sharer reads its payload straight out of an embedded root's slot
+    // (String#dup of a frozen string, Array#[] of a frozen array), and it outlives the
+    // move, so that body has to survive as it is.
+    bool wipe_body = true;
+    switch (BUILTIN_TYPE(obj)) {
+      case T_STRING:
+        wipe_body = !rb_str_embedded_shared_root_p(obj);
+        break;
+      case T_ARRAY:
+        wipe_body = !rb_ary_embedded_shared_root_p(obj);
+        break;
+      default:
+        break;
+    }
 
     // Avoid mutations using bind_call, etc.
     size_t slot_size = rb_gc_obj_slot_size(obj);

--- a/test/ruby/test_ractor.rb
+++ b/test/ruby/test_ractor.rb
@@ -509,4 +509,29 @@ class TestRactor < Test::Unit::TestCase
       end
     RUBY
   end
+
+  # A frozen array is handed out as a shared root as it is, so a subseq of an embedded
+  # one reads the elements out of its slot.  Moving the original must leave that slot
+  # alone, and must not let it move afterwards: the sharer has no other copy.
+  def test_move_array_sharing_its_embedded_elements
+    assert_ractor(<<~'RUBY', timeout: 60)
+      [8, 20, 40].each do |len|
+        r = Ractor.new { Ractor.receive }
+        ary = Array.new(len) { |i| i + 1 }    # embedded
+        ary.instance_variable_set(:@iv, [])   # unshareable, so it is moved
+        ary.freeze
+        sharer = ary[1, len - 2]              # reads ary's elements in place
+        r.send(ary, move: true)
+        assert_equal (2..len - 1).to_a, sharer, "corrupted for length #{len}"
+
+        begin
+          GC.verify_compaction_references(expand_heap: true, toward: :empty)
+        rescue NotImplementedError
+          # no compaction on this platform
+        end
+        assert_equal (2..len - 1).to_a, sharer, "corrupted by compaction, length #{len}"
+        r.value
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
The array counterpart of f4e50b9993.  A frozen array is handed out as a shared root as it is, without the shared root flag (ary_make_shared), so a subseq or a dup of an embedded one reads the elements straight out of its slot:

    ary = Array.new(40) { |i| i + 1 }
    ary.instance_variable_set(:@iv, [])   # unshareable, so it is moved
    ary.freeze
    sharer = ary[1, 38]                    # reads ary's elements in place
    r.send(ary, move: true)
    sharer                                 #=> [false, false, ...]

Two things go wrong once the root is hollowed out.  The wipe added by 556296cbe0 zeroes the slot the sharer is reading, which is the visible breakage above; skip it for an embedded shared root, as the string side already does.

The other one predates the wipe.  Arrays let a shared root move and re-point the sharer in gc_ref_update_array(), which needs to know that the payload lives in the root's slot -- and a Ractor::MovedObject no longer says so, so the sharer was left pointing into the old slot.  Pin such a root instead, the way strings have handled embedded roots since 80ea7fbad8.

Reachable since arrays moved to variable width allocation (a51f30c671): before that an embedded array was at most 3 elements, and ary_make_partial copies rather than shares at that size, so an embedded array was never a shared root.