### PR TITLE
Make Module#descendants follow the ancestors of the current box

### DIFF
--- a/class.c
+++ b/class.c
@@ -2142,6 +2142,17 @@ module_descendants_add(VALUE klass, struct descendants_traverse_data *data)
     rb_class_foreach_subclass(klass, module_descendants_recursive, (VALUE)data);
 }
 
+// an include done in another box is not in the ancestors here if the includer
+// has a classext per box, e.g. a module included into a builtin class
+static bool
+iclass_in_ancestors_p(VALUE iclass, VALUE includer)
+{
+    for (VALUE p = includer; p; p = RCLASS_SUPER(p)) {
+        if (p == iclass) return true;
+    }
+    return false;
+}
+
 static void
 module_descendants_recursive(VALUE entry, VALUE v)
 {
@@ -2159,6 +2170,7 @@ module_descendants_recursive(VALUE entry, VALUE v)
         if (!includer || UNDEF_P(includer)) return;
         if (rb_objspace_garbage_object_p(includer)) return;
         if (RCLASS_SINGLETON_P(includer)) return; // e.g. Object#extend
+        if (!iclass_in_ancestors_p(entry, includer)) return;
         module_descendants_add(includer, data);
     }
     else {

--- a/test/ruby/box/descendants.rb
+++ b/test/ruby/box/descendants.rb
@@ -1,0 +1,25 @@
+module DescendantsExt
+end
+
+class String
+  include DescendantsExt
+end
+
+class BoxedString < String
+end
+
+MainClass = Ruby::Box.main::TestBoxDescendantsMain
+
+class MainClass
+  include DescendantsExt
+end
+
+module Descendants
+  def self.ext_descendants
+    DescendantsExt.descendants
+  end
+
+  def self.string_descendants
+    String.descendants
+  end
+end

--- a/test/ruby/test_box.rb
+++ b/test/ruby/test_box.rb
@@ -352,6 +352,29 @@ class TestBox < Test::Unit::TestCase
 
     assert_equal "foo 1", @box::OpenClassWithInclude.refer_foo
   end
+
+  def test_descendants_follow_ancestors_of_the_current_box
+    setup_box
+
+    @box.require_relative('box/descendants')
+
+    assert_include @box::Descendants.ext_descendants, String
+    assert_include @box::Descendants.string_descendants, @box::BoxedString
+
+    # a builtin class has its own classext per box, so the include is invisible here
+    assert_not_include String.ancestors, @box::DescendantsExt
+    assert_not_include @box::DescendantsExt.descendants, String
+
+    # a class defined outside the box shares its classext, so the include is visible here
+    assert_include TestBoxDescendantsMain.ancestors, @box::DescendantsExt
+    assert_include @box::DescendantsExt.descendants, TestBoxDescendantsMain
+
+    assert_include @box::BoxedString.ancestors, String
+    assert_include String.descendants, @box::BoxedString
+  end
+end
+
+class TestBoxDescendantsMain
 end
 
 module ProcLookupTestA


### PR DESCRIPTION
The subclasses lists are kept only in the prime classext and thus shared by all boxes, so a module included into a builtin class in a box was reported as a descendant from other boxes, where the include is not in the ancestors of the class.

Check that the ICLASS is in the ancestors of its includer as seen from the current box.  An include into a class that has no classext per box, e.g. a class defined outside the box, stays visible because it is in the ancestors from any box.