### PR TITLE
coroutine: do not write to the target after switching away

### DIFF
--- a/coroutine/asyncify/Context.h
+++ b/coroutine/asyncify/Context.h
@@ -62,7 +62,9 @@ static inline void coroutine_initialize(struct coroutine_context *context, corou
 static inline struct coroutine_context * coroutine_transfer(struct coroutine_context * current, struct coroutine_context * target)
 {
     if (ASYNCIFY_CORO_DEBUG) fprintf(stderr, "[%s] entry (current = %p, target = %p)\n", __func__, current, target);
+#ifndef COROUTINE_TARGET_MAY_BE_FREED
     struct coroutine_context * previous = target->from;
+#endif
 
     target->from = current;
     if (ASYNCIFY_CORO_DEBUG) fprintf(stderr, "[%s] current->current_sp = %p -> %p\n", __func__, current->current_sp, rb_wasm_get_stack_pointer());
@@ -77,7 +79,11 @@ static inline struct coroutine_context * coroutine_transfer(struct coroutine_con
 
     rb_wasm_set_stack_pointer(current->current_sp);
 
+#ifndef COROUTINE_TARGET_MAY_BE_FREED
+    /* from is read only by coroutine_trampoline, when target starts, which has
+     * happened before we get here. */
     target->from = previous;
+#endif
 
     return target;
 }

--- a/coroutine/emscripten/Context.h
+++ b/coroutine/emscripten/Context.h
@@ -60,11 +60,17 @@ static inline void coroutine_initialize(
 
 static inline struct coroutine_context * coroutine_transfer(struct coroutine_context * current, struct coroutine_context * target)
 {
+#ifndef COROUTINE_TARGET_MAY_BE_FREED
     struct coroutine_context * previous = target->from;
+#endif
 
     target->from = current;
     emscripten_fiber_swap(&current->state, &target->state);
+#ifndef COROUTINE_TARGET_MAY_BE_FREED
+    /* from is read only by coroutine_trampoline, when target starts, which has
+     * happened before we get here. */
     target->from = previous;
+#endif
 
     return target;
 }

--- a/coroutine/pthread/Context.c
+++ b/coroutine/pthread/Context.c
@@ -229,7 +229,11 @@ struct coroutine_context * coroutine_transfer(struct coroutine_context * current
     pthread_testcancel();
 #endif
 
+#ifndef COROUTINE_TARGET_MAY_BE_FREED
+    /* from is read only by coroutine_trampoline, when target starts, which has
+     * happened before we get here. */
     target->from = previous;
+#endif
 
     return target;
 }

--- a/coroutine/ucontext/Context.h
+++ b/coroutine/ucontext/Context.h
@@ -60,11 +60,17 @@ static inline void coroutine_initialize(
 
 static inline struct coroutine_context * coroutine_transfer(struct coroutine_context * current, struct coroutine_context * target)
 {
+#ifndef COROUTINE_TARGET_MAY_BE_FREED
     struct coroutine_context * previous = target->from;
+#endif
 
     target->from = current;
     swapcontext(&current->state, &target->state);
+#ifndef COROUTINE_TARGET_MAY_BE_FREED
+    /* from is read only by coroutine_trampoline, when target starts, which has
+     * happened before we get here. */
     target->from = previous;
+#endif
 
     return target;
 }

--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -62,6 +62,10 @@ static pthread_condattr_t *condattr_monotonic = &condattr_mono;
 static const void *const condattr_monotonic = NULL;
 #endif
 
+/* A retiring shared native thread frees its own context while the threads it
+ * parked are still suspended with that context as their target. */
+#define COROUTINE_TARGET_MAY_BE_FREED 1
+
 #include COROUTINE_H
 
 #ifndef HAVE_SYS_EVENT_H


### PR DESCRIPTION
coroutine_transfer() restores target->from after the switch, that is, after this coroutine is resumed -- by then it may have been resumed by someone else and target may be freed.

With M:N threads it usually is: a Ruby thread parks by transferring to its shared native thread's context (thread_sched_wait_running_turn), and that thread, finding the ready queue empty, retires and frees nt and nt->nt_context.  Over 40 retires in the reproducer below, the number of threads still parked on the retiring context was a median of 19 (max 61, zero in four cases); each writes to it when it is next resumed. sizeof(ucontext_t) is 968, so the write lands in a freed 1008-byte region, and once that is reused it corrupts the new owner:

  free(): invalid next size (fast)
    ruby_xfree_sized ... st_free_entries -> rb_st_free_table
    ractor_free_all_ports -> ractor_notify_exit -> ractor_atexit
    thread_start_func_2 -> co_start -> coroutine_trampoline

  AddressSanitizer: heap-use-after-free
    WRITE of size 8 in coroutine_transfer (Context.h:97), thread T3
    968 bytes inside a 1008-byte region freed in nt_start ->
    native_thread_destroy_self, allocated in native_thread_alloc

from is read only by the trampoline, when target starts, so the restore is dead by the time the switch returns.  Skip it under COROUTINE_TARGET_MAY_BE_FREED, which thread_pthread.c defines; cont.c and other embedders keep the original behaviour.  Only ucontext runs M:N threads today, but the lifetime rule is not specific to them, so guard every backend that has the restore.

Fibers never hit this: a suspended fiber still references its target, so it cannot be collected.  A native thread's context is not a Ruby object and is freed by hand.

Reproducer: clang-20 -O1 --enable-shared --with-coroutine=ucontext, bootstraptest/test_ractor.rb (the case at line 2603 spawns 2000 Ractors) four times in parallel on four CPUs: 21 of 48 runs died before, 0 of 48 after.  Under ASAN, the isolated case eight at a time: 120 of 120 reported before, 0 of 120 after.

CI: https://github.com/ruby/ruby/actions/runs/31942932752/job/95154613098