### PR TITLE
YJIT: Handle interrupts inline at backward branches instead of side-exiting

### DIFF
--- a/yjit.c
+++ b/yjit.c
@@ -427,6 +427,15 @@ rb_object_shape_count(void)
     return ULONG2NUM((unsigned long)rb_shapes_count());
 }
 
+// Execute pending interrupts inline from JIT code, instead of taking a side
+// exit. This allows YJIT to continue running compiled code after handling
+// interrupts (e.g. from signal-based profilers using postponed jobs).
+void
+rb_yjit_execute_interrupts(rb_execution_context_t *ec)
+{
+    rb_threadptr_execute_interrupts(rb_ec_thread_ptr(ec), 0);
+}
+
 bool
 rb_yjit_shape_obj_complex_p(VALUE obj)
 {

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -1230,6 +1230,46 @@ fn gen_check_ints(
     asm.jnz(Target::side_exit(counter));
 }
 
+// Generate code to check for interrupts and handle them inline, without
+// taking a side exit. This is used at backward branches (loops) so that
+// YJIT can continue running compiled code after handling interrupts such
+// as those from signal-based profilers using rb_postponed_job_trigger.
+fn gen_check_ints_inline(
+    jit: &mut JITState,
+    asm: &mut Assembler,
+) {
+    asm_comment!(asm, "RUBY_VM_CHECK_INTS(ec) - inline");
+
+    // Spill register temps to memory unconditionally so that both the fast
+    // path (no interrupt) and slow path (interrupt taken) have values in
+    // memory at the label. This avoids the need to reload after the ccall.
+    asm.spill_regs();
+
+    // Save SP before the branch so both paths have the same SP state.
+    // gen_save_sp() also updates the SP register (x21 on arm64) and resets
+    // sp_offset to 0, which keeps CFP.sp consistent with x21 + sp_offset.
+    // Without this, writing sp_opnd(0) to CFP.sp in the slow path would
+    // desync CFP.sp from the (x21, sp_offset) pair, causing branch_stub_hit
+    // to compute the wrong reconned_sp.
+    gen_save_sp(asm);
+
+    let interrupt_flag = asm.load(Opnd::mem(32, EC, RUBY_OFFSET_EC_INTERRUPT_FLAG as i32));
+    asm.test(interrupt_flag, interrupt_flag);
+
+    let no_interrupt = asm.new_label("no_interrupt");
+    asm.jz(no_interrupt);
+
+    jit_save_pc(jit, asm);
+
+    asm.ccall(rb_yjit_execute_interrupts as *const u8, vec![EC]);
+
+    // The interrupt handler can set locals through Kernel#binding,
+    // rb_debug_inspector API, etc. (same rationale as jit_prepare_non_leaf_call).
+    asm.ctx.clear_local_types();
+
+    asm.write_label(no_interrupt);
+}
+
 // Generate a stubbed unconditional jump to the next bytecode instruction.
 // Blocks that are part of a guard chain can use this to share the same successor.
 fn jump_to_next_insn(
@@ -4694,7 +4734,7 @@ fn gen_branchif(
 
     // Check for interrupts, but only on backward branches that may create loops
     if jump_offset < 0 && jit.get_opcode() != YARVINSN_branchif_without_ints as usize {
-        gen_check_ints(asm, Counter::branchif_interrupted);
+        gen_check_ints_inline(jit, asm);
     }
 
     // Get the branch target instruction offsets
@@ -4746,7 +4786,7 @@ fn gen_branchunless(
 
     // Check for interrupts, but only on backward branches that may create loops
     if jump_offset < 0 && jit.get_opcode() != YARVINSN_branchunless_without_ints as usize {
-        gen_check_ints(asm, Counter::branchunless_interrupted);
+        gen_check_ints_inline(jit, asm);
     }
 
     // Get the branch target instruction offsets
@@ -4799,7 +4839,7 @@ fn gen_branchnil(
 
     // Check for interrupts, but only on backward branches that may create loops
     if jump_offset < 0 && jit.get_opcode() != YARVINSN_branchnil_without_ints as usize {
-        gen_check_ints(asm, Counter::branchnil_interrupted);
+        gen_check_ints_inline(jit, asm);
     }
 
     // Get the branch target instruction offsets
@@ -4954,7 +4994,7 @@ fn gen_jump(
 
     // Check for interrupts, but only on backward branches that may create loops
     if jump_offset < 0 && jit.get_opcode() != YARVINSN_jump_without_ints as usize {
-        gen_check_ints(asm, Counter::jump_interrupted);
+        gen_check_ints_inline(jit, asm);
     }
 
     // Get the branch target instruction offsets

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -1267,11 +1267,44 @@ fn gen_check_ints_inline(
 
     asm.ccall(rb_yjit_execute_interrupts as *const u8, vec![EC]);
 
-    // Restore the context, then clear local types. The interrupt handler can
-    // set local variables through Kernel#binding, rb_debug_inspector API, and
-    // other means, just like cfunc calls (see jit_prepare_non_leaf_call).
+    // Restore the context so code after the label compiles against the
+    // original stack layout (matching the fast path). Then clear local types
+    // because the interrupt handler can set locals through Kernel#binding,
+    // rb_debug_inspector API, etc. (same rationale as jit_prepare_non_leaf_call).
     asm.ctx = saved_ctx;
     asm.ctx.clear_local_types();
+
+    // Reload register temps from memory. The ccall clobbered the caller-saved
+    // temp registers, but spill_regs() (inside ccall) already stored them to
+    // memory. Reload them so both paths arrive at the label with values in
+    // registers, matching saved_ctx's reg_mapping.
+    let reg_mapping = asm.ctx.get_reg_mapping();
+    if reg_mapping != RegMapping::default() {
+        // Temporarily clear reg_mapping so that Opnd::Stack operands
+        // (from local_opnd) resolve to memory, not to the very registers
+        // we're trying to reload.
+        asm.ctx.set_reg_mapping(RegMapping::default());
+
+        let regs = Assembler::get_temp_regs();
+        for reg_opnd in reg_mapping.get_reg_opnds() {
+            let reg_idx = reg_mapping.get_reg(reg_opnd).unwrap();
+            match reg_opnd {
+                RegOpnd::Stack(stack_idx) => {
+                    let idx = (asm.ctx.get_stack_size() - 1 - stack_idx) as i32;
+                    let mem = Opnd::mem(64, SP, (asm.ctx.get_sp_offset() as i32 - idx - 1) * SIZEOF_VALUE_I32);
+                    asm.load_into(Opnd::Reg(regs[reg_idx]), mem);
+                }
+                RegOpnd::Local(local_idx) => {
+                    let num_locals = asm.get_num_locals().unwrap();
+                    let ep_offset = num_locals + VM_ENV_DATA_SIZE - 1 - local_idx as u32;
+                    let mem = asm.local_opnd(ep_offset);
+                    asm.load_into(Opnd::Reg(regs[reg_idx]), mem);
+                }
+            }
+        }
+
+        asm.ctx.set_reg_mapping(reg_mapping);
+    }
 
     asm.write_label(no_interrupt);
 }

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -1230,6 +1230,52 @@ fn gen_check_ints(
     asm.jnz(Target::side_exit(counter));
 }
 
+// Generate code to check for interrupts and handle them inline, without
+// taking a side exit. This is used at backward branches (loops) so that
+// YJIT can continue running compiled code after handling interrupts such
+// as those from signal-based profilers using rb_postponed_job_trigger.
+fn gen_check_ints_inline(
+    jit: &mut JITState,
+    asm: &mut Assembler,
+) {
+    asm_comment!(asm, "RUBY_VM_CHECK_INTS(ec) - inline");
+
+    let interrupt_flag = asm.load(Opnd::mem(32, EC, RUBY_OFFSET_EC_INTERRUPT_FLAG as i32));
+    asm.test(interrupt_flag, interrupt_flag);
+
+    let no_interrupt = asm.new_label("no_interrupt");
+    asm.jz(no_interrupt);
+
+    // Save the compile-time context before the slow path. Instructions below
+    // (jit_save_pc, lea/mov, and especially ccall which spills register temps)
+    // modify asm.ctx at compile time. Since the fast path (jz taken) skips
+    // these instructions at runtime, we must restore ctx after the slow path
+    // so that code after the no_interrupt label compiles against the original
+    // context that matches the fast-path runtime state.
+    let saved_ctx = asm.ctx;
+
+    // Like jit_prepare_non_leaf_call(), save PC and SP to CFP for backtraces
+    // and GC safety, but without record_boundary_patch_point (backward branches
+    // return EndBlock so the assertion in gen_single_block would fire;
+    // invalidation is handled by the normal block invalidation mechanism).
+    // We write SP to CFP directly instead of gen_save_sp() to avoid modifying
+    // the SP register, which is callee-saved across the ccall and must keep
+    // its original value for code after the no_interrupt label.
+    jit_save_pc(jit, asm);
+    let sp_addr = asm.lea(asm.ctx.sp_opnd(0));
+    asm.mov(Opnd::mem(64, CFP, RUBY_OFFSET_CFP_SP), sp_addr);
+
+    asm.ccall(rb_yjit_execute_interrupts as *const u8, vec![EC]);
+
+    // Restore the context, then clear local types. The interrupt handler can
+    // set local variables through Kernel#binding, rb_debug_inspector API, and
+    // other means, just like cfunc calls (see jit_prepare_non_leaf_call).
+    asm.ctx = saved_ctx;
+    asm.ctx.clear_local_types();
+
+    asm.write_label(no_interrupt);
+}
+
 // Generate a stubbed unconditional jump to the next bytecode instruction.
 // Blocks that are part of a guard chain can use this to share the same successor.
 fn jump_to_next_insn(
@@ -4685,7 +4731,7 @@ fn gen_branchif(
 
     // Check for interrupts, but only on backward branches that may create loops
     if jump_offset < 0 && jit.get_opcode() != YARVINSN_branchif_without_ints as usize {
-        gen_check_ints(asm, Counter::branchif_interrupted);
+        gen_check_ints_inline(jit, asm);
     }
 
     // Get the branch target instruction offsets
@@ -4737,7 +4783,7 @@ fn gen_branchunless(
 
     // Check for interrupts, but only on backward branches that may create loops
     if jump_offset < 0 && jit.get_opcode() != YARVINSN_branchunless_without_ints as usize {
-        gen_check_ints(asm, Counter::branchunless_interrupted);
+        gen_check_ints_inline(jit, asm);
     }
 
     // Get the branch target instruction offsets
@@ -4790,7 +4836,7 @@ fn gen_branchnil(
 
     // Check for interrupts, but only on backward branches that may create loops
     if jump_offset < 0 && jit.get_opcode() != YARVINSN_branchnil_without_ints as usize {
-        gen_check_ints(asm, Counter::branchnil_interrupted);
+        gen_check_ints_inline(jit, asm);
     }
 
     // Get the branch target instruction offsets
@@ -4945,7 +4991,7 @@ fn gen_jump(
 
     // Check for interrupts, but only on backward branches that may create loops
     if jump_offset < 0 && jit.get_opcode() != YARVINSN_jump_without_ints as usize {
-        gen_check_ints(asm, Counter::jump_interrupted);
+        gen_check_ints_inline(jit, asm);
     }
 
     // Get the branch target instruction offsets

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -150,6 +150,7 @@ extern "C" {
     pub fn rb_vm_ic_hit_p(ic: IC, reg_ep: *const VALUE) -> bool;
     pub fn rb_vm_stack_canary() -> VALUE;
     pub fn rb_vm_push_cfunc_frame(cme: *const rb_callable_method_entry_t, recv_idx: c_int);
+    pub fn rb_yjit_execute_interrupts(ec: EcPtr);
 }
 
 // Renames


### PR DESCRIPTION
### Problem

When an interrupt is pending at a backward branch (loop back-edge), YJIT takes a side exit to the interpreter. The interpreter handles the interrupt but then **continues running the loop in the interpreter** — there is no way to re-enter JIT code mid-loop because `JIT_EXEC` is only called after `send`/`invokesuper`/`invokeblock` instructions (in `insns.def`), not at branch instructions.

This means a single interrupt during a long-running loop forces the entire remaining loop execution into the interpreter.

This is particularly harmful for **signal-based profilers** (e.g. [Datadog's dd-trace-rb](https://github.com/DataDog/dd-trace-rb)) that use `rb_postponed_job_trigger` via `SIGPROF` at ~100 Hz. Each signal during a loop causes a `branchif_interrupted` side exit, and the interpreter runs the remaining iterations.

### Benchmark

```ruby
def foo
  sum = 0
  i = 0
  while i < 1_000_000; sum += i; i += 1; end
  sum
end
100.times { foo }
```

With a signal-based profiler active (Ruby 3.3, `DD_PROFILING_ENABLED=true`, also tried on Ruby 4.0.6):

| Metric | Before | After |
|--------|--------|-------|
| `ratio_in_yjit` | **8.6%** | **~100%** |
| `avg_len_in_yjit` | 2,875 | 17,000,021 |
| `side_exit_count` | 151 | 0 |
| `branchif: interrupted` exits | 71 | 0 |
| `vm_insns_count` | 1,099M | ~0 |
| `yjit_insns_count` | 103M | 1,207M |

Without profiling, the fast path (no interrupt) adds zero overhead — just a flag test and a not-taken branch.

### Solution

In general the approach is to treat interrupts like unknown C function calls which might call Ruby code (because an interrupt can be e.g. to run a Ruby-defined signal handler on the main Thread), very similar to calling a method defined in C with `rb_define_method()`, so we use the same logic, the difference is it's conditional under whether the interrupt flag is set.

At backward branches (`branchif`, `branchunless`, `branchnil`, `jump`), instead of side-exiting when the interrupt flag is set:

1. Save PC and SP to the CFP (for correct backtraces and GC safety)
2. Call `rb_threadptr_execute_interrupts` to handle the interrupt
3. Continue executing JIT code

```
// Generated code (pseudo-asm):
load [EC + interrupt_flag_offset] → r0
test r0, r0
jz   no_interrupt          // fast path: zero overhead
  save PC/SP to CFP
  call rb_yjit_execute_interrupts(EC)
no_interrupt:
  ... rest of loop body (still in JIT) ...
```

The interrupt check at `leave` and `send` is left as a side exit, since those are at method call boundaries where `JIT_EXEC` can re-enter JIT code immediately.

### Implementation notes

- SP is written to `CFP.sp` directly via `lea` + `mov` instead of calling `gen_save_sp()`. `gen_save_sp` modifies both the SP register and `ctx.sp_offset` at compile time. Since the fast path (`jz` taken) skips the slow path entirely, the code after the `no_interrupt` label is shared by both paths and must compile against the unmodified context. Writing SP to memory without touching the register or compile-time state avoids this problem.
- `record_boundary_patch_point` is not set because backward branches return `EndBlock`, and the assertion at the end of `gen_single_block` would fire. If invalidation happens during the interrupt handler, the backward branch target block gets invalidated separately and the jump to it will be redirected to the interpreter.
- If `rb_threadptr_execute_interrupts` raises an exception (e.g. `Thread#kill`, pending exceptions), the `longjmp` unwinds through the JIT frame using the saved PC/SP — same mechanism as any other non-leaf ccall from JIT code.
- `clear_local_types()` is used and necessary for correctness, this is the main trade-off. If we wanted to avoid that we'd need to do something like deopt on write to caller frame or so.