### PR TITLE
ZJIT: Expand splatarray into HIR

### DIFF
--- a/zjit/src/cruby.rs
+++ b/zjit/src/cruby.rs
@@ -131,6 +131,9 @@ unsafe extern "C" {
     pub fn rb_str_setbyte(str: VALUE, index: VALUE, value: VALUE) -> VALUE;
     pub fn rb_str_getbyte(str: VALUE, index: VALUE) -> VALUE;
     pub fn rb_vm_splat_array(flag: VALUE, ary: VALUE) -> VALUE;
+    // Defined in array.c and registered as a global GC root, so it is safe to
+    // embed in generated code.
+    pub static rb_cArray_empty_frozen: VALUE;
     pub fn rb_jit_fix_div_fix(x: VALUE, y: VALUE) -> VALUE;
     pub fn rb_jit_fix_mod_fix(x: VALUE, y: VALUE) -> VALUE;
     pub fn rb_vm_concat_array(ary1: VALUE, ary2st: VALUE) -> VALUE;

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -8394,15 +8394,103 @@ fn add_iseq_to_hir(
                     state.stack_push(insn_id);
                 }
                 YARVINSN_splatarray => {
+                    /*
+                    This is based on:
+                        static VALUE
+                        vm_splat_array(VALUE flag, VALUE ary)
+                        {
+                            if (NIL_P(ary)) {
+                                return RTEST(flag) ? rb_ary_new() : rb_cArray_empty_frozen;
+                            }
+                            VALUE tmp = rb_check_to_array(ary);
+                            if (NIL_P(tmp)) {
+                                return rb_ary_new3(1, ary);
+                            }
+                            else if (RTEST(flag)) {
+                                return rb_ary_dup(tmp);
+                            }
+                            else {
+                                return tmp;
+                            }
+                        }
+                    but we know `flag` at compile-time, and we inline the nil and is-array
+                    checks as branches so they fold away when the type of `val` is known:
+
+                                       block
+                                HasType val, NilClass
+                                  /            \
+                          is_nil_block     not_nil_block
+                          flag ? NewArray  HasType val, ArrayExact
+                               : Const []      /            \
+                                |      is_array_block   not_array_block
+                                |      flag ? ArrayDup  flag ? ToNewArray
+                                |           : val            : ToArray
+                                 \             |            /
+                                  \            |           /
+                                     join_block(result)
+
+                    rb_check_to_array returns `ary` unchanged when it is already T_ARRAY, so
+                    is_array_block only needs the flag-dependent dup. Everything else (to_ary
+                    conversion, wrapping in a one-element array) stays in the ToArray /
+                    ToNewArray fallback, which calls rb_vm_splat_array.
+                    */
                     let flag = get_arg(pc, 0);
                     let result_must_be_mutable = flag.test();
                     let val = state.stack_pop()?;
-                    let obj = if result_must_be_mutable {
-                        fun.push_insn(block, Insn::ToNewArray { val, state: exit_id })
+
+                    let is_nil_block = fun.new_block(insn_idx);
+                    let not_nil_block = fun.new_block(insn_idx);
+                    let is_array_block = fun.new_block(insn_idx);
+                    let not_array_block = fun.new_block(insn_idx);
+                    let join_block = fun.new_block(insn_idx);
+                    let join_param = fun.push_insn(join_block, Insn::Param);
+
+                    // if (NIL_P(ary))
+                    let ary_is_nil = fun.push_insn(block, Insn::HasType { val, expected: types::NilClass });
+                    fun.push_insn(block, Insn::CondBranch {
+                        val: ary_is_nil,
+                        if_true: BranchEdge { target: is_nil_block, args: vec![] },
+                        if_false: BranchEdge { target: not_nil_block, args: vec![] }
+                    });
+
+                    // return RTEST(flag) ? rb_ary_new() : rb_cArray_empty_frozen;
+                    let result = if result_must_be_mutable {
+                        fun.push_insn(is_nil_block, Insn::NewArray { elements: vec![], state: exit_id })
                     } else {
-                        fun.push_insn(block, Insn::ToArray { val, state: exit_id })
+                        fun.push_insn(is_nil_block, Insn::Const { val: Const::Value(unsafe { rb_cArray_empty_frozen }) })
                     };
-                    state.stack_push(obj);
+                    fun.push_insn(is_nil_block, Insn::Jump(BranchEdge { target: join_block, args: vec![result] }));
+
+                    // Fast path for when rb_check_to_array would return `ary` itself: exact
+                    // Array, no conversion needed. Subclasses take the fallback since HasType
+                    // can only test exact classes at runtime.
+                    let not_nil = fun.push_insn(not_nil_block, Insn::RefineType { val, new_type: types::NotNil });
+                    let is_array = fun.push_insn(not_nil_block, Insn::HasType { val: not_nil, expected: types::ArrayExact });
+                    fun.push_insn(not_nil_block, Insn::CondBranch {
+                        val: is_array,
+                        if_true: BranchEdge { target: is_array_block, args: vec![] },
+                        if_false: BranchEdge { target: not_array_block, args: vec![] }
+                    });
+
+                    // return RTEST(flag) ? rb_ary_dup(tmp) : tmp;
+                    let ary = fun.push_insn(is_array_block, Insn::RefineType { val: not_nil, new_type: types::ArrayExact });
+                    let result = if result_must_be_mutable {
+                        fun.push_insn(is_array_block, Insn::ArrayDup { val: ary, state: exit_id })
+                    } else {
+                        ary
+                    };
+                    fun.push_insn(is_array_block, Insn::Jump(BranchEdge { target: join_block, args: vec![result] }));
+
+                    // Fall back to rb_vm_splat_array for the to_ary conversion.
+                    let result = if result_must_be_mutable {
+                        fun.push_insn(not_array_block, Insn::ToNewArray { val: not_nil, state: exit_id })
+                    } else {
+                        fun.push_insn(not_array_block, Insn::ToArray { val: not_nil, state: exit_id })
+                    };
+                    fun.push_insn(not_array_block, Insn::Jump(BranchEdge { target: join_block, args: vec![result] }));
+
+                    block = join_block;
+                    state.stack_push(join_param);
                 }
                 YARVINSN_splatkw => {
                     let block_val = state.stack_pop()?;

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -7146,10 +7146,9 @@ mod hir_opt_tests {
           Jump bb3(v7, v8, v9)
         bb3(v11:BasicObject, v12:BasicObject, v13:NilClass):
           v17:ArrayExact = NewArray
-          v23:ArrayExact = ToArray v17
-          v25:BasicObject = Send v12, :call, v23 # SendFallbackReason: Complex argument passing
+          v36:BasicObject = Send v12, :call, v17 # SendFallbackReason: Complex argument passing
           CheckInterrupts
-          Return v25
+          Return v36
         ");
     }
 
@@ -14434,18 +14433,15 @@ mod hir_opt_tests {
           Jump bb3(v5, v6)
         bb3(v8:BasicObject, v9:NilClass):
           v13:ArrayExact = NewArray
-          v19:ArrayExact = ToArray v13
-          v21:BasicObject = Send v8, :foo, v19 # SendFallbackReason: Complex argument passing
-          v25:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-          v26:StringExact = StringCopy v25
+          v32:BasicObject = Send v8, :foo, v13 # SendFallbackReason: Complex argument passing
+          v36:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          v37:StringExact = StringCopy v36
           PatchPoint NoEPEscape(test)
-          v31:ArrayExact = ToArray v13
-          v33:BasicObject = Send v26, :display, v31 # SendFallbackReason: Complex argument passing
+          v55:BasicObject = Send v37, :display, v13 # SendFallbackReason: Complex argument passing
           PatchPoint NoEPEscape(test)
-          v41:ArrayExact = ToArray v13
-          v43:BasicObject = Send v8, :itself, v41 # SendFallbackReason: Complex argument passing
+          v76:BasicObject = Send v8, :itself, v13 # SendFallbackReason: Complex argument passing
           CheckInterrupts
-          Return v43
+          Return v76
         ");
     }
 
@@ -14476,14 +14472,29 @@ mod hir_opt_tests {
           IncrCounter zjit_insn_count
           IncrCounter zjit_insn_count
           IncrCounter zjit_insn_count
-          v20:ArrayExact = ToArray v11
+          v21:CBool = HasType v11, NilClass
+          CondBranch v21, bb4(), bb5()
+        bb4():
+          v23:ArrayExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          Jump bb8(v23)
+        bb5():
+          v25:NotNil = RefineType v11, NotNil
+          v26:CBool = HasType v25, ArrayExact
+          CondBranch v26, bb6(), bb7()
+        bb6():
+          v28:ArrayExact = RefineType v25, ArrayExact
+          Jump bb8(v28)
+        bb7():
+          v30:ArrayExact = ToArray v25
+          Jump bb8(v30)
+        bb8(v20:ArrayExact):
           IncrCounter zjit_insn_count
           IncrCounter complex_arg_pass_caller_splat
           IncrCounter caller_splat_profile_monomorphic
-          v23:BasicObject = Send v10, :foo, v20 # SendFallbackReason: Complex argument passing
+          v34:BasicObject = Send v10, :foo, v20 # SendFallbackReason: Complex argument passing
           IncrCounter zjit_insn_count
           CheckInterrupts
-          Return v23
+          Return v34
         ");
     }
 
@@ -14516,14 +14527,29 @@ mod hir_opt_tests {
           IncrCounter zjit_insn_count
           IncrCounter zjit_insn_count
           IncrCounter zjit_insn_count
-          v20:ArrayExact = ToArray v11
+          v21:CBool = HasType v11, NilClass
+          CondBranch v21, bb4(), bb5()
+        bb4():
+          v23:ArrayExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          Jump bb8(v23)
+        bb5():
+          v25:NotNil = RefineType v11, NotNil
+          v26:CBool = HasType v25, ArrayExact
+          CondBranch v26, bb6(), bb7()
+        bb6():
+          v28:ArrayExact = RefineType v25, ArrayExact
+          Jump bb8(v28)
+        bb7():
+          v30:ArrayExact = ToArray v25
+          Jump bb8(v30)
+        bb8(v20:ArrayExact):
           IncrCounter zjit_insn_count
           IncrCounter complex_arg_pass_caller_splat
           IncrCounter caller_splat_profile_polymorphic
-          v23:BasicObject = Send v10, :foo, v20 # SendFallbackReason: Complex argument passing
+          v34:BasicObject = Send v10, :foo, v20 # SendFallbackReason: Complex argument passing
           IncrCounter zjit_insn_count
           CheckInterrupts
-          Return v23
+          Return v34
         ");
     }
 
@@ -17243,10 +17269,25 @@ mod hir_opt_tests {
           v7:BasicObject = LoadArg :x@1
           Jump bb3(v6, v7)
         bb3(v9:HeapBasicObject, v10:BasicObject):
-          v16:ArrayExact = ToArray v10
-          v18:BasicObject = InvokeSuper v9, 0x1008, v16 # SendFallbackReason: super: complex argument passing to `super` call
+          v17:CBool = HasType v10, NilClass
+          CondBranch v17, bb4(), bb5()
+        bb4():
+          v19:ArrayExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          Jump bb8(v19)
+        bb5():
+          v21:NotNil = RefineType v10, NotNil
+          v22:CBool = HasType v21, ArrayExact
+          CondBranch v22, bb6(), bb7()
+        bb6():
+          v24:ArrayExact = RefineType v21, ArrayExact
+          Jump bb8(v24)
+        bb7():
+          v26:ArrayExact = ToArray v21
+          Jump bb8(v26)
+        bb8(v16:ArrayExact):
+          v29:BasicObject = InvokeSuper v9, 0x1010, v16 # SendFallbackReason: super: complex argument passing to `super` call
           CheckInterrupts
-          Return v18
+          Return v29
         ");
     }
 

--- a/zjit/src/hir/tests.rs
+++ b/zjit/src/hir/tests.rs
@@ -2443,10 +2443,25 @@ pub(crate) mod hir_build_tests {
           v7:BasicObject = LoadArg :a@1
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
-          v16:ArrayExact = ToArray v10
-          v18:BasicObject = Send v9, :foo, v16 # SendFallbackReason: Uncategorized(opt_send_without_block)
+          v17:CBool = HasType v10, NilClass
+          CondBranch v17, bb4(), bb5()
+        bb4():
+          v19:ArrayExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          Jump bb8(v19)
+        bb5():
+          v21:NotNil = RefineType v10, NotNil
+          v22:CBool = HasType v21, ArrayExact
+          CondBranch v22, bb6(), bb7()
+        bb6():
+          v24:ArrayExact = RefineType v21, ArrayExact
+          Jump bb8(v24)
+        bb7():
+          v26:ArrayExact = ToArray v21
+          Jump bb8(v26)
+        bb8(v16:ArrayExact):
+          v29:BasicObject = Send v9, :foo, v16 # SendFallbackReason: Uncategorized(opt_send_without_block)
           CheckInterrupts
-          Return v18
+          Return v29
         ");
     }
 
@@ -2776,14 +2791,30 @@ pub(crate) mod hir_build_tests {
           v7:BasicObject = LoadArg :*@1
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
-          v16:ArrayExact = ToNewArray v10
-          v18:Fixnum[1] = Const Value(1)
-          v20:CUInt64 = LoadField v16, :RBASIC_FLAGS@0x1001
-          v21:CUInt64 = GuardNoBitsSet v20, RUBY_FL_FREEZE=CUInt64(2048)
-          ArrayPush v16, v18
-          v24:BasicObject = Send v9, :foo, v16 # SendFallbackReason: Uncategorized(opt_send_without_block)
+          v17:CBool = HasType v10, NilClass
+          CondBranch v17, bb4(), bb5()
+        bb4():
+          v19:ArrayExact = NewArray
+          Jump bb8(v19)
+        bb5():
+          v21:NotNil = RefineType v10, NotNil
+          v22:CBool = HasType v21, ArrayExact
+          CondBranch v22, bb6(), bb7()
+        bb6():
+          v24:ArrayExact = RefineType v21, ArrayExact
+          v25:ArrayExact = ArrayDup v24
+          Jump bb8(v25)
+        bb7():
+          v27:ArrayExact = ToNewArray v21
+          Jump bb8(v27)
+        bb8(v16:ArrayExact):
+          v30:Fixnum[1] = Const Value(1)
+          v32:CUInt64 = LoadField v16, :RBASIC_FLAGS@0x1001
+          v33:CUInt64 = GuardNoBitsSet v32, RUBY_FL_FREEZE=CUInt64(2048)
+          ArrayPush v16, v30
+          v36:BasicObject = Send v9, :foo, v16 # SendFallbackReason: Uncategorized(opt_send_without_block)
           CheckInterrupts
-          Return v24
+          Return v36
         ");
     }
 
@@ -2839,21 +2870,36 @@ pub(crate) mod hir_build_tests {
           v15:NilClass = Const Value(nil)
           Jump bb3(v10, v11, v12, v13, v14, v15)
         bb3(v17:BasicObject, v18:BasicObject, v19:BasicObject, v20:BasicObject, v21:BasicObject, v22:NilClass):
-          v29:ArrayExact = ToArray v19
-          PatchPoint NoEPEscape(test)
-          v36:CPtr = GetEP 0
-          v37:CUInt64 = LoadField v36, :VM_ENV_DATA_INDEX_FLAGS@0x1004
-          v38:CBool = IsBlockParamModified v37
-          CondBranch v38, bb4(), bb5()
+          v30:CBool = HasType v19, NilClass
+          CondBranch v30, bb4(), bb5()
         bb4():
-          v40:BasicObject = LoadField v36, :&@0x1005
-          Jump bb6(v40, v40)
+          v32:ArrayExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          Jump bb8(v32)
         bb5():
-          v42:CInt64 = LoadField v36, :VM_ENV_DATA_INDEX_SPECVAL@0x1006
-          v43:CInt64 = GuardAnyBitSet v42, CUInt64(1) recompile
-          v44:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
-          Jump bb6(v44, v21)
-        bb6(v34:BasicObject, v35:BasicObject):
+          v34:NotNil = RefineType v19, NotNil
+          v35:CBool = HasType v34, ArrayExact
+          CondBranch v35, bb6(), bb7()
+        bb6():
+          v37:ArrayExact = RefineType v34, ArrayExact
+          Jump bb8(v37)
+        bb7():
+          v39:ArrayExact = ToArray v34
+          Jump bb8(v39)
+        bb8(v29:ArrayExact):
+          PatchPoint NoEPEscape(test)
+          v47:CPtr = GetEP 0
+          v48:CUInt64 = LoadField v47, :VM_ENV_DATA_INDEX_FLAGS@0x1010
+          v49:CBool = IsBlockParamModified v48
+          CondBranch v49, bb9(), bb10()
+        bb9():
+          v51:BasicObject = LoadField v47, :&@0x1011
+          Jump bb11(v51, v51)
+        bb10():
+          v53:CInt64 = LoadField v47, :VM_ENV_DATA_INDEX_SPECVAL@0x1012
+          v54:CInt64 = GuardAnyBitSet v53, CUInt64(1) recompile
+          v55:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1018))
+          Jump bb11(v55, v21)
+        bb11(v45:BasicObject, v46:BasicObject):
           SideExit SplatKwNotProfiled
         ");
     }
@@ -4277,25 +4323,40 @@ pub(crate) mod hir_build_tests {
           v15:NilClass = Const Value(nil)
           Jump bb3(v10, v11, v12, v13, v14, v15)
         bb3(v17:BasicObject, v18:BasicObject, v19:BasicObject, v20:BasicObject, v21:BasicObject, v22:NilClass):
-          v29:ArrayExact = ToArray v19
-          PatchPoint NoEPEscape(test)
-          v36:CPtr = GetEP 0
-          v37:CUInt64 = LoadField v36, :VM_ENV_DATA_INDEX_FLAGS@0x1004
-          v38:CBool = IsBlockParamModified v37
-          CondBranch v38, bb4(), bb5()
+          v30:CBool = HasType v19, NilClass
+          CondBranch v30, bb4(), bb5()
         bb4():
-          v40:BasicObject = LoadField v36, :&@0x1005
-          Jump bb6(v40, v40)
+          v32:ArrayExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          Jump bb8(v32)
         bb5():
-          v42:CInt64 = LoadField v36, :VM_ENV_DATA_INDEX_SPECVAL@0x1006
-          v43:CInt64[0] = GuardBitEquals v42, CInt64(0) recompile
-          v44:NilClass = Const Value(nil)
-          Jump bb6(v44, v21)
-        bb6(v34:BasicObject, v35:BasicObject):
-          v47:NilClass = GuardType v20, NilClass
-          v49:BasicObject = Send v17, &block, :foo, v18, v29, v47, v34 # SendFallbackReason: Uncategorized(send)
+          v34:NotNil = RefineType v19, NotNil
+          v35:CBool = HasType v34, ArrayExact
+          CondBranch v35, bb6(), bb7()
+        bb6():
+          v37:ArrayExact = RefineType v34, ArrayExact
+          Jump bb8(v37)
+        bb7():
+          v39:ArrayExact = ToArray v34
+          Jump bb8(v39)
+        bb8(v29:ArrayExact):
+          PatchPoint NoEPEscape(test)
+          v47:CPtr = GetEP 0
+          v48:CUInt64 = LoadField v47, :VM_ENV_DATA_INDEX_FLAGS@0x1010
+          v49:CBool = IsBlockParamModified v48
+          CondBranch v49, bb9(), bb10()
+        bb9():
+          v51:BasicObject = LoadField v47, :&@0x1011
+          Jump bb11(v51, v51)
+        bb10():
+          v53:CInt64 = LoadField v47, :VM_ENV_DATA_INDEX_SPECVAL@0x1012
+          v54:CInt64[0] = GuardBitEquals v53, CInt64(0) recompile
+          v55:NilClass = Const Value(nil)
+          Jump bb11(v55, v21)
+        bb11(v45:BasicObject, v46:BasicObject):
+          v58:NilClass = GuardType v20, NilClass
+          v60:BasicObject = Send v17, &block, :foo, v18, v29, v58, v45 # SendFallbackReason: Uncategorized(send)
           CheckInterrupts
-          Return v49
+          Return v60
         ");
     }
 
@@ -4419,21 +4480,36 @@ pub(crate) mod hir_build_tests {
           v15:NilClass = Const Value(nil)
           Jump bb3(v10, v11, v12, v13, v14, v15)
         bb3(v17:BasicObject, v18:BasicObject, v19:BasicObject, v20:BasicObject, v21:BasicObject, v22:NilClass):
-          v29:ArrayExact = ToArray v19
-          PatchPoint NoEPEscape(test)
-          v36:CPtr = GetEP 0
-          v37:CUInt64 = LoadField v36, :VM_ENV_DATA_INDEX_FLAGS@0x1004
-          v38:CBool = IsBlockParamModified v37
-          CondBranch v38, bb4(), bb5()
+          v30:CBool = HasType v19, NilClass
+          CondBranch v30, bb4(), bb5()
         bb4():
-          v40:BasicObject = LoadField v36, :&@0x1005
-          Jump bb6(v40, v40)
+          v32:ArrayExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          Jump bb8(v32)
         bb5():
-          v42:CInt64 = LoadField v36, :VM_ENV_DATA_INDEX_SPECVAL@0x1006
-          v43:CInt64[0] = GuardBitEquals v42, CInt64(0) recompile
-          v44:NilClass = Const Value(nil)
-          Jump bb6(v44, v21)
-        bb6(v34:BasicObject, v35:BasicObject):
+          v34:NotNil = RefineType v19, NotNil
+          v35:CBool = HasType v34, ArrayExact
+          CondBranch v35, bb6(), bb7()
+        bb6():
+          v37:ArrayExact = RefineType v34, ArrayExact
+          Jump bb8(v37)
+        bb7():
+          v39:ArrayExact = ToArray v34
+          Jump bb8(v39)
+        bb8(v29:ArrayExact):
+          PatchPoint NoEPEscape(test)
+          v47:CPtr = GetEP 0
+          v48:CUInt64 = LoadField v47, :VM_ENV_DATA_INDEX_FLAGS@0x1010
+          v49:CBool = IsBlockParamModified v48
+          CondBranch v49, bb9(), bb10()
+        bb9():
+          v51:BasicObject = LoadField v47, :&@0x1011
+          Jump bb11(v51, v51)
+        bb10():
+          v53:CInt64 = LoadField v47, :VM_ENV_DATA_INDEX_SPECVAL@0x1012
+          v54:CInt64[0] = GuardBitEquals v53, CInt64(0) recompile
+          v55:NilClass = Const Value(nil)
+          Jump bb11(v55, v21)
+        bb11(v45:BasicObject, v46:BasicObject):
           SideExit SplatKwPolymorphic
         ");
     }
@@ -4501,7 +4577,23 @@ pub(crate) mod hir_build_tests {
           v7:BasicObject = LoadArg :a@1
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
-          v15:ArrayExact = ToNewArray v10
+          v16:CBool = HasType v10, NilClass
+          CondBranch v16, bb4(), bb5()
+        bb4():
+          v18:ArrayExact = NewArray
+          Jump bb8(v18)
+        bb5():
+          v20:NotNil = RefineType v10, NotNil
+          v21:CBool = HasType v20, ArrayExact
+          CondBranch v21, bb6(), bb7()
+        bb6():
+          v23:ArrayExact = RefineType v20, ArrayExact
+          v24:ArrayExact = ArrayDup v23
+          Jump bb8(v24)
+        bb7():
+          v26:ArrayExact = ToNewArray v20
+          Jump bb8(v26)
+        bb8(v15:ArrayExact):
           CheckInterrupts
           Return v15
         ");
@@ -4556,11 +4648,27 @@ pub(crate) mod hir_build_tests {
           v7:BasicObject = LoadArg :a@1
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
-          v15:ArrayExact = ToNewArray v10
-          v17:Fixnum[1] = Const Value(1)
-          v19:CUInt64 = LoadField v15, :RBASIC_FLAGS@0x1001
-          v20:CUInt64 = GuardNoBitsSet v19, RUBY_FL_FREEZE=CUInt64(2048)
-          ArrayPush v15, v17
+          v16:CBool = HasType v10, NilClass
+          CondBranch v16, bb4(), bb5()
+        bb4():
+          v18:ArrayExact = NewArray
+          Jump bb8(v18)
+        bb5():
+          v20:NotNil = RefineType v10, NotNil
+          v21:CBool = HasType v20, ArrayExact
+          CondBranch v21, bb6(), bb7()
+        bb6():
+          v23:ArrayExact = RefineType v20, ArrayExact
+          v24:ArrayExact = ArrayDup v23
+          Jump bb8(v24)
+        bb7():
+          v26:ArrayExact = ToNewArray v20
+          Jump bb8(v26)
+        bb8(v15:ArrayExact):
+          v29:Fixnum[1] = Const Value(1)
+          v31:CUInt64 = LoadField v15, :RBASIC_FLAGS@0x1001
+          v32:CUInt64 = GuardNoBitsSet v31, RUBY_FL_FREEZE=CUInt64(2048)
+          ArrayPush v15, v29
           CheckInterrupts
           Return v15
         ");
@@ -4586,15 +4694,31 @@ pub(crate) mod hir_build_tests {
           v7:BasicObject = LoadArg :a@1
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
-          v15:ArrayExact = ToNewArray v10
-          v17:Fixnum[1] = Const Value(1)
-          v19:Fixnum[2] = Const Value(2)
-          v21:Fixnum[3] = Const Value(3)
-          v23:CUInt64 = LoadField v15, :RBASIC_FLAGS@0x1001
-          v24:CUInt64 = GuardNoBitsSet v23, RUBY_FL_FREEZE=CUInt64(2048)
-          ArrayPush v15, v17
-          ArrayPush v15, v19
-          ArrayPush v15, v21
+          v16:CBool = HasType v10, NilClass
+          CondBranch v16, bb4(), bb5()
+        bb4():
+          v18:ArrayExact = NewArray
+          Jump bb8(v18)
+        bb5():
+          v20:NotNil = RefineType v10, NotNil
+          v21:CBool = HasType v20, ArrayExact
+          CondBranch v21, bb6(), bb7()
+        bb6():
+          v23:ArrayExact = RefineType v20, ArrayExact
+          v24:ArrayExact = ArrayDup v23
+          Jump bb8(v24)
+        bb7():
+          v26:ArrayExact = ToNewArray v20
+          Jump bb8(v26)
+        bb8(v15:ArrayExact):
+          v29:Fixnum[1] = Const Value(1)
+          v31:Fixnum[2] = Const Value(2)
+          v33:Fixnum[3] = Const Value(3)
+          v35:CUInt64 = LoadField v15, :RBASIC_FLAGS@0x1001
+          v36:CUInt64 = GuardNoBitsSet v35, RUBY_FL_FREEZE=CUInt64(2048)
+          ArrayPush v15, v29
+          ArrayPush v15, v31
+          ArrayPush v15, v33
           CheckInterrupts
           Return v15
         ");


### PR DESCRIPTION
If we learn type information about the object being splatted (for
example, through inlining or profiling), we should be able to fold away
a bunch of checks and potentially extra work.
