### PR TITLE
Ractor: reclaim a dead Ractor's memory at its death

### DIFF
--- a/cont.c
+++ b/cont.c
@@ -1302,6 +1302,22 @@ static void
 fiber_free(void *ptr)
 {
     rb_fiber_t *fiber = ptr;
+
+    /* Root fiber of the thread running the final self collection: saved_ec is the ec
+     * that thread still executes on, so the thread frees the struct itself at its
+     * last step (rb_ractor_postmortem_free).  cont.self == 0 already means "no
+     * wrapper" (rb_threadptr_root_fiber_release). */
+    if (&fiber->cont.saved_ec == rb_current_execution_context(false)) {
+        fiber->cont.self = 0;
+        return;
+    }
+    rb_fiber_free_body(ptr);
+}
+
+void
+rb_fiber_free_body(void *ptr)
+{
+    rb_fiber_t *fiber = ptr;
     RUBY_FREE_ENTER("fiber");
 
     if (DEBUG) fprintf(stderr, "fiber_free: %p[%p]\n", (void *)fiber, fiber->stack.base);

--- a/ext/objspace/object_tracing.c
+++ b/ext/objspace/object_tracing.c
@@ -94,11 +94,10 @@ newobj_i(VALUE tpval, void *data)
     st_data_t v;
 
     if (st_lookup(arg->object_table, (st_data_t)obj, &v)) {
-        /* keep_remains kept this slot's entry after its object was freed. The
-         * allocator has now reused that address, so recycle the dead entry's
-         * info. A living entry here would mean two live objects at one address. */
+        /* The allocator reused this address: recycle the stale entry.  It can still
+         * be marked living -- an object in a non-main objspace dies without a
+         * FREEOBJ hook (they are restricted to the main objspace). */
         info = (struct allocation_info *)v;
-        assert(!info->living);
         delete_unique_str(arg->str_table, info->path);
         delete_unique_str(arg->str_table, info->class_path);
     }

--- a/gc.c
+++ b/gc.c
@@ -644,6 +644,7 @@ typedef struct gc_function_map {
     bool (*user_gc_disabled_p)(void *objspace_ptr);
     bool (*multi_objspace_p)(void);
     bool (*during_global_gc_p)(void *objspace_ptr);
+    bool (*during_postmortem_p)(void *objspace_ptr);
     bool (*obj_foreign_p)(void *objspace_ptr, VALUE obj);
     bool (*shref_marked_p)(void *objspace_ptr, VALUE obj);
     size_t (*heap_page_count)(void *objspace_ptr);
@@ -838,6 +839,7 @@ ruby_modular_gc_init(void)
     load_modular_gc_func(user_gc_disabled_p);
     load_modular_gc_func(multi_objspace_p);
     load_modular_gc_func(during_global_gc_p);
+    load_modular_gc_func(during_postmortem_p);
     load_modular_gc_func(obj_foreign_p);
     load_modular_gc_func(shref_marked_p);
     load_modular_gc_func(heap_page_count);
@@ -941,6 +943,7 @@ ruby_modular_gc_init(void)
 # define rb_gc_impl_user_gc_disabled_p rb_gc_functions.user_gc_disabled_p
 # define rb_gc_impl_multi_objspace_p rb_gc_functions.multi_objspace_p
 # define rb_gc_impl_during_global_gc_p rb_gc_functions.during_global_gc_p
+# define rb_gc_impl_during_postmortem_p rb_gc_functions.during_postmortem_p
 # define rb_gc_impl_obj_foreign_p rb_gc_functions.obj_foreign_p
 # define rb_gc_impl_shref_marked_p rb_gc_functions.shref_marked_p
 # define rb_gc_impl_heap_page_count rb_gc_functions.heap_page_count
@@ -3369,8 +3372,14 @@ rb_gc_mark_roots(void *objspace, const char **categoryp)
         rb_sym_global_symbols_mark_and_move();
     }
 
-    MARK_CHECKPOINT("machine_context");
-    mark_current_machine_context(ec);
+    /* The dying thread's final collection of its own objspace runs after its stack
+     * has been torn down (thread_cleanup_func), so there is no live machine context
+     * to scan -- the join value and the pins are rooted explicitly.  Scanning the
+     * half-dead stack is not only useless but faults on some platforms. */
+    if (!rb_gc_impl_during_postmortem_p(objspace)) {
+        MARK_CHECKPOINT("machine_context");
+        mark_current_machine_context(ec);
+    }
 
     MARK_CHECKPOINT("finish");
 
@@ -4201,6 +4210,17 @@ objspace_absorb_merge(void *dst, void *src)
     ASSERT_vm_locking();
     rb_gc_impl_objspace_absorb(dst, src);
     gc_absorbed_since_global_gc = true;
+}
+
+/* The dying thread's last collection of its own objspace, GVL still held; with
+ * r->postmortem set, rb_ractor_mark_local_roots roots only the join value and the
+ * registered_marks pins, so the scaffolding nobody needs any more dies here. */
+void
+rb_gc_objspace_postmortem_self(void)
+{
+    if (!rb_gc_impl_multi_objspace_p()) return;
+
+    rb_gc_impl_objspace_retire_gc(rb_gc_get_objspace());
 }
 
 void

--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -605,6 +605,7 @@ typedef struct rb_objspace {
         unsigned int during_reference_updating : 1;
         unsigned int during_minor_gc : 1;
         unsigned int during_incremental_marking : 1;
+        unsigned int during_postmortem : 1;
         unsigned int measure_gc : 1;
     } flags;
 
@@ -7805,12 +7806,25 @@ rb_gc_impl_objspace_retire_gc(void *objspace_ptr)
 {
     rb_objspace_t *objspace = objspace_ptr;
 
+    /* The dying thread's stack is already torn down here, so the root scan must skip
+     * its machine context (rb_gc_mark_roots). */
+    objspace->flags.during_postmortem = 1;
+
     gc_rest(objspace);
     gc_start_body(objspace, GPR_FLAG_FULL_MARK | GPR_FLAG_IMMEDIATE_MARK | GPR_FLAG_IMMEDIATE_SWEEP,
                   false);
 
     heap_pages_freeable_pages = objspace->empty_pages_count;
     heap_pages_free_unused_pages(objspace);
+
+    objspace->flags.during_postmortem = 0;
+}
+
+bool
+rb_gc_impl_during_postmortem_p(void *objspace_ptr)
+{
+    rb_objspace_t *objspace = objspace_ptr;
+    return objspace->flags.during_postmortem != 0;
 }
 
 static void

--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -7801,6 +7801,37 @@ rb_gc_impl_ractor_cache_free(void *objspace_ptr, void *cache)
  * mark is tiny, and it reclaims what the joining side would otherwise inherit.  Never
  * promotes to a global GC (that would STW on every Ractor death); empty pages go
  * straight back to the page pool. */
+/* Finalize the zombies whose cleanup is pure C (a dfree, no Ruby-level finalizer);
+ * the caller has no Ruby execution context any more, so zombies with a Ruby
+ * finalizer stay deferred and travel to the inheritor as before.  Returns whether
+ * anything was finalized (those pages then need one more sweep to detach). */
+static bool
+finalize_deferred_dfree_only(rb_objspace_t *objspace)
+{
+    VALUE dfree_only = 0;
+    VALUE zombie = RUBY_ATOMIC_VALUE_EXCHANGE(heap_pages_deferred_final, 0);
+    while (zombie) {
+        rb_asan_unpoison_object(zombie, false);
+        VALUE next = RZOMBIE(zombie)->next;
+        if (FL_TEST_RAW(zombie, FL_FINALIZE)) {
+            /* re-defer, with the same push as rb_gc_impl_make_zombie */
+            VALUE prev2, next2 = heap_pages_deferred_final;
+            do {
+                RZOMBIE(zombie)->next = prev2 = next2;
+                next2 = RUBY_ATOMIC_VALUE_CAS(heap_pages_deferred_final, prev2, zombie);
+            } while (next2 != prev2);
+            rb_asan_poison_object(zombie);
+        }
+        else {
+            RZOMBIE(zombie)->next = dfree_only;
+            dfree_only = zombie;
+        }
+        zombie = next;
+    }
+    if (dfree_only) finalize_list(objspace, dfree_only);
+    return dfree_only != 0;
+}
+
 void
 rb_gc_impl_objspace_retire_gc(void *objspace_ptr)
 {
@@ -7813,6 +7844,14 @@ rb_gc_impl_objspace_retire_gc(void *objspace_ptr)
     gc_rest(objspace);
     gc_start_body(objspace, GPR_FLAG_FULL_MARK | GPR_FLAG_IMMEDIATE_MARK | GPR_FLAG_IMMEDIATE_SWEEP,
                   false);
+
+    /* The sweep above turned this heap's dead IO and the like into deferred zombies
+     * (the per-Ractor stdio holds a page per Ractor otherwise); finalize the C-only
+     * ones here and re-sweep the nearly-empty heap so their pages detach as empty. */
+    if (finalize_deferred_dfree_only(objspace)) {
+        gc_start_body(objspace, GPR_FLAG_FULL_MARK | GPR_FLAG_IMMEDIATE_MARK | GPR_FLAG_IMMEDIATE_SWEEP,
+                      false);
+    }
 
     heap_pages_freeable_pages = objspace->empty_pages_count;
     heap_pages_free_unused_pages(objspace);

--- a/gc/gc_impl.h
+++ b/gc/gc_impl.h
@@ -137,6 +137,9 @@ GC_IMPL_FN void rb_gc_impl_each_objects_foreign(void *objspace_ptr, int (*callba
  * objspace and passes the per-Ractor objspace machinery (retire, absorb, ...) straight through. */
 GC_IMPL_FN bool rb_gc_impl_multi_objspace_p(void);
 GC_IMPL_FN bool rb_gc_impl_during_global_gc_p(void *objspace_ptr);
+/* Whether the current collection is a dying thread's final collection of its own
+ * objspace, whose torn-down machine context must not be scanned. */
+GC_IMPL_FN bool rb_gc_impl_during_postmortem_p(void *objspace_ptr);
 /* Whether obj is owned by an objspace other than objspace_ptr.  Always false for a single
  * objspace impl. */
 GC_IMPL_FN bool rb_gc_impl_obj_foreign_p(void *objspace_ptr, VALUE obj);

--- a/gc/mmtk/mmtk.c
+++ b/gc/mmtk/mmtk.c
@@ -1816,6 +1816,13 @@ rb_gc_impl_during_global_gc_p(void *objspace_ptr)
 }
 
 bool
+rb_gc_impl_during_postmortem_p(void *objspace_ptr)
+{
+    /* mmtk has a single objspace and no per-Ractor retire collection. */
+    return false;
+}
+
+bool
 rb_gc_impl_obj_foreign_p(void *objspace_ptr, VALUE obj)
 {
     /* With a single objspace every object is our own. */

--- a/internal/cont.h
+++ b/internal/cont.h
@@ -31,4 +31,5 @@ VALUE rb_fiber_inherit_storage(struct rb_execution_context_struct *ec, struct rb
 VALUE rb_fiberptr_self(struct rb_fiber_struct *fiber);
 unsigned int rb_fiberptr_blocking(struct rb_fiber_struct *fiber);
 struct rb_execution_context_struct * rb_fiberptr_get_ec(struct rb_fiber_struct *fiber);
+void rb_fiber_free_body(void *fiber);  /* cont.c */
 #endif /* INTERNAL_CONT_H */

--- a/internal/gc.h
+++ b/internal/gc.h
@@ -304,6 +304,7 @@ bool rb_gc_obj_foreign_p(VALUE obj);
 void *rb_gc_objspace_alloc(void);
 void rb_gc_objspace_retire_gc(void);
 void rb_gc_objspace_retire(void **objspace_slot);
+void rb_gc_objspace_postmortem_self(void);
 void rb_gc_objspace_absorb_into_current(void **objspace_slot);
 void rb_gc_objspace_absorb_all_zombies(void);
 void rb_gc_objspace_disown(void *objspace);

--- a/internal/thread.h
+++ b/internal/thread.h
@@ -55,6 +55,9 @@ void rb_ec_check_ints(struct rb_execution_context_struct *ec);
 
 void rb_thread_free_native_thread(void *th_ptr);
 
+bool rb_thread_event_hooks_registered_p(void); /* thread_pthread.c */
+void rb_thread_free_body(void *th);            /* vm.c */
+
 RUBY_SYMBOL_EXPORT_BEGIN
 
 void *rb_thread_prevent_fork(void *(*func)(void *), void *data); /* for ext/socket/raddrinfo.c */

--- a/ractor.c
+++ b/ractor.c
@@ -324,6 +324,14 @@ ractor_mark(void *ptr)
 void
 rb_ractor_mark_local_roots(rb_ractor_t *r)
 {
+    if (r->postmortem) {
+        /* The final self collection: everything else -- the Thread and Fiber
+         * wrappers, stdio, stack leftovers -- is what it exists to reclaim. */
+        rb_ractor_mark_terminated_join_value(r);
+        rb_gc_mark_vm_stack_values((long)r->registered_marks_cnt, r->registered_marks);
+        return;
+    }
+
     rb_gc_mark(r->loc);
     rb_gc_mark(r->name);
     ractor_mark_unshareable_parts(r);
@@ -621,6 +629,8 @@ vm_remove_ractor(rb_vm_t *vm, rb_ractor_t *cr)
          * cnt==1-no-zombie window where a GC skips shareable pinning and collects
          * objects (a cc, say) reachable only through this objspace. */
         if (cr->objspace) {
+            /* The final self collection already ran (rb_ractor_postmortem_collect),
+             * so the entry measures exactly the pages the joiner will inherit. */
             rb_gc_objspace_retire(&cr->objspace);
         }
         vm->ractor.cnt--;
@@ -628,6 +638,50 @@ vm_remove_ractor(rb_vm_t *vm, rb_ractor_t *cr)
         ractor_status_set(cr, ractor_terminated);
     }
     RB_VM_UNLOCK();
+}
+
+/* The dying thread's final collection of its own objspace, and the capture of what it
+ * must free itself.  Called with the GVL still held: a concurrent global GC waits for
+ * this thread's safepoint, so the collection is lock-free like any local GC. */
+void
+rb_ractor_postmortem_collect(rb_thread_t *th, struct rb_ractor_postmortem_frees *pf)
+{
+    rb_ractor_t *const cr = th->ractor;
+    VM_ASSERT(cr != GET_VM()->ractor.main_ractor);
+    VM_ASSERT(th->ec != NULL);
+
+    struct rb_fiber_struct *const fiber = th->ec->fiber_ptr;
+    const bool fiber_wrapped = fiber && rb_fiberptr_self(fiber) != 0;
+
+    /* With a thread-event hook registered the callbacks may retain any Ractor's Thread
+     * object (rb_internal_thread_event_hook_t), and such references are invisible to
+     * the reduced roots: keep the ordinary retire roots, wrappers survive to absorb. */
+    cr->postmortem = rb_gc_multi_objspace_p() && !rb_thread_event_hooks_registered_p();
+    rb_gc_objspace_postmortem_self();
+
+    /* Only what this collection provably swept (wrapper gone, struct deferred with an
+     * in-band mark) may be touched after vm_remove_ractor unlinks the Ractor. */
+    pf->th = (th->self == 0) ? th : NULL;
+    pf->fiber = (fiber_wrapped && rb_fiberptr_self(fiber) == 0) ? fiber : NULL;
+}
+
+void
+rb_ractor_postmortem_free(const struct rb_ractor_postmortem_frees *pf)
+{
+    if (pf->fiber == NULL && pf->th == NULL) return;
+
+    /* The frees below resolve their objspace through the TLS ec, which sits inside
+     * pf->fiber and leads to the retired Ractor: cut the resolution off so they fall
+     * back to the main objspace.  (The MN epilogue has already done this.) */
+#ifdef RB_THREAD_LOCAL_SPECIFIER
+    rb_current_ec_set(NULL);
+#else
+    native_tls_set(ruby_current_ec_key, NULL);
+#endif
+
+    /* the fiber struct embeds the thread's final ec, so free it first */
+    if (pf->fiber) rb_fiber_free_body(pf->fiber);
+    if (pf->th) rb_thread_free_body(pf->th);
 }
 
 static VALUE

--- a/ractor.c
+++ b/ractor.c
@@ -1383,6 +1383,9 @@ rb_ractor_stdin(void)
     }
     else {
         rb_ractor_t *cr = GET_RACTOR();
+        if (UNLIKELY(cr->r_stdin == 0)) {
+            cr->r_stdin = rb_io_prep_stdin();
+        }
         return cr->r_stdin;
     }
 }
@@ -1395,6 +1398,9 @@ rb_ractor_stdout(void)
     }
     else {
         rb_ractor_t *cr = GET_RACTOR();
+        if (UNLIKELY(cr->r_stdout == 0)) {
+            cr->r_stdout = rb_io_prep_stdout();
+        }
         return cr->r_stdout;
     }
 }
@@ -1407,6 +1413,9 @@ rb_ractor_stderr(void)
     }
     else {
         rb_ractor_t *cr = GET_RACTOR();
+        if (UNLIKELY(cr->r_stderr == 0)) {
+            cr->r_stderr = rb_io_prep_stderr();
+        }
         return cr->r_stderr;
     }
 }

--- a/ractor_core.h
+++ b/ractor_core.h
@@ -125,6 +125,10 @@ struct rb_ractor_struct {
 
     struct ccan_list_node vmlr_node;
     bool in_terminated_set;  /* vmlr_node is on vm->ractor.terminated_set */
+    /* The final self collection ran (rb_ractor_postmortem_collect): from then on
+     * rb_ractor_mark_local_roots roots only the join value and the registered_marks
+     * pins, so the dying thread's own scaffolding can be collected. */
+    bool postmortem;
 
     // ractor local data
 
@@ -221,6 +225,15 @@ bool rb_ractor_p(VALUE rv);
 void rb_ractor_living_threads_init(rb_ractor_t *r);
 void rb_ractor_living_threads_insert(rb_ractor_t *r, rb_thread_t *th);
 void rb_ractor_living_threads_remove(rb_ractor_t *r, rb_thread_t *th);
+
+/* The structs the final self collection swept while the dying thread still stood on
+ * them; that thread frees them at its very last step (rb_ractor_postmortem_free). */
+struct rb_ractor_postmortem_frees {
+    struct rb_thread_struct *th;
+    struct rb_fiber_struct *fiber;
+};
+void rb_ractor_postmortem_collect(rb_thread_t *th, struct rb_ractor_postmortem_frees *pf);
+void rb_ractor_postmortem_free(const struct rb_ractor_postmortem_frees *pf);
 void rb_ractor_cancel_creation(rb_ractor_t *r, rb_thread_t *th);
 void rb_ractor_blocking_threads_inc(rb_ractor_t *r, const char *file, int line); // TODO: file, line only for RUBY_DEBUG_LOG
 void rb_ractor_blocking_threads_dec(rb_ractor_t *r, const char *file, int line); // TODO: file, line only for RUBY_DEBUG_LOG

--- a/ractor_core.h
+++ b/ractor_core.h
@@ -138,6 +138,9 @@ struct rb_ractor_struct {
     struct rb_id_table *idkey_local_storage;
     VALUE local_storage_store_lock;
 
+    /* 0 until first use: rb_ractor_stdin and friends build them lazily, with plain
+     * stores (rooted via ractor_mark_unshareable_parts; a write barrier on the
+     * shareable wrapper would shref-pin them). */
     VALUE r_stdin;
     VALUE r_stdout;
     VALUE r_stderr;

--- a/ractor_sync.c
+++ b/ractor_sync.c
@@ -675,12 +675,6 @@ ractor_notify_exit(rb_execution_context_t *ec, rb_ractor_t *cr, VALUE legacy, bo
     VM_ASSERT(!UNDEF_P(legacy));
     VM_ASSERT(cr->sync.legacy == Qundef);
 
-    /* Last local GC before termination, in ordinary execution context: collect here
-     * what the joiner would otherwise inherit, and return empty pages to the pool. */
-    if (cr != GET_VM()->ractor.main_ractor) {
-        rb_gc_objspace_retire_gc();
-    }
-
     RACTOR_LOCK_SELF(cr);
     {
         ractor_free_all_ports(cr);

--- a/thread.c
+++ b/thread.c
@@ -827,12 +827,20 @@ thread_start_func_2(rb_thread_t *th, VALUE *stack_start)
     thread_cleanup_func(th, FALSE);
     VM_ASSERT(th->ec->vm_stack == NULL);
 
+    // A dying Ractor collects its own objspace here, before the scheduler handoff
+    // below, and captures the structs it must free at its last step.
+    struct rb_ractor_postmortem_frees pf = { NULL, NULL };
+    if (th->invoke_type == thread_invoke_type_ractor_proc) {
+        rb_ractor_postmortem_collect(th, &pf);
+    }
+
 #if defined(USE_MN_THREADS) && USE_MN_THREADS
     if (th_has_coroutine(th)) {
         // Run the coroutine thread's epilogue here, while th is still valid;
         // co_start then only makes the final transfer (see
         // coroutine_thread_terminated in thread_pthread_mn.c).
         coroutine_thread_terminated(th);
+        rb_ractor_postmortem_free(&pf);
         return 0;
     }
 #endif
@@ -843,6 +851,7 @@ thread_start_func_2(rb_thread_t *th, VALUE *stack_start)
         // So gvl_release() should be before it.
         thread_sched_to_dead(TH_SCHED(th), th);
         rb_ractor_living_threads_remove(th->ractor, th);
+        rb_ractor_postmortem_free(&pf);
     }
     else {
         rb_ractor_living_threads_remove(th->ractor, th);

--- a/thread.c
+++ b/thread.c
@@ -696,10 +696,6 @@ thread_start_func_2(rb_thread_t *th, VALUE *stack_start)
         RB_VM_LOCK();
         {
             rb_vm_ractor_blocking_cnt_dec(th->vm, th->ractor, __FILE__, __LINE__);
-            rb_ractor_t *r = th->ractor;
-            r->r_stdin = rb_io_prep_stdin();
-            r->r_stdout = rb_io_prep_stdout();
-            r->r_stderr = rb_io_prep_stderr();
 
             /* Left 0 at creation (building them then would put them in the parent's
              * objspace), so build them here out of objects this Ractor owns.  The mask

--- a/thread_none.c
+++ b/thread_none.c
@@ -331,6 +331,12 @@ rb_thread_malloc_stack_set(rb_thread_t *th, void *stack, size_t stack_size)
     // no-op
 }
 
+bool
+rb_thread_event_hooks_registered_p(void)
+{
+    return false; // hooks are not implemented on this platform
+}
+
 #endif /* THREAD_SYSTEM_DEPENDENT_IMPLEMENTATION */
 
 void

--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -3558,6 +3558,24 @@ struct rb_internal_thread_event_hook {
 
 static pthread_rwlock_t rb_internal_thread_event_hooks_rw_lock = PTHREAD_RWLOCK_INITIALIZER;
 
+/* For the GC: whether any thread-event hook is registered right now.  The rwlock
+ * makes the answer happen-after any completed registration; a hook registered
+ * after this read gets no event from the asking thread (rb_thread_execute_hooks
+ * skips a swept thread), so it never sees the objects the caller may collect. */
+bool
+rb_thread_event_hooks_registered_p(void)
+{
+    int r;
+    if ((r = pthread_rwlock_rdlock(&rb_internal_thread_event_hooks_rw_lock))) {
+        rb_bug_errno("pthread_rwlock_rdlock", r);
+    }
+    const bool registered = (rb_internal_thread_event_hooks != NULL);
+    if ((r = pthread_rwlock_unlock(&rb_internal_thread_event_hooks_rw_lock))) {
+        rb_bug_errno("pthread_rwlock_unlock", r);
+    }
+    return registered;
+}
+
 #if defined(HAVE_WORKING_FORK)
 static void
 rb_internal_thread_event_hooks_rw_lock_atfork(void)
@@ -3636,6 +3654,10 @@ static void
 rb_thread_execute_hooks(rb_event_flag_t event, rb_thread_t *th)
 {
     int r;
+
+    /* th->self == 0: the dying thread's final collection swept its Thread wrapper, so
+     * no hook existed then; one registered since has no ordering claim to this event. */
+    if (th->self == 0) return;
     if ((r = pthread_rwlock_rdlock(&rb_internal_thread_event_hooks_rw_lock))) {
         rb_bug_errno("pthread_rwlock_rdlock", r);
     }

--- a/thread_pthread_mn.c
+++ b/thread_pthread_mn.c
@@ -603,8 +603,9 @@ native_thread_create_shared(rb_thread_t *th)
     RUBY_DEBUG_LOG("th:%u vm_stack:%p machine_stack:%p", rb_th_serial(th), vm_stack, machine_stack);
     thread_sched_to_ready(TH_SCHED(th), th);
 
-    // setup nt
-    return native_thread_check_and_create_shared(th->vm);
+    // setup nt.  th is runnable now and a Ractor's thread that runs to its end frees
+    // its own rb_thread_t (rb_ractor_postmortem_free), so th must not be read again.
+    return native_thread_check_and_create_shared(vm);
 }
 
 #else // USE_MN_THREADS

--- a/thread_win32.c
+++ b/thread_win32.c
@@ -44,6 +44,12 @@ rb_internal_thread_remove_event_hook(rb_internal_thread_event_hook_t * hook)
     return false;
 }
 
+bool
+rb_thread_event_hooks_registered_p(void)
+{
+    return false; // hooks are not implemented on this platform
+}
+
 RBIMPL_ATTR_NORETURN()
 static void
 w32_error(const char *func)

--- a/vm.c
+++ b/vm.c
@@ -3994,6 +3994,21 @@ static void
 thread_free(void *ptr)
 {
     rb_thread_t *th = ptr;
+
+    /* The final self collection sweeps the wrapper of the very thread running it; the
+     * struct is still under that thread's feet (GET_EC resolves through it), so the
+     * thread frees the struct itself at its last step (rb_ractor_postmortem_free). */
+    if (th->ec != NULL && th->ec == rb_current_execution_context(false)) {
+        th->self = 0;
+        return;
+    }
+    rb_thread_free_body(ptr);
+}
+
+void
+rb_thread_free_body(void *ptr)
+{
+    rb_thread_t *th = ptr;
     RUBY_FREE_ENTER("thread");
 
     rb_threadptr_sched_free(th);


### PR DESCRIPTION
A dead Ractor used to leave its scaffolding behind: the Thread and
Fiber wrappers, the ThreadGroup, the per-Ractor stdio and whatever the
machine stack still referenced survived the final collection, merged
into the inheriting Ractor, and waited for its next major GC.  Both a
spawn-and-join loop and a fire-and-forget loop grew the heap by about
two pages per dead Ractor with nothing reclaiming them.

This series makes a Ractor's death clean itself up, in three steps:

* **Ractor: the dying thread collects its own objspace post-mortem** —
  the final collection moves to the tail of `thread_start_func_2`,
  before the scheduler handoff.  The thread still holds the GVL, so
  the collection runs lock-free like any local GC, with reduced
  marking roots (`r->postmortem`: the join value and the
  `rb_gc_register_mark_object` pins).  The two structs the thread
  stands on (its `rb_thread_t`, and the root Fiber that embeds the
  running ec) are deferred with an in-band mark and freed by the
  thread itself at its very last step, from pointers captured while
  the GVL still excluded any global GC.  While a thread-event hook is
  registered the flag stays off and the ordinary retire roots are
  kept (callbacks may retain any Ractor's Thread object).

* **GC: finalize C-only zombies in the retire collection** — the
  collection above turns dead IO objects into deferred zombies whose
  postponed job never runs (the thread is dying), so each dead Ractor
  still kept a page of zombies.  Zombies without `FL_FINALIZE` need no
  Ruby execution, only their dfree: finalize them on the spot, re-sweep
  the nearly-empty heap so their pages detach, and return the pages to
  the pool.  Zombies with a Ruby-level finalizer stay deferred and
  travel to the inheritor as before.  The dfree runs under the same
  conditions as the existing deferred-finalize path (noraise, GVL
  held), only earlier.

* **Ractor: build the per-Ractor stdio on first use** — most Ractors
  never touch stdio, yet every spawn built three IO objects under the
  VM lock.  Build them lazily in `rb_ractor_stdin` and friends; a
  Ractor that never uses stdio leaves nothing for its final collection
  to finalize.

## Performance

All numbers: release build, x86_64-linux, quiet machine, best of 3.

**Memory.** 500 dead Ractors, `heap_allocated_pages` (17 at start):

|                                  | master          | this series       |
|----------------------------------|-----------------|-------------------|
| `Ractor.new { :ok }.value` loop  | 1016 (RSS 78MB) | **18 (RSS 10.4MB)** |
| `Ractor.new { :ok }`, no join    | 1016            | **22**            |

After ~27,000 mixed spawns the residual is 13,707 pages / RSS 2.9GB on
master vs 33 pages / ~100MB with this series: dead Ractors no longer
accumulate anything.

**Throughput** (n=3000 per iteration):

|                          | master  | this series | speedup |
|--------------------------|---------|-------------|---------|
| spawn+join /s            | 6,224   | **33,666**  | 5.4x    |
| spawn+join+`$stdout` /s  | 4,777   | 22,276      | 4.7x    |
| fire-and-forget /s       | 11,448  | 23,863      | 2.1x    |

**Per operation**, `Ractor.new { :ok }.value` drops from 160.7us to
**29.7us** — below `Thread.new { }.join` (52.1us) on the same machine;
on master it was 3.1x a Thread.  For scale: `proc.call` 0.30us,
`Fiber.new {}.resume` 2.9us, fork+wait 1.4ms.

Much of the gain is second-order: dead Ractors' pages no longer pile
up in the inheritor, so every later GC walks a small heap.  Ractor-
churning test suites run an order of magnitude faster (e.g. our stress
suite: ~2 minutes -> 3.5 seconds).

**No regressions elsewhere**: Thread / Fiber / Proc / fork
microbenchmarks are within noise (+-7%) of master, and a Ractor that
does use stdio pays no penalty over the eager version.

## Verification

- btest-ruby release/debug: PASS all 2058
- test-all (release): 35852 tests, 0 failures, 0 errors
- ASAN: fire-and-forget x40 plus 2000-Ractor 4-way parallel x60, and
  pipe/file churn x5 (fd counts stable, buffered writes flushed), no
  reports.  This effort also caught a creator-side use-after-free
  (reading `th->vm` after `thread_sched_to_ready`) — fixed in the
  first commit.
- TSAN: stress suites, no reports
- thread instrumentation API tests: 13 tests x8, 0 failures
