### PR TITLE
ZJIT: Use all 8 AAPCS64 argument registers on arm64

### DIFF
--- a/zjit/src/asm/arm64/opnd.rs
+++ b/zjit/src/asm/arm64/opnd.rs
@@ -98,6 +98,8 @@ pub const X2_REG: A64Reg = A64Reg { num_bits: 64, reg_no: 2 };
 pub const X3_REG: A64Reg = A64Reg { num_bits: 64, reg_no: 3 };
 pub const X4_REG: A64Reg = A64Reg { num_bits: 64, reg_no: 4 };
 pub const X5_REG: A64Reg = A64Reg { num_bits: 64, reg_no: 5 };
+pub const X6_REG: A64Reg = A64Reg { num_bits: 64, reg_no: 6 };
+pub const X7_REG: A64Reg = A64Reg { num_bits: 64, reg_no: 7 };
 
 // caller-save registers
 pub const X9_REG: A64Reg = A64Reg { num_bits: 64, reg_no: 9 };
@@ -132,8 +134,8 @@ pub const X2: A64Opnd = A64Opnd::Reg(X2_REG);
 pub const X3: A64Opnd = A64Opnd::Reg(X3_REG);
 pub const X4: A64Opnd = A64Opnd::Reg(X4_REG);
 pub const X5: A64Opnd = A64Opnd::Reg(X5_REG);
-pub const X6: A64Opnd = A64Opnd::Reg(A64Reg { num_bits: 64, reg_no: 6 });
-pub const X7: A64Opnd = A64Opnd::Reg(A64Reg { num_bits: 64, reg_no: 7 });
+pub const X6: A64Opnd = A64Opnd::Reg(X6_REG);
+pub const X7: A64Opnd = A64Opnd::Reg(X7_REG);
 pub const X8: A64Opnd = A64Opnd::Reg(A64Reg { num_bits: 64, reg_no: 8 });
 pub const X9: A64Opnd = A64Opnd::Reg(X9_REG);
 pub const X10: A64Opnd = A64Opnd::Reg(X10_REG);
@@ -194,8 +196,8 @@ pub const W30: A64Opnd = A64Opnd::Reg(A64Reg { num_bits: 32, reg_no: 30 });
 pub const W31: A64Opnd = A64Opnd::Reg(A64Reg { num_bits: 32, reg_no: 31 });
 
 // C argument registers
-pub const C_ARG_REGS: [A64Opnd; 6] = [X0, X1, X2, X3, X4, X5];
-pub const C_ARG_REGREGS: [A64Reg; 6] = [X0_REG, X1_REG, X2_REG, X3_REG, X4_REG, X5_REG];
+pub const C_ARG_REGS: [A64Opnd; 8] = [X0, X1, X2, X3, X4, X5, X6, X7];
+pub const C_ARG_REGREGS: [A64Reg; 8] = [X0_REG, X1_REG, X2_REG, X3_REG, X4_REG, X5_REG, X6_REG, X7_REG];
 
 impl fmt::Display for A64Reg {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/zjit/src/backend/arm64/mod.rs
+++ b/zjit/src/backend/arm64/mod.rs
@@ -22,13 +22,15 @@ pub const EC: Opnd = Opnd::Reg(X20_REG);
 pub const SP: Opnd = Opnd::Reg(X21_REG);
 
 // C argument registers on this platform
-pub const C_ARG_OPNDS: [Opnd; 6] = [
+pub const C_ARG_OPNDS: [Opnd; 8] = [
     Opnd::Reg(X0_REG),
     Opnd::Reg(X1_REG),
     Opnd::Reg(X2_REG),
     Opnd::Reg(X3_REG),
     Opnd::Reg(X4_REG),
-    Opnd::Reg(X5_REG)
+    Opnd::Reg(X5_REG),
+    Opnd::Reg(X6_REG),
+    Opnd::Reg(X7_REG)
 ];
 
 // Make sure we're using the same c args everywhere
@@ -168,7 +170,6 @@ fn emit_load_value(cb: &mut CodeBlock, rd: A64Opnd, value: u64) -> usize {
 }
 
 /// List of registers that can be used for register allocation.
-/// This has the same number of registers for x86_64 and arm64.
 /// SCRATCH_OPND, SCRATCH1_OPND, and EMIT_OPND are excluded.
 pub const ALLOC_REGS: &[Reg] = &[
     X0_REG,
@@ -177,6 +178,8 @@ pub const ALLOC_REGS: &[Reg] = &[
     X3_REG,
     X4_REG,
     X5_REG,
+    X6_REG,
+    X7_REG,
     X11_REG,
     X12_REG,
 ];

--- a/zjit/src/codegen_tests.rs
+++ b/zjit/src/codegen_tests.rs
@@ -714,16 +714,17 @@ fn test_yield_inline_invocation_with_args() {
 
 #[test]
 fn test_yield_with_too_many_args_for_lir() {
-    // `self` + six yield args don't fit in C argument registers, so the direct
-    // block invocation must be rejected instead of emitting an uncompilable CCall.
+    // `self` + eight yield args don't fit in C argument registers (6 on x86_64, 8 on
+    // arm64), so the direct block invocation must be rejected instead of emitting an
+    // uncompilable CCall.
     set_call_threshold(2);
     eval("
-        def foo = yield(1, 2, 3, 4, 5, 6)
-        def test = foo { |a, b, c, d, e, f| a + b + c + d + e + f }
+        def foo = yield(1, 2, 3, 4, 5, 6, 7, 8)
+        def test = foo { |a, b, c, d, e, f, g, h| a + b + c + d + e + f + g + h }
         test
         test
     ");
-    assert_snapshot!(assert_compiles("test"), @"21");
+    assert_snapshot!(assert_compiles("test"), @"36");
 }
 
 #[test]
@@ -1495,12 +1496,14 @@ fn test_send_unexpected_keyword() {
 
 #[test]
 fn test_pos_optional_with_maybe_too_many_args() {
+    // The last call passes 8 args, which together with self exceed the C argument
+    // registers (6 on x86_64, 8 on arm64), so it runs through the dynamic send path.
     assert_snapshot!(inspect("
-        def target(a = 1, b = 2, c = 3, d = 4, e = 5, f:) = [a, b, c, d, e, f]
-        def test = [target(f: 6), target(10, 20, 30, f: 6), target(10, 20, 30, 40, 50, f: 60)]
+        def target(a = 1, b = 2, c = 3, d = 4, e = 5, f = 6, g = 7, h:) = [a, b, c, d, e, f, g, h]
+        def test = [target(h: 8), target(10, 20, 30, h: 8), target(10, 20, 30, 40, 50, 60, 70, h: 80)]
         test
         test
-    "), @"[[1, 2, 3, 4, 5, 6], [10, 20, 30, 4, 5, 6], [10, 20, 30, 40, 50, 60]]");
+    "), @"[[1, 2, 3, 4, 5, 6, 7, 8], [10, 20, 30, 4, 5, 6, 7, 8], [10, 20, 30, 40, 50, 60, 70, 80]]");
 }
 
 #[test]
@@ -1817,69 +1820,9 @@ fn test_invokesuper_to_cfunc_varargs() {
 
 #[test]
 fn test_invokesuper_to_cfunc_with_too_many_args_exits() {
-    unsafe extern "C" fn test_six_args(
-        _self: VALUE,
-        a: VALUE,
-        b: VALUE,
-        c: VALUE,
-        d: VALUE,
-        e: VALUE,
-        f: VALUE,
-    ) -> VALUE {
-        unsafe { rb_ary_new_from_args(6, a, b, c, d, e, f) }
-    }
-
-    with_rubyvm(|| {
-        let superclass = define_class("ZJITSixArgs", unsafe { rb_cObject });
-        unsafe {
-            rb_define_method(
-                superclass,
-                c"six".as_ptr(),
-                Some(std::mem::transmute::<
-                    unsafe extern "C" fn(VALUE, VALUE, VALUE, VALUE, VALUE, VALUE, VALUE) -> VALUE,
-                    unsafe extern "C" fn(VALUE) -> VALUE,
-                >(test_six_args)),
-                6,
-            );
-        }
-    });
-
-    assert_snapshot!(assert_compiles_allowing_exits(r#"
-        class ZJITSixArgsSubclass < ZJITSixArgs
-          def six(a, b, c, d, e, f)
-            super
-          end
-        end
-
-        def test
-          ZJITSixArgsSubclass.new.six(1, 2, 3, 4, 5, 6)
-        end
-
-        test
-        test
-        test
-    "#), @"[1, 2, 3, 4, 5, 6]");
-}
-
-// Repro for the production "Failed to get_opnd(vN)" panic
-// (PriceRs::PricingService#build_rust_adjustment_from_row, introduced by #17186).
-//
-// A regular send to a C method with 7 fixed args is reduced to a CCallWithFrame
-// with recv + 7 = 8 operands, which exceeds C_ARG_OPNDS.len() (6). gen_insn bails
-// with `return Err(*state)`; the caller emits a side exit and `break`s out of the
-// block. But the call's *result* is stored in a local and used in a *later* basic
-// block (the `if` arm here). Because codegen bailed before assigning a LIR operand
-// to the result, compiling that later block calls get_opnd(result) on a None entry
-// and panics. The existing `test_invokesuper_to_cfunc_with_too_many_args_exits` does
-// not catch this because there the call result is the method's tail value and is not
-// referenced past the bailed block.
-//
-// NOTE: This currently ABORTS with `Failed to get_opnd(vN)` (the bug). The snapshot
-// below is the expected behavior once the backend exits cleanly: `flag` is true so
-// `test` returns the cfunc's result, the array [1, 2, 3, 4, 5, 6, 7].
-#[test]
-fn test_ccall_with_frame_too_many_args_result_used_in_later_block() {
-    unsafe extern "C" fn test_seven_args(
+    // `self` + eight args don't fit in C argument registers (6 on x86_64, 8 on arm64),
+    // so the invokesuper to the cfunc must side-exit instead of emitting a CCall.
+    unsafe extern "C" fn test_super_eight_args(
         _self: VALUE,
         a: VALUE,
         b: VALUE,
@@ -1888,28 +1831,93 @@ fn test_ccall_with_frame_too_many_args_result_used_in_later_block() {
         e: VALUE,
         f: VALUE,
         g: VALUE,
+        h: VALUE,
     ) -> VALUE {
-        unsafe { rb_ary_new_from_args(7, a, b, c, d, e, f, g) }
+        unsafe { rb_ary_new_from_args(8, a, b, c, d, e, f, g, h) }
     }
 
     with_rubyvm(|| {
-        let klass = define_class("ZJITSevenArgs", unsafe { rb_cObject });
+        let superclass = define_class("ZJITSuperEightArgs", unsafe { rb_cObject });
+        unsafe {
+            rb_define_method(
+                superclass,
+                c"eight".as_ptr(),
+                Some(std::mem::transmute::<
+                    unsafe extern "C" fn(VALUE, VALUE, VALUE, VALUE, VALUE, VALUE, VALUE, VALUE, VALUE) -> VALUE,
+                    unsafe extern "C" fn(VALUE) -> VALUE,
+                >(test_super_eight_args)),
+                8,
+            );
+        }
+    });
+
+    assert_snapshot!(assert_compiles_allowing_exits(r#"
+        class ZJITSuperEightArgsSubclass < ZJITSuperEightArgs
+          def eight(a, b, c, d, e, f, g, h)
+            super
+          end
+        end
+
+        def test
+          ZJITSuperEightArgsSubclass.new.eight(1, 2, 3, 4, 5, 6, 7, 8)
+        end
+
+        test
+        test
+        test
+    "#), @"[1, 2, 3, 4, 5, 6, 7, 8]");
+}
+
+// Repro for the production "Failed to get_opnd(vN)" panic
+// (PriceRs::PricingService#build_rust_adjustment_from_row, introduced by #17186).
+//
+// A regular send to a C method with 8 fixed args is reduced to a CCallWithFrame
+// with recv + 8 = 9 operands, which exceeds C_ARG_OPNDS.len() (6 on x86_64, 8 on
+// arm64). gen_insn bails with `return Err(*state)`; the caller emits a side exit and
+// `break`s out of the block. But the call's *result* is stored in a local and used in
+// a *later* basic block (the `if` arm here). Because codegen bailed before assigning
+// a LIR operand to the result, compiling that later block calls get_opnd(result) on a
+// None entry and panics. The existing `test_invokesuper_to_cfunc_with_too_many_args_exits`
+// does not catch this because there the call result is the method's tail value and is
+// not referenced past the bailed block.
+//
+// NOTE: This currently ABORTS with `Failed to get_opnd(vN)` (the bug). The snapshot
+// below is the expected behavior once the backend exits cleanly: `flag` is true so
+// `test` returns the cfunc's result, the array [1, 2, 3, 4, 5, 6, 7, 8].
+#[test]
+fn test_ccall_with_frame_too_many_args_result_used_in_later_block() {
+    unsafe extern "C" fn test_eight_args(
+        _self: VALUE,
+        a: VALUE,
+        b: VALUE,
+        c: VALUE,
+        d: VALUE,
+        e: VALUE,
+        f: VALUE,
+        g: VALUE,
+        h: VALUE,
+    ) -> VALUE {
+        unsafe { rb_ary_new_from_args(8, a, b, c, d, e, f, g, h) }
+    }
+
+    with_rubyvm(|| {
+        let klass = define_class("ZJITEightArgs", unsafe { rb_cObject });
         unsafe {
             rb_define_method(
                 klass,
-                c"seven".as_ptr(),
+                c"eight".as_ptr(),
                 Some(std::mem::transmute::<
-                    unsafe extern "C" fn(VALUE, VALUE, VALUE, VALUE, VALUE, VALUE, VALUE, VALUE) -> VALUE,
+                    unsafe extern "C" fn(VALUE, VALUE, VALUE, VALUE, VALUE, VALUE, VALUE, VALUE, VALUE) -> VALUE,
                     unsafe extern "C" fn(VALUE) -> VALUE,
-                >(test_seven_args)),
-                7,
+                >(test_eight_args)),
+                8,
             );
         }
     });
 
     assert_snapshot!(assert_compiles_allowing_exits(r#"
         def test(obj, flag)
-          priceable = obj.seven(1, 2, 3, 4, 5, 6, 7)
+          priceable = obj.eight(1, 2, 3, 4, 5, 6, 7, 8)
           if flag
             priceable
           else
@@ -1917,11 +1925,11 @@ fn test_ccall_with_frame_too_many_args_result_used_in_later_block() {
           end
         end
 
-        obj = ZJITSevenArgs.new
+        obj = ZJITEightArgs.new
         test(obj, true)  # profile receiver class
         test(obj, true)  # compile -> currently panics: Failed to get_opnd(vN)
         test(obj, true)
-    "#), @"[1, 2, 3, 4, 5, 6, 7]");
+    "#), @"[1, 2, 3, 4, 5, 6, 7, 8]");
 }
 
 #[test]

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -3951,15 +3951,16 @@ mod hir_opt_tests {
 
     #[test]
     fn test_yield_with_too_many_args_for_lir_falls_back() {
-        // Captured self plus six args don't fit in C argument registers, so the profiled
-        // invokeblock specialization must not emit InvokeBlockIseqDirect.
+        // Captured self plus eight args don't fit in C argument registers (6 on x86_64,
+        // 8 on arm64), so the profiled invokeblock specialization must not emit
+        // InvokeBlockIseqDirect.
         let result = eval("
-            def foo = yield(1, 2, 3, 4, 5, 6)
-            def test = foo { |a, b, c, d, e, f| a + b + c + d + e + f }
+            def foo = yield(1, 2, 3, 4, 5, 6, 7, 8)
+            def test = foo { |a, b, c, d, e, f, g, h| a + b + c + d + e + f + g + h }
             test
             test
         ");
-        assert_eq!(VALUE::fixnum_from_usize(21), result);
+        assert_eq!(VALUE::fixnum_from_usize(36), result);
         assert_snapshot!(hir_string("foo"), @"
         fn foo@<compiled>:2:
         bb1():
@@ -3977,9 +3978,11 @@ mod hir_opt_tests {
           v16:Fixnum[4] = Const Value(4)
           v18:Fixnum[5] = Const Value(5)
           v20:Fixnum[6] = Const Value(6)
-          v22:BasicObject = InvokeBlock v10, v12, v14, v16, v18, v20 # SendFallbackReason: Too many arguments for LIR
+          v22:Fixnum[7] = Const Value(7)
+          v24:Fixnum[8] = Const Value(8)
+          v26:BasicObject = InvokeBlock v10, v12, v14, v16, v18, v20, v22, v24 # SendFallbackReason: Too many arguments for LIR
           CheckInterrupts
-          Return v22
+          Return v26
         ");
     }
 
@@ -3988,12 +3991,12 @@ mod hir_opt_tests {
         // Same as test_yield_with_too_many_args_for_lir_falls_back, but for the guard-free
         // yield dispatch inside an inlined callee whose caller passes a literal block.
         let result = eval("
-            def foo = yield(1, 2, 3, 4, 5, 6)
-            def test = foo { |a, b, c, d, e, f| a + b + c + d + e + f }
+            def foo = yield(1, 2, 3, 4, 5, 6, 7, 8)
+            def test = foo { |a, b, c, d, e, f, g, h| a + b + c + d + e + f + g + h }
             test
             test
         ");
-        assert_eq!(VALUE::fixnum_from_usize(21), result);
+        assert_eq!(VALUE::fixnum_from_usize(36), result);
         assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
@@ -4014,10 +4017,12 @@ mod hir_opt_tests {
           v31:Fixnum[4] = Const Value(4)
           v33:Fixnum[5] = Const Value(5)
           v35:Fixnum[6] = Const Value(6)
-          v37:BasicObject = InvokeBlock v25, v27, v29, v31, v33, v35 # SendFallbackReason: Too many arguments for LIR
+          v37:Fixnum[7] = Const Value(7)
+          v39:Fixnum[8] = Const Value(8)
+          v41:BasicObject = InvokeBlock v25, v27, v29, v31, v33, v35, v37, v39 # SendFallbackReason: Too many arguments for LIR
           CheckInterrupts
           PopInlineFrame
-          Return v37
+          Return v41
         ");
     }
 
@@ -4927,9 +4932,12 @@ mod hir_opt_tests {
 
     #[test]
     fn test_call_with_pos_optional_and_maybe_too_many_args() {
+        // The last call passes 8 args (7 positional + 1 keyword), which together with
+        // self exceed the C argument registers (6 on x86_64, 8 on arm64), so only that
+        // call must fall back to a dynamic send.
         eval("
-            def target(a = 1, b = 2, c = 3, d = 4, e = 5, f:) = [a, b, c, d, e, f]
-            def test = [target(f: 6), target(10, 20, 30, f: 6), target(10, 20, 30, 40, 50, f: 60)]
+            def target(a = 1, b = 2, c = 3, d = 4, e = 5, f = 6, g = 7, h:) = [a, b, c, d, e, f, g, h]
+            def test = [target(h: 8), target(10, 20, 30, h: 8), target(10, 20, 30, 40, 50, 60, 70, h: 80)]
             test
             test
         ");
@@ -4944,26 +4952,28 @@ mod hir_opt_tests {
           v4:BasicObject = LoadArg :self@0
           Jump bb3(v4)
         bb3(v6:BasicObject):
-          v11:Fixnum[6] = Const Value(6)
+          v11:Fixnum[8] = Const Value(8)
           PatchPoint MethodRedefined(Object@0x1000, target@0x1008, cme:0x1010)
-          v48:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
-          v49:BasicObject = SendDirect v48, 0x0, :target (0x1038), v11
+          v52:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
+          v53:BasicObject = SendDirect v52, 0x0, :target (0x1038), v11
           v16:Fixnum[10] = Const Value(10)
           v18:Fixnum[20] = Const Value(20)
           v20:Fixnum[30] = Const Value(30)
-          v22:Fixnum[6] = Const Value(6)
+          v22:Fixnum[8] = Const Value(8)
           PatchPoint MethodRedefined(Object@0x1000, target@0x1008, cme:0x1010)
-          v52:BasicObject = SendDirect v48, 0x0, :target (0x1038), jit_entry_idx=3, v16, v18, v20, v22
+          v56:BasicObject = SendDirect v52, 0x0, :target (0x1038), jit_entry_idx=3, v16, v18, v20, v22
           v27:Fixnum[10] = Const Value(10)
           v29:Fixnum[20] = Const Value(20)
           v31:Fixnum[30] = Const Value(30)
           v33:Fixnum[40] = Const Value(40)
           v35:Fixnum[50] = Const Value(50)
           v37:Fixnum[60] = Const Value(60)
-          v39:BasicObject = Send v48, :target, v27, v29, v31, v33, v35, v37 # SendFallbackReason: Too many arguments for LIR
-          v41:ArrayExact = NewArray v49, v52, v39
+          v39:Fixnum[70] = Const Value(70)
+          v41:Fixnum[80] = Const Value(80)
+          v43:BasicObject = Send v52, :target, v27, v29, v31, v33, v35, v37, v39, v41 # SendFallbackReason: Too many arguments for LIR
+          v45:ArrayExact = NewArray v53, v56, v43
           CheckInterrupts
-          Return v41
+          Return v45
         ");
     }
 
@@ -21259,7 +21269,7 @@ mod hir_opt_tests {
 
     #[test]
     fn test_ccall_with_frame_too_many_args_result_used_in_later_block() {
-        unsafe extern "C" fn test_seven_args(
+        unsafe extern "C" fn test_eight_args(
             _self: VALUE,
             a: VALUE,
             b: VALUE,
@@ -21268,28 +21278,29 @@ mod hir_opt_tests {
             e: VALUE,
             f: VALUE,
             g: VALUE,
+            h: VALUE,
         ) -> VALUE {
-            unsafe { rb_ary_new_from_args(7, a, b, c, d, e, f, g) }
+            unsafe { rb_ary_new_from_args(8, a, b, c, d, e, f, g, h) }
         }
 
         with_rubyvm(|| {
-            let klass = define_class("ZJITSevenArgs", unsafe { rb_cObject });
+            let klass = define_class("ZJITEightArgs", unsafe { rb_cObject });
             unsafe {
                 rb_define_method(
                     klass,
-                    c"seven".as_ptr(),
+                    c"eight".as_ptr(),
                     Some(std::mem::transmute::<
-                        unsafe extern "C" fn(VALUE, VALUE, VALUE, VALUE, VALUE, VALUE, VALUE, VALUE) -> VALUE,
+                        unsafe extern "C" fn(VALUE, VALUE, VALUE, VALUE, VALUE, VALUE, VALUE, VALUE, VALUE) -> VALUE,
                         unsafe extern "C" fn(VALUE) -> VALUE,
-                    >(test_seven_args)),
-                    7,
+                    >(test_eight_args)),
+                    8,
                 );
             }
         });
 
         eval(r#"
             def test(obj, flag)
-              priceable = obj.seven(1, 2, 3, 4, 5, 6, 7)
+              priceable = obj.eight(1, 2, 3, 4, 5, 6, 7, 8)
               if flag
                 priceable
               else
@@ -21297,7 +21308,7 @@ mod hir_opt_tests {
               end
             end
 
-            obj = ZJITSevenArgs.new
+            obj = ZJITEightArgs.new
             test(obj, true)  # profile receiver class
         "#);
         assert_snapshot!(hir_string("test"), @"
@@ -21325,19 +21336,20 @@ mod hir_opt_tests {
           v29:Fixnum[5] = Const Value(5)
           v31:Fixnum[6] = Const Value(6)
           v33:Fixnum[7] = Const Value(7)
-          v35:BasicObject = Send v14, :seven, v21, v23, v25, v27, v29, v31, v33 # SendFallbackReason: Too many arguments for LIR
+          v35:Fixnum[8] = Const Value(8)
+          v37:BasicObject = Send v14, :eight, v21, v23, v25, v27, v29, v31, v33, v35 # SendFallbackReason: Too many arguments for LIR
           PatchPoint NoEPEscape(test)
-          v42:CBool = Test v15
-          v43:Falsy = RefineType v15, Falsy
-          CondBranch v42, bb5(), bb4(v13, v14, v43, v35)
+          v44:CBool = Test v15
+          v45:Falsy = RefineType v15, Falsy
+          CondBranch v44, bb5(), bb4(v13, v14, v45, v37)
         bb5():
-          v45:Truthy = RefineType v15, Truthy
+          v47:Truthy = RefineType v15, Truthy
           CheckInterrupts
-          Return v35
-        bb4(v52:BasicObject, v53:BasicObject, v54:Falsy, v55:BasicObject):
-          v59:NilClass = Const Value(nil)
+          Return v37
+        bb4(v54:BasicObject, v55:BasicObject, v56:Falsy, v57:BasicObject):
+          v61:NilClass = Const Value(nil)
           CheckInterrupts
-          Return v59
+          Return v61
         ");
     }
 


### PR DESCRIPTION
The C calling convention for arm64 allows the use of up to 8 registers, but we've used only 6 because we were interested in using the same number of registers across different branches when we were developing YJIT. We stopped doing that for ZJIT (I forgot which PR did that first), so it should be able to use as many registers as possible.

