### PR TITLE
VM: keep vm_sendish inlined into the interpreter loop

### DIFF
--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -6141,6 +6141,10 @@ enum method_explorer_type {
     mexp_search_super,
 };
 
+ALWAYS_INLINE(static VALUE vm_sendish(struct rb_execution_context_struct *ec,
+                                      struct rb_control_frame_struct *reg_cfp,
+                                      struct rb_call_data *cd, VALUE block_handler,
+                                      enum method_explorer_type method_explorer));
 static inline VALUE
 vm_sendish(
     struct rb_execution_context_struct *ec,


### PR DESCRIPTION
gcc used to inline four vm_sendish calls into vm_exec_core; it now inlines three.  The fourth was a constprop clone -- the one specialised for the call site whose block handler is a constant -- and at +70 size units it cost two to three times what the others did, which made it the first thing to go once the inliner ran out of budget.

Nothing about the call sites changed.  vm.c pulls in vm.inc and vm_insnhelper.c, so it is one enormous translation unit, and gcc's growth budget is spent per unit: any line added anywhere in it can push out a marginal decision elsewhere.  That is what happened, and it costs about twenty instructions on every ordinary method call.

Pin it with ALWAYS_INLINE, as vm_getivar and friends already are. vm_exec_core grows from 5373 to 5668 instructions and .text by 0.7%.

    fib(32)             2.169G -> 2.000G instructions
    binary trees (D16)  34.42G -> 33.00G
    so_binary_trees     51.00G -> 49.00G

Allocation and GC-bound benchmarks are unchanged.