### PR TITLE
[Bug #22240] Protect against rb_jump_tag(TAG_RAISE) after errinfo has been cleared

### DIFF
--- a/ext/-test-/exception/nil_errinfo.c
+++ b/ext/-test-/exception/nil_errinfo.c
@@ -1,0 +1,39 @@
+#include <ruby.h>
+
+static VALUE
+raise_boom(VALUE _arg)
+{
+    rb_raise(rb_eRuntimeError, "boom");
+    UNREACHABLE_RETURN(Qnil);
+}
+
+/*
+ * If a native extension catches an exception with rb_protect()
+ * and then uses rb_funcall to run Ruby code that rescues an exception
+ * the errinfo will be set to Qnil before the extension calls rb_jump_tag.
+ * We want to defend against that.
+ *
+ * Extensions should save the errinfo before the call and restore it afterward.
+ */
+static VALUE
+raise_after_rescue_cleanup(VALUE self)
+{
+    int state = 0;
+
+    rb_protect(raise_boom, Qnil, &state);
+
+    if (state) {
+        /* Any begin/rescue that catches an exception clears ec->errinfo. */
+        rb_funcall(self, rb_intern("cleanup_with_rescue"), 0);
+        /* ec->errinfo is now Qnil, but state is still TAG_RAISE. */
+        rb_jump_tag(state);
+    }
+    return Qnil;
+}
+
+void
+Init_nil_errinfo(VALUE klass)
+{
+    rb_define_singleton_method(klass, "raise_after_rescue_cleanup",
+                               raise_after_rescue_cleanup, 0);
+}

--- a/test/-ext-/exception/test_nil_errinfo.rb
+++ b/test/-ext-/exception/test_nil_errinfo.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: false
+require 'test/unit'
+require '-test-/exception'
+
+module Bug
+  class Test_ExceptionNilErrinfo < Test::Unit::TestCase
+    def test_rescue_cleanup_produces_diagnostic
+      out, _, status = EnvUtil.invoke_ruby(%w[-W0], <<~'RUBY', true, :merge_to_stdout)
+        require '-test-/exception'
+
+        class Bug::Exception
+          def self.cleanup_with_rescue
+            begin
+              raise "cleanup error"
+            rescue
+              # entering this rescue sets ec->errinfo to Qnil
+            end
+          end
+        end
+
+        Bug::Exception.raise_after_rescue_cleanup
+      RUBY
+      assert !status.signaled?, "process must not crash"
+      assert_include out, "exception object was lost"
+      assert_include out, "RuntimeError"
+      refute_includes out, "cleanup error"
+    end
+
+    def test_rescue_cleanup_raises_latest_error
+      out, _, status = EnvUtil.invoke_ruby(%w[-W0], <<~'RUBY', true, :merge_to_stdout)
+        require '-test-/exception'
+
+        class Bug::Exception
+          def self.cleanup_with_rescue
+            begin
+              raise "cleanup error"
+            # no rescue
+            end
+          end
+        end
+
+        Bug::Exception.raise_after_rescue_cleanup
+      RUBY
+      assert !status.signaled?, "process must not crash"
+      refute_includes out, "exception object was lost"
+      assert_include out, "RuntimeError"
+      assert_include out, "cleanup error"
+    end
+  end
+end

--- a/vm.c
+++ b/vm.c
@@ -2637,7 +2637,7 @@ frame_name(const rb_control_frame_t *cfp)
 static void
 hook_before_rewind(rb_execution_context_t *ec, bool cfp_returning_with_value, int state, struct vm_throw_data *err)
 {
-    if (state == TAG_RAISE && RBASIC(err)->klass == rb_eSysStackError) {
+    if (state == TAG_RAISE && !RB_SPECIAL_CONST_P((VALUE)err) && RBASIC(err)->klass == rb_eSysStackError) {
         return;
     }
     else {
@@ -2975,6 +2975,20 @@ static inline VALUE
 vm_exec_handle_exception(rb_execution_context_t *ec, enum ruby_tag_type state, VALUE errinfo)
 {
     struct vm_throw_data *err = (struct vm_throw_data *)errinfo;
+
+    /* If rb_funcall is called between rb_protect and rb_jump_tag and the ruby
+     * code has a rescue clause errinfo will be Qnil if not properly preserved.
+     * At that point the original exception is lost.
+     * Rather than silently exiting we synthesize a RuntimeError that
+     * will either end the process or be caught by the caller. */
+    if (state == TAG_RAISE && NIL_P(errinfo)) {
+        errinfo = rb_exc_new_cstr(rb_eRuntimeError,
+            "[Bug] exception object was lost during stack unwinding; "
+            "a native extension may have run Ruby code containing a rescue clause "
+            "between rb_protect and rb_jump_tag");
+        err = (struct vm_throw_data *)errinfo;
+        ec->errinfo = errinfo;
+    }
 
     for (;;) {
         unsigned int i;


### PR DESCRIPTION
If native code calls rb_protect, then calls rb_funcall before calling rb_jump_tag, and that ruby code has a rescue clause, it may set errinfo to nil.

Previously this would cause a SEGV as we weren't checking the type and assuming errinfo was an object.

After adding a check to prevent the SEGV
the process proceeds to simply exit silently.

To avoid that we can identify when we are in this state (TAG_RAISE with nil errinfo) and create an exception to describe what happened.