### PR TITLE
Filter TracePoint events in test_trace_optimized_methods to current file

### DIFF
--- a/test/ruby/test_optimization.rb
+++ b/test/ruby/test_optimization.rb
@@ -211,7 +211,7 @@ class TestRubyOptimization < Test::Unit::TestCase
                 :&, :|, :[], :[]=, :length, :empty?, :nil?, :succ, :!, :=~]
     [:c_call, :c_return].each do |type|
       methods = []
-      tp = TracePoint.new(type) { |tp| methods << tp.method_id }
+      tp = TracePoint.new(type) { |tp| methods << tp.method_id if tp.path == __FILE__ }
       tp.enable do
         x = "a"; x = -x
         [1].max
@@ -243,7 +243,7 @@ class TestRubyOptimization < Test::Unit::TestCase
     end
 
     methods = []
-    tp = TracePoint.new(:c_call, :c_return) { |tp| methods << tp.method_id }
+    tp = TracePoint.new(:c_call, :c_return) { |tp| methods << tp.method_id if tp.path == __FILE__ }
     tp.enable do
       x = 1
       x != 42


### PR DESCRIPTION
Same as test_settracefunc.rb. This should fix flaky CI failures like
https://github.com/ruby/ruby/actions/runs/31826726042/job/94852494689
