### PR TITLE
[Feature #22231] Add IO::Buffer#index

### DIFF
--- a/io_buffer.c
+++ b/io_buffer.c
@@ -3960,6 +3960,128 @@ io_buffer_bit_count(int argc, VALUE *argv, VALUE self)
     return SIZET2NUM(count);
 }
 
+// `byte` provides the storage when the object is a single Integer byte, so it
+// must outlive the extracted bytes; likewise `object` in the remaining cases.
+static inline void
+io_buffer_extract_object(VALUE object, unsigned char *byte, const void **base, size_t *size)
+{
+    if (RB_INTEGER_TYPE_P(object)) {
+        if (rb_int_negative_p(object)) {
+            rb_raise(rb_eArgError, "Byte value can't be negative!");
+        }
+
+        unsigned long value = NUM2ULONG(object);
+
+        if (value > 0xFF) {
+            rb_raise(rb_eArgError, "Byte value must be at most 255!");
+        }
+
+        *byte = (unsigned char)value;
+        *base = byte;
+        *size = 1;
+    }
+    else if (RB_TYPE_P(object, T_STRING)) {
+        *base = RSTRING_PTR(object);
+        *size = RSTRING_LEN(object);
+    }
+    else {
+        rb_io_buffer_get_bytes_for_reading(object, base, size);
+    }
+}
+
+/*
+ *  call-seq: index(object, [offset, [length]]) -> integer or nil
+ *
+ *  Returns the offset of the first occurrence of +object+ in the buffer, or
+ *  +nil+ if it does not occur. The +object+ may be an Integer in the range
+ *  0..255 (a single byte), a String, or another IO::Buffer.
+ *
+ *  The search is performed on the bytes of the buffer without copying them, and
+ *  is byte-oriented: no encoding is considered, even if the +object+ is a String
+ *  with a non-binary encoding.
+ *
+ *    buffer = IO::Buffer.for("Hello World")
+ *    buffer.index("o")
+ *    # => 4
+ *    buffer.index("World")
+ *    # => 6
+ *    buffer.index("o".ord)
+ *    # => 4
+ *    buffer.index(IO::Buffer.for("World"))
+ *    # => 6
+ *    buffer.index("!")
+ *    # => nil
+ *
+ *  The search may be restricted to a subrange using +offset+ and +length+. The
+ *  returned offset is always relative to the start of the buffer, not to
+ *  +offset+:
+ *
+ *    buffer.index("o", 5)
+ *    # => 7
+ *    buffer.index("o", 0, 4)
+ *    # => nil
+ *
+ *  An empty +object+ matches at +offset+:
+ *
+ *    buffer.index("")
+ *    # => 0
+ *
+ *  Unlike String#index, an +offset+ or +length+ which falls outside the buffer
+ *  is an error rather than a failed match:
+ *
+ *    buffer.index("o", 100)
+ *    # => ArgumentError
+ */
+static VALUE
+io_buffer_index(int argc, VALUE *argv, VALUE self)
+{
+    rb_check_arity(argc, 1, 3);
+
+    size_t offset, length;
+    struct rb_io_buffer *buffer = io_buffer_extract_offset_length(self, argc-1, argv+1, &offset, &length);
+
+    io_buffer_validate_range(buffer, offset, length);
+
+    const void *base;
+    size_t size;
+    io_buffer_get_bytes_for_reading(buffer, &base, &size);
+
+    VALUE object = argv[0];
+    unsigned char byte;
+    const void *object_base;
+    size_t object_size;
+    io_buffer_extract_object(object, &byte, &object_base, &object_size);
+
+    VALUE result = Qnil;
+
+    if (object_size == 0) {
+        result = SIZET2NUM(offset);
+    }
+    else if (object_size <= length) {
+        // This is only reached when length > 0, so base is never NULL:
+        const unsigned char *search_base = (const unsigned char *)base + offset;
+
+        if (object_size == 1) {
+            const unsigned char *found = memchr(search_base, *(const unsigned char *)object_base, length);
+
+            if (found) {
+                result = SIZET2NUM(offset + (size_t)(found - search_base));
+            }
+        }
+        else {
+            long found = rb_memsearch(object_base, (long)object_size, search_base, (long)length, rb_ascii8bit_encoding());
+
+            if (found >= 0) {
+                result = SIZET2NUM(offset + (size_t)found);
+            }
+        }
+    }
+
+    RB_GC_GUARD(object);
+
+    return result;
+}
+
 /*
  *  Document-class: IO::Buffer
  *
@@ -4216,6 +4338,9 @@ Init_IO_Buffer(void)
     rb_define_method(rb_cIOBuffer, "not!", io_buffer_not_inplace, 0);
 
     rb_define_method(rb_cIOBuffer, "bit_count", io_buffer_bit_count, -1);
+
+    // Searching:
+    rb_define_method(rb_cIOBuffer, "index", io_buffer_index, -1);
 
     // IO operations:
     rb_define_method(rb_cIOBuffer, "read", io_buffer_read, -1);

--- a/io_buffer.c
+++ b/io_buffer.c
@@ -4319,6 +4319,161 @@ static const rb_memory_view_entry_t io_buffer_memory_view_entry = {
     .available_p_func = io_buffer_memory_view_available_p,
 };
 
+static const unsigned char *
+memory_index(const unsigned char *base, size_t size, const unsigned char *object_base, size_t object_size)
+{
+    RUBY_ASSERT(object_size > 0);
+    RUBY_ASSERT(object_size <= size);
+
+    if (object_size == 1) {
+        return memchr(base, *object_base, size);
+    }
+
+    // `rb_memsearch` takes `long` sizes, so where `size_t` is bigger, the range
+    // is searched in chunks overlapping by `object_size-1` bytes, so that a
+    // match straddling a chunk boundary is still found:
+    while (size >= object_size) {
+        size_t chunk = size < (size_t)LONG_MAX ? size : (size_t)LONG_MAX;
+
+        long index = rb_memsearch(object_base, (long)object_size, base, (long)chunk, rb_ascii8bit_encoding());
+
+        if (index >= 0) return base + index;
+
+        if (chunk == size) break;
+
+        size_t advance = chunk - (object_size - 1);
+        base += advance;
+        size -= advance;
+    }
+
+    return NULL;
+}
+
+// `byte` provides the storage when the object is a single Integer byte, so it
+// must outlive the extracted bytes; likewise `object` in the remaining cases.
+static inline void
+io_buffer_extract_object(VALUE object, unsigned char *byte, const void **base, size_t *size)
+{
+    if (RB_INTEGER_TYPE_P(object)) {
+        if (rb_int_negative_p(object)) {
+            rb_raise(rb_eArgError, "Byte value can't be negative!");
+        }
+
+        unsigned long value = NUM2ULONG(object);
+
+        if (value > 0xFF) {
+            rb_raise(rb_eArgError, "Byte value must be at most 255!");
+        }
+
+        *byte = (unsigned char)value;
+        *base = byte;
+        *size = 1;
+    }
+    else if (RB_TYPE_P(object, T_STRING)) {
+        *base = RSTRING_PTR(object);
+        *size = RSTRING_LEN(object);
+    }
+    else if (rb_obj_is_kind_of(object, rb_cIOBuffer)) {
+        rb_io_buffer_get_bytes_for_reading(object, base, size);
+    }
+    else {
+        rb_raise(rb_eTypeError, "expected Integer, String or IO::Buffer, not %"PRIsVALUE,
+                 rb_obj_class(object));
+    }
+}
+
+/*
+ *  call-seq: index(object, [offset, [length]]) -> integer or nil
+ *
+ *  Returns the offset of the first occurrence of +object+ in the buffer, or
+ *  +nil+ if it does not occur. The +object+ may be an Integer in the range
+ *  0..255, a String, or another IO::Buffer. The search is byte-oriented: the
+ *  encoding of a String +object+ is ignored.
+ *
+ *    buffer = IO::Buffer.for("Hello World")
+ *    buffer.index("o")
+ *    # => 4
+ *    buffer.index("o".ord)
+ *    # => 4
+ *    buffer.index(IO::Buffer.for("World"))
+ *    # => 6
+ *    buffer.index("!")
+ *    # => nil
+ *
+ *  The search may be restricted to a subrange using +offset+ and +length+, and
+ *  the returned offset remains relative to the start of the buffer. An empty
+ *  +object+ matches at +offset+:
+ *
+ *    buffer.index("o", 5)
+ *    # => 7
+ *    buffer.index("o", 0, 4)
+ *    # => nil
+ *    buffer.index("", 3)
+ *    # => 3
+ *
+ *  Following String#index, a range outside the buffer is not an error: an
+ *  +offset+ beyond the end returns +nil+, and a +length+ beyond the end searches
+ *  to the end of the buffer:
+ *
+ *    buffer.index("o", 100)
+ *    # => nil
+ *    buffer.index("o", 0, 100)
+ *    # => 4
+ */
+static VALUE
+io_buffer_index(int argc, VALUE *argv, VALUE self)
+{
+    rb_check_arity(argc, 1, 3);
+
+    struct rb_io_buffer *buffer = get_io_buffer(self);
+
+    size_t offset = 0;
+    if (argc >= 2 && !NIL_P(argv[1])) {
+        offset = io_buffer_extract_offset(argv[1]);
+    }
+
+    size_t length = SIZE_MAX;
+    if (argc >= 3 && !NIL_P(argv[2])) {
+        length = io_buffer_extract_length(argv[2]);
+    }
+
+    // Take the pointers only once the arguments are extracted: they must not be
+    // held across anything which could free, resize or move the memory.
+    const void *base;
+    size_t size;
+    io_buffer_get_bytes_for_reading(buffer, &base, &size);
+
+    VALUE object = argv[0];
+    unsigned char byte;
+    const void *object_base;
+    size_t object_size;
+    io_buffer_extract_object(object, &byte, &object_base, &object_size);
+
+    if (object_size > LONG_MAX) {
+        rb_raise(rb_eArgError, "The given value is bigger than the maximum search size!");
+    }
+
+    // Unlike the other range operations, an offset or length outside the buffer
+    // cannot match rather than being an error, as with String#index:
+    if (offset > size) return Qnil;
+
+    if (length > size - offset) length = size - offset;
+
+    if (object_size == 0) return SIZET2NUM(offset);
+    if (object_size > length) return Qnil;
+
+    RUBY_ASSERT(base != NULL);
+
+    const unsigned char *search_base = (const unsigned char *)base + offset;
+    const unsigned char *found = memory_index(search_base, length, object_base, object_size);
+
+    RB_GC_GUARD(object);
+
+    if (!found) return Qnil;
+
+    return SIZET2NUM(offset + (size_t)(found - search_base));
+}
+
 /*
  *  Document-class: IO::Buffer
  *
@@ -4590,6 +4745,9 @@ Init_IO_Buffer(void)
     rb_define_method(rb_cIOBuffer, "not!", io_buffer_not_inplace, 0);
 
     rb_define_method(rb_cIOBuffer, "bit_count", io_buffer_bit_count, -1);
+
+    // Searching:
+    rb_define_method(rb_cIOBuffer, "index", io_buffer_index, -1);
 
     // IO operations:
     rb_define_method(rb_cIOBuffer, "read", io_buffer_read, -1);

--- a/test/ruby/test_io_buffer.rb
+++ b/test/ruby/test_io_buffer.rb
@@ -1508,6 +1508,172 @@ class TestIOBuffer < Test::Unit::TestCase
     assert_raise(ArgumentError) { IO::Buffer.for("\xFF").bit_count(1, 1) }
   end
 
+  def test_index_integer
+    buffer = IO::Buffer.for("Hello World")
+
+    assert_equal 4,  buffer.index("o".ord)
+    assert_equal 0,  buffer.index("H".ord)
+    assert_equal 10, buffer.index("d".ord)
+    assert_nil       buffer.index("!".ord)
+
+    # NUL is an ordinary byte here, not a terminator:
+    assert_equal 5, IO::Buffer.for("Hello\x00World").index(0)
+  end
+
+  def test_index_string
+    buffer = IO::Buffer.for("Hello World")
+
+    assert_equal 0,  buffer.index("Hello")
+    assert_equal 6,  buffer.index("World")
+    assert_equal 4,  buffer.index("o")
+    assert_equal 0,  buffer.index("Hello World")
+    assert_nil       buffer.index("world")
+    assert_nil       buffer.index("Hello!")
+
+    assert_equal 6, buffer.index("World".dup.force_encoding(Encoding::UTF_8))
+  end
+
+  def test_index_string_long
+    # Values longer than SIZEOF_VALUE take a different search path internally:
+    buffer = IO::Buffer.for(("x" * 100) + "abcdefghijklmnop" + ("y" * 100))
+
+    assert_equal 100, buffer.index("abcdefghijklmnop")
+    assert_nil        buffer.index("abcdefghijklmnopq")
+  end
+
+  def test_index_binary
+    buffer = IO::Buffer.for("\x00\x01\xFF\xFE\x00\x01")
+
+    assert_equal 2, buffer.index("\xFF\xFE".b)
+    assert_equal 0, buffer.index("\x00\x01".b)
+    assert_equal 4, buffer.index("\x00\x01".b, 1)
+  end
+
+  def test_index_buffer
+    buffer = IO::Buffer.for("Hello World")
+
+    assert_equal 6, buffer.index(IO::Buffer.for("World"))
+    assert_equal 3, buffer.index(IO::Buffer.for("lo W"))
+    assert_equal 4, buffer.index(IO::Buffer.for("o"))
+    assert_nil      buffer.index(IO::Buffer.for("world"))
+
+    assert_equal 6, buffer.index(buffer.slice(6, 5))
+  end
+
+  def test_index_invalid_object
+    buffer = IO::Buffer.for("Hello World")
+
+    assert_raise_with_message(TypeError, "expected Integer, String or IO::Buffer, not Symbol") { buffer.index(:World) }
+    assert_raise(TypeError) { buffer.index(nil) }
+    assert_raise(TypeError) { buffer.index(1.0) }
+
+    assert_raise(ArgumentError) { buffer.index(256) }
+    assert_raise(ArgumentError) { buffer.index(-1) }
+  end
+
+  def test_index_slice
+    buffer = IO::Buffer.for("Hello World")
+    slice = buffer.slice(6, 5)
+
+    # Offsets are relative to the slice, not to the underlying buffer:
+    assert_equal 1, slice.index("o")
+    assert_equal 0, slice.index("World")
+    assert_nil      slice.index("Hello")
+    assert_nil      slice.index("H")
+  end
+
+  def test_index_offset
+    buffer = IO::Buffer.for("Hello World")
+
+    # The result is relative to the start of the buffer, not to the offset:
+    assert_equal 4, buffer.index("o", 0)
+    assert_equal 4, buffer.index("o", 4)
+    assert_equal 7, buffer.index("o", 5)
+    assert_nil      buffer.index("o", 8)
+
+    # An offset equal to the size searches an empty range:
+    assert_nil buffer.index("o", buffer.size)
+  end
+
+  def test_index_length
+    buffer = IO::Buffer.for("Hello World")
+
+    assert_equal 4, buffer.index("o", 0, 5)
+    assert_nil      buffer.index("o", 0, 4)
+    assert_equal 7, buffer.index("o", 5, 3)
+    assert_nil      buffer.index("o", 5, 2)
+
+    # The search value must fit entirely within the range:
+    assert_equal 6, buffer.index("World", 0, 11)
+    assert_nil      buffer.index("World", 0, 10)
+
+    assert_nil buffer.index("H", 0, 0)
+  end
+
+  def test_index_empty_object
+    buffer = IO::Buffer.for("Hello World")
+
+    assert_equal 0, buffer.index("")
+    assert_equal 3, buffer.index("", 3)
+    assert_equal 11, buffer.index("", buffer.size)
+    assert_equal 3, buffer.index("", 3, 0)
+    assert_equal 0, buffer.index(IO::Buffer.new(0))
+
+    assert_equal 0, IO::Buffer.new(0).index("")
+  end
+
+  def test_index_object_longer_than_range
+    buffer = IO::Buffer.for("Hello")
+
+    assert_nil buffer.index("Hello World")
+    assert_nil buffer.index("Hello", 1)
+    assert_nil buffer.index("ello", 0, 4)
+    assert_nil IO::Buffer.new(0).index("H")
+  end
+
+  def test_index_out_of_range
+    buffer = IO::Buffer.for("Hello World")
+
+    # Following String#index, an offset past the end does not match, and a
+    # length past the end searches to the end of the buffer:
+    assert_nil      buffer.index("o", 12)
+    assert_nil      buffer.index("", 12)
+    assert_equal 4, buffer.index("o", 0, 12)
+    assert_equal 7, buffer.index("o", 6, 6)
+    assert_equal 6, buffer.index("World", 0, 100)
+
+    # Negative offsets and lengths remain an error:
+    assert_raise(ArgumentError) { buffer.index("o", -1) }
+    assert_raise(ArgumentError) { buffer.index("o", 0, -1) }
+    assert_raise(ArgumentError) { buffer.index("o", 12, -1) }
+  end
+
+  def test_index_freed
+    buffer = IO::Buffer.new(128)
+    buffer.set_string("Hello World")
+    buffer.free
+
+    # A freed buffer is empty rather than invalid, so there is nothing to find:
+    assert_nil buffer.index("World")
+    assert_equal 0, buffer.index("")
+    assert_nil buffer.index("World", 1)
+    assert_nil buffer.index("", 1)
+  end
+
+  def test_index_invalidated
+    inner = IO::Buffer.new(IO::Buffer::PAGE_SIZE)
+    slice = inner.slice(0, 16)
+    inner.free
+
+    assert_raise(IO::Buffer::InvalidatedError) { slice.index("A") }
+
+    inner2 = IO::Buffer.new(IO::Buffer::PAGE_SIZE)
+    object = inner2.slice(0, 16)
+    inner2.free
+
+    assert_raise(IO::Buffer::InvalidatedError) { IO::Buffer.for("Hello World").index(object) }
+  end
+
   def test_shared
     message = "Hello World"
     buffer = IO::Buffer.new(64, IO::Buffer::MAPPED | IO::Buffer::SHARED)

--- a/test/ruby/test_io_buffer.rb
+++ b/test/ruby/test_io_buffer.rb
@@ -880,6 +880,166 @@ class TestIOBuffer < Test::Unit::TestCase
     assert_raise(ArgumentError) { IO::Buffer.for("\xFF").bit_count(1, 1) }
   end
 
+  def test_index_integer
+    buffer = IO::Buffer.for("Hello World")
+
+    assert_equal 4,  buffer.index("o".ord)
+    assert_equal 0,  buffer.index("H".ord)
+    assert_equal 10, buffer.index("d".ord)
+    assert_nil       buffer.index("!".ord)
+
+    # NUL is an ordinary byte here, not a terminator:
+    assert_equal 5, IO::Buffer.for("Hello\x00World").index(0)
+  end
+
+  def test_index_string
+    buffer = IO::Buffer.for("Hello World")
+
+    assert_equal 0,  buffer.index("Hello")
+    assert_equal 6,  buffer.index("World")
+    assert_equal 4,  buffer.index("o")
+    assert_equal 0,  buffer.index("Hello World")
+    assert_nil       buffer.index("world")
+    assert_nil       buffer.index("Hello!")
+
+    assert_equal 6, buffer.index("World".dup.force_encoding(Encoding::UTF_8))
+  end
+
+  def test_index_string_long
+    # Values longer than SIZEOF_VALUE take a different search path internally:
+    buffer = IO::Buffer.for(("x" * 100) + "abcdefghijklmnop" + ("y" * 100))
+
+    assert_equal 100, buffer.index("abcdefghijklmnop")
+    assert_nil        buffer.index("abcdefghijklmnopq")
+  end
+
+  def test_index_binary
+    buffer = IO::Buffer.for("\x00\x01\xFF\xFE\x00\x01")
+
+    assert_equal 2, buffer.index("\xFF\xFE".b)
+    assert_equal 0, buffer.index("\x00\x01".b)
+    assert_equal 4, buffer.index("\x00\x01".b, 1)
+  end
+
+  def test_index_buffer
+    buffer = IO::Buffer.for("Hello World")
+
+    assert_equal 6, buffer.index(IO::Buffer.for("World"))
+    assert_equal 3, buffer.index(IO::Buffer.for("lo W"))
+    assert_equal 4, buffer.index(IO::Buffer.for("o"))
+    assert_nil      buffer.index(IO::Buffer.for("world"))
+
+    assert_equal 6, buffer.index(buffer.slice(6, 5))
+  end
+
+  def test_index_invalid_object
+    buffer = IO::Buffer.for("Hello World")
+
+    assert_raise(TypeError) { buffer.index(:World) }
+    assert_raise(TypeError) { buffer.index(nil) }
+    assert_raise(TypeError) { buffer.index(1.0) }
+
+    assert_raise(ArgumentError) { buffer.index(256) }
+    assert_raise(ArgumentError) { buffer.index(-1) }
+  end
+
+  def test_index_slice
+    buffer = IO::Buffer.for("Hello World")
+    slice = buffer.slice(6, 5)
+
+    # Offsets are relative to the slice, not to the underlying buffer:
+    assert_equal 1, slice.index("o")
+    assert_equal 0, slice.index("World")
+    assert_nil      slice.index("Hello")
+    assert_nil      slice.index("H")
+  end
+
+  def test_index_offset
+    buffer = IO::Buffer.for("Hello World")
+
+    # The result is relative to the start of the buffer, not to the offset:
+    assert_equal 4, buffer.index("o", 0)
+    assert_equal 4, buffer.index("o", 4)
+    assert_equal 7, buffer.index("o", 5)
+    assert_nil      buffer.index("o", 8)
+
+    # An offset equal to the size searches an empty range:
+    assert_nil buffer.index("o", buffer.size)
+  end
+
+  def test_index_length
+    buffer = IO::Buffer.for("Hello World")
+
+    assert_equal 4, buffer.index("o", 0, 5)
+    assert_nil      buffer.index("o", 0, 4)
+    assert_equal 7, buffer.index("o", 5, 3)
+    assert_nil      buffer.index("o", 5, 2)
+
+    # The search value must fit entirely within the range:
+    assert_equal 6, buffer.index("World", 0, 11)
+    assert_nil      buffer.index("World", 0, 10)
+
+    assert_nil buffer.index("H", 0, 0)
+  end
+
+  def test_index_empty_object
+    buffer = IO::Buffer.for("Hello World")
+
+    assert_equal 0, buffer.index("")
+    assert_equal 3, buffer.index("", 3)
+    assert_equal 11, buffer.index("", buffer.size)
+    assert_equal 3, buffer.index("", 3, 0)
+    assert_equal 0, buffer.index(IO::Buffer.new(0))
+
+    assert_equal 0, IO::Buffer.new(0).index("")
+  end
+
+  def test_index_object_longer_than_range
+    buffer = IO::Buffer.for("Hello")
+
+    assert_nil buffer.index("Hello World")
+    assert_nil buffer.index("Hello", 1)
+    assert_nil buffer.index("ello", 0, 4)
+    assert_nil IO::Buffer.new(0).index("H")
+  end
+
+  def test_index_out_of_range
+    buffer = IO::Buffer.for("Hello World")
+
+    # Unlike String#index, an out-of-range offset or length is an error rather
+    # than a failed match:
+    assert_raise(ArgumentError) { buffer.index("o", 12) }
+    assert_raise(ArgumentError) { buffer.index("o", 0, 12) }
+    assert_raise(ArgumentError) { buffer.index("o", 6, 6) }
+    assert_raise(ArgumentError) { buffer.index("o", -1) }
+    assert_raise(ArgumentError) { buffer.index("o", 0, -1) }
+  end
+
+  def test_index_freed
+    buffer = IO::Buffer.new(128)
+    buffer.set_string("Hello World")
+    buffer.free
+
+    # A freed buffer is empty rather than invalid, so there is nothing to find:
+    assert_nil buffer.index("World")
+    assert_equal 0, buffer.index("")
+    assert_raise(ArgumentError) { buffer.index("World", 1) }
+  end
+
+  def test_index_invalidated
+    inner = IO::Buffer.new(IO::Buffer::PAGE_SIZE)
+    slice = inner.slice(0, 16)
+    inner.free
+
+    assert_raise(IO::Buffer::InvalidatedError) { slice.index("A") }
+
+    inner2 = IO::Buffer.new(IO::Buffer::PAGE_SIZE)
+    object = inner2.slice(0, 16)
+    inner2.free
+
+    assert_raise(IO::Buffer::InvalidatedError) { IO::Buffer.for("Hello World").index(object) }
+  end
+
   def test_shared
     message = "Hello World"
     buffer = IO::Buffer.new(64, IO::Buffer::MAPPED | IO::Buffer::SHARED)


### PR DESCRIPTION
Adds `IO::Buffer#index(object, offset = 0, length = size - offset)`, returning the offset of the first occurrence of `object` within the given range, or `nil`. `object` may be an `Integer` byte value, a `String`, or another `IO::Buffer`.

A new helper `io_buffer_extract_object` normalizes those three argument types to a pointer and a length.

Single-byte values use `memchr`. Longer values use `rb_memsearch` with `rb_ascii8bit_encoding()`, which keeps the search byte-oriented; unlike `String#index` there is no character-boundary check, since the buffer has no encoding.