### PR TITLE
Get main Ractor to not take VM lock during local GC sweeping

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -4164,7 +4164,9 @@ rb_gc_vm_refresh_zombie_pages(void)
 void
 rb_gc_finish_in_flight_gc(void)
 {
-    rb_gc_impl_gc_rest(rb_gc_get_objspace());
+    RB_VM_LOCKING() { // keep assertions happy
+        rb_gc_impl_gc_rest(rb_gc_get_objspace());
+    }
 }
 
 /* True while a zombie is being absorbed.  The zombie's count is decremented before the

--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -4483,17 +4483,11 @@ gc_sweep_page(rb_objspace_t *objspace, rb_heap_t *heap, struct gc_sweep_context 
         }
     }
 
-    /* main's local GC is lock-free, but freeing a shareable object referenced from a
-     * VM-global weak table (rb_gc_obj_free_vm_weak_references: ci_table, fstring, symbol,
-     * cme) mutates that table, so wrap the page's free loop in a no-barrier VM lock.
-     * Under a global GC the barrier already protects those tables, and a compacting
-     * local GC holds the barrier VM lock from gc_enter, so this nests harmlessly.  A
-     * non-main Ractor's local GC never frees such objects and does not take it. */
-    const bool sweep_needs_vm_lock =
-        objspace == global_objspace->main_objspace && rb_gc_multi_ractor_p() && !objspace->flags.during_global_gc;
-    unsigned int sweep_lock_lev = 0;
-    if (sweep_needs_vm_lock) sweep_lock_lev = RB_GC_VM_LOCK_NO_BARRIER();
-
+    /* pinned_roots_mark pins every shareable object each local cycle, so a local GC
+     * only ever frees non-shareable objects.  VM-global weak tables hold only shareable
+     * entries, so their per-object cleanup is unreachable here; the one reachable path
+     * (rb_free_generic_ivar) uses its own mutex. This is the same reason a non-main ractor's
+     * sweep is already lock-free. Compacting and global GCs hold the barrier lock already. */
     for (int i = 0; i < bitmap_plane_count; i++) {
         bitset = ~bits[i];
         if (bitset) {
@@ -4501,8 +4495,6 @@ gc_sweep_page(rb_objspace_t *objspace, rb_heap_t *heap, struct gc_sweep_context 
         }
         p += BITS_BITLENGTH * slot_size;
     }
-
-    if (sweep_needs_vm_lock) RB_GC_VM_UNLOCK_NO_BARRIER(sweep_lock_lev);
 
     /* Bulk-clear the freed slots' shareable and shref bits before the freelist is
      * published, so a reused slot is clean.  Freed slots are exactly the unmarked ones,


### PR DESCRIPTION
Sweeping unshareables generally doesn't modify global VM data structures. The exception is rb_free_generic_ivar, which modifies the generic_fields_tbl. However, that table has its own mutex protecting it.