### PR TITLE
parse.y: fix high nibble in invalid byte escapes

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -6817,7 +6817,7 @@ rb_parser_str_escape(struct parser_params *p, rb_parser_string_t *str)
             if (pend < ptr + n)
                 n = (int)(pend - ptr);
             while (n--) {
-                c = *ptr & 0xf0 >> 4;
+                c = ((unsigned char)*ptr >> 4) & 0x0f;
                 charbuf[2] = (c < 10) ? '0' + c : 'A' + c - 10;
                 c = *ptr & 0x0f;
                 charbuf[3] = (c < 10) ? '0' + c : 'A' + c - 10;


### PR DESCRIPTION
`rb_parser_str_escape` used `*ptr & 0xf0 >> 4` to extract the high nibble of invalid bytes.
Since the shift operator has higher precedence than bitwise AND, this was evaluated as:

```c
*ptr & (0xf0 >> 4)
```

As a result, both hexadecimal digits were derived from the low nibble. For example, `0xAB` was displayed as `\xBB` instead of `\xAB`. Use an explicit unsigned-byte shift to extract the high nibble correctly. This only changes the escaped representation used by parser debug output.