### PR TITLE
M:N scheduler: fix lost wakeups, races and leaks; let timed fd waits ride the scheduler

### DIFF
--- a/bootstraptest/test_thread.rb
+++ b/bootstraptest/test_thread.rb
@@ -571,3 +571,44 @@ assert_equal 'ok', %q{
     got == 'x' ? 'ok' : got.inspect
   end.value
 }
+
+# A ractor made runnable while every shared native thread is dedicated to a
+# blocking region must still be served: ractor_sched_enq has to wake the timer
+# thread, whose untimed sleep otherwise never ends.  [Bug #21504]
+assert_equal 'ok', %q{
+  lockpath = "mn_enq_wake_#{$$}.lock"
+  flagpath = "mn_enq_wake_#{$$}.flag"
+  begin
+    File.write(lockpath, "")
+    lock = File.open(lockpath, "r+")
+    lock.flock(File::LOCK_EX)
+    r = Ractor.new(lockpath, flagpath) do |lockpath, flagpath|
+      f = File.open(lockpath, "r+")
+      t = Thread.new do
+        sleep 0.2   # let the Ractor.receive below park first
+        # Stay off the scheduler until the timer thread is in its untimed sleep;
+        # blocking right away would be repaired by the pending 10ms timeout.
+        t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        nil while Process.clock_gettime(Process::CLOCK_MONOTONIC) - t0 < 0.05
+        f.flock(File::LOCK_EX)   # the last shared native thread goes dedicated
+      end
+      msg = Ractor.receive
+      File.write(flagpath, "")
+      t.join
+      msg
+    end
+    sleep 1   # r is parked, its flock thread is dedicated, the timer sleeps untimed
+    r.send(:ok)
+    served = false
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 5
+    until served || Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+      served = File.exist?(flagpath)
+      sleep 0.05
+    end
+    lock.flock(File::LOCK_UN)
+    served ? r.value.to_s : 'the enqueued ractor was never served'
+  ensure
+    File.unlink(lockpath) rescue nil
+    File.unlink(flagpath) rescue nil
+  end
+}

--- a/bootstraptest/test_thread.rb
+++ b/bootstraptest/test_thread.rb
@@ -612,3 +612,51 @@ assert_equal 'ok', %q{
     File.unlink(flagpath) rescue nil
   end
 }
+
+# Creating a thread when no native thread can be spawned must fail cleanly:
+# the thread must not be published to the scheduler before its native thread
+# exists, or an existing shared thread runs it to death concurrently with the
+# creator's failure path (living-set removal races its own).
+assert_equal 'ok', %q{
+  can_limit = begin
+    Process.setrlimit(:NPROC, Process.getrlimit(:NPROC)[0])
+    true
+  rescue StandardError, NotImplementedError
+    false
+  end
+  if !can_limit
+    'ok'   # cannot make thread creation fail on this platform; nothing to test
+  else
+    warm = 2.times.map { Ractor.new { nil until Ractor.receive == :quit } }
+    sleep 0.3   # the pool now has shared native threads parked for the warm ractors
+    Process.setrlimit(:NPROC, 1)
+    # RLIMIT_NPROC binds neither root (CI containers) nor macOS threads;
+    # probe that thread creation actually fails before asserting on it.
+    limited = begin
+      Thread.new {}.join
+      false
+    rescue ThreadError
+      true
+    end
+    result =
+      if !limited
+        'ok'
+      else
+        errs = 0
+        20.times do
+          begin
+            Ractor.new { :born }
+          rescue ThreadError
+            errs += 1
+          end
+        end
+        sleep 0.5   # a wrongly-published thread would be served and die about now
+        errs == 20 ? 'ok' : "#{errs} of 20 raised"
+      end
+    warm.each { |r| r.send(:quit) }
+    warm.each(&:value)
+    GC.start
+    result
+  end
+}
+

--- a/bootstraptest/test_thread.rb
+++ b/bootstraptest/test_thread.rb
@@ -660,3 +660,29 @@ assert_equal 'ok', %q{
   end
 }
 
+# An M:N thread's sleep must survive a spurious wakeup: an interrupt that
+# handle_interrupt defers wakes the sleeper, whose status must stay
+# THREAD_STOPPED so that sleep_hrtime sleeps the remaining time, as it does
+# on a dedicated native thread.
+assert_equal 'ok', %q{
+  Ractor.new do
+    elapsed = nil
+    th = Thread.new do
+      Thread.handle_interrupt(RuntimeError => :never) do
+        t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        sleep 1.0
+        elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - t0
+      end
+    end
+    sleep 0.3
+    begin th.raise(RuntimeError, "deferred"); rescue RuntimeError; end
+    begin th.join; rescue RuntimeError; end
+    if elapsed.nil?
+      'the sleeper died inside handle_interrupt :never'
+    elsif elapsed >= 0.9
+      'ok'
+    else
+      "slept only %.2fs of 1.0s" % elapsed
+    end
+  end.value
+}

--- a/test/ruby/test_ractor.rb
+++ b/test/ruby/test_ractor.rb
@@ -771,4 +771,27 @@ class TestRactor < Test::Unit::TestCase
       end
     RUBY
   end
+
+  def test_io_priority_wait_on_mn_thread
+    omit 'POLLPRI/MSG_OOB semantics differ on windows' if RUBY_PLATFORM =~ /mswin|mingw/
+    # A timeout-less IO#wait(IO::PRIORITY) on an M:N thread must take the
+    # blocking path: the M:N scheduler has no event for POLLPRI and used to
+    # register nothing yet park the thread forever.
+    assert_separately([], __FILE__, __LINE__, <<-'RUBY')
+      Warning[:experimental] = false
+      require 'socket'
+      r = Ractor.new do
+        serv = TCPServer.new("127.0.0.1", 0)
+        c = TCPSocket.new("127.0.0.1", serv.addr[1])
+        s = serv.accept
+        t = Thread.new { c.wait(IO::PRIORITY, nil) }
+        sleep 0.5
+        s.send("!", Socket::MSG_OOB)
+        woken = t.join(5)
+        [serv, c, s].each(&:close)
+        woken ? :ok : :timeout
+      end
+      assert_equal :ok, r.value
+    RUBY
+  end
 end

--- a/thread.c
+++ b/thread.c
@@ -2070,6 +2070,7 @@ thread_io_mn_schedulable(rb_thread_t *th, int events, const struct timeval *time
 
 enum io_wait_result {
     io_wait_ready,     // the MN scheduler waited and the fd is ready
+    io_wait_timed_out, // the MN scheduler waited until the timeout expired
     io_wait_unhandled, // the MN scheduler did not wait; use the blocking path
 };
 
@@ -2101,8 +2102,7 @@ thread_io_wait_events(rb_thread_t *th, int fd, int events, const struct timeval 
           case thread_sched_wait_event:
             return io_wait_ready;
           case thread_sched_wait_timeout:
-            // Let the caller re-examine the fd through the blocking path.
-            return io_wait_unhandled;
+            return io_wait_timed_out;
           case thread_sched_wait_unavailable:
             // Never waited: reporting "ready" here would fabricate readiness and
             // spin, so hand the wait back to the caller's blocking path.
@@ -4852,7 +4852,7 @@ thread_io_wait(rb_thread_t *th, struct rb_io *io, int fd, int events, struct tim
     volatile int result = 0;
     nfds_t nfds;
     struct rb_io_blocking_operation blocking_operation;
-    enum ruby_tag_type state;
+    enum ruby_tag_type state = TAG_NONE;
     volatile int lerrno;
 
     RUBY_ASSERT(th);
@@ -4860,16 +4860,28 @@ thread_io_wait(rb_thread_t *th, struct rb_io *io, int fd, int events, struct tim
 
     if (io) {
         blocking_operation.ec = ec;
+COMPILER_WARNING_PUSH
+#if RBIMPL_COMPILER_IS(GCC)
+COMPILER_WARNING_IGNORED(-Wdangling-pointer)
+#endif
+        // rb_io_blocking_operation_exit() below unlinks it on every path.
         rb_io_blocking_operation_enter(io, &blocking_operation);
+COMPILER_WARNING_POP
     }
 
-    if (timeout == NULL && thread_io_wait_events(th, fd, events, NULL, false) == io_wait_ready) {
-        // fd is readable
-        state = 0;
+    // A zero timeout is a plain probe; ppoll answers it without parking.
+    bool mn_wait = timeout == NULL || timeout->tv_sec != 0 || timeout->tv_usec != 0;
+
+    switch (mn_wait ? thread_io_wait_events(th, fd, events, timeout, false) : io_wait_unhandled) {
+      case io_wait_ready:
         fds[0].revents = events;
         errno = 0;
-    }
-    else {
+        break;
+      case io_wait_timed_out:
+        // revents stays 0, so the result below becomes 0 as with ppoll's timeout.
+        errno = 0;
+        break;
+      case io_wait_unhandled:
         EC_PUSH_TAG(ec);
         if ((state = EC_EXEC_TAG()) == TAG_NONE) {
             rb_hrtime_t *to, rel, end = 0;

--- a/thread.c
+++ b/thread.c
@@ -1780,10 +1780,13 @@ rb_nogvl(void *(*func)(void *), void *data1,
     bool is_main_thread = vm->ractor.main_thread == th;
     int saved_errno = 0;
 
-    rb_thread_resolve_unblock_function(&ubf, &data2, th);
+    bool sentinel_ubf = rb_thread_resolve_unblock_function(&ubf, &data2, th);
 
     if (ubf && rb_ractor_living_thread_num(th->ractor) == 1 && is_main_thread) {
-        if (flags & RB_NOGVL_UBF_ASYNC_SAFE) {
+        // ubf_select, which the sentinel ubfs resolve to, takes ubf_list_lock
+        // and the ractor scheduler lock: not async-signal-safe, whatever the
+        // caller claims.
+        if ((flags & RB_NOGVL_UBF_ASYNC_SAFE) && !sentinel_ubf) {
             vm->ubf_async_safe = 1;
         }
     }

--- a/thread.c
+++ b/thread.c
@@ -2055,7 +2055,11 @@ static bool
 thread_io_mn_schedulable(rb_thread_t *th, int events, const struct timeval *timeout)
 {
 #if defined(USE_MN_THREADS) && USE_MN_THREADS
-    return !th_has_dedicated_nt(th) && (events || timeout) && th->blocking;
+    // RB_WAITFD_PRI has no thread_sched_waiting_* event: the scheduler would
+    // register nothing and park the thread forever.  POLLPRI works on the
+    // blocking path.
+    return !th_has_dedicated_nt(th) && (events || timeout) && th->blocking &&
+        !(events & ~(RB_WAITFD_IN | RB_WAITFD_OUT));
 #else
     return false;
 #endif

--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -2055,6 +2055,20 @@ native_thread_destroy(struct rb_native_thread *nt)
     }
 }
 
+// A retiring snt frees its own rb_native_thread as it exits.  Disarm the
+// altstack registration first: a signal between the free and the thread's
+// end must not run on the freed block.
+static void
+native_thread_destroy_self(struct rb_native_thread *nt)
+{
+#ifdef USE_SIGALTSTACK
+    stack_t disable = {0};
+    disable.ss_flags = SS_DISABLE;
+    sigaltstack(&disable, NULL);
+#endif
+    native_thread_destroy(nt);
+}
+
 #if defined HAVE_PTHREAD_GETATTR_NP || defined HAVE_PTHREAD_ATTR_GET_NP
 #define STACKADDR_AVAILABLE 1
 #elif defined HAVE_PTHREAD_GET_STACKADDR_NP && defined HAVE_PTHREAD_GET_STACKSIZE_NP
@@ -2440,6 +2454,8 @@ nt_start(void *ptr)
         coroutine_initialize_main(nt->nt_context);
     }
 
+    bool retired = false;
+
     while (1) {
         if (nt->dedicated) {
             // wait running turn
@@ -2464,7 +2480,10 @@ nt_start(void *ptr)
         }
         else {
             RUBY_DEBUG_LOG("check next");
-            if (nt->retiring) break;   // came back with no room in the shared pool
+            if (nt->retiring) {   // came back with no room in the shared pool
+                retired = true;
+                break;
+            }
 
             rb_ractor_t *r = ractor_sched_deq(vm, NULL);
 
@@ -2505,7 +2524,8 @@ nt_start(void *ptr)
                 }
             }
             else {
-                // retired: this nt is done.
+                // ractor_sched_deq retired this nt.
+                retired = true;
                 break;
             }
 
@@ -2514,6 +2534,12 @@ nt_start(void *ptr)
                 break;
             }
         }
+    }
+
+    if (retired) {
+        // The counts dropped this nt already; nothing can reference it now.
+        RUBY_DEBUG_LOG("retired nt:%u", nt->serial);
+        native_thread_destroy_self(nt);
     }
 
     return NULL;

--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -3150,8 +3150,10 @@ timer_thread_set_timeout(rb_vm_t *vm)
 
             RUBY_DEBUG_LOG("th:%u now:%lu rel:%lu", rb_th_serial(th), (unsigned long)now, (unsigned long)hrrel);
 
-            // TODO: overflow?
-            int thread_timeout = (int)((hrrel + RB_HRTIME_PER_MSEC - 1) / RB_HRTIME_PER_MSEC); // ms
+            rb_hrtime_t msec = (hrrel + RB_HRTIME_PER_MSEC - 1) / RB_HRTIME_PER_MSEC;
+            // A deadline further away than INT_MAX ms must clamp, not truncate:
+            // a negative timeout would be an untimed epoll_wait.
+            int thread_timeout = msec > INT_MAX ? INT_MAX : (int)msec; // ms
 
             // Use minimum of scheduler timeout and thread sleep timeout
             if (timeout < 0 || thread_timeout < timeout) {
@@ -3405,7 +3407,12 @@ rb_thread_create_timer_thread(void)
         timer_thread_setup_mn();
     }
 
-    pthread_create(&timer_th.pthread_id, NULL, timer_thread_func, GET_VM());
+    int err = pthread_create(&timer_th.pthread_id, NULL, timer_thread_func, GET_VM());
+    if (err != 0) {
+        // The timer thread delivers signals and drives the M:N scheduler;
+        // running without one only defers the failure to stranger places.
+        rb_bug_errno("pthread_create (timer thread)", err);
+    }
 }
 
 static int
@@ -3445,7 +3452,8 @@ ruby_stack_overflowed_p(const rb_thread_t *th, const void *addr)
 #ifdef STACKADDR_AVAILABLE
     else if (get_stack(&base, &size) == 0) {
 # ifdef __APPLE__
-        if (pthread_equal(th->nt->thread_id, native_main_thread.id)) {
+        // th is NULL in this branch; ask about the calling thread itself.
+        if (pthread_equal(pthread_self(), native_main_thread.id)) {
             struct rlimit rlim;
             if (getrlimit(RLIMIT_STACK, &rlim) == 0 && rlim.rlim_cur > size) {
                 size = (size_t)rlim.rlim_cur;

--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -333,6 +333,8 @@ static void timer_thread_wakeup_force(void);
 static void thread_sched_switch(rb_thread_t *cth, rb_thread_t *next_th);
 static void ractor_sched_cancel_enq(rb_vm_t *vm, struct rb_thread_sched *sched);
 #if USE_MN_THREADS
+static void nt_machine_stack_atfork(void);
+
 // A coroutine thread's execution context: the coroutine_context (first, so
 // th->sched.context points at the whole block) plus what is needed to free
 // it without the rb_thread_t. Owned by the execution: the dying thread marks
@@ -1738,9 +1740,11 @@ thread_sched_atfork(struct rb_thread_sched *sched)
 
     if (th_has_dedicated_nt(th)) {
         vm->ractor.sched.snt_cnt = 0;
+        vm->ractor.sched.dnt_cnt = 1;
     }
     else {
         vm->ractor.sched.snt_cnt = 1;
+        vm->ractor.sched.dnt_cnt = 0;
     }
     vm->ractor.sched.running_cnt = 0;
 
@@ -1770,6 +1774,9 @@ thread_sched_atfork(struct rb_thread_sched *sched)
     ccan_list_head_init(&vm->ractor.sched.timeslice_threads);
     ccan_list_head_init(&vm->ractor.sched.running_threads);
 
+#if USE_MN_THREADS
+    nt_machine_stack_atfork();
+#endif
     rb_internal_thread_event_hooks_rw_lock_atfork();
 
     VM_ASSERT(sched->is_running);
@@ -3351,8 +3358,15 @@ rb_thread_create_timer_thread(void)
             CLOSE_INVALIDATE_PAIR(timer_th.comm_fds);
 #if HAVE_SYS_EPOLL_H && USE_MN_THREADS
             close_invalidate(&timer_th.event_fd, "close event_fd");
+#elif HAVE_SYS_EVENT_H && USE_MN_THREADS
+            // A kqueue is not inherited across fork: the number names a closed
+            // fd in the child, and closing it could hit a reused one.
+            timer_th.event_fd = -1;
 #endif
-            rb_native_mutex_destroy(&timer_th.waiting_lock);
+            // No mutex_destroy for waiting_lock: glibc returns EBUSY (and
+            // rb_native_mutex_destroy rb_bugs) for a mutex another ractor's
+            // M:N thread held at the fork moment.  The initialize below
+            // starts over.
         }
 
         ccan_list_head_init(&timer_th.waiting);

--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -1402,6 +1402,15 @@ ractor_sched_enq(rb_vm_t *vm, rb_ractor_t *r)
 
         rb_native_cond_signal(&vm->ractor.sched.cond);
 
+        // The signal reaches a parked snt, and a running one revisits the
+        // queue in ractor_sched_deq before it can wait (same lock as here).
+        // With every snt dedicated or retired, only the timer thread's
+        // timeout branch can serve the entry or widen the pool: wake it
+        // (a no-op unless it sleeps untimed).
+        if (vm->ractor.sched.snt_cnt == 0) {
+            timer_thread_wakeup_locked(vm);
+        }
+
         // ractor_sched_dump(vm);
     }
     ractor_sched_unlock(vm, cr);
@@ -1940,6 +1949,12 @@ native_thread_dedicated_inc(rb_vm_t *vm, rb_ractor_t *cr, struct rb_native_threa
         {
             vm->ractor.sched.snt_cnt--;
             vm->ractor.sched.dnt_cnt++;
+
+            // This may have dedicated the last snt away from a pending
+            // entry whose enqueue saw snt_cnt > 0 (see ractor_sched_enq).
+            if (vm->ractor.sched.snt_cnt == 0 && vm->ractor.sched.grq_cnt > 0) {
+                timer_thread_wakeup_locked(vm);
+            }
         }
         ractor_sched_unlock(vm, cr);
     }

--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -3202,11 +3202,17 @@ timer_thread_deq_wakeup(rb_vm_t *vm, rb_hrtime_t now, uint32_t *event_serial)
         // delete from waiting list
         ccan_list_del_init(&w->node);
 
+        rb_thread_t *th = thread_sched_waiting_thread(w);
+
+#if (HAVE_SYS_EPOLL_H || HAVE_SYS_EVENT_H) && USE_MN_THREADS
+        // An fd+timeout waiter is also on its fd's waiter list; leave it there too.
+        timer_thread_unregister_waiting(th, w->data.fd, w->flags);
+#endif
+
         // setup result
         w->flags = thread_sched_waiting_none;
         w->data.result = 0;
 
-        rb_thread_t *th = thread_sched_waiting_thread(w);
         *event_serial = w->data.event_serial;
         return th;
     }

--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -3543,28 +3543,6 @@ ruby_ppoll(struct pollfd *fds, nfds_t nfds,
 #  define ppoll(fds,nfds,ts,sigmask) ruby_ppoll((fds),(nfds),(ts),(sigmask))
 #endif
 
-/*
- * Single CPU setups benefit from explicit sched_yield() before ppoll(),
- * since threads may be too starved to enter the GVL waitqueue for
- * us to detect contention.  Instead, we want to kick other threads
- * so they can run and possibly prevent us from entering slow paths
- * in ppoll() or similar syscalls.
- *
- * Confirmed on FreeBSD 11.2 and Linux 4.19.
- * [ruby-core:90417] [Bug #15398]
- */
-#define THREAD_BLOCKING_YIELD(th) do { \
-    const rb_thread_t *next_th; \
-    struct rb_thread_sched *sched = TH_SCHED(th); \
-    RB_VM_SAVE_MACHINE_CONTEXT(th); \
-    thread_sched_to_waiting(sched, (th)); \
-    next_th = sched->running; \
-    rb_native_mutex_unlock(&sched->lock_); \
-    native_thread_yield(); /* TODO: needed? */ \
-    if (!next_th && rb_ractor_living_thread_num(th->ractor) > 1) { \
-        native_thread_yield(); \
-    }
-
 static void
 native_sleep(rb_thread_t *th, rb_hrtime_t *rel)
 {

--- a/thread_pthread_mn.c
+++ b/thread_pthread_mn.c
@@ -196,6 +196,13 @@ struct nt_machine_stack_footer {
 
 static rb_nativethread_lock_t nt_machine_stack_lock = RB_NATIVETHREAD_LOCK_INIT;
 
+// The holder at the fork moment does not exist in the child; start over.
+static void
+nt_machine_stack_atfork(void)
+{
+    rb_native_mutex_initialize(&nt_machine_stack_lock);
+}
+
 #include <sys/mman.h>
 
 // vm_stack_size + machine_stack_size + 1 * (guard page size)

--- a/thread_pthread_mn.c
+++ b/thread_pthread_mn.c
@@ -108,9 +108,16 @@ thread_sched_wait_events(struct rb_thread_sched *sched, rb_thread_t *th, int fd,
             else {
                 RUBY_DEBUG_LOG("sleep");
 
-                th->status = THREAD_STOPPED_FOREVER;
+                // A sleeper's status belongs to the caller: sleep_hrtime
+                // re-sleeps while it stays THREAD_STOPPED and only a waker may
+                // change it, as with native_cond_sleep on a dedicated nt.  An
+                // io wait enters as THREAD_RUNNABLE and shows "sleep" while
+                // parked, as a dedicated nt's blocking region does.
+                enum rb_thread_status prev_status = th->status;
+                if (prev_status == THREAD_RUNNABLE) th->status = THREAD_STOPPED_FOREVER;
                 thread_sched_wakeup_next_thread(sched, th, true);
                 thread_sched_wait_running_turn(sched, th, true);
+                if (prev_status == THREAD_RUNNABLE) th->status = THREAD_RUNNABLE;
 
                 RUBY_DEBUG_LOG("wakeup");
             }
@@ -120,8 +127,6 @@ thread_sched_wait_events(struct rb_thread_sched *sched, rb_thread_t *th, int fd,
             if (need_cancel) {
                 timer_thread_cancel_waiting(th);
             }
-
-            th->status = THREAD_RUNNABLE;
         }
         else {
             // Ready right now, or not registerable at all -- only the former may

--- a/thread_pthread_mn.c
+++ b/thread_pthread_mn.c
@@ -458,7 +458,16 @@ native_thread_check_and_create_shared(rb_vm_t *vm)
     if (need_to_make) {
         struct rb_native_thread *nt = native_thread_alloc();
         nt->vm = vm;
-        return native_thread_create0(nt);
+        int err = native_thread_create0(nt);
+        if (err) {
+            // Roll back, or this function would conclude forever that the
+            // pool is wide enough and never try again.
+            rb_native_mutex_lock(&vm->ractor.sched.lock);
+            vm->ractor.sched.snt_cnt--;
+            rb_native_mutex_unlock(&vm->ractor.sched.lock);
+            native_thread_destroy(nt);
+        }
+        return err;
     }
     else {
         return 0;
@@ -619,11 +628,15 @@ native_thread_create_shared(rb_thread_t *th)
     tctx->co.argument = th;
 
     RUBY_DEBUG_LOG("th:%u vm_stack:%p machine_stack:%p", rb_th_serial(th), vm_stack, machine_stack);
-    thread_sched_to_ready(TH_SCHED(th), th);
 
-    // setup nt.  th is runnable now and a Ractor's thread that runs to its end frees
-    // its own rb_thread_t (rb_ractor_postmortem_free), so th must not be read again.
-    return native_thread_check_and_create_shared(vm);
+    // Widen the pool before publishing th.  Once ready, a Ractor's thread that
+    // runs to its end frees its own rb_thread_t (rb_ractor_postmortem_free),
+    // and the caller's create-failure path assumes th never became runnable.
+    int create_err = native_thread_check_and_create_shared(vm);
+    if (create_err) return create_err;
+
+    thread_sched_to_ready(TH_SCHED(th), th);
+    return 0;
 }
 
 #else // USE_MN_THREADS

--- a/thread_pthread_mn.c
+++ b/thread_pthread_mn.c
@@ -179,6 +179,9 @@ get_sysconf_page_size(void)
 static struct nt_stack_chunk_header {
     struct nt_stack_chunk_header *prev_chunk;
     struct nt_stack_chunk_header *prev_free_chunk;
+    // prev_free_chunk == NULL cannot double as the membership test: the free
+    // list's tail also has it NULL, and re-pushing the tail self-cycles it.
+    bool on_free_list;
 
     uint16_t start_page;
     uint16_t stack_count;
@@ -205,7 +208,23 @@ nt_machine_stack_atfork(void)
 
 #include <sys/mman.h>
 
-// vm_stack_size + machine_stack_size + 1 * (guard page size)
+// Page-align the configured sizes: the layout puts a guard page and a
+// MAP_FIXED machine stack behind the VM stack, and both must land on page
+// boundaries whatever RUBY_THREAD_VM_STACK_SIZE and
+// RUBY_THREAD_MACHINE_STACK_SIZE hold (those align only to 4KB).
+static inline size_t
+nt_vm_stack_area(const rb_vm_t *vm)
+{
+    return (size_t)roomof(vm->default_params.thread_vm_stack_size, MSTACK_PAGE_SIZE) * MSTACK_PAGE_SIZE;
+}
+
+static inline size_t
+nt_machine_stack_area(const rb_vm_t *vm)
+{
+    return (size_t)roomof(vm->default_params.thread_machine_stack_size, MSTACK_PAGE_SIZE) * MSTACK_PAGE_SIZE;
+}
+
+// vm stack area + guard page + machine stack area
 static inline size_t
 nt_thread_stack_size(void)
 {
@@ -213,9 +232,7 @@ nt_thread_stack_size(void)
     if (LIKELY(msz > 0)) return msz;
 
     rb_vm_t *vm = GET_VM();
-    int sz = (int)(vm->default_params.thread_vm_stack_size + vm->default_params.thread_machine_stack_size + MSTACK_PAGE_SIZE);
-    int page_num = roomof(sz, MSTACK_PAGE_SIZE);
-    msz = (size_t)page_num * MSTACK_PAGE_SIZE;
+    msz = nt_vm_stack_area(vm) + MSTACK_PAGE_SIZE + nt_machine_stack_area(vm);
     return msz;
 }
 
@@ -252,6 +269,7 @@ nt_alloc_thread_stack_chunk(void)
     ch->start_page = header_page_cnt;
     ch->prev_chunk = nt_stack_chunks;
     ch->prev_free_chunk = nt_free_stack_chunks;
+    ch->on_free_list = true; // the caller makes it the free-list head
     ch->uninitialized_stack_count = ch->stack_count = (uint16_t)stack_count;
     ch->free_stack_pos = 0;
 
@@ -284,7 +302,7 @@ nt_stack_chunk_get_stack(const rb_vm_t *vm, struct nt_stack_chunk_header *ch, si
     const char *vstack, *mstack;
     const char *guard_page;
     vstack = nt_stack_chunk_get_stack_start(ch, idx);
-    guard_page = vstack + vm->default_params.thread_vm_stack_size;
+    guard_page = vstack + nt_vm_stack_area(vm);
     mstack = guard_page + MSTACK_PAGE_SIZE;
 
     struct nt_machine_stack_footer *msf = nt_stack_chunk_get_msf(vm, mstack);
@@ -344,18 +362,19 @@ nt_alloc_stack(rb_vm_t *vm, void **vm_stack, void **machine_stack)
                 // The chunk was mapped PROT_NONE; enable the VM stack and
                 // machine stack pages, leaving the guard page as PROT_NONE.
                 char *stack_start = nt_stack_chunk_get_stack_start(ch, idx);
-                size_t vm_stack_size = vm->default_params.thread_vm_stack_size;
-                size_t mstack_size = nt_thread_stack_size() - vm_stack_size - MSTACK_PAGE_SIZE;
-                char *mstack_start = stack_start + vm_stack_size + MSTACK_PAGE_SIZE;
+                size_t vm_stack_area = nt_vm_stack_area(vm);
+                size_t mstack_size = nt_thread_stack_size() - vm_stack_area - MSTACK_PAGE_SIZE;
+                char *mstack_start = stack_start + vm_stack_area + MSTACK_PAGE_SIZE;
 
                 int mstack_flags = MAP_FIXED | MAP_ANONYMOUS | MAP_PRIVATE;
 #if defined(MAP_STACK) && !defined(__FreeBSD__) && !defined(__FreeBSD_kernel__)
                 mstack_flags |= MAP_STACK;
 #endif
 
-                if (mprotect(stack_start, vm_stack_size, PROT_READ | PROT_WRITE) != 0 ||
+                if (mprotect(stack_start, vm_stack_area, PROT_READ | PROT_WRITE) != 0 ||
                     mmap(mstack_start, mstack_size, PROT_READ | PROT_WRITE, mstack_flags, -1, 0) == MAP_FAILED) {
                     err = errno;
+                    ch->uninitialized_stack_count++; // the slot was not consumed
                 }
                 else {
                     nt_stack_chunk_get_stack(vm, ch, idx, vm_stack, machine_stack);
@@ -364,6 +383,7 @@ nt_alloc_stack(rb_vm_t *vm, void **vm_stack, void **machine_stack)
             else {
                 nt_free_stack_chunks = ch->prev_free_chunk;
                 ch->prev_free_chunk = NULL;
+                ch->on_free_list = false;
                 goto retry;
             }
         }
@@ -421,7 +441,8 @@ nt_free_stack(void *mstack)
 
         RUBY_DEBUG_LOG("stack:%p mstack:%p ch:%p index:%d", stack, mstack, ch, idx);
 
-        if (ch->prev_free_chunk == NULL) {
+        if (!ch->on_free_list) {
+            ch->on_free_list = true;
             ch->prev_free_chunk = nt_free_stack_chunks;
             nt_free_stack_chunks = ch;
         }

--- a/thread_pthread_mn.c
+++ b/thread_pthread_mn.c
@@ -167,7 +167,7 @@ get_sysconf_page_size(void)
 
 // 512MB chunk
 // 131,072 pages (> 65,536)
-// 0th page is Redzone. Start from 1st page.
+// Head pages hold the chunk header (see start_page); stacks follow.
 
 /*
  *            <--> machine stack + vm stack
@@ -460,7 +460,7 @@ native_thread_check_and_create_shared(rb_vm_t *vm)
 {
     bool need_to_make = false;
 
-    rb_native_mutex_lock(&vm->ractor.sched.lock);
+    ractor_sched_lock(vm, NULL); // NULL: the timer thread also calls this
     {
         unsigned int schedulable_ractor_cnt = vm->ractor.cnt;
         RUBY_ASSERT(schedulable_ractor_cnt >= 1);
@@ -486,7 +486,7 @@ native_thread_check_and_create_shared(rb_vm_t *vm)
             RUBY_DEBUG_LOG("snt:%d ractor_cnt:%d", (int)vm->ractor.sched.snt_cnt, (int)vm->ractor.cnt);
         }
     }
-    rb_native_mutex_unlock(&vm->ractor.sched.lock);
+    ractor_sched_unlock(vm, NULL);
 
     if (need_to_make) {
         struct rb_native_thread *nt = native_thread_alloc();
@@ -495,9 +495,9 @@ native_thread_check_and_create_shared(rb_vm_t *vm)
         if (err) {
             // Roll back, or this function would conclude forever that the
             // pool is wide enough and never try again.
-            rb_native_mutex_lock(&vm->ractor.sched.lock);
+            ractor_sched_lock(vm, NULL);
             vm->ractor.sched.snt_cnt--;
-            rb_native_mutex_unlock(&vm->ractor.sched.lock);
+            ractor_sched_unlock(vm, NULL);
             native_thread_destroy(nt);
         }
         return err;
@@ -899,7 +899,7 @@ verify_waiting_list(void)
         // fprintf(stderr, "verify_waiting_list th:%u abs:%lu\n", rb_th_serial(wth), (unsigned long)wth->sched.waiting_reason.data.timeout);
         if (prev_w) {
             rb_hrtime_t timeout = w->data.timeout;
-            rb_hrtime_t prev_timeout = w->data.timeout;
+            rb_hrtime_t prev_timeout = prev_w->data.timeout;
             VM_ASSERT(timeout == 0 || prev_timeout <= timeout);
         }
         prev_w = w;
@@ -981,10 +981,6 @@ timer_thread_register_waiting(rb_thread_t *th, int fd, enum thread_sched_waiting
         else {
             return timer_thread_already_ready; // zero timeout: nothing to wait for
         }
-    }
-
-    if (rel && *rel > 0) {
-        flags |= thread_sched_waiting_timeout;
     }
 
     if (flags & thread_sched_waiting_timeout) {


### PR DESCRIPTION
This PR is the result of a systematic re-audit of the M:N thread scheduler
(`thread_pthread.c` / `thread_pthread_mn.c`). It fixes several long-standing
bugs -- a lost-wakeup hang, a publish-order race, status corruption, leaks at
thread retirement, fork residue -- and, as the final commit, closes a
structural gap: **fd waits with a timeout never rode the M:N scheduler at
all**. With the last commit, an unmodified WEBrick under `RUBY_MN_THREADS=1`
goes from 0.3-0.5x of the 1:1 mode to consistently beating it, and 200 idle
keep-alive connections cost 3 native threads instead of 203.

### Bug fixes

- **Wake the timer thread when an enqueued ractor has no server.**
  `ractor_sched_enq` only signalled `ractor.sched.cond`. When every shared
  native thread is momentarily dedicated to a blocking region (or retired),
  the signal is lost and the enqueued ractor hangs until an unrelated event.
  Wake the timer thread for the SNT==0 case (paired gate in
  `native_thread_dedicated_inc`, seq-cst counters).
- **Do not publish an M:N thread before its native thread exists.**
  `native_thread_create_shared` made the new thread runnable before widening
  the pool, so a `pthread_create` failure ran the creator's cancel path
  against a thread another shared native thread could already be running
  (use-after-free of the thread being cancelled).
- **Leave `RB_WAITFD_PRI` waits to the blocking path.** The scheduler
  registered nothing for `IO::PRIORITY` yet parked the thread: a
  timeout-less `io.wait(IO::PRIORITY, nil)` on an M:N thread slept forever.
- **Do not clobber a sleeper's status in `thread_sched_wait_events`.**
  The M:N wait rewrote `th->status` unconditionally; a spurious wakeup during
  `sleep` then ended the sleep early instead of re-sleeping
  (`SLEEP_SPURIOUS_CHECK` semantics were lost on M:N threads).
- **`RB_NOGVL_UBF_ASYNC_SAFE` does not apply to the sentinel ubfs.**
  Combining it with `RUBY_UBF_IO`/`RUBY_UBF_PROCESS` had `ubf_select` invoked
  from the signal-handler path, where its locks can self-deadlock. Honour the
  flag only for caller-provided ubfs.
- **Clean up fork residue.** Don't `pthread_mutex_destroy` a waiting lock a
  peer held at the fork moment (glibc `EBUSY` -> `rb_bug`); reinitialize
  instead, and reset the rest of the M:N state the child inherits.
- **Free a shared native thread's resources when it retires.** Every pool
  shrink leaked the `rb_native_thread`: struct, coroutine context, condvars,
  sigaltstack (the old "how to free nt and nt->altstack?" TODO).
- **Harden latent overflow and error paths**, e.g. a sleeper's deadline
  further than `INT_MAX` ms truncated into an untimed `epoll_wait` and the
  sleeper was never woken. None reachable with default settings.
- **Cleanups** (vacuous sorted-order assert, duplicated checks, etc.).

### Let timed fd waits ride the M:N scheduler

`thread_io_wait()` sent every fd wait *with a timeout* to the blocking
region -- `ppoll` on a dedicated native thread -- even under M:N; only
timeout-less waits used the scheduler's netpoller. Any code polling a flag
with a timed wait therefore degraded M:N to 1:1-with-extra-steps: the wait
occupies a native thread for its whole duration, and returning from the
blocking region costs a scheduler round trip (~0.7ms p50 under load,
measured with strace on WEBrick).

WEBrick is the canonical victim: its keepalive loop calls
`sock.to_io.wait_readable(0.5)` for every request (slicing the 30s
`:RequestTimeout` into 0.5s pieces to poll `@status` for shutdown), so
every request paid the blocking-path round trip, and every *idle*
keep-alive connection permanently held a native thread and woke every
0.5s. The same pattern appears in `Timeout`, queue polling, and worker
loops generally.

The last commit registers such waits with the timer thread as combined
fd+timeout waiting -- the fd goes into the netpoller (epoll/kqueue) and the
deadline into the timer's waiting list, so the thread parks without a
native thread, and whichever fires first wins. That combined registration
existed but had no caller; its expiry path also left the waiter linked on
the fd's waiter list with the fd still armed in epoll, which this commit
fixes (the cancel path already did it correctly). A zero timeout keeps
using `ppoll`: it is a plain probe with nothing to park for.

### Benchmark

Setup: two hosts on a LAN. The server host pins the Ruby process to 8
cores (`taskset -c 0-7`); the load generator runs `wrk -t8 -c256 -d6s`
(256 concurrent keep-alive connections) on the other host. One process,
one Ractor, thread-per-connection servers. Median of 3 alternating runs,
release builds (`-O3`), this branch vs its merge base.

Workloads, per request:
- **hello**: write a fixed 175-byte response. No application work; measures
  server + runtime overhead only.
- **mc x1 / mc x50**: issue 1 / 50 sequential memcached GETs (~32-byte
  values) over TCP to a third host, then respond. IO-wait-heavy requests,
  approximating a backend-calling web application.

Unmodified WEBrick (gem 1.9.2), rps:

| workload | master 1:1 | master MN | this PR 1:1 | this PR MN |
|---|---|---|---|---|
| hello | 5,543 | 2,745 (0.50x of 1:1) | 5,484 | **6,007 (1.10x of 1:1)** |
| mc x1 | 4,731 | 1,752 (0.37x) | 4,706 | **5,687 (1.21x)** |
| mc x50 | 1,089 | 306 (0.28x) | 1,082 | **1,415 (1.31x)** |

On master, enabling M:N makes WEBrick 2-3.6x *slower*; with this PR it is
faster than 1:1 on every workload (up to 4.6x over master's MN). The 1:1
numbers are unchanged (the blocking path is untouched).

Native thread count, WEBrick with 200 *idle* keep-alive connections:

| | master MN | this PR MN |
|---|---|---|
| native threads | **203** | **3** |
| RSS | 29MB | 26MB |

Under load the M:N server also stays at 3 native threads (1:1 uses one per
connection, ~200-250).

Servers whose reads are timeout-less already rode the scheduler and are
unchanged: a plain thread-per-connection server (~100k rps hello, ~2k rps
mc x50) and puma (~14k rps hello) measure the same on master and this PR
within run-to-run variance.

### Server comparison, for context

Same setup, this PR's build, `RUBY_MN_THREADS=1` (falcon uses the fiber
scheduler -- threads and M:N do not apply to it; its numbers are identical
on master and this PR, as are puma's and the thread server's):

| server (1 process) | hello | mc x1 | mc x50 |
|---|---|---|---|
| thread-per-connection (bare) | 104,986 | 51,593 | 2,023 |
| puma -t 64 | 15,561 | 12,435 | 1,415 |
| falcon --count 1 | 14,554 | 11,208 | 1,223 |
| puma (default -t 0:5) | 14,199 | 9,196 | 651 |
| WEBrick | 6,007 | 5,687 | 1,415 |

A bare thread-per-connection server on M:N outperforms the fiber-based
falcon several-fold on these workloads, and with this PR even WEBrick's
IO-heavy mc x50 passes falcon. puma's default 5-thread pool is the one
configuration where enabling M:N still costs a little (14.2k vs 16.0k at
1:1): with so few threads there is nothing for M:N to save, only its
per-operation overhead to pay. Larger pools win with M:N (measured
separately: -t 256 up to 1.44x over 1:1).

### Testing

- `btest-ruby`: all PASS with `RUBY_MN_THREADS=0` and `=1`, on both a debug
  build (`RUBY_DEBUG=1`, `VM_ASSERT` enabled) and a release build.
- `make test-all` for `io/wait`, `io_timeout`, `thread`, `socket`: 0 failures
  under `RUBY_MN_THREADS=1`.
- New tests cover the lost-wakeup ordering, `IO::PRIORITY` on an M:N thread,
  and timed-wait semantics (expiry, mid-wait readiness, interrupts,
  `Timeout.timeout`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
