### PR TITLE
Check ObjectSpace._id2ref returns the object with the requested object_id

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -1973,6 +1973,28 @@ build_id2ref_i(VALUE obj, void *data)
     }
 }
 
+static bool
+object_id_matches_p(VALUE obj, VALUE object_id)
+{
+    VALUE id;
+
+    switch (BUILTIN_TYPE(obj)) {
+      case T_CLASS:
+      case T_MODULE:
+        // Classes and modules do not store their object id in fields.
+        id = RCLASS(obj)->object_id;
+        break;
+      default:
+        {
+            shape_id_t shape_id = RBASIC_SHAPE_ID(obj);
+            id = rb_shape_has_object_id(shape_id) ? object_id_get(obj, shape_id) : 0;
+        }
+        break;
+    }
+
+    return id && object_id_cmp((st_data_t)id, (st_data_t)object_id) == 0;
+}
+
 static VALUE
 object_id_to_ref(void *objspace_ptr, VALUE object_id)
 {
@@ -2003,7 +2025,14 @@ object_id_to_ref(void *objspace_ptr, VALUE object_id)
     }
 
     VALUE obj;
-    bool found = st_lookup(id2ref_tbl, object_id, &obj) && !rb_gc_impl_garbage_object_p(objspace, obj);
+    // The entry may be stale and point to a slot which was freed since. That
+    // slot's page may even have been reused by another size pool, in which case
+    // the address might no longer be on a slot boundary. rb_gc_pointer_to_heap_p()
+    // rejects that, so the remaining checks only ever look at a valid slot.
+    bool found = st_lookup(id2ref_tbl, object_id, &obj) &&
+        rb_gc_pointer_to_heap_p(obj) &&
+        !rb_gc_impl_garbage_object_p(objspace, obj) &&
+        object_id_matches_p(obj, object_id);
 
     RB_GC_VM_UNLOCK(lev);
 

--- a/test/ruby/test_objectspace.rb
+++ b/test/ruby/test_objectspace.rb
@@ -78,6 +78,33 @@ End
     RUBY
   end
 
+  def test_id2ref_no_wrong_object_for_generic_fields # [Bug #22200]
+    assert_separately([], <<-'End')
+      Warning[:deprecated] = false
+
+      # Ensure the id2ref table exists
+      anchor = Object.new
+      ObjectSpace._id2ref(anchor.object_id)
+
+      ids = Array.new(10_000) { |i| +"str-#{i}" }.map(&:object_id)
+      GC.start(full_mark: true, immediate_sweep: false)
+
+      recyclers = []
+      5.times do
+        recyclers.concat(Array.new(1_000) { +"recycler" })
+        ids.each do |id|
+          begin
+            obj = ObjectSpace._id2ref(id)
+            assert_equal(id, obj.object_id,
+              "_id2ref returned wrong object")
+          rescue RangeError
+            # expected for recycled objects
+          end
+        end
+      end
+    End
+  end
+
   def test_id2ref_invalid_argument
     msg = /no implicit conversion/
     assert_raise_with_message(TypeError, msg) { EnvUtil.suppress_warning { ObjectSpace._id2ref(nil) } }


### PR DESCRIPTION
[[Bug #22200]](https://bugs.ruby-lang.org/issues/22200)

The `id2ref_tbl` entry of an object with generic fields (String, Array, Hash, etc.) is only removed when its companion `imemo_fields` is swept, which can be much later than the owner's own sweep. Until then the entry points to a slot which may already have been reused by an unrelated new object, and `_id2ref` returned that object instead of raising `RangeError`.

`garbage_object_p()` cannot catch this, because the new occupant is a live and marked object. So check the object we found actually has the `object_id` we were asked for, and raise `RangeError` otherwise.

Reading the `object_id` of the found object should be safe because `garbage_object_p()`
rejects `T_NONE`, `T_MOVED` and `T_ZOMBIE` slots as well as unmarked objects on
pages not swept yet, so the slot still holds a valid object.
This is unlike during sweeping, where the companion `T_IMEMO/fields` may be on a page already reused by another size pool with a different slot size (the issue with the previous approach in #18238).

Two things make reading the found object safe:
- `rb_gc_pointer_to_heap_p()` rejects addresses which are not on a slot boundary for the page's current slot_size, as well as pages sitting in the global empty pages pool. A stale entry may point into a page which was emptied during sweeping and then reused by another size pool, so this is needed here too, not only during sweeping.
- `garbage_object_p()` then rejects `T_NONE`, `T_MOVED` and `T_ZOMBIE` slots as well as unmarked objects on pages not swept yet.

So the slot holds a valid, unfreed object and reading its fields (and its companion `imemo_fields`) is well-defined. The difference with #18238 is not that the hazard is absent here, but that it is cheap to guard: this runs once per `_id2ref` call, whereas during sweeping the same check would run per swept object with an `object_id`, and would still need a `rb_gc_modular_gc_loaded_p()` carve-out since mmtk implements `pointer_to_heap_p()` as `mmtk_is_mmtk_object()`.