### PR TITLE
Revert "Fix ObjectSpace._id2ref returning wrong object for generic-field types"

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -2043,43 +2043,19 @@ obj_free_object_id(VALUE obj)
             break;
           }
           default:
-          {
-            // Generic-field types (String, Array, Hash, etc.) store their
-            // object_id in a companion T_IMEMO/fields. Read the id from
-            // the companion so we can eagerly delete the id2ref_tbl entry
-            // during the owner's sweep, rather than deferring it until the
-            // companion's sweep (which may be much later). [Bug #22200]
-            shape_id_t shape_id = RBASIC_SHAPE_ID(obj);
-            if (!rb_shape_has_object_id(shape_id)) {
-                return;
-            }
-
-            VALUE fields_obj = rb_obj_fields_no_ractor_check(obj);
-            if (fields_obj) {
-                // The companion imemo may already have been swept (on a
-                // different page), in which case its flags are zero and
-                // IMEMO_TYPE_P returns false — the T_IMEMO case above
-                // already handled the deletion.
-                asan_unpoisoning_object(fields_obj) {
-                    if (IMEMO_TYPE_P(fields_obj, imemo_fields) &&
-                        rb_shape_has_object_id(RBASIC_SHAPE_ID(fields_obj))) {
-                        obj_id = object_id_get(fields_obj, RBASIC_SHAPE_ID(fields_obj));
-                        // Clear the imemo so that when it is swept later,
-                        // obj_free_object_id won't try to delete the same
-                        // id2ref_tbl entry a second time.
-                        rb_imemo_fields_clear(fields_obj);
-                    }
-                }
-            }
-            break;
-          }
+            // For generic_fields, the T_IMEMO/fields is responsible for freeing the id.
+            return;
         }
 
         if (RB_UNLIKELY(obj_id)) {
             RUBY_ASSERT(FIXNUM_P(obj_id) || RB_TYPE_P(obj_id, T_BIGNUM));
 
             if (!st_delete(id2ref_tbl, (st_data_t *)&obj_id, NULL)) {
-                rb_bug("Object ID seen, but not in _id2ref table: object_id=%llu object=%s", NUM2ULL(obj_id), rb_obj_info(obj));
+                // The the object is a T_IMEMO/fields, then it's possible the actual object
+                // has been garbage collected already.
+                if (!RB_TYPE_P(obj, T_IMEMO)) {
+                    rb_bug("Object ID seen, but not in _id2ref table: object_id=%llu object=%s", NUM2ULL(obj_id), rb_obj_info(obj));
+                }
             }
         }
     }

--- a/test/ruby/test_objectspace.rb
+++ b/test/ruby/test_objectspace.rb
@@ -56,7 +56,7 @@ End
   end
 
   def test_id2ref_geniv_liveness
-    assert_in_out_err(["-e", <<~'RUBY'], "", %w(:ok), [])
+    assert_in_out_err(["-W0", "-e", <<~'RUBY'], "", %w(:ok), [])
       ObjectSpace._id2ref(Object.new.object_id)
 
       strings1 = 10_000.times.map { String.new(capacity: 80) }

--- a/test/ruby/test_objectspace.rb
+++ b/test/ruby/test_objectspace.rb
@@ -55,6 +55,29 @@ End
     EOS
   end
 
+  def test_id2ref_geniv_liveness
+    assert_in_out_err(["-e", <<~'RUBY'], "", %w(:ok), [])
+      ObjectSpace._id2ref(Object.new.object_id)
+
+      strings1 = 10_000.times.map { String.new(capacity: 80) }
+      strings2 = 10_000.times.map { String.new(capacity: 80) }
+
+      object_ids1 = strings1.map(&:object_id)
+      strings1.clear
+      GC.start(immediate_sweep: false)
+
+      object_ids2 = strings2.map(&:object_id)
+
+      GC.start # finish previous sweep
+
+      strings2_round_trip = object_ids2.map { |id| ObjectSpace._id2ref(id) }
+      strings2.zip(strings2_round_trip).each do |str1, str2|
+        raise unless str1.equal?(str2)
+      end
+      p :ok
+    RUBY
+  end
+
   def test_id2ref_invalid_argument
     msg = /no implicit conversion/
     assert_raise_with_message(TypeError, msg) { EnvUtil.suppress_warning { ObjectSpace._id2ref(nil) } }

--- a/test/ruby/test_objectspace.rb
+++ b/test/ruby/test_objectspace.rb
@@ -55,33 +55,6 @@ End
     EOS
   end
 
-  def test_id2ref_no_wrong_object_for_generic_fields # [Bug #22200]
-    assert_separately([], <<-'End')
-      Warning[:deprecated] = false
-
-      # Ensure the id2ref table exists
-      anchor = Object.new
-      ObjectSpace._id2ref(anchor.object_id)
-
-      ids = Array.new(10_000) { |i| +"str-#{i}" }.map(&:object_id)
-      GC.start(full_mark: true, immediate_sweep: false)
-
-      recyclers = []
-      5.times do
-        recyclers.concat(Array.new(1_000) { +"recycler" })
-        ids.each do |id|
-          begin
-            obj = ObjectSpace._id2ref(id)
-            assert_equal(id, obj.object_id,
-              "_id2ref returned wrong object")
-          rescue RangeError
-            # expected for recycled objects
-          end
-        end
-      end
-    End
-  end
-
   def test_id2ref_invalid_argument
     msg = /no implicit conversion/
     assert_raise_with_message(TypeError, msg) { EnvUtil.suppress_warning { ObjectSpace._id2ref(nil) } }


### PR DESCRIPTION
Reverts ruby/ruby#18209

Per Luke's comment in https://github.com/ruby/ruby/pull/18209#issuecomment-5206777937, this tries to look at an imemo_fields object which may have already been recycled and replaced with a new unrelated imemo_fields object.

As a rule, we should not include anything in `obj_free_object_id` or any other part of the sweep step that attempts to look at other objects.

On my machine this crashes the GC with the following scripts (which doesn't even include invalid calls to id2ref w/ a dead object_id)

```ruby
ObjectSpace._id2ref(Object.new.object_id)

strings1 = 10_000.times.map { String.new(capacity: 120) }
strings1.each{|x| x.instance_variable_set(:@foo, :bad) }
strings2 = 10_000.times.map { String.new(capacity: 120) }

object_ids1 = strings1.map(&:object_id)
strings1.clear
GC.start(immediate_sweep: false)

object_ids2 = strings2.map(&:object_id)
strings2.each{|x| x.instance_variable_set(:@foo, :this_crashes_somehow) }
```

Here's a more reliable reproduction.

```ruby
ObjectSpace._id2ref(Object.new.object_id)

strings1 = 10_000.times.map { String.new(capacity: 80) }
strings2 = 10_000.times.map { String.new(capacity: 80) }

object_ids1 = strings1.map(&:object_id)
strings1.clear
GC.start(immediate_sweep: false)

object_ids2 = strings2.map(&:object_id)

GC.start # finish previous sweep, incorrectly removes some strings2 ids from the table

# Crashes with "recycled object" even though strings2 are all still live
strings2_round_trip = object_ids2.map { |id| ObjectSpace._id2ref(id) }

strings2.zip(strings2_round_trip).each do |str1, str2|
  raise unless str1.equal?(str2)
end
```

As I've argued in https://bugs.ruby-lang.org/issues/22200, we should not be fixing this. `_id2ref` has always been unsafe to call with arbitrary values, and IMO fixing it for datadog's known unsafe and invalid usage is an unnecessary risk.