### PR TITLE
[Feature #22245] Array#&: avoid hashing a much longer argument

### DIFF
--- a/array.c
+++ b/array.c
@@ -5874,6 +5874,48 @@ rb_ary_difference_multi(int argc, VALUE *argv, VALUE ary)
 }
 
 
+static VALUE
+ary_and_hash_self(VALUE ary1, VALUE ary2)
+{
+    long i, j, capa = RARRAY_LEN(ary1);
+    volatile VALUE seen_buf;
+    bool *seen = ALLOCV_N(bool, seen_buf, capa);
+    VALUE hash = ary_tmp_hash_new(ary1);
+    VALUE ary3 = rb_ary_new_capa(capa);
+
+    for (i=0; i<RARRAY_LEN(ary1) && i<capa; i++) {
+        VALUE v = RARRAY_AREF(ary1, i);
+        long idx = RARRAY_LEN(ary3);
+
+        if (!rb_hash_add_new_element(hash, v, LONG2FIX(idx))) {
+            /* ary3 has room for every element from the initial ary1. */
+            RARRAY_PTR_USE(ary3, ptr, {
+                RB_OBJ_WRITE(ary3, &ptr[idx], v);
+            });
+            ARY_SET_LEN(ary3, idx + 1);
+            seen[idx] = false;
+        }
+    }
+
+    for (i=0; i<RARRAY_LEN(ary2); i++) {
+        st_data_t idx;
+        st_data_t key = (st_data_t)RARRAY_AREF(ary2, i);
+
+        if (rb_hash_stlike_delete(hash, &key, &idx)) {
+            seen[FIX2LONG((VALUE)idx)] = true;
+        }
+    }
+
+    RARRAY_PTR_USE(ary3, ptr, {
+        for (i=j=0; i<RARRAY_LEN(ary3); i++) {
+            if (seen[i]) ptr[j++] = ptr[i];
+        }
+    }); /* WB: no new reference */
+    ary_resize_smaller(ary3, j);
+    ALLOCV_END(seen_buf);
+    return ary3;
+}
+
 /*
  *  call-seq:
  *    self & other_array -> new_array
@@ -5891,8 +5933,8 @@ rb_ary_difference_multi(int argc, VALUE *argv, VALUE ary)
  *
  *    [0, 1, 2] & [3, 2, 1, 0] # => [0, 1, 2]
  *
- *  Identifies common elements using method <tt>#eql?</tt>
- *  (as defined in each element of +self+).
+ *  Uses methods <tt>#hash</tt> and <tt>#eql?</tt> to identify common elements.
+ *  Which array's elements receive <tt>#eql?</tt> is not specified.
  *
  *  Related: see {Methods for Combining}[rdoc-ref:Array@Methods+for+Combining].
  */
@@ -5906,10 +5948,10 @@ rb_ary_and(VALUE ary1, VALUE ary2)
     long i;
 
     ary2 = to_ary(ary2);
-    ary3 = rb_ary_new();
-    if (RARRAY_LEN(ary1) == 0 || RARRAY_LEN(ary2) == 0) return ary3;
+    if (RARRAY_LEN(ary1) == 0 || RARRAY_LEN(ary2) == 0) return rb_ary_new();
 
     if (RARRAY_LEN(ary1) <= SMALL_ARRAY_LEN && RARRAY_LEN(ary2) <= SMALL_ARRAY_LEN) {
+        ary3 = rb_ary_new();
         for (i=0; i<RARRAY_LEN(ary1); i++) {
             v = RARRAY_AREF(ary1, i);
             if (!rb_ary_includes_by_eql(ary2, v)) continue;
@@ -5919,6 +5961,13 @@ rb_ary_and(VALUE ary1, VALUE ary2)
         return ary3;
     }
 
+    if (RARRAY_LEN(ary1) <= RARRAY_LEN(ary2) / 2) {
+        /* Hash ary1 only when it is at most half as long as ary2.  Benchmarks
+         * show no consistent win for comparable lengths. */
+        return ary_and_hash_self(ary1, ary2);
+    }
+
+    ary3 = rb_ary_new();
     hash = ary_make_hash(ary2);
 
     for (i=0; i<RARRAY_LEN(ary1); i++) {
@@ -5936,13 +5985,14 @@ rb_ary_and(VALUE ary1, VALUE ary2)
  *  call-seq:
  *    intersection(*other_arrays) -> new_array
  *
- *  Returns a new array containing each element in +self+ that is +#eql?+
- *  to at least one element in each of the given +other_arrays+;
- *  duplicates are omitted:
+ *  Returns a new array containing the _intersection_ of +self+ and all given
+ *  +other_arrays+; that is, containing those elements found in +self+ and in
+ *  every given array. Duplicates are omitted:
  *
  *    [0, 0, 1, 1, 2, 3].intersection([0, 1, 2], [0, 1, 3]) # => [0, 1]
  *
  *  Each element must correctly implement method <tt>#hash</tt>.
+ *  Which array's elements receive <tt>#eql?</tt> is not specified.
  *
  *  Order from +self+ is preserved:
  *

--- a/benchmark/array_intersection.yml
+++ b/benchmark/array_intersection.yml
@@ -7,8 +7,37 @@ prelude: |
   big2 = [1, 2, 3] * 64
   big3 = [1, 2] * 64
 
+  # The smallest shape that reaches the hash-based paths: a user-supplied key
+  # list & model attribute names (e.g. ActiveModel#serializable_hash(only:)).
+  attr_names = (1..50).map { |i| "attribute_%02d" % i }
+  only_keys  = [1, 10, 20, 30, 40, 50].map { |i| "attribute_%02d" % i }
+
+  # Synthetic id lists, modeled on has_many collection replacement, which
+  # intersects the new and the original target arrays; all present, spread
+  # evenly.  A receiver 1/1000 as long as the argument.
+  ids_long     = Array.new(10_000) { |i| i * 3 }
+  ids_short_10 = Array.new(10) { |i| i * 30 }
+
+  # Near-equal sizes with high overlap: two similar id lists.  Stays on the
+  # existing path, and guards against the length rule flipping too early.
+  ids_near = Array.new(9_999) { |i| i * 3 }
+
+  # At the exact 2x cut, where the length rule is least informed.  With
+  # distinct values the new path builds the smaller table; with a
+  # duplicate-heavy argument the old path has less to hash, which is the
+  # least favorable measured shape for the new path.
+  ids_5k        = Array.new(5_000) { |i| i * 3 }
+  receiver_2x   = Array.new(5_000) { |i| i * 6 + 3 }
+  mixed_arg_10k = Array.new(10_000) { |i| (i % 100) * 3 }
+
 benchmark:
   small-&: small1 & small2 & small3 & small4
   small-intersection: small1.intersection(small2, small3, small4)
   big-&: big1 & big2 & big3
   big-intersection: big1.intersection(big2, big3)
+  attr-filter-6-and-50: only_keys & attr_names
+  short-receiver-10-and-10k: ids_short_10 & ids_long
+  long-receiver-control-10k-and-10: ids_long & ids_short_10
+  near-equal-10k: ids_near & ids_long
+  ratio-2.0-5000-and-10k: receiver_2x & ids_long
+  partial-dup-arg-5k-and-10k: ids_5k & mixed_arg_10k

--- a/test/ruby/test_array.rb
+++ b/test/ruby/test_array.rb
@@ -248,6 +248,153 @@ class TestArray < Test::Unit::TestCase
     assert_equal(@cls[],     @cls[ 1, 2, 3 ]*64 & @cls[ 4, 5, 6 ]*64)
   end
 
+  def test_AND_short_receiver_big_argument # '&'
+    # receiver shorter than half the argument, both above the small-array limit
+    assert_equal(@cls[*(21..30).to_a], @cls[*(1..30).to_a] & @cls[*(21..300).to_a])
+    assert_equal(@cls[], @cls[*(1..20).to_a] & @cls[*(21..220).to_a])
+
+    # threshold boundary: results agree just below, at, and above the 2x
+    # cut (test_AND_short_receiver_path_selection keeps both branches
+    # covered)
+    receiver_20 = (1..20).to_a
+    assert_equal(@cls[*receiver_20], @cls[*receiver_20] & @cls[*(1..39).to_a])
+    assert_equal(@cls[*receiver_20], @cls[*receiver_20] & @cls[*(1..40).to_a])
+    assert_equal(@cls[*receiver_20], @cls[*receiver_20] & @cls[*(1..41).to_a])
+
+    # the seen buffer above the 1024-byte ALLOCV limit goes to the heap
+    receiver_1100 = (1..1100).map { |i| "heap_#{i}" }
+    assert_equal(@cls[*receiver_1100], @cls[*receiver_1100] & @cls[*(1..2200).map { |i| "heap_#{i}" }])
+
+    # duplicates collapse to the first occurrence, order is preserved from self
+    assert_equal(@cls[5, 1, 2, 3], @cls[5, 1, 5, 2, 5, 3] * 5 & @cls[*(1..200).to_a])
+
+    # result contains self's objects (first occurrence), not the argument's
+    receiver_objects = (1..20).map { |i| i.to_s }
+    argument_objects = (1..200).map { |i| i.to_s }
+    result = @cls[*receiver_objects] & @cls[*argument_objects]
+    assert_equal(receiver_objects, result)
+    result.each_with_index { |s, i| assert_same(receiver_objects[i], s) }
+
+    # recursive arrays hash and compare on the new path
+    rec = @cls[]
+    rec << rec
+    assert_equal([rec], @cls[*[rec] * 20] & @cls[*[rec] * 40])
+  end
+
+  def test_AND_short_receiver_path_selection # '&'
+    # implementation-coverage guard, not part of the Array#& contract: it
+    # keeps the tests above from silently covering one path only.  The
+    # shapes stay well away from the 2x cut, so tuning the cut does not
+    # break them.  Update freely if the strategy changes.
+    hash_order_class = Class.new do
+      attr_reader :v
+      define_method(:initialize) { |v, log, tag| @v = v; @log = log; @tag = tag }
+      define_method(:hash) { @log << @tag; @v.hash }
+      def eql?(other); other.instance_of?(self.class) && other.v == @v; end
+    end
+    build_operand = ->(log, tag, range) { @cls[*range.map { |i| hash_order_class.new(i, log, tag) }] }
+    far_above = []
+    build_operand.call(far_above, :receiver, 1..20) & build_operand.call(far_above, :argument, 1..200)
+    assert_equal(:receiver, far_above.first) # much shorter receiver: it is hashed
+    far_below = []
+    build_operand.call(far_below, :receiver, 1..20) & build_operand.call(far_below, :argument, 1..30)
+    assert_equal(:argument, far_below.first) # comparable lengths: the argument is hashed
+  end
+
+  def test_AND_short_receiver_hash_collision # '&'
+    collision_element_class = Class.new do
+      attr_reader :x
+      def initialize(x); @x = x; end
+      def hash; 0; end
+      def eql?(other); @x == other.x; end
+    end
+    receiver_objects = (1..20).map { |i| collision_element_class.new(i) }
+    argument_objects = (1..40).map { |i| collision_element_class.new(i * 2) }
+    result = @cls[*receiver_objects] & @cls[*argument_objects]
+    assert_equal(receiver_objects.select { |o| o.x.even? }, result)
+  end
+
+  def test_AND_short_receiver_compaction # '&'
+    begin
+      GC.compact
+    rescue NotImplementedError
+      omit "GC.compact is not supported on this platform"
+    end
+    # user #hash forces compaction (with reference verification and heap
+    # expansion, so objects genuinely move) while the result array holds
+    # the receiver's candidates: halfway through the receiver, and again
+    # on the first element of the other operand.  The result must still
+    # contain the receiver's own objects in order.
+    receiver_values = (1..1200).to_a
+    argument_values = (1..2600).to_a
+    compaction_points = { receiver: receiver_values.length / 2, argument: 1 }
+    hashed = Hash.new(0)
+    compacted = []
+    element_class = Class.new do
+      define_method(:initialize) { |v, side| @v = v; @side = side }
+      attr_reader :v
+      define_method(:hash) do
+        hashed[@side] += 1
+        if hashed[@side] == compaction_points[@side]
+          compacted << @side
+          GC.verify_compaction_references(expand_heap: true, toward: :empty)
+        end
+        @v.hash
+      end
+      def eql?(other); other.instance_of?(self.class) && other.v == @v; end
+    end
+    receiver = receiver_values.map { |i| element_class.new(i, :receiver) }
+    argument = argument_values.map { |i| element_class.new(i, :argument) }
+    result = @cls[*receiver] & @cls[*argument]
+    assert_equal([:argument, :receiver], compacted.sort, "both compaction points must be reached")
+    assert_equal(receiver.length, result.length)
+    result.each_with_index { |o, i| assert_same(receiver[i], o) }
+  end
+
+  def test_AND_short_receiver_mutating_hash # '&'
+    # results under mid-operation operand mutation are unspecified; each
+    # scenario asserts that the mutating callback really ran (the latch)
+    # and that the operation completes safely: the result holds the
+    # receiver's elements in receiver order, without duplicates
+    cleared = false
+    argument_mutator = Object.new
+    mutated_argument = @cls[*(1..40).to_a]
+    argument_mutator.define_singleton_method(:hash) { cleared = true; mutated_argument.clear; 0 }
+    mutated_argument[2] = argument_mutator
+    receiver = @cls[*(1..20).to_a]
+    result = receiver & mutated_argument
+    assert(cleared, "the argument-clearing #hash did not run")
+    assert_equal(receiver.select { |e| result.include?(e) }, result)
+    assert_equal(result.uniq, result)
+
+    appended = false
+    receiver_mutator = Object.new
+    mutated_receiver = @cls[*(1..19).to_a]
+    receiver_mutator.define_singleton_method(:hash) { appended = true; mutated_receiver << 999; 0 }
+    mutated_receiver << receiver_mutator
+    result = mutated_receiver & @cls[*(1..40).to_a]
+    assert(appended, "the receiver-growing #hash did not run")
+    assert_equal(mutated_receiver.select { |e| result.include?(e) }, result)
+    assert_equal(result.uniq, result)
+
+    # a receiver element whose #hash appends a matching element to the
+    # argument while the receiver is being hashed: the scan that follows
+    # may see the grown argument and match it (hashing the argument
+    # first, as before the change, returned []); either reachable result
+    # is accepted
+    growing_argument = @cls[*(101..140).to_a]
+    added = false
+    argument_grower = Object.new
+    argument_grower.define_singleton_method(:hash) do
+      growing_argument << argument_grower unless added
+      added = true
+      0
+    end
+    result = @cls[*(1..19).to_a, argument_grower] & growing_argument
+    assert(added, "the argument-growing #hash did not run")
+    assert_include([[], [argument_grower]], result)
+  end
+
   def test_intersection
     assert_equal(@cls[1, 2], @cls[1, 2, 3].intersection(@cls[1, 2]))
     assert_equal(@cls[ ], @cls[1].intersection(@cls[ ]))
@@ -263,6 +410,7 @@ class TestArray < Test::Unit::TestCase
     assert_equal(@cls[ ], @cls[ ].intersection(@cls[1] * 64))
     assert_equal(@cls[1], (@cls[1, 2, 3] * 64).intersection((@cls[1, 2] * 64), (@cls[1] * 64)))
     assert_equal(@cls[ ], (@cls[1, 2, 3] * 64).intersection(@cls[4, 5, 6] * 64))
+    assert_equal(@cls[1, 2], (@cls[1, 2] * 32).intersection(@cls[*(1..200).to_a], @cls[*(1..50).to_a]))
   end
 
   def test_MUL # '*'


### PR DESCRIPTION
Implements [Feature #22245].

## Problem

`Array#&` returns elements in `self` order. Callers therefore cannot always swap the arrays for better performance.

On the hash-based path (taken when either array has more than 16 elements), Ruby always builds a temporary hash from the argument. As a result, `short & long` builds a large hash even though the result can contain at most the distinct elements of `short`.

## Change

When `self` is at most half as long as the argument, `rb_ary_and` now:

1. stores the first distinct objects from `self` in the result array, with a hash that maps each one to its position;
2. scans the argument, deletes each match from the hash, and marks its position;
3. compacts the marked candidates in `self` order.

For example:

```text
self candidates:      [A(self), B(self), C(self)]
temporary hash:       {A(self) => 0, B(self) => 1, C(self) => 2}
argument match order: C(argument), A(argument)
seen:                 [true, false, true]
result:               [A(self), C(self)]
```

This keeps the returned objects, order, and duplicate removal unchanged for built-in values and well-behaved custom equality methods.

The new path allocates one `ALLOCV_N` buffer, also sized by `len(self)`, for the seen flags. Together with the hash and result array, its extra memory stays proportional to the shorter array.

The `2x` threshold keeps near-equal arrays on the current path. It is an empirical starting point, not an API rule. [Feature #22245] records the benchmark rationale.

`Array#intersection` uses `rb_ary_and` and gets the same change.

## Observable behavior

The current path hashes the argument and probes with elements from `self`. The new path hashes `self` and probes with elements from the argument. For stable, side-effect-free methods, the hash-based paths make the same number of `#hash` calls. The receiver, order, and number of `#eql?` calls can change; mutation or exceptions can also change how many calls complete.

The RDoc for `Array#&` and `Array#intersection` no longer specifies which array's elements receive `#eql?`. The result from `self` remains specified. [Feature #22245] contains a `SimpleDelegator` example for asymmetric equality and discusses mutation, exceptions, and object lifetime.

## Main results

Benchmarks used the same Ruby commit with and without the patch on macOS arm64 and Ubuntu 24.04 x86-64. Reproduce with `make benchmark ITEM=array_intersection COMPARE_RUBY=<ruby without the patch>`.

| Case | Change (macOS arm64) |
|---|---:|
| `attr-filter-6-and-50` | ~1.77x |
| `short-receiver-10-and-10k` | ~2.74x |
| `partial-dup-arg-5k-and-10k` | ~0.64x |

The last row is the known duplicate-heavy trade-off below.

In three adjacent Linux x86-64 rounds with reversed executable order, the first two shapes improved by 1.66x and 2.46x. Other id-list shapes moved by 1.11-1.23x, but small-array controls that never enter the new branch moved by 8-16% in the same rounds, so I make no threshold claim from those smaller deltas.

`1000 & 10_000_000` reduced peak RSS from about 465 MB to about 94 MB.

With unmodified Rails 8.1 Active Model code, an `ActiveModel#serializable_hash(only: 6 of 50 attributes)` benchmark improved from about 3.6 µs to about 2.8 µs per call. The control path without `only:` did not change.

The unmodified `ruby/ruby-bench` Lobsters workload, with Rails 8.1.1, executed the new branch 152 times across application boot and three iterations; 150 calls came from Active Model serialization. Six clean alternating A/B batches found no detectable whole-workload change.

## Trade-offs

The choice uses lengths, not the number of distinct values. A long argument with few distinct values can be cheaper to hash than a shorter distinct `self`. The benchmark file includes that shape as `partial-dup-arg-5k-and-10k`. Its mirror, a duplicate-heavy `self` against a long distinct argument, becomes faster with this change.

Hash-collision sensitivity moves from the argument to `self` on the new path. The worst-case complexity does not change, but different input can trigger it. [Feature #22245] gives measurements for both trade-offs.

## Safety

User `#hash` and `#eql?` methods can run the GC or mutate either array. The new helper saves the initial length of `self` as `capa`. Its candidate loop checks both the current length and `i < capa`, so callback-driven growth cannot write past the result array or `seen`.

Candidate slots use `RB_OBJ_WRITE` before `ARY_SET_LEN`. The final compaction only moves references already held by the result array, then `ary_resize_smaller` sets its length. The only raw buffer contains `bool` flags, not Ruby object references.

## Tests

Tests cover:

- both sides of the `2x` threshold;
- duplicates and hash collisions;
- recursive arrays and Array subclasses;
- mutation during `#hash`;
- GC compaction during the new hash path.

The strategy-specific tests are marked as implementation guards. They can be updated if Ruby later chooses another result-equivalent strategy.

`ruby/test_array.rb` and `spec/ruby/core/array` pass. A randomized differential run of about 1,500 mixed-type cases, both array orders, and multi-argument forms produced identical results against current Ruby.
