### PR TITLE
Sizing the M:N shared thread pool

### DIFF
--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -1408,10 +1408,6 @@ ractor_sched_enq(rb_vm_t *vm, rb_ractor_t *r)
 }
 
 
-#ifndef SNT_KEEP_SECONDS
-#define SNT_KEEP_SECONDS 0
-#endif
-
 #ifndef MINIMUM_SNT
 // make at least MINIMUM_SNT snts for debug.
 #define MINIMUM_SNT 0
@@ -1433,25 +1429,11 @@ ractor_sched_deq(rb_vm_t *vm, rb_ractor_t *cr)
         while ((r = ccan_list_pop(&vm->ractor.sched.grq, rb_ractor_t, threads.sched.grq_node)) == NULL) {
             RUBY_DEBUG_LOG("wait grq_cnt:%d", (int)vm->ractor.sched.grq_cnt);
 
-#if SNT_KEEP_SECONDS > 0
-            rb_hrtime_t abs = rb_hrtime_add(rb_hrtime_now(), RB_HRTIME_PER_SEC * SNT_KEEP_SECONDS);
-            if (native_cond_timedwait(&vm->ractor.sched.cond, &vm->ractor.sched.lock, &abs) == ETIMEDOUT) {
-                RUBY_DEBUG_LOG("timeout, grq_cnt:%d", (int)vm->ractor.sched.grq_cnt);
-                VM_ASSERT(r == NULL);
-                vm->ractor.sched.snt_cnt--;
-                vm->ractor.sched.running_cnt--;
-                break;
-            }
-            else {
-                RUBY_DEBUG_LOG("wakeup grq_cnt:%d", (int)vm->ractor.sched.grq_cnt);
-            }
-#else
             ractor_sched_set_unlocked(vm, cr);
             rb_native_cond_wait(&vm->ractor.sched.cond, &vm->ractor.sched.lock);
             ractor_sched_set_locked(vm, cr);
 
             RUBY_DEBUG_LOG("wakeup grq_cnt:%d", (int)vm->ractor.sched.grq_cnt);
-#endif
         }
 
         VM_ASSERT(rb_current_execution_context(false) == NULL);
@@ -1461,10 +1443,6 @@ ractor_sched_deq(rb_vm_t *vm, rb_ractor_t *cr)
             VM_ASSERT(vm->ractor.sched.grq_cnt > 0);
             vm->ractor.sched.grq_cnt--;
             RUBY_DEBUG_LOG("r:%d grq_cnt:%u", (int)rb_ractor_id(r), vm->ractor.sched.grq_cnt);
-        }
-        else {
-            VM_ASSERT(SNT_KEEP_SECONDS > 0);
-            // timeout
         }
     }
     ractor_sched_unlock(vm, cr);

--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -1954,8 +1954,17 @@ native_thread_dedicated_dec(rb_vm_t *vm, rb_ractor_t *cr, struct rb_native_threa
     if (nt->dedicated == 0) {
         ractor_sched_lock(vm, cr);
         {
-            nt->vm->ractor.sched.snt_cnt++;
-            nt->vm->ractor.sched.dnt_cnt--;
+            /* max_cpu bounds the shared threads and this is where one rejoins
+             * them, so this is where the cap has to hold.  A thread with no room
+             * to come back to belongs to neither count until it ends. */
+            if (vm->ractor.sched.snt_cnt < vm->ractor.sched.max_cpu ||
+                (int)vm->ractor.sched.snt_cnt <= MINIMUM_SNT) {
+                vm->ractor.sched.snt_cnt++;
+            }
+            else {
+                nt->retiring = true;
+            }
+            vm->ractor.sched.dnt_cnt--;
         }
         ractor_sched_unlock(vm, cr);
     }
@@ -2430,6 +2439,8 @@ nt_start(void *ptr)
         }
         else {
             RUBY_DEBUG_LOG("check next");
+            if (nt->retiring) break;   // came back with no room in the shared pool
+
             rb_ractor_t *r = ractor_sched_deq(vm, NULL);
 
             if (r) {

--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -1413,10 +1413,24 @@ ractor_sched_enq(rb_vm_t *vm, rb_ractor_t *r)
 #define MINIMUM_SNT 0
 #endif
 
+/* A shared thread woken with nothing to run is one whose turn another thread
+ * took first.  After this many in a row it gives itself back: the queue keeps
+ * running dry, so the pool is wider than the work.  0 retires on the first one
+ * and is too eager to be useful; a negative value keeps every thread. */
+#ifndef SNT_IDLE_RETIRE
+#define SNT_IDLE_RETIRE 3
+#endif
+
+/* Never give the last shared thread back.  With none left an enqueue has nobody
+ * to signal, and the only code that makes one runs on the timer thread's
+ * timeout branch, which is reached only once it has seen a backlog. */
+#define SNT_KEEP_MINIMUM (MINIMUM_SNT > 1 ? MINIMUM_SNT : 1)
+
 static rb_ractor_t *
 ractor_sched_deq(rb_vm_t *vm, rb_ractor_t *cr)
 {
     rb_ractor_t *r;
+    int idle_streak = 0;   // consecutive pops that found the queue empty
 
     ractor_sched_lock(vm, cr);
     {
@@ -1428,6 +1442,13 @@ ractor_sched_deq(rb_vm_t *vm, rb_ractor_t *cr)
 
         while ((r = ccan_list_pop(&vm->ractor.sched.grq, rb_ractor_t, threads.sched.grq_node)) == NULL) {
             RUBY_DEBUG_LOG("wait grq_cnt:%d", (int)vm->ractor.sched.grq_cnt);
+
+            if (SNT_IDLE_RETIRE >= 0 && ++idle_streak > SNT_IDLE_RETIRE &&
+                (int)vm->ractor.sched.snt_cnt > SNT_KEEP_MINIMUM) {
+                vm->ractor.sched.snt_cnt--;
+                RUBY_DEBUG_LOG("retire, snt_cnt:%d", (int)vm->ractor.sched.snt_cnt);
+                break;   // returning NULL ends this nt; see the caller
+            }
 
             ractor_sched_set_unlocked(vm, cr);
             rb_native_cond_wait(&vm->ractor.sched.cond, &vm->ractor.sched.lock);
@@ -1443,6 +1464,10 @@ ractor_sched_deq(rb_vm_t *vm, rb_ractor_t *cr)
             VM_ASSERT(vm->ractor.sched.grq_cnt > 0);
             vm->ractor.sched.grq_cnt--;
             RUBY_DEBUG_LOG("r:%d grq_cnt:%u", (int)rb_ractor_id(r), vm->ractor.sched.grq_cnt);
+        }
+        else {
+            // the retire branch is the only way out of the loop without a ractor
+            VM_ASSERT(idle_streak > SNT_IDLE_RETIRE);
         }
     }
     ractor_sched_unlock(vm, cr);
@@ -2458,7 +2483,7 @@ nt_start(void *ptr)
                 }
             }
             else {
-                // timeout -> deleted.
+                // retired: this nt is done.
                 break;
             }
 

--- a/thread_pthread.h
+++ b/thread_pthread.h
@@ -138,6 +138,10 @@ struct rb_native_thread {
     struct coroutine_context *nt_context;
     int dedicated;
 
+    // set when this thread came back from a blocking region with no room left
+    // in the shared pool; it ends when it next asks for work
+    bool retiring;
+
     // A terminating coroutine records its context here before its final
     // transfer; this nt's loop reclaims it. (Not via coroutine_transfer()'s
     // return value: its meaning differs between the amd64 asm and ucontext.)


### PR DESCRIPTION
The pool of shared native threads grows past `RUBY_MAX_CPU` and never shrinks. On
an 8-core machine a Ractor server settles on 23 to 51 native threads where 7 to
16 would serve it better, and throughput falls by up to 4x as a result.

Three commits, `thread_pthread.c` and one field in `thread_pthread.h`, +39 −21.

## Why the pool grows

`native_thread_check_and_create_shared` honours `max_cpu`, but that is only half
of it. `snt_cnt` also drops whenever a thread enters a blocking region and rises
again when it leaves, and the rejoining side checks nothing:

```c
native_thread_dedicated_inc:  snt_cnt--;  dnt_cnt++;   /* into read(2)     */
native_thread_dedicated_dec:  snt_cnt++;  dnt_cnt--;   /* back out, no cap */
```

So while a thread is away in a syscall the timer thread reads the dip as a
shortage and hires a replacement, and when the original returns nobody is let go.
On an HTTP/1.1 Ractor server that transition happens about once per dispatch —
roughly 300k times a second — so the pool ratchets up until it is bounded only by
how many threads block at once.

| RUBY_MAX_CPU=16, 8 cores, 256 connections | native threads | req/s |
|---|---|---|
| static response | 44 | 48,696 |
| one LAN memcached lookup per request | 43 | 23,988 |
| thirty such lookups per request | 49 | 1,493 |

## Why the surplus costs throughput

Only `max_cpu` threads can run Ruby at once, so the extra ones add no
parallelism. What they do is drain the global ready queue: a thread coming back
for more work finds it empty and parks, and every dispatch after that is a
handoff to a sleeping thread on another core instead of a continuation on the one
that just freed up. Against a correctly sized pool, `perf stat` puts that at 2.15
CPU migrations per request instead of 0.01, 2.2x the cache misses, and IPC down
from 0.51 to 0.45. A pool sized to the work leaves a backlog instead, and then
nothing has to be woken at all.

## The changes

**1. Keep `RUBY_MAX_CPU` when a thread rejoins the shared pool.** The check goes
where the invariant is broken — the point at which a thread comes back from a
blocking region. A thread that finds no room left is on its way out: it belongs
to neither count and ends when it next asks for work, which is the first moment
it is not running anything.

**2. Remove the unused `SNT_KEEP_SECONDS` path.** It retires a shared thread that
waits that many seconds without being given a ractor — the same idea as the rule
below, keyed on elapsed time rather than on fruitless wakeups. It has been
defined to 0 since be1bbd5b7d introduced it in 2023, so it has not been compiled
since, and as written it would not correct the oversupply this PR is about: the
deadline is recomputed on every turn of the wait loop, so a thread that keeps
being woken to find the queue empty resets it every time and never expires. It
also reads the clock inside the scheduler lock on every wait, and it decrements
`running_cnt`, which counts the threads on `vm->ractor.sched.running_threads`
while a thread waiting here holds none.

**3. Retire a shared thread the work does not need.** Being at the cap is not the
same as being the right size, and the default cap is the number of logical CPUs.
A thread woken to find nothing to run has had its turn taken by a thread that
never waited — evidence that the pool is wider than the work. After
`SNT_IDLE_RETIRE` of those in a row it gives itself back. The counter resets on
any successful dequeue, so it only fires under persistent oversupply and stops as
soon as the pool is small enough to keep a backlog. The last shared thread is
never given back.

`SNT_IDLE_RETIRE` defaults to 3; 1 through 3 measure the same, 0 retires so
eagerly that the pool cannot grow when it should (up to 4x slower at low
connection counts), and a negative value disables the rule.

## Results

`RUBY_MAX_CPU` at its default of 16. req/s, with the settled native thread count
in parentheses.

| workload | connections | master | + cap | + retire |
|---|---|---|---|---|
| static response | 16 | 70,830 (23) | 70,548 (19) | 91,530 (7) |
| static response | 32 | 62,828 (23) | 64,989 (19) | 135,974 (8) |
| static response | 128 | 60,919 (33) | 63,873 (26) | 174,597 (9) |
| static response | 256 | 48,696 (44) | 89,499 (21) | 186,613 (10) |
| memcached ×1 | 32 | 30,560 (24) | 33,563 (19) | 62,100 (7) |
| memcached ×1 | 128 | 33,592 (38) | 32,892 (24) | 93,784 (10) |
| memcached ×1 | 256 | 23,988 (43) | 56,347 (20) | 98,033 (11) |
| memcached ×30 | 32 | 1,974 (26) | 1,991 (21) | 3,657 (6) |
| memcached ×30 | 256 | 1,493 (49) | 4,452 (25) | 6,007 (8) |
| allocation-heavy | 128 | 23,239 (35) | 36,186 (21) | 37,682 (16) |
| allocation-heavy | 256 | 22,746 (35) | 37,939 (19) | 38,177 (19) |
| 10ms of CPU work | 128 | 484–666 (22) | 616–684 (19) | 516–672 (19) |
| 10ms of CPU work | 256 | 591–611 (23) | 589–632 (19) | 465–637 (19) |

Sweeping `RUBY_MAX_CPU` from 1 to 64 and connections from 1 to 256 across five
workloads (315 points) gives the same picture: master falls away as the cap rises
because the pool grows past it, and with the cap honoured the curve flattens.

Two results worth stating plainly:

- **At `RUBY_MAX_CPU` of 1 or 2, master is faster**, because it ignores the cap
  and runs more threads than asked for. Honouring a setting that low costs
  throughput by construction. The default is `nproc`, so this is unlikely to be
  hit in practice.
- **Requests that do 10ms or more of their own work see no difference.** The
  ranges in the last two rows are three to four runs of the same point; they
  overlap in every column. At that size the scheduler is not what limits the
  server. These changes matter for servers whose per-request work is short enough
  for scheduling to be visible — a static response, a cache lookup, a proxy hop.

## For scale

The same machine, the same master build, serving thirty LAN memcached lookups per
request at 256 connections — the shape where the HTTP layer is amortised enough
for the comparison to mean something. Median of three 30s runs; memory is total
PSS across the process tree, sampled at the plateau.

| server | req/s | memory | processes | native threads |
|---|---|---|---|---|
| puma, 16 processes × 8 threads | 5,601 | 503 MB | 17 | 240 |
| falcon, 16 processes | 6,621 | 370 MB | 17 | 32 |
| this Ractor server, master | 1,407 | 160 MB | 1 | 51 |
| this Ractor server, patched | 6,201 | 181 MB | 1 | 8 |

At matched throughput the Ractor server holds 2.0x less than falcon and 2.8x less
than puma, in one process instead of seventeen. On the static response the same
four rows are 171,371 req/s at 121 MB patched, against 42,254 at 117 MB on
master, falcon at 64,638 and 607 MB, and puma at 59,056 and 3,227 MB. Puma's
figure there is dominated by allocator retention from an unrelated regression in
current master's malloc-based GC trigger, so read it as a property of the build
rather than of puma.

This is not a like-for-like server comparison — the Ractor server is a
hand-written HTTP/1.1 server with no Rack layer, so it carries less per-request
overhead than either of the others. The point is only the position of the two
Ractor rows: without these changes a Ractor server loses to puma and falcon on
IO-bound work; with them it is competitive.

## Tests

- `make btest-ruby` — 2062 PASS, with each commit applied on its own.
- `test/ruby/test_ractor.rb`, `test_thread.rb`, `test_io.rb`, `test_fiber.rb` —
  445 tests, 9861 assertions, 0 failures, 0 errors.
- A `RUBY_DEBUG=1` build serving the same workloads at 32, 128 and 256
  connections, so the assertions in `ractor_sched_deq` are live while threads
  retire: no failures, and the pool settles at 11 to 19 threads instead of the
  23 to 44 that build reaches without the rule.

## How it was measured

AMD Ryzen 9 5900HX, 8 physical cores / 16 logical, Linux 6.8. An HTTP/1.1 server
on Ractors: one acceptor thread, 16 worker Ractors, one Ruby thread per
connection. `h2load --h1 -D 6` after a 2s warm-up, one run per point except where
a range is given; the scale table uses `-D 30` because the memory figure needs a
plateau. memcached runs on a second host over the LAN (147µs round trip). The
load generator shares the machine with the server, so the numbers include its
cost. "+ cap" is the branch with `SNT_IDLE_RETIRE` set to -1, so the two columns
differ only by the retire rule.

Every table above was measured on the current head of this branch. The
`RUBY_MAX_CPU` 1-to-64 sweep and the `perf stat` counters were measured on an
earlier revision, before the branch was rebased; the three commits have not
changed in behaviour since.
