### PR TITLE
GC: scan a thread's machine stack once per collection

### DIFF
--- a/ractor.c
+++ b/ractor.c
@@ -268,10 +268,6 @@ ractor_mark_unshareable_parts(rb_ractor_t *r)
         ccan_list_for_each(&r->threads.set, th, lt_node) {
             VM_ASSERT(th != NULL);
             rb_gc_mark(th->self);
-            /* Mark the EC directly: the stack must stay alive even in windows where
-             * the Thread wrapper's own mark has not been traversed yet (mid-creation,
-             * teardown). */
-            if (th->ec) rb_execution_context_mark(th->ec);
 
             /* A thread's ec lives inside the root fiber struct and is freed with that
              * fiber's wrapper object, so keep the fiber wrappers alive from here too. */
@@ -279,9 +275,15 @@ ractor_mark_unshareable_parts(rb_ractor_t *r)
                 VALUE root_fiber_self = rb_fiberptr_self(th->root_fiber);
                 if (root_fiber_self) rb_gc_mark(root_fiber_self);
             }
-            if (th->ec && th->ec->fiber_ptr) {
-                VALUE fiber_self = rb_fiberptr_self(th->ec->fiber_ptr);
-                if (fiber_self) rb_gc_mark(fiber_self);
+            /* The ec sits inside its fiber, so marking that fiber's wrapper scans the ec
+             * as well.  Only when there is no wrapper yet (mid-creation, teardown) does
+             * the ec need marking of its own. */
+            VALUE ec_fiber_self = (th->ec && th->ec->fiber_ptr) ? rb_fiberptr_self(th->ec->fiber_ptr) : 0;
+            if (ec_fiber_self) {
+                rb_gc_mark(ec_fiber_self);
+            }
+            else if (th->ec) {
+                rb_execution_context_mark(th->ec);
             }
 
             /* Root the thread's remaining possessions directly as well; thgroup in


### PR DESCRIPTION
The Ractor root scan marked each thread's ec directly and then marked the wrapper of the fiber that ec lives in.  Both reach rb_execution_context_mark, so every thread's machine stack was scanned conservatively twice per collection -- with 5000 threads, 750270 scans where 362326 were needed.

Marking the fiber wrapper is enough: th->ec is &fiber->cont.saved_ec (thread_mark asserts as much), the wrapper goes on the mark stack during the root scan, and the stack drains before anything is swept.  Only when there is no wrapper yet, mid-creation or teardown, does the ec still need marking of its own.

benchmark/vm_thread_pass_flood.rb, which floods 5000 threads:

    collections           157      157      (unchanged)
    time in GC            0.84s -> 0.49s
    thread creation       1.17s -> 0.81s