### PR TITLE
ZJIT: Compute the String#<< encoding check in HIR

### DIFF
--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -639,7 +639,7 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
         Insn::StringConcat { strings, state } => gen_string_concat(jit, asm, function, opnds!(strings), &function.frame_state(*state)),
         &Insn::StringGetbyte { string, index } => gen_string_getbyte(asm, opnd!(string), opnd!(index)),
         Insn::StringSetbyteFixnum { string, index, value } => gen_string_setbyte_fixnum(asm, opnd!(string), opnd!(index), opnd!(value)),
-        Insn::StringAppend { recv, other, state } => gen_string_append(jit, asm, function, opnd!(recv), opnd!(other), &function.frame_state(*state)),
+        Insn::StringAppend { recv, other, encodings_match, state } => gen_string_append(jit, asm, function, opnd!(recv), opnd!(other), opnd!(encodings_match), &function.frame_state(*state)),
         Insn::StringAppendCodepoint { recv, other, state } => gen_string_append_codepoint(jit, asm, function, opnd!(recv), opnd!(other), &function.frame_state(*state)),
         Insn::StringEqual { left, right } => gen_string_equal(asm, opnd!(left), opnd!(right)),
         Insn::StringIntern { val, state } => gen_intern(asm, opnd!(val), &function.frame_state(*state)),
@@ -4077,23 +4077,14 @@ fn gen_string_setbyte_fixnum(asm: &mut Assembler, string: Opnd, index: Opnd, val
     asm_ccall!(asm, rb_str_setbyte, string, index, value)
 }
 
-fn gen_string_append(jit: &mut JITState, asm: &mut Assembler, function: &Function, string: Opnd, val: Opnd, state: &FrameState) -> Opnd {
+fn gen_string_append(jit: &mut JITState, asm: &mut Assembler, function: &Function, string: Opnd, val: Opnd, encodings_match: Opnd, state: &FrameState) -> Opnd {
     gen_prepare_non_leaf_call(jit, asm, function, state);
 
-    // Test if string encodings differ. If different, use rb_str_buf_append. If the same,
-    // use rb_jit_str_simple_append, which calls rb_str_cat.
+    // Test the encodings_match operand computed in HIR. If encodings differ, use
+    // rb_str_buf_append. If the same, use rb_jit_str_simple_append, which calls rb_str_cat.
     asm_comment!(asm, "<< on strings");
-
-    // Take receiver's object flags XOR arg's flags. If any
-    // string-encoding flags are different between the two,
-    // the encodings don't match.
-    let string_reg = asm.load_mem(string);
-    let val_reg = asm.load_mem(val);
-    let flags_xor = asm.xor(
-        Opnd::mem(VALUE_BITS, string_reg, RUBY_OFFSET_RBASIC_FLAGS),
-        Opnd::mem(VALUE_BITS, val_reg, RUBY_OFFSET_RBASIC_FLAGS)
-    );
-    asm.test(flags_xor, Opnd::UImm(RUBY_ENCODING_MASK as u64));
+    let encodings_match = asm.load_mem(encodings_match);
+    asm.test(encodings_match, encodings_match);
 
     let hir_block_id = asm.current_block().hir_block_id;
     let rpo_idx = asm.current_block().rpo_index;
@@ -4102,7 +4093,7 @@ fn gen_string_append(jit: &mut JITState, asm: &mut Assembler, function: &Functio
     let result_block = asm.new_block(hir_block_id, false, rpo_idx);
     let result_edge = Target::Block(Box::new(lir::BranchEdge { target: result_block, args: vec![] }));
 
-    asm.jnz(jit, mismatch_edge);
+    asm.jz(jit, mismatch_edge);
 
     // If encodings match, call the simple append function
     asm_ccall!(asm, rb_jit_str_simple_append, string, val);

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -639,7 +639,7 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
         Insn::StringConcat { strings, state } => gen_string_concat(jit, asm, function, opnds!(strings), &function.frame_state(*state)),
         &Insn::StringGetbyte { string, index } => gen_string_getbyte(asm, opnd!(string), opnd!(index)),
         Insn::StringSetbyteFixnum { string, index, value } => gen_string_setbyte_fixnum(asm, opnd!(string), opnd!(index), opnd!(value)),
-        Insn::StringAppend { recv, other, encodings_match, state } => gen_string_append(jit, asm, function, opnd!(recv), opnd!(other), opnd!(encodings_match), &function.frame_state(*state)),
+        Insn::StringAppend { recv, other, flags_xor, state } => gen_string_append(jit, asm, function, opnd!(recv), opnd!(other), opnd!(flags_xor), &function.frame_state(*state)),
         Insn::StringAppendCodepoint { recv, other, state } => gen_string_append_codepoint(jit, asm, function, opnd!(recv), opnd!(other), &function.frame_state(*state)),
         Insn::StringEqual { left, right } => gen_string_equal(asm, opnd!(left), opnd!(right)),
         Insn::StringIntern { val, state } => gen_intern(asm, opnd!(val), &function.frame_state(*state)),
@@ -694,6 +694,7 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
         Insn::FixnumXor { left, right } => gen_fixnum_xor(asm, opnd!(left), opnd!(right)),
         Insn::IntAnd { left, right } => asm.and(opnd!(left), opnd!(right)),
         Insn::IntOr { left, right } => gen_int_or(asm, opnd!(left), opnd!(right)),
+        Insn::IntXor { left, right } => gen_int_xor(asm, opnd!(left), opnd!(right)),
         &Insn::FixnumLShift { left, right, state } => {
             // We only create FixnumLShift when we know the shift amount statically and it's in [0,
             // 63].
@@ -2821,6 +2822,11 @@ fn gen_int_or(asm: &mut Assembler, left: lir::Opnd, right: lir::Opnd) -> lir::Op
     asm.or(left, right)
 }
 
+/// Compile C integer ^ C integer.
+fn gen_int_xor(asm: &mut Assembler, left: lir::Opnd, right: lir::Opnd) -> lir::Opnd {
+    asm.xor(left, right)
+}
+
 /// Compile Fixnum ^ Fixnum
 fn gen_fixnum_xor(asm: &mut Assembler, left: lir::Opnd, right: lir::Opnd) -> lir::Opnd {
     // XOR and then re-tag the resulting fixnum
@@ -4077,14 +4083,17 @@ fn gen_string_setbyte_fixnum(asm: &mut Assembler, string: Opnd, index: Opnd, val
     asm_ccall!(asm, rb_str_setbyte, string, index, value)
 }
 
-fn gen_string_append(jit: &mut JITState, asm: &mut Assembler, function: &Function, string: Opnd, val: Opnd, encodings_match: Opnd, state: &FrameState) -> Opnd {
+fn gen_string_append(jit: &mut JITState, asm: &mut Assembler, function: &Function, string: Opnd, val: Opnd, flags_xor: Opnd, state: &FrameState) -> Opnd {
     gen_prepare_non_leaf_call(jit, asm, function, state);
 
-    // Test the encodings_match operand computed in HIR. If encodings differ, use
-    // rb_str_buf_append. If the same, use rb_jit_str_simple_append, which calls rb_str_cat.
+    // Test if string encodings differ. If different, use rb_str_buf_append. If the same,
+    // use rb_jit_str_simple_append, which calls rb_str_cat.
     asm_comment!(asm, "<< on strings");
-    let encodings_match = asm.load_mem(encodings_match);
-    asm.test(encodings_match, encodings_match);
+
+    // flags_xor is the receiver's object flags XOR arg's flags, computed in HIR. If any
+    // string-encoding flags are different between the two, the encodings don't match.
+    let flags_xor = asm.load_mem(flags_xor);
+    asm.test(flags_xor, Opnd::UImm(RUBY_ENCODING_MASK as u64));
 
     let hir_block_id = asm.current_block().hir_block_id;
     let rpo_idx = asm.current_block().rpo_index;
@@ -4093,7 +4102,7 @@ fn gen_string_append(jit: &mut JITState, asm: &mut Assembler, function: &Functio
     let result_block = asm.new_block(hir_block_id, false, rpo_idx);
     let result_edge = Target::Block(Box::new(lir::BranchEdge { target: result_block, args: vec![] }));
 
-    asm.jz(jit, mismatch_edge);
+    asm.jnz(jit, mismatch_edge);
 
     // If encodings match, call the simple append function
     asm_ccall!(asm, rb_jit_str_simple_append, string, val);

--- a/zjit/src/cruby_methods.rs
+++ b/zjit/src/cruby_methods.rs
@@ -563,7 +563,16 @@ fn inline_string_append(fun: &mut hir::Function, block: hir::BlockId, recv: hir:
     if fun.likely_a(recv, types::StringExact, state) && fun.likely_a(other, types::String, state) {
         let recv = fun.coerce_to(block, recv, types::StringExact, state);
         let other = fun.coerce_to(block, other, types::String, state);
-        let _ = fun.push_insn(block, hir::Insn::StringAppend { recv, other, state });
+        // Compute whether the two strings' encodings match in HIR, so that optimizer
+        // passes can see the flag loads and fold the check when encodings are known.
+        // StringAppend picks the append function off the result at run time.
+        let mask = fun.push_insn(block, hir::Insn::Const { val: hir::Const::CUInt64(RUBY_ENCODING_MASK as u64) });
+        let recv_flags = fun.load_rbasic_flags(block, recv);
+        let recv_enc = fun.push_insn(block, hir::Insn::IntAnd { left: recv_flags, right: mask });
+        let other_flags = fun.load_rbasic_flags(block, other);
+        let other_enc = fun.push_insn(block, hir::Insn::IntAnd { left: other_flags, right: mask });
+        let encodings_match = fun.push_insn(block, hir::Insn::IsBitEqual { left: recv_enc, right: other_enc });
+        let _ = fun.push_insn(block, hir::Insn::StringAppend { recv, other, encodings_match, state });
         return Some(recv);
     }
     if fun.likely_a(recv, types::StringExact, state) && fun.likely_a(other, types::Fixnum, state) {

--- a/zjit/src/cruby_methods.rs
+++ b/zjit/src/cruby_methods.rs
@@ -563,16 +563,14 @@ fn inline_string_append(fun: &mut hir::Function, block: hir::BlockId, recv: hir:
     if fun.likely_a(recv, types::StringExact, state) && fun.likely_a(other, types::String, state) {
         let recv = fun.coerce_to(block, recv, types::StringExact, state);
         let other = fun.coerce_to(block, other, types::String, state);
-        // Compute whether the two strings' encodings match in HIR, so that optimizer
-        // passes can see the flag loads and fold the check when encodings are known.
-        // StringAppend picks the append function off the result at run time.
-        let mask = fun.push_insn(block, hir::Insn::Const { val: hir::Const::CUInt64(RUBY_ENCODING_MASK as u64) });
+        // Load both strings' flags in HIR so that optimizer passes can dedup the loads,
+        // while codegen keeps the encoding comparison fused with its branch. XOR the
+        // flags in HIR too; passing both loads into StringAppend would keep one more
+        // value alive into its ccall, which currently spills a register.
         let recv_flags = fun.load_rbasic_flags(block, recv);
-        let recv_enc = fun.push_insn(block, hir::Insn::IntAnd { left: recv_flags, right: mask });
         let other_flags = fun.load_rbasic_flags(block, other);
-        let other_enc = fun.push_insn(block, hir::Insn::IntAnd { left: other_flags, right: mask });
-        let encodings_match = fun.push_insn(block, hir::Insn::IsBitEqual { left: recv_enc, right: other_enc });
-        let _ = fun.push_insn(block, hir::Insn::StringAppend { recv, other, encodings_match, state });
+        let flags_xor = fun.push_insn(block, hir::Insn::IntXor { left: recv_flags, right: other_flags });
+        let _ = fun.push_insn(block, hir::Insn::StringAppend { recv, other, flags_xor, state });
         return Some(recv);
     }
     if fun.likely_a(recv, types::StringExact, state) && fun.likely_a(other, types::Fixnum, state) {

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -958,7 +958,9 @@ pub enum Insn {
     /// Call rb_str_getbyte with known-Fixnum index
     StringGetbyte { string: InsnId, index: InsnId },
     StringSetbyteFixnum { string: InsnId, index: InsnId, value: InsnId },
-    StringAppend { recv: InsnId, other: InsnId, state: InsnId },
+    /// Append `other` to `recv`. `encodings_match` is a CBool that selects between a simple
+    /// memcpy-based append (rb_jit_str_simple_append) and the encoding-aware rb_str_buf_append.
+    StringAppend { recv: InsnId, other: InsnId, encodings_match: InsnId, state: InsnId },
     StringAppendCodepoint { recv: InsnId, other: InsnId, state: InsnId },
     StringEqual { left: InsnId, right: InsnId },
 
@@ -1379,8 +1381,13 @@ macro_rules! for_each_operand_impl {
                 $visit_one!(*index);
                 $visit_one!(*value);
             }
-            Insn::StringAppend { recv, other, state }
-            | Insn::StringAppendCodepoint { recv, other, state } => {
+            Insn::StringAppend { recv, other, encodings_match, state } => {
+                $visit_one!(*recv);
+                $visit_one!(*other);
+                $visit_one!(*encodings_match);
+                $visit_one!(*state);
+            }
+            Insn::StringAppendCodepoint { recv, other, state } => {
                 $visit_one!(*recv);
                 $visit_one!(*other);
                 $visit_one!(*state);
@@ -2093,8 +2100,8 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
             Insn::StringSetbyteFixnum { string, index, value, .. } => {
                 write!(f, "StringSetbyteFixnum {string}, {index}, {value}")
             }
-            Insn::StringAppend { recv, other, .. } => {
-                write!(f, "StringAppend {recv}, {other}")
+            Insn::StringAppend { recv, other, encodings_match, .. } => {
+                write!(f, "StringAppend {recv}, {other}, encodings_match: {encodings_match}")
             }
             Insn::StringAppendCodepoint { recv, other, .. } => {
                 write!(f, "StringAppendCodepoint {recv}, {other}")
@@ -7059,9 +7066,10 @@ impl Function {
             // Instructions with String operands
             Insn::StringCopy { val, .. } => self.assert_subtype(insn_id, val, types::StringExact),
             Insn::StringIntern { val, .. } => self.assert_subtype(insn_id, val, types::StringExact),
-            Insn::StringAppend { recv, other, .. } => {
+            Insn::StringAppend { recv, other, encodings_match, .. } => {
                 self.assert_subtype(insn_id, recv, types::StringExact)?;
-                self.assert_subtype(insn_id, other, types::String)
+                self.assert_subtype(insn_id, other, types::String)?;
+                self.assert_subtype(insn_id, encodings_match, types::CBool)
             }
             Insn::StringAppendCodepoint { recv, other, .. } => {
                 self.assert_subtype(insn_id, recv, types::StringExact)?;

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -958,9 +958,10 @@ pub enum Insn {
     /// Call rb_str_getbyte with known-Fixnum index
     StringGetbyte { string: InsnId, index: InsnId },
     StringSetbyteFixnum { string: InsnId, index: InsnId, value: InsnId },
-    /// Append `other` to `recv`. `encodings_match` is a CBool that selects between a simple
+    /// Append `other` to `recv`. `flags_xor` is the XOR of the two strings' RBasic flags
+    /// loaded in HIR; codegen tests its encoding bits to select between a simple
     /// memcpy-based append (rb_jit_str_simple_append) and the encoding-aware rb_str_buf_append.
-    StringAppend { recv: InsnId, other: InsnId, encodings_match: InsnId, state: InsnId },
+    StringAppend { recv: InsnId, other: InsnId, flags_xor: InsnId, state: InsnId },
     StringAppendCodepoint { recv: InsnId, other: InsnId, state: InsnId },
     StringEqual { left: InsnId, right: InsnId },
 
@@ -1236,6 +1237,7 @@ pub enum Insn {
     FixnumXor  { left: InsnId, right: InsnId },
     IntAnd     { left: InsnId, right: InsnId },
     IntOr      { left: InsnId, right: InsnId },
+    IntXor     { left: InsnId, right: InsnId },
     FixnumLShift { left: InsnId, right: InsnId, state: InsnId },
     FixnumRShift { left: InsnId, right: InsnId },
 
@@ -1381,10 +1383,10 @@ macro_rules! for_each_operand_impl {
                 $visit_one!(*index);
                 $visit_one!(*value);
             }
-            Insn::StringAppend { recv, other, encodings_match, state } => {
+            Insn::StringAppend { recv, other, flags_xor, state } => {
                 $visit_one!(*recv);
                 $visit_one!(*other);
-                $visit_one!(*encodings_match);
+                $visit_one!(*flags_xor);
                 $visit_one!(*state);
             }
             Insn::StringAppendCodepoint { recv, other, state } => {
@@ -1468,6 +1470,7 @@ macro_rules! for_each_operand_impl {
             | Insn::FixnumXor { left, right }
             | Insn::IntAnd { left, right }
             | Insn::IntOr { left, right }
+            | Insn::IntXor { left, right }
             | Insn::FixnumRShift { left, right }
             | Insn::IsBitEqual { left, right }
             | Insn::IsBitNotEqual { left, right } => {
@@ -1857,6 +1860,7 @@ impl Insn {
             Insn::FixnumXor { .. } => effects::Empty,
             Insn::IntAnd { .. } => effects::Empty,
             Insn::IntOr { .. } => effects::Empty,
+            Insn::IntXor { .. } => effects::Empty,
             Insn::FixnumLShift { .. } => effects::Empty,
             Insn::FixnumRShift { .. } => effects::Empty,
             Insn::AnyToString { .. } => effects::Any,
@@ -2100,8 +2104,8 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
             Insn::StringSetbyteFixnum { string, index, value, .. } => {
                 write!(f, "StringSetbyteFixnum {string}, {index}, {value}")
             }
-            Insn::StringAppend { recv, other, encodings_match, .. } => {
-                write!(f, "StringAppend {recv}, {other}, encodings_match: {encodings_match}")
+            Insn::StringAppend { recv, other, flags_xor, .. } => {
+                write!(f, "StringAppend {recv}, {other}, flags_xor: {flags_xor}")
             }
             Insn::StringAppendCodepoint { recv, other, .. } => {
                 write!(f, "StringAppendCodepoint {recv}, {other}")
@@ -2248,6 +2252,7 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
             Insn::FixnumXor  { left, right, .. } => { write!(f, "FixnumXor {left}, {right}") },
             Insn::IntAnd     { left, right } => { write!(f, "IntAnd {left}, {right}") },
             Insn::IntOr      { left, right } => { write!(f, "IntOr {left}, {right}") },
+            Insn::IntXor     { left, right } => { write!(f, "IntXor {left}, {right}") },
             Insn::FixnumLShift { left, right, .. } => { write!(f, "FixnumLShift {left}, {right}") },
             Insn::FixnumRShift { left, right, .. } => { write!(f, "FixnumRShift {left}, {right}") },
             Insn::GuardType { val, guard_type, recompile, .. } => {
@@ -3418,6 +3423,7 @@ impl Function {
             Insn::FixnumXor  { .. } => types::Fixnum,
             Insn::IntAnd { .. } => types::CInt64,
             Insn::IntOr { left, .. } => self.type_of(*left).unspecialized(),
+            Insn::IntXor { left, .. } => self.type_of(*left).unspecialized(),
             Insn::FixnumLShift { .. } => types::Fixnum,
             Insn::FixnumRShift { .. } => types::Fixnum,
             Insn::PutSpecialObject { .. } => types::BasicObject,
@@ -7066,10 +7072,10 @@ impl Function {
             // Instructions with String operands
             Insn::StringCopy { val, .. } => self.assert_subtype(insn_id, val, types::StringExact),
             Insn::StringIntern { val, .. } => self.assert_subtype(insn_id, val, types::StringExact),
-            Insn::StringAppend { recv, other, encodings_match, .. } => {
+            Insn::StringAppend { recv, other, flags_xor, .. } => {
                 self.assert_subtype(insn_id, recv, types::StringExact)?;
                 self.assert_subtype(insn_id, other, types::String)?;
-                self.assert_subtype(insn_id, encodings_match, types::CBool)
+                self.assert_subtype(insn_id, flags_xor, types::CUInt64)
             }
             Insn::StringAppendCodepoint { recv, other, .. } => {
                 self.assert_subtype(insn_id, recv, types::StringExact)?;
@@ -7128,7 +7134,8 @@ impl Function {
                 }
             }
             Insn::IntAnd { left, right }
-            | Insn::IntOr { left, right } => {
+            | Insn::IntOr { left, right }
+            | Insn::IntXor { left, right } => {
                 // TODO: Expand this to other matching C integer sizes when we need them.
                 let left_type = self.type_of(left);
                 if left_type.is_subtype(types::CInt64) {

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -13148,13 +13148,10 @@ mod hir_opt_tests {
           PatchPoint MethodRedefined(String@0x1008, <<@0x1010, cme:0x1018)
           v29:StringExact = GuardType v12, StringExact recompile
           v30:String = GuardType v13, String
-          v31:CUInt64[532676608] = Const CUInt64(532676608)
-          v32:CUInt64 = LoadField v29, :RBASIC_FLAGS@0x1040
-          v33:CInt64 = IntAnd v32, v31
-          v34:CUInt64 = LoadField v30, :RBASIC_FLAGS@0x1040
-          v35:CInt64 = IntAnd v34, v31
-          v36:CBool = IsBitEqual v33, v35
-          v37:StringExact = StringAppend v29, v30, encodings_match: v36
+          v31:CUInt64 = LoadField v29, :RBASIC_FLAGS@0x1040
+          v32:CUInt64 = LoadField v30, :RBASIC_FLAGS@0x1040
+          v33:CUInt64 = IntXor v31, v32
+          v34:StringExact = StringAppend v29, v30, flags_xor: v33
           CheckInterrupts
           Return v29
         ");
@@ -13220,13 +13217,10 @@ mod hir_opt_tests {
           PatchPoint MethodRedefined(String@0x1008, <<@0x1010, cme:0x1018)
           v29:StringExact = GuardType v12, StringExact recompile
           v30:String = GuardType v13, String
-          v31:CUInt64[532676608] = Const CUInt64(532676608)
-          v32:CUInt64 = LoadField v29, :RBASIC_FLAGS@0x1040
-          v33:CInt64 = IntAnd v32, v31
-          v34:CUInt64 = LoadField v30, :RBASIC_FLAGS@0x1040
-          v35:CInt64 = IntAnd v34, v31
-          v36:CBool = IsBitEqual v33, v35
-          v37:StringExact = StringAppend v29, v30, encodings_match: v36
+          v31:CUInt64 = LoadField v29, :RBASIC_FLAGS@0x1040
+          v32:CUInt64 = LoadField v30, :RBASIC_FLAGS@0x1040
+          v33:CUInt64 = IntXor v31, v32
+          v34:StringExact = StringAppend v29, v30, flags_xor: v33
           CheckInterrupts
           Return v29
         ");
@@ -15055,19 +15049,16 @@ mod hir_opt_tests {
           v28:StringExact = StringCopy v27
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, <<@0x1010, cme:0x1018)
-          v50:CUInt64[532676608] = Const CUInt64(532676608)
-          v51:CUInt64 = LoadField v17, :RBASIC_FLAGS@0x1040
-          v52:CInt64 = IntAnd v51, v50
-          v53:CUInt64 = LoadField v28, :RBASIC_FLAGS@0x1040
-          v54:CInt64 = IntAnd v53, v50
-          v55:CBool = IsBitEqual v52, v54
-          v56:StringExact = StringAppend v17, v28, encodings_match: v55
+          v50:CUInt64 = LoadField v17, :RBASIC_FLAGS@0x1040
+          v51:CUInt64 = LoadField v28, :RBASIC_FLAGS@0x1040
+          v52:CUInt64 = IntXor v50, v51
+          v53:StringExact = StringAppend v17, v28, flags_xor: v52
           PatchPoint NoEPEscape(test)
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, ==@0x1041, cme:0x1048)
-          v61:BoolExact = StringEqual v17, v22
+          v58:BoolExact = StringEqual v17, v22
           CheckInterrupts
-          Return v61
+          Return v58
         ");
     }
 

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -13148,7 +13148,13 @@ mod hir_opt_tests {
           PatchPoint MethodRedefined(String@0x1008, <<@0x1010, cme:0x1018)
           v29:StringExact = GuardType v12, StringExact recompile
           v30:String = GuardType v13, String
-          v31:StringExact = StringAppend v29, v30
+          v31:CUInt64[532676608] = Const CUInt64(532676608)
+          v32:CUInt64 = LoadField v29, :RBASIC_FLAGS@0x1040
+          v33:CInt64 = IntAnd v32, v31
+          v34:CUInt64 = LoadField v30, :RBASIC_FLAGS@0x1040
+          v35:CInt64 = IntAnd v34, v31
+          v36:CBool = IsBitEqual v33, v35
+          v37:StringExact = StringAppend v29, v30, encodings_match: v36
           CheckInterrupts
           Return v29
         ");
@@ -13214,7 +13220,13 @@ mod hir_opt_tests {
           PatchPoint MethodRedefined(String@0x1008, <<@0x1010, cme:0x1018)
           v29:StringExact = GuardType v12, StringExact recompile
           v30:String = GuardType v13, String
-          v31:StringExact = StringAppend v29, v30
+          v31:CUInt64[532676608] = Const CUInt64(532676608)
+          v32:CUInt64 = LoadField v29, :RBASIC_FLAGS@0x1040
+          v33:CInt64 = IntAnd v32, v31
+          v34:CUInt64 = LoadField v30, :RBASIC_FLAGS@0x1040
+          v35:CInt64 = IntAnd v34, v31
+          v36:CBool = IsBitEqual v33, v35
+          v37:StringExact = StringAppend v29, v30, encodings_match: v36
           CheckInterrupts
           Return v29
         ");
@@ -15043,13 +15055,19 @@ mod hir_opt_tests {
           v28:StringExact = StringCopy v27
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, <<@0x1010, cme:0x1018)
-          v50:StringExact = StringAppend v17, v28
+          v50:CUInt64[532676608] = Const CUInt64(532676608)
+          v51:CUInt64 = LoadField v17, :RBASIC_FLAGS@0x1040
+          v52:CInt64 = IntAnd v51, v50
+          v53:CUInt64 = LoadField v28, :RBASIC_FLAGS@0x1040
+          v54:CInt64 = IntAnd v53, v50
+          v55:CBool = IsBitEqual v52, v54
+          v56:StringExact = StringAppend v17, v28, encodings_match: v55
           PatchPoint NoEPEscape(test)
           PatchPoint NoSingletonClass(String@0x1008)
-          PatchPoint MethodRedefined(String@0x1008, ==@0x1040, cme:0x1048)
-          v55:BoolExact = StringEqual v17, v22
+          PatchPoint MethodRedefined(String@0x1008, ==@0x1041, cme:0x1048)
+          v61:BoolExact = StringEqual v17, v22
           CheckInterrupts
-          Return v55
+          Return v61
         ");
     }
 


### PR DESCRIPTION
WIP patch for https://github.com/ruby/ruby/pull/18230#issuecomment-5209691117

This seems currently slower than the previous version:

```
before: ruby 4.1.0dev (2026-08-07T15:21:02Z master cd070c053f) +ZJIT +PRISM [x86_64-linux]
after: ruby 4.1.0dev (2026-08-07T16:28:34Z zjit-str-append-hir 2db47f7f49) +ZJIT +PRISM [x86_64-linux]

----------  -----------  -----------  -------------  ------------
bench       before (ms)   after (ms)  after 1st itr  before/after
str_concat  14.3 ± 9.3%  14.7 ± 8.9%          0.996         0.968
----------  -----------  -----------  -------------  ------------
```