### PR TITLE
Skip incompatible RBS tests for json gem v3

### DIFF
--- a/tool/rbs_skip_tests
+++ b/tool/rbs_skip_tests
@@ -54,6 +54,19 @@ test_collection_install__set_pathname__manifest(RBS::CliTest)
 # json-schema passes the obsolete `quirks_mode` parameter, but json gem v3 rejects it
 RBS::SchemaTest
 
+# RBS 4.0.3's JSON tests use APIs removed or changed in json gem v3
+test_dump(JSONInstanceTest)
+test_parse(JSONInstanceTest)
+test_parse!(JSONInstanceTest)
+test_create_id(JSONSingletonTest)
+test_create_id_eq(JSONSingletonTest)
+test_dump(JSONSingletonTest)
+test_load(JSONSingletonTest)
+test_load_file(JSONSingletonTest)
+test_load_file!(JSONSingletonTest)
+test_parse(JSONSingletonTest)
+test_parse!(JSONSingletonTest)
+
 # RBS 4.0.3's RDoc plugin is incompatible with the RDoc 7.2.0 development revision
 test_attr_decl_1(RDocPluginParserTest)
 test_attr_decl_2(RDocPluginParserTest)

--- a/tool/rbs_skip_tests
+++ b/tool/rbs_skip_tests
@@ -51,6 +51,9 @@ test_new(RegexpSingletonTest)
 test_collection_install__pathname_set(RBS::CliTest)
 test_collection_install__set_pathname__manifest(RBS::CliTest)
 
+# json-schema passes the obsolete `quirks_mode` parameter, but json gem v3 rejects it
+RBS::SchemaTest
+
 # RBS 4.0.3's RDoc plugin is incompatible with the RDoc 7.2.0 development revision
 test_attr_decl_1(RDocPluginParserTest)
 test_attr_decl_2(RDocPluginParserTest)

--- a/tool/test-bundled-gems.rb
+++ b/tool/test-bundled-gems.rb
@@ -95,8 +95,21 @@ File.foreach("#{gem_dir}/bundled_gems") do |line|
 
   case gem
   when "rbs"
-    # TODO: We should skip test file instead of test class/methods
+    # json gem v3 removed JSON additions.
     skip_test_files = %w[
+      test/stdlib/json/JSONBigDecimal_test.rb
+      test/stdlib/json/JSONComplex_test.rb
+      test/stdlib/json/JSONDateTime_test.rb
+      test/stdlib/json/JSONDate_test.rb
+      test/stdlib/json/JSONException_test.rb
+      test/stdlib/json/JSONOpenStruct_test.rb
+      test/stdlib/json/JSONRange_test.rb
+      test/stdlib/json/JSONRational_test.rb
+      test/stdlib/json/JSONRegexp_test.rb
+      test/stdlib/json/JSONSet_test.rb
+      test/stdlib/json/JSONStruct_test.rb
+      test/stdlib/json/JSONSymbol_test.rb
+      test/stdlib/json/JSONTime_test.rb
     ]
 
     skip_test_files.each do |file|


### PR DESCRIPTION
RBS 4.0.3 still tests APIs that json gem v3 removed or changed. It also passes the obsolete `quirks_mode` parameter through `json-schema`.

Skip the affected JSON addition files, individual JSON API cases, and `RBS::SchemaTest` through the existing bundled-gem skip mechanisms.