### PR TITLE
ZJIT: Split SendDirect argument planning from HIR emission

### DIFF
--- a/zjit.rb
+++ b/zjit.rb
@@ -105,6 +105,7 @@ class << RubyVM::ZJIT
     print_counters_with_prefix(prefix: 'unspecialized_super_def_type_', prompt: 'not optimized method types for super', buf:, stats:, limit: 20)
     print_counters_with_prefix(prefix: 'uncategorized_fallback_yarv_insn_', prompt: 'instructions with uncategorized fallback reason', buf:, stats:, limit: 20)
     print_counters_with_prefix(prefix: 'send_fallback_', prompt: 'send fallback reasons', buf:, stats:, limit: 20)
+    print_counters_with_prefix(prefix: 'send_direct_fallback_context_', prompt: 'SendDirect fallback contexts', buf:, stats:, limit: 10)
     print_counters_with_prefix(prefix: 'setivar_fallback_', prompt: 'setivar fallback reasons', buf:, stats:, limit: 5)
     print_counters_with_prefix(prefix: 'getivar_fallback_', prompt: 'getivar fallback reasons', buf:, stats:, limit: 5)
     print_counters_with_prefix(prefix: 'definedivar_fallback_', prompt: 'definedivar fallback reasons', buf:, stats:, limit: 5)

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -798,8 +798,6 @@ pub enum SendFallbackReason {
     SuperNotOptimizedMethodType(MethodType),
     /// The `super` call is polymorpic.
     SuperPolymorphic,
-    /// The `super` target call uses a complex argument pattern that the optimizer does not support.
-    SuperTargetComplexArgsPass,
     /// The `invokeblock` instruction is not yet optimized in `type_specialize`.
     InvokeBlockNotSpecialized,
     /// The runtime block handler at a polymorphic `invokeblock` site did not match any
@@ -854,7 +852,6 @@ impl Display for SendFallbackReason {
             SuperNotOptimizedMethodType(method_type) => write!(f, "super: unsupported target method type {:?}", method_type),
             SuperPolymorphic => write!(f, "super: polymorphic call site"),
             SuperTargetNotFound => write!(f, "super: profiled target method cannot be found"),
-            SuperTargetComplexArgsPass => write!(f, "super: complex argument passing to `super` target call"),
             InvokeBlockNotSpecialized => write!(f, "InvokeBlock: not yet specialized"),
             InvokeBlockPolymorphicMiss => write!(f, "InvokeBlock: polymorphic dispatch miss"),
             SendForwardNotSpecialized => write!(f, "SendForward: not yet specialized"),
@@ -2602,13 +2599,10 @@ pub enum ValidationError {
     MiscValidationError(InsnId, String),
 }
 
-/// Check if we can do a direct send to the given iseq with the given args.
-fn can_direct_send(function: &mut Function, block: BlockId, iseq: *const rb_iseq_t, ci: *const rb_callinfo, send_insn: InsnId, args: &[InsnId], has_block: bool) -> bool {
-    let mut can_send = true;
-    let mut count_failure = |counter| {
-        can_send = false;
-        function.count(block, counter);
-    };
+/// Check if we can emit SendDirect to the given ISEQ with the given arguments.
+fn can_direct_send(iseq: *const rb_iseq_t, ci: *const rb_callinfo, args: &[InsnId], has_block: bool) -> Result<(), SendDirectFailure> {
+    let mut complex_arg_counters = vec![];
+    let mut count_failure = |counter| complex_arg_counters.push(counter);
     let params = unsafe { iseq.params() };
 
     let callee_has_block_param = 0 != params.flags.has_block();
@@ -2630,9 +2624,11 @@ fn can_direct_send(function: &mut Function, block: BlockId, iseq: *const rb_iseq
     if caller_passes_block && 0 == params.flags.use_block()
                                        { count_failure(complex_arg_pass_does_not_use_block) }
 
-    if !can_send {
-        function.set_dynamic_send_reason(send_insn, ComplexArgPass);
-        return false;
+    if !complex_arg_counters.is_empty() {
+        return Err(SendDirectFailure::with_counters(
+            ComplexArgPass,
+            complex_arg_counters,
+        ));
     }
 
     let lead_num = params.lead_num;
@@ -2647,8 +2643,7 @@ fn can_direct_send(function: &mut Function, block: BlockId, iseq: *const rb_iseq
     let caller_positional = match args.len().checked_sub(caller_kw_count) {
         Some(count) => count,
         None => {
-            function.set_dynamic_send_reason(send_insn, ArgcParamMismatch);
-            return false;
+            return Err(SendDirectFailure::new(ArgcParamMismatch));
         }
     };
 
@@ -2660,8 +2655,7 @@ fn can_direct_send(function: &mut Function, block: BlockId, iseq: *const rb_iseq
     let caller_positional_i32 = match c_int::try_from(effective_positional) {
         Ok(argc) => argc,
         Err(_) => {
-            function.set_dynamic_send_reason(send_insn, ArgcParamMismatch);
-            return false;
+            return Err(SendDirectFailure::new(ArgcParamMismatch));
         }
     };
     let min_positional = lead_num + post_num;
@@ -2671,8 +2665,7 @@ fn can_direct_send(function: &mut Function, block: BlockId, iseq: *const rb_iseq
         (min_positional..=min_positional + opt_num).contains(&caller_positional_i32)
     };
     if !positional_ok {
-        function.set_dynamic_send_reason(send_insn, ArgcParamMismatch);
-        return false
+        return Err(SendDirectFailure::new(ArgcParamMismatch));
     }
 
     // Plain keyword-to-positional-hash is safe to synthesize below. Keep VM
@@ -2681,9 +2674,10 @@ fn can_direct_send(function: &mut Function, block: BlockId, iseq: *const rb_iseq
     if keywords_as_positional_hash
         && (params.flags.accepts_no_kwarg() != 0 || params.flags.ruby2_keywords() != 0)
     {
-        function.count(block, complex_arg_pass_keyword_to_positional_hash);
-        function.set_dynamic_send_reason(send_insn, ComplexArgPass);
-        return false;
+        return Err(SendDirectFailure::with_counters(
+            ComplexArgPass,
+            vec![complex_arg_pass_keyword_to_positional_hash],
+        ));
     }
 
     // After keyword-to-positional-hash, SendDirect receives no keyword slots;
@@ -2694,8 +2688,7 @@ fn can_direct_send(function: &mut Function, block: BlockId, iseq: *const rb_iseq
         .map(|argc| (kw_req_num..=kw_total_num).contains(argc))
         .unwrap_or(false);
     if !keyword_ok {
-        function.set_dynamic_send_reason(send_insn, ArgcParamMismatch);
-        return false
+        return Err(SendDirectFailure::new(ArgcParamMismatch));
     }
 
     // asm.ccall() doesn't support 6+ args. Compute the final argc after keyword setup
@@ -2717,17 +2710,15 @@ fn can_direct_send(function: &mut Function, block: BlockId, iseq: *const rb_iseq
 
     // TODO: Support passing arguments on the stack in C calls
     if c_argc > C_ARG_OPNDS.len() {
-        function.set_dynamic_send_reason(send_insn, TooManyArgsForLir);
-        return false;
+        return Err(SendDirectFailure::new(TooManyArgsForLir));
     }
 
     // IseqCall stores the JIT entry index and argc as u16.
     if u16::try_from(send_argc).is_err() {
-        function.set_dynamic_send_reason(send_insn, TooManyArgsForLir);
-        return false;
+        return Err(SendDirectFailure::new(TooManyArgsForLir));
     }
 
-    can_send
+    Ok(())
 }
 
 /// Policy that controls how optimization passes generate code.
@@ -2836,6 +2827,70 @@ struct SendDirectArgs {
     args: Vec<InsnId>,
     kw_bits: u32,
     jit_entry_idx: u16,
+}
+
+/// One SendDirect argument before its HIR value is materialized.
+#[derive(Clone)]
+enum SendDirectArg {
+    /// A HIR value already present in the original Send argument vector.
+    Existing(InsnId),
+    /// A Ruby value to materialize as a Const instruction on the selected path.
+    Constant(VALUE),
+    /// Explicit caller keywords to materialize as one positional Hash.
+    KeywordHash(Vec<SendDirectArg>),
+    /// Values to materialize as the Array passed to a callee rest parameter.
+    RestArray(Vec<SendDirectArg>),
+}
+
+/// Side-effect-free description of the argument setup for one SendDirect path.
+struct SendDirectPlan {
+    /// Argument slots in the shape expected by SendDirect.
+    args: Vec<SendDirectArg>,
+    /// Optional keyword slots omitted by the caller.
+    kw_bits: u32,
+    /// Optional positional entry selected from the caller's argument count.
+    jit_entry_idx: u16,
+}
+
+/// Why a SendDirect plan could not be built, including feature counters that
+/// should only be recorded when the caller keeps the dynamic fallback.
+struct SendDirectFailure {
+    reason: SendFallbackReason,
+    counters: Vec<Counter>,
+}
+
+/// Call context in which SendDirect argument planning failed.
+enum SendDirectFallbackContext {
+    Send,
+    Super,
+}
+
+impl SendDirectFailure {
+    fn new(reason: SendFallbackReason) -> Self {
+        Self { reason, counters: vec![] }
+    }
+
+    fn with_counters(reason: SendFallbackReason, counters: Vec<Counter>) -> Self {
+        Self { reason, counters }
+    }
+
+    fn record(
+        &self,
+        function: &mut Function,
+        block: BlockId,
+        send_insn: InsnId,
+        context: SendDirectFallbackContext,
+    ) {
+        for &counter in &self.counters {
+            function.count(block, counter);
+        }
+        let context_counter = match context {
+            SendDirectFallbackContext::Send => Counter::send_direct_fallback_context_send,
+            SendDirectFallbackContext::Super => Counter::send_direct_fallback_context_super,
+        };
+        function.count(block, context_counter);
+        function.set_dynamic_send_reason(send_insn, self.reason);
+    }
 }
 
 unsafe extern "C" {
@@ -3641,35 +3696,67 @@ impl Function {
         }
     }
 
-    /// Prepare arguments for a direct send, handling keyword argument reordering,
-    /// default synthesis, and rest parameter packing.
-    /// Returns the arguments to use for the SendDirect instruction,
-    /// or Err with the fallback reason if direct send isn't possible.
-    fn prepare_direct_send_args(
-        &mut self,
-        block: BlockId,
-        args: &[InsnId],
-        ci: *const rb_callinfo,
-        iseq: IseqPtr,
-        state: InsnId,
-    ) -> Result<SendDirectArgs, SendFallbackReason> {
-        let (processed_args, caller_argc, kw_bits) = self.setup_keyword_arguments(block, args, ci, iseq, state)?;
-        let (processed_args, jit_entry_idx) = self.setup_rest_parameter(block, processed_args, iseq, state)?;
+    /// Validate and normalize SendDirect arguments without emitting HIR.
+    fn plan_send_direct_args(&self, args: &[InsnId], ci: *const rb_callinfo, iseq: IseqPtr, has_block: bool) -> Result<SendDirectPlan, SendDirectFailure> {
+        can_direct_send(iseq, ci, args, has_block)?;
+        let args = args.iter().copied().map(SendDirectArg::Existing).collect();
+        let (args, kw_bits) = Self::plan_send_direct_keyword_arguments(args, ci, iseq)
+            .map_err(SendDirectFailure::new)?;
+        let (args, jit_entry_idx) = Self::plan_send_direct_rest_parameter(args, iseq)
+            .map_err(SendDirectFailure::new)?;
 
-        // If args were reordered or synthesized, create a new snapshot with the updated stack
-        let send_state = if processed_args != args {
-            let new_state = self.frame_state(state).with_replaced_args(&processed_args, caller_argc);
+        Ok(SendDirectPlan {
+            args,
+            kw_bits,
+            jit_entry_idx,
+        })
+    }
+
+    /// Materialize a validated SendDirect plan in the selected runtime path.
+    fn emit_send_direct_args(&mut self, block: BlockId, plan: SendDirectPlan, original_args: &[InsnId], state: InsnId) -> SendDirectArgs {
+        let args: Vec<_> = plan
+            .args
+            .into_iter()
+            .map(|arg| self.emit_send_direct_arg(block, arg, state))
+            .collect();
+
+        // If args were reordered or synthesized, create a new snapshot with the updated stack.
+        let send_state = if args != original_args {
+            let new_state = self.frame_state(state).with_replaced_args(&args, original_args.len());
             self.push_insn(block, Insn::Snapshot { state: Box::new(new_state) })
         } else {
             state
         };
 
-        Ok(SendDirectArgs {
+        SendDirectArgs {
             state: send_state,
-            args: processed_args,
-            kw_bits,
-            jit_entry_idx,
-        })
+            args,
+            kw_bits: plan.kw_bits,
+            jit_entry_idx: plan.jit_entry_idx,
+        }
+    }
+
+    fn emit_send_direct_arg(&mut self, block: BlockId, arg: SendDirectArg, state: InsnId) -> InsnId {
+        match arg {
+            SendDirectArg::Existing(value) => value,
+            SendDirectArg::Constant(value) => {
+                self.push_insn(block, Insn::Const { val: Const::Value(value) })
+            }
+            SendDirectArg::KeywordHash(elements) => {
+                let elements = elements
+                    .into_iter()
+                    .map(|arg| self.emit_send_direct_arg(block, arg, state))
+                    .collect();
+                self.push_insn(block, Insn::NewHash { elements, state })
+            }
+            SendDirectArg::RestArray(elements) => {
+                let elements = elements
+                    .into_iter()
+                    .map(|arg| self.emit_send_direct_arg(block, arg, state))
+                    .collect();
+                self.push_insn(block, Insn::NewArray { elements, state })
+            }
+        }
     }
 
     /// Reorder keyword arguments to match the callee's expected order, and synthesize
@@ -3678,24 +3765,20 @@ impl Function {
     /// The output always contains all of the callee's keyword arguments (required + optional),
     /// so the returned vec may be larger than the input args.
     ///
-    /// Returns Ok with (processed_args, caller_argc, kw_bits) if successful, or Err with the fallback reason if not.
-    /// - caller_argc: number of arguments the caller actually pushed (for stack calculations)
+    /// Returns Ok with (processed_args, kw_bits) if successful, or Err with the fallback reason if not.
     /// - kw_bits: bitmask indicating which optional keywords were NOT provided by the caller
     ///            (used by checkkeyword to determine if non-constant defaults need evaluation)
-    fn setup_keyword_arguments(
-        &mut self,
-        block: BlockId,
-        args: &[InsnId],
+    fn plan_send_direct_keyword_arguments(
+        args: Vec<SendDirectArg>,
         ci: *const rb_callinfo,
         iseq: IseqPtr,
-        state: InsnId,
-    ) -> Result<(Vec<InsnId>, usize, u32), SendFallbackReason> {
+    ) -> Result<(Vec<SendDirectArg>, u32), SendFallbackReason> {
         let kwarg = unsafe { rb_vm_ci_kwarg(ci) };
         let callee_keyword = unsafe { rb_get_iseq_body_param_keyword(iseq) };
         if callee_keyword.is_null() {
             if kwarg.is_null() {
                 // Neither caller nor callee have keywords - nothing to do
-                return Ok((args.to_vec(), args.len(), 0));
+                return Ok((args, 0));
             }
 
             let params = unsafe { iseq.params() };
@@ -3720,15 +3803,13 @@ impl Function {
             let mut elements = Vec::with_capacity(caller_kw_count * 2);
             for i in 0..caller_kw_count {
                 let keyword = unsafe { get_cikw_keywords_idx(kwarg, i as i32) };
-                let key = self.push_insn(block, Insn::Const { val: Const::Value(keyword) });
-                elements.push(key);
-                elements.push(args[kw_args_start + i]);
+                elements.push(SendDirectArg::Constant(keyword));
+                elements.push(args[kw_args_start + i].clone());
             }
 
-            let hash = self.push_insn(block, Insn::NewHash { elements, state });
             let mut processed_args = args[..kw_args_start].to_vec();
-            processed_args.push(hash);
-            return Ok((processed_args, args.len(), 0));
+            processed_args.push(SendDirectArg::KeywordHash(elements));
+            return Ok((processed_args, 0));
         }
 
         // kwarg may be null if caller passes no keywords but callee has optional keywords
@@ -3784,7 +3865,7 @@ impl Function {
         // Reorder keyword arguments to match callee expectation.
         // Track which optional keywords were not provided via kw_bits.
         let mut kw_bits: u32 = 0;
-        let mut reordered_kw_args: Vec<InsnId> = Vec::with_capacity(callee_kw_count);
+        let mut reordered_kw_args = Vec::with_capacity(callee_kw_count);
         for i in 0..callee_kw_count {
             let expected_id = unsafe { *callee_kw_table.add(i) };
 
@@ -3792,7 +3873,7 @@ impl Function {
             let mut found = false;
             for (j, &caller_id) in caller_kw_order.iter().enumerate() {
                 if caller_id == expected_id {
-                    reordered_kw_args.push(args[kw_args_start + j]);
+                    reordered_kw_args.push(args[kw_args_start + j].clone());
                     found = true;
                     break;
                 }
@@ -3814,22 +3895,18 @@ impl Function {
                     // Push Qnil as a placeholder; the callee's checkkeyword will detect this
                     // and branch to evaluate the default expression.
                     kw_bits |= 1 << default_idx;
-                    let nil_insn = self.push_insn(block, Insn::Const { val: Const::Value(Qnil) });
-                    reordered_kw_args.push(nil_insn);
+                    reordered_kw_args.push(SendDirectArg::Constant(Qnil));
                 } else {
                     // Constant default value - use it directly
-                    let const_insn = self.push_insn(block, Insn::Const { val: Const::Value(default_value) });
-                    reordered_kw_args.push(const_insn);
+                    reordered_kw_args.push(SendDirectArg::Constant(default_value));
                 }
             }
         }
 
         // Replace the keyword arguments with the reordered ones.
-        // Keep track of the original caller argc for stack calculations.
-        let caller_argc = args.len();
         let mut processed_args = args[..kw_args_start].to_vec();
         processed_args.extend(reordered_kw_args);
-        Ok((processed_args, caller_argc, kw_bits))
+        Ok((processed_args, kw_bits))
     }
 
     /// Compute the positional optional entry index and pack positional arguments
@@ -3839,20 +3916,17 @@ impl Function {
     /// the callee's *rest array before entering the method body.
     ///
     /// The input args must already have keyword arguments normalized to the callee's
-    /// keyword table order by setup_keyword_arguments. This function only reshapes
+    /// keyword table order by plan_send_direct_keyword_arguments. This function only reshapes
     /// the positional section before those keyword slots.
     ///
     /// Returns Ok with (processed_args, jit_entry_idx) if successful, or Err with
     /// the fallback reason if direct send isn't possible.
     /// - processed_args: arguments to use for SendDirect after optional rest packing
     /// - jit_entry_idx: number of positional optional parameters provided by the caller
-    fn setup_rest_parameter(
-        &mut self,
-        block: BlockId,
-        args: Vec<InsnId>,
+    fn plan_send_direct_rest_parameter(
+        args: Vec<SendDirectArg>,
         iseq: IseqPtr,
-        state: InsnId,
-    ) -> Result<(Vec<InsnId>, u16), SendFallbackReason> {
+    ) -> Result<(Vec<SendDirectArg>, u16), SendFallbackReason> {
         let params = unsafe { iseq.params() };
         let lead_num = params.lead_num as usize;
         let opt_num = params.opt_num as usize;
@@ -3884,14 +3958,9 @@ impl Function {
         let (prefix, rest_and_suffix) = args.split_at(rest_start);
         let (rest_elements, suffix) = rest_and_suffix.split_at(rest_end - rest_start);
 
-        let rest = self.push_insn(block, Insn::NewArray {
-            elements: rest_elements.to_vec(),
-            state,
-        });
-
         let mut packed_args = Vec::with_capacity(prefix.len() + 1 + suffix.len());
         packed_args.extend_from_slice(prefix);
-        packed_args.push(rest);
+        packed_args.push(SendDirectArg::RestArray(rest_elements.to_vec()));
         packed_args.extend_from_slice(suffix);
 
         Ok((packed_args, jit_entry_idx))
@@ -4402,13 +4471,8 @@ impl Function {
                             // Only specialize positional-positional calls
                             // TODO(max): Handle other kinds of parameter passing
                             let iseq = unsafe { get_def_iseq_ptr((*cme).def) };
-                            if !can_direct_send(self, block, iseq, ci, insn_id, args.as_slice(), has_block) {
-                                self.push_insn_id(block, insn_id); continue;
-                            }
-
-                            // Check if the args are compatible before emitting any assmptions
-                            let Ok(SendDirectArgs { state: send_state, args: send_args, kw_bits, jit_entry_idx }) = self.prepare_direct_send_args(block, &args, ci, iseq, send_frame_state)
-                                .inspect_err(|&reason| self.set_dynamic_send_reason(insn_id, reason)) else {
+                            let Ok(plan) = self.plan_send_direct_args(&args, ci, iseq, has_block)
+                                .inspect_err(|failure| failure.record(self, block, insn_id, SendDirectFallbackContext::Send)) else {
                                 self.push_insn_id(block, insn_id); continue;
                             };
 
@@ -4427,6 +4491,8 @@ impl Function {
                                 self.insn_types[recv.to_usize()] = self.infer_type(recv);
                             }
 
+                            let SendDirectArgs { state: send_state, args: send_args, kw_bits, jit_entry_idx } =
+                                self.emit_send_direct_args(block, plan, &args, send_frame_state);
                             let replacement = self.try_inline_send_direct(block, Insn::SendDirect(Box::new(SendDirectData { recv, cd, cme, iseq, args: send_args, kw_bits, jit_entry_idx, state: send_state, block: send_block })));
                             self.make_equal_to(insn_id, replacement);
                         } else if !has_block && def_type == VM_METHOD_TYPE_BMETHOD {
@@ -4442,13 +4508,8 @@ impl Function {
                             let capture = unsafe { proc_block.as_.captured.as_ref() };
                             let iseq = unsafe { *capture.code.iseq.as_ref() };
 
-                            if !can_direct_send(self, block, iseq, ci, insn_id, args.as_slice(), has_block) {
-                                self.push_insn_id(block, insn_id); continue;
-                            }
-
-                            // Check if the args are compatible before emitting any assmptions
-                            let Ok(SendDirectArgs { state: send_state, args: send_args, kw_bits, jit_entry_idx }) = self.prepare_direct_send_args(block, &args, ci, iseq, send_frame_state)
-                                .inspect_err(|&reason| self.set_dynamic_send_reason(insn_id, reason)) else {
+                            let Ok(plan) = self.plan_send_direct_args(&args, ci, iseq, has_block)
+                                .inspect_err(|failure| failure.record(self, block, insn_id, SendDirectFallbackContext::Send)) else {
                                 self.push_insn_id(block, insn_id); continue;
                             };
 
@@ -4470,6 +4531,8 @@ impl Function {
                                 recv = self.guard_type_recompile(block, recv, Type::from_profiled_type(profiled_type), state, Recompile);
                             }
 
+                            let SendDirectArgs { state: send_state, args: send_args, kw_bits, jit_entry_idx } =
+                                self.emit_send_direct_args(block, plan, &args, send_frame_state);
                             let replacement = self.try_inline_send_direct(block, Insn::SendDirect(Box::new(SendDirectData { recv, cd, cme, iseq, args: send_args, kw_bits, jit_entry_idx, state: send_state, block: None })));
                             self.make_equal_to(insn_id, replacement);
                         } else if !has_block && def_type == VM_METHOD_TYPE_IVAR && args.is_empty() {
@@ -4995,21 +5058,16 @@ impl Function {
                             // Check if the super method's parameters support direct send.
                             // If not, we can't do direct dispatch.
                             let super_iseq = unsafe { get_def_iseq_ptr((*super_cme).def) };
-                            // TODO: pass Option<blockiseq> to can_direct_send when we start specializing `super { ... }`.
-                            if !can_direct_send(self, block, super_iseq, ci, insn_id, args.as_slice(), false) {
-                                self.push_insn_id(block, insn_id);
-                                self.set_dynamic_send_reason(insn_id, SuperTargetComplexArgsPass);
-                                continue;
-                            }
-
-                            // Check if the args are compatible before emitting any assmptions
-                            let Ok(SendDirectArgs { state: send_state, args: send_args, kw_bits, jit_entry_idx }) = self.prepare_direct_send_args(block, &args, ci, super_iseq, state)
-                                .inspect_err(|&reason| self.set_dynamic_send_reason(insn_id, reason)) else {
+                            // TODO: pass Option<blockiseq> to plan_send_direct_args when we start specializing `super { ... }`.
+                            let Ok(plan) = self.plan_send_direct_args(&args, ci, super_iseq, false)
+                                .inspect_err(|failure| failure.record(self, block, insn_id, SendDirectFallbackContext::Super)) else {
                                 self.push_insn_id(block, insn_id); continue;
                             };
 
                             emit_super_call_guards(self, block, super_cme, current_cme, mid, state, frame_state.iseq);
 
+                            let SendDirectArgs { state: send_state, args: send_args, kw_bits, jit_entry_idx } =
+                                self.emit_send_direct_args(block, plan, &args, state);
                             // Use SendDirect with the super method's CME and ISEQ.
                             let replacement = self.try_inline_send_direct(block, Insn::SendDirect(Box::new(SendDirectData {
                                 recv,
@@ -5176,8 +5234,8 @@ impl Function {
         // Inline callees with required, optional, post-required positional, keyword, and
         // block parameters, including callees that dispatch to a passed block with `yield`.
         // Double-splat (kwrest) and forwardable params stay out of the general
-        // inliner for now. Rest params are already normalized to a packed Array by
-        // prepare_direct_send_args, so the inliner can map that Array to the rest local.
+        // inliner for now. SendDirect argument emission normalizes rest params to a
+        // packed Array, so the inliner can map that Array to the rest local.
         let params = unsafe { callee_iseq.params() };
         if params.flags.forwardable() != 0
             || params.flags.has_kwrest() != 0
@@ -5339,9 +5397,8 @@ impl Function {
                 // begins when `lead_num + k + post_num + kw_num` arguments are
                 // passed: it runs the default-init code for the remaining
                 // `opt_num - k` optionals (if any) before falling through into the
-                // post-default body. SendDirect emission already guarantees
-                // `prepare_direct_send_args` records the matching `jit_entry_idx`
-                // when it packs the caller args, so do not recover the optional
+                // post-default body. SendDirect argument planning records the matching
+                // `jit_entry_idx` before packing the caller args, so do not recover the optional
                 // positional count from args.len() here.
                 let callee_params = unsafe { iseq.params() };
                 let lead_num = callee_params.lead_num as usize;
@@ -5435,7 +5492,7 @@ impl Function {
                 //     trailing args, but their position in the local table leaves a gap
                 //     of (opt_num - passed_opt_num) above the args' compact layout, so we
                 //     shift the arg index down by that amount. Keyword args follow this
-                //     same arithmetic because `prepare_direct_send_args` already
+                //     same arithmetic because SendDirect argument planning already
                 //     reordered them into callee table order with defaults filled in.
                 //   * the hidden kw_bits storage local (when the callee has keywords) is
                 //     aliased to the SendDirect's compile-time kw_bits value as a fixnum

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -2841,8 +2841,8 @@ enum SendDirectArg {
     RestArray(Vec<SendDirectArg>),
 }
 
-/// Side-effect-free description of the argument setup for one SendDirect path.
-struct SendDirectPlan {
+/// Side-effect-free SendDirect argument setup before HIR emission.
+struct SendDirectCall {
     /// Argument slots in the shape expected by SendDirect.
     args: Vec<SendDirectArg>,
     /// Optional keyword slots omitted by the caller.
@@ -2851,7 +2851,7 @@ struct SendDirectPlan {
     jit_entry_idx: u16,
 }
 
-/// Why a SendDirect plan could not be built, including feature counters that
+/// Why a SendDirect call could not be built, including feature counters that
 /// should only be recorded when the caller keeps the dynamic fallback.
 struct SendDirectFailure {
     reason: SendFallbackReason,
@@ -3696,7 +3696,7 @@ impl Function {
     }
 
     /// Validate and normalize SendDirect arguments without emitting HIR.
-    fn plan_send_direct_args(&self, args: &[InsnId], ci: *const rb_callinfo, iseq: IseqPtr, has_block: bool) -> Result<SendDirectPlan, SendDirectFailure> {
+    fn build_send_direct_args(&self, args: &[InsnId], ci: *const rb_callinfo, iseq: IseqPtr, has_block: bool) -> Result<SendDirectCall, SendDirectFailure> {
         can_direct_send(iseq, ci, args, has_block)?;
         let args = args.iter().copied().map(SendDirectArg::Existing).collect();
         let (args, kw_bits) = Self::plan_send_direct_keyword_arguments(args, ci, iseq)
@@ -3704,16 +3704,16 @@ impl Function {
         let (args, jit_entry_idx) = Self::plan_send_direct_rest_parameter(args, iseq)
             .map_err(SendDirectFailure::new)?;
 
-        Ok(SendDirectPlan {
+        Ok(SendDirectCall {
             args,
             kw_bits,
             jit_entry_idx,
         })
     }
 
-    /// Materialize a validated SendDirect plan in the selected runtime path.
-    fn emit_send_direct_args(&mut self, block: BlockId, plan: SendDirectPlan, original_args: &[InsnId], state: InsnId) -> SendDirectArgs {
-        let args: Vec<_> = plan
+    /// Materialize a validated SendDirect call in the selected runtime path.
+    fn emit_send_direct_args(&mut self, block: BlockId, call: SendDirectCall, original_args: &[InsnId], state: InsnId) -> SendDirectArgs {
+        let args: Vec<_> = call
             .args
             .into_iter()
             .map(|arg| self.emit_send_direct_arg(block, arg, state))
@@ -3730,8 +3730,8 @@ impl Function {
         SendDirectArgs {
             state: send_state,
             args,
-            kw_bits: plan.kw_bits,
-            jit_entry_idx: plan.jit_entry_idx,
+            kw_bits: call.kw_bits,
+            jit_entry_idx: call.jit_entry_idx,
         }
     }
 
@@ -4474,7 +4474,7 @@ impl Function {
                             // Only specialize positional-positional calls
                             // TODO(max): Handle other kinds of parameter passing
                             let iseq = unsafe { get_def_iseq_ptr((*cme).def) };
-                            let Ok(plan) = self.plan_send_direct_args(&args, ci, iseq, has_block)
+                            let Ok(call) = self.build_send_direct_args(&args, ci, iseq, has_block)
                                 .inspect_err(|failure| failure.record(self, block, insn_id, SendDirectFallbackContext::Send)) else {
                                 self.push_insn_id(block, insn_id); continue;
                             };
@@ -4495,7 +4495,7 @@ impl Function {
                             }
 
                             let SendDirectArgs { state: send_state, args: send_args, kw_bits, jit_entry_idx } =
-                                self.emit_send_direct_args(block, plan, &args, send_frame_state);
+                                self.emit_send_direct_args(block, call, &args, send_frame_state);
                             let replacement = self.try_inline_send_direct(block, Insn::SendDirect(Box::new(SendDirectData { recv, cd, cme, iseq, args: send_args, kw_bits, jit_entry_idx, state: send_state, block: send_block })));
                             self.make_equal_to(insn_id, replacement);
                         } else if !has_block && def_type == VM_METHOD_TYPE_BMETHOD {
@@ -4511,7 +4511,7 @@ impl Function {
                             let capture = unsafe { proc_block.as_.captured.as_ref() };
                             let iseq = unsafe { *capture.code.iseq.as_ref() };
 
-                            let Ok(plan) = self.plan_send_direct_args(&args, ci, iseq, has_block)
+                            let Ok(call) = self.build_send_direct_args(&args, ci, iseq, has_block)
                                 .inspect_err(|failure| failure.record(self, block, insn_id, SendDirectFallbackContext::Send)) else {
                                 self.push_insn_id(block, insn_id); continue;
                             };
@@ -4535,7 +4535,7 @@ impl Function {
                             }
 
                             let SendDirectArgs { state: send_state, args: send_args, kw_bits, jit_entry_idx } =
-                                self.emit_send_direct_args(block, plan, &args, send_frame_state);
+                                self.emit_send_direct_args(block, call, &args, send_frame_state);
                             let replacement = self.try_inline_send_direct(block, Insn::SendDirect(Box::new(SendDirectData { recv, cd, cme, iseq, args: send_args, kw_bits, jit_entry_idx, state: send_state, block: None })));
                             self.make_equal_to(insn_id, replacement);
                         } else if !has_block && def_type == VM_METHOD_TYPE_IVAR && args.is_empty() {
@@ -5061,8 +5061,8 @@ impl Function {
                             // Check if the super method's parameters support direct send.
                             // If not, we can't do direct dispatch.
                             let super_iseq = unsafe { get_def_iseq_ptr((*super_cme).def) };
-                            // TODO: pass Option<blockiseq> to plan_send_direct_args when we start specializing `super { ... }`.
-                            let Ok(plan) = self.plan_send_direct_args(&args, ci, super_iseq, false)
+                            // TODO: pass Option<blockiseq> to build_send_direct_args when we start specializing `super { ... }`.
+                            let Ok(call) = self.build_send_direct_args(&args, ci, super_iseq, false)
                                 .inspect_err(|failure| failure.record(self, block, insn_id, SendDirectFallbackContext::Super)) else {
                                 self.push_insn_id(block, insn_id); continue;
                             };
@@ -5070,7 +5070,7 @@ impl Function {
                             emit_super_call_guards(self, block, super_cme, current_cme, mid, state, frame_state.iseq);
 
                             let SendDirectArgs { state: send_state, args: send_args, kw_bits, jit_entry_idx } =
-                                self.emit_send_direct_args(block, plan, &args, state);
+                                self.emit_send_direct_args(block, call, &args, state);
                             // Use SendDirect with the super method's CME and ISEQ.
                             let replacement = self.try_inline_send_direct(block, Insn::SendDirect(Box::new(SendDirectData {
                                 recv,

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -2830,7 +2830,6 @@ struct SendDirectArgs {
 }
 
 /// One SendDirect argument before its HIR value is materialized.
-#[derive(Clone)]
 enum SendDirectArg {
     /// A HIR value already present in the original Send argument vector.
     Existing(InsnId),
@@ -3800,14 +3799,15 @@ impl Function {
             // become one final positional Hash before regular parameter setup.
             let caller_kw_count = unsafe { get_cikw_keyword_len(kwarg) } as usize;
             let kw_args_start = args.len() - caller_kw_count;
+            let mut processed_args = args;
+            let keyword_values = processed_args.split_off(kw_args_start);
             let mut elements = Vec::with_capacity(caller_kw_count * 2);
-            for i in 0..caller_kw_count {
+            for (i, value) in keyword_values.into_iter().enumerate() {
                 let keyword = unsafe { get_cikw_keywords_idx(kwarg, i as i32) };
                 elements.push(SendDirectArg::Constant(keyword));
-                elements.push(args[kw_args_start + i].clone());
+                elements.push(value);
             }
 
-            let mut processed_args = args[..kw_args_start].to_vec();
             processed_args.push(SendDirectArg::KeywordHash(elements));
             return Ok((processed_args, 0));
         }
@@ -3862,6 +3862,12 @@ impl Function {
             }
         }
 
+        // Move caller keyword values out of the positional prefix. Wrap them in
+        // Option so reordering can take each value without cloning it.
+        let mut processed_args = args;
+        let keyword_values = processed_args.split_off(kw_args_start);
+        let mut keyword_values: Vec<_> = keyword_values.into_iter().map(Some).collect();
+
         // Reorder keyword arguments to match callee expectation.
         // Track which optional keywords were not provided via kw_bits.
         let mut kw_bits: u32 = 0;
@@ -3873,7 +3879,7 @@ impl Function {
             let mut found = false;
             for (j, &caller_id) in caller_kw_order.iter().enumerate() {
                 if caller_id == expected_id {
-                    reordered_kw_args.push(args[kw_args_start + j].clone());
+                    reordered_kw_args.push(keyword_values[j].take().unwrap());
                     found = true;
                     break;
                 }
@@ -3904,7 +3910,6 @@ impl Function {
         }
 
         // Replace the keyword arguments with the reordered ones.
-        let mut processed_args = args[..kw_args_start].to_vec();
         processed_args.extend(reordered_kw_args);
         Ok((processed_args, kw_bits))
     }
@@ -3955,13 +3960,11 @@ impl Function {
         // [lead, filled opts, rest array, post, kw...].
         let rest_start = lead_num + passed_opt_num;
         let rest_end = positional_argc - post_num;
-        let (prefix, rest_and_suffix) = args.split_at(rest_start);
-        let (rest_elements, suffix) = rest_and_suffix.split_at(rest_end - rest_start);
-
-        let mut packed_args = Vec::with_capacity(prefix.len() + 1 + suffix.len());
-        packed_args.extend_from_slice(prefix);
-        packed_args.push(SendDirectArg::RestArray(rest_elements.to_vec()));
-        packed_args.extend_from_slice(suffix);
+        let mut packed_args = args;
+        let mut rest_elements = packed_args.split_off(rest_start);
+        let suffix = rest_elements.split_off(rest_end - rest_start);
+        packed_args.push(SendDirectArg::RestArray(rest_elements));
+        packed_args.extend(suffix);
 
         Ok((packed_args, jit_entry_idx))
     }

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -4540,13 +4540,13 @@ mod hir_opt_tests {
           v11:Fixnum[1] = Const Value(1)
           v13:Fixnum[2] = Const Value(2)
           v15:Fixnum[3] = Const Value(3)
-          v23:ArrayExact = NewArray v11, v13, v15
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
-          v26:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
-          PushInlineFrame :foo, v26 (0x1038), num_args=1
+          v24:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
+          v25:ArrayExact = NewArray v11, v13, v15
+          PushInlineFrame :foo, v24 (0x1038), num_args=1
           PatchPoint NoSingletonClass(Array@0x1060)
           PatchPoint MethodRedefined(Array@0x1060, length@0x1068, cme:0x1070)
-          v49:CInt64 = ArrayLength v23
+          v49:CInt64 = ArrayLength v25
           v50:Fixnum = BoxFixnum v49
           CheckInterrupts
           PopInlineFrame
@@ -4580,13 +4580,13 @@ mod hir_opt_tests {
           v19:Fixnum[5] = Const Value(5)
           v21:Fixnum[6] = Const Value(6)
           v23:Fixnum[7] = Const Value(7)
-          v31:ArrayExact = NewArray v11, v13, v15, v17, v19, v21, v23
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
-          v34:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
-          PushInlineFrame :foo, v34 (0x1038), num_args=1
+          v32:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
+          v33:ArrayExact = NewArray v11, v13, v15, v17, v19, v21, v23
+          PushInlineFrame :foo, v32 (0x1038), num_args=1
           PatchPoint NoSingletonClass(Array@0x1060)
           PatchPoint MethodRedefined(Array@0x1060, length@0x1068, cme:0x1070)
-          v57:CInt64 = ArrayLength v31
+          v57:CInt64 = ArrayLength v33
           v58:Fixnum = BoxFixnum v57
           CheckInterrupts
           PopInlineFrame
@@ -4616,13 +4616,13 @@ mod hir_opt_tests {
           v11:Fixnum[1] = Const Value(1)
           v13:Fixnum[2] = Const Value(2)
           v15:Fixnum[3] = Const Value(3)
-          v23:ArrayExact = NewArray v11, v13, v15
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
-          v26:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
-          PushInlineFrame :foo, v26 (0x1038), num_args=1
+          v24:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
+          v25:ArrayExact = NewArray v11, v13, v15
+          PushInlineFrame :foo, v24 (0x1038), num_args=1
           PatchPoint NoSingletonClass(Array@0x1060)
           PatchPoint MethodRedefined(Array@0x1060, length@0x1068, cme:0x1070)
-          v55:CInt64 = ArrayLength v23
+          v55:CInt64 = ArrayLength v25
           v56:Fixnum = BoxFixnum v55
           v38:CPtr = GetEP 0
           v39:CInt64 = LoadField v38, :VM_ENV_DATA_INDEX_SPECVAL@0x1098
@@ -4657,11 +4657,11 @@ mod hir_opt_tests {
           v11:Fixnum[1] = Const Value(1)
           v13:Fixnum[2] = Const Value(2)
           v15:Fixnum[3] = Const Value(3)
-          v23:ArrayExact = NewArray v11, v13, v15
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
-          v26:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
+          v24:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
+          v25:ArrayExact = NewArray v11, v13, v15
           v57:NilClass = Const Value(nil)
-          PushInlineFrame :foo, v26 (0x1038), num_args=1
+          PushInlineFrame :foo, v24 (0x1038), num_args=1
           v37:CPtr = GetEP 0
           v38:CUInt64 = LoadField v37, :VM_ENV_DATA_INDEX_FLAGS@0x1060
           v39:CBool = IsBlockParamModified v38
@@ -4677,7 +4677,7 @@ mod hir_opt_tests {
         bb8(v35:BasicObject, v36:BasicObject):
           PatchPoint NoSingletonClass(Array@0x1070)
           PatchPoint MethodRedefined(Array@0x1070, length@0x1078, cme:0x1080)
-          v66:CInt64 = ArrayLength v23
+          v66:CInt64 = ArrayLength v25
           v67:Fixnum = BoxFixnum v66
           v52:BasicObject = Send v35, :call, v67 # SendFallbackReason: Send: unsupported optimized method type BlockCall
           CheckInterrupts
@@ -4709,13 +4709,13 @@ mod hir_opt_tests {
           v13:Fixnum[2] = Const Value(2)
           v15:Fixnum[3] = Const Value(3)
           v17:Fixnum[4] = Const Value(4)
-          v25:ArrayExact = NewArray v13, v15
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
-          v28:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
-          PushInlineFrame :foo, v28 (0x1038), num_args=3
+          v26:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
+          v27:ArrayExact = NewArray v13, v15
+          PushInlineFrame :foo, v26 (0x1038), num_args=3
           PatchPoint NoSingletonClass(Array@0x1060)
           PatchPoint MethodRedefined(Array@0x1060, length@0x1068, cme:0x1070)
-          v61:CInt64 = ArrayLength v25
+          v61:CInt64 = ArrayLength v27
           v62:Fixnum = BoxFixnum v61
           PatchPoint MethodRedefined(Integer@0x1098, +@0x10a0, cme:0x10a8)
           v66:Fixnum = FixnumAdd v62, v11
@@ -4748,14 +4748,14 @@ mod hir_opt_tests {
           v11:Fixnum[1] = Const Value(1)
           v13:Fixnum[2] = Const Value(2)
           v15:Fixnum[40] = Const Value(40)
-          v23:ArrayExact = NewArray v11, v13
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
-          v26:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
+          v24:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
+          v25:ArrayExact = NewArray v11, v13
           v47:Fixnum[0] = Const Value(0)
-          PushInlineFrame :foo, v26 (0x1038), num_args=2
+          PushInlineFrame :foo, v24 (0x1038), num_args=2
           PatchPoint NoSingletonClass(Array@0x1060)
           PatchPoint MethodRedefined(Array@0x1060, length@0x1068, cme:0x1070)
-          v56:CInt64 = ArrayLength v23
+          v56:CInt64 = ArrayLength v25
           v57:Fixnum = BoxFixnum v56
           PatchPoint MethodRedefined(Integer@0x1098, +@0x10a0, cme:0x10a8)
           v61:Fixnum = FixnumAdd v57, v15
@@ -4786,18 +4786,18 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           v11:Fixnum[1] = Const Value(1)
           v13:Fixnum[2] = Const Value(2)
-          v21:Fixnum[40] = Const Value(40)
-          v22:ArrayExact = NewArray v11, v13
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
-          v25:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
+          v22:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
+          v23:ArrayExact = NewArray v11, v13
+          v24:Fixnum[40] = Const Value(40)
           v46:Fixnum[0] = Const Value(0)
-          PushInlineFrame :foo, v25 (0x1038), num_args=2
+          PushInlineFrame :foo, v22 (0x1038), num_args=2
           PatchPoint NoSingletonClass(Array@0x1060)
           PatchPoint MethodRedefined(Array@0x1060, length@0x1068, cme:0x1070)
-          v55:CInt64 = ArrayLength v22
+          v55:CInt64 = ArrayLength v23
           v56:Fixnum = BoxFixnum v55
           PatchPoint MethodRedefined(Integer@0x1098, +@0x10a0, cme:0x10a8)
-          v60:Fixnum = FixnumAdd v56, v21
+          v60:Fixnum = FixnumAdd v56, v24
           CheckInterrupts
           PopInlineFrame
           Return v60
@@ -4827,11 +4827,11 @@ mod hir_opt_tests {
           v13:Fixnum[20] = Const Value(20)
           v15:Fixnum[30] = Const Value(30)
           v17:Fixnum[40] = Const Value(40)
-          v25:ArrayExact = NewArray v15, v17
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
-          v28:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
-          PushInlineFrame :foo, v28 (0x1038), num_args=3
-          v41:ArrayExact = NewArray v11, v13, v25
+          v26:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
+          v27:ArrayExact = NewArray v15, v17
+          PushInlineFrame :foo, v26 (0x1038), num_args=3
+          v41:ArrayExact = NewArray v11, v13, v27
           CheckInterrupts
           PopInlineFrame
           Return v41
@@ -4957,9 +4957,9 @@ mod hir_opt_tests {
           v13:Fixnum[1] = Const Value(1)
           v15:Fixnum[2] = Const Value(2)
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
-          v25:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
+          v24:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           v44:Fixnum[0] = Const Value(0)
-          PushInlineFrame :foo, v25 (0x1038), num_args=3
+          PushInlineFrame :foo, v24 (0x1038), num_args=3
           v39:ArrayExact = NewArray v13, v15, v11
           CheckInterrupts
           PopInlineFrame
@@ -4990,9 +4990,9 @@ mod hir_opt_tests {
           v13:Fixnum[2] = Const Value(2)
           v15:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
-          v25:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
+          v24:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           v44:Fixnum[0] = Const Value(0)
-          PushInlineFrame :foo, v25 (0x1038), num_args=3
+          PushInlineFrame :foo, v24 (0x1038), num_args=3
           v39:ArrayExact = NewArray v11, v15, v13
           CheckInterrupts
           PopInlineFrame
@@ -5096,13 +5096,13 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           v11:Fixnum[1] = Const Value(1)
           v13:Fixnum[3] = Const Value(3)
-          v34:Fixnum[4] = Const Value(4)
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
-          v37:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
+          v35:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
+          v36:Fixnum[4] = Const Value(4)
           v74:Fixnum[0] = Const Value(0)
-          PushInlineFrame :foo, v37 (0x1038), num_args=3
+          PushInlineFrame :foo, v35 (0x1038), num_args=3
           v52:Fixnum[2] = Const Value(2)
-          v68:ArrayExact = NewArray v11, v52, v13, v34
+          v68:ArrayExact = NewArray v11, v52, v13, v36
           CheckInterrupts
           PopInlineFrame
           v18:Fixnum[1] = Const Value(1)
@@ -5110,7 +5110,7 @@ mod hir_opt_tests {
           v22:Fixnum[40] = Const Value(40)
           v24:Fixnum[30] = Const Value(30)
           v98:Fixnum[0] = Const Value(0)
-          PushInlineFrame :foo, v37 (0x1038), num_args=4
+          PushInlineFrame :foo, v35 (0x1038), num_args=4
           v93:ArrayExact = NewArray v18, v20, v24, v22
           PopInlineFrame
           v28:ArrayExact = NewArray v68, v93
@@ -5185,11 +5185,11 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           v11:Fixnum[1] = Const Value(1)
-          v19:StaticSymbol[:k] = Const Value(VALUE(0x1000))
-          v20:HashExact = NewHash v19: v11
-          PatchPoint MethodRedefined(Object@0x1008, foo@0x1010, cme:0x1018)
-          v23:ObjectSubclass[class_exact*:Object@VALUE(0x1008)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1008)] recompile
-          PushInlineFrame :foo, v23 (0x1040), num_args=1
+          PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
+          v20:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
+          v21:StaticSymbol[:k] = Const Value(VALUE(0x1038))
+          v22:HashExact = NewHash v21: v11
+          PushInlineFrame :foo, v20 (0x1040), num_args=1
           PatchPoint NoSingletonClass(Hash@0x1068)
           PatchPoint MethodRedefined(Hash@0x1068, class@0x1070, cme:0x1078)
           v44:ClassSubclass[Hash@0x1068] = Const Value(VALUE(0x1068))
@@ -5220,13 +5220,13 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           v11:Fixnum[1] = Const Value(1)
           v13:Fixnum[2] = Const Value(2)
-          v21:StaticSymbol[:k] = Const Value(VALUE(0x1000))
-          v22:StaticSymbol[:v] = Const Value(VALUE(0x1008))
-          v23:HashExact = NewHash v21: v11, v22: v13
-          PatchPoint MethodRedefined(Object@0x1010, foo@0x1018, cme:0x1020)
-          v26:ObjectSubclass[class_exact*:Object@VALUE(0x1010)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1010)] recompile
+          PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
+          v22:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
+          v23:StaticSymbol[:k] = Const Value(VALUE(0x1038))
+          v24:StaticSymbol[:v] = Const Value(VALUE(0x1040))
+          v25:HashExact = NewHash v23: v11, v24: v13
           CheckInterrupts
-          Return v23
+          Return v25
         ");
     }
 
@@ -5251,12 +5251,12 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           v11:Fixnum[1] = Const Value(1)
           v13:Fixnum[2] = Const Value(2)
-          v21:StaticSymbol[:k] = Const Value(VALUE(0x1000))
-          v22:HashExact = NewHash v21: v13
-          PatchPoint MethodRedefined(Object@0x1008, foo@0x1010, cme:0x1018)
-          v25:ObjectSubclass[class_exact*:Object@VALUE(0x1008)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1008)] recompile
-          PushInlineFrame :foo, v25 (0x1040), num_args=2
-          v36:ArrayExact = NewArray v11, v22
+          PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
+          v22:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
+          v23:StaticSymbol[:k] = Const Value(VALUE(0x1038))
+          v24:HashExact = NewHash v23: v13
+          PushInlineFrame :foo, v22 (0x1040), num_args=2
+          v36:ArrayExact = NewArray v11, v24
           CheckInterrupts
           PopInlineFrame
           Return v36
@@ -5283,13 +5283,13 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           v11:Fixnum[1] = Const Value(1)
-          v19:StaticSymbol[:k] = Const Value(VALUE(0x1000))
-          v20:HashExact = NewHash v19: v11
-          PatchPoint MethodRedefined(Object@0x1008, foo@0x1010, cme:0x1018)
-          v23:ObjectSubclass[class_exact*:Object@VALUE(0x1008)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1008)] recompile
-          PushInlineFrame :foo, v23 (0x1040), num_args=1
+          PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
+          v20:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
+          v21:StaticSymbol[:k] = Const Value(VALUE(0x1038))
+          v22:HashExact = NewHash v21: v11
+          PushInlineFrame :foo, v20 (0x1040), num_args=1
           v31:Fixnum[2] = Const Value(2)
-          v42:ArrayExact = NewArray v20, v31
+          v42:ArrayExact = NewArray v22, v31
           CheckInterrupts
           PopInlineFrame
           Return v42
@@ -5356,6 +5356,7 @@ mod hir_opt_tests {
           v14:Fixnum[1] = Const Value(1)
           IncrCounter zjit_insn_count
           IncrCounter complex_arg_pass_keyword_to_positional_hash
+          IncrCounter send_direct_fallback_context_send
           v17:BasicObject = Send v7, :foo, v14 # SendFallbackReason: Complex argument passing
           IncrCounter zjit_insn_count
           CheckInterrupts
@@ -5389,6 +5390,7 @@ mod hir_opt_tests {
           v14:Fixnum[1] = Const Value(1)
           IncrCounter zjit_insn_count
           IncrCounter complex_arg_pass_keyword_to_positional_hash
+          IncrCounter send_direct_fallback_context_send
           v17:BasicObject = Send v7, :foo, v14 # SendFallbackReason: Complex argument passing
           IncrCounter zjit_insn_count
           CheckInterrupts
@@ -5417,13 +5419,13 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           v11:Fixnum[1] = Const Value(1)
           v13:Fixnum[3] = Const Value(3)
-          v21:StaticSymbol[:k] = Const Value(VALUE(0x1000))
-          v22:HashExact = NewHash v21: v13
-          v23:ArrayExact = NewArray
-          PatchPoint MethodRedefined(Object@0x1008, foo@0x1010, cme:0x1018)
-          v26:ObjectSubclass[class_exact*:Object@VALUE(0x1008)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1008)] recompile
-          PushInlineFrame :foo, v26 (0x1040), num_args=3
-          v39:ArrayExact = NewArray v11, v22, v23
+          PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
+          v22:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
+          v23:StaticSymbol[:k] = Const Value(VALUE(0x1038))
+          v24:HashExact = NewHash v23: v13
+          v25:ArrayExact = NewArray
+          PushInlineFrame :foo, v22 (0x1040), num_args=3
+          v39:ArrayExact = NewArray v11, v24, v25
           CheckInterrupts
           PopInlineFrame
           Return v39
@@ -5450,15 +5452,15 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           v11:Fixnum[1] = Const Value(1)
-          v19:StaticSymbol[:k] = Const Value(VALUE(0x1000))
-          v20:HashExact = NewHash v19: v11
-          v21:ArrayExact = NewArray v20
-          PatchPoint MethodRedefined(Object@0x1008, foo@0x1010, cme:0x1018)
-          v24:ObjectSubclass[class_exact*:Object@VALUE(0x1008)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1008)] recompile
-          PushInlineFrame :foo, v24 (0x1040), num_args=1
+          PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
+          v20:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
+          v21:StaticSymbol[:k] = Const Value(VALUE(0x1038))
+          v22:HashExact = NewHash v21: v11
+          v23:ArrayExact = NewArray v22
+          PushInlineFrame :foo, v20 (0x1040), num_args=1
           CheckInterrupts
           PopInlineFrame
-          Return v21
+          Return v23
         ");
     }
 
@@ -5484,13 +5486,13 @@ mod hir_opt_tests {
           v11:Fixnum[1] = Const Value(1)
           v13:Fixnum[2] = Const Value(2)
           v15:Fixnum[3] = Const Value(3)
-          v23:StaticSymbol[:k] = Const Value(VALUE(0x1000))
-          v24:HashExact = NewHash v23: v15
+          PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
+          v24:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           v25:ArrayExact = NewArray v13
-          PatchPoint MethodRedefined(Object@0x1008, foo@0x1010, cme:0x1018)
-          v28:ObjectSubclass[class_exact*:Object@VALUE(0x1008)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1008)] recompile
-          PushInlineFrame :foo, v28 (0x1040), num_args=3
-          v41:ArrayExact = NewArray v11, v25, v24
+          v26:StaticSymbol[:k] = Const Value(VALUE(0x1038))
+          v27:HashExact = NewHash v26: v15
+          PushInlineFrame :foo, v24 (0x1040), num_args=3
+          v41:ArrayExact = NewArray v11, v25, v27
           CheckInterrupts
           PopInlineFrame
           Return v41
@@ -5606,6 +5608,7 @@ mod hir_opt_tests {
           v14:Fixnum[1] = Const Value(1)
           IncrCounter zjit_insn_count
           IncrCounter complex_arg_pass_param_kwrest
+          IncrCounter send_direct_fallback_context_send
           v17:BasicObject = Send v7, :foo, v14 # SendFallbackReason: Complex argument passing
           IncrCounter zjit_insn_count
           CheckInterrupts
@@ -5686,11 +5689,11 @@ mod hir_opt_tests {
           v4:BasicObject = LoadArg :self@0
           Jump bb3(v4)
         bb3(v6:BasicObject):
-          v17:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
-          v20:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
+          v18:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
+          v19:Fixnum[1] = Const Value(1)
           v38:Fixnum[0] = Const Value(0)
-          PushInlineFrame :foo, v20 (0x1038), num_args=1
+          PushInlineFrame :foo, v18 (0x1038), num_args=1
           v30:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Integer@0x1060, +@0x1068, cme:0x1070)
           v47:Fixnum[2] = Const Value(2)
@@ -5758,6 +5761,7 @@ mod hir_opt_tests {
           IncrCounter zjit_insn_count
           IncrCounter zjit_insn_count
           IncrCounter complex_arg_pass_param_kwrest
+          IncrCounter send_direct_fallback_context_send
           v14:BasicObject = Send v7, :foo # SendFallbackReason: Complex argument passing
           IncrCounter zjit_insn_count
           CheckInterrupts
@@ -6088,9 +6092,9 @@ mod hir_opt_tests {
           v14:NilClass = Const Value(nil)
           PatchPoint MethodRedefined(Hash@0x1008, new@0x1009, cme:0x1010)
           v44:HashExact = ObjectAllocClass Hash:VALUE(0x1008)
-          v45:Fixnum[0] = Const Value(0)
           PatchPoint NoSingletonClass(Hash@0x1008)
           PatchPoint MethodRedefined(Hash@0x1008, initialize@0x1038, cme:0x1040)
+          v48:Fixnum[0] = Const Value(0)
           v97:Fixnum[0] = Const Value(0)
           v98:NilClass = Const Value(nil)
           PushInlineFrame :initialize, v44 (0x1068), num_args=1
@@ -6106,7 +6110,7 @@ mod hir_opt_tests {
           v88:BasicObject = GetBlockParam :block, l0, EP@4
           Jump bb13(v88)
         bb13(v81:BasicObject):
-          v91:BasicObject = InvokeBuiltin rb_hash_init, v44, v45, v64, v64, v81
+          v91:BasicObject = InvokeBuiltin rb_hash_init, v44, v48, v64, v64, v81
           CheckInterrupts
           PopInlineFrame
           Return v44
@@ -16304,7 +16308,7 @@ mod hir_opt_tests {
 
           def call
             puts [], [], [], []     # fill VM stack with junk
-            read_nil_local(true, 1, 1) # expected direct send
+            read_nil_local(true, 1, 1) # expected SendDirect
           end
 
           call # profile
@@ -17712,6 +17716,46 @@ mod hir_opt_tests {
           v32:BasicObject = InvokeSuper v25, 0x1010, v26 # SendFallbackReason: super: complex argument passing to `super` call
           CheckInterrupts
           Return v32
+        ");
+    }
+
+    #[test]
+    fn test_invokesuper_with_missing_keyword_tracks_super_target_context() {
+        enable_zjit_stats();
+        eval("
+          class A
+            def foo(k:) = k
+          end
+
+          class B < A
+            def foo
+              super()
+            end
+          end
+
+          begin; B.new.foo; rescue ArgumentError; end
+          begin; B.new.foo; rescue ArgumentError; end
+        ");
+
+        assert_snapshot!(hir_string_proc("B.new.method(:foo)"), @"
+        fn foo@<compiled>:8:
+        bb1():
+          EntryPoint interpreter
+          v1:HeapBasicObject = LoadSelf
+          Jump bb3(v1)
+        bb2():
+          EntryPoint JIT(0)
+          v4:HeapBasicObject = LoadArg :self@0
+          IncrCounterPtr
+          Jump bb3(v4)
+        bb3(v7:HeapBasicObject):
+          IncrCounter zjit_insn_count
+          IncrCounter zjit_insn_count
+          IncrCounter send_direct_fallback_context_super
+          v14:BasicObject = InvokeSuper v7, 0x1000 # SendFallbackReason: Argument count does not match parameter count
+          IncrCounter zjit_insn_count
+          CheckInterrupts
+          Return v14
         ");
     }
 
@@ -21015,14 +21059,14 @@ mod hir_opt_tests {
           v7:BasicObject = LoadArg :n@1
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
-          v22:Fixnum[10] = Const Value(10)
           PatchPoint MethodRedefined(Object@0x1008, add_optkw@0x1010, cme:0x1018)
-          v25:ObjectSubclass[class_exact*:Object@VALUE(0x1008)] = GuardType v9, ObjectSubclass[class_exact*:Object@VALUE(0x1008)] recompile
+          v23:ObjectSubclass[class_exact*:Object@VALUE(0x1008)] = GuardType v9, ObjectSubclass[class_exact*:Object@VALUE(0x1008)] recompile
+          v24:Fixnum[10] = Const Value(10)
           v43:Fixnum[0] = Const Value(0)
-          PushInlineFrame :add_optkw, v25 (0x1040), num_args=2
+          PushInlineFrame :add_optkw, v23 (0x1040), num_args=2
           PatchPoint MethodRedefined(Integer@0x1068, +@0x1070, cme:0x1078)
           v50:Fixnum = GuardType v10, Fixnum recompile
-          v51:Fixnum = FixnumAdd v50, v22
+          v51:Fixnum = FixnumAdd v50, v24
           CheckInterrupts
           PopInlineFrame
           Return v51
@@ -21071,9 +21115,9 @@ mod hir_opt_tests {
           v16:Fixnum[3] = Const Value(3)
           v18:Fixnum[2] = Const Value(2)
           PatchPoint MethodRedefined(Object@0x1008, add_kws@0x1010, cme:0x1018)
-          v28:ObjectSubclass[class_exact*:Object@VALUE(0x1008)] = GuardType v9, ObjectSubclass[class_exact*:Object@VALUE(0x1008)] recompile
+          v27:ObjectSubclass[class_exact*:Object@VALUE(0x1008)] = GuardType v9, ObjectSubclass[class_exact*:Object@VALUE(0x1008)] recompile
           v61:Fixnum[0] = Const Value(0)
-          PushInlineFrame :add_kws, v28 (0x1040), num_args=3
+          PushInlineFrame :add_kws, v27 (0x1040), num_args=3
           v40:Fixnum[100] = Const Value(100)
           PatchPoint MethodRedefined(Integer@0x1068, *@0x1070, cme:0x1078)
           v68:Fixnum = GuardType v10, Fixnum recompile
@@ -21127,14 +21171,14 @@ mod hir_opt_tests {
           v7:BasicObject = LoadArg :n@1
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
-          v22:NilClass = Const Value(nil)
           PatchPoint MethodRedefined(Object@0x1008, add_optkw_dyn@0x1010, cme:0x1018)
-          v25:ObjectSubclass[class_exact*:Object@VALUE(0x1008)] = GuardType v9, ObjectSubclass[class_exact*:Object@VALUE(0x1008)] recompile
+          v23:ObjectSubclass[class_exact*:Object@VALUE(0x1008)] = GuardType v9, ObjectSubclass[class_exact*:Object@VALUE(0x1008)] recompile
+          v24:NilClass = Const Value(nil)
           v63:Fixnum[1] = Const Value(1)
-          PushInlineFrame :add_optkw_dyn, v25 (0x1040), num_args=2
+          PushInlineFrame :add_optkw_dyn, v23 (0x1040), num_args=2
           v34:BoolExact = FixnumBitCheck v63, 0
           v36:CBool = Test v34
-          CondBranch v36, bb6(v22), bb7()
+          CondBranch v36, bb6(v24), bb7()
         bb7():
           v42:Fixnum[2] = Const Value(2)
           PatchPoint MethodRedefined(Integer@0x1068, *@0x1070, cme:0x1078)

--- a/zjit/src/hir/tests.rs
+++ b/zjit/src/hir/tests.rs
@@ -206,12 +206,12 @@ mod snapshot_tests {
           v13:Fixnum[1] = Const Value(1)
           v15:Fixnum[2] = Const Value(2)
           v16:Any = Snapshot FrameState { pc: 0x1008, stack: [v6, v11, v13, v15], locals: [] }
-          v23:Any = Snapshot FrameState { pc: 0x1008, stack: [v6, v13, v15, v11], locals: [] }
           PatchPoint MethodRedefined(Object@0x1010, foo@0x1018, cme:0x1020)
-          v25:ObjectSubclass[class_exact*:Object@VALUE(0x1010)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1010)] recompile
+          v24:ObjectSubclass[class_exact*:Object@VALUE(0x1010)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1010)] recompile
+          v25:Any = Snapshot FrameState { pc: 0x1008, stack: [v24, v13, v15, v11], locals: [] }
           v44:Fixnum[0] = Const Value(0)
           v27:Any = Snapshot FrameState { pc: 0x1008, stack: [], locals: [] }
-          PushInlineFrame :foo, v25 (0x1048), num_args=3
+          PushInlineFrame :foo, v24 (0x1048), num_args=3
           v38:Any = Snapshot FrameState { pc: 0x1070, stack: [v13, v15, v11], locals: [a=v13, b=v15, c=v11, ID(0)=v44], caller: v27 }
           v39:ArrayExact = NewArray v13, v15, v11
           v40:Any = Snapshot FrameState { pc: 0x1078, stack: [v39], locals: [a=v13, b=v15, c=v11, ID(0)=v44], caller: v27 }

--- a/zjit/src/stats.rs
+++ b/zjit/src/stats.rs
@@ -292,7 +292,6 @@ make_counters! {
         send_fallback_super_not_optimized_method_type,
         send_fallback_super_polymorphic,
         send_fallback_super_target_not_found,
-        send_fallback_super_target_complex_args_pass,
         send_fallback_cannot_send_direct,
         send_fallback_invokeblock_not_specialized,
         send_fallback_invokeblock_polymorphic_miss,
@@ -444,6 +443,11 @@ make_counters! {
     caller_splat_profile_skewed_polymorphic,
     caller_splat_profile_megamorphic,
     caller_splat_profile_skewed_megamorphic,
+
+    // Contexts in which SendDirect argument planning failed. These are kept
+    // outside dynamic_send because the detailed fallback reason is also counted.
+    send_direct_fallback_context_send,
+    send_direct_fallback_context_super,
 
     // Writes to the VM frame
     vm_write_jit_frame_count,
@@ -708,7 +712,6 @@ pub fn send_fallback_counter(reason: crate::hir::SendFallbackReason) -> Counter 
         SuperNotOptimizedMethodType(_)            => send_fallback_super_not_optimized_method_type,
         SuperPolymorphic                          => send_fallback_super_polymorphic,
         SuperTargetNotFound                       => send_fallback_super_target_not_found,
-        SuperTargetComplexArgsPass                => send_fallback_super_target_complex_args_pass,
         InvokeBlockNotSpecialized                 => send_fallback_invokeblock_not_specialized,
         InvokeBlockPolymorphicMiss                => send_fallback_invokeblock_polymorphic_miss,
         SendForwardNotSpecialized                 => send_fallback_sendforward_not_specialized,


### PR DESCRIPTION
Related: https://github.com/Shopify/ruby/issues/1004, https://github.com/Shopify/ruby/issues/1004#issuecomment-5248700028

SendDirect argument setup mixes validation with fallback accounting and HIR emission. This makes it difficult to evaluate argument shapes before building the corresponding CFG paths.
```
Before:

can_direct_send
└─ eligibility checks + fallback accounting
prepare_direct_send_args
└─ argument setup checks + HIR emission

After:

plan_send_direct_args
└─ eligibility and argument setup checks → SendDirectPlan
emit_send_direct_args
└─ SendDirectPlan → HIR
```

Build a side-effect-free plan first, then emit HIR from the validated plan. Record fallback state only when planning fails and the original Send is kept. This will simplify [polymorphic caller-splat
dispatch](https://github.com/Shopify/ruby/issues/1004#issuecomment-5064253071) implementation.