### PR TITLE
ZJIT: Re-introduce allocation fast path

### DIFF
--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -502,6 +502,13 @@ typedef struct mark_stack {
 
 typedef int (*gc_compact_compare_func)(const void *l, const void *r, void *d);
 
+typedef struct rb_heap_newobj {
+    uintptr_t alloc_cursor;
+    uintptr_t alloc_cursor_end;
+    struct free_region *alloc_next_region;
+    struct heap_page *alloc_using_page;
+} rb_heap_newobj_t;
+
 typedef struct rb_heap_struct {
     short slot_size;
 
@@ -518,12 +525,7 @@ typedef struct rb_heap_struct {
     size_t empty_slots;
 
     /* Bump-pointer allocation state; only this objspace's owner thread writes it. */
-    struct {
-        uintptr_t alloc_cursor;
-        uintptr_t alloc_cursor_end;
-        struct free_region *alloc_next_region;
-        struct heap_page *alloc_using_page;
-    } newobj;
+    rb_heap_newobj_t newobj;
 
     struct heap_page *free_pages;
     struct ccan_list_head pages;
@@ -2981,10 +2983,40 @@ bool
 rb_gc_impl_zjit_new_obj_fastpath(void *objspace_ptr, size_t alloc_size, VALUE flags, VALUE klass,
                                  struct rb_gc_zjit_fastpath *fastpath)
 {
-    /* Bump-pointer allocation state lives in the per-objspace heaps, but ZJIT's inline
-     * fastpath assumes a separate cache structure; report "no fastpath" (as gc/wbcheck
-     * does).  The heaps are single-writer, so one could be offered later. */
+#if USE_ZJIT
+    size_t heap_idx = 0;
+    size_t slot_size = 0;
+    for (; heap_idx < HEAP_COUNT; heap_idx++) {
+        if (alloc_size + RVALUE_OVERHEAD <= pool_slot_sizes[heap_idx]) {
+            slot_size = pool_slot_sizes[heap_idx];
+            break;
+        }
+    }
+    if (slot_size == 0) return false;
+
+#undef heaps
+    size_t base = offsetof(rb_objspace_t, heaps)
+                  + heap_idx * sizeof(rb_heap_t)
+                  + offsetof(rb_heap_t, newobj);
+#define heaps objspace->heaps
+
+    struct rb_gc_zjit_default_new_obj_fastpath default_fastpath = {
+        base + offsetof(rb_heap_newobj_t, alloc_cursor),
+        base + offsetof(rb_heap_newobj_t, alloc_cursor_end),
+        slot_size,
+        base - offsetof(rb_heap_t, newobj) + offsetof(rb_heap_t, total_allocated_objects),
+        flags,
+        klass
+    };
+
+    memset(fastpath, 0, sizeof(*fastpath));
+    fastpath->kind = RB_GC_ZJIT_FASTPATH_DEFAULT;
+    memcpy(fastpath->data.words, &default_fastpath, sizeof(default_fastpath));
+
+    return true;
+#else
     return false;
+#endif
 }
 
 NOINLINE(static VALUE newobj_refill(rb_objspace_t *objspace, size_t heap_idx));
@@ -3070,6 +3102,11 @@ newobj_slowpath(VALUE klass, VALUE flags, rb_objspace_t *objspace, int wb_protec
 
     obj = newobj_alloc(objspace, heap_idx);
     newobj_init(klass, flags, wb_protected, objspace, obj);
+
+    if (RB_UNLIKELY(ruby_gc_stressful)) {
+        rb_heap_t *heap = &heaps[heap_idx];
+        heap->newobj.alloc_cursor_end = heap->newobj.alloc_cursor;
+    }
 
     return obj;
 }

--- a/gc/default/zjit_fastpath.h
+++ b/gc/default/zjit_fastpath.h
@@ -11,6 +11,7 @@ struct rb_gc_zjit_default_new_obj_fastpath {
     size_t cursor_offset;
     size_t cursor_end_offset;
     size_t slot_size;
+    size_t total_allocated_objects_offset;
     VALUE flags;
     VALUE klass;
 };

--- a/gc/gc.h
+++ b/gc/gc.h
@@ -123,10 +123,10 @@ MODULAR_GC_FN void rb_gc_rp(VALUE);
 MODULAR_GC_FN void rb_gc_handle_weak_references(VALUE obj);
 MODULAR_GC_FN bool rb_gc_obj_needs_cleanup_p(VALUE obj);
 
+void rb_gc_initialize_vm_context(struct rb_gc_vm_context *context);
 #if USE_MODULAR_GC
 MODULAR_GC_FN bool rb_gc_event_hook_required_p(rb_event_flag_t event);
 MODULAR_GC_FN void *rb_gc_get_ractor_newobj_cache(void);
-MODULAR_GC_FN void rb_gc_initialize_vm_context(struct rb_gc_vm_context *context);
 MODULAR_GC_FN void rb_gc_move_obj_during_marking(VALUE from, VALUE to);
 MODULAR_GC_FN void rb_gc_print_backtrace();
 #endif

--- a/zjit.c
+++ b/zjit.c
@@ -168,10 +168,20 @@ rb_zjit_singleton_class_p(VALUE klass)
     return RCLASS_SINGLETON_P(klass);
 }
 
+/*
+ * These offsets differ between x68_64 and arm64, so we must generate them each
+ * time. We can't bake them into zjit_struct_offsets
+ */
 size_t
 rb_zjit_offset_ractor_newobj_cache(void)
 {
     return offsetof(rb_ractor_t, newobj_cache);
+}
+
+size_t
+rb_zjit_offset_ractor_objspace(void)
+{
+    return offsetof(rb_ractor_t, objspace);
 }
 
 VALUE

--- a/zjit/src/codegen/gc_fastpath.rs
+++ b/zjit/src/codegen/gc_fastpath.rs
@@ -5,6 +5,7 @@ use crate::cruby::{
     RB_GC_ZJIT_FASTPATH_DEFAULT, RB_GC_ZJIT_FASTPATH_MMTK,
     RUBY_OFFSET_EC_THREAD_PTR, RUBY_OFFSET_RBASIC_FLAGS, RUBY_OFFSET_RBASIC_KLASS,
     RUBY_OFFSET_THREAD_RACTOR, VALUE, VALUE_BITS, rb_zjit_offset_ractor_newobj_cache,
+    rb_zjit_offset_ractor_objspace,
 };
 use super::JITState;
 
@@ -14,6 +15,7 @@ struct RbGcZjitDefaultNewObjFastpath {
     cursor_offset: usize,
     cursor_end_offset: usize,
     slot_size: usize,
+    total_allocated_objects_offset: usize,
     flags: VALUE,
     klass: VALUE,
 }
@@ -178,13 +180,14 @@ fn emit_default_new_obj_fastpath(
     let cursor_offset: i32 = fastpath.cursor_offset.try_into().ok()?;
     let cursor_end_offset: i32 = fastpath.cursor_end_offset.try_into().ok()?;
     let slot_size: u64 = fastpath.slot_size.try_into().ok()?;
+    let total_allocated_objects_offset: i32 = fastpath.total_allocated_objects_offset.try_into().ok()?;
 
     let thread = asm.load(Opnd::mem(64, EC, RUBY_OFFSET_EC_THREAD_PTR as i32));
     let ractor = asm.load(Opnd::mem(64, thread, RUBY_OFFSET_THREAD_RACTOR as i32));
-    let ractor_newobj_cache_offset: i32 = unsafe { rb_zjit_offset_ractor_newobj_cache() }
+    let ractor_objspace_offset: i32 = unsafe { rb_zjit_offset_ractor_objspace() }
         .try_into()
-        .expect("ractor newobj cache offset fits in i32");
-    let gc_cache = asm.load(Opnd::mem(64, ractor, ractor_newobj_cache_offset));
+        .expect("ractor objspace offset fits in i32");
+    let gc_cache = asm.load(Opnd::mem(64, ractor, ractor_objspace_offset));
 
     let cursor = asm.load(Opnd::mem(64, gc_cache, cursor_offset));
     let cursor_end = asm.load(Opnd::mem(64, gc_cache, cursor_end_offset));
@@ -194,6 +197,9 @@ fn emit_default_new_obj_fastpath(
     asm.jl(jit, miss.clone());
 
     asm.store(Opnd::mem(64, gc_cache, cursor_offset), new_cursor);
+    let total_allocated = asm.load(Opnd::mem(64, gc_cache, total_allocated_objects_offset));
+    let new_total = asm.add(total_allocated, Opnd::UImm(1));
+    asm.store(Opnd::mem(64, gc_cache, total_allocated_objects_offset), new_total);
     asm.store(
         Opnd::mem(VALUE_BITS, cursor, RUBY_OFFSET_RBASIC_FLAGS),
         fastpath.flags.as_u64().into(),

--- a/zjit/src/cruby.rs
+++ b/zjit/src/cruby.rs
@@ -123,6 +123,7 @@ unsafe extern "C" {
     ) -> *const rb_callable_method_entry_t;
 
     pub fn rb_zjit_offset_ractor_newobj_cache() -> usize;
+    pub fn rb_zjit_offset_ractor_objspace() -> usize;
 
     // Floats within range will be encoded without creating objects in the heap.
     // (Range is 0x3000000000000001 to 0x4fffffffffffffff (1.7272337110188893E-77 to 2.3158417847463237E+77).

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -2027,6 +2027,7 @@ pub struct rb_gc_zjit_default_new_obj_fastpath {
     pub cursor_offset: usize,
     pub cursor_end_offset: usize,
     pub slot_size: usize,
+    pub total_allocated_objects_offset: usize,
     pub flags: VALUE,
     pub klass: VALUE,
 }


### PR DESCRIPTION
Re-enable rb_gc_impl_zjit_new_obj_fastpath, was stubbed to "return false" by the recent rlgc merge.  The bump-pointer state moved out of the deleted rb_ractor_newobj_cache_t into the per-objspace rb_heap_t.newobj, so the fastpath and the JIT codegen now index that struct and reach it through ractor->objspace instead of ractor->newobj_cache.