### PR TITLE
Clearing the IO buffer and the encoding converter correctly

### DIFF
--- a/io.c
+++ b/io.c
@@ -545,6 +545,7 @@ rb_cloexec_fcntl_dupfd(int fd, int minfd)
 
 static int io_fflush(rb_io_t *);
 static rb_io_t *flush_before_seek(rb_io_t *fptr, bool discard_rbuf);
+static void clear_readconv(rb_io_t *fptr);
 static void clear_codeconv(rb_io_t *fptr);
 
 #define FMODE_SIGNAL_ON_EPIPE (1<<17)
@@ -2482,6 +2483,7 @@ rb_io_seek(VALUE io, VALUE offset, int whence)
     GetOpenFile(io, fptr);
     pos = io_seek(fptr, pos, whence);
     if (pos < 0 && errno) rb_sys_fail_path(fptr->pathv);
+    if (fptr->readconv) clear_readconv(fptr);
 
     return INT2FIX(0);
 }
@@ -2593,11 +2595,10 @@ rb_io_set_pos(VALUE io, VALUE offset)
     GetOpenFile(io, fptr);
     pos = io_seek(fptr, pos, SEEK_SET);
     if (pos < 0 && errno) rb_sys_fail_path(fptr->pathv);
+    if (fptr->readconv) clear_readconv(fptr);
 
     return OFFT2NUM(pos);
 }
-
-static void clear_readconv(rb_io_t *fptr);
 
 /*
  *  call-seq:

--- a/io.c
+++ b/io.c
@@ -8378,13 +8378,7 @@ io_reopen(VALUE io, VALUE nfile)
                      rb_io_fmode_modestr(orig->mode));
         }
     }
-    if (fptr->mode & FMODE_WRITABLE) {
-        if (io_fflush(fptr) < 0)
-            rb_sys_fail_on_write(fptr);
-    }
-    else {
-        flush_before_seek(fptr, true);
-    }
+    flush_before_seek(fptr, true);
     if (orig->mode & FMODE_READABLE) {
         pos = io_tell(orig);
     }

--- a/io.c
+++ b/io.c
@@ -8538,6 +8538,7 @@ rb_io_reopen(int argc, VALUE *argv, VALUE file)
             rb_sys_fail_on_write(fptr);
     }
     fptr->rbuf.off = fptr->rbuf.len = 0;
+    clear_codeconv(fptr);
 
     if (fptr->stdio_file) {
         int e = rb_freopen(rb_str_encode_ospath(fptr->pathv),

--- a/io.c
+++ b/io.c
@@ -8379,6 +8379,8 @@ io_reopen(VALUE io, VALUE nfile)
         }
     }
     flush_before_seek(fptr, true);
+    /* in flush_before_seek, clear_codeconv called only if rbuf is filled */
+    clear_codeconv(fptr);
     if (orig->mode & FMODE_READABLE) {
         pos = io_tell(orig);
     }

--- a/io.c
+++ b/io.c
@@ -5667,6 +5667,7 @@ free_io_buffer(rb_io_buffer_t *buf)
         ruby_xfree_sized(buf->ptr, (size_t)buf->capa);
         buf->ptr = NULL;
     }
+    buf->off = buf->len = buf->capa = 0;
 }
 
 static void

--- a/test/ruby/test_io.rb
+++ b/test/ruby/test_io.rb
@@ -363,6 +363,42 @@ class TestIO < Test::Unit::TestCase
     }
   end
 
+  def test_ungetc_with_seek_textmode
+    bug22239 = '[Bug #22239]'
+    make_tempfile {|t|
+      open(t.path, "rt") {|f|
+        f.ungetc('a')
+        f.seek(2, :SET)
+        assert_equal('o', f.getc, bug22239)
+      }
+
+      open(t.path, "rt") {|f|
+        f.getc
+        f.ungetc('a')
+        f.seek(2, :SET)
+        assert_equal('o', f.getc, bug22239)
+      }
+    }
+  end
+
+  def test_ungetc_with_pos_textmode
+    bug22239 = '[Bug #22239]'
+    make_tempfile {|t|
+      open(t.path, "rt") {|f|
+        f.ungetc('a')
+        f.pos = 2
+        assert_equal('o', f.getc, bug22239)
+      }
+
+      open(t.path, "rt") {|f|
+        f.getc
+        f.ungetc('a')
+        f.pos = 2
+        assert_equal('o', f.getc, bug22239)
+      }
+    }
+  end
+
   def test_eof_after_seek_with_pending_char
     bug22239 = '[Bug #22239]'
     make_tempfile {|t|

--- a/test/ruby/test_io.rb
+++ b/test/ruby/test_io.rb
@@ -363,6 +363,103 @@ class TestIO < Test::Unit::TestCase
     }
   end
 
+  def test_eof_after_seek_with_pending_char
+    bug22239 = '[Bug #22239]'
+    make_tempfile {|t|
+      open(t.path, "rt") {|f|
+        f.getc
+        f.ungetc('a')
+        f.seek(0, IO::SEEK_END)
+        assert_predicate(f, :eof?, bug22239)
+        assert_nil(f.getc, bug22239)
+      }
+    }
+  end
+
+  def test_sysseek_after_rewind_with_pending_char
+    bug22239 = '[Bug #22239]'
+    make_tempfile {|t|
+      open(t.path, "rt") {|f|
+        f.getc
+        f.ungetc('a')
+        f.rewind
+        assert_nothing_raised(IOError, bug22239) {f.sysseek(0)}
+      }
+    }
+  end
+
+  def test_getbyte_after_rewind_with_pending_char
+    bug22239 = '[Bug #22239]'
+    make_tempfile {|t|
+      open(t.path, "rt") {|f|
+        f.getc
+        f.ungetc('a')
+        f.rewind
+        assert_nothing_raised(IOError, bug22239) {f.getbyte}
+      }
+    }
+  end
+
+  def test_getbyte_after_seek_with_pending_char
+    bug22239 = '[Bug #22239]'
+    make_tempfile {|t|
+      open(t.path, "rt") {|f|
+        f.getc
+        f.ungetc('a')
+        f.seek(0, :SET)
+        assert_nothing_raised(IOError, bug22239) {f.getbyte}
+      }
+    }
+  end
+
+  def test_getbyte_after_pos_with_pending_char
+    bug22239 = '[Bug #22239]'
+    make_tempfile {|t|
+      open(t.path, "rt") {|f|
+        f.getc
+        f.ungetc('a')
+        f.pos = 0
+        assert_nothing_raised(IOError, bug22239) {f.getbyte}
+      }
+    }
+  end
+
+  def test_getbyte_after_flush_with_pending_char
+    bug22239 = '[Bug #22239]'
+    make_tempfile {|t|
+      open(t.path, "rt") {|f|
+        f.getc
+        f.ungetc('a')
+        f.flush
+        assert_nothing_raised(IOError, bug22239) {f.getbyte}
+      }
+    }
+  end
+
+  def test_getbyte_after_binmode_with_pending_char
+    bug22239 = '[Bug #22239]'
+    make_tempfile {|t|
+      open(t.path, "rt") {|f|
+        f.getc
+        f.ungetc('a')
+        f.binmode
+        assert_nothing_raised(IOError, bug22239) {f.getbyte}
+      }
+    }
+  end
+
+  def test_getbyte_after_tell_with_pending_char
+    bug22239 = '[Bug #22239]'
+    make_tempfile {|t|
+      open(t.path, "rt") {|f|
+        f.getc
+        f.ungetc('a')
+        f.tell
+        assert_nothing_raised(IOError, bug22239) {f.getbyte}
+      }
+    }
+  end
+
   def test_ungetbyte
     make_tempfile {|t|
       t.open

--- a/test/ruby/test_io.rb
+++ b/test/ruby/test_io.rb
@@ -2834,6 +2834,29 @@ class TestIO < Test::Unit::TestCase
     f1.close
   end
 
+  def test_reopen_with_pending_char
+    bug22239 = '[Bug #22239]'
+    make_tempfile {|t|
+      open(__FILE__, "rt") {|f|
+        f.ungetc(f.getc)
+        f.reopen(t.path, "rt")
+        assert_equal("foo\n", f.gets, bug22239)
+      }
+
+      open(__FILE__, "rt") {|f|
+        f.ungetc('a')
+        f.reopen(t.path, "rt")
+        assert_equal("foo\n", f.gets, bug22239)
+      }
+
+      open(__FILE__, "rt") {|f|
+        f.ungetc(f.getc)
+        f.reopen(t.path, "rt")
+        assert_nothing_raised(IOError, bug22239) {f.getbyte}
+      }
+    }
+  end
+
   def test_reopen_io_with_pending_byte
     bug22239 = '[Bug #22239]'
     mkcdtmpdir {

--- a/test/ruby/test_io.rb
+++ b/test/ruby/test_io.rb
@@ -2834,6 +2834,47 @@ class TestIO < Test::Unit::TestCase
     f1.close
   end
 
+  def test_reopen_io_with_pending_byte
+    bug22239 = '[Bug #22239]'
+    mkcdtmpdir {
+      File.binwrite("src", "0123456789")
+
+      ["rb", "r+b"].each {|mode|
+        open("src", mode) {|f|
+          f.getbyte
+          IO.pipe {|r, w|
+            w.binmode
+            w.write("ABC")
+            w.close
+            f.reopen(r)
+            assert_equal("ABC", f.read, "reopen a #{mode} IO #{bug22239}")
+          }
+        }
+      }
+    }
+  end
+
+  def test_reopen_io_with_pending_byte_then_write
+    bug22239 = '[Bug #22239]'
+    mkcdtmpdir {
+      File.binwrite("src", "abc")
+
+      ["rb", "r+b"].each_with_index {|mode, i|
+        dst = "dst#{i}"
+        open("src", mode) {|f|
+          f.getbyte
+          open(dst, "wb") {|f2|
+            f2.write("XXXXXXXX")
+            f.reopen(f2)
+            f.write("Y")
+            f.flush
+          }
+        }
+        assert_equal("XXXXXXXXY", File.binread(dst), "reopen a #{mode} IO #{bug22239}")
+      }
+    }
+  end
+
   def make_tempfile_for_encoding
     t = make_tempfile
     open(t.path, "rb+:utf-8") {|f| f.puts "\u7d05\u7389bar\n"}

--- a/test/ruby/test_io.rb
+++ b/test/ruby/test_io.rb
@@ -2877,6 +2877,29 @@ class TestIO < Test::Unit::TestCase
     }
   end
 
+  def test_reopen_io_with_pending_char
+    bug22239 = '[Bug #22239]'
+    make_tempfile {|t|
+      open(__FILE__, "rt") {|f|
+        f.ungetc(f.getc)
+        open(t.path, "rt") {|f2| f.reopen(f2)}
+        assert_equal("foo\n", f.gets, bug22239)
+      }
+
+      open(__FILE__, "rt") {|f|
+        f.ungetc('a')
+        open(t.path, "rt") {|f2| f.reopen(f2)}
+        assert_equal("foo\n", f.gets, bug22239)
+      }
+
+      open(__FILE__, "rt") {|f|
+        f.ungetc(f.getc)
+        open(t.path, "rt") {|f2| f.reopen(f2)}
+        assert_nothing_raised(IOError, bug22239) {f.getbyte}
+      }
+    }
+  end
+
   def test_reopen_io_with_pending_byte_then_write
     bug22239 = '[Bug #22239]'
     mkcdtmpdir {


### PR DESCRIPTION
fixes [Bug #22239](https://bugs.ruby-lang.org/issues/22239)
