### PR TITLE
Use configured libruby in mkmf checks

### DIFF
--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -66,7 +66,6 @@ jobs:
           tag: clang-22
           with_gcc: 'clang-22 -flto=auto'
           optflags: '-O2'
-          enable_shared: false
         timeout-minutes: 30
       - { uses: './.github/actions/compilers', name: '-O0', with: { optflags: '-O0 -march=x86-64 -mtune=generic' }, timeout-minutes: 8 }
       # - { uses: './.github/actions/compilers', name: '-O3', with: { optflags: '-O3 -march=x86-64 -mtune=generic', check: true } }

--- a/lib/mkmf.rb
+++ b/lib/mkmf.rb
@@ -539,7 +539,6 @@ MSG
   end
 
   def link_config(ldflags, opt="", libpath=$DEFLIBPATH|$LIBPATH)
-    librubyarg = $extmk ? $LIBRUBYARG_STATIC : "$(LIBRUBYARG)"
     conf = RbConfig::CONFIG.merge('hdrdir' => $hdrdir.quote,
                                   'src' => "#{conftest_source}",
                                   'arch_hdrdir' => $arch_hdrdir.quote,
@@ -550,7 +549,7 @@ MSG
                                   'ARCH_FLAG' => "#$ARCH_FLAG",
                                   'LDFLAGS' => "#$LDFLAGS #{ldflags}",
                                   'LOCAL_LIBS' => "#$LOCAL_LIBS #$libs",
-                                  'LIBS' => "#{librubyarg} #{opt} #$LIBS")
+                                  'LIBS' => "$(LIBRUBYARG) #{opt} #$LIBS")
     conf['LIBPATH'] = libpathflag(libpath.map {|s| RbConfig::expand(s.dup, conf)})
     conf
   end

--- a/test/mkmf/test_mkmf.rb
+++ b/test/mkmf/test_mkmf.rb
@@ -11,3 +11,17 @@ class TestMkmfGlobal < Test::Unit::TestCase
     end
   end
 end
+
+class TestMkmfLinkConfig < Test::Unit::TestCase
+  def test_use_configured_libruby_for_bundled_extensions
+    librubyarg = RbConfig::CONFIG["LIBRUBYARG"]
+
+    RbConfig::CONFIG["LIBRUBYARG"] = "-lruby"
+    assert_include(Shellwords.shellsplit(link_command("")), "-lruby")
+
+    RbConfig::CONFIG["LIBRUBYARG"] = "-lruby-static"
+    assert_include(Shellwords.shellsplit(link_command("")), "-lruby-static")
+  ensure
+    RbConfig::CONFIG["LIBRUBYARG"] = librubyarg
+  end
+end


### PR DESCRIPTION
## Summary

- Use the configured `LIBRUBYARG` when linking `mkmf` test programs.
- Cover both shared and static library selections.

## Background

Bundled extension checks always linked `libruby-static`, even when Ruby was configured with shared library support.  This needlessly makes every test link process the static library's LTO objects.  The configured `LIBRUBYARG` already selects the appropriate shared or static library, and the shared library is updated after static extensions are determined through `LIBRUBY_SO_UPDATE`.

## Verification

- `make test-all TESTS=mkmf/test_mkmf.rb`
- Clean Full LTO build with all bundled extensions
