### PR TITLE
[Bug #22123] Do not consume `BUNDLER_SETUP` outside the main box

### DIFF
--- a/gem_prelude.rb
+++ b/gem_prelude.rb
@@ -1,4 +1,15 @@
 begin
+  # rubygems.rb requires ENV["BUNDLER_SETUP"] at its end so that bundler/setup
+  # runs before error_highlight, did_you_mean and syntax_suggest are loaded.
+  # That is unnecessary once they are autoloaded ([Feature #21951]), and it
+  # must not happen outside the main box: Bundler evaluates gemspecs through
+  # TOPLEVEL_BINDING, which always belongs to the main box, so it would run
+  # Bundler code there before RubyGems finishes loading. Either way Bundler is
+  # set up by RUBYOPT=-rbundler/setup after the boot sequence.
+  if %i[ErrorHighlight DidYouMean SyntaxSuggest].any? {|c| Object.autoload?(c) } ||
+     (defined?(Ruby::Box) && Ruby::Box.enabled? && !Ruby::Box.current.main?)
+    bundler_setup = ENV.delete("BUNDLER_SETUP")
+  end
   require 'rubygems'
 rescue LoadError => e
   raise unless e.path == 'rubygems'
@@ -6,4 +17,6 @@ rescue LoadError => e
   warn "`RubyGems' were not loaded."
 else
   require 'bundled_gems'
+ensure
+  ENV["BUNDLER_SETUP"] = bundler_setup if bundler_setup
 end if defined?(Gem)

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -1471,4 +1471,9 @@ else
 end
 eval File.read(path), nil, file
 
+# bundler/setup has to run before error_highlight, did_you_mean and
+# syntax_suggest are loaded, so that the Gemfile controls their versions
+# ([Bug #19089]). Ruby 4.1 autoloads them ([Feature #21951]) and deletes this
+# variable while loading RubyGems, so this can go once 4.1 is the oldest
+# supported version.
 require ENV["BUNDLER_SETUP"] if ENV["BUNDLER_SETUP"] && !defined?(Bundler)

--- a/test/ruby/test_box.rb
+++ b/test/ruby/test_box.rb
@@ -944,9 +944,11 @@ class TestBox < Test::Unit::TestCase
       assert_in_out_err([env, "--enable=gems"], "#{<<-"begin;"}\n#{<<-'end;'}") do |output, error|
         begin;
           Ruby::Box.new
-          puts File.readlines(ENV["BUNDLER_SETUP_LOG"], chomp: true)
+          autoloaded = %i[ErrorHighlight DidYouMean SyntaxSuggest].any? {|c| Object.autoload?(c) }
+          loaded = File.readlines(ENV["BUNDLER_SETUP_LOG"], chomp: true)
+          puts loaded == (autoloaded ? [] : ["true"]) ? "ok" : "loaded in #{loaded.inspect}"
         end;
-        assert_equal [], output
+        assert_equal ["ok"], output
       end
     end
   end

--- a/test/ruby/test_box.rb
+++ b/test/ruby/test_box.rb
@@ -938,6 +938,47 @@ class TestBox < Test::Unit::TestCase
     end
   end
 
+  def test_bundler_setup_not_loaded_while_decorator_gems_are_autoloaded
+    with_bundler_setup_log do |env|
+      # assert_separately w/ ENV_ENABLE_BOX and --enable=gems causes timeouts on CI @ Windows
+      assert_in_out_err([env, "--enable=gems"], "#{<<-"begin;"}\n#{<<-'end;'}") do |output, error|
+        begin;
+          Ruby::Box.new
+          puts File.readlines(ENV["BUNDLER_SETUP_LOG"], chomp: true)
+        end;
+        assert_equal [], output
+      end
+    end
+  end
+
+  def test_bundler_setup_loaded_only_in_main_box
+    with_bundler_setup_log do |env|
+      opts = [env, "--enable=gems", "--disable=error_highlight", "--disable=did_you_mean", "--disable=syntax_suggest"]
+      assert_in_out_err(opts, "#{<<-"begin;"}\n#{<<-'end;'}") do |output, error|
+        begin;
+          Ruby::Box.new
+          puts File.readlines(ENV["BUNDLER_SETUP_LOG"], chomp: true)
+        end;
+        assert_equal ["true"], output
+      end
+    end
+  end
+
+  # Runs a BUNDLER_SETUP script that records the box it was loaded in, after
+  # touching RubyGems through TOPLEVEL_BINDING as Bundler does for gemspecs.
+  def with_bundler_setup_log
+    Tempfile.create(["bundler_setup", ".rb"]) do |setup|
+      Tempfile.create(["bundler_setup_log", ".txt"]) do |log|
+        setup.puts 'eval("Gem::Specification", TOPLEVEL_BINDING.dup)'
+        setup.puts 'File.write(ENV["BUNDLER_SETUP_LOG"], "#{Ruby::Box.current.main?}\n", mode: "a")'
+        setup.close
+        log.close
+
+        yield ENV_ENABLE_BOX.merge("BUNDLER_SETUP" => setup.path, "BUNDLER_SETUP_LOG" => log.path)
+      end
+    end
+  end
+
   def test_require_list_loaded_only_in_main_box
     Tempfile.create(["req_a", ".rb"]) do |t1|
       Tempfile.create(["req_b", ".rb"]) do |t2|


### PR DESCRIPTION
Under `RUBY_BOX=1`, `bundle exec ruby` fails before user code runs with `uninitialized constant Gem::Specification` while Bundler loads a path gem's gemspec. Bundler evaluates gemspecs through `TOPLEVEL_BINDING`, which always belongs to the main box, so consuming `ENV["BUNDLER_SETUP"]` while the root box loads RubyGems runs Bundler code in the main box before RubyGems has finished loading there. Every box consumes the variable, so each `Ruby::Box.new` also re-resolves the Gemfile, which took 1.144s here against 0.040s without a bundle.

`gem_prelude.rb` now hides the variable while a box other than the main box loads RubyGems, and hides it everywhere once `error_highlight`, `did_you_mean` and `syntax_suggest` are autoloaded, because the early `bundler/setup` only existed to pin those versions. `bundle exec` also passes `-rbundler/setup` through `RUBYOPT`, which runs after the boot sequence, so running under `bundle exec` is unaffected.

Code that clears or replaces `RUBYOPT` for a child process now gets a child outside the bundle on Ruby 4.1.

https://bugs.ruby-lang.org/issues/22123

Closes https://github.com/ruby/ruby/pull/17323
