### PR TITLE
Clear page->has_{shareable,shref}_objects during gc_sweep_page

### DIFF
--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -4505,10 +4505,15 @@ gc_sweep_page(rb_objspace_t *objspace, rb_heap_t *heap, struct gc_sweep_context 
     if (sweep_page->flags.has_shareable_objects || sweep_page->flags.has_shref_objects) {
         bits_t *shareable_bits = sweep_page->shareable_bits;
         bits_t *shref_bits = sweep_page->shref_bits;
+        bits_t sh = 0, sr = 0;
         for (int i = 0; i < bitmap_plane_count; i++) {
             shareable_bits[i] &= bits[i];
             shref_bits[i] &= bits[i];
+            sh |= shareable_bits[i];
+            sr |= shref_bits[i];
         }
+        if (!sh) sweep_page->flags.has_shareable_objects = FALSE;
+        if (!sr) sweep_page->flags.has_shref_objects = FALSE;
     }
 
     asan_unlock_freelist(sweep_page);


### PR DESCRIPTION
If these fields are never cleared, then a Ruby process that transitions to multi-ractor mode will have many of its pages marked with one these bits. The global GC will have to go over every live page during pinned_roots_mark even if there are no shareables or shrefs on the page.