### PR TITLE
Do not resolve dependency names against the build directory

### DIFF
--- a/lib/mkmf/depend.rb
+++ b/lib/mkmf/depend.rb
@@ -550,6 +550,23 @@ class MakeMakefile::Depend
     expanded.start_with?(prefix) ? expanded.delete_prefix(prefix) : path
   end
 
+  # Makes +path+ relative to #root without consulting the current
+  # directory.  Unlike #relative_source, a relative name that does not
+  # refer to a source-tree file is kept as-is: generated dependencies
+  # such as builtin_binary.rbbin live in the build directory, and must
+  # keep the name their Make rules use even when the tool runs in a
+  # build directory nested inside the source tree.
+  def relative_dependency(path)
+    expanded = File.expand_path(path, @root)
+    prefix = @root + File::SEPARATOR
+    if expanded.start_with?(prefix) &&
+        (File.absolute_path?(path) || File.exist?(expanded))
+      expanded.delete_prefix(prefix)
+    else
+      path
+    end
+  end
+
   # Converts an extension dependency to the Make variable path it requires.
   def extension_dependency(file, source_dir)
     case file
@@ -607,7 +624,7 @@ class MakeMakefile::Depend
     end
     files = files.flat_map {|file| expand.call(file, [])}
     files.each_with_object([]) do |file, deps|
-      file = relative_source(file)
+      file = relative_dependency(file)
       dep = if file.start_with?('$(', '{$(')
         file
       elsif target = dependency_target(file, declaration_input)
@@ -696,7 +713,7 @@ class MakeMakefile::Depend
 
   # Appends Make dependency rules for +src+ to +out+ and returns +out+.
   def makedepend(src, out = [], target: nil, input: nil, project: false)
-    src = relative_source(src)
+    src = relative_dependency(src)
     declaration_input = input || dependency_input(src)
     declarations = dependency_declarations(declaration_input, source: src)
     vpath = dependency_vpath(input, src)
@@ -1001,7 +1018,7 @@ class MakeMakefile::Depend
     changed = false
     inputs.each do |input|
       if input.end_with?(".c", ".y")
-        out.puts makedepend(input)
+        out.puts makedepend(relative_source(input))
       else
         deps = dependency_file_content(input) || File.read(input)
         dependency_declarations(input, content: deps)

--- a/tool/test/test_mkdepend.rb
+++ b/tool/test/test_mkdepend.rb
@@ -973,6 +973,32 @@ class TestMkdepend < Test::Unit::TestCase
     end
   end
 
+  def test_run_from_build_directory_keeps_generated_dependency_names
+    Dir.mktmpdir('mkdepend-builddir') do |dir|
+      File.write(File.join(dir, 'builtin.c'), <<~SOURCE)
+        #include "builtin_binary.rbbin"
+      SOURCE
+      input = File.join(dir, 'depend')
+      File.write(input, <<~DEPEND)
+        #{MARK_START}
+        builtin.$(OBJEXT): {$(VPATH)}builtin.c
+        #{MARK_END}
+      DEPEND
+      build = File.join(dir, '.build')
+      FileUtils.mkdir_p(build)
+      File.write(File.join(build, 'builtin_binary.rbbin'), '')
+      output = File.join(build, '.deps')
+
+      mkdepend = TestDepend.new(root: dir)
+      Dir.chdir(build) do
+        assert_true(mkdepend.run([input], mode: :output, output: output))
+      end
+      generated = File.read(File.join(output, 'depend'))
+      assert_include(generated, "builtin.$(OBJEXT): builtin_binary.rbbin\n")
+      assert_not_include(generated, '.build/builtin_binary.rbbin')
+    end
+  end
+
   def test_normalize_dependency_rules_removes_vpath_search
     assert_equal(
       "one.h two.h\n",


### PR DESCRIPTION
tool/mkdepend.rb resolved dependency names against the current working directory before falling back to the source root.  When configure re-runs in an already-built build directory nested inside the source tree (e.g. .ruby under the checkout), leftover generated files such as builtin_binary.rbbin got emitted as build-dir-relative paths:

    builtin.$(OBJEXT): .ruby/builtin_binary.rbbin

Make satisfies such a prerequisite through VPATH as a plain existing file, so it never matches the builtin_binary.rbbin rule and the file is never regenerated.  Linking a stale builtin_binary.rbbin with up-to-date *.rbinc function tables then makes the built ruby fail to boot during make install:

    <internal:gc>: builtin function index (8) mismatch (expect _bi454 but _bi464) (ArgumentError)

The same defect also emitted .ruby/probes.h and
.ruby/vm_call_iseq_optimized.inc, and dropped the enc/trans/*.trans dependencies of the generated transcoder sources.

Convert dependency names against the source root only, never the current working directory, so that generated files keep the bare names their Make rules use and the generated dependencies no longer vary with leftover build artifacts.