### PR TITLE
Fix FrozenError in test_execopts_rlimit when ASAN_OPTIONS is set

### DIFF
--- a/test/ruby/test_process.rb
+++ b/test/ruby/test_process.rb
@@ -210,7 +210,8 @@ class TestProcess < Test::Unit::TestCase
     # the ASAN runtime library sets RLIMIT_CORE to 0, "to avoid dumping a 16T+ core file", and
     # that inteferes with this test.
     asan_options = ENV['ASAN_OPTIONS'] || ''
-    asan_options  << ':' unless asan_options.empty?
+    # NOTE: ENV['ASAN_OPTIONS'] returns a frozen String, so append non-destructively.
+    asan_options += ':' unless asan_options.empty?
     env = {
       'ASAN_OPTIONS' => "#{asan_options}disable_coredump=0"
     }


### PR DESCRIPTION
ENV['ASAN_OPTIONS'] returns a frozen String, so the destructive `<<` raised `can't modify frozen String` whenever ASAN_OPTIONS was set in the environment (it only worked before because the fallback '' literal is mutable). Append non-destructively with `+=` instead.