### PR TITLE
Omit Proc#syntax_tree binary round-trip test when coverage is enabled

### DIFF
--- a/test/ruby/test_proc_syntax_tree.rb
+++ b/test/ruby/test_proc_syntax_tree.rb
@@ -85,7 +85,12 @@ class TestProcSyntaxTree < Test::Unit::TestCase
   def test_source_hash_survives_binary_round_trip
     with_loaded_file("def proc_ast_test_binary = :ok\n") do |path|
       iseq = RubyVM::InstructionSequence.compile_file(path)
-      loaded = RubyVM::InstructionSequence.load_from_binary(iseq.to_binary)
+      loaded = begin
+        RubyVM::InstructionSequence.load_from_binary(iseq.to_binary)
+      rescue RuntimeError => e
+        omit e.message if /compile with coverage/ =~ e.message
+        raise
+      end
 
       assert_equal iseq.source_hash, loaded.source_hash
       assert_equal (PRISM ? :program_node : :SCOPE), loaded.syntax_tree.type


### PR DESCRIPTION
The ruby/actions coverage workflow (`make -s check COVERAGE=true`) went
green once after #18237, then started failing again on every run with:

    RuntimeError: should not compile with coverage

raised by `TestProcSyntaxTree#test_source_hash_survives_binary_round_trip`
(test/ruby/test_proc_syntax_tree.rb:88), added in 6e65742a9f (#18005),
which calls `RubyVM::InstructionSequence#to_binary` directly without the
coverage guard (example run:
https://github.com/ruby/actions/actions/runs/31226236692).

This change guards the call with the same rescue/omit idiom established
in #18237 (test_iseq.rb's `iseq_to_binary` helper and test_iseq_load.rb).
Under coverage the test is omitted; in regular CI it still verifies the
binary round-trip. This is the only `to_binary` call in the file, and a
sweep of test/ found no other unguarded direct calls.

Verified with `ruby -c` and `git apply --check` against master (66c8e49a18).

🤖 Generated with [Claude Code](https://claude.com/claude-code)