### PR TITLE
Bump irb to latest master

### DIFF
--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -39,7 +39,7 @@ benchmark           0.5.0   https://github.com/ruby/benchmark
 logger              1.7.0   https://github.com/ruby/logger
 rdoc                8.0.0   https://github.com/ruby/rdoc
 win32ole            1.9.3   https://github.com/ruby/win32ole
-irb                 1.18.0  https://github.com/ruby/irb
+irb                 1.18.0  https://github.com/ruby/irb f1d8d5a2e3fb64f63231302900e20f29518e7ffa
 reline              0.6.3   https://github.com/ruby/reline
 readline            0.0.4   https://github.com/ruby/readline
 fiddle              1.1.8   https://github.com/ruby/fiddle


### PR DESCRIPTION
It contains https://github.com/ruby/irb/commit/f1d8d5a2e3fb64f63231302900e20f29518e7ffa which adapts to a prism change (example failure https://github.com/ruby/ruby/actions/runs/31018812758/job/92349873936)

cc @tompng 