### PR TITLE
M:N scheduler: replace the timed-waiter list with a hierarchical timer wheel

### DIFF
--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -3091,9 +3091,22 @@ static struct {
     struct kevent finished_events[KQUEUE_EVENTS_MAX];
 #endif
 
-    // waiting threads list
-    struct ccan_list_head waiting; // waiting threads in ractors
+#if USE_MN_THREADS
+    /* Timed waiters, bucketed by deadline into a hierarchical timer wheel;
+     * untimed (fd-only) waiters keep a plain list.  Both under waiting_lock.
+     * The wheel operations all live in thread_pthread_mn.c (timer_wheel_*). */
+#define TIMER_WHEEL_LEVELS 4
+#define TIMER_WHEEL_SLOT_BITS 6
+#define TIMER_WHEEL_SLOTS (1 << TIMER_WHEEL_SLOT_BITS)
+    struct timer_wheel_level {
+        uint64_t occupied; // bit s: slots[s] is non-empty
+        struct ccan_list_head slots[TIMER_WHEEL_SLOTS];
+    } wheel[TIMER_WHEEL_LEVELS];
+    uint64_t wheel_cursor_tick; // slots for ticks <= this are drained
+    rb_hrtime_t next_expiry;   // never later than the earliest deadline
+    struct ccan_list_head waiting_untimed;
     pthread_mutex_t waiting_lock;
+#endif
 
 #if (HAVE_SYS_EPOLL_H || HAVE_SYS_EVENT_H) && USE_MN_THREADS
     // fd -> struct rb_fd_waiters, in chunks so entries never move.
@@ -3109,21 +3122,8 @@ static struct {
 
 static void timer_thread_check_timeslice(rb_vm_t *vm);
 static int timer_thread_set_timeout(rb_vm_t *vm);
-static void timer_thread_wakeup_thread(rb_thread_t *th, uint32_t event_serial);
-static rb_thread_t *thread_sched_waiting_thread(struct rb_thread_sched_waiting *w);
 
 #include "thread_pthread_mn.c"
-
-static rb_thread_t *
-thread_sched_waiting_thread(struct rb_thread_sched_waiting *w)
-{
-    if (w) {
-        return (rb_thread_t *)((size_t)w - offsetof(rb_thread_t, sched.waiting_reason));
-    }
-    else {
-        return NULL;
-    }
-}
 
 static int
 timer_thread_set_timeout(rb_vm_t *vm)
@@ -3154,31 +3154,7 @@ timer_thread_set_timeout(rb_vm_t *vm)
     }
     ractor_sched_unlock(vm, NULL);
 
-    // Always check waiting threads to find minimum timeout
-    // even when scheduler has work (grq_cnt > 0)
-    rb_native_mutex_lock(&timer_th.waiting_lock);
-    {
-        struct rb_thread_sched_waiting *w = ccan_list_top(&timer_th.waiting, struct rb_thread_sched_waiting, node);
-        rb_thread_t *th = thread_sched_waiting_thread(w);
-
-        if (th && (th->sched.waiting_reason.flags & thread_sched_waiting_timeout)) {
-            rb_hrtime_t now = rb_hrtime_now();
-            rb_hrtime_t hrrel = rb_hrtime_sub(th->sched.waiting_reason.data.timeout, now);
-
-            RUBY_DEBUG_LOG("th:%u now:%lu rel:%lu", rb_th_serial(th), (unsigned long)now, (unsigned long)hrrel);
-
-            rb_hrtime_t msec = (hrrel + RB_HRTIME_PER_MSEC - 1) / RB_HRTIME_PER_MSEC;
-            // A deadline further away than INT_MAX ms must clamp, not truncate:
-            // a negative timeout would be an untimed epoll_wait.
-            int thread_timeout = msec > INT_MAX ? INT_MAX : (int)msec; // ms
-
-            // Use minimum of scheduler timeout and thread sleep timeout
-            if (timeout < 0 || thread_timeout < timeout) {
-                timeout = thread_timeout;
-            }
-        }
-    }
-    rb_native_mutex_unlock(&timer_th.waiting_lock);
+    timeout = timer_wheel_timeout(timeout);
 
     RUBY_DEBUG_LOG("timeout:%d inf:%d", timeout, (int)vm->ractor.sched.timeslice_wait_inf);
 
@@ -3197,83 +3173,6 @@ timer_thread_check_signal(rb_vm_t *vm)
         RUBY_DEBUG_LOG("signum:%d", signum);
         threadptr_trap_interrupt(vm->ractor.main_thread);
     }
-}
-
-static bool
-timer_thread_check_exceed(rb_hrtime_t abs, rb_hrtime_t now)
-{
-    return abs <= now;
-}
-
-static rb_thread_t *
-timer_thread_deq_wakeup(rb_vm_t *vm, rb_hrtime_t now, uint32_t *event_serial)
-{
-    struct rb_thread_sched_waiting *w = ccan_list_top(&timer_th.waiting, struct rb_thread_sched_waiting, node);
-
-    if (w != NULL &&
-        (w->flags & thread_sched_waiting_timeout) &&
-        timer_thread_check_exceed(w->data.timeout, now)) {
-
-        RUBY_DEBUG_LOG("wakeup th:%u", rb_th_serial(thread_sched_waiting_thread(w)));
-
-        // delete from waiting list
-        ccan_list_del_init(&w->node);
-
-        rb_thread_t *th = thread_sched_waiting_thread(w);
-
-#if (HAVE_SYS_EPOLL_H || HAVE_SYS_EVENT_H) && USE_MN_THREADS
-        // An fd+timeout waiter is also on its fd's waiter list; leave it there too.
-        timer_thread_unregister_waiting(th, w->data.fd, w->flags);
-#endif
-
-        // setup result
-        w->flags = thread_sched_waiting_none;
-        w->data.result = 0;
-
-        *event_serial = w->data.event_serial;
-        return th;
-    }
-
-    return NULL;
-}
-
-static void
-timer_thread_wakeup_thread_locked(struct rb_thread_sched *sched, rb_thread_t *th, uint32_t event_serial)
-{
-    if (sched->running != th && th->sched.event_serial == event_serial) {
-        thread_sched_to_ready_common(sched, th, true, false);
-    }
-}
-
-static void
-timer_thread_wakeup_thread(rb_thread_t *th, uint32_t event_serial)
-{
-    RUBY_DEBUG_LOG("th:%u", rb_th_serial(th));
-    struct rb_thread_sched *sched = TH_SCHED(th);
-
-    thread_sched_lock(sched, th);
-    {
-        timer_thread_wakeup_thread_locked(sched, th, event_serial);
-    }
-    thread_sched_unlock(sched, th);
-}
-
-static void
-timer_thread_check_timeout(rb_vm_t *vm)
-{
-    rb_hrtime_t now = rb_hrtime_now();
-    rb_thread_t *th;
-    uint32_t event_serial;
-
-    rb_native_mutex_lock(&timer_th.waiting_lock);
-    {
-        while ((th = timer_thread_deq_wakeup(vm, now, &event_serial)) != NULL) {
-            rb_native_mutex_unlock(&timer_th.waiting_lock);
-            timer_thread_wakeup_thread(th, event_serial);
-            rb_native_mutex_lock(&timer_th.waiting_lock);
-        }
-    }
-    rb_native_mutex_unlock(&timer_th.waiting_lock);
 }
 
 static void
@@ -3420,8 +3319,18 @@ rb_thread_create_timer_thread(void)
             // starts over.
         }
 
-        ccan_list_head_init(&timer_th.waiting);
+#if USE_MN_THREADS
+        for (int lvl = 0; lvl < TIMER_WHEEL_LEVELS; lvl++) {
+            timer_th.wheel[lvl].occupied = 0;
+            for (int slot = 0; slot < TIMER_WHEEL_SLOTS; slot++) {
+                ccan_list_head_init(&timer_th.wheel[lvl].slots[slot]);
+            }
+        }
+        timer_th.wheel_cursor_tick = timer_wheel_tick(rb_hrtime_now());
+        timer_th.next_expiry = TIMER_WHEEL_NO_EXPIRY;
+        ccan_list_head_init(&timer_th.waiting_untimed);
         rb_native_mutex_initialize(&timer_th.waiting_lock);
+#endif
 
         // open communication channel
         setup_communication_pipe_internal(timer_th.comm_fds);

--- a/thread_pthread.h
+++ b/thread_pthread.h
@@ -52,8 +52,13 @@ struct rb_thread_sched_waiting {
         int result;
     } data;
 
-    // connected to timer_th.waiting (ordered by timeout)
+    // connected to a timer_th wheel slot (timed) or timer_th.waiting_untimed
     struct ccan_list_node node;
+
+    /* which wheel slot `node` is on; meaningful only while flags has
+     * thread_sched_waiting_timeout */
+    uint8_t wheel_lvl;
+    uint8_t wheel_slot;
 
     // connected to rb_fd_waiters.waiters of data.fd
     struct ccan_list_node fd_node;

--- a/thread_pthread_mn.c
+++ b/thread_pthread_mn.c
@@ -2,8 +2,306 @@
 
 #if USE_MN_THREADS
 
+#if HAVE_SYS_EPOLL_H || HAVE_SYS_EVENT_H
 static void timer_thread_unregister_waiting(rb_thread_t *th, int fd, enum thread_sched_waiting_flag flags);
-static void timer_thread_wakeup_thread_locked(struct rb_thread_sched *sched, rb_thread_t *th, uint32_t event_serial);
+#endif
+
+static bool
+timer_thread_check_exceed(rb_hrtime_t abs, rb_hrtime_t now)
+{
+    return abs <= now;
+}
+
+static rb_thread_t *
+thread_sched_waiting_thread(struct rb_thread_sched_waiting *w)
+{
+    if (w) {
+        return (rb_thread_t *)((size_t)w - offsetof(rb_thread_t, sched.waiting_reason));
+    }
+    else {
+        return NULL;
+    }
+}
+
+#define TIMER_WHEEL_NO_EXPIRY RB_HRTIME_MAX
+#ifndef TIMER_WHEEL_TICK_MS
+#define TIMER_WHEEL_TICK_MS 1 // L0 slot width; coarser trades sleep accuracy for fewer drains
+#endif
+
+/* Timer wheel over the timed waiters.  Every operation runs under
+ * timer_th.waiting_lock.
+ *
+ * Level L buckets deadlines into 64 slots of 64^L ms each; a deadline is
+ * placed by its distance from the drain cursor, so its slot is always
+ * strictly ahead of the cursor at that level.  The drain refines a
+ * not-yet-due waiter onto a finer level instead of cascading whole slots,
+ * so one waiter moves at most once per level over its lifetime.
+ *
+ * This is the hierarchical timing wheel of Varghese & Lauck, "Hashed and
+ * Hierarchical Timing Wheels" (SOSP '87). */
+
+static uint64_t
+timer_wheel_tick(rb_hrtime_t hrt)
+{
+    return hrt / (RB_HRTIME_PER_MSEC * TIMER_WHEEL_TICK_MS);
+}
+
+static inline int
+timer_wheel_ctz64(uint64_t v)
+{
+#if defined(__GNUC__) || defined(__clang__)
+    return __builtin_ctzll(v);
+#else
+    int n = 0;
+    while (!(v & 1)) { v >>= 1; n++; }
+    return n;
+#endif
+}
+
+static int
+timer_wheel_level(uint64_t dist_ms)
+{
+    if (dist_ms < ((uint64_t)1 << TIMER_WHEEL_SLOT_BITS)) return 0;
+    if (dist_ms < ((uint64_t)1 << 2 * TIMER_WHEEL_SLOT_BITS)) return 1;
+    if (dist_ms < ((uint64_t)1 << 3 * TIMER_WHEEL_SLOT_BITS)) return 2;
+    return TIMER_WHEEL_LEVELS - 1;
+}
+
+static void
+timer_wheel_insert(struct rb_thread_sched_waiting *w)
+{
+    uint64_t dl_tick = timer_wheel_tick(w->data.timeout);
+    uint64_t cur = timer_th.wheel_cursor_tick;
+
+    /* A deadline at or behind the cursor parks one tick ahead: its own slot
+     * is already drained and would otherwise wait out a full wheel turn. */
+    uint64_t target = dl_tick > cur ? dl_tick : cur + 1;
+    int lvl = timer_wheel_level(target - cur);
+    int shift = lvl * TIMER_WHEEL_SLOT_BITS;
+    uint64_t slot_tick = target >> shift;
+
+    if (lvl == TIMER_WHEEL_LEVELS - 1) {
+        /* Beyond the wheel range: park on the farthest slot; the drain
+         * re-inserts it with the then-smaller distance. */
+        uint64_t far = (cur >> shift) + TIMER_WHEEL_SLOTS - 1;
+        if (slot_tick > far) slot_tick = far;
+    }
+
+    int slot = (int)(slot_tick & (TIMER_WHEEL_SLOTS - 1));
+
+    ccan_list_add_tail(&timer_th.wheel[lvl].slots[slot], &w->node);
+    timer_th.wheel[lvl].occupied |= UINT64_C(1) << slot;
+    w->wheel_lvl = (uint8_t)lvl;
+    w->wheel_slot = (uint8_t)slot;
+
+    if (w->data.timeout < timer_th.next_expiry) {
+        timer_th.next_expiry = w->data.timeout;
+    }
+}
+
+// Unlink a waiter from the wheel slot or the untimed list it is on.
+static void
+timer_wheel_del(struct rb_thread_sched_waiting *w)
+{
+    ccan_list_del_init(&w->node);
+
+    if (w->flags & thread_sched_waiting_timeout) {
+        struct timer_wheel_level *lv = &timer_th.wheel[w->wheel_lvl];
+        if (ccan_list_empty(&lv->slots[w->wheel_slot])) {
+            lv->occupied &= ~(UINT64_C(1) << w->wheel_slot);
+        }
+    }
+}
+
+/* A lower bound on the earliest deadline: the start time of the nearest
+ * occupied slot per level.  Never later than any real deadline, so waking
+ * by it is at worst early, which is harmless. */
+static rb_hrtime_t
+timer_wheel_next_expiry(void)
+{
+    rb_hrtime_t best = TIMER_WHEEL_NO_EXPIRY;
+
+    for (int lvl = 0; lvl < TIMER_WHEEL_LEVELS; lvl++) {
+        uint64_t occ = timer_th.wheel[lvl].occupied;
+        if (!occ) continue;
+
+        int shift = lvl * TIMER_WHEEL_SLOT_BITS;
+        uint64_t cur_tick = timer_th.wheel_cursor_tick >> shift;
+        unsigned base = (unsigned)((cur_tick + 1) & (TIMER_WHEEL_SLOTS - 1));
+        // rotate so bit k = slot for tick cur_tick+1+k
+        uint64_t rot = (occ >> base) | (base ? (occ << (TIMER_WHEEL_SLOTS - base)) : 0);
+        uint64_t tick = cur_tick + 1 + timer_wheel_ctz64(rot);
+        rb_hrtime_t start = (rb_hrtime_t)(tick << shift) * RB_HRTIME_PER_MSEC * TIMER_WHEEL_TICK_MS;
+
+        if (start < best) best = start;
+    }
+
+    return best;
+}
+
+/* Drain every slot whose tick moved behind `now`, collecting due waiters
+ * onto `expired` and re-bucketing not-yet-due ones onto a finer level.
+ * timer_th.waiting_lock must be held. */
+static void
+timer_wheel_drain(rb_hrtime_t now, uint64_t now_tick, struct ccan_list_head *expired)
+{
+    uint64_t prev_tick = timer_th.wheel_cursor_tick;
+    timer_th.wheel_cursor_tick = now_tick;  // re-inserts below map against the new cursor
+    /* A deadline inside the current tick parks one tick ahead, so its slot
+     * start is later than the deadline.  Keep the exact value: the recompute
+     * below only knows slot starts, and next_expiry must not exceed a deadline. */
+    rb_hrtime_t reinserted = TIMER_WHEEL_NO_EXPIRY;
+
+    for (int lvl = 0; lvl < TIMER_WHEEL_LEVELS; lvl++) {
+        int shift = lvl * TIMER_WHEEL_SLOT_BITS;
+        uint64_t from = prev_tick >> shift;
+        uint64_t to = now_tick >> shift;
+
+        if (to == from) break; // no boundary crossed; coarser levels crossed none either
+
+        uint64_t steps = to - from;
+        if (steps > TIMER_WHEEL_SLOTS) steps = TIMER_WHEEL_SLOTS;
+        struct timer_wheel_level *lv = &timer_th.wheel[lvl];
+
+        for (uint64_t tick = to - steps + 1; tick <= to; tick++) {
+            int slot = (int)(tick & (TIMER_WHEEL_SLOTS - 1));
+
+            if (!(lv->occupied & (UINT64_C(1) << slot))) continue;
+            lv->occupied &= ~(UINT64_C(1) << slot);
+
+            /* Detach first: a far-future waiter re-clamped by the insert below
+             * can land back on this very slot and must not be drained again. */
+            struct ccan_list_head pending;
+            ccan_list_head_init(&pending);
+            ccan_list_append_list(&pending, &lv->slots[slot]);
+
+            struct rb_thread_sched_waiting *w;
+            while ((w = ccan_list_pop(&pending, struct rb_thread_sched_waiting, node)) != NULL) {
+                if (timer_thread_check_exceed(w->data.timeout, now)) {
+                    rb_thread_t *th = thread_sched_waiting_thread(w);
+
+                    RUBY_DEBUG_LOG("wakeup th:%u", rb_th_serial(th));
+
+#if HAVE_SYS_EPOLL_H || HAVE_SYS_EVENT_H
+                    // An fd+timeout waiter is also on its fd's waiter list.
+                    timer_thread_unregister_waiting(th, w->data.fd, w->flags);
+#endif
+                    /* flags stay set until the wakeup below takes them under
+                     * the lock: a waiter whose flags are already cleared may
+                     * run and re-register through this same `w`, which would
+                     * relink the node we are still holding on `expired`. */
+                    w->data.result = 0;
+
+                    ccan_list_add_tail(expired, &w->node);
+                }
+                else {
+                    /* arrived early: the distance shrank, so this lands on a
+                     * finer level (or a farther slot of the coarsest one) */
+                    if (w->data.timeout < reinserted) reinserted = w->data.timeout;
+                    timer_wheel_insert(w);
+                }
+            }
+        }
+    }
+
+    timer_th.next_expiry = timer_wheel_next_expiry();
+    if (reinserted < timer_th.next_expiry) timer_th.next_expiry = reinserted;
+}
+
+/* Merge the wheel's next expiry into the poll timeout (ms; -1 = none).
+ * Checked even when the scheduler has other work (grq_cnt > 0). */
+static int
+timer_wheel_timeout(int timeout)
+{
+    rb_native_mutex_lock(&timer_th.waiting_lock);
+    {
+        if (timer_th.next_expiry != TIMER_WHEEL_NO_EXPIRY) {
+            rb_hrtime_t now = rb_hrtime_now();
+            rb_hrtime_t hrrel = rb_hrtime_sub(timer_th.next_expiry, now);
+
+            RUBY_DEBUG_LOG("now:%lu rel:%lu", (unsigned long)now, (unsigned long)hrrel);
+
+            rb_hrtime_t msec = (hrrel + RB_HRTIME_PER_MSEC - 1) / RB_HRTIME_PER_MSEC;
+            // A deadline further away than INT_MAX ms must clamp, not truncate:
+            // a negative timeout would be an untimed epoll_wait.
+            int thread_timeout = msec > INT_MAX ? INT_MAX : (int)msec; // ms
+
+            // Use minimum of scheduler timeout and thread sleep timeout
+            if (timeout < 0 || thread_timeout < timeout) {
+                timeout = thread_timeout;
+            }
+        }
+    }
+    rb_native_mutex_unlock(&timer_th.waiting_lock);
+
+    return timeout;
+}
+
+static void
+timer_thread_wakeup_thread_locked(struct rb_thread_sched *sched, rb_thread_t *th, uint32_t event_serial)
+{
+    if (sched->running != th && th->sched.event_serial == event_serial) {
+        thread_sched_to_ready_common(sched, th, true, false);
+    }
+}
+
+static void
+timer_thread_wakeup_thread(rb_thread_t *th, uint32_t event_serial)
+{
+    RUBY_DEBUG_LOG("th:%u", rb_th_serial(th));
+    struct rb_thread_sched *sched = TH_SCHED(th);
+
+    thread_sched_lock(sched, th);
+    {
+        timer_thread_wakeup_thread_locked(sched, th, event_serial);
+    }
+    thread_sched_unlock(sched, th);
+}
+
+#define TIMEOUT_WAKE_BATCH 16
+
+static void
+timer_thread_check_timeout(rb_vm_t *vm)
+{
+    rb_hrtime_t now = rb_hrtime_now();
+    uint64_t now_tick = timer_wheel_tick(now);
+    struct ccan_list_head expired;
+
+    ccan_list_head_init(&expired);
+
+    struct timeout_wake { rb_thread_t *th; uint32_t serial; } batch[TIMEOUT_WAKE_BATCH];
+    bool more = true;
+
+    while (more) {
+        int n = 0;
+
+        rb_native_mutex_lock(&timer_th.waiting_lock);
+        {
+            // A second pass finds the cursor already at now_tick and drains nothing.
+            if (now_tick > timer_th.wheel_cursor_tick) {
+                timer_wheel_drain(now, now_tick, &expired);
+            }
+
+            struct rb_thread_sched_waiting *w;
+            while (n < TIMEOUT_WAKE_BATCH &&
+                   (w = ccan_list_pop(&expired, struct rb_thread_sched_waiting, node)) != NULL) {
+                // Name the thread and its serial here, then release it: once the
+                // flags are clear the thread may run and re-register through `w`,
+                // and a serial read after that would match the new registration.
+                batch[n].th = thread_sched_waiting_thread(w);
+                batch[n].serial = w->data.event_serial;
+                w->flags = thread_sched_waiting_none;
+                n++;
+            }
+            more = !ccan_list_empty(&expired);
+        }
+        rb_native_mutex_unlock(&timer_th.waiting_lock);
+
+        for (int i = 0; i < n; i++) {
+            timer_thread_wakeup_thread(batch[i].th, batch[i].serial);
+        }
+    }
+}
 
 static bool
 timer_thread_cancel_waiting(rb_thread_t *th)
@@ -14,7 +312,7 @@ timer_thread_cancel_waiting(rb_thread_t *th)
     {
         if (th->sched.waiting_reason.flags) {
             canceled = true;
-            ccan_list_del_init(&th->sched.waiting_reason.node);
+            timer_wheel_del(&th->sched.waiting_reason);
             timer_thread_unregister_waiting(th, th->sched.waiting_reason.data.fd, th->sched.waiting_reason.flags);
             th->sched.waiting_reason.flags = thread_sched_waiting_none;
         }
@@ -672,24 +970,8 @@ native_thread_create_shared(rb_thread_t *th)
     return 0;
 }
 
-#else // USE_MN_THREADS
-
-static int
-native_thread_create_shared(rb_thread_t *th)
-{
-    rb_bug("unreachable");
-}
-
-static enum thread_sched_wait_result
-thread_sched_wait_events(struct rb_thread_sched *sched, rb_thread_t *th, int fd, enum thread_sched_waiting_flag events, rb_hrtime_t *rel)
-{
-    rb_bug("unreachable");
-}
-
-#endif // USE_MN_THREADS
-
 /// EPOLL/KQUEUE specific code
-#if (HAVE_SYS_EPOLL_H || HAVE_SYS_EVENT_H) && USE_MN_THREADS
+#if HAVE_SYS_EPOLL_H || HAVE_SYS_EVENT_H
 
 /// Per-fd waiter table (struct rb_fd_waiters).  One fd may have several waiters
 /// -- a reader and a writer on one socket -- so the backend is armed with their
@@ -891,18 +1173,27 @@ static void
 verify_waiting_list(void)
 {
 #if VM_CHECK_MODE > 0
-    struct rb_thread_sched_waiting *w, *prev_w = NULL;
+    struct rb_thread_sched_waiting *w;
 
-    // waiting list's timeout order should be [1, 2, 3, ..., 0, 0, 0]
+    for (int lvl = 0; lvl < TIMER_WHEEL_LEVELS; lvl++) {
+        const struct timer_wheel_level *lv = &timer_th.wheel[lvl];
 
-    ccan_list_for_each(&timer_th.waiting, w, node) {
-        // fprintf(stderr, "verify_waiting_list th:%u abs:%lu\n", rb_th_serial(wth), (unsigned long)wth->sched.waiting_reason.data.timeout);
-        if (prev_w) {
-            rb_hrtime_t timeout = w->data.timeout;
-            rb_hrtime_t prev_timeout = prev_w->data.timeout;
-            VM_ASSERT(timeout == 0 || prev_timeout <= timeout);
+        for (int slot = 0; slot < TIMER_WHEEL_SLOTS; slot++) {
+            bool occupied = (lv->occupied >> slot) & 1;
+            VM_ASSERT(occupied == !ccan_list_empty(&lv->slots[slot]));
+
+            ccan_list_for_each(&lv->slots[slot], w, node) {
+                VM_ASSERT(w->flags & thread_sched_waiting_timeout);
+                VM_ASSERT(w->data.timeout != 0);
+                VM_ASSERT(w->wheel_lvl == lvl);
+                VM_ASSERT(w->wheel_slot == slot);
+            }
         }
-        prev_w = w;
+    }
+
+    ccan_list_for_each(&timer_th.waiting_untimed, w, node) {
+        VM_ASSERT(!(w->flags & thread_sched_waiting_timeout));
+        VM_ASSERT(w->data.timeout == 0);
     }
 #endif
 }
@@ -1036,36 +1327,21 @@ timer_thread_register_waiting(rb_thread_t *th, int fd, enum thread_sched_waiting
 
             if (abs == 0) { // no timeout
                 VM_ASSERT(!(flags & thread_sched_waiting_timeout));
-                ccan_list_add_tail(&timer_th.waiting, &th->sched.waiting_reason.node);
+                ccan_list_add_tail(&timer_th.waiting_untimed, &th->sched.waiting_reason.node);
             }
             else {
                 RUBY_DEBUG_LOG("abs:%lu", (unsigned long)abs);
                 VM_ASSERT(flags & thread_sched_waiting_timeout);
 
-                // insert th to sorted list (TODO: O(n))
-                struct rb_thread_sched_waiting *w, *prev_w = NULL;
-
-                ccan_list_for_each(&timer_th.waiting, w, node) {
-                    if ((w->flags & thread_sched_waiting_timeout) &&
-                        w->data.timeout < abs) {
-                        prev_w = w;
-                    }
-                    else {
-                        break;
-                    }
-                }
-
-                if (prev_w) {
-                    ccan_list_add_after(&timer_th.waiting, &prev_w->node, &th->sched.waiting_reason.node);
-                }
-                else {
-                    ccan_list_add(&timer_th.waiting, &th->sched.waiting_reason.node);
-                }
+                rb_hrtime_t prev_expiry = timer_th.next_expiry;
+                timer_wheel_insert(&th->sched.waiting_reason);
 
                 verify_waiting_list();
 
-                // update timeout seconds; force wake so timer thread notices short deadlines
-                timer_thread_wakeup_force();
+                if (timer_th.next_expiry < prev_expiry) {
+                    // an earlier deadline than the timer thread is armed for
+                    timer_thread_wakeup_force();
+                }
             }
         }
         else {
@@ -1184,7 +1460,7 @@ timer_thread_wake_fd_waiters(int fd, uint32_t generation, uint32_t wake_flags, i
                     }
 
                     ccan_list_del_init(&w->fd_node);
-                    ccan_list_del_init(&w->node); // also leaves the timeout list
+                    timer_wheel_del(w); // also leaves the timer wheel
 
                     w->flags = thread_sched_waiting_none;
                     w->data.fd = -1;
@@ -1320,7 +1596,9 @@ timer_thread_polling(rb_vm_t *vm)
     }
 }
 
-#else // HAVE_SYS_EPOLL_H || HAVE_SYS_EVENT_H
+#endif // HAVE_SYS_EPOLL_H || HAVE_SYS_EVENT_H
+
+#else // USE_MN_THREADS
 
 static void
 timer_thread_setup_mn(void)
@@ -1370,4 +1648,28 @@ timer_thread_polling(rb_vm_t *vm)
     }
 }
 
-#endif // HAVE_SYS_EPOLL_H || HAVE_SYS_EVENT_H
+static int
+native_thread_create_shared(rb_thread_t *th)
+{
+    rb_bug("unreachable");
+}
+
+static enum thread_sched_wait_result
+thread_sched_wait_events(struct rb_thread_sched *sched, rb_thread_t *th, int fd, enum thread_sched_waiting_flag events, rb_hrtime_t *rel)
+{
+    rb_bug("unreachable");
+}
+
+static int
+timer_wheel_timeout(int timeout)
+{
+    return timeout; // no M:N threads, no timed waiters
+}
+
+static void
+timer_thread_check_timeout(rb_vm_t *vm)
+{
+    // no M:N threads, no timed waiters
+}
+
+#endif // USE_MN_THREADS


### PR DESCRIPTION
### Problem

`timer_thread_register_waiting()` keeps timed waiters on a single list
sorted by deadline and inserts with a linear scan (the code itself says
`// insert th to sorted list (TODO: O(n))`).

The most ordinary server pattern hits this scan's worst case, not its
average: waits produced by a server share a handful of timeout values
(one keep-alive timeout, one read timeout), so a newly registered wait's
deadline is almost always later than every deadline already waiting, and
each insert walks the whole list.  With 8000 connections parked in a
keep-alive wait, every re-registration walks 8000 nodes; at ~4000
re-registrations/s that is ~32M nodes/s, and a profile shows ~50% of the
server's CPU inside `thread_sched_wait_events` (39.7% + 10.5%).  The
result is that enabling M:N makes such a server *slower* than 1:1
threads, which otherwise it beats.

### Design

Bucket timed waiters into a 4-level timer wheel, 64 slots per level, 1ms
slots at the finest level and 64x coarser per level (~4.6h of direct
range):

- **Insertion is O(1)**: the level is picked from the deadline's distance
  to the drain cursor, the slot by division -- no comparisons, no
  traversal.  Deadlines beyond the range park on the coarsest level's
  farthest slot and re-sort on arrival, so sleep duration is unbounded.
- **Removal stays O(1)** -- this is the reason for a wheel rather than a
  heap.  Removal is the *most frequent* operation: most timed fd waits
  are cancelled by their fd becoming ready, not by expiring.  A heap
  pays O(log n) restructuring per removal; the wheel unlinks a node and
  clears an occupancy bit (each node records its level and slot).
- **The wheel never fires late**: a deadline is floored to its slot, so
  the drain visits it at or before the deadline.  A waiter found early is
  re-bucketed onto a finer level ("refinement"); each waiter moves at
  most once per level over its lifetime, so there is no O(n) cascade.
- **The cached next-expiry is a lower bound**, maintained only by
  insertion (a min-update) and recomputed after a drain with one
  bit-scan per level.  Removal does no bookkeeping at all: a stale bound
  only wakes the timer thread early, and waking early is harmless.  The
  timer thread is now woken only when an insertion shortens the bound,
  instead of on every insertion.

Untimed (fd-only) waiters move to a plain list of their own.  The wheel
is compiled only with `USE_MN_THREADS`; without it the timer thread's
timeout check compiles to nothing.

The structure is the hierarchical timing wheel of Varghese & Lauck,
"Hashed and Hierarchical Timing Wheels: Data Structures for the Efficient
Implementation of a Timer Facility" (SOSP '87).

### Benchmark

Two LAN hosts (the same machines as the ruby/ruby#18328 measurements,
but a different workload): the server is pinned to 8 cores, the load
host holds 8000 idle streaming connections (each receives 20 bytes
every 2s, i.e. every connection sits in a timed read most of the time),
and throughput is probed with a separate `wrk -t2 -c8`.
Thread-per-connection servers; same-day A/B; release builds.

Probe throughput with 8000 held connections, requests/sec:

| server | master M:N | this PR M:N | 1:1 (reference) |
|---|---|---|---|
| PuMaNy (*) | 2,940 | **7,365** | 5,423 / 5,313 |
| puma -t 0:20000 | 3,196 | **6,605** | 5,505 / 5,458 |
| falcon (fibers; control) | 4,2k-5,7k | 4,2k-5,7k | -- |

(*) PuMaNy: Puma modified to serve each connection with a dedicated
thread, instead of a worker pool.

On master, M:N was ~45% *behind* 1:1 here; with this PR it is 21-39%
ahead, while using 4-5 native threads against 1:1's 8000.  With 2000
held connections: 9,827 -> 13,125 (1:1: 9,503).  With none held, and for
all 1:1 rows, the change is within noise.  In the 8000-connection
profile `thread_sched_wait_events` drops from ~50% of CPU to out of the
top ten; the remaining cost is GC marking the 8000 threads' stacks.

### Testing

- `btest-ruby`: all PASS with `RUBY_MN_THREADS=0` and `=1` on a debug
  build -- `VM_CHECK_MODE` re-verifies the wheel's invariants (occupancy
  bitmap consistency, node/slot agreement, untimed-list purity) on every
  insertion -- and on a release build.
- `make test-all` for `io/wait`, `io_timeout`, `thread`: 0 failures.
- sleep precision: measured oversleep <= 0.5ms for durations from 1ms to
  1.2s, both modes; 500 threads sleeping staggered durations all wake on
  time.  (Flooring plus refinement never fires early *or* late beyond
  the pre-existing 1ms epoll_wait quantization.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
