### PR TITLE
Omit direct ISeq#to_binary tests when coverage is enabled

### DIFF
--- a/test/-ext-/eval/test_iseq_load.rb
+++ b/test/-ext-/eval/test_iseq_load.rb
@@ -4,7 +4,12 @@ require "-test-/eval"
 
 class IseqLoadTest < Test::Unit::TestCase
   def test_rb_iseq_load_from_binary
-    binary = RubyVM::InstructionSequence.compile('1 + 1').to_binary
+    binary = begin
+      RubyVM::InstructionSequence.compile('1 + 1').to_binary
+    rescue RuntimeError => e
+      omit e.message if /compile with coverage/ =~ e.message
+      raise
+    end
     assert_equal 2, rb_iseq_load_from_binary(binary).eval
   end
 end

--- a/test/ruby/test_iseq.rb
+++ b/test/ruby/test_iseq.rb
@@ -976,7 +976,7 @@ class TestISeq < Test::Unit::TestCase
       obj
     RUBY
 
-    binary = iseq.to_binary # [Bug # 21370]
+    binary = iseq_to_binary(iseq) # [Bug # 21370]
     roundtripped_iseq = RubyVM::InstructionSequence.load_from_binary(binary)
     object = roundtripped_iseq.eval
     assert_equal 1, object.test


### PR DESCRIPTION
The ruby/actions coverage workflow (`make -s check COVERAGE=true`) has been
failing on every scheduled run with:

    RuntimeError: should not compile with coverage

raised by two tests that call `RubyVM::InstructionSequence#to_binary`
directly (example run: https://github.com/ruby/actions/actions/runs/31150771393):

- `TestISeq#test_serialize_anonymous_outer_variables` (test/ruby/test_iseq.rb)
- `IseqLoadTest#test_rb_iseq_load_from_binary` (test/-ext-/eval/test_iseq_load.rb)

`#to_binary` intentionally refuses to serialize an iseq while coverage is
enabled. Sibling tests in test_iseq.rb already handle this via the
`iseq_to_binary` helper, which omits the test under coverage; these two
were the only remaining direct calls.

This change routes `test_serialize_anonymous_outer_variables` through the
existing helper and guards `test_rb_iseq_load_from_binary` with the same
rescue/omit idiom. Verified with `ruby -c` and `git apply --check` against
master (7e1a7201c4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
