### PR TITLE
Bump json-schema to fix rbs CI error

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -1613,7 +1613,7 @@ no-install-for-test-bundled-gems: no-update-default-gemspecs
 yes-install-for-test-bundled-gems: yes-update-default-gemspecs
 	$(XRUBY) -C "$(srcdir)" -r./tool/lib/gem_env.rb bin/gem \
 		install --no-document --conservative \
-		"hoe" "json-schema:5.1.0" "test-unit-rr" "rspec" "zeitwerk" \
+		"hoe" "json-schema:6.2.0" "test-unit-rr" "rspec" "zeitwerk" \
 		"sinatra" "rack" "tilt" "mustermann" "base64" "compact_index" "rack-test" "logger" "kpeg" "tracer" "minitest-mock"
 
 test-bundled-gems-fetch: yes-test-bundled-gems-fetch


### PR DESCRIPTION
Old json-schema used `quirks_mode`, which was removed from `json` 2015-09-11 (2.0.0).

See: <https://github.com/ruby/ruby/actions/runs/31500530224/job/93810249311>
