### PR TITLE
Fixed the check to determine whether mkmf.rb has already been loaded

### DIFF
--- a/enc/make_encmake.rb
+++ b/enc/make_encmake.rb
@@ -6,7 +6,7 @@ dir = File.expand_path("../..", __FILE__)
 # baseruby's cgi/escape.so and source cgi/escape.rb via erb.
 $:.unshift("#{dir}/lib") unless defined?(CROSS_COMPILING)
 $:.unshift(Dir.pwd, "#{dir}/tool/lib")
-if $".grep(/mkmf/).empty?
+unless $".any? {|feat| File.basename(feat) == "/mkmf.rb"}
   $" << "mkmf.rb"
   load File.expand_path("lib/mkmf.rb", dir)
 end


### PR DESCRIPTION
With a simple match for `/mkmf/`, any name might match if the source directory name contains `mkmf`.