### PR TITLE
Load did_you_mean before the GC compact stress block

### DIFF
--- a/test/ruby/test_exception.rb
+++ b/test/ruby/test_exception.rb
@@ -1479,6 +1479,12 @@ $stderr = $stdout; raise "\x82\xa0"') do |outs, errs, status|
 
   def test_detailed_message_under_gc_compact_stress
     omit "compaction doesn't work well on s390x" if RUBY_PLATFORM =~ /s390x/ # https://github.com/ruby/ruby/pull/5077
+
+    # The first error display lazily requires did_you_mean and friends; inside the
+    # block that library load costs one full mark+compact per allocation, enough to
+    # trip the parallel runner's no-response timeout.  Load it here instead.
+    RuntimeError.new("").detailed_message
+
     EnvUtil.under_gc_compact_stress do
       e = RuntimeError.new("foo\nbar\nbaz")
       assert_equal("foo (RuntimeError)\nbar\nbaz", e.detailed_message)


### PR DESCRIPTION
TestException#test_detailed_message_under_gc_compact_stress calls Exception#detailed_message inside EnvUtil.under_gc_compact_stress.  The first error display of a process lazily requires the decoration gems (error_highlight, did_you_mean, syntax_suggest -- error.c's require_decoration_gems), so the whole library load happened inside the block, where GC.stress makes every allocation a full mark+compact.

The cost of each of those collections is proportional to the live heap, so the load does not just take a while, it degrades with the age of the worker.  Measured here (x86_64, idle, gems enabled):

  live slots    block
      14k       13.7s
     114k       61.8s
     414k      222.9s

A test-all worker that has already run other files sits far above that, and the parallel runner kills a worker that has not responded for 1200s (worker_timeout) with SIGSEGV -- which is what CI reported:

  worker 63824=ruby/test_exception does not respond; SEGV is sent

  1) Timeout:
  TestException#test_detailed_message_under_gc_compact_stress

  rb_crash_63824.txt:
  lib/did_you_mean/spell_checker.rb: [BUG] Segmentation fault at 0x000003e90000f94a
    test/ruby/test_exception.rb:1484:in 'detailed_message'
    lib/did_you_mean.rb:4:in '<top (required)>'
    lib/did_you_mean.rb:4:in 'require_relative'

(The reported "address" is not a fault address: for a signal sent by another process siginfo's si_addr aliases si_pid/si_uid, so it reads back as (uid << 32) | sender_pid -- 0x3e9 is uid 1001, the runner user.)

Whether this test took milliseconds or ran past the timeout depended on whether an earlier file in the same worker had already loaded did_you_mean, which made it look like a random hang.  It only bites where the decoration gems are enabled: `make test-all` passes --disable-gems through RUN_OPTS, but the ZJIT/YJIT jobs override RUN_OPTS, so gems are on there.

Do the load before the block; this test is about detailed_message, not about require.  With gems enabled, the block goes from 28.7s to 0.22s; the --disable-gems path is unchanged (0.17s).

CI: https://github.com/ruby/ruby/actions/runs/31860169748/job/94952042861