### PR TITLE
[DOC] Fix incorrect method references in backtrace documentation

### DIFF
--- a/error.c
+++ b/error.c
@@ -2108,7 +2108,7 @@ rb_check_backtrace(VALUE bt)
  *      # hiding the parts of the backtrace related to the internals
  *      # of the "json" library
  *
- *      # The error has both #backtace and #backtrace_locations set
+ *      # The error has both #backtrace and #backtrace_locations set
  *      # consistently:
  *      begin
  *        parse_payload('{"wrong: "json"')

--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -767,7 +767,7 @@ location_to_str_m(VALUE self)
 
 /*
  * Returns the same as calling +inspect+ on the string representation of
- * #to_str
+ * #to_s
  */
 static VALUE
 location_inspect_m(VALUE self)


### PR DESCRIPTION
Two documentation fixes for incorrect method references.

Thread::Backtrace::Location#inspect referenced a non-existent #to_str instead of #to_s, and prevented the docs from rendering a link

Exception#set_backtrace's example contained #backtace.