### PR TITLE
GC: measure the pause and the marking phase of a global collection

### DIFF
--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -8326,10 +8326,14 @@ gc_enter(rb_objspace_t *objspace, enum gc_enter_event event, unsigned int *lock_
           case gc_enter_event_start:
           case gc_enter_event_continue:
           case gc_enter_event_rest:
+          case gc_enter_event_global:
+            /* A global GC is the longest pause the process takes, so it is the last thing
+             * the profiler may leave unmeasured.  The switch below stops the world for it,
+             * which is exactly the interval gc_stop_time is meant to name, so start the
+             * clock here like a local collection does. */
             objspace->profile.gc_pause_start_time = rb_hrtime_now();
             break;
           case gc_enter_event_finalizer:
-          case gc_enter_event_global:
             break;
         }
     }

--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -8782,7 +8782,11 @@ gc_start_global(rb_objspace_t *driver, unsigned int reason, bool compact)
     }
 
     /* steps 6-7: every Ractor's roots (gc.c walks them all and re-pins in-flight payloads),
-     * then one unified precise mark. */
+     * then one unified precise mark.  A global GC does not go through gc_marks, so the marking
+     * phase is opened here instead; it closes after rb_ractor_finish_marking below, which is
+     * where gc_marks_finish ends for a local collection. */
+    gc_marking_enter(driver);
+
     mark_roots(driver, NULL);
     gc_mark_stacked_objects_all(driver);
 
@@ -8800,6 +8804,8 @@ gc_start_global(rb_objspace_t *driver, unsigned int reason, bool compact)
      * each storage.  Free the key structs while still inside the barrier (a local GC never
      * can; see rb_ractor_finish_marking). */
     rb_ractor_finish_marking();
+
+    gc_marking_exit(driver);
 
     /* Clean the VM-global weak tables once, before sweeping any objspace (gc_sweep_start
      * skips it during a global GC; the decision comes from the objspace-independent unified

--- a/test/ruby/test_gc.rb
+++ b/test/ruby/test_gc.rb
@@ -637,6 +637,8 @@ class TestGc < Test::Unit::TestCase
       # A global collection stops the world for its whole duration, so its pause time is
       # recorded like a local one's -- and the phases it measures fit inside it.
       assert_operator record[:GC_PAUSE_TIME], :>, 0.0
+      assert_operator record[:GC_MARK_WALL_TIME], :>, 0.0
+      assert_operator record[:GC_SWEEP_WALL_TIME], :>, 0.0
       assert_in_delta record[:GC_PAUSE_TIME], record[:GC_STOP_TIME] + record[:GC_STW_TIME], 0.001
       assert_operator record[:GC_MARK_WALL_TIME] + record[:GC_SWEEP_WALL_TIME], :<=, record[:GC_PAUSE_TIME]
     RUBY

--- a/test/ruby/test_gc.rb
+++ b/test/ruby/test_gc.rb
@@ -633,6 +633,12 @@ class TestGc < Test::Unit::TestCase
       record = GC::Profiler.raw_data.last
       assert_not_nil record
       assert_kind_of Float, record[:GC_WALL_TIME]
+
+      # A global collection stops the world for its whole duration, so its pause time is
+      # recorded like a local one's -- and the phases it measures fit inside it.
+      assert_operator record[:GC_PAUSE_TIME], :>, 0.0
+      assert_in_delta record[:GC_PAUSE_TIME], record[:GC_STOP_TIME] + record[:GC_STW_TIME], 0.001
+      assert_operator record[:GC_MARK_WALL_TIME] + record[:GC_SWEEP_WALL_TIME], :<=, record[:GC_PAUSE_TIME]
     RUBY
   ensure
     GC::Profiler.disable


### PR DESCRIPTION
A global collection stops every Ractor for its entire duration, and it is the only
collection whose pause the profiler did not measure.  `GC::Profiler` reported it as
free:

```
local collection   PAUSE=0.000641170 STOP=0.000001886 STW=0.000639284 MARK=0.000467187 SWEEP=0.000148768
global collection  PAUSE=0.000000000 STOP=0.000000000 STW=0.000000000 MARK=0.000000000 SWEEP=0.000054897
```

Two separate holes, one commit each.

## The pause

`gc_enter` starts the pause clock for `gc_enter_event_start`, `_continue` and `_rest`,
but `gc_enter_event_global` sat in the `break`-only group next to
`gc_enter_event_finalizer`.  With `gc_pause_start_time` left at 0, the whole

```c
if (objspace->profile.gc_pause_start_time) { ... }
```

block in `gc_exit` was skipped, so `GC_PAUSE_TIME`, `GC_STOP_TIME` and `GC_STW_TIME`
stayed 0.0.

`gc_enter` stops the world for a global collection immediately below, with
`RB_GC_VM_LOCK()` plus `rb_gc_vm_barrier()`.  That is exactly the interval
`gc_stop_time` already names for a local collection, so starting the clock in the same
place gives the same decomposition: `gc_stop_time` is the wait for the barrier,
`gc_stw_time` the stopped interval.

## The marking phase

`gc_start_global` does not go through `gc_marks`, which is what opens and closes the
marking phase for a local collection, so nothing measured the unified mark:
`GC_MARK_WALL_TIME` came back 0.0, and `objspace->profile.marking_time_ns` -- what
`GC.stat` reports as `:marking_time` -- never moved for a global collection either.
Sweeping was already measured, because `gc_start_global` reaches it through `gc_sweep`.

`gc_marking_enter` now opens at the root pass and `gc_marking_exit` closes after
`rb_ractor_finish_marking`, which is where `gc_marks_finish` ends for a local
collection.  Cleaning the VM-global weak tables stays outside: for a local collection
that is `gc_sweep_start`'s work, not the mark's.

## After

```
local collection   PAUSE=0.000657792 STOP=0.000001397 STW=0.000656395 MARK=0.000489119 SWEEP=0.000142970
global collection  PAUSE=0.000584526 STOP=0.000001886 STW=0.000582640 MARK=0.000505252 SWEEP=0.000052802
```

`GC_STOP_TIME + GC_STW_TIME == GC_PAUSE_TIME` holds for a global collection now, and
the phases it measures fit inside its pause.

## Why it was failing CI

`TestGc#test_profiler_raw_data_includes_wall_time` asserts

```ruby
assert_operator record[:GC_MARK_WALL_TIME] + record[:GC_SWEEP_WALL_TIME], :<=, record[:GC_PAUSE_TIME] + 0.001
```

With `GC_PAUSE_TIME` at 0.0 this degenerates to `mark + sweep <= 0.001`, so it passed
only while a collection stayed under the 1ms slack.  `GC.start` takes the global path
from the first Ractor the process creates onwards, and test-all reuses worker
processes, so whether the test hits it depends on how the suite is split.  It failed on
ci.rvm.jp master@oci-aarch64 6442788 with 0.001849049.

## Cost

Two clock reads per global collection -- the ones a local collection already pays --
against a collection that stops every Ractor for hundreds of microseconds.  3000 global
collections, best of 5:

```
before  18.163 s  (6054.4 us each)
after   17.369 s  (5789.7 us each)
```

The after run coming out faster is noise; the point is that the difference is below it.

## Test

`test_profiler_raw_data_with_another_ractor` already makes a Ractor before it looks at
the record, so the assertions go there.  Each commit's assertions fail without that
commit's change.

## Tests run

- `make btest`: PASS all 2058
- `make test-all TESTS=-j8`: 36055 tests, 7794556 assertions, 0 failures, 0 errors, 186 skips
- `make test-spec`: 3455 files, 33019 examples, 247064 expectations, 0 failures, 0 errors
- `make test-all TESTS="ruby/test_gc.rb ruby/test_gc_compact.rb ruby/test_ractor.rb objspace"`:
  200 tests, 97941 assertions, 0 failures, 0 errors
