### PR TITLE
Get main Ractor to not take VM lock during local GC marking when JIT is enabled

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -3333,20 +3333,18 @@ rb_gc_mark_roots(void *objspace, const char **categoryp)
      * live there.  A non-main Ractor's local GC skips them; a global GC walks all. */
     if (global_gc || objspace == vm->ractor.main_ractor->objspace) {
         /* Only the main Ractor can register at_exit/END procs (a non-main one gets an
-         * IsolationError), and end_procs is a lock-free linked list, so only main --
-         * the thread that registers, or a stop-the-world global GC, walks it. */
+         * IsolationError) so end_procs is a lock-free linked list */
         MARK_CHECKPOINT("end_proc");
         rb_mark_end_proc();
 
         MARK_CHECKPOINT("vm");
-        /* rb_vm_mark walks VM-global weak tables that other Ractors rewrite under the
-         * VM lock, so main's otherwise lock-free local GC takes a no-barrier VM lock
-         * for this stretch; under a global GC the barrier already protects it. */
+        /* rb_vm_mark and the JIT root marks walk VM-global weak tables and shared singleton
+         * JIT state that other Ractors rewrite under the VM lock, so main's otherwise
+         * lock-free local GC takes the VM lock for this stretch */
         const bool vm_mark_needs_lock = rb_multi_ractor_p() && !global_gc;
         unsigned int vm_mark_lock_lev = 0;
         if (vm_mark_needs_lock) vm_mark_lock_lev = RB_GC_VM_LOCK_NO_BARRIER();
         rb_vm_mark(vm);
-        if (vm_mark_needs_lock) RB_GC_VM_UNLOCK_NO_BARRIER(vm_mark_lock_lev);
 
         if (global_gc) {
             /* Mark and pin the shareable REFs of in-flight (off-heap) move couriers,
@@ -3376,6 +3374,7 @@ rb_gc_mark_roots(void *objspace, const char **categoryp)
             rb_zjit_root_mark();
         }
 #endif
+        if (vm_mark_needs_lock) RB_GC_VM_UNLOCK_NO_BARRIER(vm_mark_lock_lev);
 
         if (global_gc || rb_gc_single_objspace_p()) {
             MARK_CHECKPOINT("global_symbols");

--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -4693,12 +4693,11 @@ gc_sweep_page(rb_objspace_t *objspace, rb_heap_t *heap, struct gc_sweep_context 
         }
     }
 
-    /* main's local GC is lock-free, but freeing a shareable object referenced from a
-     * VM-global weak table (rb_gc_obj_free_vm_weak_references: ci_table, fstring, symbol,
-     * cme) mutates that table, so wrap the page's free loop in a no-barrier VM lock.
-     * Under a global GC the barrier already protects those tables, and a compacting
-     * local GC holds the barrier VM lock from gc_enter, so this nests harmlessly.  A
-     * non-main Ractor's local GC never frees such objects and does not take it. */
+    /* main's local GC is lock-free, but freeing a dead object can mutate VM-global state
+     * that other Ractors rewrite under the VM lock: weak tables (rb_gc_obj_free_vm_weak_
+     * references: ci_table, fstring, symbol, cme). (JIT iseq frees are not reached here:
+     * iseqs are born shareable and a local GC never frees shareable objects.) Wrap the
+     * page's free loop in a no-barrier VM lock (FIXME). */
     const bool sweep_needs_vm_lock =
         objspace == global_objspace->main_objspace && rb_gc_multi_ractor_p() && !objspace->flags.during_global_gc;
     unsigned int sweep_lock_lev = 0;
@@ -8543,18 +8542,18 @@ gc_clock_end(struct timespec *ts)
 }
 
 /* Whether a non-global local GC holds the no-barrier VM lock for its whole run.  Main's
- * ordinary local GC is lock-free; only its compaction or an enabled JIT holds it (see the
- * comment in the function body). */
+ * ordinary local GC is lock-free; only compaction holds it (see the comment in the
+ * function body). */
 static inline bool
 gc_local_gc_holds_vm_lock(const rb_objspace_t *objspace)
 {
-    /* Main's local GC is lock-free at the gc_enter level (bounded no-barrier windows
-     * cover the VM-global weak tables; compaction takes its barrier lock separately).
-     * What DOES hold the lock for the whole GC is an enabled JIT: marking reaches
-     * rb_yjit_iseq_mark / rb_zjit_iseq_mark through shareable iseq payloads, which must
-     * exclude another Ractor's concurrent compile (rb_iseq_mark_and_move asserts it). */
+    /* Main's local GC is lock-free at the gc_enter level.  The VM-global roots and JIT
+     * root marks that need the VM lock take a bounded no-barrier window in rb_gc_mark_roots.
+     * (JIT iseq payload marks and frees are not reached during a local GC: iseqs are born
+     * shareable and a local GC never traverses or frees them.)  Compaction takes its
+     * barrier lock separately (gc_enter handles it before this function runs). */
     return objspace == global_objspace->main_objspace &&
-           (objspace->flags.during_compacting || rb_yjit_enabled_p || rb_zjit_enabled_p);
+           objspace->flags.during_compacting;
 }
 
 static inline bool
@@ -8562,20 +8561,15 @@ gc_enter(rb_objspace_t *objspace, enum gc_enter_event event, unsigned int *lock_
 {
     /* A local GC runs on its owner thread and takes neither the VM lock nor a barrier:
      * containment makes the heap single-writer (only a stop-the-world global GC writes pages
-     * across objspaces).  There are two exceptions.
+     * across objspaces).
      *
-     * - A global GC stops the world (VM lock + barrier).  A GC has no safepoints and a
-     *   thread only joins after gc_exit, so the barrier implicitly waits for every in-flight
-     *   local GC.
-     * - Main objspace's local GC also walks VM-global roots (rb_vm_mark) that change under
-     *   the VM lock, so it takes the lock without raising a barrier.  Non-main objspaces run
-     *   as they are.  A thread waiting for the VM lock here joins a pending global barrier
-     *   *before* starting its own GC, never in the middle of one.
+     * Main's local GC walks VM-global roots (rb_vm_mark) and JIT root marks that change under
+     * the VM lock but takes the lock in rb_gc_mark_roots rather than holding it for the full GC.
      *
-     * Hence a GC must never take the VM lock from inside itself: the waiter would join a
-     * pending barrier mid-collection and expose its half-collected heap to the global GC.
-     * Shared structures the GC paths touch use their own native mutexes (registered
-     * globals, generic fields) or the page-pool lock. */
+     * NOTE: The GC must never take the barrier VM lock from inside itself: the waiter could
+     * join a pending barrier mid-collection and expose its half-collected heap to the global
+     * GC. A no-barrier lock is safe. Other shared structures the GC paths touch use their own
+     * native mutexes or the page-pool lock. */
     *lock_lev = 0;
 
     RUBY_DTRACE_GC_HOOK(ENTER, event);

--- a/iseq.c
+++ b/iseq.c
@@ -423,9 +423,8 @@ rb_iseq_mark_and_move(rb_iseq_t *iseq, bool reference_updating)
 
 #if USE_YJIT || USE_ZJIT
         /* The JIT payload's critical section is the VM lock (racing other Ractors'
-         * compile/invalidate; yjit/zjit assert it).  A lock-free local GC also reaches
-         * here, so take it without joining a barrier.  mmtk marks on a GC worker with no
-         * EC, where the lock cannot be taken, nor needed: stop-the-world. */
+         * compile/invalidate). Iseqs are born shareable, so a multi-Ractor local GC
+         * never traverses them. */
         const bool jit_payload_lock_p = rb_gc_multi_objspace_p();
         bool jit_payload_p = false;
 # if USE_YJIT


### PR DESCRIPTION
It still needs to take the VM lock occasionally to protect certain global data structures during marking but it doesn't have to take the lock the entire time. The problem with a long-held VM lock is that it increases the chance that other Ractors will block on it (and increases the amount of time they will be blocked).

Note: It still takes the VM lock around the sweep of every page but I'll work on that in a separate PR.