### PR TITLE
ZJIT: Deduplicate ivar branches

### DIFF
--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5538,19 +5538,29 @@ impl Function {
         self.push_insn(block, Insn::GuardType { val: recv, guard_type: types::HeapBasicObject, state, recompile: None })
     }
 
+    /// Describe the code `load_ivar` will emit for `shape`: `None` when the ivar is undefined
+    /// for the shape (a constant nil), otherwise the ivar index and layout that together
+    /// determine the access path and field offset. Shapes with equal outcomes generate
+    /// identical code.
+    fn load_ivar_outcome(shape: ShapeId, id: ID) -> Option<(attr_index_t, ShapeLayout)> {
+        let mut ivar_index: attr_index_t = 0;
+        if unsafe { rb_shape_get_iv_index(shape.0, id, &mut ivar_index) } {
+            Some((ivar_index, shape.layout()))
+        } else {
+            None
+        }
+    }
+
     fn load_ivar(&mut self, block: BlockId, self_val: InsnId, recv_type: ProfiledType, id: ID) -> InsnId {
         // Too-complex shapes use hash tables; rb_shape_get_iv_index doesn't support them.
         // Callers must filter these out before calling load_ivar.
         assert!(!recv_type.shape().is_complex(), "load_ivar called with too-complex shape");
-        let mut ivar_index: attr_index_t = 0;
-        if ! unsafe { rb_shape_get_iv_index(recv_type.shape().0, id, &mut ivar_index) } {
+        let Some((ivar_index, layout)) = Self::load_ivar_outcome(recv_type.shape(), id) else {
             // If there is no IVAR index, then the ivar was undefined when we
             // entered the compiler.  That means we can just return nil for this
             // shape + iv name
             return self.push_insn(block, Insn::Const { val: Const::Value(Qnil) });
-        }
-
-        let layout = recv_type.shape().layout();
+        };
 
         match layout {
             ShapeLayout::RClass | ShapeLayout::Extended => {
@@ -7260,7 +7270,10 @@ impl Function {
 
     /// Dispatch an ivar access to profiled shapes. Callbacks generate the optimized access and
     /// generic fallback, optionally returning a value to pass through the join block.
-    fn dispatch_ivar<T: Copy>(
+    ///
+    /// Profiles whose optimized code would be identical (equal `outcome_key`, e.g. two shapes
+    /// that store the ivar at the same offset) share a single optimized block.
+    fn dispatch_ivar<T: Copy, K: PartialEq>(
         &mut self,
         profiles: &[T],
         mut block: BlockId,
@@ -7271,6 +7284,7 @@ impl Function {
         fallback_counter: Counter,
         has_result: bool,
         profile_shape: impl Fn(T) -> ShapeId,
+        outcome_key: impl Fn(T) -> K,
         mut emit_optimized: impl FnMut(&mut Function, BlockId, T) -> Option<InsnId>,
         mut emit_fallback: impl FnMut(&mut Function, BlockId) -> Option<InsnId>,
     ) -> Option<(BlockId, Option<InsnId>)> {
@@ -7306,8 +7320,11 @@ impl Function {
         let last_shape_index = profiles.len() - 1;
         let join_block = self.new_block(insn_idx);
         let result = has_result.then(|| self.push_insn(join_block, Insn::Param));
+        let mut optimized_blocks: Vec<(K, BlockId)> = Vec::with_capacity(profiles.len());
         for (i, &profile) in profiles.iter().enumerate() {
-            let optimized_block = self.new_block(insn_idx);
+            let key = outcome_key(profile);
+            let existing = optimized_blocks.iter().find(|(k, _)| *k == key).map(|&(_, block)| block);
+            let optimized_block = existing.unwrap_or_else(|| self.new_block(insn_idx));
             if i == last_shape_index {
                 if self.policy.no_side_exits {
                     // If the policy doesn't allow exits, make a fallback block and jump to it if the shape doesn't match.
@@ -7332,8 +7349,11 @@ impl Function {
                 self.push_insn(block, branch(matches, optimized_block, next_block));
                 block = next_block;
             }
-            let optimized_result = emit_optimized(self, optimized_block, profile);
-            self.push_insn(optimized_block, Insn::Jump(result_edge(join_block, optimized_result)));
+            if existing.is_none() {
+                let optimized_result = emit_optimized(self, optimized_block, profile);
+                self.push_insn(optimized_block, Insn::Jump(result_edge(join_block, optimized_result)));
+                optimized_blocks.push((key, optimized_block));
+            }
         }
         Some((join_block, result))
     }
@@ -7360,6 +7380,7 @@ impl Function {
             Counter::getivar_fallback_no_side_exits,
             true,
             |profiled_type| profiled_type.shape(),
+            |profiled_type| Self::load_ivar_outcome(profiled_type.shape(), id),
             |fun, block, profiled_type| Some(fun.load_ivar(block, self_param, profiled_type, id)),
             |fun, block| Some(fun.push_insn(block, Insn::GetIvar { self_val: self_param, id, ic, state: exit_id })),
         )?;
@@ -7397,6 +7418,13 @@ impl Function {
             Counter::setivar_fallback_no_side_exits,
             false,
             |spec| spec.profiled_type.shape(),
+            // The emitted code is determined by the field offset, the storage layout, and the
+            // shape transition (if any); see emit_optimized_setivar.
+            |spec| (
+                spec.ivar_index,
+                spec.profiled_type.shape().layout(),
+                (spec.next_shape != spec.profiled_type.shape()).then_some(spec.next_shape),
+            ),
             |fun, block, spec| {
                 fun.emit_optimized_setivar(block, self_param, id, val, spec);
                 None

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5538,11 +5538,11 @@ impl Function {
         self.push_insn(block, Insn::GuardType { val: recv, guard_type: types::HeapBasicObject, state, recompile: None })
     }
 
-    /// Describe the code `load_ivar` will emit for `shape`: `None` when the ivar is undefined
-    /// for the shape (a constant nil), otherwise the ivar index and layout that together
-    /// determine the access path and field offset. Shapes with equal outcomes generate
-    /// identical code.
-    fn load_ivar_outcome(shape: ShapeId, id: ID) -> Option<(attr_index_t, ShapeLayout)> {
+    /// Describe where `shape` stores the ivar `id`: `None` when the ivar is undefined for the
+    /// shape (`load_ivar` emits a constant nil), otherwise the ivar index and layout that
+    /// together determine the access path and field offset. Shapes with equal storage keys
+    /// generate identical code in `load_ivar`.
+    fn ivar_storage_key(shape: ShapeId, id: ID) -> Option<(attr_index_t, ShapeLayout)> {
         let mut ivar_index: attr_index_t = 0;
         if unsafe { rb_shape_get_iv_index(shape.0, id, &mut ivar_index) } {
             Some((ivar_index, shape.layout()))
@@ -5555,7 +5555,7 @@ impl Function {
         // Too-complex shapes use hash tables; rb_shape_get_iv_index doesn't support them.
         // Callers must filter these out before calling load_ivar.
         assert!(!recv_type.shape().is_complex(), "load_ivar called with too-complex shape");
-        let Some((ivar_index, layout)) = Self::load_ivar_outcome(recv_type.shape(), id) else {
+        let Some((ivar_index, layout)) = Self::ivar_storage_key(recv_type.shape(), id) else {
             // If there is no IVAR index, then the ivar was undefined when we
             // entered the compiler.  That means we can just return nil for this
             // shape + iv name
@@ -7271,7 +7271,7 @@ impl Function {
     /// Dispatch an ivar access to profiled shapes. Callbacks generate the optimized access and
     /// generic fallback, optionally returning a value to pass through the join block.
     ///
-    /// Profiles whose optimized code would be identical (equal `outcome_key`, e.g. two shapes
+    /// Profiles whose optimized code would be identical (equal `storage_key`, e.g. two shapes
     /// that store the ivar at the same offset) share a single optimized block.
     fn dispatch_ivar<T: Copy, K: PartialEq>(
         &mut self,
@@ -7284,7 +7284,7 @@ impl Function {
         fallback_counter: Counter,
         has_result: bool,
         profile_shape: impl Fn(T) -> ShapeId,
-        outcome_key: impl Fn(T) -> K,
+        storage_key: impl Fn(T) -> K,
         mut emit_optimized: impl FnMut(&mut Function, BlockId, T) -> Option<InsnId>,
         mut emit_fallback: impl FnMut(&mut Function, BlockId) -> Option<InsnId>,
     ) -> Option<(BlockId, Option<InsnId>)> {
@@ -7322,7 +7322,7 @@ impl Function {
         let result = has_result.then(|| self.push_insn(join_block, Insn::Param));
         let mut optimized_blocks: Vec<(K, BlockId)> = Vec::with_capacity(profiles.len());
         for (i, &profile) in profiles.iter().enumerate() {
-            let key = outcome_key(profile);
+            let key = storage_key(profile);
             let existing = optimized_blocks.iter().find(|(k, _)| *k == key).map(|&(_, block)| block);
             let optimized_block = existing.unwrap_or_else(|| self.new_block(insn_idx));
             if i == last_shape_index {
@@ -7380,7 +7380,7 @@ impl Function {
             Counter::getivar_fallback_no_side_exits,
             true,
             |profiled_type| profiled_type.shape(),
-            |profiled_type| Self::load_ivar_outcome(profiled_type.shape(), id),
+            |profiled_type| Self::ivar_storage_key(profiled_type.shape(), id),
             |fun, block, profiled_type| Some(fun.load_ivar(block, self_param, profiled_type, id)),
             |fun, block| Some(fun.push_insn(block, Insn::GetIvar { self_val: self_param, id, ic, state: exit_id })),
         )?;

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -7450,6 +7450,53 @@ mod hir_opt_tests {
     }
 
     #[test]
+    fn test_specialize_polymorphic_setivar_same_offset() {
+        set_call_threshold(3);
+        // Both shapes already have @a at the same index with no shape transition, so the
+        // polymorphic dispatch should share a single optimized store block.
+        eval("
+            class C
+              def test = @a = 5
+            end
+            obj = C.new
+            obj.instance_variable_set(:@a, 1)
+            obj.test
+            obj = C.new
+            obj.instance_variable_set(:@a, 1)
+            obj.instance_variable_set(:@b, 1)
+            obj.test
+            TEST = C.instance_method(:test)
+        ");
+        assert_snapshot!(hir_string_proc("TEST"), @"
+        fn test@<compiled>:3:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          Jump bb3(v1)
+        bb2():
+          EntryPoint JIT(0)
+          v4:BasicObject = LoadArg :self@0
+          Jump bb3(v4)
+        bb3(v6:BasicObject):
+          v10:Fixnum[5] = Const Value(5)
+          PatchPoint SingleRactorMode
+          v14:HeapBasicObject = GuardType v6, HeapBasicObject
+          v15:CShape = LoadField v14, :shape_id@0x1000
+          v16:CShape[0x1001] = Const CShape(0x1001)
+          v17:CBool = IsBitEqual v15, v16
+          CondBranch v17, bb5(), bb6()
+        bb6():
+          v22:CShape[0x1002] = GuardBitEquals v15, CShape(0x1002) recompile
+          Jump bb5()
+        bb5():
+          StoreField v14, :@a@0x1003, v10
+          WriteBarrier v14, v10
+          CheckInterrupts
+          Return v10
+        ");
+    }
+
+    #[test]
     fn test_dont_specialize_complex_shape_setivar() {
         eval(r#"
             class C
@@ -10264,20 +10311,81 @@ mod hir_opt_tests {
           v14:CShape[0x1001] = Const CShape(0x1001)
           v15:CBool = IsBitEqual v12, v14
           CondBranch v15, bb5(), bb6()
-        bb5():
-          v17:BasicObject = LoadField v11, :@foo@0x1002
-          Jump bb4(v17)
         bb6():
-          v19:CShape[0x1003] = GuardBitEquals v12, CShape(0x1003) recompile
-          v21:BasicObject = LoadField v11, :@foo@0x1002
-          Jump bb4(v21)
-        bb4(v13:BasicObject):
-          v24:Fixnum[1] = Const Value(1)
+          v19:CShape[0x1002] = GuardBitEquals v12, CShape(0x1002) recompile
+          Jump bb5()
+        bb5():
+          v17:BasicObject = LoadField v11, :@foo@0x1003
+          v22:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Integer@0x1008, +@0x1010, cme:0x1018)
-          v35:Fixnum = GuardType v13, Fixnum recompile
-          v36:Fixnum = FixnumAdd v35, v24
+          v33:Fixnum = GuardType v17, Fixnum recompile
+          v34:Fixnum = FixnumAdd v33, v22
           CheckInterrupts
-          Return v36
+          Return v34
+        ");
+    }
+
+    #[test]
+    fn test_optimize_getivar_polymorphic_extended_same_index() {
+        set_call_threshold(3);
+        // Both shapes have extended (heap) fields with @foo at the same index, so the
+        // polymorphic dispatch should share a single optimized load block. The extended
+        // layout is part of the dedup key, so this must not merge with embedded loads.
+        // Allocate both objects before filling them so both start in a small slot,
+        // outgrow it, and spill their fields to the heap (extended layout); an object
+        // allocated after the class has seen large instances would get a large slot and
+        // stay embedded.
+        eval(r#"
+            class C
+              def variant_a
+                @foo = 1
+                100.times { |i| instance_variable_set(:"@a#{i}", i) }
+              end
+
+              def variant_b
+                @foo = 2
+                100.times { |i| instance_variable_set(:"@b#{i}", i) }
+              end
+
+              def foo = @foo + 1
+            end
+
+            O1 = C.new
+            O2 = C.new
+            O1.variant_a
+            O2.variant_b
+            O1.foo
+            O2.foo
+        "#);
+        assert_snapshot!(hir_string_proc("C.instance_method(:foo)"), @"
+        fn foo@<compiled>:13:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          Jump bb3(v1)
+        bb2():
+          EntryPoint JIT(0)
+          v4:BasicObject = LoadArg :self@0
+          Jump bb3(v4)
+        bb3(v6:BasicObject):
+          PatchPoint SingleRactorMode
+          v11:HeapBasicObject = GuardType v6, HeapBasicObject
+          v12:CShape = LoadField v11, :shape_id@0x1000
+          v14:CShape[0x1001] = Const CShape(0x1001)
+          v15:CBool = IsBitEqual v12, v14
+          CondBranch v15, bb5(), bb6()
+        bb6():
+          v20:CShape[0x1002] = GuardBitEquals v12, CShape(0x1002) recompile
+          Jump bb5()
+        bb5():
+          v17:IMemo = LoadField v11, :fields_obj@0x1003
+          v18:BasicObject = LoadField v17, :@foo@0x1003
+          v23:Fixnum[1] = Const Value(1)
+          PatchPoint MethodRedefined(Integer@0x1008, +@0x1010, cme:0x1018)
+          v34:Fixnum = GuardType v18, Fixnum recompile
+          v35:Fixnum = FixnumAdd v34, v23
+          CheckInterrupts
+          Return v35
         ");
     }
 


### PR DESCRIPTION
If we have two shapes S1 and S2 that both have `@a` at the same offset,
we can make polymorphic ivar lookups share code to read `@a`.
