### PR TITLE
Ractor: send the exit tokens after the post-mortem collection

### DIFF
--- a/ractor.c
+++ b/ractor.c
@@ -629,7 +629,7 @@ vm_remove_ractor(rb_vm_t *vm, rb_ractor_t *cr)
          * cnt==1-no-zombie window where a GC skips shareable pinning and collects
          * objects (a cc, say) reachable only through this objspace. */
         if (cr->objspace) {
-            /* The final self collection already ran (rb_ractor_postmortem_collect),
+            /* The final self collection already ran (ractor_postmortem_collect),
              * so the entry measures exactly the pages the joiner will inherit. */
             rb_gc_objspace_retire(&cr->objspace);
         }
@@ -643,8 +643,8 @@ vm_remove_ractor(rb_vm_t *vm, rb_ractor_t *cr)
 /* The dying thread's final collection of its own objspace, and the capture of what it
  * must free itself.  Called with the GVL still held: a concurrent global GC waits for
  * this thread's safepoint, so the collection is lock-free like any local GC. */
-void
-rb_ractor_postmortem_collect(rb_thread_t *th, struct rb_ractor_postmortem_frees *pf)
+static void
+ractor_postmortem_collect(rb_thread_t *th, struct rb_ractor_postmortem_frees *pf)
 {
     rb_ractor_t *const cr = th->ractor;
     VM_ASSERT(cr != GET_VM()->ractor.main_ractor);
@@ -855,6 +855,15 @@ static void
 ractor_atexit(rb_execution_context_t *ec, rb_ractor_t *cr, VALUE result, bool exc)
 {
     ractor_notify_exit(ec, cr, result, exc);
+}
+
+/* The dying thread's last work inside its Ractor.  The order is the point: a joiner woken
+ * before the collection spins in ractor_value for the whole of it. */
+void
+rb_ractor_postmortem(rb_thread_t *th, struct rb_ractor_postmortem_frees *pf)
+{
+    ractor_postmortem_collect(th, pf);
+    ractor_send_exit_tokens(th->ec, th->ractor);
 }
 
 void

--- a/ractor_core.h
+++ b/ractor_core.h
@@ -125,7 +125,7 @@ struct rb_ractor_struct {
 
     struct ccan_list_node vmlr_node;
     bool in_terminated_set;  /* vmlr_node is on vm->ractor.terminated_set */
-    /* The final self collection ran (rb_ractor_postmortem_collect): from then on
+    /* The final self collection ran (ractor_postmortem_collect): from then on
      * rb_ractor_mark_local_roots roots only the join value and the registered_marks
      * pins, so the dying thread's own scaffolding can be collected. */
     bool postmortem;
@@ -235,7 +235,7 @@ struct rb_ractor_postmortem_frees {
     struct rb_thread_struct *th;
     struct rb_fiber_struct *fiber;
 };
-void rb_ractor_postmortem_collect(rb_thread_t *th, struct rb_ractor_postmortem_frees *pf);
+void rb_ractor_postmortem(rb_thread_t *th, struct rb_ractor_postmortem_frees *pf);
 void rb_ractor_postmortem_free(const struct rb_ractor_postmortem_frees *pf);
 void rb_ractor_cancel_creation(rb_ractor_t *r, rb_thread_t *th);
 void rb_ractor_blocking_threads_inc(rb_ractor_t *r, const char *file, int line); // TODO: file, line only for RUBY_DEBUG_LOG

--- a/ractor_sync.c
+++ b/ractor_sync.c
@@ -15,7 +15,8 @@ static VALUE rb_cRactorPort;
 
 static VALUE ractor_receive(rb_execution_context_t *ec, const struct ractor_port *rp);
 static VALUE ractor_send(rb_execution_context_t *ec, const struct ractor_port *rp, VALUE obj, VALUE move);
-static VALUE ractor_try_send(rb_execution_context_t *ec, const struct ractor_port *rp, VALUE obj, VALUE move);
+static struct ractor_basket *ractor_basket_new_ref(VALUE shareable);
+static void ractor_send_basket(rb_execution_context_t *ec, const struct ractor_port *rp, struct ractor_basket *b, bool raise_on_error);
 static void ractor_add_port(rb_ractor_t *r, st_data_t id);
 
 // The off-heap courier used for moves.  It is defined in ractor.c.
@@ -684,16 +685,21 @@ ractor_notify_exit(rb_execution_context_t *ec, rb_ractor_t *cr, VALUE legacy, bo
     }
     RACTOR_UNLOCK_SELF(cr);
 
-    // send token
+}
 
-    VALUE token = ractor_exit_token(exc);
+/* Sent after the dying thread's post-mortem collection: waking a joiner any earlier makes
+ * ractor_value spin for the whole of that collection. */
+static void
+ractor_send_exit_tokens(rb_execution_context_t *ec, rb_ractor_t *cr)
+{
+    VALUE token = ractor_exit_token(cr->sync.legacy_exc);
     struct ractor_monitor *rm, *nxt;
 
     ccan_list_for_each_safe(&cr->sync.monitors, rm, nxt, node)
     {
         RUBY_DEBUG_LOG("port:%u@r%u", (unsigned int)ractor_port_id(&rm->port), (unsigned int)rb_ractor_id(rm->port.r));
 
-        ractor_try_send(ec, &rm->port, token, false);
+        ractor_send_basket(ec, &rm->port, ractor_basket_new_ref(token), false);
 
         ccan_list_del(&rm->node);
         SIZED_FREE(rm);
@@ -1602,6 +1608,26 @@ ractor_send_basket(rb_execution_context_t *ec, const struct ractor_port *rp, str
     }
 }
 
+/* A shareable payload needs no preparation, so this skips the tag ractor_basket_new
+ * pushes.  The exit tokens travel this way: they are sent from a thread whose EC has
+ * already lost its VM stack, and EC_PUSH_TAG reads ec->cfp under ZJIT. */
+static struct ractor_basket *
+ractor_basket_new_ref(VALUE shareable)
+{
+    struct ractor_basket *b = ractor_basket_alloc();
+
+    b->type = basket_type_ref;
+    b->sender = Qnil;
+    b->p.v = shareable;
+    b->p.exception = false;
+    b->p.marshaled = false;
+    b->p.move_courier = NULL;
+    b->p.pinned = NULL;
+    b->p.pinned_cnt = 0;
+
+    return b;
+}
+
 static VALUE
 ractor_send0(rb_execution_context_t *ec, const struct ractor_port *rp, VALUE obj, VALUE move, bool raise_on_error)
 {
@@ -1615,12 +1641,6 @@ static VALUE
 ractor_send(rb_execution_context_t *ec, const struct ractor_port *rp, VALUE obj, VALUE move)
 {
     return ractor_send0(ec, rp, obj, move, true);
-}
-
-static VALUE
-ractor_try_send(rb_execution_context_t *ec, const struct ractor_port *rp, VALUE obj, VALUE move)
-{
-    return ractor_send0(ec, rp, obj, move, false);
 }
 
 // Ractor::Selector

--- a/thread.c
+++ b/thread.c
@@ -827,7 +827,7 @@ thread_start_func_2(rb_thread_t *th, VALUE *stack_start)
     // below, and captures the structs it must free at its last step.
     struct rb_ractor_postmortem_frees pf = { NULL, NULL };
     if (th->invoke_type == thread_invoke_type_ractor_proc) {
-        rb_ractor_postmortem_collect(th, &pf);
+        rb_ractor_postmortem(th, &pf);
     }
 
 #if defined(USE_MN_THREADS) && USE_MN_THREADS


### PR DESCRIPTION
Ractor#join waits on a monitor port, and the exit token was sent from ractor_notify_exit as the Ractor's block ends.  Ractor#value then has to wait for ractor_terminated on its own -- vm_remove_ractor retires the objspace the joiner is about to absorb -- and it does so by spinning on rb_thread_schedule().

Now that the dying thread collects its own objspace post-mortem, that spin covers a whole local GC: the joiner burns a core for as long as the child's final collection takes, which grows with the child's heap.

Split the notification: the value is published at atexit as before, but the tokens go out after the collection, while the dying thread still holds the GVL. What the joiner spins over is then only the scheduler handoff and vm_remove_ractor, which is constant.  Both steps are now rb_ractor_postmortem(), so their order is stated in one place.

Post-join spin, by the number of objects the child allocated:

``` 
       0:    13us ->   3us
   10000:   961us ->   3us
  100000:  5211us -> 199us   (the remainder is the absorb itself)
  ```