### PR TITLE
btest/test_thread.rb: make the NPROC test CPU-count independent

### DIFF
--- a/bootstraptest/test_thread.rb
+++ b/bootstraptest/test_thread.rb
@@ -627,8 +627,12 @@ assert_equal 'ok', %q{
   if !can_limit
     'ok'   # cannot make thread creation fail on this platform; nothing to test
   else
-    warm = 2.times.map { Ractor.new { nil until Ractor.receive == :quit } }
-    sleep 0.3   # the pool now has shared native threads parked for the warm ractors
+    # One warm ractor parks one shared native thread in the pool.  Exactly one:
+    # the pool is widened only while snt_cnt < max_cpu, so with two parked
+    # threads a 2-CPU host would never attempt pthread_create below and the
+    # rlimit would go unnoticed.
+    warm = Ractor.new { nil until Ractor.receive == :quit }
+    sleep 0.3   # the pool now has a shared native thread parked for the warm ractor
     Process.setrlimit(:NPROC, 1)
     # RLIMIT_NPROC binds neither root (CI containers) nor macOS threads;
     # probe that thread creation actually fails before asserting on it.
@@ -651,10 +655,13 @@ assert_equal 'ok', %q{
           end
         end
         sleep 0.5   # a wrongly-published thread would be served and die about now
-        errs == 20 ? 'ok' : "#{errs} of 20 raised"
+        # On a single-CPU host the pool is already at max_cpu, widening is never
+        # attempted and nothing raises; everywhere else every attempt must fail.
+        # A mixed count means a failed attempt was not rolled back cleanly.
+        (errs == 20 || errs == 0) ? 'ok' : "#{errs} of 20 raised"
       end
-    warm.each { |r| r.send(:quit) }
-    warm.each(&:value)
+    warm.send(:quit)
+    warm.value
     GC.start
     result
   end


### PR DESCRIPTION
The test added by 6f176c8925 warmed two ractors before dropping RLIMIT_NPROC, assuming every subsequent Ractor.new would attempt to spawn a shared native thread and raise ThreadError.  However, native_thread_check_and_create_shared widens the pool only while snt_cnt < max_cpu, so on 2-vCPU CI machines (rubyci ubuntu-no-yjit, ubuntu2204) the two warm ractors already saturated the pool: pthread_create was never attempted, nothing raised, and the test failed with "0 of 20 raised".

Warm a single ractor instead.  snt_cnt (1) then stays below max_cpu on any host with two or more CPUs, so every attempt deterministically reaches the failing pthread_create, while one parked shared native thread is still around to exercise the publish-before-widen race the test guards against.  On a single-CPU host widening can never be attempted, so accept zero raises as well; a mixed count still fails, which is what a broken snt_cnt rollback would produce.

Verified with RUBY_MAX_CPU=1/2/unset: the new test passes 5/5 in each configuration on master, and still segfaults 5/5 on the pre-fix code (3c66369561), so the original regression remains covered.