### PR TITLE
GC: remember an old parent once while marking its children

### DIFF
--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -5387,6 +5387,9 @@ rgengc_check_relation(rb_objspace_t *objspace, VALUE obj)
     if (objspace->rgengc.parent_object_old_p) {
         if (RVALUE_WB_UNPROTECTED(objspace, obj) || !RVALUE_OLD_P(objspace, obj)) {
             rgengc_remember(objspace, objspace->rgengc.parent_object);
+            /* It is in the rememberset now, so its remaining children have nothing left
+             * to ask for: stop testing them. */
+            objspace->rgengc.parent_object_old_p = false;
         }
     }
 }


### PR DESCRIPTION
rgengc_check_relation asks rgengc_remember to remember the parent for every child that is young or write-barrier unprotected.  Remembering is idempotent -- it sets a bit and a page flag -- so an old array of freshly allocated elements pays a page lookup, a bitmap test and a store per element to reach a state the first element already reached.

Clear parent_object_old_p once the parent is remembered.  The flag is read only here and written only when a walk of one object's children starts and ends, so dropping it mid-walk skips the two bitmap reads for the remaining children and nothing else.

Twenty minor collections over a 200k-element old array refilled with young arrays: 4.14G -> 4.02G instructions.