### PR TITLE
ZJIT: Exit infer_types early if no back traversals

### DIFF
--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -3676,12 +3676,33 @@ impl Function {
         let mut reachable = BlockSet::with_capacity(self.blocks.len());
         reachable.insert(self.entries_block);
 
-        // Walk the graph, computing types until fixpoint
+        // Repeatedly walk the graph in RPO order, computing types until fixpoint. For each
+        // iteration over the CFG, track the following two attributes to detect the fixpoint:
+        //
+        // 1. if new types were inferred
+        // 2. if back edges were traversed
+        //
+        // For point (1), if no new types were inferred it means no new information is available.
+        // Further repetitions will not change the result.
+        //
+        // For point (2), if the RPO walk does not traverse a back edge, type information can only
+        // be propagated forwards. It follows that a node's type can only be inferred from its
+        // predecessors. RPO ordering ensures all of a node's predecessors have been processed;
+        // therefore, a single walk of the RPO ordering will reach the fixpoint.
         let rpo = self.reverse_post_order();
+        // Map BlockId -> rpo index. Used to detect back edge traversal. If an edge targets a block
+        // with rpo index <= the current rpo index it's a back edge. Note that `rpo_order` must be
+        // of size `self.blocks.len()` to support all possible block IDs; however, `rpo` only
+        // includes reachable blocks. Any blocks not present in `rpo` default to `usize::MAX`.
+        let mut rpo_order = vec![usize::MAX; self.blocks.len()];
+        for (idx, &block_id) in rpo.iter().enumerate() {
+            rpo_order[block_id.to_usize()] = idx;
+        }
         loop {
             let mut changed = false;
+            let mut traversed_back_edge = false;
             let mut num_instructions = 0;
-            for &block in &rpo {
+            for (rpo_index, &block) in rpo.iter().enumerate() {
                 if !reachable.get(block) { continue; }
                 for i in 0..self.blocks[block.to_usize()].insns.len() {
                     let insn_id = self.blocks[block.to_usize()].insns[i];
@@ -3703,6 +3724,7 @@ impl Function {
                                     let param = self.blocks[if_true.target.to_usize()].params[idx];
                                     changed |= set_type!(param, self.type_of(param).union(arg_type));
                                 }
+                                traversed_back_edge |= rpo_order[if_true.target.to_usize()] <= rpo_index;
                             }
                             if self.type_of(*val).could_be(Type::from_cbool(false)) {
                                 reachable.insert(if_false.target);
@@ -3711,6 +3733,7 @@ impl Function {
                                     let param = self.blocks[if_false.target.to_usize()].params[idx];
                                     changed |= set_type!(param, self.type_of(param).union(arg_type));
                                 }
+                                traversed_back_edge |= rpo_order[if_false.target.to_usize()] <= rpo_index;
                             }
                             continue;
                         }
@@ -3721,6 +3744,7 @@ impl Function {
                                 let param = self.blocks[target.to_usize()].params[idx];
                                 changed |= set_type!(param, self.type_of(param).union(arg_type));
                             }
+                            traversed_back_edge |= rpo_order[target.to_usize()] <= rpo_index;
                             continue;
                         }
                         Insn::Entries { targets } => {
@@ -3735,7 +3759,7 @@ impl Function {
                     changed |= set_type!(insn_id, insn_type);
                 }
             }
-            if !changed {
+            if !changed || !traversed_back_edge {
                 self.num_instructions = num_instructions;
                 break;
             }


### PR DESCRIPTION
Function::infer_types repeatedly loops over all blocks and instructions in Reverse Post Order (RPO), progressively updating the types. The loop continues until a fixpoint is reached (no further type changes will occur).

This patch improves performance by adding an early exit if no back edge traversals have occurred. If there were no back traversals the fixpoint has already been reached, and continuing to loop will not change the result.

Note, I'm considering an edge that links a block back to itself as a back edge. The block can loop with different arguments, causing further type propagation.

This patch reduces compile_hir_time from ~960ms to ~880ms.

Before:

    % for i in $(seq 0 5); do WARMUP_ITRS=0 MIN_BENCH_ITRS=2 MIN_BENCH_TIME=0 ./ruby --zjit --zjit-stats ruby-bench/benchmarks/lobsters/benchmark.rb 2>&1 | grep compile_hir_time; done
    compile_hir_time: 949ms
    compile_hir_time: 962ms
    compile_hir_time: 975ms
    compile_hir_time: 976ms
    compile_hir_time: 952ms
    compile_hir_time: 951ms

After:

    % for i in $(seq 0 5); do WARMUP_ITRS=0 MIN_BENCH_ITRS=2 MIN_BENCH_TIME=0 ./ruby --zjit --zjit-stats ruby-bench/benchmarks/lobsters/benchmark.rb 2>&1 | grep compile_hir_time; done
    compile_hir_time: 866ms
    compile_hir_time: 881ms
    compile_hir_time: 881ms
    compile_hir_time: 894ms
    compile_hir_time: 897ms
    compile_hir_time: 862ms