### PR TITLE
Drop revision.h dependency from dump_ast

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -1344,11 +1344,11 @@ $(BUILTIN_BINARY:no=builtin)_binary.rbbin:
 
 $(BUILTIN_RB_INCS): $(tooldir)/mk_builtin_loader.rb $(DUMP_AST_TARGET)
 
-dump_ast$(BUILD_EXEEXT): $(tooldir)/dump_ast.c $(LIBPRISM_OBJS) revision.h
+dump_ast$(BUILD_EXEEXT): $(tooldir)/dump_ast.c $(LIBPRISM_OBJS)
 	$(ECHO) compiling $@
 	$(Q) $(CC) $(CFLAGS) $(OUTFLAG)$@ $(INCFLAGS) $(tooldir)/dump_ast.c $(LIBPRISM_OBJS)
 
-build-tool/Makefile: $(tooldir)/dump_ast.mkmf.rb prism-srcs prism-incs revision.h
+build-tool/Makefile: $(tooldir)/dump_ast.mkmf.rb prism-srcs prism-incs
 	+$(BASERUBY) -s $(tooldir)/dump_ast.mkmf.rb \
 	    "-INCFLAGS=$(INCFLAGS)" "-make=$(MAKE)" "-objext=$(OBJEXT)" \
 	    build-tool $(tooldir)/dump_ast.c dump_ast.$(OBJEXT) $(LIBPRISM_OBJS)

--- a/tool/dump_ast.c
+++ b/tool/dump_ast.c
@@ -27,19 +27,70 @@ print_error(const pm_diagnostic_t *diagnostic, void *data)
     fprintf(stderr, "%" PRIi32 ":%" PRIu32 ":%s\n", line_column.line, line_column.column, pm_diagnostic_message(diagnostic));
 }
 
+static void
+usage(const char *prog)
+{
+    fprintf(stderr, "Usage: %s [options]... <filename>\n"
+            "Options:\n"
+            "  -v, --version: show Prism version\n"
+            "  -h, --help: show this message\n"
+            "", prog);
+}
+
 int
-main(int argc, const char *argv[]) {
-    if (argc != 2) {
-        fprintf(stderr, "Usage: %s <filename>\n", argv[0]);
+main(int argc, const char *argv[])
+{
+    const char *filepath = 0;
+
+    for (int i = 1; i < argc; ++i) {
+        const char *arg = argv[i];
+        if (arg[0] != '-') {
+            if (filepath) {
+                fprintf(stderr, "too many filename\n");
+                goto usage;
+            }
+            filepath = arg;
+        }
+        else if (arg[1] == '-') {
+            if (!arg[2]) break;
+            if (strcmp(arg + 2, "version") == 0) {
+              version:
+                fputs("Prism " PRISM_VERSION "\n", stdout);
+                return EXIT_SUCCESS;
+            }
+            if (strcmp(arg + 2, "help") == 0) {
+              help:
+                usage(argv[0]);
+                return EXIT_SUCCESS;
+            }
+            fprintf(stderr, "unknown option %s\n", arg);
+            goto usage;
+        }
+        else {
+            while (*++arg) {
+                switch (*arg) {
+                  case 'v':
+                    goto version;
+                  case 'h':
+                    goto help;
+                  default:
+                    fprintf(stderr, "unknown option -%c\n", *arg);
+                    goto usage;
+                }
+            }
+        }
+    }
+
+    if (!filepath) {
+      usage:
+        usage(argv[0]);
         return EXIT_FAILURE;
     }
 
-    const char *filepath = argv[1];
     pm_source_init_result_t init_result;
     pm_source_t *source = pm_source_mapped_new(filepath, 0, &init_result);
 
-    if (init_result != PM_SOURCE_INIT_SUCCESS)
-    {
+    if (init_result != PM_SOURCE_INIT_SUCCESS) {
         fprintf(stderr, "unable to map file: %s\n", filepath);
         return EXIT_FAILURE;
     }

--- a/tool/dump_ast.c
+++ b/tool/dump_ast.c
@@ -2,7 +2,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <inttypes.h>
-#include "revision.h"
 
 /*
  * When prism is compiled as part of CRuby, the xmalloc/xfree/etc. macros are
@@ -28,97 +27,19 @@ print_error(const pm_diagnostic_t *diagnostic, void *data)
     fprintf(stderr, "%" PRIi32 ":%" PRIu32 ":%s\n", line_column.line, line_column.column, pm_diagnostic_message(diagnostic));
 }
 
-#if defined(RUBY_RELEASE_DATETIME) && defined(RUBY_RELEASE_DATETIME)
-# define SHOW_PROGRAM_VERSION 2
-#elif defined(RUBY_RELEASE_DATETIME) || defined(RUBY_RELEASE_DATETIME)
-# define SHOW_PROGRAM_VERSION 1
-#else
-# define SHOW_PROGRAM_VERSION 0
-#endif
-#if SHOW_PROGRAM_VERSION
-# define usage_versions "and program versions"
-#else
-# define usage_versions "version"
-#endif
-
-static void
-usage(const char *prog)
-{
-    fprintf(stderr, "Usage: %s [options]... <filename>\n"
-            "Options:\n"
-            "  -v, --version: show Prism " usage_versions "\n"
-            "  -h, --help: show this message\n"
-            "", prog);
-}
-
 int
-main(int argc, const char *argv[])
-{
-    const char *filepath = 0;
-
-    for (int i = 1; i < argc; ++i) {
-        const char *arg = argv[i];
-        if (arg[0] != '-') {
-            if (filepath) {
-                fprintf(stderr, "too many filename\n");
-                goto usage;
-            }
-            filepath = arg;
-        }
-        else if (arg[1] == '-') {
-            if (!arg[2]) break;
-            if (strcmp(arg + 2, "version") == 0) {
-              version:
-                fputs("Prism " PRISM_VERSION
-#if SHOW_PROGRAM_VERSION
-                      " ["
-# ifdef RUBY_RELEASE_DATETIME
-                      RUBY_RELEASE_DATETIME
-# endif
-# if SHOW_PROGRAM_VERSION > 1
-                      " "
-# endif
-# ifdef RUBY_REVISION
-                      RUBY_REVISION
-# endif
-                      "]"
-#endif
-                      "\n", stdout);
-                return EXIT_SUCCESS;
-            }
-            if (strcmp(arg + 2, "help") == 0) {
-              help:
-                usage(argv[0]);
-                return EXIT_SUCCESS;
-            }
-            fprintf(stderr, "unknown option %s\n", arg);
-            goto usage;
-        }
-        else {
-            while (*++arg) {
-                switch (*arg) {
-                  case 'v':
-                    goto version;
-                  case 'h':
-                    goto help;
-                  default:
-                    fprintf(stderr, "unknown option -%c\n", *arg);
-                    goto usage;
-                }
-            }
-        }
-    }
-
-    if (!filepath) {
-      usage:
-        usage(argv[0]);
+main(int argc, const char *argv[]) {
+    if (argc != 2) {
+        fprintf(stderr, "Usage: %s <filename>\n", argv[0]);
         return EXIT_FAILURE;
     }
 
+    const char *filepath = argv[1];
     pm_source_init_result_t init_result;
     pm_source_t *source = pm_source_mapped_new(filepath, 0, &init_result);
 
-    if (init_result != PM_SOURCE_INIT_SUCCESS) {
+    if (init_result != PM_SOURCE_INIT_SUCCESS)
+    {
         fprintf(stderr, "unable to map file: %s\n", filepath);
         return EXIT_FAILURE;
     }


### PR DESCRIPTION
~~This reverts commit dd93d13c8a38d1116f4df24c117e902f8144db43 (#18071).~~

Baking revision.h into dump_ast couples every builtin *.rbinc to the current commit: whenever HEAD changes, e.g. when switching between two branches that only differ under yjit/, revision.h is regenerated, dump_ast is relinked, all $(BUILTIN_RB_INCS) are regenerated with identical content but fresh timestamps, and every C file that includes one of them is recompiled, followed by relinking miniruby and ruby.

~~The --version banner was the only use of revision.h in dump_ast, and #18071 did not state a motivation for it, so remove the option rather than keeping the revision out of its prerequisites.~~

This PR does https://github.com/ruby/ruby/pull/18224#issuecomment-5210514306 to address the issue.