### PR TITLE
Fix formatting in ObjectSpace._id2ref error path

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -2012,10 +2012,10 @@ object_id_to_ref(void *objspace_ptr, VALUE object_id)
     }
 
     if (rb_funcall(object_id, rb_intern(">="), 1, ULL2NUM(LAST_OBJECT_ID()))) {
-        rb_raise(rb_eRangeError, "%+"PRIsVALUE" is not an id value", rb_funcall(object_id, rb_intern("to_s"), 1, INT2FIX(10)));
+        rb_raise(rb_eRangeError, "%"PRIsVALUE" is not an id value", object_id);
     }
     else {
-        rb_raise(rb_eRangeError, "%+"PRIsVALUE" is a recycled object", rb_funcall(object_id, rb_intern("to_s"), 1, INT2FIX(10)));
+        rb_raise(rb_eRangeError, "%"PRIsVALUE" is a recycled object", object_id);
     }
 }
 
@@ -2146,7 +2146,7 @@ id2ref(VALUE objid)
                 }
             }
 
-            rb_raise(rb_eRangeError, "%+"PRIsVALUE" is not an id value", rb_int2str(objid, 10));
+            rb_raise(rb_eRangeError, "%"PRIsVALUE" is not an id value", objid);
         }
     }
 
@@ -2155,7 +2155,7 @@ id2ref(VALUE objid)
         return obj;
     }
     else {
-        rb_raise(rb_eRangeError, "%+"PRIsVALUE" is the id of an unshareable object on multi-ractor", rb_int2str(objid, 10));
+        rb_raise(rb_eRangeError, "%"PRIsVALUE" is the id of an unshareable object on multi-ractor", objid);
     }
 }
 

--- a/test/ruby/test_objectspace.rb
+++ b/test/ruby/test_objectspace.rb
@@ -73,6 +73,12 @@ End
     assert_raise_with_message(RangeError, msg) { EnvUtil.suppress_warning { ObjectSpace._id2ref(:a.object_id + 256) } }
   end
 
+def test_id2ref_invalid_object_id
+    invalid_id = Object.new.object_id + 1000
+    assert_raise_with_message(RangeError, "#{invalid_id} is not an id value") { EnvUtil.suppress_warning { ObjectSpace._id2ref(invalid_id) } }
+    assert_raise_with_message(RangeError, "#{2**80} is not an id value") { EnvUtil.suppress_warning { ObjectSpace._id2ref(2**80) } }
+  end
+
   def test_count_objects
     h = {}
     ObjectSpace.count_objects(h)

--- a/test/ruby/test_objectspace.rb
+++ b/test/ruby/test_objectspace.rb
@@ -73,7 +73,7 @@ End
     assert_raise_with_message(RangeError, msg) { EnvUtil.suppress_warning { ObjectSpace._id2ref(:a.object_id + 256) } }
   end
 
-def test_id2ref_invalid_object_id
+  def test_id2ref_invalid_object_id
     invalid_id = Object.new.object_id + 1000
     assert_raise_with_message(RangeError, "#{invalid_id} is not an id value") { EnvUtil.suppress_warning { ObjectSpace._id2ref(invalid_id) } }
     assert_raise_with_message(RangeError, "#{2**80} is not an id value") { EnvUtil.suppress_warning { ObjectSpace._id2ref(2**80) } }


### PR DESCRIPTION
Error formatting in `ObjectSpace._id2ref` was using a rather unusual way to format an Integer: 
```c
rb_raise(rb_eRangeError, "%+"PRIsVALUE" ...", rb_int2str(objid, 10));
// and also
rb_raise(rb_eRangeError, "%+"PRIsVALUE" ...", rb_funcall(object_id, rb_intern("to_s"), 1, INT2FIX(10)));
```
`%+"PRIsVALUE"` calls `rb_inspect()` which calls `rb_funcallv()`, and somehow that crashed in at least one instance.
Let's use the safer and far more common `%"PRIsVALUE"` directly passing the `Integer` instead, so we don't go through so many indirections and we use a well-tested path.
Since we are formatting an Integer there is no need for `inspect`, `to_s` should be fine enough.

Stacktrace of such a crash on Ruby 4.0.5:
```
0x7a315daa20d8 rb_funcallv (/usr/src/ruby/vm_eval.c:1080)
0x7a315d91a964 rb_inspect (/usr/src/ruby/object.c:747)
0x7a315d9e0f82 ruby__sfvextra (/usr/src/ruby/sprintf.c:1115)
0x7a315d9e3e0e BSD_vfprintf (/usr/src/ruby/vsnprintf.c:832)
0x7a315d9e52e0 ruby_vsprintf0 (/usr/src/ruby/sprintf.c:1166)
0x7a315d9e5642 rb_enc_vsprintf (/usr/src/ruby/sprintf.c:1195)
0x7a315d868cbb rb_raise (/usr/src/ruby/error.c:3800)
0x7a315d776933 os_id2ref (/usr/src/ruby/gc.c:2159)
```

**This crash is probably not only caused by that**, but it'd avoid an extra failure on top of another one, potentially hiding information from the original failure.
Might be related to https://bugs.ruby-lang.org/issues/22200.

I think this is very low risk so I think worth fixing on the Ruby 4.0 branch.
This doesn't apply on master where `ObjectSpace._id2ref` has been removed.