### PR TITLE
Recurse into MatchData children in move preflight

### DIFF
--- a/ractor.c
+++ b/ractor.c
@@ -2726,8 +2726,12 @@ move_preflight(VALUE obj, st_table *seen)
       case T_STRING:
       case T_OBJECT:
         break;                       /* children are ivars only (below) */
-      case T_MATCH:
-        break;                       /* child = Regexp (shareable) + String */
+      case T_MATCH: {
+        struct RMatch *rm = RMATCH(obj);
+        move_preflight(rm->regexp, seen);
+        move_preflight(rm->str, seen);
+        break;
+      }
       case T_ARRAY:
         for (long i = 0; i < RARRAY_LEN(obj); i++) {
             move_preflight(RARRAY_AREF(obj, i), seen);

--- a/ractor.c
+++ b/ractor.c
@@ -2724,8 +2724,12 @@ move_preflight(VALUE obj, st_table *seen)
       case T_STRING:
       case T_OBJECT:
         break;                       /* children are ivars only (below) */
-      case T_MATCH:
-        break;                       /* child = Regexp (shareable) + String */
+      case T_MATCH: {
+        struct RMatch *rm = RMATCH(obj);
+        move_preflight(rm->regexp, seen);
+        move_preflight(rm->str, seen);
+        break;
+      }
       case T_ARRAY:
         for (long i = 0; i < RARRAY_LEN(obj); i++) {
             move_preflight(RARRAY_AREF(obj, i), seen);

--- a/test/ruby/test_ractor.rb
+++ b/test/ruby/test_ractor.rb
@@ -619,7 +619,8 @@ class TestRactor < Test::Unit::TestCase
       sibling = +"hello"
       m = "foo".match(Class.new(Regexp).new("o"))
       r = Ractor.new { Ractor.receive }
-      r.send([sibling, m], move: true) rescue Ractor::Error # expected: the Regexp subclass is unshareable
+      refute Ractor.shareable?(m.regexp), "the Regexp subclass must be unshareable for this test"
+      r.send([sibling, m], move: true) rescue Ractor::Error # the Regexp subclass is unshareable
       assert_equal "hello", sibling
     RUBY
   end

--- a/test/ruby/test_ractor.rb
+++ b/test/ruby/test_ractor.rb
@@ -614,6 +614,16 @@ class TestRactor < Test::Unit::TestCase
     RUBY
   end
 
+  def test_move_preflight_matchdata_leaves_graph_intact
+    assert_ractor(<<~'RUBY', timeout: 60)
+      sibling = +"hello"
+      m = "foo".match(Class.new(Regexp).new("o"))
+      r = Ractor.new { Ractor.receive }
+      r.send([sibling, m], move: true) rescue Ractor::Error # expected: the Regexp subclass is unshareable
+      assert_equal "hello", sibling
+    RUBY
+  end
+
   def test_bignum_to_s
     assert_ractor(<<~'RUBY')
       8.times.map do


### PR DESCRIPTION
move_preflight did not recurse into the regexp and the matched string of a MatchData. A Regexp subclass is not shareable, so it passed preflight. move_capture then mutated earlier sources in the graph before the raise. This left the sources destroyed.

Recurse into rm->regexp and rm->str in preflight. This mirrors move_capture. The raise now happens before any mutation.