### PR TITLE
Refactor core_hash_merge_ptr and core_hash_merge_kw

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -5406,7 +5406,7 @@ compile_hash(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, int meth
      * - It contains key-value pairs.  So we need to take every two elements.
      *   We can assume that the length is always even.
      *
-     * - Merging is done by a method call (id_core_hash_merge_ptr).
+     * - Merging is done by a method call (id_core_hash_merge_bang_ptr).
      *   Sometimes we need to insert the receiver, so "anchor" is needed.
      *   In addition, a method call is much slower than concatarray.
      *   So it pays only when the subsequence is really long.
@@ -5436,7 +5436,7 @@ compile_hash(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, int meth
             ADD_INSN1(ret, line_node, putspecialobject, INT2FIX(VM_SPECIAL_OBJECT_VMCORE));  \
             ADD_INSN(ret, line_node, swap);                                                  \
             APPEND_LIST(ret, anchor);                                                   \
-            ADD_SEND(ret, line_node, id_core_hash_merge_ptr, INT2FIX(stack_len + 1));        \
+            ADD_SEND(ret, line_node, id_core_hash_merge_bang_ptr, INT2FIX(stack_len + 1));        \
         }                                                                               \
         INIT_ANCHOR(anchor);                                                            \
         first_chunk = stack_len = 0;                                                    \
@@ -5482,7 +5482,7 @@ compile_hash(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, int meth
 
                     ADD_INSN1(ret, line_node, putobject, hash);
 
-                    ADD_SEND(ret, line_node, id_core_hash_merge_kwd, INT2FIX(2));
+                    ADD_SEND(ret, line_node, id_core_hash_merge_bang_kwd, INT2FIX(2));
                 }
                 RB_OBJ_WRITTEN(iseq, Qundef, hash);
             }
@@ -5556,7 +5556,7 @@ compile_hash(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, int meth
 
                         NO_CHECK(COMPILE(ret, "keyword splat", kw));
 
-                        ADD_SEND(ret, line_node, id_core_hash_merge_kwd, INT2FIX(2));
+                        ADD_SEND(ret, line_node, id_core_hash_merge_bang_kwd, INT2FIX(2));
                     }
                 }
 
@@ -10217,7 +10217,7 @@ compile_super(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, i
                 ADD_INSN1(args, node, putobject, ID2SYM(id));
                 ADD_GETLOCAL(args, node, idx, lvar_level);
             }
-            ADD_SEND(args, node, id_core_hash_merge_ptr, INT2FIX(i * 2 + 1));
+            ADD_SEND(args, node, id_core_hash_merge_bang_ptr, INT2FIX(i * 2 + 1));
             flag |= VM_CALL_KW_SPLAT| VM_CALL_KW_SPLAT_MUT;
         }
         else if (local_body->param.flags.has_kwrest) {

--- a/defs/id.def
+++ b/defs/id.def
@@ -98,7 +98,10 @@ firstline, predefined = __LINE__+1, %[\
   core#define_singleton_method
   core#set_postexe
   core#hash_merge_ptr
+  core#hash_merge_bang_ptr
   core#hash_merge_kwd
+  core#hash_merge_bang_kwd
+  core#hash_coerce
   core#raise
   core#sprintf
 

--- a/hash.c
+++ b/hash.c
@@ -1641,6 +1641,17 @@ hash_dup(VALUE hash, VALUE klass, VALUE flags)
     return hash_copy(dup, hash);
 }
 
+static VALUE
+hash_dup_capa(VALUE hash, size_t capa)
+{
+    VALUE ret = hash_alloc_capa(rb_cHash, 0, Qnil, capa, false);
+    if (capa > RHASH_AR_TABLE_MAX_SIZE) {
+        RHASH_SET_ST_FLAG(ret);
+    }
+    hash_copy(ret, hash);
+    return ret;
+}
+
 VALUE
 rb_hash_dup(VALUE hash)
 {
@@ -5218,6 +5229,32 @@ rb_hash_new_with_bulk_insert(long argc, const VALUE *argv)
 {
     VALUE val = rb_hash_new_capa(argc / 2);
     rb_hash_bulk_insert(argc, argv, val);
+    return val;
+}
+
+VALUE
+rb_hash_merge2_bulk(VALUE hash, long argc, const VALUE *argv, bool dup)
+{
+    VALUE val = hash;
+    if (dup) {
+        // This is used to build literal hashes and keyword arguments,
+        // we can assume duplicate keys are very rare.
+        val = hash_dup_capa(val, RHASH_SIZE(val) + argc / 2);
+    }
+    rb_hash_bulk_insert(argc, argv, val);
+    return val;
+}
+
+VALUE
+rb_hash_merge2(VALUE h1, VALUE h2, bool dup)
+{
+    VALUE val = h1;
+    if (dup) {
+        // This is used to build literal hashes and keyword arguments,
+        // we can assume duplicate keys are very rare.
+        val = hash_dup_capa(val, RHASH_SIZE(val) + RHASH_SIZE(h2));
+    }
+    rb_hash_foreach(h2, rb_hash_update_i, val);
     return val;
 }
 

--- a/internal/hash.h
+++ b/internal/hash.h
@@ -111,6 +111,8 @@ int rb_hash_stlike_foreach_with_replace(VALUE hash, st_foreach_check_callback_fu
 RUBY_SYMBOL_EXPORT_END
 
 VALUE rb_hash_new_with_bulk_insert(long argc, const VALUE *argv);
+VALUE rb_hash_merge2(VALUE h1, VALUE h2, bool dup);
+VALUE rb_hash_merge2_bulk(VALUE hash, long argc, const VALUE *argv, bool dup);
 VALUE rb_hash_resurrect(VALUE hash);
 int rb_hash_stlike_lookup(VALUE hash, st_data_t key, st_data_t *pval);
 VALUE rb_hash_keys(VALUE hash);

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -1494,6 +1494,7 @@ pm_compile_hash_elements(rb_iseq_t *iseq, const pm_node_t *node, const pm_node_l
 
     int stack_length = 0;
     bool first_chunk = true;
+    bool owned_hash = false;
 
     // This is an optimization wherein we keep track of whether or not the
     // previous element was a static literal. If it was, then we do not attempt
@@ -1504,21 +1505,27 @@ pm_compile_hash_elements(rb_iseq_t *iseq, const pm_node_t *node, const pm_node_l
     DECL_ANCHOR(anchor);
 
     // Convert pushed elements to a hash, and merge if needed.
-#define FLUSH_CHUNK                                                                         \
-    if (stack_length) {                                                                     \
-        if (first_chunk) {                                                                  \
-            PUSH_SEQ(ret, anchor);                                                          \
-            PUSH_INSN1(ret, location, newhash, INT2FIX(stack_length));                      \
-            first_chunk = false;                                                            \
-        }                                                                                   \
-        else {                                                                              \
-            PUSH_INSN1(ret, location, putspecialobject, INT2FIX(VM_SPECIAL_OBJECT_VMCORE)); \
-            PUSH_INSN(ret, location, swap);                                                 \
-            PUSH_SEQ(ret, anchor);                                                          \
-            PUSH_SEND(ret, location, id_core_hash_merge_ptr, INT2FIX(stack_length + 1));    \
-        }                                                                                   \
-        INIT_ANCHOR(anchor);                                                                \
-        stack_length = 0;                                                                   \
+#define FLUSH_CHUNK                                                                               \
+    if (stack_length) {                                                                           \
+        if (first_chunk) {                                                                        \
+            PUSH_SEQ(ret, anchor);                                                                \
+            PUSH_INSN1(ret, location, newhash, INT2FIX(stack_length));                            \
+            first_chunk = false;                                                                  \
+        }                                                                                         \
+        else {                                                                                    \
+            PUSH_INSN1(ret, location, putspecialobject, INT2FIX(VM_SPECIAL_OBJECT_VMCORE));       \
+            PUSH_INSN(ret, location, swap);                                                       \
+            PUSH_SEQ(ret, anchor);                                                                \
+            if (owned_hash) {                                                                     \
+                PUSH_SEND(ret, location, id_core_hash_merge_bang_ptr, INT2FIX(stack_length + 1)); \
+            }                                                                                     \
+            else {                                                                                \
+                PUSH_SEND(ret, location, id_core_hash_merge_ptr, INT2FIX(stack_length + 1));      \
+                owned_hash = true;                                                                \
+            }                                                                                     \
+        }                                                                                         \
+        INIT_ANCHOR(anchor);                                                                      \
+        stack_length = 0;                                                                         \
     }
 
     for (size_t index = 0; index < elements->size; index++) {
@@ -1538,7 +1545,9 @@ pm_compile_hash_elements(rb_iseq_t *iseq, const pm_node_t *node, const pm_node_l
                 size_t count = 1;
                 while (index + count < elements->size && PM_NODE_FLAG_P(elements->nodes[index + count], PM_NODE_FLAG_STATIC_LITERAL)) count++;
 
-                if ((first_chunk && stack_length == 0) || count >= min_tmp_hash_length) {
+                bool first_element = first_chunk && stack_length == 0;
+
+                if (first_element || count >= min_tmp_hash_length) {
                     // The subsequence of elements in this hash is long enough
                     // to merit its own hash.
                     VALUE ary = rb_ary_hidden_new(count);
@@ -1564,7 +1573,14 @@ pm_compile_hash_elements(rb_iseq_t *iseq, const pm_node_t *node, const pm_node_l
                     // Emit optimized code.
                     FLUSH_CHUNK;
                     if (first_chunk) {
-                        PUSH_INSN1(ret, location, duphash, hash);
+                        if (count == elements->size) {
+                            // A fully literal hash.
+                            PUSH_INSN1(ret, location, duphash, hash);
+                        }
+                        else {
+                            // Partial hash that will be merged with a newly built one, no need to dup
+                            PUSH_INSN1(ret, location, putobject, rb_obj_reveal(hash, rb_cHash));
+                        }
                         first_chunk = false;
                     }
                     else {
@@ -1611,61 +1627,60 @@ pm_compile_hash_elements(rb_iseq_t *iseq, const pm_node_t *node, const pm_node_l
             bool last_element = index == elements->size - 1;
             bool only_element = first_element && last_element;
 
-            if (empty_hash) {
-                if (only_element && argument) {
-                    // **{} appears at the only keyword argument in method call,
-                    // so it won't be modified.
-                    //
-                    // This is only done for method calls and not for literal
-                    // hashes, because literal hashes should always result in a
-                    // new hash.
-                    PUSH_INSN(ret, location, putnil);
-                }
-                else if (first_element) {
-                    // **{} appears as the first keyword argument, so it may be
-                    // modified. We need to create a fresh hash object.
-                    PUSH_INSN1(ret, location, newhash, INT2FIX(0));
-                }
-                // Any empty keyword splats that are not the first can be
-                // ignored since merging an empty hash into the existing hash is
-                // the same as not merging it.
-            }
-            else {
-                if (only_element && argument) {
-                    // ** is only keyword argument in the method call. Use it
-                    // directly. This will be not be flagged as mutable. This is
-                    // only done for method calls and not for literal hashes,
-                    // because literal hashes should always result in a new
-                    // hash.
-                    if (shareability == 0) {
-                        PM_COMPILE_NOT_POPPED(element);
+            if (only_element) {
+                if (argument) {
+                    if (empty_hash) {
+                        // **{} appears at the only keyword argument in method call
+                        // We can substitute it for `**nil`.
+                        PUSH_INSN(ret, location, putnil);
                     }
                     else {
-                        pm_compile_shareable_constant_value(iseq, element, shareability, path, ret, scope_node, false);
+                        // ** is the only element.
+                        // Since we're in a method call, we can use it directly.
+                        // This will be not be flagged as mutable.
+                        if (shareability == 0) {
+                            PM_COMPILE_NOT_POPPED(element);
+                        }
+                        else {
+                            pm_compile_shareable_constant_value(iseq, element, shareability, path, ret, scope_node, false);
+                        }
                     }
                 }
                 else {
-                    // There is more than one keyword argument, or this is not a
-                    // method call. In that case, we need to add an empty hash
-                    // (if first keyword), or merge the hash to the accumulated
-                    // hash (if not the first keyword).
+                    // {**something}
+                    // We can simply call `core_hash_coerce(something)` to ensure it is coerced
+                    // into a mutable Hash.
                     PUSH_INSN1(ret, location, putspecialobject, INT2FIX(VM_SPECIAL_OBJECT_VMCORE));
-
-                    if (first_element) {
-                        PUSH_INSN1(ret, location, newhash, INT2FIX(0));
-                    }
-                    else {
-                        PUSH_INSN(ret, location, swap);
-                    }
-
                     if (shareability == 0) {
                         PM_COMPILE_NOT_POPPED(element);
                     }
                     else {
                         pm_compile_shareable_constant_value(iseq, element, shareability, path, ret, scope_node, false);
                     }
+                    PUSH_SEND(ret, location, id_core_hash_coerce, INT2FIX(1));
+                }
+            }
+            else {
+                if (!first_element) {
+                    PUSH_INSN1(ret, location, putspecialobject, INT2FIX(VM_SPECIAL_OBJECT_VMCORE));
+                    PUSH_INSN(ret, location, swap);
+                }
 
-                    PUSH_SEND(ret, location, id_core_hash_merge_kwd, INT2FIX(2));
+                if (shareability == 0) {
+                    PM_COMPILE_NOT_POPPED(element);
+                }
+                else {
+                    pm_compile_shareable_constant_value(iseq, element, shareability, path, ret, scope_node, false);
+                }
+
+                if (!first_element) {
+                    if (owned_hash) {
+                        PUSH_SEND(ret, location, id_core_hash_merge_bang_kwd, INT2FIX(2));
+                    }
+                    else {
+                        PUSH_SEND(ret, location, id_core_hash_merge_kwd, INT2FIX(2));
+                        owned_hash = true;
+                    }
                 }
             }
 

--- a/test/ruby/test_allocation.rb
+++ b/test/ruby/test_allocation.rb
@@ -70,7 +70,11 @@ class TestAllocation < Test::Unit::TestCase
 
       #{checks}
 
-      assert_empty(failures)
+      if failures.empty?
+        assert true
+      else
+        assert false, failures.join("\\n")
+      end
     RUBY
   end
 

--- a/test/ruby/test_keyword.rb
+++ b/test/ruby/test_keyword.rb
@@ -224,6 +224,8 @@ class TestKeywordArguments < Test::Unit::TestCase
     assert_equal([[], {}], skws(*nil, **nil))
 
     assert_equal({}, {**nil})
+    assert_equal({}, {**nil, **nil})
+    assert_equal({}, {**nil, **nil, **nil})
     assert_equal({a: 1}, {a: 1, **nil})
     assert_equal({a: 1}, {**nil, a: 1})
   end
@@ -497,6 +499,7 @@ class TestKeywordArguments < Test::Unit::TestCase
     def self.yo(*a, **kw) = kw
     assert_equal_not_same kw, yo(**kw)
     assert_equal_not_same kw, yo(**kw, **kw)
+    assert_equal_not_same kw, yo(**kw, **kw, **kw, **kw)
 
     singleton_class.send(:remove_method, :yo)
     def self.yo(opts) = opts
@@ -4187,7 +4190,7 @@ class TestKeywordArguments < Test::Unit::TestCase
       end
     end
 
-    assert_raise_with_message(TypeError, /expected Hash/, bug13015) do
+    assert_raise_with_message(TypeError, /no implicit conversion of Array into Hash/, bug13015) do
       klass.new(d: 4)
     end
   end

--- a/vm.c
+++ b/vm.c
@@ -4236,40 +4236,113 @@ m_core_set_postexe(VALUE self)
     return Qnil;
 }
 
-static VALUE core_hash_merge_kwd(VALUE hash, VALUE kw);
-
 static VALUE
-core_hash_merge(VALUE hash, long argc, const VALUE *argv)
+core_hash_merge(VALUE hash, long argc, const VALUE *argv, bool dup)
 {
-    Check_Type(hash, T_HASH);
-    VM_ASSERT(argc % 2 == 0);
-    rb_hash_bulk_insert(argc, argv, hash);
-    return hash;
+    if (NIL_P(hash)) {
+        hash = rb_cHash_empty_frozen;
+    }
+    else {
+        hash = rb_to_hash_type(hash);
+        Check_Type(hash, T_HASH);
+    }
+
+    return rb_hash_merge2_bulk(hash, argc, argv, dup);
 }
 
 static VALUE
 m_core_hash_merge_ptr(int argc, VALUE *argv, VALUE recv)
 {
     VALUE hash = argv[0];
+    VM_ASSERT(argc % 2 == 1);
 
-    REWIND_CFP(hash = core_hash_merge(hash, argc-1, argv+1));
+    REWIND_CFP(hash = core_hash_merge(hash, argc - 1, argv + 1, true));
 
     return hash;
 }
 
-static int
-kwmerge_i(VALUE key, VALUE value, VALUE hash)
+static VALUE
+m_core_hash_merge_bang_ptr(int argc, VALUE *argv, VALUE recv)
 {
-    rb_hash_aset(hash, key, value);
-    return ST_CONTINUE;
+    VALUE hash = argv[0];
+    VM_ASSERT(argc % 2 == 1);
+
+    REWIND_CFP(hash = core_hash_merge(hash, argc - 1, argv + 1, false));
+
+    return hash;
+}
+
+static VALUE
+core_hash_merge_kwd(VALUE hash, VALUE kw, bool dup)
+{
+    kw = rb_to_hash_type(kw);
+    if (NIL_P(hash)) {
+        return dup ? rb_hash_resurrect(kw) : kw;
+    }
+    else {
+        hash = rb_to_hash_type(hash);
+        Check_Type(hash, T_HASH);
+        return rb_hash_merge2(hash, kw, dup);
+    }
 }
 
 static VALUE
 m_core_hash_merge_kwd(VALUE recv, VALUE hash, VALUE kw)
 {
-    if (!NIL_P(kw)) {
-        REWIND_CFP(hash = core_hash_merge_kwd(hash, kw));
+    // We don't own `hash` so we can't mutate it, nor just return it.
+    if (NIL_P(kw)) {
+        if (NIL_P(hash)) {
+            // If we knew that we're dealing with keyword arguments, and not a hash literal,
+            // we could return nil here.
+            return rb_hash_new();
+        }
+
+        hash = rb_hash_resurrect(hash);
     }
+    else {
+        REWIND_CFP(hash = core_hash_merge_kwd(hash, kw, true));
+    }
+    VM_ASSERT(CLASS_OF(hash));
+    return hash;
+}
+
+static VALUE
+m_core_hash_merge_bang_kwd(VALUE recv, VALUE hash, VALUE kw)
+{
+    // We own `hash` we should mutate it in place if possible.
+    if (NIL_P(kw)) {
+        if (NIL_P(hash)) {
+            hash = rb_hash_new();
+        }
+        else {
+            hash = rb_hash_resurrect(hash);
+        }
+    }
+    else {
+        REWIND_CFP(hash = core_hash_merge_kwd(hash, kw, false));
+    }
+    VM_ASSERT(CLASS_OF(hash));
+    return hash;
+}
+
+static VALUE
+core_hash_coerce(VALUE hash)
+{
+    if (NIL_P(hash)) {
+        return rb_hash_new();
+    }
+    VALUE new_hash = rb_to_hash_type(hash);
+    if (new_hash == hash) {
+        new_hash = rb_hash_dup(new_hash);
+    }
+    return new_hash;
+}
+
+static VALUE
+m_core_hash_coerce(VALUE recv, VALUE hash)
+{
+    REWIND_CFP(hash = core_hash_coerce(hash));
+    VM_ASSERT(CLASS_OF(hash));
     return hash;
 }
 
@@ -4289,13 +4362,6 @@ static VALUE
 m_core_ensure_shareable(VALUE recv, VALUE obj, VALUE name)
 {
     return rb_ractor_ensure_shareable(obj, name);
-}
-
-static VALUE
-core_hash_merge_kwd(VALUE hash, VALUE kw)
-{
-    rb_hash_foreach(rb_to_hash_type(kw), kwmerge_i, hash);
-    return hash;
 }
 
 extern VALUE *rb_gc_stack_start;
@@ -4466,7 +4532,10 @@ Init_VM(void)
     rb_define_method_id(klass, id_core_undef_method, m_core_undef_method, 2);
     rb_define_method_id(klass, id_core_set_postexe, m_core_set_postexe, 0);
     rb_define_method_id(klass, id_core_hash_merge_ptr, m_core_hash_merge_ptr, -1);
+    rb_define_method_id(klass, id_core_hash_merge_bang_ptr, m_core_hash_merge_bang_ptr, -1);
     rb_define_method_id(klass, id_core_hash_merge_kwd, m_core_hash_merge_kwd, 2);
+    rb_define_method_id(klass, id_core_hash_merge_bang_kwd, m_core_hash_merge_bang_kwd, 2);
+    rb_define_method_id(klass, id_core_hash_coerce, m_core_hash_coerce, 1);
     rb_define_method_id(klass, id_core_raise, f_raise, -1);
     rb_define_method_id(klass, id_core_sprintf, f_sprintf, -1);
     rb_define_method_id(klass, idProc, f_proc, 0);

--- a/zjit/src/hir/tests.rs
+++ b/zjit/src/hir/tests.rs
@@ -2754,17 +2754,13 @@ pub(crate) mod hir_build_tests {
           v7:BasicObject = LoadArg :a@1
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
-          v15:ClassSubclass[VMFrozenCore] = Const Value(VALUE(0x1008))
-          v17:HashExact = NewHash
-          PatchPoint NoEPEscape(test)
-          v22:BasicObject = Send v15, :core#hash_merge_kwd, v17, v10 # SendFallbackReason: Uncategorized(opt_send_without_block)
-          v24:ClassSubclass[VMFrozenCore] = Const Value(VALUE(0x1008))
-          v27:StaticSymbol[:b] = Const Value(VALUE(0x1010))
-          v29:Fixnum[1] = Const Value(1)
-          v31:BasicObject = Send v24, :core#hash_merge_ptr, v22, v27, v29 # SendFallbackReason: Uncategorized(opt_send_without_block)
-          v33:BasicObject = Send v9, :foo, v31 # SendFallbackReason: Uncategorized(opt_send_without_block)
+          v16:ClassSubclass[VMFrozenCore] = Const Value(VALUE(0x1008))
+          v19:StaticSymbol[:b] = Const Value(VALUE(0x1010))
+          v21:Fixnum[1] = Const Value(1)
+          v23:BasicObject = Send v16, :core#hash_merge_ptr, v10, v19, v21 # SendFallbackReason: Uncategorized(opt_send_without_block)
+          v25:BasicObject = Send v9, :foo, v23 # SendFallbackReason: Uncategorized(opt_send_without_block)
           CheckInterrupts
-          Return v33
+          Return v25
         ");
     }
 


### PR DESCRIPTION
Rather than start from a mutable hash created with `newhash` or `duphash`, and then iteratively insert into it, it's preferable to start from a constant hidden hash, so that we can directly allocate the final hash with the right size.

For instance:

```ruby
{a: 1, B => 2, c: 3}
```

Before:

```
0000 duphash                                {a: 1}                    (   1)[Li]
0002 putspecialobject                       1
0004 swap
0005 opt_getconstant_path                   <ic:0 B>
0007 putobject                              2
0009 putobject                              :c
0011 putobject                              3
0013 opt_send_without_block                 <calldata!mid:core#hash_merge_ptr, argc:5, ARGS_SIMPLE>
```

After:

```
0000 putobject                              {a: 1}                    (   1)[Li]
0002 putspecialobject                       1
0004 swap
0005 opt_getconstant_path                   <ic:0 B>
0007 putobject                              2
0009 putobject                              :c
0011 putobject                              3
0013 opt_send_without_block                 <calldata!mid:core#hash_merge_ptr, argc:5, ARGS_SIMPLE>
```

Since, `duphash` has no idea how large the final hash might be, it can't right-size the hash it allocates.

Hence it's preferable to use a `putobject` and let `hash_merge_ptr` compute the final hash right size by assuming all keys are unique.