### PR TITLE
Exclude test_profiler_raw_data_with_another_ractor on MMTk

### DIFF
--- a/test/.excludes-mmtk/TestGc.rb
+++ b/test/.excludes-mmtk/TestGc.rb
@@ -15,6 +15,7 @@ exclude(:test_old_to_young_reference, "testing behaviour specific to default GC"
 exclude(:test_profiler_enabled, "MMTk does not have GC::Profiler")
 exclude(:test_profiler_raw_data, "MMTk does not have GC::Profiler")
 exclude(:test_profiler_raw_data_since, "MMTk does not have GC::Profiler")
+exclude(:test_profiler_raw_data_with_another_ractor, "MMTk does not have GC::Profiler")
 exclude(:test_profiler_raw_data_limit, "MMTk does not have GC::Profiler")
 exclude(:test_profiler_raw_data_reports_compaction_separately_from_sweep_wall_time, "MMTk does not have GC::Profiler")
 exclude(:test_profiler_raw_data_includes_wall_time, "MMTk does not have GC::Profiler")


### PR DESCRIPTION
MMTk does not define GC::Profiler, so the test added in 339d6b8346 fails there with "uninitialized constant GC::Profiler", the same way every other GC::Profiler test in this file would.