### PR TITLE
Page pool: allow OS to free page and arena memory when only 1 objspace

### DIFF
--- a/cont.c
+++ b/cont.c
@@ -16,13 +16,6 @@
 #include <sys/mman.h>
 #endif
 
-// On Solaris, madvise() is NOT declared for SUS (XPG4v2) or later,
-// but MADV_* macros are defined when __EXTENSIONS__ is defined.
-#ifdef NEED_MADVICE_PROTOTYPE_USING_CADDR_T
-#include <sys/types.h>
-extern int madvise(caddr_t, size_t, int);
-#endif
-
 #include COROUTINE_H
 
 #include "eval_intern.h"
@@ -34,6 +27,7 @@ extern int madvise(caddr_t, size_t, int);
 #include "internal/gc.h"
 #include "internal/proc.h"
 #include "internal/sanitizers.h"
+#include "internal/vm_map.h"
 #include "internal/warnings.h"
 #include "ruby/fiber/scheduler.h"
 #include "yjit.h"
@@ -501,12 +495,7 @@ fiber_pool_allocate_memory(size_t * count, size_t stride)
         }
         else {
             ruby_annotate_mmap(base, mmap_size, "Ruby:fiber_pool_allocate_memory");
-#if defined(MADV_FREE_REUSE)
-            // On Mac MADV_FREE_REUSE is necessary for the task_info api
-            // to keep the accounting accurate as possible when a page is marked as reusable
-            // it can possibly not occurring at first call thus re-iterating if necessary.
-            while (madvise(base, mmap_size, MADV_FREE_REUSE) == -1 && errno == EAGAIN);
-#endif
+            rb_vm_map_reuse(base, mmap_size);
             return base;
         }
 #endif
@@ -820,7 +809,7 @@ fiber_pool_stack_acquire(struct fiber_pool * fiber_pool)
 }
 
 // We advise the operating system that the stack memory pages are no longer being used.
-// This introduce some performance overhead but allows system to relaim memory when there is pressure.
+// This introduces some performance overhead but allows the system to reclaim memory when there is pressure.
 static inline void
 fiber_pool_stack_free(struct fiber_pool_stack * stack)
 {
@@ -843,37 +832,7 @@ fiber_pool_stack_free(struct fiber_pool_stack * stack)
     // In addition, it's actually slightly desirable to not do anything here,
     // but that results in higher memory usage.
 
-#ifdef __wasi__
-    // WebAssembly doesn't support madvise, so we just don't do anything.
-#elif VM_CHECK_MODE > 0 && defined(MADV_DONTNEED)
-    if (!advice) advice = MADV_DONTNEED;
-    // This immediately discards the pages and the memory is reset to zero.
-    madvise(base, size, advice);
-#elif defined(MADV_FREE_REUSABLE)
-    if (!advice) advice = MADV_FREE_REUSABLE;
-    // Darwin / macOS / iOS.
-    // Acknowledge the kernel down to the task info api we make this
-    // page reusable for future use.
-    // As for MADV_FREE_REUSABLE below we ensure in the rare occasions the task was not
-    // completed at the time of the call to re-iterate.
-    while (madvise(base, size, advice) == -1 && errno == EAGAIN);
-#elif defined(MADV_FREE)
-    if (!advice) advice = MADV_FREE;
-    // Recent Linux.
-    madvise(base, size, advice);
-#elif defined(MADV_DONTNEED)
-    if (!advice) advice = MADV_DONTNEED;
-    // Old Linux.
-    madvise(base, size, advice);
-#elif defined(POSIX_MADV_DONTNEED)
-    if (!advice) advice = POSIX_MADV_DONTNEED;
-    // Solaris?
-    posix_madvise(base, size, advice);
-#elif defined(_WIN32)
-    VirtualAlloc(base, size, MEM_RESET, PAGE_READWRITE);
-    // Not available in all versions of Windows.
-    //DiscardVirtualMemory(base, size);
-#endif
+    rb_vm_map_reusable_lazy(base, size, advice);
 
 #if defined(COROUTINE_SANITIZE_ADDRESS)
     __asan_poison_memory_region(fiber_pool_stack_poison_base(stack), fiber_pool_stack_poison_size(stack));

--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -38,6 +38,7 @@
 #include "gc/gc_impl.h"
 #include "yjit.h"
 #include "zjit.h"
+#include "internal/vm_map.h"
 
 #ifdef BUILDING_MODULAR_GC
 /* hrtime.h transitively includes internal/time.h -> internal/bits.h, which are
@@ -773,15 +774,24 @@ typedef struct rb_objspace {
 typedef struct rb_global_objspace {
     struct {
         rb_nativethread_lock_t lock;
-        struct heap_page_body *freelist; /* bodies to reuse; the next pointer lives in the body */
+        struct heap_page_body *hot_list; /* ≤ PAGE_POOL_HOT_MAX un-advised bodies; link at body offset 0 */
+        int hot_count;
+        size_t os_page_size;             /* sysconf(_SC_PAGE_SIZE), cached at init */
         /* List of mmap'd memory regions (arenas) for page bodies. */
         struct page_arena {
             struct page_arena *next;
-            char *start;                 /* usable area, HEAP_PAGE_ALIGN aligned */
-            size_t size;                 /* usable bytes (a multiple of HEAP_PAGE_SIZE) */
-        } *arenas;                       /* every arena, newest first */
-        char *arena_cursor;              /* first body not yet carved out of the newest arena */
-        char *arena_end;
+            char *start;                  /* usable area, HEAP_PAGE_ALIGN aligned */
+            size_t size;                  /* usable bytes (a multiple of HEAP_PAGE_SIZE) */
+            struct heap_page_body *cold_freelist; /* free bodies of this arena; link at body offset 0 */
+            int free_count;               /* bodies of this arena currently free (hot list + cold_freelist) */
+            int cold_count;               /* bodies on cold_freelist (subset of free_count) */
+        } *arenas;                        /* every arena, newest first */
+        char *arena_cursor;               /* first body not yet carved out of the newest arena */
+        char *arena_end;                  /* end of current arena */
+        struct page_arena *arena_current; /* arena that arena_cursor carves from */
+        int arena_count;                  /* current mapped arenas (for GC.stat total_pages) */
+        int advised_count;                /* page bodies with MADV_* applied (for GC.stat discarded pages) */
+        size_t arenas_unmapped;           /* cumulative arenas munmapped (for GC.stat) */
     } page_pool;
 
     /* Zombie pages left after the last global cycle (roughly the live data).  Updated
@@ -838,8 +848,9 @@ static rb_global_objspace_t *global_objspace = NULL;
 static void objspace_absorb(rb_objspace_t *dst, rb_objspace_t *src);
 
 
-static struct heap_page_body *page_pool_acquire(void);
-static void page_pool_release(struct heap_page_body *body);
+static struct heap_page_body *page_pool_acquire(struct page_arena **arena_out);
+static void page_pool_release(struct heap_page_body *body, struct page_arena *arena);
+static void page_pool_reclaim(rb_global_objspace_t *g);
 
 static void
 global_objspace_init(void)
@@ -847,14 +858,23 @@ global_objspace_init(void)
     if (global_objspace == NULL) {
         rb_global_objspace_t *g = &rb_global_objspace_instance;
         rb_native_mutex_initialize(&g->page_pool.lock);
-        g->page_pool.freelist = NULL;
+        g->page_pool.hot_list = NULL;
+        g->page_pool.hot_count = 0;
         g->page_pool.arenas = NULL;
         g->page_pool.arena_cursor = NULL;
         g->page_pool.arena_end = NULL;
+        g->page_pool.arena_current = NULL;
+        g->page_pool.arena_count = 0;
+        g->page_pool.advised_count = 0;
+        g->page_pool.arenas_unmapped = 0;
+#ifdef HAVE_MMAP
+        g->page_pool.os_page_size = sysconf(_SC_PAGE_SIZE);
+#else
+        g->page_pool.os_page_size = 0;
+#endif
         global_objspace = g;
     }
 }
-
 
 #ifndef HEAP_PAGE_ALIGN_LOG
 /* default tiny heap size: 64KiB */
@@ -1013,6 +1033,7 @@ struct heap_page {
 
     struct heap_page *free_next;
     struct heap_page_body *body;
+    struct page_arena *arena;
     struct ccan_list_node page_node;
 
     bits_t wb_unprotected_bits[HEAP_PAGE_BITMAP_LIMIT];
@@ -2183,11 +2204,11 @@ gc_aligned_free(void *ptr, size_t size)
 }
 
 static void
-heap_page_body_free(struct heap_page_body *page_body)
+heap_page_body_free(struct heap_page_body *page_body, struct page_arena *arena)
 {
     GC_ASSERT((uintptr_t)page_body % HEAP_PAGE_ALIGN == 0);
 
-    page_pool_release(page_body);
+    page_pool_release(page_body, arena);
 }
 
 /* Insert into page_index.  Writers serialize on page_pool.lock; lomem and himem are a
@@ -2249,7 +2270,7 @@ heap_page_free(rb_objspace_t *objspace, struct heap_page *page)
 {
     global_page_index_remove(page);
     objspace->heap_pages.freed_pages++;
-    heap_page_body_free(page->body);
+    heap_page_body_free(page->body, page->arena);
     free(page);
 }
 
@@ -2340,9 +2361,24 @@ gc_aligned_malloc(size_t alignment, size_t size)
 }
 
 /* The page pool (global_objspace->page_pool): heap page bodies are carved out of large
- * arenas and reused through the pool's freelist. */
+ * arenas and reused through the pool.  Free bodies are split into a small global hot
+ * list (≤ PAGE_POOL_HOT_MAX, never madvise'd) and per-arena cold freelists (eligible for
+ * OS release — see page_pool_reclaim). Both lists use an in-body link at offset 0. */
 
 #define PAGE_POOL_ARENA_SIZE (HEAP_PAGE_SIZE * 32) /* 2MiB with 64KiB pages */
+#define PAGE_POOL_ARENA_BODIES (PAGE_POOL_ARENA_SIZE / HEAP_PAGE_SIZE) /* 32 */
+#define PAGE_POOL_HOT_MAX 0 /* disabled — empty_pages is the retention buffer */
+#define PAGE_POOL_ARENA_KEEP_HALF (PAGE_POOL_ARENA_BODIES / 2) /* 16 */
+
+/* Steal bit 0 of the in-body link word: set iff the body has been madvise'd (cold). */
+#define PAGE_POOL_ADVISED_BIT ((uintptr_t)1)
+
+/* While a body is free, the arena back-pointer is stored at offset sizeof(header) — one
+ * word past the link, inside the spared first OS page.  PAGE_POOL_SCRATCH_SIZE covers
+ * both the link (offset 0) and the tag for ASAN unpoison. */
+#define PAGE_POOL_BODY_ARENA(body) \
+    (*(struct page_arena **)((char *)(body) + sizeof(struct heap_page_header)))
+#define PAGE_POOL_SCRATCH_SIZE (sizeof(struct heap_page_header) + sizeof(void *))
 
 #ifdef HAVE_MMAP
 /* mmap a new arena to carve from.  Called with the pool lock held, at which point the
@@ -2400,8 +2436,13 @@ page_pool_add_arena(rb_global_objspace_t *g)
     }
     arena->start = aligned;
     arena->size = PAGE_POOL_ARENA_SIZE;
+    arena->cold_freelist = NULL;
+    arena->free_count = 0;
+    arena->cold_count = 0;
     arena->next = g->page_pool.arenas;
     g->page_pool.arenas = arena;
+    g->page_pool.arena_count++;
+    g->page_pool.arena_current = arena;
 
     g->page_pool.arena_cursor = aligned;
     g->page_pool.arena_end = aligned + PAGE_POOL_ARENA_SIZE;
@@ -2411,42 +2452,72 @@ page_pool_add_arena(rb_global_objspace_t *g)
 #endif
 
 static struct heap_page_body *
-page_pool_acquire(void)
+page_pool_acquire(struct page_arena **arena_out)
 {
     struct heap_page_body *body = NULL;
+    bool need_reuse = false;
 
     if (HEAP_PAGE_ALLOC_USE_MMAP) {
 #ifdef HAVE_MMAP
         rb_global_objspace_t *g = global_objspace;
 
         rb_native_mutex_lock(&g->page_pool.lock);
-        if (g->page_pool.freelist != NULL) {
-            body = g->page_pool.freelist;
-            asan_unpoison_memory_region(body, sizeof(struct heap_page_body *), false);
-            g->page_pool.freelist = *(struct heap_page_body **)body;
+        if (g->page_pool.hot_list != NULL) {
+            body = g->page_pool.hot_list;
+            asan_unpoison_memory_region(body, PAGE_POOL_SCRATCH_SIZE, false);
+            uintptr_t link = *(uintptr_t *)body;
+            g->page_pool.hot_list = (struct heap_page_body *)(link & ~PAGE_POOL_ADVISED_BIT);
+            g->page_pool.hot_count--;
+            struct page_arena *arena = PAGE_POOL_BODY_ARENA(body);
+            arena->free_count--;
+            *arena_out = arena;
         }
-        else if (g->page_pool.arena_cursor != g->page_pool.arena_end ||
-                 page_pool_add_arena(g)) {
-            GC_ASSERT(g->page_pool.arena_cursor + HEAP_PAGE_SIZE <= g->page_pool.arena_end);
-            body = (struct heap_page_body *)g->page_pool.arena_cursor;
-            g->page_pool.arena_cursor += HEAP_PAGE_SIZE;
+        else {
+            // find cold page body (madvised reusable)
+            for (struct page_arena *a = g->page_pool.arenas; a; a = a->next) {
+                if (a->cold_count > 0) {
+                    body = a->cold_freelist;
+                    asan_unpoison_memory_region(body, PAGE_POOL_SCRATCH_SIZE, false);
+                    uintptr_t link = *(uintptr_t *)body;
+                    a->cold_freelist = (struct heap_page_body *)(link & ~PAGE_POOL_ADVISED_BIT);
+                    a->cold_count--;
+                    a->free_count--;
+                    *arena_out = a;
+                    need_reuse = (link & PAGE_POOL_ADVISED_BIT) != 0;
+                    if (need_reuse) g->page_pool.advised_count--;
+                    break;
+                }
+            }
+            if (body == NULL &&
+                (g->page_pool.arena_cursor != g->page_pool.arena_end ||
+                 page_pool_add_arena(g))) {
+                GC_ASSERT(g->page_pool.arena_cursor + HEAP_PAGE_SIZE <= g->page_pool.arena_end);
+                body = (struct heap_page_body *)g->page_pool.arena_cursor;
+                g->page_pool.arena_cursor += HEAP_PAGE_SIZE;
+                *arena_out = g->page_pool.arena_current;
+            }
         }
         rb_native_mutex_unlock(&g->page_pool.lock);
 
         if (body != NULL) {
+            if (need_reuse) {
+                rb_vm_map_reuse((char *)body + g->page_pool.os_page_size,
+                                 HEAP_PAGE_SIZE - g->page_pool.os_page_size);
+            }
             asan_unpoison_memory_region(body, HEAP_PAGE_SIZE, false);
         }
 #endif
     }
     else {
         body = gc_aligned_malloc(HEAP_PAGE_ALIGN, HEAP_PAGE_SIZE);
+        *arena_out = NULL;
     }
 
     return body;
 }
 
 static void
-page_pool_release(struct heap_page_body *body)
+page_pool_release(struct heap_page_body *body, struct page_arena *arena)
 {
     if (HEAP_PAGE_ALLOC_USE_MMAP) {
 #ifdef HAVE_MMAP
@@ -2454,10 +2525,20 @@ page_pool_release(struct heap_page_body *body)
 
         rb_native_mutex_lock(&g->page_pool.lock);
         /* A body in the empty-pages pool stays fully poisoned (see gc_sweep_page), so
-         * unpoison its head before linking it into the pool freelist. */
-        asan_unpoison_memory_region(body, sizeof(struct heap_page_body *), false);
-        *(struct heap_page_body **)body = g->page_pool.freelist;
-        g->page_pool.freelist = body;
+         * unpoison the scratch area (link + arena tag) before writing. */
+        asan_unpoison_memory_region(body, PAGE_POOL_SCRATCH_SIZE, false);
+        arena->free_count++;
+        PAGE_POOL_BODY_ARENA(body) = arena;
+        if (g->page_pool.hot_count < PAGE_POOL_HOT_MAX) {
+            *(uintptr_t *)body = (uintptr_t)g->page_pool.hot_list;
+            g->page_pool.hot_list = body;
+            g->page_pool.hot_count++;
+        }
+        else {
+            *(uintptr_t *)body = (uintptr_t)arena->cold_freelist;
+            arena->cold_freelist = body;
+            arena->cold_count++;
+        }
         asan_poison_memory_region(body, HEAP_PAGE_SIZE);
         rb_native_mutex_unlock(&g->page_pool.lock);
 #endif
@@ -2467,10 +2548,123 @@ page_pool_release(struct heap_page_body *body)
     }
 }
 
-static struct heap_page_body *
-heap_page_body_allocate(void)
+/* Allow the OS to reclaim pool memory. Runs only at major GC in single-objspace mode
+ * (see gc_sweep_finish).
+ *
+ * Step A: madvise cold bodies, sparing the first OS page (which holds the in-body
+ * freelist link and arena tag).
+ *
+ * Step B: munmap arenas whose 32 bodies are all free, keeping one extra empty
+ * arena as a retention buffer when the remaining free pool is < half an arena. */
+static void
+page_pool_reclaim(rb_global_objspace_t *g)
 {
-    struct heap_page_body *page_body = page_pool_acquire();
+    if (!HEAP_PAGE_ALLOC_USE_MMAP) return;
+#ifdef HAVE_MMAP
+    size_t os_page_size = g->page_pool.os_page_size;
+
+    rb_native_mutex_lock(&g->page_pool.lock);
+
+    /* Step A — advise cold bodies (immediate release: drop RSS now if the platform allows). */
+    if (os_page_size < HEAP_PAGE_SIZE) {
+        for (struct page_arena *a = g->page_pool.arenas; a; a = a->next) {
+            for (struct heap_page_body *body = a->cold_freelist; body; ) {
+                asan_unpoison_memory_region(body, PAGE_POOL_SCRATCH_SIZE, false);
+                uintptr_t link = *(uintptr_t *)body;
+                struct heap_page_body *next =
+                    (struct heap_page_body *)(link & ~PAGE_POOL_ADVISED_BIT);
+                if (!(link & PAGE_POOL_ADVISED_BIT)) {
+                    rb_vm_map_reusable_immediate((char *)body + os_page_size,
+                                        HEAP_PAGE_SIZE - os_page_size, 0);
+                    *(uintptr_t *)body = link | PAGE_POOL_ADVISED_BIT;
+                    g->page_pool.advised_count++;
+                }
+                asan_poison_memory_region(body, PAGE_POOL_SCRATCH_SIZE);
+                body = next;
+            }
+        }
+    }
+
+    /* Step B — munmap fully-free arenas (with retention buffer).
+     *
+     * total_free = Σ free_count; free_count already includes hot-list bodies
+     * (page_pool_release increments it unconditionally), so no separate hot_count.
+     * An arena is eligible when all 32 of its bodies are free AND none sit on
+     * the hot list (≤5 entries, pre-scanned).  Keep one extra empty arena when
+     * the rest of the free pool is < half an arena, to avoid thrash. */
+    int total_free = 0;
+    for (struct page_arena *a = g->page_pool.arenas; a; a = a->next) {
+        total_free += a->free_count;
+    }
+
+    struct page_arena *hot_arenas[PAGE_POOL_HOT_MAX ? PAGE_POOL_HOT_MAX : 1];
+    int n_hot_arenas = 0;
+    /* Collect arenas that have a hot body (≤ PAGE_POOL_HOT_MAX entries). */
+    for (struct heap_page_body *body = g->page_pool.hot_list; body; ) {
+        asan_unpoison_memory_region(body, PAGE_POOL_SCRATCH_SIZE, false);
+        uintptr_t link = *(uintptr_t *)body;
+        struct heap_page_body *next =
+            (struct heap_page_body *)(link & ~PAGE_POOL_ADVISED_BIT);
+        struct page_arena *arena = PAGE_POOL_BODY_ARENA(body);
+        bool found = false;
+        for (int i = 0; i < n_hot_arenas; i++) {
+            if (hot_arenas[i] == arena) { found = true; break; }
+        }
+        if (!found && n_hot_arenas < PAGE_POOL_HOT_MAX) {
+            hot_arenas[n_hot_arenas++] = arena;
+        }
+        asan_poison_memory_region(body, PAGE_POOL_SCRATCH_SIZE);
+        body = next;
+    }
+
+    bool retained_one = false;
+    struct page_arena **pp = &g->page_pool.arenas;
+    // munmap fully free arenas
+    while (*pp) {
+        struct page_arena *a = *pp;
+        bool has_hot = false;
+        for (int i = 0; i < n_hot_arenas; i++) {
+            if (hot_arenas[i] == a) { has_hot = true; break; }
+        }
+        if (a->free_count != PAGE_POOL_ARENA_BODIES || has_hot) {
+            pp = &a->next;
+            continue;
+        }
+        GC_ASSERT(a->cold_count == PAGE_POOL_ARENA_BODIES);
+
+        int free_elsewhere = total_free - PAGE_POOL_ARENA_BODIES;
+        if (free_elsewhere < PAGE_POOL_ARENA_KEEP_HALF && !retained_one) {
+            retained_one = true;
+            pp = &a->next;
+            continue;
+        }
+
+        *pp = a->next;
+        if (munmap(a->start, a->size)) {
+            rb_bug("page_pool_reclaim: munmap failed");
+        }
+        total_free -= PAGE_POOL_ARENA_BODIES;
+        g->page_pool.advised_count -= PAGE_POOL_ARENA_BODIES;
+        g->page_pool.arena_count--;
+        g->page_pool.arenas_unmapped++;
+        if (a == g->page_pool.arena_current) {
+            // During next acquire, any remaining arenas that have cold bodies are used. This is guaranteed
+            // because of the retention buffer.
+            g->page_pool.arena_current = NULL;
+            g->page_pool.arena_cursor = NULL;
+            g->page_pool.arena_end = NULL;
+        }
+        free(a);
+    }
+
+    rb_native_mutex_unlock(&g->page_pool.lock);
+#endif
+}
+
+static struct heap_page_body *
+heap_page_body_allocate(struct page_arena **arena_out)
+{
+    struct heap_page_body *page_body = page_pool_acquire(arena_out);
 
     GC_ASSERT(page_body == NULL || (uintptr_t)page_body % HEAP_PAGE_ALIGN == 0);
 
@@ -2501,14 +2695,15 @@ heap_page_resurrect(rb_objspace_t *objspace)
 static struct heap_page *
 heap_page_allocate(rb_objspace_t *objspace)
 {
-    struct heap_page_body *page_body = heap_page_body_allocate();
+    struct page_arena *arena;
+    struct heap_page_body *page_body = heap_page_body_allocate(&arena);
     if (page_body == 0) {
         rb_memerror();
     }
 
     struct heap_page *page = calloc1(sizeof(struct heap_page));
     if (page == 0) {
-        heap_page_body_free(page_body);
+        heap_page_body_free(page_body, arena);
         rb_memerror();
     }
 
@@ -2539,6 +2734,7 @@ heap_page_allocate(rb_objspace_t *objspace)
     if (heap_pages_himem < end) heap_pages_himem = end;
 
     page->body = page_body;
+    page->arena = arena;
     page_body->header.page = page;
     page->objspace = objspace;
 
@@ -4864,6 +5060,11 @@ gc_sweep_finish(rb_objspace_t *objspace)
 
     gc_prof_set_heap_info(objspace);
     heap_pages_free_unused_pages(objspace);
+    if (rb_gc_single_objspace_p() && is_full_marking(objspace)) {
+        /* gc_marks_finish retains ~2/3 of empty pages in objspace->empty_pages for reuse,
+         * only the excess reaches the pool. */
+        page_pool_reclaim(global_objspace);
+    }
 
     for (int i = 0; i < HEAP_COUNT; i++) {
         rb_heap_t *heap = &heaps[i];
@@ -10021,6 +10222,10 @@ enum gc_stat_sym {
     gc_stat_sym_total_remembered_normal_object_count,
     gc_stat_sym_total_remembered_shady_object_count,
 #endif
+    gc_stat_sym_page_pool_arenas,
+    gc_stat_sym_page_pool_arenas_freed,
+    gc_stat_sym_page_pool_total_pages,
+    gc_stat_sym_page_pool_discarded_pages,
     gc_stat_sym_last
 };
 
@@ -10073,6 +10278,10 @@ setup_gc_stat_symbols(void)
         S(total_remembered_normal_object_count);
         S(total_remembered_shady_object_count);
 #endif /* RGENGC_PROFILE */
+        S(page_pool_arenas);
+        S(page_pool_arenas_freed);
+        S(page_pool_total_pages);
+        S(page_pool_discarded_pages);
 #undef S
     }
 }
@@ -10158,6 +10367,11 @@ rb_gc_impl_stat(void *objspace_ptr, VALUE hash_or_sym)
     SET(heap_free_slots, objspace_free_slots(objspace));
     SET(heap_final_slots, total_final_slots_count(objspace));
     SET(heap_marked_slots, objspace->marked_slots);
+
+    SET(page_pool_arenas, global_objspace->page_pool.arena_count);
+    SET(page_pool_arenas_freed, global_objspace->page_pool.arenas_unmapped);
+    SET(page_pool_total_pages, (size_t)global_objspace->page_pool.arena_count * PAGE_POOL_ARENA_BODIES);
+    SET(page_pool_discarded_pages, global_objspace->page_pool.advised_count);
 
 #if RGENGC_PROFILE
     SET(total_generated_normal_object_count, objspace->profile.total_generated_normal_object_count);

--- a/internal/vm_map.h
+++ b/internal/vm_map.h
@@ -1,0 +1,95 @@
+#ifndef INTERNAL_VM_MAP_H
+#define INTERNAL_VM_MAP_H
+/**
+ * @author     Ruby developers <ruby-core@ruby-lang.org>
+ * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
+ *             Permission  is hereby  granted,  to  either redistribute  and/or
+ *             modify this file, provided that  the  conditions mentioned in the
+ *             file COPYING are met.  Consult the file for details.
+ * @brief      Shared per-platform virtual memory mapping helpers.
+ */
+#include "ruby/internal/config.h"
+#include <stddef.h>             /* for size_t */
+
+#ifdef HAVE_SYS_MMAN_H
+# include <sys/mman.h>
+#endif
+#ifdef HAVE_ERRNO_H
+# include <errno.h>             /* for errno, EAGAIN */
+#endif
+
+// On Solaris, madvise() is NOT declared for SUS (XPG4v2) or later,
+// but MADV_* macros are defined when __EXTENSIONS__ is defined.
+#ifdef NEED_MADVICE_PROTOTYPE_USING_CADDR_T
+#include <sys/types.h>
+extern int madvise(caddr_t, size_t, int);
+#endif
+
+// Reduces RSS lazily if possible, otherwise does it immediately. Keeps the mapping.
+static inline void
+rb_vm_map_reusable_lazy(void *addr, size_t len, int advice)
+{
+#ifdef __wasi__
+    /* WebAssembly doesn't support madvise. */
+#elif defined(VM_CHECK_MODE) && VM_CHECK_MODE > 0 && defined(MADV_DONTNEED)
+    if (!advice) advice = MADV_DONTNEED;
+    madvise(addr, len, advice);
+#elif defined(MADV_FREE_REUSABLE)
+    /* Darwin / macOS / iOS.  Drops phys_footprint; pages stay in resident_size
+     * until the kernel reclaims them.  Retry on EAGAIN. */
+    if (!advice) advice = MADV_FREE_REUSABLE;
+    while (madvise(addr, len, advice) == -1 && errno == EAGAIN);
+#elif defined(MADV_FREE)
+    /* Recent Linux. */
+    if (!advice) advice = MADV_FREE;
+    madvise(addr, len, advice);
+#elif defined(MADV_DONTNEED)
+    /* Old Linux. */
+    if (!advice) advice = MADV_DONTNEED;
+    madvise(addr, len, advice);
+#elif defined(POSIX_MADV_DONTNEED)
+    /* Solaris. */
+    if (!advice) advice = POSIX_MADV_DONTNEED;
+    posix_madvise(addr, len, advice);
+#elif defined(_WIN32)
+    VirtualAlloc(addr, len, MEM_RESET, PAGE_READWRITE);
+#endif
+}
+
+// Reduces RSS immediately if possible, otherwise does it lazily. Keeps the mapping.
+static inline void
+rb_vm_map_reusable_immediate(void *addr, size_t len, int advice)
+{
+#ifdef __wasi__
+    /* WebAssembly doesn't support madvise. */
+#elif defined(MADV_FREE_REUSABLE)
+    /* The most aggressive option is MADV_FREE_REUSABLE — same as _lazy.  It drops
+     * phys_footprint immediately.  Retry on EAGAIN. */
+    if (!advice) advice = MADV_FREE_REUSABLE;
+    while (madvise(addr, len, advice) == -1 && errno == EAGAIN);
+#elif defined(MADV_DONTNEED)
+    /* Linux: kernel discards physical pages immediately; next touch
+     * zero-faults and RSS drops at once. */
+    if (!advice) advice = MADV_DONTNEED;
+    madvise(addr, len, advice);
+#elif defined(POSIX_MADV_DONTNEED)
+    if (!advice) advice = POSIX_MADV_DONTNEED;
+    posix_madvise(addr, len, advice);
+#elif defined(_WIN32)
+    // Does not reduce working set immediately. We would need 2 system calls to do this.
+    VirtualAlloc(addr, len, MEM_RESET, PAGE_READWRITE);
+#endif
+}
+
+/* Re-acquire pages previously given back. Only needed for certain platforms. */
+static inline void
+rb_vm_map_reuse(void *addr, size_t len)
+{
+#if defined(MADV_FREE_REUSE)
+    /* Darwin: mandatory handshake with MADV_FREE_REUSABLE.  Retry on EAGAIN. */
+    while (madvise(addr, len, MADV_FREE_REUSE) == -1 && errno == EAGAIN);
+#endif
+    /* Linux/Windows/wasi: no-op (fault re-materializes zero-filled pages). */
+}
+
+#endif /* INTERNAL_VM_MAP_H */


### PR DESCRIPTION
This patch allows the OS to free page and arena memory. This only happens in single objspace mode at the end of a major GC. There is still an empty_pages list per objspace, and this stays resident as before. Only pages previously munmapped pre-rlgc are madvised(DONTNEED)'d. We call these discarded pages. Once an arena (2MB) has all of its 32 pages (each 64K) discarded, we munmap the arena. At least 1 arena is kept mapped at all times.

The following fields are added to GC.stat for the default GC:

  page_pool_arenas // number of mapped arenas
  page_pool_arenas_freed // number of freed (unmapped) arenas
  page_pool_total_pages // total pages in all arenas (arena_count * 32 currently)
  page_pool_discarded_pages // number of madvise(DONTNEED) pages (they can still be mapped)

Future work:

* Reduce the amount of empty pages per objspace or get rid of objspace->empty_pages altogether and keep a certain amount of resident pages in the pool for all objspaces.

* Allow reclaiming memory when there are multiple Ractors.