### PR TITLE
st.c: swap types of `entries_start` and `rebuilds_num`

### DIFF
--- a/include/ruby/st.h
+++ b/include/ruby/st.h
@@ -78,13 +78,16 @@ struct st_table_entry; /* defined in st.c */
 
 struct st_table {
     /* Cached features of the table -- see st.c for more details.  */
-    unsigned char entry_power, bin_power, size_ind, entries_start;
+    unsigned char entry_power, bin_power, size_ind;
     /* How many times the table was rebuilt.  */
-    unsigned int rebuilds_num;
+    unsigned char rebuilds_num;
+    /* Start index of entries in array entries. */
+    unsigned int entries_start;
+
     const struct st_hash_type *type;
     /* Number of entries currently in the table.  */
     st_index_t num_entries;
-    /* Start and bound index of entries in array entries.
+    /* bound index of entries in array entries.
        entries_starts and entries_bound are in interval
        [0,allocated_entries].  */
     st_index_t entries_bound;

--- a/internal/set_table.h
+++ b/internal/set_table.h
@@ -9,14 +9,17 @@ typedef struct set_table_entry set_table_entry;
 
 struct set_table {
     /* Cached features of the table -- see st.c for more details.  */
-    unsigned char entry_power, bin_power, size_ind, entries_start;
+    unsigned char entry_power, bin_power, size_ind;
     /* How many times the table was rebuilt.  */
-    unsigned int rebuilds_num;
+    unsigned char rebuilds_num;
+
+    /* Start index of entries in array entries. */
+    unsigned int entries_start;
     const struct st_hash_type *type;
     /* Number of entries currently in the table.  */
     st_index_t num_entries;
 
-    /* Start and bound index of entries in array entries.
+    /* bound index of entries in array entries.
        entries_starts and entries_bound are in interval
        [0,allocated_entries].  */
     st_index_t entries_bound;

--- a/st.c
+++ b/st.c
@@ -131,7 +131,7 @@
 #define ATTRIBUTE_UNUSED
 #endif
 
-#define MAX_ENTRIES_START ((unsigned char)-1)
+#define MAX_ENTRIES_START ((unsigned int)-1)
 
 /* The type of hashes.  */
 typedef st_index_t st_hash_t;
@@ -1387,10 +1387,7 @@ update_range_for_deleted(st_table *tab, st_index_t n)
         st_index_t bound = tab->entries_bound;
         st_table_entry *entries = tab->entries;
         while (start < bound && DELETED_ENTRY_P(&entries[start])) start++;
-        if (start > MAX_ENTRIES_START) {
-            start = MAX_ENTRIES_START;
-        }
-        tab->entries_start = start;
+        tab->entries_start = start > MAX_ENTRIES_START ? MAX_ENTRIES_START : (unsigned int)start;
     }
 }
 
@@ -3086,10 +3083,7 @@ set_update_range_for_deleted(set_table *tab, st_index_t n)
         st_index_t bound = tab->entries_bound;
         set_table_entry *entries = tab->entries;
         while (start < bound && DELETED_ENTRY_P(&entries[start])) start++;
-        if (start > MAX_ENTRIES_START) {
-            start = MAX_ENTRIES_START;
-        }
-        tab->entries_start = start;
+        tab->entries_start = start > MAX_ENTRIES_START ? MAX_ENTRIES_START : (unsigned int)start;
     }
 }
 


### PR DESCRIPTION
Followup: https://github.com/ruby/ruby/pull/18149

A char is more than large enough for counting rebuilds, and it's fine if it rolls over.
The table being rebuilt exactly 255 times between two check seems impossible.

On the other hand, if `Hash#shift` is abused, `entries_start` is more likely to reach MAX_UCHAR.

So swapping the two members is preferable.