### PR TITLE
[Bug #22223] Check SO_ERROR after waiting for nonblocking connect

### DIFF
--- a/ext/socket/lib/socket.rb
+++ b/ext/socket/lib/socket.rb
@@ -58,6 +58,13 @@ class Addrinfo
         when :wait_writable
           sock.wait_writable(timeout) or
             raise Errno::ETIMEDOUT, "user specified timeout for #{self.ip_address}:#{self.ip_port}"
+          # Check SO_ERROR instead of relying on the connect_nonblock retry;
+          # some kernels (e.g. Darwin 27) answer the retry connect(2) with
+          # EISCONN even when the connection has failed.  [Bug #22223]
+          err = sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_ERROR).int
+          unless err.zero?
+            raise SystemCallError.new("connect(2) for #{self.ip_address}:#{self.ip_port}", err)
+          end
         end while true
       else
         sock.connect(self)

--- a/test/socket/test_socket.rb
+++ b/test/socket/test_socket.rb
@@ -604,6 +604,16 @@ class TestSocket < Test::Unit::TestCase
     sock.close if sock && ! sock.closed?
   end
 
+  def test_connect_timeout_connection_refused
+    server = TCPServer.new("127.0.0.1", 0)
+    port = server.addr[1]
+    server.close
+
+    assert_raise(Errno::ECONNREFUSED) do
+      Socket.tcp("127.0.0.1", port, connect_timeout: 5)
+    end
+  end unless /mswin|mingw/ =~ RUBY_PLATFORM
+
   def test_getifaddrs
     begin
       list = Socket.getifaddrs


### PR DESCRIPTION
On macOS 27 (beta, Darwin 27), `Socket.tcp` with `connect_timeout:` returns an unconnected socket instead of raising `Errno::ECONNREFUSED` when nothing is listening. The kernel answers the retry `connect(2)` on a refused nonblocking socket with `EISCONN`, which `Addrinfo#connect_internal` takes as success. `getsockopt(SO_ERROR)` still holds the real error, so check it after `wait_writable` before retrying `connect_nonblock`, the same approach `wait_connectable()` in `init.c` already uses.

Verified on an affected machine (build 26A5388g). `Socket.tcp` with `connect_timeout:`, the HEv2 last-candidate fallback, and `Addrinfo#connect` with `timeout:` now raise `Errno::ECONNREFUSED`. Success and `ETIMEDOUT` paths are unchanged. The added test fails on Darwin 27 without the fix and passes with it.

https://bugs.ruby-lang.org/issues/22223
