### PR TITLE
ZJIT: Delete a stale comment reporting a wrong default value

### DIFF
--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -30,7 +30,7 @@ use crate::options::{get_option, InlineDepth, PerfMap, DEFAULT_MAX_VERSIONS};
 use crate::cast::IntoUsize;
 
 /// Maximum number of compiled versions per ISEQ.
-/// Configurable via --zjit-max-versions (default: 2).
+/// Configurable via --zjit-max-versions.
 pub fn max_iseq_versions() -> usize {
     unsafe { crate::options::OPTIONS.as_ref() }
         .map_or(DEFAULT_MAX_VERSIONS, |opts| opts.max_versions)


### PR DESCRIPTION
When I bumped the default max ISEQ versions from 2 to 4 in #17562, I overlooked this comment. It's not user-facing, so I've removed it. It's easy enough to check the `DEFAULT_MAX_VERSIONS` value for anyone interested.
