### PR TITLE
GC: keep the marking helpers inlined

### DIFF
--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -5381,6 +5381,11 @@ init_mark_stack(mark_stack_t *stack)
 
 /* Marking */
 
+ALWAYS_INLINE(static int gc_mark_set(rb_objspace_t *objspace, VALUE obj));
+ALWAYS_INLINE(static void gc_mark_check_t_none(rb_objspace_t *objspace, VALUE obj));
+ALWAYS_INLINE(static void rgengc_check_relation(rb_objspace_t *objspace, VALUE obj));
+ALWAYS_INLINE(static void gc_aging(rb_objspace_t *objspace, VALUE obj));
+ALWAYS_INLINE(static void gc_grey(rb_objspace_t *objspace, VALUE obj));
 static void
 rgengc_check_relation(rb_objspace_t *objspace, VALUE obj)
 {


### PR DESCRIPTION
gcc stopped inlining the small helpers gc_mark calls for every reference it marks.  From -fopt-info-inline on gc.c, before and after the per-Ractor GC landed:

    gc_mark_set           -> gc_mark    10 -> 2
    gc_mark_check_t_none  -> gc_mark     8 -> 0
    rgengc_check_relation -> gc_mark     8 -> 4
    RVALUE_AGE_INC        -> gc_aging    2 -> 0

gc.c is one translation unit -- it includes the whole default implementation -- so gcc's growth budget is spent across all of it, and the added code pushed these out even though none of it runs on this path.  Marking then pays a call per reference.

Pin them with ALWAYS_INLINE.  .text does not grow (5834940 -> 5834812 bytes): what the inlining adds, the vanished call sequences take back.

Instructions retired, and wall clock as the best of seven runs:

    60 full collections, 207k live       3.74G -> 3.48G    0.39s -> 0.33s
    marking objects, hashes and classes  3.67G -> 3.43G
    allocation loop (40M [])            14.17G -> 13.85G   0.92s -> 0.86s
    allocation mixed with collection    18.06G -> 17.74G   1.28s -> 1.18s
    binary trees (depth 16)             34.42G -> 34.15G   3.06s -> 3.00s

Time moves more than the instruction count does: what goes away is a call and its register traffic on every marked reference.