### PR TITLE
ZJIT: Don't side-exit on throw insn

### DIFF
--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1685,7 +1685,7 @@ vm_throw_start(const rb_execution_context_t *ec, rb_control_frame_t *const reg_c
     else if (state == TAG_BREAK) {
         int is_orphan = 1;
         const VALUE *ep = GET_EP();
-        const rb_iseq_t *base_iseq = GET_ISEQ();
+        const rb_iseq_t *base_iseq = CFP_ISEQ(reg_cfp);
         escape_cfp = reg_cfp;
 
         while (ISEQ_BODY(base_iseq)->type != ISEQ_TYPE_BLOCK) {

--- a/zjit.c
+++ b/zjit.c
@@ -17,6 +17,7 @@
 #include "insns_info.inc"
 #include "zjit.h"
 #include "vm_insnhelper.h"
+#include "eval_intern.h"
 #include "probes.h"
 #include "probes_helper.h"
 #include "constant.h"
@@ -43,6 +44,18 @@ const zjit_jit_frame_t rb_zjit_c_frame = (zjit_jit_frame_t) {
     .iseq = 0,
     .materialize_block_code = false,
 };
+
+extern VALUE rb_vm_throw(const rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, rb_num_t throw_state, VALUE throwobj);
+
+NORETURN(void rb_zjit_throw(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, rb_num_t throw_state, VALUE throwobj));
+void
+rb_zjit_throw(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, rb_num_t throw_state, VALUE throwobj)
+{
+    rb_zjit_materialize_frames_for_longjmp(ec, ec->cfp);
+    VALUE throw_data = rb_vm_throw(ec, reg_cfp, throw_state, throwobj);
+    ec->errinfo = throw_data;
+    EC_JUMP_TAG(ec, ec->tag->state);
+}
 
 void rb_zjit_profile_disable(const rb_iseq_t *iseq);
 int rb_zjit_insn_to_bare_insn(int insn);

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -787,7 +787,7 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
         &Insn::IsA { val, class } => gen_is_a(jit, asm, opnd!(val), opnd!(class)),
         &Insn::ArrayMax { ref elements, state } => gen_array_max(jit, asm, function, opnds!(elements), &function.frame_state(state)),
         &Insn::ArrayMin { ref elements, state } => gen_array_min(jit, asm, function, opnds!(elements), &function.frame_state(state)),
-        &Insn::Throw { state, .. } => no_output!(gen_throw(jit, asm, function, &function.frame_state(state))),
+        &Insn::Throw { throw_state, val, state } => no_output!(gen_throw(jit, asm, function, throw_state, opnd!(val), &function.frame_state(state))),
         &Insn::CondBranch { .. }
         | &Insn::Jump { .. } | Insn::Entries { .. } => unreachable!(),
     };
@@ -2693,10 +2693,16 @@ fn gen_return(asm: &mut Assembler, val: lir::Opnd) {
     asm.cret(C_RET_OPND);
 }
 
-fn gen_throw(jit: &mut JITState, asm: &mut Assembler, function: &Function, state: &FrameState) {
-    // TODO: Consider calling rb_vm_throw and propagating ec->tag->state to the interpreter.
-    // Also consider making it a jump on method inlining.
-    gen_side_exit(jit, asm, function, &SideExitReason::Throw, None, state);
+/// Compile throw (non-local break/return)
+fn gen_throw(jit: &mut JITState, asm: &mut Assembler, function: &Function, throw_state: u32, throwobj: lir::Opnd, state: &FrameState) {
+    // TODO: Consider making it a jump on method inlining (under restrictions like no ensure)
+    gen_prepare_non_leaf_call(jit, asm, function, state);
+
+    unsafe extern "C" {
+        fn rb_zjit_throw(ec: EcPtr, reg_cfp: CfpPtr, throw_state: u64, throwobj: VALUE) -> !;
+    }
+    asm_ccall!(asm, rb_zjit_throw, EC, CFP, Opnd::UImm(throw_state as u64), throwobj);
+    asm.jmp(ZJITState::get_exit_trampoline().into()); // dead but gives block a valid terminator
 }
 
 /// Compile Fixnum + Fixnum
@@ -3206,28 +3212,6 @@ pub(crate) fn iseq_may_write_block_code(iseq: IseqPtr) -> bool {
                 return true;
             }
             _ => {}
-        }
-
-        insn_idx = insn_idx.saturating_add(unsafe { rb_insn_len(VALUE(opcode as usize)) }.try_into().unwrap());
-    }
-
-    false
-}
-
-/// True if the block ISEQ contains a `throw` opcode (break, non-local return). ZJIT can't
-/// compile `throw`, so inlining such a block's frame would side-exit + deopt on every call.
-/// These blocks fall back to `vm_yield`, which handles the non-local exit in C.
-/// (`next`/`redo` lower to `leave`/`jump`, not `throw`, so they stay inlinable.)
-pub(crate) fn block_iseq_may_throw(iseq: IseqPtr) -> bool {
-    let encoded_size = unsafe { rb_iseq_encoded_size(iseq) };
-    let mut insn_idx: u32 = 0;
-
-    while insn_idx < encoded_size {
-        let pc = unsafe { rb_iseq_pc_at_idx(iseq, insn_idx) };
-        let opcode = unsafe { rb_iseq_bare_opcode_at_pc(iseq, pc) } as u32;
-
-        if opcode == YARVINSN_throw {
-            return true;
         }
 
         insn_idx = insn_idx.saturating_add(unsafe { rb_insn_len(VALUE(opcode as usize)) }.try_into().unwrap());

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -2893,11 +2893,10 @@ fn block_call_inlinable(flags: u32) -> bool {
     (flags & (VM_CALL_ARGS_SPLAT | VM_CALL_KW_SPLAT | VM_CALL_KWARG | VM_CALL_ARGS_BLOCKARG)) == 0
 }
 
-/// Ok if `yield` with `argc` positional args can dispatch by inlining the block ISEQ
-/// frame. The block must take the simple callee-setup path (`rb_simple_iseq_p`)
-/// with an exact arity match, avoid arg0 auto-splat, and contain no `throw` (break /
-/// non-local return). Anything else falls back to the generic `invokeblock` dispatch,
-/// with the returned reason attached to the fallback instruction.
+/// Ok if `yield` with `argc` positional args can dispatch by inlining the block ISEQ frame.
+/// The block must take the simple callee-setup path (`rb_simple_iseq_p`) with an exact arity
+/// match and avoid arg0 auto-splat. Anything else falls back to the generic `invokeblock`
+/// dispatch, with the returned reason attached to the fallback instruction.
 fn block_call_inlinable_iseq(iseq: IseqPtr, argc: usize) -> Result<(), SendFallbackReason> {
     if !unsafe { rb_simple_iseq_p(iseq) } {
         return Err(InvokeBlockNotSpecialized);
@@ -2914,9 +2913,6 @@ fn block_call_inlinable_iseq(iseq: IseqPtr, argc: usize) -> Result<(), SendFallb
     // TODO: Support passing arguments on the stack in C calls
     if 1 + argc > C_ARG_OPNDS.len() {
         return Err(TooManyArgsForLir);
-    }
-    if crate::codegen::block_iseq_may_throw(iseq) {
-        return Err(InvokeBlockNotSpecialized);
     }
     Ok(())
 }


### PR DESCRIPTION
We now materialize the necessary frames and call vm_throw directly. This is a minor performance win, but we can now inline BlockIseqDirect blocks that use the `throw` instruction (break/return).