### PR TITLE
Get rid of `rb_hash_new_with_size`

### DIFF
--- a/array.c
+++ b/array.c
@@ -3303,7 +3303,7 @@ static VALUE
 rb_ary_to_h(VALUE ary)
 {
     long i;
-    VALUE hash = rb_hash_new_with_size(RARRAY_LEN(ary));
+    VALUE hash = rb_hash_new_capa(RARRAY_LEN(ary));
     int block_given = rb_block_given_p();
 
     for (i=0; i<RARRAY_LEN(ary); i++) {
@@ -5739,7 +5739,7 @@ static inline VALUE
 ary_tmp_hash_new(VALUE ary)
 {
     long size = RARRAY_LEN(ary);
-    VALUE hash = rb_hash_new_with_size(size);
+    VALUE hash = rb_hash_new_capa(size);
 
     RBASIC_CLEAR_CLASS(hash);
     return hash;

--- a/box.c
+++ b/box.c
@@ -183,8 +183,8 @@ box_entry_initialize(rb_box_t *box)
     box->loaded_features_realpaths = rb_hash_dup(master->loaded_features_realpaths);
     box->loaded_features_realpath_map = rb_hash_dup(master->loaded_features_realpath_map);
     box->loading_table = st_init_strtable();
-    box->ruby_dln_libmap = rb_hash_new_with_size(0);
-    box->gvar_tbl = rb_hash_new_with_size(0);
+    box->ruby_dln_libmap = rb_hash_new();
+    box->gvar_tbl = rb_hash_new();
     box->classext_cow_classes = st_init_numtable();
 
     box->is_user = true;
@@ -902,8 +902,8 @@ initialize_master_box(void)
     master->loaded_features_realpath_map = rb_hash_new();
     rb_obj_hide(master->loaded_features_realpath_map);
 
-    master->ruby_dln_libmap = rb_hash_new_with_size(0);
-    master->gvar_tbl = rb_hash_new_with_size(0);
+    master->ruby_dln_libmap = rb_hash_new();
+    master->gvar_tbl = rb_hash_new();
     master->classext_cow_classes = NULL; // classext CoW never happen on the master box
 
     vm->master_box = master;

--- a/compile.c
+++ b/compile.c
@@ -14428,7 +14428,7 @@ static VALUE
 ibf_load_object_hash(const struct ibf_load *load, const struct ibf_object_header *header, ibf_offset_t offset)
 {
     long len = (long)ibf_load_small_value(load, &offset);
-    VALUE obj = header->frozen ? rb_hash_alloc_fixed_size(rb_cHash, len) : rb_hash_new_with_size(len);
+    VALUE obj = header->frozen ? rb_hash_alloc_fixed_size(rb_cHash, len) : rb_hash_new_capa(len);
     int i;
 
     for (i = 0; i < len; i++) {

--- a/enumerator.c
+++ b/enumerator.c
@@ -4671,7 +4671,7 @@ InitVM_Enumerator(void)
     rb_define_method(rb_cLazy, "with_index", lazy_with_index, -1);
     rb_define_method(rb_cLazy, "tap_each", lazy_tap_each, 0);
 
-    lazy_use_super_method = rb_hash_new_with_size(18);
+    lazy_use_super_method = rb_hash_new_capa(18);
     rb_hash_aset(lazy_use_super_method, sym("map"), sym("_enumerable_map"));
     rb_hash_aset(lazy_use_super_method, sym("collect"), sym("_enumerable_collect"));
     rb_hash_aset(lazy_use_super_method, sym("flat_map"), sym("_enumerable_flat_map"));

--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -10042,7 +10042,7 @@ type_name(int type, VALUE obj)
 static void
 gc_count_add_each_types(VALUE hash, const char *name, const size_t *types)
 {
-    VALUE result = rb_hash_new_with_size(T_MASK);
+    VALUE result = rb_hash_new_capa(T_MASK);
     int i;
     for (i=0; i<T_MASK; i++) {
         const char *type = type_name(i, 0);
@@ -12457,7 +12457,7 @@ rb_gc_impl_after_fork(void *objspace_ptr, rb_pid_t pid)
     }
 }
 
-VALUE rb_ident_hash_new_with_size(st_index_t size);
+VALUE rb_ident_hash_new_capa(long size);
 
 #if GC_DEBUG_STRESS_TO_CLASS
 /*
@@ -12473,7 +12473,7 @@ rb_gcdebug_add_stress_to_class(int argc, VALUE *argv, VALUE self)
     rb_objspace_t *objspace = rb_gc_get_objspace();
 
     if (!stress_to_class) {
-        set_stress_to_class(rb_ident_hash_new_with_size(argc));
+        set_stress_to_class(rb_ident_hash_new_capa(argc));
     }
 
     for (int i = 0; i < argc; i++) {

--- a/hash.c
+++ b/hash.c
@@ -1546,12 +1546,6 @@ copy_compare_by_id(VALUE hash, VALUE basis)
 }
 
 VALUE
-rb_hash_new_with_size(st_index_t size)
-{
-    return hash_alloc_capa(rb_cHash, 0, Qnil, size, false);
-}
-
-VALUE
 rb_hash_new_capa(long capa)
 {
     return hash_alloc_capa(rb_cHash, 0, Qnil, capa, false);
@@ -2722,7 +2716,7 @@ rb_hash_slice(int argc, VALUE *argv, VALUE hash)
     if (argc == 0 || RHASH_EMPTY_P(hash)) {
         return copy_compare_by_id(rb_hash_new(), hash);
     }
-    result = copy_compare_by_id(rb_hash_new_with_size(argc), hash);
+    result = copy_compare_by_id(rb_hash_new_capa(argc), hash);
 
     for (i = 0; i < argc; i++) {
         key = argv[i];
@@ -3813,7 +3807,7 @@ to_h_i(VALUE key, VALUE value, VALUE hash)
 static VALUE
 rb_hash_to_h_block(VALUE hash)
 {
-    VALUE h = rb_hash_new_with_size(RHASH_SIZE(hash));
+    VALUE h = rb_hash_new_capa(RHASH_SIZE(hash));
     rb_hash_foreach(hash, to_h_i, h);
     return h;
 }
@@ -4208,7 +4202,7 @@ rb_hash_invert_i(VALUE key, VALUE value, VALUE hash)
 static VALUE
 rb_hash_invert(VALUE hash)
 {
-    VALUE h = rb_hash_new_with_size(RHASH_SIZE(hash));
+    VALUE h = rb_hash_new_capa(RHASH_SIZE(hash));
 
     rb_hash_foreach(hash, rb_hash_invert_i, h);
     return h;
@@ -4813,7 +4807,7 @@ rb_ident_hash_new(void)
 }
 
 VALUE
-rb_ident_hash_new_with_size(st_index_t size)
+rb_ident_hash_new_capa(long size)
 {
     VALUE hash = rb_hash_new();
     hash_st_table_init(hash, &identhash, size);
@@ -5203,7 +5197,7 @@ rb_hash_bulk_insert(long argc, const VALUE *argv, VALUE hash)
 VALUE
 rb_hash_new_with_bulk_insert(long argc, const VALUE *argv)
 {
-    VALUE val = rb_hash_new_with_size(argc / 2);
+    VALUE val = rb_hash_new_capa(argc / 2);
     rb_hash_bulk_insert(argc, argv, val);
     return val;
 }
@@ -6229,7 +6223,7 @@ env_slice(int argc, VALUE *argv, VALUE _)
     if (argc == 0) {
         return rb_hash_new();
     }
-    result = rb_hash_new_with_size(argc);
+    result = rb_hash_new_capa(argc);
 
     for (i = 0; i < argc; i++) {
         key = argv[i];

--- a/internal/hash.h
+++ b/internal/hash.h
@@ -88,7 +88,7 @@ int rb_hash_stlike_foreach_with_replace(VALUE hash, st_foreach_check_callback_fu
 int rb_hash_stlike_update(VALUE hash, st_data_t key, st_update_callback_func *func, st_data_t arg);
 bool rb_hash_default_unredefined(VALUE hash);
 VALUE rb_hash_alloc_fixed_size(VALUE klass, st_index_t size);
-VALUE rb_ident_hash_new_with_size(st_index_t size);
+VALUE rb_ident_hash_new_capa(long size);
 void rb_hash_free(VALUE hash);
 RUBY_EXTERN VALUE rb_cHash_empty_frozen;
 
@@ -110,7 +110,6 @@ VALUE rb_ident_hash_new(void);
 int rb_hash_stlike_foreach(VALUE hash, st_foreach_callback_func *func, st_data_t arg);
 RUBY_SYMBOL_EXPORT_END
 
-VALUE rb_hash_new_with_size(st_index_t size);
 VALUE rb_hash_new_with_bulk_insert(long argc, const VALUE *argv);
 VALUE rb_hash_resurrect(VALUE hash);
 int rb_hash_stlike_lookup(VALUE hash, st_data_t key, st_data_t *pval);

--- a/iseq.c
+++ b/iseq.c
@@ -943,7 +943,7 @@ make_compile_option(rb_compile_option_t *option, VALUE opt)
 static VALUE
 make_compile_option_value(rb_compile_option_t *option)
 {
-    VALUE opt = rb_hash_new_with_size(11);
+    VALUE opt = rb_hash_new_capa(11);
 #define SET_COMPILE_OPTION(o, h, mem) \
   rb_hash_aset((h), ID2SYM(rb_intern(#mem)), RBOOL((o)->mem))
 #define SET_COMPILE_OPTION_NUM(o, h, mem) \

--- a/marshal.c
+++ b/marshal.c
@@ -1874,7 +1874,7 @@ r_object0(struct load_arg *arg, bool partial, int *ivp, VALUE extmod)
 static VALUE
 r_object_for(struct load_arg *arg, bool partial, int *ivp, VALUE klass, VALUE extmod, int type)
 {
-    VALUE (*hash_new_with_size)(st_index_t) = rb_hash_new_with_size;
+    VALUE (*hash_new_capa)(long) = rb_hash_new_capa;
     VALUE v = Qnil;
     long id;
     st_data_t link;
@@ -1950,7 +1950,7 @@ r_object_for(struct load_arg *arg, bool partial, int *ivp, VALUE klass, VALUE ex
             if ((c == rb_cHash) &&
                 /* Hack for compare_by_identity */
                 (type == TYPE_HASH || type == TYPE_HASH_DEF)) {
-                hash_new_with_size = rb_ident_hash_new_with_size;
+                hash_new_capa = rb_ident_hash_new_capa;
                 goto type_hash;
             }
             v = r_object_for(arg, partial, 0, c, extmod, type);
@@ -2126,7 +2126,7 @@ r_object_for(struct load_arg *arg, bool partial, int *ivp, VALUE klass, VALUE ex
         {
             long len = r_keep_readable(arg, r_long(arg), 2);
 
-            v = hash_new_with_size(len);
+            v = hash_new_capa(len);
             v = r_entry(v, arg);
             arg->readable += (len - 1) * 2;
             while (len--) {

--- a/re.c
+++ b/re.c
@@ -893,7 +893,7 @@ static VALUE
 rb_reg_named_captures(VALUE re)
 {
     regex_t *reg = (rb_reg_check(re), RREGEXP_PTR(re));
-    VALUE hash = rb_hash_new_with_size(onig_number_of_names(reg));
+    VALUE hash = rb_hash_new_capa(onig_number_of_names(reg));
     onig_foreach_name(reg, reg_named_captures_iter, (void*)hash);
     return hash;
 }
@@ -2669,11 +2669,11 @@ match_deconstruct_keys(VALUE match, VALUE keys)
     match_check(match);
 
     if (NIL_P(RMATCH(match)->regexp)) {
-        return rb_hash_new_with_size(0);
+        return rb_hash_new();
     }
 
     if (NIL_P(keys)) {
-        h = rb_hash_new_with_size(onig_number_of_names(RREGEXP_PTR(RMATCH(match)->regexp)));
+        h = rb_hash_new_capa(onig_number_of_names(RREGEXP_PTR(RMATCH(match)->regexp)));
 
         struct named_captures_data data = { h, match, 1 };
 
@@ -2685,10 +2685,10 @@ match_deconstruct_keys(VALUE match, VALUE keys)
     Check_Type(keys, T_ARRAY);
 
     if (onig_number_of_names(RREGEXP_PTR(RMATCH(match)->regexp)) < RARRAY_LEN(keys)) {
-        return rb_hash_new_with_size(0);
+        return rb_hash_new();
     }
 
-    h = rb_hash_new_with_size(RARRAY_LEN(keys));
+    h = rb_hash_new_capa(RARRAY_LEN(keys));
 
     for (i=0; i<RARRAY_LEN(keys); i++) {
         VALUE key = RARRAY_AREF(keys, i);

--- a/set.c
+++ b/set.c
@@ -2215,13 +2215,13 @@ set_to_hash_i(st_data_t key, st_data_t arg)
 static VALUE
 set_i_to_h(VALUE set)
 {
-    st_index_t size = RSET_SIZE(set);
+    long size = RSET_SIZE(set);
     VALUE hash;
     if (RSET_COMPARE_BY_IDENTITY(set)) {
-        hash = rb_ident_hash_new_with_size(size);
+        hash = rb_ident_hash_new_capa(size);
     }
     else {
-        hash = rb_hash_new_with_size(size);
+        hash = rb_hash_new_capa(size);
     }
     rb_hash_set_default(hash, Qfalse);
 

--- a/struct.c
+++ b/struct.c
@@ -321,7 +321,7 @@ rb_data_s_new(int argc, const VALUE *argv, VALUE klass)
         int num_members = RARRAY_LENINT(members);
 
         rb_check_arity(argc, 0, num_members);
-        VALUE arg_hash = rb_hash_new_with_size(argc);
+        VALUE arg_hash = rb_hash_new_capa(argc);
         for (long i=0; i<argc; i++) {
             VALUE k = rb_ary_entry(members, i), v = argv[i];
             rb_hash_aset(arg_hash, k, v);
@@ -1088,7 +1088,7 @@ rb_struct_to_a(VALUE s)
 static VALUE
 rb_struct_to_h(VALUE s)
 {
-    VALUE h = rb_hash_new_with_size(RSTRUCT_LEN_RAW(s));
+    VALUE h = rb_hash_new_capa(RSTRUCT_LEN_RAW(s));
     VALUE members = rb_struct_members(s);
     long i;
     int block_given = rb_block_given_p();
@@ -1142,9 +1142,9 @@ deconstruct_keys(VALUE s, VALUE keys, bool name_only)
 
     }
     if (RSTRUCT_LEN_RAW(s) < RARRAY_LEN(keys)) {
-        return rb_hash_new_with_size(0);
+        return rb_hash_new();
     }
-    h = rb_hash_new_with_size(RARRAY_LEN(keys));
+    h = rb_hash_new_capa(RARRAY_LEN(keys));
     for (i=0; i<RARRAY_LEN(keys); i++) {
         VALUE key = RARRAY_AREF(keys, i);
         int i = rb_struct_pos(s, &key, name_only);

--- a/time.c
+++ b/time.c
@@ -5191,7 +5191,7 @@ time_deconstruct_keys(VALUE time, VALUE keys)
     MAKE_TM_ENSURE(time, tobj, tobj->vtm.yday != 0);
 
     if (NIL_P(keys)) {
-        h = rb_hash_new_with_size(11);
+        h = rb_hash_new_capa(11);
 
         rb_hash_aset(h, sym_year, tobj->vtm.year);
         rb_hash_aset(h, sym_month, INT2FIX(tobj->vtm.mon));
@@ -5215,7 +5215,7 @@ time_deconstruct_keys(VALUE time, VALUE keys)
 
     }
 
-    h = rb_hash_new_with_size(RARRAY_LEN(keys));
+    h = rb_hash_new_capa(RARRAY_LEN(keys));
 
     for (i=0; i<RARRAY_LEN(keys); i++) {
         VALUE key = RARRAY_AREF(keys, i);

--- a/vm.c
+++ b/vm.c
@@ -3671,7 +3671,7 @@ static VALUE
 vm_default_params(void)
 {
     rb_vm_t *vm = GET_VM();
-    VALUE result = rb_hash_new_with_size(4);
+    VALUE result = rb_hash_new_capa(4);
 #define SET(name) rb_hash_aset(result, ID2SYM(rb_intern(#name)), SIZET2NUM(vm->default_params.name));
     SET(thread_vm_stack_size);
     SET(thread_machine_stack_size);

--- a/vm_args.c
+++ b/vm_args.c
@@ -192,7 +192,7 @@ args_kw_argv_to_hash(struct args_info *args)
     const struct rb_callinfo_kwarg *kw_arg = args->kw_arg;
     const VALUE *const passed_keywords = kw_arg->keywords;
     const int kw_len = kw_arg->keyword_len;
-    VALUE h = rb_hash_new_with_size(kw_len);
+    VALUE h = rb_hash_new_capa(kw_len);
     const int kw_start = args->argc - kw_len;
     const VALUE * const kw_argv = args->argv + kw_start;
     int i;
@@ -293,7 +293,7 @@ static VALUE
 make_rest_kw_hash(const VALUE *passed_keywords, int passed_keyword_len, const VALUE *kw_argv)
 {
     int i;
-    VALUE obj = rb_hash_new_with_size(passed_keyword_len);
+    VALUE obj = rb_hash_new_capa(passed_keyword_len);
 
     for (i=0; i<passed_keyword_len; i++) {
         if (!UNDEF_P(kw_argv[i])) {

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -2784,7 +2784,7 @@ vm_caller_setup_arg_kw(rb_control_frame_t *cfp, struct rb_calling_info *calling,
 {
     const VALUE *const passed_keywords = vm_ci_kwarg(ci)->keywords;
     const int kw_len = vm_ci_kwarg(ci)->keyword_len;
-    const VALUE h = rb_hash_new_with_size(kw_len);
+    const VALUE h = rb_hash_new_capa(kw_len);
     VALUE *sp = cfp->sp;
     int i;
 
@@ -6529,7 +6529,7 @@ vm_opt_newarray_pack_buffer(rb_execution_context_t *ec, rb_num_t array_len, cons
         int argc = 1;
 
         if (!UNDEF_P(buffer)) {
-            args[1] = rb_hash_new_with_size(1);
+            args[1] = rb_hash_new_capa(1);
             rb_hash_aset(args[1], ID2SYM(idBuffer), buffer);
             kw_splat = RB_PASS_KEYWORDS;
             argc++;

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -98,7 +98,7 @@ fn main() {
         .allowlist_function("rb_obj_frozen_p")
         .allowlist_type("ruby_encoding_consts")
         .allowlist_function("rb_hash_new")
-        .allowlist_function("rb_hash_new_with_size")
+        .allowlist_function("rb_hash_new_capa")
         .allowlist_function("rb_hash_resurrect")
         .allowlist_function("rb_to_hash_type")
         .allowlist_type("st_retval")

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -2725,9 +2725,9 @@ fn gen_newhash(
     jit_prepare_call_with_gc(jit, asm);
 
     if num != 0 {
-        // val = rb_hash_new_with_size(num / 2);
+        // val = rb_hash_new_capa(num / 2);
         let new_hash = asm.ccall(
-            rb_hash_new_with_size as *const u8,
+            rb_hash_new_capa as *const u8,
             vec![Opnd::UImm(num / 2)]
         );
 
@@ -6770,7 +6770,7 @@ fn c_method_tracing_currently_enabled(jit: &JITState) -> bool {
 unsafe extern "C" fn build_kwhash(ci: *const rb_callinfo, sp: *const VALUE) -> VALUE {
     let kw_arg = vm_ci_kwarg(ci);
     let kw_len: usize = get_cikw_keyword_len(kw_arg).try_into().unwrap();
-    let hash = rb_hash_new_with_size(kw_len as u64);
+    let hash = rb_hash_new_capa(kw_len as i64);
 
     for kwarg_idx in 0..kw_len {
         let key = get_cikw_keywords_idx(kw_arg, kwarg_idx.try_into().unwrap());
@@ -8588,7 +8588,7 @@ fn gen_iseq_kw_call(
 
                 // Use the total number of supplied keywords as a size upper bound
                 let keyword_len = unsafe { (*keywords).keyword_len } as usize;
-                let hash = unsafe { rb_hash_new_with_size(keyword_len as u64) };
+                let hash = unsafe { rb_hash_new_capa(keyword_len as i64) };
 
                 // Put pairs into the kwrest hash as the mask describes
                 for kwarg_idx in 0..keyword_len {

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -257,7 +257,6 @@ pub const RSTRING_NOEMBED: ruby_rstring_flags = 8192;
 pub const RSTRING_FSTR: ruby_rstring_flags = 536870912;
 pub type ruby_rstring_flags = u32;
 pub type st_data_t = ::std::os::raw::c_ulong;
-pub type st_index_t = st_data_t;
 pub const ST_CONTINUE: st_retval = 0;
 pub const ST_STOP: st_retval = 1;
 pub const ST_DELETE: st_retval = 2;
@@ -1055,6 +1054,7 @@ extern "C" {
     pub fn rb_ary_push(ary: VALUE, elem: VALUE) -> VALUE;
     pub fn rb_ary_clear(ary: VALUE) -> VALUE;
     pub fn rb_hash_new() -> VALUE;
+    pub fn rb_hash_new_capa(capa: ::std::os::raw::c_long) -> VALUE;
     pub fn rb_hash_aref(hash: VALUE, key: VALUE) -> VALUE;
     pub fn rb_hash_aset(hash: VALUE, key: VALUE, val: VALUE) -> VALUE;
     pub fn rb_hash_bulk_insert(argc: ::std::os::raw::c_long, argv: *const VALUE, hash: VALUE);
@@ -1158,7 +1158,6 @@ extern "C" {
         chilled: bool,
     ) -> VALUE;
     pub fn rb_to_hash_type(obj: VALUE) -> VALUE;
-    pub fn rb_hash_new_with_size(size: st_index_t) -> VALUE;
     pub fn rb_hash_resurrect(hash: VALUE) -> VALUE;
     pub fn rb_hash_stlike_lookup(
         hash: VALUE,

--- a/zjit/bindgen/src/main.rs
+++ b/zjit/bindgen/src/main.rs
@@ -139,7 +139,7 @@ fn main() {
         .allowlist_function("rb_class_real")
         .allowlist_type("ruby_encoding_consts")
         .allowlist_function("rb_hash_new")
-        .allowlist_function("rb_hash_new_with_size")
+        .allowlist_function("rb_hash_new_capa")
         .allowlist_function("rb_hash_resurrect")
         .allowlist_function("rb_hash_stlike_foreach")
         .allowlist_function("rb_to_hash_type")

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -2556,10 +2556,10 @@ fn gen_new_hash(
                     asm.store(Opnd::mem(VALUE_BITS, hash, RUBY_OFFSET_RHASH_IFNONE), Qnil.into());
                 },
                 |asm| {
-                    asm_ccall!(asm, rb_hash_new_with_size, num_pairs.into())
+                    asm_ccall!(asm, rb_hash_new_capa, num_pairs.into())
                 })
         } else {
-            asm_ccall!(asm, rb_hash_new_with_size, num_pairs.into())
+            asm_ccall!(asm, rb_hash_new_capa, num_pairs.into())
         };
 
         let argv = gen_push_opnds(jit, asm, &elements);

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -326,7 +326,6 @@ pub const RSTRING_NOEMBED: ruby_rstring_flags = 8192;
 pub const RSTRING_FSTR: ruby_rstring_flags = 536870912;
 pub type ruby_rstring_flags = u32;
 pub type st_data_t = ::std::os::raw::c_ulong;
-pub type st_index_t = st_data_t;
 pub const ST_CONTINUE: st_retval = 0;
 pub const ST_STOP: st_retval = 1;
 pub const ST_DELETE: st_retval = 2;
@@ -2134,6 +2133,7 @@ unsafe extern "C" {
     pub fn rb_ary_clear(ary: VALUE) -> VALUE;
     pub fn rb_ary_concat(lhs: VALUE, rhs: VALUE) -> VALUE;
     pub fn rb_hash_new() -> VALUE;
+    pub fn rb_hash_new_capa(capa: ::std::os::raw::c_long) -> VALUE;
     pub fn rb_hash_aref(hash: VALUE, key: VALUE) -> VALUE;
     pub fn rb_hash_aset(hash: VALUE, key: VALUE, val: VALUE) -> VALUE;
     pub fn rb_hash_bulk_insert(argc: ::std::os::raw::c_long, argv: *const VALUE, hash: VALUE);
@@ -2262,7 +2262,6 @@ unsafe extern "C" {
         func: st_foreach_callback_func,
         arg: st_data_t,
     ) -> ::std::os::raw::c_int;
-    pub fn rb_hash_new_with_size(size: st_index_t) -> VALUE;
     pub fn rb_hash_new_with_bulk_insert(argc: ::std::os::raw::c_long, argv: *const VALUE) -> VALUE;
     pub fn rb_hash_resurrect(hash: VALUE) -> VALUE;
     pub fn rb_hash_stlike_lookup(


### PR DESCRIPTION
It's redundant with `rb_hash_new_capa` which is public API, might as well use that one.