### PR TITLE
[Feature #22244] Loose matching encoding names

### DIFF
--- a/encoding.c
+++ b/encoding.c
@@ -13,6 +13,7 @@
 
 #include <ctype.h>
 
+#include "constant.h"
 #include "encindex.h"
 #include "internal.h"
 #include "internal/enc.h"
@@ -698,24 +699,23 @@ enc_dup_name(st_data_t name)
     return (st_data_t)strdup((const char *)name);
 }
 
-/*
- * Returns copied alias name when the key is added for st_table,
- * else returns NULL.
- */
-static int
+static void
 enc_alias_internal(struct enc_table *enc_table, const char *alias, int idx)
 {
     ASSERT_vm_locking();
-    return st_insert2(enc_table->names, (st_data_t)alias, (st_data_t)idx,
-                      enc_dup_name);
+    st_insert2(enc_table->names, (st_data_t)alias, (st_data_t)idx,
+               enc_dup_name);
 }
 
+/*
+ * Registers alias to enc_table.
+ */
 static int
 enc_alias(struct enc_table *enc_table, const char *alias, int idx)
 {
     if (!valid_encoding_name_p(alias)) return -1;
-    if (!enc_alias_internal(enc_table, alias, idx))
-        set_encoding_const(alias, enc_from_index(enc_table, idx));
+    enc_alias_internal(enc_table, alias, idx);
+    set_encoding_const(alias, enc_from_index(enc_table, idx));
     return idx;
 }
 
@@ -754,13 +754,134 @@ rb_encdb_alias(const char *alias, const char *orig)
     return r;
 }
 
+static inline bool
+char_in_range(unsigned int c, unsigned int low, unsigned int up)
+{
+    return (c - low) <= (up - low);
+}
+
+static inline bool
+char_in_alphabet(unsigned int c)
+{
+    return char_in_range(c | ('a' ^ 'A'), 'a' | 'A', 'z' | 'Z');
+}
+
+static inline bool
+char_in_digit(unsigned int c)
+{
+    return char_in_range(c, '0', '9');
+}
+
+static inline unsigned char
+skipping(unsigned int c, const char *string)
+{
+    size_t i = 0;
+    if (c != '_' && c != '-') return c;
+    if (!(c = *string)) {
+        return '\0';
+    }
+    else if (char_in_digit(c)) {
+#if 0
+        while (char_in_alphabet(c = string[++i]));
+        if (!char_in_digit(c)) return '\0';
+#else
+        return '\0'; /* ISO-8859 => ISO8859 */
+#endif
+    }
+    else if (char_in_alphabet(c)) {
+        while (char_in_alphabet(c = string[++i]));
+        if (!char_in_digit(c)) return '\0';
+    }
+    return '-';
+}
+
+static int
+enc_name_cmp(st_data_t a1, st_data_t a2)
+{
+    const char *s1 = (const char *)a1, *s2 = (const char *)a2;
+    char c1, c2;
+    bool alpha = false;
+
+    while (1) {
+        c1 = *s1++;
+        c2 = *s2++;
+        if (c1 == '\0' || c2 == '\0') {
+            if (c1 != '\0') return 1;
+            if (c2 != '\0') return -1;
+            return 0;
+        }
+        if (char_in_range(c1, 'A', 'Z')) c1 += 'a' - 'A';
+        if (char_in_range(c2, 'A', 'Z')) c2 += 'a' - 'A';
+        if (c1 != c2) {
+            if (alpha) {
+                alpha = false;
+                if ((c1 = skipping(c1, s1)) == '\0' ||
+                    (c2 = skipping(c2, s2)) == '\0') {
+                    if (c1 != '\0' || c2 != '\0') {
+                        s1 -= c1 != '\0';
+                        s2 -= c2 != '\0';
+                    }
+                    continue;
+                }
+            }
+            if (c1 > c2)
+                return 1;
+            else
+                return -1;
+        }
+        else {
+            alpha = char_in_range(c1, 'a', 'z');
+        }
+    }
+}
+
+static st_index_t
+enc_name_hash(st_data_t arg)
+ {
+    const st_index_t FNV1_32A_INIT = 0x811c9dc5;
+    const st_index_t FNV_32_PRIME = 0x01000193;
+
+    const char *string = (const char *)arg;
+    st_index_t hval = FNV1_32A_INIT;
+    bool alpha = false;
+
+    /*
+     * FNV-1a hash each octet in the buffer
+     */
+    while (*string) {
+        unsigned int c = (unsigned char)*string++;
+        if (char_in_range(c, 'A', 'Z')) {
+            c += 'a' - 'A';
+            alpha = true;
+        }
+        else if (char_in_range(c, 'a', 'z')) {
+            alpha = true;
+        }
+        else if (alpha) {
+            alpha = false;
+            c = skipping(c, string);
+            if (c == '\0') continue;
+        }
+        hval ^= c;
+
+        /* multiply by the 32 bit FNV magic prime mod 2^32 */
+        hval *= FNV_32_PRIME;
+    }
+    return hval;
+}
+
+static const struct st_hash_type type_enc_name = {
+    enc_name_cmp,
+    enc_name_hash,
+};
+
 static void
 rb_enc_init(struct enc_table *enc_table)
 {
     ASSERT_vm_locking();
     enc_table_expand(enc_table, ENCODING_COUNT + 1);
     if (!enc_table->names) {
-        enc_table->names = st_init_strcasetable_with_size(ENCODING_LIST_CAPA);
+        enc_table->names = st_init_table_with_size(&type_enc_name, ENCODING_LIST_CAPA);
     }
 #define OnigEncodingASCII_8BIT OnigEncodingASCII
 #define ENC_REGISTER(enc) enc_register_at(enc_table, ENCINDEX_##enc, rb_enc_name(&OnigEncoding##enc), &OnigEncoding##enc)
@@ -1796,7 +1917,7 @@ void
 rb_enc_set_default_internal(VALUE encoding)
 {
     enc_set_default_encoding(&default_internal, encoding,
-                            "internal");
+                             "internal");
 }
 
 /*
@@ -1821,6 +1942,16 @@ set_default_internal(VALUE klass, VALUE encoding)
 }
 
 static void
+define_encoding_const(const char *name, VALUE encoding)
+{
+    ID cid = rb_intern(name);
+    rb_const_entry_t *entry = rb_const_lookup(rb_cEncoding, cid);
+    if (!entry || entry->value != encoding) {
+        rb_const_set(rb_cEncoding, cid, encoding);
+    }
+}
+
+static void
 set_encoding_const(const char *name, rb_encoding *enc)
 {
     VALUE encoding = rb_enc_from_encoding(enc);
@@ -1837,7 +1968,7 @@ set_encoding_const(const char *name, rb_encoding *enc)
     if (!*s) {
         if (s - name > ENCODING_NAMELEN_MAX) return;
         valid = 1;
-        rb_define_const(rb_cEncoding, name, encoding);
+        define_encoding_const(name, encoding);
     }
     if (!valid || haslower) {
         size_t len = s - name;
@@ -1859,14 +1990,14 @@ set_encoding_const(const char *name, rb_encoding *enc)
                 if (!ISALNUM(*s)) *s = '_';
             }
             if (hasupper) {
-                rb_define_const(rb_cEncoding, name, encoding);
+                define_encoding_const(name, encoding);
             }
         }
         if (haslower) {
             for (s = (char *)name; *s; ++s) {
                 if (ISLOWER(*s)) *s = ONIGENC_ASCII_CODE_TO_UPPER_CASE((int)*s);
             }
-            rb_define_const(rb_cEncoding, name, encoding);
+            define_encoding_const(name, encoding);
         }
     }
 }

--- a/prism/encoding.c
+++ b/prism/encoding.c
@@ -5135,17 +5135,23 @@ const pm_encoding_t pm_encodings[] = {
 const pm_encoding_t *
 pm_encoding_find(const uint8_t *start, const uint8_t *end) {
     size_t width = (size_t) (end - start);
+    int utf8_end = 0;
 
     // First, we're going to check for UTF-8. This is the most common encoding.
     // UTF-8 can contain extra information at the end about the platform it is
     // encoded on, such as UTF-8-MAC or UTF-8-UNIX. We'll ignore those suffixes.
-    if ((start + 5 <= end) && (pm_strncasecmp(start, (const uint8_t *) "UTF-8", 5) == 0)) {
+#define ENCODING_MATCH_PREFIX(name) \
+    ((width >= sizeof(name) - 1 && pm_strncasecmp(start, (const uint8_t *) name, width) == 0) ? sizeof(name) - 1 : 0)
+#define ENCODING1_AT(name, offset, encoding) \
+    if (width == sizeof(name) - 1 + (offset) && pm_strncasecmp(start + (offset), (const uint8_t *) name, width - (offset)) == 0) return &pm_encodings[encoding];
+
+    utf8_end = ENCODING_MATCH_PREFIX("UTF-8");
+    if (!utf8_end) utf8_end = ENCODING_MATCH_PREFIX("UTF8");
+    if (utf8_end) {
 #ifndef PRISM_ENCODING_EXCLUDE_FULL
         // We need to explicitly handle UTF-8-HFS, as that one needs to switch
         // over to being UTF8-MAC.
-        if (width == 9 && (pm_strncasecmp(start + 5, (const uint8_t *) "-HFS", 4) == 0)) {
-            return &pm_encodings[PM_ENCODING_UTF8_MAC];
-        }
+        ENCODING1_AT("-HFS", utf8_end, PM_ENCODING_UTF8_MAC);
 #endif
 
         // Otherwise we'll return the default UTF-8 encoding.
@@ -5154,7 +5160,7 @@ pm_encoding_find(const uint8_t *start, const uint8_t *end) {
 
     // Next, we're going to loop through each of the encodings that we handle
     // explicitly. If we found one that we understand, we'll use that value.
-#define ENCODING1(name, encoding) if (width == sizeof(name) - 1 && pm_strncasecmp(start, (const uint8_t *) name, width) == 0) return &pm_encodings[encoding];
+#define ENCODING1(name, encoding) ENCODING1_AT(name, 0, encoding)
 #define ENCODING2(name1, name2, encoding) ENCODING1(name1, encoding) ENCODING1(name2, encoding)
 
     if (width >= 3) {
@@ -5294,7 +5300,7 @@ pm_encoding_find(const uint8_t *start, const uint8_t *end) {
             case 'S': case 's':
                 ENCODING1("SJIS", PM_ENCODING_WINDOWS_31J);
 #ifndef PRISM_ENCODING_EXCLUDE_FULL
-                ENCODING1("Shift_JIS", PM_ENCODING_SHIFT_JIS);
+                ENCODING2("Shift_JIS", "ShiftJIS", PM_ENCODING_SHIFT_JIS);
                 ENCODING1("SJIS-DoCoMo", PM_ENCODING_SJIS_DOCOMO);
                 ENCODING1("SJIS-KDDI", PM_ENCODING_SJIS_KDDI);
                 ENCODING1("SJIS-SoftBank", PM_ENCODING_SJIS_SOFTBANK);
@@ -5317,18 +5323,18 @@ pm_encoding_find(const uint8_t *start, const uint8_t *end) {
 #endif
                 break;
             case 'W': case 'w':
-                ENCODING1("Windows-31J", PM_ENCODING_WINDOWS_31J);
+                ENCODING2("Windows-31J", "Windows31J", PM_ENCODING_WINDOWS_31J);
 #ifndef PRISM_ENCODING_EXCLUDE_FULL
-                ENCODING1("Windows-874", PM_ENCODING_WINDOWS_874);
-                ENCODING1("Windows-1250", PM_ENCODING_WINDOWS_1250);
-                ENCODING1("Windows-1251", PM_ENCODING_WINDOWS_1251);
-                ENCODING1("Windows-1252", PM_ENCODING_WINDOWS_1252);
-                ENCODING1("Windows-1253", PM_ENCODING_WINDOWS_1253);
-                ENCODING1("Windows-1254", PM_ENCODING_WINDOWS_1254);
-                ENCODING1("Windows-1255", PM_ENCODING_WINDOWS_1255);
-                ENCODING1("Windows-1256", PM_ENCODING_WINDOWS_1256);
-                ENCODING1("Windows-1257", PM_ENCODING_WINDOWS_1257);
-                ENCODING1("Windows-1258", PM_ENCODING_WINDOWS_1258);
+                ENCODING2("Windows-874", "Windows874", PM_ENCODING_WINDOWS_874);
+                ENCODING2("Windows-1250", "Windows1250", PM_ENCODING_WINDOWS_1250);
+                ENCODING2("Windows-1251", "Windows1251", PM_ENCODING_WINDOWS_1251);
+                ENCODING2("Windows-1252", "Windows1252", PM_ENCODING_WINDOWS_1252);
+                ENCODING2("Windows-1253", "Windows1253", PM_ENCODING_WINDOWS_1253);
+                ENCODING2("Windows-1254", "Windows1254", PM_ENCODING_WINDOWS_1254);
+                ENCODING2("Windows-1255", "Windows1255", PM_ENCODING_WINDOWS_1255);
+                ENCODING2("Windows-1256", "Windows1256", PM_ENCODING_WINDOWS_1256);
+                ENCODING2("Windows-1257", "Windows1257", PM_ENCODING_WINDOWS_1257);
+                ENCODING2("Windows-1258", "Windows1258", PM_ENCODING_WINDOWS_1258);
 #endif
                 break;
             case '6':


### PR DESCRIPTION
Ignore `/[A-Za-z]\K-(?=\d)|[a-z]\K_(?=[\dA-Z])/`, that is:

* hyphen following alphabets and succeeded by numbers.
* underscore following a lower letter and succeeded by an upper letter.
