### PR TITLE
Shrink iseq->body struct: allocate iseq->body->variable lazily

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -359,7 +359,7 @@ ast_s_of(rb_execution_context_t *ec, VALUE module, VALUE body, VALUE keep_script
         rb_raise(rb_eRuntimeError, "cannot get AST for ISEQ compiled by prism");
     }
 
-    lines = ISEQ_BODY(iseq)->variable ? ISEQ_BODY(iseq)->variable->script_lines : Qnil;
+    lines = ISEQ_SCRIPT_LINES(iseq);
 
     VALUE path = rb_iseq_path(iseq);
     int e_option = RSTRING_LEN(path) == 2 && memcmp(RSTRING_PTR(path), "-e", 2) == 0;

--- a/ast.c
+++ b/ast.c
@@ -359,7 +359,7 @@ ast_s_of(rb_execution_context_t *ec, VALUE module, VALUE body, VALUE keep_script
         rb_raise(rb_eRuntimeError, "cannot get AST for ISEQ compiled by prism");
     }
 
-    lines = ISEQ_BODY(iseq)->variable.script_lines;
+    lines = ISEQ_BODY(iseq)->variable ? ISEQ_BODY(iseq)->variable->script_lines : Qnil;
 
     VALUE path = rb_iseq_path(iseq);
     int e_option = RSTRING_LEN(path) == 2 && memcmp(RSTRING_PTR(path), "-e", 2) == 0;

--- a/compile.c
+++ b/compile.c
@@ -1015,7 +1015,7 @@ rb_iseq_translate_threaded_code(rb_iseq_t *iseq)
 VALUE *
 rb_iseq_original_iseq(const rb_iseq_t *iseq) /* cold path */
 {
-    struct rb_iseq_variable *v = ISEQ_BODY(iseq)->variable;
+    struct rb_iseq_variable *v = ISEQ_VARIABLE(iseq);
     VALUE *original_code = v ? RUBY_ATOMIC_PTR_LOAD(v->original_iseq) : NULL;
 
     if (original_code) return original_code;
@@ -1532,7 +1532,7 @@ new_child_iseq(rb_iseq_t *iseq, const NODE *const node,
                                     line_no, parent,
                                     isolated_depth ? isolated_depth + 1 : 0,
                                     type, ISEQ_COMPILE_DATA(iseq)->option,
-                                    ISEQ_BODY(iseq)->variable ? ISEQ_BODY(iseq)->variable->script_lines : Qnil);
+                                    ISEQ_SCRIPT_LINES(iseq));
     debugs("[new_child_iseq]< ---------------------------------------\n");
     return ret_iseq;
 }
@@ -9447,7 +9447,7 @@ compile_builtin_mandatory_only_method(rb_iseq_t *iseq, const NODE *node, const N
                            rb_iseq_path(iseq), rb_iseq_realpath(iseq),
                            nd_line(line_node), NULL, 0,
                            ISEQ_TYPE_METHOD, ISEQ_COMPILE_DATA(iseq)->option,
-                           ISEQ_BODY(iseq)->variable ? ISEQ_BODY(iseq)->variable->script_lines : Qnil);
+                           ISEQ_SCRIPT_LINES(iseq));
     RB_OBJ_WRITE(iseq, &ISEQ_BODY(iseq)->mandatory_only_iseq, (VALUE)mandatory_only_iseq);
 
     ALLOCV_END(idtmp);
@@ -13820,7 +13820,7 @@ ibf_dump_iseq_each(struct ibf_dump *dump, const rb_iseq_t *iseq)
     ibf_dump_write_small_value(dump, mandatory_only_iseq_index);
     ibf_dump_write_small_value(dump, IBF_BODY_OFFSET(ci_entries_offset));
     ibf_dump_write_small_value(dump, IBF_BODY_OFFSET(outer_variables_offset));
-    ibf_dump_write_small_value(dump, body->variable ? body->variable->flip_count : 0);
+    ibf_dump_write_small_value(dump, ISEQ_FLIP_CNT(iseq));
     ibf_dump_write_small_value(dump, body->local_table_size);
     ibf_dump_write_small_value(dump, body->ivc_size);
     ibf_dump_write_small_value(dump, body->icvarc_size);
@@ -15242,7 +15242,7 @@ rb_iseq_dup_with_independent_caches(const rb_iseq_t *src_root)
         struct rb_iseq_constant_body *cb = ISEQ_BODY(copy);
         if (!cb->local_iseq) RB_OBJ_WRITE(copy, &cb->local_iseq, sb->local_iseq);
         RB_OBJ_WRITE(copy, &cb->location.pathobj, sb->location.pathobj);
-        VALUE sl = sb->variable ? sb->variable->script_lines : Qnil;
+        VALUE sl = ISEQ_SCRIPT_LINES(src_root);
         VALUE cov = ISEQ_COVERAGE(src_root);
         if (!NIL_P(sl) || !NIL_P(cov)) {
             struct rb_iseq_variable *v = rb_iseq_variable_ensure(copy);

--- a/compile.c
+++ b/compile.c
@@ -1015,7 +1015,8 @@ rb_iseq_translate_threaded_code(rb_iseq_t *iseq)
 VALUE *
 rb_iseq_original_iseq(const rb_iseq_t *iseq) /* cold path */
 {
-    VALUE *original_code = RUBY_ATOMIC_PTR_LOAD(ISEQ_BODY(iseq)->variable.original_iseq);
+    struct rb_iseq_variable *v = ISEQ_BODY(iseq)->variable;
+    VALUE *original_code = v ? RUBY_ATOMIC_PTR_LOAD(v->original_iseq) : NULL;
 
     if (original_code) return original_code;
     original_code = ALLOC_N(VALUE, ISEQ_BODY(iseq)->iseq_size);
@@ -1037,7 +1038,8 @@ rb_iseq_original_iseq(const rb_iseq_t *iseq) /* cold path */
 
     /* Concurrent callers can each build a copy; publish only fully
      * translated code and keep the first one. */
-    VALUE *prev = ATOMIC_PTR_CAS(ISEQ_BODY(iseq)->variable.original_iseq,
+    v = rb_iseq_variable_ensure((rb_iseq_t *)iseq);
+    VALUE *prev = ATOMIC_PTR_CAS(v->original_iseq,
                                  NULL, original_code);
     if (prev) {
         SIZED_FREE_N(original_code, ISEQ_BODY(iseq)->iseq_size);
@@ -1530,7 +1532,7 @@ new_child_iseq(rb_iseq_t *iseq, const NODE *const node,
                                     line_no, parent,
                                     isolated_depth ? isolated_depth + 1 : 0,
                                     type, ISEQ_COMPILE_DATA(iseq)->option,
-                                    ISEQ_BODY(iseq)->variable.script_lines);
+                                    ISEQ_BODY(iseq)->variable ? ISEQ_BODY(iseq)->variable->script_lines : Qnil);
     debugs("[new_child_iseq]< ---------------------------------------\n");
     return ret_iseq;
 }
@@ -9445,7 +9447,7 @@ compile_builtin_mandatory_only_method(rb_iseq_t *iseq, const NODE *node, const N
                            rb_iseq_path(iseq), rb_iseq_realpath(iseq),
                            nd_line(line_node), NULL, 0,
                            ISEQ_TYPE_METHOD, ISEQ_COMPILE_DATA(iseq)->option,
-                           ISEQ_BODY(iseq)->variable.script_lines);
+                           ISEQ_BODY(iseq)->variable ? ISEQ_BODY(iseq)->variable->script_lines : Qnil);
     RB_OBJ_WRITE(iseq, &ISEQ_BODY(iseq)->mandatory_only_iseq, (VALUE)mandatory_only_iseq);
 
     ALLOCV_END(idtmp);
@@ -13818,7 +13820,7 @@ ibf_dump_iseq_each(struct ibf_dump *dump, const rb_iseq_t *iseq)
     ibf_dump_write_small_value(dump, mandatory_only_iseq_index);
     ibf_dump_write_small_value(dump, IBF_BODY_OFFSET(ci_entries_offset));
     ibf_dump_write_small_value(dump, IBF_BODY_OFFSET(outer_variables_offset));
-    ibf_dump_write_small_value(dump, body->variable.flip_count);
+    ibf_dump_write_small_value(dump, body->variable ? body->variable->flip_count : 0);
     ibf_dump_write_small_value(dump, body->local_table_size);
     ibf_dump_write_small_value(dump, body->ivc_size);
     ibf_dump_write_small_value(dump, body->icvarc_size);
@@ -14010,10 +14012,12 @@ ibf_load_iseq_each(struct ibf_load *load, rb_iseq_t *iseq, ibf_offset_t offset)
     load_body->ci_size = ci_size;
     load_body->insns_info.size = insns_info_size;
 
-    ISEQ_COVERAGE_SET(iseq, Qnil);
+    // variable is NULL from ZALLOC; only allocate if flip_count is non-zero.
     ISEQ_ORIGINAL_ISEQ_CLEAR(iseq);
-    load_body->variable.flip_count = variable_flip_count;
-    load_body->variable.script_lines = Qnil;
+    if (variable_flip_count) {
+        struct rb_iseq_variable *v = rb_iseq_variable_ensure(iseq);
+        v->flip_count = variable_flip_count;
+    }
 
     load_body->location.first_lineno = location_first_lineno;
     load_body->location.node_id = location_node_id;
@@ -15238,8 +15242,13 @@ rb_iseq_dup_with_independent_caches(const rb_iseq_t *src_root)
         struct rb_iseq_constant_body *cb = ISEQ_BODY(copy);
         if (!cb->local_iseq) RB_OBJ_WRITE(copy, &cb->local_iseq, sb->local_iseq);
         RB_OBJ_WRITE(copy, &cb->location.pathobj, sb->location.pathobj);
-        RB_OBJ_WRITE(copy, &cb->variable.script_lines, sb->variable.script_lines);
-        ISEQ_COVERAGE_SET(copy, ISEQ_COVERAGE(src_root));
+        VALUE sl = sb->variable ? sb->variable->script_lines : Qnil;
+        VALUE cov = ISEQ_COVERAGE(src_root);
+        if (!NIL_P(sl) || !NIL_P(cov)) {
+            struct rb_iseq_variable *v = rb_iseq_variable_ensure(copy);
+            RB_OBJ_WRITE(copy, &v->script_lines, sl);
+            RB_OBJ_WRITE(copy, &v->coverage, cov);
+        }
 
         if (i == 0) {
             RB_OBJ_WRITE(copy, &cb->parent_iseq, sb->parent_iseq);

--- a/iseq.c
+++ b/iseq.c
@@ -219,6 +219,7 @@ rb_iseq_free(const rb_iseq_t *iseq)
         }
 
         ISEQ_ORIGINAL_ISEQ_CLEAR(iseq);
+        if (body->variable) xfree(body->variable);
 
         struct rb_iseq_param_keyword *pkw = (struct rb_iseq_param_keyword *)body->param.keyword;
         if (pkw != NULL) {
@@ -240,6 +241,51 @@ rb_iseq_free(const rb_iseq_t *iseq)
     }
 
     RUBY_FREE_LEAVE("iseq");
+}
+
+/* CAS-publish the out-of-lined variable struct: concurrent callers (e.g. two
+ * dumpers hitting rb_iseq_original_iseq on a shared iseq) can each build a
+ * copy, mirroring the original_iseq CAS in compile.c. */
+struct rb_iseq_variable *
+rb_iseq_variable_ensure(rb_iseq_t *iseq)
+{
+    struct rb_iseq_variable *v = ISEQ_BODY(iseq)->variable;
+    if (v) return v;
+    v = ALLOC(struct rb_iseq_variable);
+    v->flip_count = 0;
+    v->script_lines = Qnil;
+    v->coverage = Qnil;
+    v->pc2branchindex = Qnil;
+    v->original_iseq = NULL;
+    struct rb_iseq_variable *prev = ATOMIC_PTR_CAS(ISEQ_BODY(iseq)->variable, NULL, v);
+    if (prev) {
+        xfree(v);
+        v = prev;
+    }
+    return v;
+}
+
+void
+rb_iseq_coverage_set(rb_iseq_t *iseq, VALUE cov)
+{
+    struct rb_iseq_variable *v = rb_iseq_variable_ensure(iseq);
+    RB_OBJ_WRITE(iseq, &v->coverage, cov);
+}
+
+void
+rb_iseq_pc2branchindex_set(rb_iseq_t *iseq, VALUE h)
+{
+    struct rb_iseq_variable *v = rb_iseq_variable_ensure(iseq);
+    RB_OBJ_WRITE(iseq, &v->pc2branchindex, h);
+}
+
+rb_snum_t
+rb_iseq_flip_cnt_increment(const rb_iseq_t *iseq)
+{
+    struct rb_iseq_variable *v = rb_iseq_variable_ensure((rb_iseq_t *)iseq);
+    rb_snum_t cnt = v->flip_count;
+    v->flip_count += 1;
+    return cnt;
 }
 
 typedef VALUE iseq_value_itr_t(void *ctx, VALUE obj);
@@ -377,7 +423,7 @@ rb_iseq_mark_and_move(rb_iseq_t *iseq, bool reference_updating)
 
         rb_iseq_mark_and_move_each_body_value(iseq, reference_updating ? ISEQ_ORIGINAL_ISEQ(iseq) : NULL);
 
-        rb_gc_mark_and_move(&body->variable.script_lines);
+        if (body->variable) rb_gc_mark_and_move(&body->variable->script_lines);
         rb_gc_mark_and_move(&body->location.label);
         rb_gc_mark_and_move(&body->location.base_label);
         rb_gc_mark_and_move(&body->location.pathobj);
@@ -489,8 +535,10 @@ rb_iseq_mark_and_move(rb_iseq_t *iseq, bool reference_updating)
 
         // TODO: ractor aware coverage
         if (!rb_gc_checking_shareable()) {
-            rb_gc_mark_and_move(&body->variable.coverage);
-            rb_gc_mark_and_move(&body->variable.pc2branchindex);
+            if (body->variable) {
+                rb_gc_mark_and_move(&body->variable->coverage);
+                rb_gc_mark_and_move(&body->variable->pc2branchindex);
+            }
         }
     }
 
@@ -542,6 +590,7 @@ rb_iseq_memsize(const rb_iseq_t *iseq)
 
     if (ISEQ_EXECUTABLE_P(iseq) && body) {
         size += sizeof(struct rb_iseq_constant_body);
+        if (body->variable) size += sizeof(struct rb_iseq_variable);
         size += body->iseq_size * sizeof(VALUE);
         size += body->insns_info.size * (sizeof(struct iseq_insn_info_entry) + sizeof(unsigned int));
         size += body->local_table_size * sizeof(ID); // body->local_table
@@ -759,15 +808,19 @@ prepare_iseq_build(rb_iseq_t *iseq,
     if (iseq != body->local_iseq) {
         RB_OBJ_WRITE(iseq, &body->location.base_label, ISEQ_BODY(body->local_iseq)->location.label);
     }
-    ISEQ_COVERAGE_SET(iseq, Qnil);
+    // variable is NULL from ZALLOC; accessors return the correct defaults
+    // (coverage=Qnil, flip_count=0, script_lines=Qnil, original_iseq=NULL).
+    // Only reset fields on an already-allocated variable (re-compilation).
     ISEQ_ORIGINAL_ISEQ_CLEAR(iseq);
-    body->variable.flip_count = 0;
-
-    if (NIL_P(script_lines)) {
-        RB_OBJ_WRITE(iseq, &body->variable.script_lines, Qnil);
+    if (body->variable) {
+        body->variable->flip_count = 0;
+        RB_OBJ_WRITE(iseq, &body->variable->script_lines, Qnil);
+        RB_OBJ_WRITE(iseq, &body->variable->coverage, Qnil);
     }
-    else {
-        RB_OBJ_WRITE(iseq, &body->variable.script_lines, rb_ractor_make_shareable(script_lines));
+
+    if (!NIL_P(script_lines)) {
+        struct rb_iseq_variable *v = rb_iseq_variable_ensure(iseq);
+        RB_OBJ_WRITE(iseq, &v->script_lines, rb_ractor_make_shareable(script_lines));
     }
 
     ISEQ_COMPILE_DATA_ALLOC(iseq);
@@ -1130,7 +1183,7 @@ rb_iseq_new_with_opt(VALUE ast_value, VALUE name, VALUE path, VALUE realpath,
         script_lines = rb_parser_build_script_lines_from(body->script_lines);
     }
     else if (parent) {
-        script_lines = ISEQ_BODY(parent)->variable.script_lines;
+        script_lines = ISEQ_BODY(parent)->variable ? ISEQ_BODY(parent)->variable->script_lines : Qnil;
     }
 
     prepare_iseq_build(iseq, name, path, realpath, first_lineno, node ? &node->nd_loc : NULL, prepare_node_id(node),
@@ -4596,7 +4649,7 @@ static VALUE
 iseqw_script_lines(VALUE self)
 {
     const rb_iseq_t *iseq = iseqw_check(self);
-    return ISEQ_BODY(iseq)->variable.script_lines;
+    return ISEQ_BODY(iseq)->variable ? ISEQ_BODY(iseq)->variable->script_lines : Qnil;
 }
 
 /* Returns the hash of the source this iseq was compiled from, or nil if it

--- a/iseq.c
+++ b/iseq.c
@@ -249,13 +249,13 @@ rb_iseq_free(const rb_iseq_t *iseq)
 struct rb_iseq_variable *
 rb_iseq_variable_ensure(rb_iseq_t *iseq)
 {
-    struct rb_iseq_variable *v = ISEQ_BODY(iseq)->variable;
+    struct rb_iseq_variable *v = ISEQ_VARIABLE(iseq);
     if (v) return v;
     v = ALLOC(struct rb_iseq_variable);
     v->flip_count = 0;
     v->script_lines = Qnil;
-    v->coverage = Qnil;
-    v->pc2branchindex = Qnil;
+    v->coverage = Qfalse;
+    v->pc2branchindex = Qfalse;
     v->original_iseq = NULL;
     struct rb_iseq_variable *prev = ATOMIC_PTR_CAS(ISEQ_BODY(iseq)->variable, NULL, v);
     if (prev) {
@@ -268,6 +268,7 @@ rb_iseq_variable_ensure(rb_iseq_t *iseq)
 void
 rb_iseq_coverage_set(rb_iseq_t *iseq, VALUE cov)
 {
+    if (!RTEST(cov) && !ISEQ_VARIABLE(iseq)) return;
     struct rb_iseq_variable *v = rb_iseq_variable_ensure(iseq);
     RB_OBJ_WRITE(iseq, &v->coverage, cov);
 }
@@ -275,6 +276,7 @@ rb_iseq_coverage_set(rb_iseq_t *iseq, VALUE cov)
 void
 rb_iseq_pc2branchindex_set(rb_iseq_t *iseq, VALUE h)
 {
+    if (!RTEST(h) && !ISEQ_VARIABLE(iseq)) return;
     struct rb_iseq_variable *v = rb_iseq_variable_ensure(iseq);
     RB_OBJ_WRITE(iseq, &v->pc2branchindex, h);
 }
@@ -423,7 +425,8 @@ rb_iseq_mark_and_move(rb_iseq_t *iseq, bool reference_updating)
 
         rb_iseq_mark_and_move_each_body_value(iseq, reference_updating ? ISEQ_ORIGINAL_ISEQ(iseq) : NULL);
 
-        if (body->variable) rb_gc_mark_and_move(&body->variable->script_lines);
+        struct rb_iseq_variable *v = ISEQ_VARIABLE(iseq);
+        if (v) rb_gc_mark_and_move(&v->script_lines);
         rb_gc_mark_and_move(&body->location.label);
         rb_gc_mark_and_move(&body->location.base_label);
         rb_gc_mark_and_move(&body->location.pathobj);
@@ -535,9 +538,9 @@ rb_iseq_mark_and_move(rb_iseq_t *iseq, bool reference_updating)
 
         // TODO: ractor aware coverage
         if (!rb_gc_checking_shareable()) {
-            if (body->variable) {
-                rb_gc_mark_and_move(&body->variable->coverage);
-                rb_gc_mark_and_move(&body->variable->pc2branchindex);
+            if (v) {
+                rb_gc_mark_and_move(&v->coverage);
+                rb_gc_mark_and_move(&v->pc2branchindex);
             }
         }
     }
@@ -808,9 +811,6 @@ prepare_iseq_build(rb_iseq_t *iseq,
     if (iseq != body->local_iseq) {
         RB_OBJ_WRITE(iseq, &body->location.base_label, ISEQ_BODY(body->local_iseq)->location.label);
     }
-    // variable is NULL from ZALLOC; accessors return the correct defaults
-    // (coverage=Qnil, flip_count=0, script_lines=Qnil, original_iseq=NULL).
-    // Only reset fields on an already-allocated variable (re-compilation).
     ISEQ_ORIGINAL_ISEQ_CLEAR(iseq);
     if (body->variable) {
         body->variable->flip_count = 0;
@@ -1183,7 +1183,7 @@ rb_iseq_new_with_opt(VALUE ast_value, VALUE name, VALUE path, VALUE realpath,
         script_lines = rb_parser_build_script_lines_from(body->script_lines);
     }
     else if (parent) {
-        script_lines = ISEQ_BODY(parent)->variable ? ISEQ_BODY(parent)->variable->script_lines : Qnil;
+        script_lines = ISEQ_SCRIPT_LINES(parent);
     }
 
     prepare_iseq_build(iseq, name, path, realpath, first_lineno, node ? &node->nd_loc : NULL, prepare_node_id(node),
@@ -1680,7 +1680,9 @@ remove_coverage_i(void *vstart, void *vend, size_t stride, void *data)
 
         if (rb_obj_is_iseq(v)) {
             rb_iseq_t *iseq = (rb_iseq_t *)v;
-            ISEQ_COVERAGE_SET(iseq, Qnil);
+            if (ISEQ_VARIABLE(iseq)) {
+                ISEQ_COVERAGE_SET(iseq, Qnil);
+            }
         }
 
         asan_poison_object_if(ptr, v);
@@ -4649,7 +4651,7 @@ static VALUE
 iseqw_script_lines(VALUE self)
 {
     const rb_iseq_t *iseq = iseqw_check(self);
-    return ISEQ_BODY(iseq)->variable ? ISEQ_BODY(iseq)->variable->script_lines : Qnil;
+    return ISEQ_SCRIPT_LINES(iseq);
 }
 
 /* Returns the hash of the source this iseq was compiled from, or nil if it

--- a/iseq.h
+++ b/iseq.h
@@ -58,41 +58,45 @@ typedef void (*rb_iseq_callback)(const rb_iseq_t *, void *);
 
 extern const ID rb_iseq_shared_exc_local_tbl[];
 
-#define ISEQ_COVERAGE(iseq)           ISEQ_BODY(iseq)->variable.coverage
-#define ISEQ_COVERAGE_SET(iseq, cov)  RB_OBJ_WRITE(iseq, &ISEQ_BODY(iseq)->variable.coverage, cov)
+/* Ensure body->variable is allocated, returning the struct. */
+struct rb_iseq_variable *rb_iseq_variable_ensure(rb_iseq_t *iseq);
+
+#define ISEQ_COVERAGE(iseq) \
+    (ISEQ_BODY(iseq)->variable ? ISEQ_BODY(iseq)->variable->coverage : Qnil)
+void rb_iseq_coverage_set(rb_iseq_t *iseq, VALUE cov);
+#define ISEQ_COVERAGE_SET(iseq, cov) rb_iseq_coverage_set(iseq, cov)
 #define ISEQ_LINE_COVERAGE(iseq)      RARRAY_AREF(ISEQ_COVERAGE(iseq), COVERAGE_INDEX_LINES)
 #define ISEQ_BRANCH_COVERAGE(iseq)    RARRAY_AREF(ISEQ_COVERAGE(iseq), COVERAGE_INDEX_BRANCHES)
 
-#define ISEQ_PC2BRANCHINDEX(iseq)         ISEQ_BODY(iseq)->variable.pc2branchindex
-#define ISEQ_PC2BRANCHINDEX_SET(iseq, h)  RB_OBJ_WRITE(iseq, &ISEQ_BODY(iseq)->variable.pc2branchindex, h)
+#define ISEQ_PC2BRANCHINDEX(iseq) \
+    (ISEQ_BODY(iseq)->variable ? ISEQ_BODY(iseq)->variable->pc2branchindex : Qnil)
+void rb_iseq_pc2branchindex_set(rb_iseq_t *iseq, VALUE h);
+#define ISEQ_PC2BRANCHINDEX_SET(iseq, h) rb_iseq_pc2branchindex_set(iseq, h)
 
-#define ISEQ_FLIP_CNT(iseq) ISEQ_BODY(iseq)->variable.flip_count
+#define ISEQ_FLIP_CNT(iseq) \
+    (ISEQ_BODY(iseq)->variable ? ISEQ_BODY(iseq)->variable->flip_count : 0)
+rb_snum_t rb_iseq_flip_cnt_increment(const rb_iseq_t *iseq);
+#define ISEQ_FLIP_CNT_INCREMENT(iseq) rb_iseq_flip_cnt_increment(iseq)
 
 #define ISEQ_FROZEN_STRING_LITERAL_ENABLED 1
 #define ISEQ_FROZEN_STRING_LITERAL_DISABLED 0
 #define ISEQ_FROZEN_STRING_LITERAL_UNSET -1
 
-static inline rb_snum_t
-ISEQ_FLIP_CNT_INCREMENT(const rb_iseq_t *iseq)
-{
-    rb_snum_t cnt = ISEQ_BODY(iseq)->variable.flip_count;
-    ISEQ_BODY(iseq)->variable.flip_count += 1;
-    return cnt;
-}
-
 static inline VALUE *
 ISEQ_ORIGINAL_ISEQ(const rb_iseq_t *iseq)
 {
-    return ISEQ_BODY(iseq)->variable.original_iseq;
+    return ISEQ_BODY(iseq)->variable ? ISEQ_BODY(iseq)->variable->original_iseq : NULL;
 }
 
 static inline void
 ISEQ_ORIGINAL_ISEQ_CLEAR(const rb_iseq_t *iseq)
 {
-    VALUE *ptr = (VALUE *)ISEQ_BODY(iseq)->variable.original_iseq;
-    if (ptr) {
-        ISEQ_BODY(iseq)->variable.original_iseq = NULL;
-        SIZED_FREE_N(ptr, ISEQ_BODY(iseq)->iseq_size);
+    if (ISEQ_BODY(iseq)->variable) {
+        VALUE *ptr = ISEQ_BODY(iseq)->variable->original_iseq;
+        if (ptr) {
+            ISEQ_BODY(iseq)->variable->original_iseq = NULL;
+            SIZED_FREE_N(ptr, ISEQ_BODY(iseq)->iseq_size);
+        }
     }
 }
 

--- a/iseq.h
+++ b/iseq.h
@@ -61,40 +61,80 @@ extern const ID rb_iseq_shared_exc_local_tbl[];
 /* Ensure body->variable is allocated, returning the struct. */
 struct rb_iseq_variable *rb_iseq_variable_ensure(rb_iseq_t *iseq);
 
-#define ISEQ_COVERAGE(iseq) \
-    (ISEQ_BODY(iseq)->variable ? ISEQ_BODY(iseq)->variable->coverage : Qnil)
+static inline struct rb_iseq_variable *
+ISEQ_BODY_VARIABLE(const rb_iseq_t *iseq)
+{
+    return ISEQ_BODY(iseq)->variable;
+}
+
+/* NULL-safe read accessors for body->variable fields. */
+static inline VALUE
+ISEQ_BODY_VARIABLE_SCRIPT_LINES(const rb_iseq_t *iseq)
+{
+    struct rb_iseq_variable *v = ISEQ_BODY_VARIABLE(iseq);
+    return v ? v->script_lines : Qnil;
+}
+
+static inline VALUE
+ISEQ_BODY_VARIABLE_COVERAGE(const rb_iseq_t *iseq)
+{
+    struct rb_iseq_variable *v = ISEQ_BODY_VARIABLE(iseq);
+    return v ? v->coverage : Qfalse;
+}
+
+static inline VALUE
+ISEQ_BODY_VARIABLE_PC2BRANCHINDEX(const rb_iseq_t *iseq)
+{
+    struct rb_iseq_variable *v = ISEQ_BODY_VARIABLE(iseq);
+    return v ? v->pc2branchindex : Qfalse;
+}
+
+static inline rb_snum_t
+ISEQ_BODY_VARIABLE_FLIP_CNT(const rb_iseq_t *iseq)
+{
+    struct rb_iseq_variable *v = ISEQ_BODY_VARIABLE(iseq);
+    return v ? v->flip_count : 0;
+}
+
+static inline VALUE *
+ISEQ_BODY_VARIABLE_ORIGINAL_ISEQ(const rb_iseq_t *iseq)
+{
+    struct rb_iseq_variable *v = ISEQ_BODY_VARIABLE(iseq);
+    return v ? v->original_iseq : NULL;
+}
+
+/* Write accessors (lazily allocate variable as needed). */
 void rb_iseq_coverage_set(rb_iseq_t *iseq, VALUE cov);
-#define ISEQ_COVERAGE_SET(iseq, cov) rb_iseq_coverage_set(iseq, cov)
+void rb_iseq_pc2branchindex_set(rb_iseq_t *iseq, VALUE h);
+rb_snum_t rb_iseq_flip_cnt_increment(const rb_iseq_t *iseq);
+
+/* Short macros for reading variable fields. */
+#define ISEQ_VARIABLE(iseq)           ISEQ_BODY_VARIABLE(iseq)
+#define ISEQ_SCRIPT_LINES(iseq)       ISEQ_BODY_VARIABLE_SCRIPT_LINES(iseq)
+#define ISEQ_COVERAGE(iseq)           ISEQ_BODY_VARIABLE_COVERAGE(iseq)
+#define ISEQ_COVERAGE_SET(iseq, cov)  rb_iseq_coverage_set(iseq, cov)
 #define ISEQ_LINE_COVERAGE(iseq)      RARRAY_AREF(ISEQ_COVERAGE(iseq), COVERAGE_INDEX_LINES)
 #define ISEQ_BRANCH_COVERAGE(iseq)    RARRAY_AREF(ISEQ_COVERAGE(iseq), COVERAGE_INDEX_BRANCHES)
 
-#define ISEQ_PC2BRANCHINDEX(iseq) \
-    (ISEQ_BODY(iseq)->variable ? ISEQ_BODY(iseq)->variable->pc2branchindex : Qnil)
-void rb_iseq_pc2branchindex_set(rb_iseq_t *iseq, VALUE h);
-#define ISEQ_PC2BRANCHINDEX_SET(iseq, h) rb_iseq_pc2branchindex_set(iseq, h)
+#define ISEQ_PC2BRANCHINDEX(iseq)       ISEQ_BODY_VARIABLE_PC2BRANCHINDEX(iseq)
+#define ISEQ_PC2BRANCHINDEX_SET(iseq,h) rb_iseq_pc2branchindex_set(iseq, h)
 
-#define ISEQ_FLIP_CNT(iseq) \
-    (ISEQ_BODY(iseq)->variable ? ISEQ_BODY(iseq)->variable->flip_count : 0)
-rb_snum_t rb_iseq_flip_cnt_increment(const rb_iseq_t *iseq);
-#define ISEQ_FLIP_CNT_INCREMENT(iseq) rb_iseq_flip_cnt_increment(iseq)
+#define ISEQ_FLIP_CNT(iseq)             ISEQ_BODY_VARIABLE_FLIP_CNT(iseq)
+#define ISEQ_FLIP_CNT_INCREMENT(iseq)   rb_iseq_flip_cnt_increment(iseq)
+#define ISEQ_ORIGINAL_ISEQ(iseq)        ISEQ_BODY_VARIABLE_ORIGINAL_ISEQ(iseq)
 
 #define ISEQ_FROZEN_STRING_LITERAL_ENABLED 1
 #define ISEQ_FROZEN_STRING_LITERAL_DISABLED 0
 #define ISEQ_FROZEN_STRING_LITERAL_UNSET -1
 
-static inline VALUE *
-ISEQ_ORIGINAL_ISEQ(const rb_iseq_t *iseq)
-{
-    return ISEQ_BODY(iseq)->variable ? ISEQ_BODY(iseq)->variable->original_iseq : NULL;
-}
-
 static inline void
 ISEQ_ORIGINAL_ISEQ_CLEAR(const rb_iseq_t *iseq)
 {
-    if (ISEQ_BODY(iseq)->variable) {
-        VALUE *ptr = ISEQ_BODY(iseq)->variable->original_iseq;
+    struct rb_iseq_variable *v = ISEQ_BODY_VARIABLE(iseq);
+    if (v) {
+        VALUE *ptr = v->original_iseq;
         if (ptr) {
-            ISEQ_BODY(iseq)->variable->original_iseq = NULL;
+            v->original_iseq = NULL;
             SIZED_FREE_N(ptr, ISEQ_BODY(iseq)->iseq_size);
         }
     }

--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -560,7 +560,7 @@ location_source_first_lineno(const rb_iseq_t *iseq, VALUE script_lines)
 
     while (ISEQ_BODY(source_iseq)->parent_iseq) {
         const rb_iseq_t *parent = ISEQ_BODY(source_iseq)->parent_iseq;
-        if (ISEQ_BODY(parent)->variable.script_lines != script_lines) break;
+        if ((ISEQ_BODY(parent)->variable ? ISEQ_BODY(parent)->variable->script_lines : Qnil) != script_lines) break;
         source_iseq = parent;
     }
 
@@ -608,7 +608,7 @@ location_source_range_m(VALUE self)
 
     VALUE path = rb_iseq_path(iseq);
     VALUE absolute_path = rb_iseq_realpath(iseq);
-    VALUE script_lines = ISEQ_BODY(iseq)->variable.script_lines;
+    VALUE script_lines = ISEQ_BODY(iseq)->variable ? ISEQ_BODY(iseq)->variable->script_lines : Qnil;
     VALUE source;
     VALUE parser_path = path;
     int first_lineno = 1;

--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -560,7 +560,7 @@ location_source_first_lineno(const rb_iseq_t *iseq, VALUE script_lines)
 
     while (ISEQ_BODY(source_iseq)->parent_iseq) {
         const rb_iseq_t *parent = ISEQ_BODY(source_iseq)->parent_iseq;
-        if ((ISEQ_BODY(parent)->variable ? ISEQ_BODY(parent)->variable->script_lines : Qnil) != script_lines) break;
+        if (ISEQ_SCRIPT_LINES(parent) != script_lines) break;
         source_iseq = parent;
     }
 
@@ -608,7 +608,7 @@ location_source_range_m(VALUE self)
 
     VALUE path = rb_iseq_path(iseq);
     VALUE absolute_path = rb_iseq_realpath(iseq);
-    VALUE script_lines = ISEQ_BODY(iseq)->variable ? ISEQ_BODY(iseq)->variable->script_lines : Qnil;
+    VALUE script_lines = ISEQ_SCRIPT_LINES(iseq);
     VALUE source;
     VALUE parser_path = path;
     int first_lineno = 1;

--- a/vm_core.h
+++ b/vm_core.h
@@ -416,6 +416,16 @@ enum lvar_state {
     lvar_reassigned,
 };
 
+/* Lazily-allocated per-iseq variable data. NULL when unused (the common case:
+ * no coverage, no script_lines, no flip-flops, no disassembly). */
+struct rb_iseq_variable {
+    rb_snum_t flip_count;
+    VALUE script_lines;
+    VALUE coverage;
+    VALUE pc2branchindex;
+    VALUE *original_iseq;
+};
+
 struct rb_iseq_constant_body {
     enum rb_iseq_type type;
 
@@ -527,13 +537,7 @@ struct rb_iseq_constant_body {
     union iseq_inline_storage_entry *is_entries; /* [ TS_IVC | TS_ICVARC | TS_ISE | TS_IC ] */
     struct rb_call_data *call_data; //struct rb_call_data calls[ci_size];
 
-    struct {
-        rb_snum_t flip_count;
-        VALUE script_lines;
-        VALUE coverage;
-        VALUE pc2branchindex;
-        VALUE *original_iseq;
-    } variable;
+    struct rb_iseq_variable *variable;
 
     unsigned int local_table_size;
     unsigned int ic_size;     // Number of IC caches

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -650,6 +650,14 @@ pub type rb_jit_func_t = ::std::option::Option<
     ) -> VALUE,
 >;
 #[repr(C)]
+pub struct rb_iseq_variable {
+    pub flip_count: rb_snum_t,
+    pub script_lines: VALUE,
+    pub coverage: VALUE,
+    pub pc2branchindex: VALUE,
+    pub original_iseq: *mut VALUE,
+}
+#[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rb_iseq_constant_body_rb_iseq_parameters {
     pub flags: rb_iseq_constant_body_rb_iseq_parameters__bindgen_ty_1,
@@ -1273,16 +1281,8 @@ pub union rb_iseq_constant_body_iseq_insn_info__bindgen_ty_1 {
     pub succ_index_table: *mut succ_index_table,
 }
 #[repr(C)]
-pub struct rb_iseq_constant_body__bindgen_ty_1 {
-    pub flip_count: rb_snum_t,
-    pub script_lines: VALUE,
-    pub coverage: VALUE,
-    pub pc2branchindex: VALUE,
-    pub original_iseq: *mut VALUE,
-}
-#[repr(C)]
 #[derive(Copy, Clone)]
-pub union rb_iseq_constant_body__bindgen_ty_2 {
+pub union rb_iseq_constant_body__bindgen_ty_1 {
     pub list: *mut iseq_bits_t,
     pub single: iseq_bits_t,
 }

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -2099,7 +2099,7 @@ pub struct zjit_jit_frame {
     pub stack: __IncompleteArrayField<VALUE>,
 }
 pub const ISEQ_BODY_OFFSET_PARAM: zjit_struct_offsets = 16;
-pub const ISEQ_BODY_OFFSET_OUTER_VARIABLES: zjit_struct_offsets = 280;
+pub const ISEQ_BODY_OFFSET_OUTER_VARIABLES: zjit_struct_offsets = 248;
 pub const RUBY_OFFSET_THREAD_RACTOR: zjit_struct_offsets = 24;
 pub type zjit_struct_offsets = u32;
 #[repr(C)]


### PR DESCRIPTION
Most of the time in a production app most iseqs won't have iseq->body->variable set to anything non-default. We can allocate it lazily and save 32 bytes per iseq. Some large apps have millions of iseqs, so it adds up.

32B saved per iseq * 2mil iseqs =~ 64 MB