### PR TITLE
GC: fix page pool advised_count underflow on 64KiB-page systems

### DIFF
--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -2578,8 +2578,14 @@ page_pool_reclaim(rb_global_objspace_t *g)
 
     rb_native_mutex_lock(&g->page_pool.lock);
 
+    /* Advising spares the first OS page of a body (it holds the in-body freelist link
+     * and the arena tag), so it needs sub-page granularity: when the OS page size is
+     * >= HEAP_PAGE_SIZE (e.g. 64KiB pages on aarch64) no body is ever advised, and
+     * advised_count must not be adjusted anywhere either. */
+    const bool can_advise = os_page_size < HEAP_PAGE_SIZE;
+
     /* Step A — advise cold bodies (immediate release: drop RSS now if the platform allows). */
-    if (os_page_size < HEAP_PAGE_SIZE) {
+    if (can_advise) {
         for (struct page_arena *a = g->page_pool.arenas; a; a = a->next) {
             for (struct heap_page_body *body = a->cold_freelist; body; ) {
                 asan_unpoison_memory_region(body, PAGE_POOL_SCRATCH_SIZE, false);
@@ -2657,7 +2663,12 @@ page_pool_reclaim(rb_global_objspace_t *g)
             rb_bug("page_pool_reclaim: munmap failed");
         }
         total_free -= PAGE_POOL_ARENA_BODIES;
-        g->page_pool.advised_count -= PAGE_POOL_ARENA_BODIES;
+        /* Every body of this arena is on its cold freelist, so Step A above has just
+         * advised all of them -- but only if this platform can advise at all. */
+        if (can_advise) {
+            g->page_pool.advised_count -= PAGE_POOL_ARENA_BODIES;
+            GC_ASSERT(g->page_pool.advised_count >= 0);
+        }
         g->page_pool.arena_count--;
         g->page_pool.arenas_unmapped++;
         if (a == g->page_pool.arena_current) {

--- a/test/ruby/test_gc.rb
+++ b/test/ruby/test_gc.rb
@@ -304,6 +304,26 @@ class TestGc < Test::Unit::TestCase
     assert_equal stat[:total_freed_objects], stat_heap_sum[:total_freed_objects]
   end
 
+  def test_page_pool_stat_consistency
+    omit 'no page pool' unless GC.stat.key?(:page_pool_total_pages)
+
+    # Freeing arenas back to the OS must keep page_pool_discarded_pages in range.
+    # An underflowed counter wraps to a huge value, which also makes GC.stat
+    # allocate a Bignum and perturb the object counts it reports.
+    assert_separately([], __FILE__, __LINE__, <<~RUBY, timeout: 60)
+      3.times do
+        ary = 200_000.times.map { "x" * 40 }
+        ary.clear
+        GC.start(full_mark: true, immediate_sweep: true)
+        GC.start(full_mark: true, immediate_sweep: true)
+      end
+
+      stat = GC.stat
+      assert_operator stat[:page_pool_discarded_pages], :<=, stat[:page_pool_total_pages]
+      assert_operator stat[:page_pool_arenas], :>=, 0 # arenas is always 0 if doesn't have mmap
+    RUBY
+  end
+
   def test_measure_total_time
     assert_separately([], __FILE__, __LINE__, <<~RUBY, timeout: 60)
       GC.measure_total_time = false


### PR DESCRIPTION
page_pool_reclaim() advises (madvise) cold page bodies only when the OS page size is smaller than HEAP_PAGE_SIZE, because the first OS page of a body holds the in-body freelist link and the arena tag and must be spared.  On systems whose page size is >= HEAP_PAGE_SIZE (64KiB pages on aarch64, e.g. the oci-aarch64 CI machine) Step A therefore never increments page_pool.advised_count -- but Step B still subtracted PAGE_POOL_ARENA_BODIES (32) from it for every munmap'd arena, so the counter went negative.

advised_count is an int reported through GC.stat as page_pool_discarded_pages with SIZET2NUM(), so a negative value is converted to a huge unsigned value and GC.stat has to allocate a Bignum for it.  That allocation happens after GC.stat has already read the slot counters, so any pair of "read stats, then read them again another way" observes one extra live object, which is exactly what these two tests do (both fail by exactly 1 in the same direction).

Skip the Step B adjustment when the platform cannot advise at all.  When it can, every body of an unmapped arena is on its cold freelist and was just advised by Step A, so subtracting 32 stays exact.

Verified by simulating a 64KiB page size (forcing
page_pool.os_page_size = HEAP_PAGE_SIZE) on x86_64: before the fix GC.stat[:page_pool_discarded_pages] reads 18446744073709551456 after arenas are unmapped and the test_stat comparison is off by 1; after the fix it reads 0 and test/ruby/test_gc.rb passes both with and without the simulation.

Error:
  1) Failure:
  TestGc#test_stat_heap_constraints [test/ruby/test_gc.rb:298]:
  <357949> expected but was
  <357950>.

  2) Failure:
  TestGc#test_stat [test/ruby/test_gc.rb:178]:
  <356712> expected but was
  <356711>.

  (5 consecutive master@oci-aarch64 runs since 9ebb977651)

CI: https://ci.rvm.jp/results/master@oci-aarch64/6449795
Log: https://ci.rvm.jp/logfiles/brlog.master.20260814-161514