### PR TITLE
Ractor: let ruby_vm_destruct wait for the postmortem epilogue

### DIFF
--- a/thread.c
+++ b/thread.c
@@ -842,12 +842,25 @@ thread_start_func_2(rb_thread_t *th, VALUE *stack_start)
 #endif
 
     if (th->invoke_type == thread_invoke_type_ractor_proc) {
+        // The postmortem epilogue below runs after this Ractor is unlinked and no
+        // longer counted, with the GVL already released, and it frees through
+        // VM-global state (the jit_cont list and its mutex, the fiber pool, the
+        // main objspace's malloc accounting).  Nothing else holds the main Ractor
+        // back at that point, so count it like a coroutine epilogue: then
+        // ruby_vm_destruct waits for it (rb_thread_sched_wait_winding) instead of
+        // tearing that state down underneath.  th is freed by the epilogue, so
+        // keep the VM pointer.
+        rb_vm_t *const vm = th->vm;
+        rb_thread_sched_winding_begin(vm);
+
         // after rb_ractor_living_threads_remove()
         // GC will happen anytime and this ractor can be collected (and destroy GVL).
         // So gvl_release() should be before it.
         thread_sched_to_dead(TH_SCHED(th), th);
         rb_ractor_living_threads_remove(th->ractor, th);
         rb_ractor_postmortem_free(&pf);
+
+        rb_thread_sched_winding_end(vm);
     }
     else {
         rb_ractor_living_threads_remove(th->ractor, th);

--- a/thread_none.c
+++ b/thread_none.c
@@ -340,6 +340,19 @@ rb_thread_event_hooks_registered_p(void)
 #endif /* THREAD_SYSTEM_DEPENDENT_IMPLEMENTATION */
 
 void
+rb_thread_sched_winding_begin(rb_vm_t *vm)
+{
+    // nothing to count: rb_thread_sched_wait_winding below never waits
+    (void)vm;
+}
+
+void
+rb_thread_sched_winding_end(rb_vm_t *vm)
+{
+    (void)vm;
+}
+
+void
 rb_thread_sched_wait_winding(rb_vm_t *vm)
 {
     // no coroutine (M:N) threads on this implementation: nothing winds down

--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -1340,6 +1340,23 @@ grq_size(rb_vm_t *vm, rb_ractor_t *cr)
 }
 #endif
 
+// A native thread enters/leaves an epilogue that outlives its Ractor: from
+// the increment until the decrement, ruby_vm_destruct waits for it below.
+// The increment must happen while the VM still counts the thread's Ractor,
+// so that the two never look absent at the same time.
+void
+rb_thread_sched_winding_begin(rb_vm_t *vm)
+{
+    RUBY_ATOMIC_INC(vm->ractor.sched.winding_cnt);
+}
+
+void
+rb_thread_sched_winding_end(rb_vm_t *vm)
+{
+    VM_ASSERT(RUBY_ATOMIC_LOAD(vm->ractor.sched.winding_cnt) > 0);
+    RUBY_ATOMIC_DEC(vm->ractor.sched.winding_cnt);
+}
+
 // ruby_vm_destruct: wait until no native thread is between a coroutine
 // epilogue and its reclaim -- past that point the reclaim frees through the
 // (about to be destroyed) objspace and reads the (about to be unset) VM.

--- a/thread_win32.c
+++ b/thread_win32.c
@@ -1021,6 +1021,19 @@ rb_thread_malloc_stack_set(rb_thread_t *th, void *stack, size_t stack_size)
 #endif /* THREAD_SYSTEM_DEPENDENT_IMPLEMENTATION */
 
 void
+rb_thread_sched_winding_begin(rb_vm_t *vm)
+{
+    // nothing to count: rb_thread_sched_wait_winding below never waits
+    (void)vm;
+}
+
+void
+rb_thread_sched_winding_end(rb_vm_t *vm)
+{
+    (void)vm;
+}
+
+void
 rb_thread_sched_wait_winding(rb_vm_t *vm)
 {
     // no coroutine (M:N) threads on this implementation: nothing winds down


### PR DESCRIPTION
Since "Ractor: the dying thread collects its own objspace post-mortem" (e768a87a17), a dying Ractor thread runs rb_ractor_postmortem_free() after thread_sched_to_dead() (its GVL is gone) and after rb_ractor_living_threads_remove() -> vm_remove_ractor(), which unlinks the Ractor, decrements vm->ractor.cnt and signals the terminate waiter. From that point nothing holds the main Ractor back, but the epilogue still frees through VM-global state: rb_fiber_free_body() -> cont_free() takes jit_cont_lock and returns the stack to the shared fiber pool, and both frees update the main objspace's malloc accounting.

The coroutine epilogue has the same hazard and is covered: coroutine_thread_terminated() bumps vm->ractor.sched.winding_cnt and ruby_vm_destruct() spins in rb_thread_sched_wait_winding() until the reclaim is done.  The non-coroutine path -- the ordinary Ractor.new-spawned dedicated thread -- was not counted, so a main Ractor that exits while the dying thread is still in the epilogue tears that state down underneath it.

Count the epilogue in winding_cnt as well.  The increment happens before the Ractor stops being counted, so there is no window where the VM sees neither the Ractor nor the epilogue.

Reproduced deterministically by delaying the epilogue (50ms) and the process exit (400ms) on top of e768a87a17: 6/6 runs of `Ractor.new{ 1 }.value` died with

  [BUG] pthread_mutex_lock: Invalid argument (EINVAL)
    rb_native_mutex_lock (thread_pthread.c:128)
    jit_cont_free (cont.c:1419)
    cont_free (cont.c:1185)
    rb_ractor_postmortem_free (ractor.c:683)
    thread_start_func_2 (thread.c:851)

i.e. the epilogue locking jit_cont_lock after rb_jit_cont_finish() destroyed it.  With this change the same harness is clean 6/6, and test/ruby/test_ractor.rb, test/objspace/test_ractor.rb and the strscan/digest/io-wait/io-console Ractor tests pass.

This is the most likely cause of the heap corruption CI has been reporting since e768a87a17 landed (2026-08-10 18:33 UTC): every failing case is a child process that runs one Ractor and exits.

Error:
  TestIOWaitInRactor#test_ractor [test/io/wait/test_ractor.rb:9]:
  pid 68552 exit 0
  | free(): corrupted unsorted chunks
  1. [2/2] Assertion for "stderr" | <[]> expected but was | <["free(): corrupted unsorted chunks"]>.

  (also TestStringScannerRactor#test_ractor, TestDigestRactor::*,
   TestIOConsoleInRactor#test_ractor -- 16 of the 63 master runs since
   2026-08-10, none in the 87 runs before it)

  TestObjSpaceRactor#test_copy_finalizer [test/objspace/test_ractor.rb:57]:
  ==96541==ERROR: AddressSanitizer: heap-use-after-free on address 0x520000000088
  WRITE of size 8 at 0x520000000088 thread T5

CI: https://github.com/ruby/ruby/actions/runs/31886577248/job/95016642538
CI: https://github.com/ruby/ruby/actions/runs/31427322788 (ASAN, x86_64)