### PR TITLE
Remove dead global table pre-sweep code

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -4803,20 +4803,6 @@ vm_weak_table_frozen_strings_foreach(VALUE *str, void *data)
 
 void rb_fstring_foreach_with_replace(int (*callback)(VALUE *str, void *data), void *data);
 
-// Whether this table must be cleaned every GC after marking.
-// Other tables may be skipped cleaned up per-object via rb_gc_obj_free_vm_weak_references.
-bool
-rb_gc_vm_weak_table_essential_p(enum rb_gc_vm_weak_tables table)
-{
-    /* No bulk cleanup: the generic_fields table is process-wide, so a local GC must not
-     * wipe other Ractors' live entries.  They are dropped per freed object instead
-     * (rb_gc_obj_free_vm_weak_references), and dead keys drain in the global GC's weak pass. */
-    switch (table) {
-      default:
-        return false;
-    }
-}
-
 /* Callback of rb_generic_fields_tables_foreach: walk one generic_fields table with the
  * gen_fields foreach used by compaction, recording the current table in foreach_data so
  * a moved key is re-inserted into the right one. */

--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -4750,15 +4750,6 @@ gc_sweep_freeobj_hooks(rb_objspace_t *objspace)
     }
 }
 
-static int
-gc_sweep_weak_table_i(VALUE val, void *data)
-{
-    rb_objspace_t *objspace = data;
-    if (RB_SPECIAL_CONST_P(val)) return ST_CONTINUE;
-    if (RVALUE_MARKED(objspace, val)) return ST_CONTINUE;
-    return ST_DELETE;
-}
-
 static void
 gc_sweep_start(rb_objspace_t *objspace)
 {
@@ -4771,22 +4762,6 @@ gc_sweep_start(rb_objspace_t *objspace)
          * cannot fire during a non-main Ractor's lock-free local sweep. */
         GC_ASSERT(objspace == global_objspace->main_objspace);
         gc_sweep_freeobj_hooks(objspace);
-    }
-
-    /* Clean the VM-global tables.  Under a global GC every objspace's sweep passes here,
-     * but there is one table per VM and the decision is a (page-relative) mark bit, so
-     * repeating it is idempotent waste: gc_start_global does it once before sweeping. */
-    if (!objspace->flags.during_global_gc) {
-        for (int table = 0; table < RB_GC_VM_WEAK_TABLE_COUNT; table++) {
-            if (!rb_gc_vm_weak_table_essential_p(table)) continue;
-            rb_gc_vm_weak_table_foreach(
-                gc_sweep_weak_table_i,
-                NULL,
-                objspace,
-                true,
-                table
-            );
-        }
     }
 
 #if GC_CAN_COMPILE_COMPACTION
@@ -8870,14 +8845,6 @@ gc_start_global(rb_objspace_t *driver, unsigned int reason, bool compact)
     rb_ractor_finish_marking();
 
     gc_marking_exit(driver);
-
-    /* Clean the VM-global weak tables once, before sweeping any objspace (gc_sweep_start
-     * skips it during a global GC; the decision comes from the objspace-independent unified
-     * mark). */
-    for (int table = 0; table < RB_GC_VM_WEAK_TABLE_COUNT; table++) {
-        if (!rb_gc_vm_weak_table_essential_p(table)) continue;
-        rb_gc_vm_weak_table_foreach(gc_sweep_weak_table_i, NULL, driver, true, table);
-    }
 
     /* step 9: sweep every objspace inside the barrier, not lazily.  Dead shareable objects
      * are reclaimed here and emptied pages go back to the pool. */

--- a/gc/gc.h
+++ b/gc/gc.h
@@ -85,7 +85,6 @@ bool rb_gc_single_objspace_p(void);
 void rb_gc_reset_absorbed_since_global_gc(void);
 MODULAR_GC_FN size_t rb_gc_obj_optimal_size(VALUE obj);
 MODULAR_GC_FN void rb_gc_mark_children(void *objspace, VALUE obj);
-MODULAR_GC_FN bool rb_gc_vm_weak_table_essential_p(enum rb_gc_vm_weak_tables table);
 MODULAR_GC_FN void rb_gc_vm_weak_table_foreach(vm_table_foreach_callback_func callback, vm_table_update_callback_func update_callback, void *data, bool weak_only, enum rb_gc_vm_weak_tables table);
 /* The global GC's weak pass over generic_fields (called from a gc-impl). */
 MODULAR_GC_FN void rb_gc_vm_generic_fields_mark_foreach(int (*cb)(VALUE key, VALUE val, void *arg), void *arg);


### PR DESCRIPTION
RLGC made it unsafe to pre-sweep the global weak tables in the global GC, because we could be sweeping references to objects in multiple ractors.

Now the local GC's handle this by having each object remove it's own table references.

The consequence of this is that `rb_gc_vm_weak_table_essential_p` is always false now, which means that all of the callsites are no-ops, meaning we can remove the whole thing from the GC API.