### PR TITLE
ZJIT: Strength-reduce Fixnum % and / by power-of-two constants

### DIFF
--- a/zjit/src/codegen_tests.rs
+++ b/zjit/src/codegen_tests.rs
@@ -3076,6 +3076,60 @@ fn test_fixnum_mod_negative() {
 }
 
 #[test]
+fn test_fixnum_mod_pow2_constant() {
+    // Modulo by a positive power-of-two constant is strength-reduced to FixnumAnd
+    eval("
+        def test(a) = a % 8
+        test(13) # profile opt_mod
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_mod);
+    assert_snapshot!(assert_compiles("[test(13), test(8), test(0), test(-1), test(-8), test(4611686018427387903), test(-4611686018427387904)]"), @"[5, 0, 0, 7, 0, 7, 0]");
+}
+
+#[test]
+fn test_fixnum_mod_one_constant() {
+    eval("
+        def test(a) = a % 1
+        test(13) # profile opt_mod
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_mod);
+    assert_snapshot!(assert_compiles("[test(13), test(-13)]"), @"[0, 0]");
+}
+
+#[test]
+fn test_fixnum_mod_negative_pow2_constant() {
+    // Only positive power-of-two divisors are strength-reduced
+    eval("
+        def test(a) = a % -8
+        test(13) # profile opt_mod
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_mod);
+    assert_snapshot!(assert_compiles("[test(13), test(-13)]"), @"[-3, -5]");
+}
+
+#[test]
+fn test_fixnum_div_pow2_constant() {
+    // Division by a positive power-of-two constant is strength-reduced to FixnumRShift
+    eval("
+        def test(a) = a / 8
+        test(13) # profile opt_div
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_div);
+    assert_snapshot!(assert_compiles("[test(13), test(-13), test(0), test(-1), test(4611686018427387903), test(-4611686018427387904)]"), @"[1, -2, 0, -1, 576460752303423487, -576460752303423488]");
+}
+
+#[test]
+fn test_fixnum_div_negative_pow2_constant() {
+    // Only positive power-of-two divisors are strength-reduced
+    eval("
+        def test(a) = a / -8
+        test(13) # profile opt_div
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_div);
+    assert_snapshot!(assert_compiles("[test(13), test(-13)]"), @"[-2, 1]");
+}
+
+#[test]
 fn test_fixnum_aref_constant_index() {
     eval("
         def test(a) = a[12]

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -6005,6 +6005,9 @@ impl Function {
     ///
     /// It can fold fixnum math, truthiness tests, and branches with constant conditionals.
     fn fold_constants(&mut self) {
+        fn is_power_of_two(d: i64) -> bool {
+            d > 0 && (d & (d - 1)) == 0
+        }
         // TODO(max): Determine if it's worth it for us to reflow types after each branch
         // simplification. This means that we can have nice cascading optimizations if what used to
         // be a union of two different basic block arguments now has a single value.
@@ -6177,6 +6180,19 @@ impl Function {
                     &Insn::FixnumDiv { left, right, .. } => {
                         match (self.type_of(left).fixnum_value(), self.type_of(right).fixnum_value()) {
                             (_, Some(1)) => { self.make_equal_to(insn_id, left); continue; }
+                            // Strength-reduce division by a power of two to an arithmetic right
+                            // shift. Both Ruby's Integer#/ and a sign-extending shift round the
+                            // quotient towards negative infinity, so this holds for all fixnums.
+                            (None, Some(d)) if is_power_of_two(d) => {
+                                let shift = self.new_insn(Insn::Const { val: Const::Value(VALUE::fixnum_from_isize(d.trailing_zeros() as isize)) });
+                                self.insn_types[shift.0] = self.infer_type(shift);
+                                new_insns.push(shift);
+                                let replacement = self.new_insn(Insn::FixnumRShift { left, right: shift });
+                                self.make_equal_to(insn_id, replacement);
+                                self.insn_types[replacement.0] = self.infer_type(replacement);
+                                new_insns.push(replacement);
+                                continue;
+                            }
                             _ => {}
                         }
                         self.fold_fixnum_bop(insn_id, left, right, |l, r| match (l, r) {
@@ -6191,6 +6207,22 @@ impl Function {
                         })
                     }
                     &Insn::FixnumMod { left, right, .. } => {
+                        match (self.type_of(left).fixnum_value(), self.type_of(right).fixnum_value()) {
+                            // Strength-reduce modulo by a power of two to a bitwise AND. The sign
+                            // of Ruby's Integer#% follows the (positive) divisor, so the result is
+                            // in [0, d), which matches two's complement AND for all fixnums.
+                            (None, Some(d)) if is_power_of_two(d) => {
+                                let mask = self.new_insn(Insn::Const { val: Const::Value(VALUE::fixnum_from_isize((d - 1) as isize)) });
+                                self.insn_types[mask.0] = self.infer_type(mask);
+                                new_insns.push(mask);
+                                let replacement = self.new_insn(Insn::FixnumAnd { left, right: mask });
+                                self.make_equal_to(insn_id, replacement);
+                                self.insn_types[replacement.0] = self.infer_type(replacement);
+                                new_insns.push(replacement);
+                                continue;
+                            }
+                            _ => {}
+                        }
                         self.fold_fixnum_bop(insn_id, left, right, |l, r| match (l, r) {
                             (Some(l), Some(r)) if r != 0 => {
                                 let l_obj = VALUE::fixnum_from_isize(l as isize);

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -543,6 +543,194 @@ mod hir_opt_tests {
     }
 
     #[test]
+    fn test_reduce_fixnum_mod_pow2() {
+        eval("
+            def test(n)
+              n % 8
+            end
+            test 1; test 2
+        ");
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:3:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          v2:CPtr = LoadSP
+          v3:BasicObject = LoadField v2, :n@0x1000
+          Jump bb3(v1, v3)
+        bb2():
+          EntryPoint JIT(0)
+          v6:BasicObject = LoadArg :self@0
+          v7:BasicObject = LoadArg :n@1
+          Jump bb3(v6, v7)
+        bb3(v9:BasicObject, v10:BasicObject):
+          v15:Fixnum[8] = Const Value(8)
+          PatchPoint MethodRedefined(Integer@0x1008, %@0x1010, cme:0x1018)
+          v26:Fixnum = GuardType v10, Fixnum recompile
+          v28:Fixnum[7] = Const Value(7)
+          v29:Fixnum = FixnumAnd v26, v28
+          CheckInterrupts
+          Return v29
+        ");
+    }
+
+    #[test]
+    fn test_dont_reduce_fixnum_mod_non_pow2() {
+        eval("
+            def test(n)
+              n % 6
+            end
+            test 1; test 2
+        ");
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:3:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          v2:CPtr = LoadSP
+          v3:BasicObject = LoadField v2, :n@0x1000
+          Jump bb3(v1, v3)
+        bb2():
+          EntryPoint JIT(0)
+          v6:BasicObject = LoadArg :self@0
+          v7:BasicObject = LoadArg :n@1
+          Jump bb3(v6, v7)
+        bb3(v9:BasicObject, v10:BasicObject):
+          v15:Fixnum[6] = Const Value(6)
+          PatchPoint MethodRedefined(Integer@0x1008, %@0x1010, cme:0x1018)
+          v26:Fixnum = GuardType v10, Fixnum recompile
+          v27:Fixnum = FixnumMod v26, v15
+          CheckInterrupts
+          Return v27
+        ");
+    }
+
+    #[test]
+    fn test_dont_reduce_fixnum_mod_negative_pow2() {
+        eval("
+            def test(n)
+              n % -8
+            end
+            test 1; test 2
+        ");
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:3:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          v2:CPtr = LoadSP
+          v3:BasicObject = LoadField v2, :n@0x1000
+          Jump bb3(v1, v3)
+        bb2():
+          EntryPoint JIT(0)
+          v6:BasicObject = LoadArg :self@0
+          v7:BasicObject = LoadArg :n@1
+          Jump bb3(v6, v7)
+        bb3(v9:BasicObject, v10:BasicObject):
+          v15:Fixnum[-8] = Const Value(-8)
+          PatchPoint MethodRedefined(Integer@0x1008, %@0x1010, cme:0x1018)
+          v26:Fixnum = GuardType v10, Fixnum recompile
+          v27:Fixnum = FixnumMod v26, v15
+          CheckInterrupts
+          Return v27
+        ");
+    }
+
+    #[test]
+    fn test_reduce_fixnum_div_pow2() {
+        eval("
+            def test(n)
+              n / 8
+            end
+            test 1; test 2
+        ");
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:3:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          v2:CPtr = LoadSP
+          v3:BasicObject = LoadField v2, :n@0x1000
+          Jump bb3(v1, v3)
+        bb2():
+          EntryPoint JIT(0)
+          v6:BasicObject = LoadArg :self@0
+          v7:BasicObject = LoadArg :n@1
+          Jump bb3(v6, v7)
+        bb3(v9:BasicObject, v10:BasicObject):
+          v15:Fixnum[8] = Const Value(8)
+          PatchPoint MethodRedefined(Integer@0x1008, /@0x1010, cme:0x1018)
+          v26:Fixnum = GuardType v10, Fixnum recompile
+          v28:Fixnum[3] = Const Value(3)
+          v29:Fixnum = FixnumRShift v26, v28
+          CheckInterrupts
+          Return v29
+        ");
+    }
+
+    #[test]
+    fn test_dont_reduce_fixnum_div_non_pow2() {
+        eval("
+            def test(n)
+              n / 6
+            end
+            test 1; test 2
+        ");
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:3:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          v2:CPtr = LoadSP
+          v3:BasicObject = LoadField v2, :n@0x1000
+          Jump bb3(v1, v3)
+        bb2():
+          EntryPoint JIT(0)
+          v6:BasicObject = LoadArg :self@0
+          v7:BasicObject = LoadArg :n@1
+          Jump bb3(v6, v7)
+        bb3(v9:BasicObject, v10:BasicObject):
+          v15:Fixnum[6] = Const Value(6)
+          PatchPoint MethodRedefined(Integer@0x1008, /@0x1010, cme:0x1018)
+          v26:Fixnum = GuardType v10, Fixnum recompile
+          v27:Integer = FixnumDiv v26, v15
+          CheckInterrupts
+          Return v27
+        ");
+    }
+
+    #[test]
+    fn test_dont_reduce_fixnum_div_negative_pow2() {
+        eval("
+            def test(n)
+              n / -8
+            end
+            test 1; test 2
+        ");
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:3:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          v2:CPtr = LoadSP
+          v3:BasicObject = LoadField v2, :n@0x1000
+          Jump bb3(v1, v3)
+        bb2():
+          EntryPoint JIT(0)
+          v6:BasicObject = LoadArg :self@0
+          v7:BasicObject = LoadArg :n@1
+          Jump bb3(v6, v7)
+        bb3(v9:BasicObject, v10:BasicObject):
+          v15:Fixnum[-8] = Const Value(-8)
+          PatchPoint MethodRedefined(Integer@0x1008, /@0x1010, cme:0x1018)
+          v26:Fixnum = GuardType v10, Fixnum recompile
+          v27:Integer = FixnumDiv v26, v15
+          CheckInterrupts
+          Return v27
+        ");
+    }
+
+    #[test]
     fn test_fold_fixnum_mod_zero_by_zero() {
         eval("
             def test


### PR DESCRIPTION
This PR strength-reduces `FixnumDiv` and `FixnumMod` (C calls) by power-of-two constants into `FixnumRShift` and `FixnumAnd` (pure arithmetic instructions) respectively.

This speeds up optcarrot by 5%:

```
before: ruby 4.1.0dev (2026-08-07T19:50:38Z master 969d44cc4b) +ZJIT +PRISM [x86_64-linux]
after: ruby 4.1.0dev (2026-08-07T20:24:31Z zjit-mod-div-pow2 f457f7bae0) +ZJIT +PRISM [x86_64-linux]

---------  ------------  ------------  -------------  ------------
bench       before (ms)    after (ms)  after 1st itr  before/after
optcarrot  953.8 ± 2.0%  908.1 ± 1.3%          1.096         1.050
---------  ------------  ------------  -------------  ------------
```