### PR TITLE
[4.0] Fix GC compaction re-embedding for arrays and strings

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -641,6 +641,7 @@ typedef struct gc_function_map {
     void (*remove_weak)(void *objspace_ptr, VALUE parent_obj, VALUE *ptr);
     // Compaction
     bool (*object_moved_p)(void *objspace_ptr, VALUE obj);
+    bool (*pinned_p)(void *objspace_ptr, VALUE obj);
     VALUE (*location)(void *objspace_ptr, VALUE value);
     // Write barriers
     void (*writebarrier)(void *objspace_ptr, VALUE a, VALUE b);
@@ -815,6 +816,7 @@ ruby_modular_gc_init(void)
     load_modular_gc_func(remove_weak);
     // Compaction
     load_modular_gc_func(object_moved_p);
+    load_modular_gc_func(pinned_p);
     load_modular_gc_func(location);
     // Write barriers
     load_modular_gc_func(writebarrier);
@@ -895,6 +897,7 @@ ruby_modular_gc_init(void)
 # define rb_gc_impl_remove_weak rb_gc_functions.remove_weak
 // Compaction
 # define rb_gc_impl_object_moved_p rb_gc_functions.object_moved_p
+# define rb_gc_impl_pinned_p rb_gc_functions.pinned_p
 # define rb_gc_impl_location rb_gc_functions.location
 // Write barriers
 # define rb_gc_impl_writebarrier rb_gc_functions.writebarrier
@@ -3569,7 +3572,10 @@ gc_ref_update_array(void *objspace, VALUE v)
         }
 
         if (rb_gc_obj_slot_size(v) >= rb_ary_size_as_embedded(v)) {
-            if (rb_ary_embeddable_p(v)) {
+            /* Skip pinned arrays: a pinned array may be referenced from a
+             * conservative root holding RARRAY_PTR across this compaction, so
+             * freeing its heap buffer here would dangle that pointer. */
+            if (rb_ary_embeddable_p(v) && !rb_gc_impl_pinned_p(objspace, v)) {
                 rb_ary_make_embedded(v);
             }
         }
@@ -4146,9 +4152,12 @@ rb_gc_update_object_references(void *objspace, VALUE obj)
             }
 
             /* If, after move the string is not embedded, and can fit in the
-             * slot it's been placed in, then re-embed it. */
+             * slot it's been placed in, then re-embed it. Skip pinned objects:
+             * a local holding RSTRING_PTR across this compaction could otherwise
+             * point to freed memory even if the String is marked and pinned. */
             if (rb_gc_obj_slot_size(obj) >= rb_str_size_as_embedded(obj)) {
-                if (!STR_EMBED_P(obj) && rb_str_reembeddable_p(obj)) {
+                if (!STR_EMBED_P(obj) && rb_str_reembeddable_p(obj)
+                        && !rb_gc_impl_pinned_p(objspace, obj)) {
                     rb_str_make_embedded(obj);
                 }
             }

--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -2214,6 +2214,12 @@ rb_gc_impl_obj_slot_size(VALUE obj)
     return GET_HEAP_PAGE(obj)->slot_size - RVALUE_OVERHEAD;
 }
 
+bool
+rb_gc_impl_pinned_p(void *objspace_ptr, VALUE obj)
+{
+    return RVALUE_PINNED((rb_objspace_t *)objspace_ptr, obj);
+}
+
 static inline size_t
 heap_slot_size(unsigned char pool_id)
 {

--- a/gc/gc_impl.h
+++ b/gc/gc_impl.h
@@ -86,6 +86,7 @@ GC_IMPL_FN void rb_gc_impl_mark_weak(void *objspace_ptr, VALUE *ptr);
 GC_IMPL_FN void rb_gc_impl_remove_weak(void *objspace_ptr, VALUE parent_obj, VALUE *ptr);
 // Compaction
 GC_IMPL_FN bool rb_gc_impl_object_moved_p(void *objspace_ptr, VALUE obj);
+GC_IMPL_FN bool rb_gc_impl_pinned_p(void *objspace_ptr, VALUE obj);
 GC_IMPL_FN VALUE rb_gc_impl_location(void *objspace_ptr, VALUE value);
 // Write barriers
 GC_IMPL_FN void rb_gc_impl_writebarrier(void *objspace_ptr, VALUE a, VALUE b);

--- a/gc/mmtk/mmtk.c
+++ b/gc/mmtk/mmtk.c
@@ -787,6 +787,13 @@ rb_gc_impl_object_moved_p(void *objspace_ptr, VALUE obj)
     rb_bug("unimplemented");
 }
 
+bool
+rb_gc_impl_pinned_p(void *objspace_ptr, VALUE obj)
+{
+    /* MMTk tracks pinning separately */
+    return false;
+}
+
 VALUE
 rb_gc_impl_location(void *objspace_ptr, VALUE value)
 {

--- a/test/ruby/test_gc_compact.rb
+++ b/test/ruby/test_gc_compact.rb
@@ -485,4 +485,19 @@ class TestGCCompact < Test::Unit::TestCase
       assert_equal("hello", obj.instance_variable_get(:@str))
     RUBY
   end
+
+  # Regression test for [Bug #22237]
+  def test_str_and_ary_ptr_references_dont_go_stale_after_compaction
+    assert_separately([], <<~'RUBY')
+      input = "aaa"
+      iterations = 20_000
+      GC.auto_compact = true
+      Object.new # increases chance of memory corruption or segfault
+
+      iterations.times do |i|
+        s = input.tr("\u0080", "\u20AC").dup
+        assert_equal input, s
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Don't re-embed after compaction for these types if they are pinned because if these objects aren't embedded we want to keep their xmalloc's backing storage intact so that RARRAY_PTR and RSTRING_PTR don't point to freed memory across a compaction event. If the object is pinned we want to be able to trust that these pointers can't go stale across an allocation.

Fixes [Bug #22237] (Backport 4.0)