### PR TITLE
[DOC] Fix five sample snippets that fail to run

### DIFF
--- a/doc/language/ractor.md
+++ b/doc/language/ractor.md
@@ -533,9 +533,7 @@ In order to dynamically define a method with `Module#define_method` that can be 
 
 ```ruby
 class A
-  define_method :testing, &Ractor.shareable_proc do
-    p self
-  end
+  define_method(:testing, Ractor.shareable_proc { p self })
 end
 Ractor.new do
   a = A.new

--- a/ext/objspace/lib/objspace.rb
+++ b/ext/objspace/lib/objspace.rb
@@ -70,7 +70,7 @@ module ObjectSpace
   # If _shapes_ is +false+, no shapes are dumped.
   #
   # To only dump objects allocated past a certain point you can combine _since_ and _shapes_:
-  #   ObjectSpace.trace_object_allocations
+  #   ObjectSpace.trace_object_allocations_start
   #   GC.start
   #   gc_generation = GC.count
   #   shape_generation = RubyVM.stat(:next_shape_id)

--- a/io_buffer.c
+++ b/io_buffer.c
@@ -1819,15 +1819,15 @@ io_buffer_slice(int argc, VALUE *argv, VALUE self)
  *  Transfers ownership of the underlying memory to a new buffer, causing the
  *  current buffer to become uninitialized.
  *
- *    buffer = IO::Buffer.new('test')
+ *    buffer = IO::Buffer.for('test')
  *    other = buffer.transfer
  *    other
  *    # =>
- *    # #<IO::Buffer 0x00007f136a15f7b0+4 SLICE>
+ *    # #<IO::Buffer 0x00007f136a15f7b0+4 EXTERNAL READONLY SLICE>
  *    # 0x00000000  74 65 73 74                                     test
  *    buffer
  *    # =>
- *    # #<IO::Buffer 0x0000000000000000+0 NULL>
+ *    # #<IO::Buffer 0x0000000000000000+0 NULL EXTERNAL READONLY>
  *    buffer.null?
  *    # => true
  */

--- a/lib/delegate.rb
+++ b/lib/delegate.rb
@@ -252,6 +252,8 @@ end
 # and even to change the object being delegated to at a later time with
 # #__setobj__.
 #
+#   require 'date'
+#
 #   class User
 #     def born_on
 #       Date.new(1989, 9, 10)

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -2442,7 +2442,7 @@ rb_obj_instance_exec(int argc, const VALUE *argv, VALUE self)
  *      class Foo; end
  *
  *      Foo.module_eval("puts __LINE__") # => 1
- *      Foo.module_eval("puts __FILE__", nil, 10) # => 10
+ *      Foo.module_eval("puts __LINE__", nil, 10) # => 10
  *
  *  When a block is given, evaluates the block in the context
  *  of +self+:


### PR DESCRIPTION
Each commit fixes one documentation example that raises an exception or prints something other than the documented output when copied and run. The second `Module#module_eval` lineno example evaluated `__FILE__` where `__LINE__` was intended. The `IO::Buffer#transfer` example passed a string to `IO::Buffer.new`, which takes a size and raises `TypeError`, so it now uses `IO::Buffer.for` with the sample output updated to match. The `ObjectSpace.dump_all` example called `trace_object_allocations` without a block, which raises `LocalJumpError`. The `SimpleDelegator` example used `Date` without `require 'date'`. The shareable proc example in `doc/language/ractor.md` attached a `do` block to `define_method` while also passing a block argument, which fails to parse. All corrected examples were run against master to confirm the shown output.
