### PR TITLE
Fix ObjectSpace.shareable_objects_from: don't return foreign unshareables

### DIFF
--- a/ext/objspace/objspace.c
+++ b/ext/objspace/objspace.c
@@ -19,6 +19,7 @@
 #include "internal/objspace.h"
 #include "internal/sanitizers.h"
 #include "ruby/io.h"
+#include "ruby/ractor.h"
 #include "ruby/re.h"
 #include "ruby/st.h"
 #include "symbol.h"
@@ -571,7 +572,7 @@ reachable_object_from_i(VALUE obj, void *data_ptr)
     VALUE key = obj;
     VALUE val = obj;
 
-    if (!rb_objspace_garbage_object_p(obj)) {
+    if ((!rb_objspace_foreign_object_p(obj) || RB_OBJ_SHAREABLE_P(obj)) && !rb_objspace_garbage_object_p(obj)) {
         if (NIL_P(rb_hash_lookup(data->refs, key))) {
             rb_hash_aset(data->refs, key, Qtrue);
 
@@ -679,7 +680,7 @@ reachable_object_from_root_i(const char *category, VALUE obj, void *ptr)
         rb_hash_aset(data->categories, category_str, category_objects);
     }
 
-    if (!rb_objspace_garbage_object_p(obj) &&
+    if ((!rb_objspace_foreign_object_p(obj) || RB_OBJ_SHAREABLE_P(obj)) && !rb_objspace_garbage_object_p(obj) &&
         obj != data->categories &&
         obj != data->last_category_objects) {
         if (rb_objspace_internal_object_p(obj)) {

--- a/gc.c
+++ b/gc.c
@@ -2218,6 +2218,12 @@ rb_objspace_garbage_object_p(VALUE obj)
     return !SPECIAL_CONST_P(obj) && rb_gc_impl_garbage_object_p(rb_gc_get_objspace(), obj);
 }
 
+int
+rb_objspace_foreign_object_p(VALUE obj)
+{
+    return !SPECIAL_CONST_P(obj) && rb_gc_obj_foreign_p(obj);
+}
+
 #define OBJ_ID_INCREMENT (RUBY_IMMEDIATE_MASK + 1)
 #define LAST_OBJECT_ID() (object_id_counter * OBJ_ID_INCREMENT)
 

--- a/internal/gc.h
+++ b/internal/gc.h
@@ -236,6 +236,7 @@ void rb_objspace_reachable_objects_from(VALUE obj, void (func)(VALUE, void *), v
 void rb_objspace_reachable_objects_from_root(void (func)(const char *category, VALUE, void *), void *data);
 int rb_objspace_internal_object_p(VALUE obj);
 int rb_objspace_garbage_object_p(VALUE obj);
+int rb_objspace_foreign_object_p(VALUE obj);
 void rb_gc_declare_weak_references(VALUE obj);
 bool rb_gc_handle_weak_references_alive_p(VALUE obj);
 

--- a/test/objspace/test_objspace.rb
+++ b/test/objspace/test_objspace.rb
@@ -173,6 +173,34 @@ class TestObjSpace < Test::Unit::TestCase
     end;
   end
 
+  def test_reachable_objects_from_doesnt_break_ractor_containment
+    assert_ractor("#{<<-"begin;"}#{<<-'end;'}")
+    begin;
+      require "objspace"
+      port = Ractor::Port.new
+      ch = Ractor.new(port) do |port|
+        o = Object.new
+        def o.inspect = "unshareable!"
+        sc = o.singleton_class
+        port << [sc] # TODO: singleton classes of unshareables should not be shareable
+        Ractor.receive # wait
+      end
+
+      sc_ary = port.receive
+
+      found = false
+      ObjectSpace.reachable_objects_from(sc_ary).each do |obj|
+        if obj.inspect == "unshareable!"
+          found = true
+        end
+      end
+
+      ch.send(:go)
+      ch.join
+      refute found, "ObjectSpace.reachable_objects_from breaks ractor containment"
+    end;
+  end
+
   def test_trace_object_allocations_stop_first
     assert_ruby_status([], "#{<<~"begin;"}\n#{<<~'end;'}")
     begin;


### PR DESCRIPTION
After the rlgc merge, this method and also ObjectSpace.shareable_objects_from_roots could return foreign unshareables which violates Ractor containment.