### PR TITLE
[Bug #22080] Raise on invalid to_int result

### DIFF
--- a/kernel.rb
+++ b/kernel.rb
@@ -195,7 +195,7 @@ module Kernel
   # Returns an integer converted from +object+.
   #
   # Tries to convert +object+ to an integer
-  # using +to_int+ first and +to_i+ second;
+  # using +to_int+, +to_str+, and +to_i+, in that order;
   # see below for exceptions.
   #
   # With a non-zero +base+, +object+ must be a string or convertible
@@ -269,10 +269,13 @@ module Kernel
   #
   # - Raises TypeError if +object+ does not respond to +to_int+ or +to_i+.
   # - Raises TypeError if +object+ is +nil+.
+  # - Raises TypeError if +to_int+, +to_str+, or +to_i+ returns a non-nil
+  #   object of the wrong class.
   # - Raises ArgumentError if +object+ is an invalid string.
   #
-  # With +exception+ given as +false+, an exception of any kind is suppressed
-  # and +nil+ is returned.
+  # With +exception+ given as +false+, conversion failures are suppressed and
+  # +nil+ is returned. A TypeError is still raised if +to_int+ or +to_str+
+  # returns a non-nil object of the wrong class.
   #
   def Integer(arg, base = 0, exception: true)
     if Primitive.mandatory_only?

--- a/object.c
+++ b/object.c
@@ -3428,9 +3428,16 @@ rb_check_to_i(VALUE val)
 }
 
 static VALUE
+rb_try_to_int(VALUE val)
+{
+    return try_to_int(val, idTo_int, FALSE);
+}
+
+static VALUE
 rb_convert_to_integer(VALUE val, int base, int raise_exception)
 {
     VALUE tmp;
+    int state;
 
     if (base) {
         tmp = rb_check_string_type(val);
@@ -3462,9 +3469,12 @@ rb_convert_to_integer(VALUE val, int base, int raise_exception)
         rb_cant_convert(val, "Integer");
     }
 
-    tmp = rb_protect(rb_check_to_int, val, NULL);
-    if (RB_INTEGER_TYPE_P(tmp)) return tmp;
+    tmp = rb_protect(rb_try_to_int, val, &state);
+    if (!state && RB_INTEGER_TYPE_P(tmp)) return tmp;
     rb_set_errinfo(Qnil);
+    if (!state && !NIL_P(tmp)) {
+        rb_cant_convert_invalid_return(val, "Integer", "to_int", tmp);
+    }
     if (!NIL_P(tmp = rb_check_string_type(val))) {
         return rb_str_convert_to_inum(tmp, base, TRUE, raise_exception);
     }

--- a/spec/ruby/core/kernel/Integer_spec.rb
+++ b/spec/ruby/core/kernel/Integer_spec.rb
@@ -14,20 +14,34 @@ describe "Kernel#Integer" do
     Integer(100).should == 100
   end
 
-  it "raises a TypeError when to_int returns not-an-Integer object and to_i returns nil" do
-    obj = mock("object")
-    obj.should_receive(:to_int).and_return("1")
-    obj.should_receive(:to_i).and_return(nil)
-    -> {
-      Integer(obj)
-    }.should raise_consistent_error(TypeError, "can't convert MockObject into Integer (MockObject#to_i gives nil)")
+  ruby_version_is ""..."4.1" do
+    it "raises a TypeError when to_int returns not-an-Integer object and to_i returns nil" do
+      obj = mock("object")
+      obj.should_receive(:to_int).and_return("1")
+      obj.should_receive(:to_i).and_return(nil)
+      -> {
+        Integer(obj)
+      }.should raise_consistent_error(TypeError, "can't convert MockObject into Integer (MockObject#to_i gives nil)")
+    end
+
+    it "returns a result of to_i when to_int does not return an Integer" do
+      obj = mock("object")
+      obj.should_receive(:to_int).and_return("1")
+      obj.should_receive(:to_i).and_return(42)
+      Integer(obj).should == 42
+    end
   end
 
-  it "return a result of to_i when to_int does not return an Integer" do
-    obj = mock("object")
-    obj.should_receive(:to_int).and_return("1")
-    obj.should_receive(:to_i).and_return(42)
-    Integer(obj).should == 42
+  ruby_version_is "4.1" do
+    it "raises a TypeError when to_int does not return an Integer" do
+      obj = mock("object")
+      obj.should_receive(:to_int).and_return("1")
+      obj.should_not_receive(:to_str)
+      obj.should_not_receive(:to_i)
+      -> {
+        Integer(obj)
+      }.should raise_consistent_error(TypeError, "can't convert MockObject into Integer (MockObject#to_int gives String)")
+    end
   end
 
   it "returns a result of to_str" do
@@ -93,6 +107,13 @@ describe "Kernel#Integer" do
     Integer(obj).should == 1
   end
 
+  it "calls to_i on an object whose to_int raises" do
+    obj = mock("object")
+    obj.should_receive(:to_int).and_raise("conversion failed")
+    obj.should_receive(:to_i).and_return(1)
+    Integer(obj).should == 1
+  end
+
   it "raises a TypeError if to_i returns a value that is not an Integer" do
     obj = mock("object")
     obj.should_receive(:to_i).and_return("1")
@@ -131,6 +152,27 @@ describe "Kernel#Integer" do
   end
 
   describe "when passed exception: false" do
+    ruby_version_is ""..."4.1" do
+      it "returns a result of to_i when to_int does not return an Integer" do
+        obj = mock("object")
+        obj.should_receive(:to_int).and_return("1")
+        obj.should_receive(:to_i).and_return(42)
+        Integer(obj, exception: false).should == 42
+      end
+    end
+
+    ruby_version_is "4.1" do
+      it "raises a TypeError when to_int does not return an Integer" do
+        obj = mock("object")
+        obj.should_receive(:to_int).and_return("1")
+        obj.should_not_receive(:to_str)
+        obj.should_not_receive(:to_i)
+        -> {
+          Integer(obj, exception: false)
+        }.should raise_consistent_error(TypeError, "can't convert MockObject into Integer (MockObject#to_int gives String)")
+      end
+    end
+
     describe "and to_i returns a value that is not an Integer" do
       it "swallows an error" do
         obj = mock("object")

--- a/test/ruby/test_integer.rb
+++ b/test/ruby/test_integer.rb
@@ -140,12 +140,19 @@ class TestInteger < Test::Unit::TestCase
     assert_equal(2 ** 50, Integer(2.0 ** 50))
     assert_raise(TypeError) { Integer(nil) }
 
-    bug14552 = '[ruby-core:85813]'
+    bug22080 = '[Bug #22080]'
     obj = Object.new
     def obj.to_int; "str"; end
-    assert_raise(TypeError, bug14552) { Integer(obj) }
+    def obj.to_str; raise "to_str should not be called"; end
+    def obj.to_i; raise "to_i should not be called"; end
+    assert_raise_with_message(TypeError, /Object#to_int gives String/, bug22080) {
+      Integer(obj)
+    }
+
+    obj = Object.new
+    def obj.to_int; raise "conversion failed"; end
     def obj.to_i; 42; end
-    assert_equal(42, Integer(obj), bug14552)
+    assert_equal(42, Integer(obj))
 
     obj = Object.new
     def obj.to_i; "str"; end
@@ -204,6 +211,13 @@ class TestInteger < Test::Unit::TestCase
       o = Object.new
       def o.to_int; raise; end
       assert_equal(nil, Integer(o, exception: false))
+    }
+    o = Object.new
+    def o.to_int; "str"; end
+    def o.to_str; raise "to_str should not be called"; end
+    def o.to_i; raise "to_i should not be called"; end
+    assert_raise_with_message(TypeError, /Object#to_int gives String/, '[Bug #22080]') {
+      Integer(o, exception: false)
     }
     assert_nothing_raised(FloatDomainError) {
       assert_equal(nil, Integer(Float::INFINITY, exception: false))


### PR DESCRIPTION
`Kernel#Integer` currently treats a non-Integer result from `to_int` as a failed conversion and falls back to `to_str` or `to_i`.

A non-nil result of the wrong type violates the conversion method contract. Raise `TypeError` for that case, including when `exception: false`, while retaining the existing fallback behavior when `to_int` is absent, returns `nil`, or raises.

This also tightens `rb_Integer()` in the public C API (used by `sprintf`, `Time.at`, `Time#strftime`, zlib, and openssl), which shares `Kernel#Integer` semantics. In-tree callers are unaffected; this matches the fallback behavior `Integer.try_convert` has had all along.

`Float()` and `Rational()` have the same asymmetry for wrong-type `to_f`/`to_r` results; they are left unchanged here to keep this scoped to the decision on the ticket, which notes the alignment can be revisited if real-world breakage appears.

Update the documentation and guarded specs to reflect the corrected contract.

https://bugs.ruby-lang.org/issues/22080