### PR TITLE
GC: record a profile entry for a global collection

### DIFF
--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -697,9 +697,10 @@ typedef struct rb_objspace {
         rb_hrtime_t gc_stop_time;
         rb_hrtime_t gc_mark_phase_wall_start_time;
         rb_hrtime_t gc_sweep_phase_wall_start_time;
+#if GC_PROFILE_MORE_DETAIL
         size_t total_allocated_objects_at_gc_start;
         size_t heap_used_at_gc_start;
-        size_t heap_total_slots_at_gc_start;
+#endif
 
         /* basic statistics */
         size_t count;
@@ -7919,9 +7920,10 @@ static void
 gc_start_record(rb_objspace_t *objspace, unsigned int reason, bool full_mark)
 {
     objspace->profile.latest_gc_info = reason;
+#if GC_PROFILE_MORE_DETAIL
     objspace->profile.total_allocated_objects_at_gc_start = total_allocated_objects(objspace);
     objspace->profile.heap_used_at_gc_start = rb_darray_size(objspace->heap_pages.sorted);
-    objspace->profile.heap_total_slots_at_gc_start = objspace_available_slots(objspace);
+#endif
     objspace->profile.weak_references_count = 0;
     gc_prof_setup_new_record(objspace, reason);
     gc_reset_malloc_info(objspace, full_mark);

--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -7913,7 +7913,21 @@ gc_reset_malloc_info(rb_objspace_t *objspace, bool full_mark)
 #endif
 }
 
-static void gc_start_global(rb_objspace_t *driver, bool compact);
+/* What a collection records about itself before it runs.  A global collection reports the
+ * driver's objspace, so it comes through here too. */
+static void
+gc_start_record(rb_objspace_t *objspace, unsigned int reason, bool full_mark)
+{
+    objspace->profile.latest_gc_info = reason;
+    objspace->profile.total_allocated_objects_at_gc_start = total_allocated_objects(objspace);
+    objspace->profile.heap_used_at_gc_start = rb_darray_size(objspace->heap_pages.sorted);
+    objspace->profile.heap_total_slots_at_gc_start = objspace_available_slots(objspace);
+    objspace->profile.weak_references_count = 0;
+    gc_prof_setup_new_record(objspace, reason);
+    gc_reset_malloc_info(objspace, full_mark);
+}
+
+static void gc_start_global(rb_objspace_t *driver, unsigned int reason, bool compact);
 
 /* Decide whether this collection has to be global.  A local GC can reclaim neither
  * shareable objects nor zombie objspaces, so once those grow past their limits only a
@@ -7967,7 +7981,7 @@ gc_start_body(rb_objspace_t *objspace, unsigned int reason, bool allow_global)
      * (only a global cycle reclaims dead shareable objects and zombie pages).  The
      * exception is the retire GC, which never promotes: a Ractor's death must not STW. */
     if (allow_global && gc_need_global_p(objspace)) {
-        gc_start_global(objspace, false);
+        gc_start_global(objspace, reason, false);
         return TRUE;
     }
 
@@ -8072,13 +8086,7 @@ gc_start_body(rb_objspace_t *objspace, unsigned int reason, bool allow_global)
     }
 
     objspace->profile.count++;
-    objspace->profile.latest_gc_info = reason;
-    objspace->profile.total_allocated_objects_at_gc_start = total_allocated_objects(objspace);
-    objspace->profile.heap_used_at_gc_start = rb_darray_size(objspace->heap_pages.sorted);
-    objspace->profile.heap_total_slots_at_gc_start = objspace_available_slots(objspace);
-    objspace->profile.weak_references_count = 0;
-    gc_prof_setup_new_record(objspace, reason);
-    gc_reset_malloc_info(objspace, do_full_mark);
+    gc_start_record(objspace, reason, do_full_mark);
 
     gc_event_hook(objspace, RUBY_INTERNAL_EVENT_GC_START);
 
@@ -8683,15 +8691,18 @@ gc_global_mark_generic_fields(rb_objspace_t *driver)
 /* Two Ractors choosing a global GC at once are serialized by the barrier in gc_enter and
  * simply run two cycles back to back.  The second is wasted work, not an error. */
 static void
-gc_start_global(rb_objspace_t *driver, bool compact)
+gc_start_global(rb_objspace_t *driver, unsigned int reason, bool compact)
 {
     unsigned int lock_lev;
     gc_enter(driver, gc_enter_event_global, &lock_lev);
 
     /* A global GC is a collection of the driver's objspace too, and its profile.count
      * below says so, so report it like a local one.  The driver is the objspace whose
-     * count moves, which is the one a hook reading GC.stat would compare against. */
+     * count moves, which is the one a hook reading GC.stat would compare against.  For
+     * the same reason it records a profile entry and reports what triggered it. */
+    gc_start_record(driver, reason, true);
     gc_event_hook(driver, RUBY_INTERNAL_EVENT_GC_START);
+    gc_prof_timer_start(driver);
 
     GC_ASSERT(is_mark_stack_empty(&driver->mark_stack));
 
@@ -8915,6 +8926,7 @@ gc_start_global(rb_objspace_t *driver, bool compact)
      * zombie_objspaces entry and posted the merge to main as a postponed job; the objspace
      * stays enumerable until main absorbs it at its next safepoint. */
 
+    gc_prof_timer_stop(driver);
     gc_exit(driver, gc_enter_event_global, &lock_lev);
 }
 
@@ -9182,7 +9194,7 @@ rb_gc_impl_start(void *objspace_ptr, bool full_mark, bool immediate_mark, bool i
      * collector that reclaims shareable and cross-objspace garbage.  It stops the world,
      * so auto_compact is honoured here too (mirroring full mark x autocompact locally). */
     if (!rb_gc_single_objspace_p() && (reason & GPR_FLAG_FULL_MARK)) {
-        gc_start_global(objspace, compact || ruby_enable_autocompact);
+        gc_start_global(objspace, reason, compact || ruby_enable_autocompact);
     }
     else {
         garbage_collect(objspace, reason);

--- a/test/ruby/test_gc.rb
+++ b/test/ruby/test_gc.rb
@@ -619,6 +619,25 @@ class TestGc < Test::Unit::TestCase
     RUBY
   end
 
+  def test_profiler_raw_data_with_another_ractor
+    # A second objspace sends GC.start through the global collector, which has to record
+    # a profile entry the same way a local collection does.
+    assert_separately([], <<~RUBY)
+      Warning[:experimental] = false
+      Ractor.new {}.value
+
+      GC::Profiler.enable
+      GC::Profiler.clear
+      GC.start
+
+      record = GC::Profiler.raw_data.last
+      assert_not_nil record
+      assert_kind_of Float, record[:GC_WALL_TIME]
+    RUBY
+  ensure
+    GC::Profiler.disable
+  end
+
   def test_profiler_raw_data_includes_wall_time
     auto_compact = GC.auto_compact if GC.respond_to?(:auto_compact)
     GC.auto_compact = false if GC.respond_to?(:auto_compact=)


### PR DESCRIPTION
`gc_start_global` never called `gc_prof_setup_new_record`, so once a process has a second
objspace and `GC.start` runs a global collection, `GC::Profiler` records nothing:
`raw_data` comes back empty and `raw_data.last` is `nil`.

```
$ ruby -e 'GC::Profiler.enable; GC.start; p GC::Profiler.raw_data.size'
1
$ ruby -e 'Ractor.new{}.value; GC::Profiler.enable; GC.start; p GC::Profiler.raw_data.size'
0
```

`GC.start` takes the global path whenever `!rb_gc_single_objspace_p() && (reason &
GPR_FLAG_FULL_MARK)` -- that is, from the first Ractor the process ever creates onwards.

## Why it looks like a flake

`TestGc#test_profiler_raw_data_includes_wall_time` does `GC::Profiler.raw_data.last[...]`,
which raises `undefined method '[]' for nil` in that state.  test-all reuses worker
processes, so the test fails whenever its worker has already run something that makes a
Ractor -- which depends on how the suite is split.  Seen on ci.rvm.jp
master@oci-aarch64 6442491 (72dc9c777c, `-j3`), and reproducible anywhere with the
one-liner above.

## What was missing

Everything `gc_start` does to report a collection:

| | |
|---|---|
| `gc_prof_setup_new_record` + `gc_prof_timer_start/stop` | the record itself, and its times |
| `profile.latest_gc_info` | `GC.latest_gc_info` kept reporting the previous local collection |
| `heap_used_at_gc_start`, `heap_total_slots_at_gc_start`, `total_allocated_objects_at_gc_start`, `weak_references_count` | the figures the record is built from at the end of the collection |
| `gc_reset_malloc_info` | the record's malloc figures, and the malloc trigger -- a global collection is a collection, so what accumulated before it must not count towards the next one |

With the fix a global collection's record matches what a local one produces
(`HEAP_TOTAL_SIZE` 1112264 vs 1112280 for the same workload).

`gc_reset_malloc_info` also resets the malloc trigger; a malloc-heavy workload collects
the same number of times and ends with the same `malloc_increase_bytes_limit` before and
after.

## Test

`test_profiler_raw_data_with_another_ractor` makes a Ractor first and then checks the
record.  It fails without the fix and does not depend on test ordering.

## Second commit: fields nothing reads

Of the four figures a collection snapshots about itself, three are read only by
`gc_prof_set_heap_info` inside `#if GC_PROFILE_MORE_DETAIL`, and one of those --
`heap_total_slots_at_gc_start` -- has no reader at all.  A default build walks every heap
twice per collection to fill fields it will never look at.  The two the detailed profiler
wants go behind the same `#if`; the third is dropped.

## Tests run

- `make btest`: PASS all 2058
- `make test-all TESTS=-j3`: 35866 tests, 7773529 assertions, 0 failures, 0 errors
- `make test-spec`: 3455 files, 33019 examples, 0 failures, 0 errors
- A `GC_PROFILE_MORE_DETAIL=1` build compiles and reports `HEAP_USE_PAGES` /
  `HEAP_LIVE_OBJECTS` for a global collection as well.
