### PR TITLE
Skip traversing the global symbol table during main's local GCs

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -3377,8 +3377,10 @@ rb_gc_mark_roots(void *objspace, const char **categoryp)
         }
 #endif
 
-        MARK_CHECKPOINT("global_symbols");
-        rb_sym_global_symbols_mark_and_move();
+        if (global_gc || rb_gc_single_objspace_p()) {
+            MARK_CHECKPOINT("global_symbols");
+            rb_sym_global_symbols_mark_and_move();
+        }
     }
 
     /* The dying thread's final collection of its own objspace runs after its stack

--- a/symbol.c
+++ b/symbol.c
@@ -361,6 +361,8 @@ set_id_entry(rb_symbols_t *symbols, rb_id_serial_t num, VALUE str, VALUE sym)
     ASSERT_vm_locking();
     RUBY_ASSERT_BUILTIN_TYPE(str, T_STRING);
     RUBY_ASSERT_BUILTIN_TYPE(sym, T_SYMBOL);
+    RUBY_ASSERT(RB_OBJ_SHAREABLE_P(str));
+    RUBY_ASSERT(RB_SPECIAL_CONST_P(sym) || RB_OBJ_SHAREABLE_P(sym));
 
     size_t idx = num / ID_ENTRY_UNIT;
 


### PR DESCRIPTION
These are all shareable objects, and `gc_mark` still traverses non-foreign shareables. For local GC, pinned_roots_mark will keep these objects alive anyway.