### PR TITLE
Fix btest with MMTK & DRUBY_DEBUG

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -4723,7 +4723,9 @@ vm_weak_table_gen_fields_foreach(st_data_t key, st_data_t value, st_data_t data)
         // set the shape on it so that the GC finalizer won't try to remove
         // it again.  A "root shape" indicates to the GC that this object
         // has no fields on it, hence it won't be in the gen fields table.
-        RBASIC_SET_SHAPE_ID((VALUE)key, ROOT_SHAPE_ID);
+        if (BUILTIN_TYPE((VALUE)key) != T_NONE) {
+            RBASIC_SET_SHAPE_ID((VALUE)key, ROOT_SHAPE_ID);
+        }
         return ST_DELETE;
 
       case ST_REPLACE: {

--- a/gc/mmtk/mmtk.c
+++ b/gc/mmtk/mmtk.c
@@ -704,15 +704,6 @@ rb_mmtk_align_obj_size(size_t object_size)
     return (object_size + MMTk_MIN_OBJ_ALIGN - 1) & ~((size_t)MMTk_MIN_OBJ_ALIGN - 1);
 }
 
-static inline size_t
-rb_mmtk_total_obj_size(size_t payload_size)
-{
-    if (payload_size < sizeof(struct RBasic) + sizeof(VALUE)) {
-        payload_size = sizeof(struct RBasic) + sizeof(VALUE);
-    }
-    return rb_mmtk_align_obj_size(payload_size + sizeof(VALUE));
-}
-
 bool
 rb_gc_impl_zjit_new_obj_fastpath(void *objspace_ptr, size_t alloc_size, VALUE flags, VALUE klass,
                                  struct rb_gc_zjit_fastpath *fastpath)
@@ -720,7 +711,7 @@ rb_gc_impl_zjit_new_obj_fastpath(void *objspace_ptr, size_t alloc_size, VALUE fl
 #if USE_ZJIT
     struct objspace *objspace = objspace_ptr;
 
-    size_t total_size = rb_mmtk_total_obj_size(alloc_size);
+    size_t total_size = rb_mmtk_align_obj_size(alloc_size + sizeof(VALUE));
     size_t object_size = total_size - sizeof(VALUE);
     size_t value_size_shift = sizeof(VALUE) == 8 ? 3 : 2;
 
@@ -1035,7 +1026,7 @@ rb_gc_impl_new_obj(void *objspace_ptr, void *cache_ptr, VALUE klass, VALUE flags
     }
 
     // Layout: [hidden size header (sizeof(VALUE))][payload (alloc_size)]
-    size_t total_size = rb_mmtk_total_obj_size(alloc_size);
+    size_t total_size = rb_mmtk_align_obj_size(alloc_size + sizeof(VALUE));
     size_t object_size = total_size - sizeof(VALUE);
     MMTk_AllocationSemantics semantics = total_size > objspace->max_non_los_default_alloc_bytes
         ? MMTK_ALLOCATION_SEMANTICS_LOS
@@ -1093,7 +1084,7 @@ rb_gc_impl_size_slot_size(void *objspace_ptr, size_t size)
         rb_bug("rb_gc_impl_size_slot_size: size too large (size=%"PRIuSIZE")", size);
     }
 
-    return rb_mmtk_total_obj_size(size) - sizeof(VALUE);
+    return rb_mmtk_align_obj_size(size + sizeof(VALUE)) - sizeof(VALUE);
 }
 
 bool

--- a/gc/mmtk/mmtk.c
+++ b/gc/mmtk/mmtk.c
@@ -1849,7 +1849,7 @@ bool
 rb_gc_impl_shref_marked_p(void *objspace_ptr, VALUE obj)
 {
     /* With a single objspace there is no cross-objspace pinning to track. */
-    return false;
+    return true;
 }
 
 size_t

--- a/gc/mmtk/mmtk.c
+++ b/gc/mmtk/mmtk.c
@@ -704,6 +704,15 @@ rb_mmtk_align_obj_size(size_t object_size)
     return (object_size + MMTk_MIN_OBJ_ALIGN - 1) & ~((size_t)MMTk_MIN_OBJ_ALIGN - 1);
 }
 
+static inline size_t
+rb_mmtk_total_obj_size(size_t payload_size)
+{
+    if (payload_size < sizeof(struct RBasic) + sizeof(VALUE)) {
+        payload_size = sizeof(struct RBasic) + sizeof(VALUE);
+    }
+    return rb_mmtk_align_obj_size(payload_size + sizeof(VALUE));
+}
+
 bool
 rb_gc_impl_zjit_new_obj_fastpath(void *objspace_ptr, size_t alloc_size, VALUE flags, VALUE klass,
                                  struct rb_gc_zjit_fastpath *fastpath)
@@ -711,7 +720,7 @@ rb_gc_impl_zjit_new_obj_fastpath(void *objspace_ptr, size_t alloc_size, VALUE fl
 #if USE_ZJIT
     struct objspace *objspace = objspace_ptr;
 
-    size_t total_size = rb_mmtk_align_obj_size(alloc_size + sizeof(VALUE));
+    size_t total_size = rb_mmtk_total_obj_size(alloc_size);
     size_t object_size = total_size - sizeof(VALUE);
     size_t value_size_shift = sizeof(VALUE) == 8 ? 3 : 2;
 
@@ -1026,7 +1035,7 @@ rb_gc_impl_new_obj(void *objspace_ptr, void *cache_ptr, VALUE klass, VALUE flags
     }
 
     // Layout: [hidden size header (sizeof(VALUE))][payload (alloc_size)]
-    size_t total_size = rb_mmtk_align_obj_size(alloc_size + sizeof(VALUE));
+    size_t total_size = rb_mmtk_total_obj_size(alloc_size);
     size_t object_size = total_size - sizeof(VALUE);
     MMTk_AllocationSemantics semantics = total_size > objspace->max_non_los_default_alloc_bytes
         ? MMTK_ALLOCATION_SEMANTICS_LOS
@@ -1084,7 +1093,7 @@ rb_gc_impl_size_slot_size(void *objspace_ptr, size_t size)
         rb_bug("rb_gc_impl_size_slot_size: size too large (size=%"PRIuSIZE")", size);
     }
 
-    return rb_mmtk_align_obj_size(size + sizeof(VALUE)) - sizeof(VALUE);
+    return rb_mmtk_total_obj_size(size) - sizeof(VALUE);
 }
 
 bool

--- a/ractor.c
+++ b/ractor.c
@@ -252,11 +252,7 @@ ractor_mark_unshareable_parts(rb_ractor_t *r)
     // mark the received messages (the structures the owner mutates guard themselves)
     ractor_sync_mark(r);
 
-    /* Structures the owner mutates while running follow.  Only the root scan calls
-     * this: a local GC for itself, a global GC for the whole set under the barrier.  A
-     * terminated Ractor has left the set; zombie_objspaces covers it instead. */
-    VM_ASSERT(r == rb_current_ractor_raw(false) || rb_gc_during_global_gc_p());
-    VM_ASSERT(!rb_ractor_status_p(r, ractor_terminated));
+    /* Structures the owner mutates while running follow. */
 
     rb_hook_list_mark(&r->pub.hooks);
     if (r->pub.targeted_hooks.num_entries) {
@@ -334,6 +330,11 @@ rb_ractor_mark_local_roots(rb_ractor_t *r)
 
     rb_gc_mark(r->loc);
     rb_gc_mark(r->name);
+    /* Only the root scan calls this: a local GC for itself, a global GC for the whole
+     * set under the barrier.  A terminated Ractor has left the set; zombie_objspaces
+     * covers it instead. */
+    VM_ASSERT(r == rb_current_ractor_raw(false) || rb_gc_during_global_gc_p());
+    VM_ASSERT(!rb_ractor_status_p(r, ractor_terminated));
     ractor_mark_unshareable_parts(r);
 
     /* This Ractor's rb_gc_register_mark_object pins, treated conservatively: a local GC

--- a/shape.c
+++ b/shape.c
@@ -1343,7 +1343,6 @@ rb_shape_verify_consistency(VALUE obj, shape_id_t shape_id)
 
     if (rb_shape_verify_capacity_consistency_p(obj)) {
         attr_index_t shape_id_capacity = rb_shape_embedded_capacity(shape_id);
-        RUBY_ASSERT(shape_id_capacity > 0);
 
         size_t shape_id_slot_size = shape_id_capacity * sizeof(VALUE) + sizeof(struct RBasic);
         size_t actual_slot_size = rb_gc_obj_slot_size(obj);

--- a/vm.c
+++ b/vm.c
@@ -276,8 +276,8 @@ vm_ep_in_heap_p_(const rb_execution_context_t *ec, const VALUE *ep)
 int
 rb_vm_ep_in_heap_p(const VALUE *ep)
 {
-    const rb_execution_context_t *ec = GET_EC();
-    if (ec->vm_stack == NULL) return TRUE;
+    const rb_execution_context_t *ec = rb_current_execution_context(false);
+    if (ec == NULL || ec->vm_stack == NULL) return TRUE;
     return vm_ep_in_heap_p_(ec, ep);
 }
 #endif

--- a/vm_callinfo.h
+++ b/vm_callinfo.h
@@ -648,12 +648,23 @@ vm_ccs_p(const struct rb_class_cc_entries *ccs)
 }
 
 static inline bool
+vm_cc_check_cme_unlocked(const struct rb_callcache *cc, const rb_callable_method_entry_t *cme)
+{
+    return vm_cc_cme(cc) == cme ||
+        (cme->def->iseq_overload && vm_cc_cme(cc) == rb_vm_lookup_overloaded_cme(cme));
+}
+
+static inline bool
 vm_cc_check_cme(const struct rb_callcache *cc, const rb_callable_method_entry_t *cme)
 {
     bool valid;
-    RB_VM_LOCKING_NO_BARRIER() {
-        valid = vm_cc_cme(cc) == cme ||
-            (cme->def->iseq_overload && vm_cc_cme(cc) == rb_vm_lookup_overloaded_cme(cme));
+    if (rb_current_execution_context(false) == NULL) {
+        valid = vm_cc_check_cme_unlocked(cc, cme);
+    }
+    else {
+        RB_VM_LOCKING_NO_BARRIER() {
+            valid = vm_cc_check_cme_unlocked(cc, cme);
+        }
     }
     if (valid) {
         return true;

--- a/vm_sync.c
+++ b/vm_sync.c
@@ -17,10 +17,16 @@ vm_locked(rb_vm_t *vm)
 }
 
 #if RUBY_DEBUG > 0
+static bool
+vm_lock_assertable_p(void)
+{
+    return rb_current_execution_context(false) != NULL;
+}
+
 void
 RUBY_ASSERT_vm_locking(void)
 {
-    if (rb_multi_ractor_p()) {
+    if (vm_lock_assertable_p() && rb_multi_ractor_p()) {
         rb_vm_t *vm = GET_VM();
         VM_ASSERT(vm_locked(vm));
     }
@@ -29,7 +35,7 @@ RUBY_ASSERT_vm_locking(void)
 void
 RUBY_ASSERT_vm_locking_with_barrier(void)
 {
-    if (rb_multi_ractor_p()) {
+    if (vm_lock_assertable_p() && rb_multi_ractor_p()) {
         rb_vm_t *vm = GET_VM();
         VM_ASSERT(vm_locked(vm));
 
@@ -43,7 +49,7 @@ RUBY_ASSERT_vm_locking_with_barrier(void)
 void
 RUBY_ASSERT_vm_unlocking(void)
 {
-    if (rb_multi_ractor_p()) {
+    if (vm_lock_assertable_p() && rb_multi_ractor_p()) {
         rb_vm_t *vm = GET_VM();
         VM_ASSERT(!vm_locked(vm));
     }


### PR DESCRIPTION
When attempting to build a debug build of Ruby with MMTk enabled and run the tests with MMTk enabled I encountered various issues. First in the compilation stages and then running the tests. 

The fixes contained in this PR get us to a point where we can successfully build, and then run `make btest` and `make test`. I have not yet tested `make check` or `make test-all` as it's pretty slow on my machine.

The following build was used:

```
bash autogen.sh
./configure \
    --prefix=$HOME/.rubies/ruby-mmtk \
    --disable-install-doc \
    --enable-devel \
    --enable-debug-env \
    --with-modular-gc=$HOME/.rubies/ruby-mmtk/lib/ruby/gc \
    optflags=-O0 \
    "debugflags=-ggdb3 -fno-omit-frame-pointer" \
    cppflags=-DRUBY_DEBUG=1 \

make -j22 && make install
make modular-gc MODULAR_GC=mmtk
make install-modular-gc MODULAR_GC=mmtk
```

Followed by the test run: 

```
RUST_LOG= RUBY_GC_LIBRARY=mmtk make btest
```