### PR TITLE
ZJIT: Stop calls into code invalidated by EP escape

### DIFF
--- a/zjit/src/codegen_tests.rs
+++ b/zjit/src/codegen_tests.rs
@@ -7771,6 +7771,45 @@ fn test_keep_jit_frame_for_caught_jump() {
     assert_snapshot!(result, @":ok");
 }
 
+// A NoEPEscape patch point can be reached without the frame's locals ever being
+// written to the stack: JIT-to-JIT calls don't write locals, and the code before
+// the patch point may be leaf. When an EP escape fires while the version limit
+// prevents invalidate_iseq_version() from running, every version containing a
+// patched point must still stop receiving calls. Otherwise a fresh call would
+// side-exit through the patched point's without_locals() frame state and the
+// interpreter would read garbage locals.
+#[test]
+fn test_no_ep_escape_invalidation_at_max_versions() {
+    rb_zjit_prepare_options();
+    let old_call_threshold = unsafe { crate::options::rb_zjit_call_threshold };
+    let old_max_versions = get_option!(max_versions);
+    set_call_threshold(2);
+    set_max_versions(1);
+    let result = inspect(r#"
+        def ep_escape_callee(a = "expected")
+          binding if @ep_escape
+          a
+        end
+
+        def ep_escape_caller = ep_escape_callee
+
+        def ep_escape_dirty(x) = x
+        def ep_escape_dirty_caller = ep_escape_dirty(:garbage)
+
+        @ep_escape = nil
+        ep_escape_callee; ep_escape_callee    # profile + compile callee
+        ep_escape_caller; ep_escape_caller    # profile + compile caller
+        @ep_escape = true
+        ep_escape_caller                      # binding escapes callee's EP -> invalidation
+        @ep_escape = nil
+        ep_escape_dirty_caller                # dirty the stale local's stack slot
+        ep_escape_caller
+    "#);
+    set_max_versions(old_max_versions);
+    set_call_threshold(old_call_threshold);
+    assert_snapshot!(result, @r#""expected""#);
+}
+
 #[test]
 fn test_float_arithmetic() {
     set_call_threshold(1);

--- a/zjit/src/invariants.rs
+++ b/zjit/src/invariants.rs
@@ -222,26 +222,50 @@ pub extern "C" fn rb_zjit_invalidate_no_ep_escape(iseq: IseqPtr) {
         if let Some(patch_points) = invariants.no_ep_escape_iseq_patch_points.remove(&iseq) {
             debug!("EP is escaped: {}", iseq_name(iseq));
 
+            // Collect the versions that contain these patch points before the macro
+            // consumes them. A NoEPEscape(iseq) patch point may live in another
+            // ISEQ's version when `iseq` was inlined into a caller.
+            let mut patched_versions: Vec<IseqVersionRef> = patch_points.iter().map(|patch_point| patch_point.version).collect();
+
             // Invalidate the patch points for this ISEQ
             let cb = ZJITState::get_code_block();
             compile_patch_points!(cb, patch_points, EP, "EP is escaped: {}", iseq_name(iseq));
 
-            // Also invalidate the ISEQ version so the method falls back to the
-            // interpreter on the next call. NoEPEscape PatchPoint side exits use
-            // without_locals() and don't save locals to the frame. If a PatchPoint
-            // fires on a later call (where EP hasn't escaped), the interpreter would
-            // read stale locals (e.g., nil instead of [] for keyword defaults).
+            // Also invalidate every version that contains one of the patched points,
+            // and this ISEQ's latest version, so that no new call runs the patched code.
+            // NoEPEscape PatchPoint side exits use without_locals() and don't save
+            // locals to the frame. If a PatchPoint fires on a later call (where EP
+            // hasn't escaped), the interpreter would read stale locals (e.g., nil
+            // instead of [] for keyword defaults).
             //
-            // We can't use invalidate_iseq_version() here because it skips when
-            // at MAX_ISEQ_VERSIONS (to prevent unbounded recompilation). Instead,
-            // directly mark the version as invalidated and reset jit_func so the
-            // interpreter takes over permanently.
-            let payload = crate::payload::get_or_create_iseq_payload(iseq);
-            if let Some(version) = payload.versions.last_mut() {
+            // We can't rely on the invalidate_iseq_version() calls made by
+            // compile_patch_points! because it skips when at MAX_ISEQ_VERSIONS
+            // (to prevent unbounded recompilation). Instead, directly mark the
+            // versions as invalidated, reset jit_func, and re-stub incoming
+            // JIT-to-JIT calls so the interpreter takes over permanently.
+            let payload = get_or_create_iseq_payload(iseq);
+            patched_versions.extend(payload.versions.last());
+            for mut version in patched_versions {
                 use crate::payload::IseqStatus;
+                let owner_iseq = unsafe { version.as_ref() }.iseq;
+                if owner_iseq.is_null() {
+                    continue;
+                }
                 if unsafe { version.as_ref() }.status != IseqStatus::Invalidated {
                     unsafe { version.as_mut() }.status = IseqStatus::Invalidated;
-                    unsafe { rb_iseq_reset_jit_func(iseq) };
+                    unsafe { rb_iseq_reset_jit_func(owner_iseq) };
+
+                    // Re-stub incoming JIT-to-JIT calls. Resetting jit_func is not
+                    // enough: SendDirect callers jump straight into the invalidated
+                    // code, whose NoEPEscape patch points now side-exit with
+                    // without_locals() frame states. A frame entered through a
+                    // JIT-to-JIT call does not write locals to the stack, so resuming
+                    // the interpreter through such an exit would read garbage locals.
+                    for incoming in unsafe { version.as_ref() }.incoming.iter() {
+                        if let Err(err) = crate::codegen::gen_iseq_call(cb, incoming) {
+                            debug!("{err:?}: gen_iseq_call failed during EP escape invalidation: {}", iseq_name(owner_iseq));
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
When rb_zjit_invalidate_no_ep_escape() fires, it patches NoEPEscape patch points into side exits and marks the ISEQ's latest version as invalidated. However, that was not enough to stop calls into the patched code:

* SendDirect callers jump straight into the invalidated code without consulting jit_func.
* When the ISEQ was inlined into a caller, the patched NoEPEscape point lives in the caller's version, which invalidate_iseq_version() leaves valid when the caller is at the version limit.

NoEPEscape patch point side exits use without_locals() frame states, which assume the frame's local slots are up to date. That holds for the activation that triggered the escape (its locals were spilled at the preceding non-leaf call), but not for a fresh call: a frame entered through a JIT-to-JIT call never writes its locals to the stack, and the code before the patch point can be entirely leaf. Such a call resumes the interpreter with garbage locals.

This [reproduced on CI](https://github.com/ruby/ruby/actions/runs/31617845858/job/94185011119) as TestGemCompactIndexClient errors like "invalid access mode digest/sha2": CacheFile#open reached the version limit, a later block-handler Proc materialization escaped its EP, and JIT-compiled callers kept entering the patched code, so the interpreter resumed with a stale write_mode local read from a dead stack slot.

Fix this by invalidating every version that contains a patched NoEPEscape point: mark it invalidated, reset its jit_func, and re-stub its incoming JIT-to-JIT calls, regardless of the version limit.