### PR TITLE
Sort Array and Enumerable with Ruby's own introsort instead of qsort_r

### DIFF
--- a/array.c
+++ b/array.c
@@ -3568,49 +3568,61 @@ sort_returned(struct ary_sort_data *data)
     sort_reentered(data->ary);
 }
 
-static int
-sort_1(const void *ap, const void *bp, void *dummy)
+static inline bool
+sort_1_less(VALUE a, VALUE b, void *dummy)
 {
     struct ary_sort_data *data = dummy;
-    VALUE retval = sort_reentered(data->ary);
-    VALUE a = *(const VALUE *)ap, b = *(const VALUE *)bp;
     VALUE args[2];
     int n;
 
+    sort_reentered(data->ary);
     args[0] = a;
     args[1] = b;
-    retval = rb_yield_values2(2, args);
+    VALUE retval = rb_yield_values2(2, args);
     n = rb_cmpint(retval, a, b);
     sort_returned(data);
-    return n;
+    return n < 0;
 }
 
-static int
-sort_2(const void *ap, const void *bp, void *dummy)
+static inline bool
+sort_2_less(VALUE a, VALUE b, void *dummy)
 {
     struct ary_sort_data *data = dummy;
-    VALUE retval = sort_reentered(data->ary);
-    VALUE a = *(const VALUE *)ap, b = *(const VALUE *)bp;
     int n;
 
+    sort_reentered(data->ary);
+
     if (FIXNUM_P(a) && FIXNUM_P(b) && CMP_OPTIMIZABLE(INTEGER)) {
-        if ((long)a > (long)b) return 1;
-        if ((long)a < (long)b) return -1;
-        return 0;
+        return (SIGNED_VALUE)a < (SIGNED_VALUE)b;
     }
     if (STRING_P(a) && STRING_P(b) && CMP_OPTIMIZABLE(STRING)) {
-        return rb_str_cmp(a, b);
+        return rb_str_cmp(a, b) < 0;
     }
     if (RB_FLOAT_TYPE_P(a) && CMP_OPTIMIZABLE(FLOAT)) {
-        return rb_float_cmp(a, b);
+        return rb_float_cmp(a, b) < 0;
     }
 
-    retval = rb_funcallv(a, id_cmp, 1, &b);
+    VALUE retval = rb_funcallv(a, id_cmp, 1, &b);
     n = rb_cmpint(retval, a, b);
     sort_returned(data);
 
-    return n;
+    return n < 0;
 }
+
+/* Array#sort with a block: the yield dominates, but sorting in Ruby's own
+ * introsort rather than qsort_r keeps a raising block from unwinding through
+ * libc and stranding its scratch buffer. */
+#define SORT_NAME ary_sort_block
+#define SORT_ELEM VALUE
+#define SORT_LESS(a, b, arg) sort_1_less(a, b, arg)
+#include "sort_template.h"
+
+/* Array#sort with no block. Expanding the comparison inline here is the point:
+ * behind qsort_r's function pointer it could never be. */
+#define SORT_NAME ary_sort_cmp
+#define SORT_ELEM VALUE
+#define SORT_LESS(a, b, arg) sort_2_less(a, b, arg)
+#include "sort_template.h"
 
 /*
  *  call-seq:
@@ -3635,8 +3647,12 @@ rb_ary_sort_bang(VALUE ary)
         data.ary = tmp;
         data.receiver = ary;
         RARRAY_PTR_USE(tmp, ptr, {
-            ruby_qsort(ptr, len, sizeof(VALUE),
-                       rb_block_given_p()?sort_1:sort_2, &data);
+            if (rb_block_given_p()) {
+                ary_sort_block_sort(ptr, ptr + len, &data);
+            }
+            else {
+                ary_sort_cmp_sort(ptr, ptr + len, &data);
+            }
         }); /* WB: no new reference */
         rb_ary_modify(ary);
         if (ARY_EMBED_P(tmp)) {

--- a/benchmark/array_sort_shapes.yml
+++ b/benchmark/array_sort_shapes.yml
@@ -1,0 +1,23 @@
+prelude: |
+  n = 100000
+  random = Array.new(n) {|i| (i * 2654435761) % n }
+  sorted = (0...n).to_a
+  reversed = sorted.reverse
+  two_runs = (0...n/2).to_a + (0...n/2).to_a
+  equal = Array.new(n, 7)
+  strings = random.map(&:to_s)
+  floats = random.map {|i| i / 7.0 }
+
+benchmark:
+  sort_random: random.dup.sort!
+  sort_sorted: sorted.dup.sort!
+  sort_reversed: reversed.dup.sort!
+  sort_two_runs: two_runs.dup.sort!
+  sort_equal: equal.dup.sort!
+  sort_string: strings.dup.sort!
+  sort_float: floats.dup.sort!
+  sort_block: random.dup.sort! {|a, b| a <=> b }
+  sort_by_int: random.sort_by {|a| a }
+  sort_by_string: strings.sort_by {|a| a }
+
+loop_count: 20

--- a/enum.c
+++ b/enum.c
@@ -1436,31 +1436,10 @@ sort_by_i(RB_BLOCK_CALL_FUNC_ARGLIST(i, _data))
     return Qnil;
 }
 
-static int
-sort_by_cmp(const void *ap, const void *bp, void *data)
-{
-    VALUE a;
-    VALUE b;
-    VALUE ary = (VALUE)data;
-
-    if (RBASIC(ary)->klass) {
-        rb_raise(rb_eRuntimeError, "sort_by reentered");
-    }
-
-    a = *(VALUE *)ap;
-    b = *(VALUE *)bp;
-
-    return OPTIMIZED_CMP(a, b);
-}
-
 
 /*
     This is parts of uniform sort
 */
-
-#define uless rb_uniform_is_less
-#define UNIFORM_SWAP(a,b)\
-    do{struct rb_uniform_sort_data tmp = a; a = b; b = tmp;}  while(0)
 
 struct rb_uniform_sort_data {
     VALUE v;
@@ -1484,146 +1463,30 @@ rb_uniform_is_less(VALUE a, VALUE b)
     }
 }
 
+/* Direct primitive data compare sort, for keys that are all Fixnum or all Float. */
+#define SORT_NAME rb_uniform
+#define SORT_ELEM struct rb_uniform_sort_data
+#define SORT_LESS(a, b, arg) ((void)(arg), rb_uniform_is_less((a).v, (b).v))
+#include "sort_template.h"
+
+/* The same sort for pairs whose keys need a general comparison. */
 static inline bool
-rb_uniform_is_larger(VALUE a, VALUE b)
+rb_sort_by_pair_is_less(struct rb_uniform_sort_data a,
+                        struct rb_uniform_sort_data b, void *arg)
 {
+    VALUE ary = (VALUE)arg;
 
-    if (FIXNUM_P(a) && FIXNUM_P(b)) {
-        return (SIGNED_VALUE)a > (SIGNED_VALUE)b;
+    if (RBASIC(ary)->klass) {
+        rb_raise(rb_eRuntimeError, "sort_by reentered");
     }
-    else if (FIXNUM_P(a)) {
-        RUBY_ASSERT(RB_FLOAT_TYPE_P(b));
-        return rb_float_cmp(b, a) < 0;
-    }
-    else {
-        RUBY_ASSERT(RB_FLOAT_TYPE_P(a));
-        return rb_float_cmp(a, b) > 0;
-    }
+
+    return OPTIMIZED_CMP(a.v, b.v) < 0;
 }
 
-#define med3_val(a,b,c) (uless(a,b)?(uless(b,c)?b:uless(c,a)?a:c):(uless(c,b)?b:uless(a,c)?a:c))
-
-static void
-rb_uniform_insertionsort_2(struct rb_uniform_sort_data* ptr_begin,
-                           struct rb_uniform_sort_data* ptr_end)
-{
-    if ((ptr_end - ptr_begin) < 2) return;
-    struct rb_uniform_sort_data tmp, *j, *k,
-                                *index = ptr_begin+1;
-    for (; index < ptr_end; index++) {
-        tmp = *index;
-        j = k = index;
-        if (uless(tmp.v, ptr_begin->v)) {
-            while (ptr_begin < j) {
-                *j = *(--k);
-                j = k;
-            }
-        }
-        else {
-            while (uless(tmp.v, (--k)->v)) {
-                *j = *k;
-                j = k;
-            }
-        }
-        *j = tmp;
-    }
-}
-
-static inline void
-rb_uniform_heap_down_2(struct rb_uniform_sort_data* ptr_begin,
-                       size_t offset, size_t len)
-{
-    size_t c;
-    struct rb_uniform_sort_data tmp = ptr_begin[offset];
-    while ((c = (offset<<1)+1) <= len) {
-        if (c < len && uless(ptr_begin[c].v, ptr_begin[c+1].v)) {
-            c++;
-        }
-        if (!uless(tmp.v, ptr_begin[c].v)) break;
-        ptr_begin[offset] = ptr_begin[c];
-        offset = c;
-    }
-    ptr_begin[offset] = tmp;
-}
-
-static void
-rb_uniform_heapsort_2(struct rb_uniform_sort_data* ptr_begin,
-                      struct rb_uniform_sort_data* ptr_end)
-{
-    size_t n = ptr_end - ptr_begin;
-    if (n < 2) return;
-
-    for (size_t offset = n>>1; offset > 0;) {
-        rb_uniform_heap_down_2(ptr_begin, --offset, n-1);
-    }
-    for (size_t offset = n-1; offset > 0;) {
-        UNIFORM_SWAP(*ptr_begin, ptr_begin[offset]);
-        rb_uniform_heap_down_2(ptr_begin, 0, --offset);
-    }
-}
-
-
-static void
-rb_uniform_quicksort_intro_2(struct rb_uniform_sort_data* ptr_begin,
-                             struct rb_uniform_sort_data* ptr_end, size_t d)
-{
-
-    if (ptr_end - ptr_begin <= 16) {
-        rb_uniform_insertionsort_2(ptr_begin, ptr_end);
-        return;
-    }
-    if (d == 0) {
-        rb_uniform_heapsort_2(ptr_begin, ptr_end);
-        return;
-    }
-
-    VALUE x = med3_val(ptr_begin->v,
-                       ptr_begin[(ptr_end - ptr_begin)>>1].v,
-                       ptr_end[-1].v);
-    struct rb_uniform_sort_data *i = ptr_begin;
-    struct rb_uniform_sort_data *j = ptr_end-1;
-
-    do {
-        while (uless(i->v, x)) i++;
-        while (uless(x, j->v)) j--;
-        if (i <= j) {
-            UNIFORM_SWAP(*i, *j);
-            i++;
-            j--;
-        }
-    } while (i <= j);
-    j++;
-    if (ptr_end - j > 1)   rb_uniform_quicksort_intro_2(j, ptr_end, d-1);
-    if (i - ptr_begin > 1) rb_uniform_quicksort_intro_2(ptr_begin, i, d-1);
-}
-
-/**
- * Direct primitive data compare sort. Implement with intro sort.
- * @param[in]     ptr_begin  The begin address of target rb_ary's raw pointer.
- * @param[in]     ptr_end    The end address of target rb_ary's raw pointer.
-**/
-static void
-rb_uniform_intro_sort_2(struct rb_uniform_sort_data* ptr_begin,
-                        struct rb_uniform_sort_data* ptr_end)
-{
-    size_t n = ptr_end - ptr_begin;
-    size_t d = CHAR_BIT * sizeof(n) - nlz_intptr(n) - 1;
-    bool sorted_flag = true;
-
-    for (struct rb_uniform_sort_data* ptr = ptr_begin+1; ptr < ptr_end; ptr++) {
-        if (rb_uniform_is_larger((ptr-1)->v, (ptr)->v)) {
-            sorted_flag = false;
-            break;
-        }
-    }
-
-    if (sorted_flag) {
-        return;
-    }
-    rb_uniform_quicksort_intro_2(ptr_begin, ptr_end, d<<1);
-}
-
-#undef uless
+#define SORT_NAME rb_sort_by_pair
+#define SORT_ELEM struct rb_uniform_sort_data
+#define SORT_LESS(a, b, arg) rb_sort_by_pair_is_less(a, b, arg)
+#include "sort_template.h"
 
 
 /*
@@ -1745,13 +1608,15 @@ enum_sort_by(VALUE obj)
     if (RARRAY_LEN(ary) > 2) {
         if (data->primitive_uniformed) {
             RARRAY_PTR_USE(ary, ptr,
-                           rb_uniform_intro_sort_2((struct rb_uniform_sort_data*)ptr,
-                                                   (struct rb_uniform_sort_data*)(ptr + RARRAY_LEN(ary))));
+                           rb_uniform_sort((struct rb_uniform_sort_data*)ptr,
+                                           (struct rb_uniform_sort_data*)(ptr + RARRAY_LEN(ary)),
+                                           NULL));
         }
         else {
             RARRAY_PTR_USE(ary, ptr,
-                           ruby_qsort(ptr, RARRAY_LEN(ary)/2, 2*sizeof(VALUE),
-                                      sort_by_cmp, (void *)ary));
+                           rb_sort_by_pair_sort((struct rb_uniform_sort_data*)ptr,
+                                                (struct rb_uniform_sort_data*)(ptr + RARRAY_LEN(ary)),
+                                                (void *)ary));
         }
     }
     if (RBASIC(ary)->klass) {
@@ -1986,6 +1851,33 @@ nmin_block_cmp(const void *ap, const void *bp, void *_data)
     return rb_cmpint(cmp, a, b);
 }
 
+/* nmin_cmp and nmin_block_cmp both read only the first VALUE of an element, so
+ * one instantiation per layout covers either of them. */
+static inline bool
+nmin_value_is_less(VALUE a, VALUE b, void *arg)
+{
+    struct nmin_data *data = arg;
+    return (*data->cmpfunc)(&a, &b, data) < 0;
+}
+
+#define SORT_NAME nmin_value
+#define SORT_ELEM VALUE
+#define SORT_LESS(a, b, arg) nmin_value_is_less(a, b, arg)
+#include "sort_template.h"
+
+static inline bool
+nmin_pair_is_less(struct rb_uniform_sort_data a,
+                  struct rb_uniform_sort_data b, void *arg)
+{
+    struct nmin_data *data = arg;
+    return (*data->cmpfunc)(&a, &b, data) < 0;
+}
+
+#define SORT_NAME nmin_pair
+#define SORT_ELEM struct rb_uniform_sort_data
+#define SORT_LESS(a, b, arg) nmin_pair_is_less(a, b, arg)
+#include "sort_template.h"
+
 static void
 nmin_filter(struct nmin_data *data)
 {
@@ -2141,10 +2033,9 @@ rb_nmin_run(VALUE obj, VALUE num, int by, int rev, int ary)
     if (by) {
         long i;
         RARRAY_PTR_USE(result, ptr, {
-            ruby_qsort(ptr,
-                       RARRAY_LEN(result)/2,
-                       sizeof(VALUE)*2,
-                       data.cmpfunc, (void *)&data);
+            nmin_pair_sort((struct rb_uniform_sort_data *)ptr,
+                           (struct rb_uniform_sort_data *)(ptr + RARRAY_LEN(result)),
+                           &data);
             for (i=1; i<RARRAY_LEN(result); i+=2) {
                 ptr[i/2] = ptr[i];
             }
@@ -2153,8 +2044,7 @@ rb_nmin_run(VALUE obj, VALUE num, int by, int rev, int ary)
     }
     else {
         RARRAY_PTR_USE(result, ptr, {
-            ruby_qsort(ptr, RARRAY_LEN(result), sizeof(VALUE),
-                       data.cmpfunc, (void *)&data);
+            nmin_value_sort(ptr, ptr + RARRAY_LEN(result), &data);
         });
     }
     if (rev) {

--- a/sort_template.h
+++ b/sort_template.h
@@ -1,0 +1,222 @@
+/**********************************************************************
+
+  sort_template.h -
+
+  Introsort, generic over the element type and the comparison.
+
+  This is the sort that Enumerable#sort_by has used for uniform Fixnum
+  and Float keys since [Feature #19643], lifted out of enum.c so that
+  every core sort can share it.  Unlike qsort_r it allocates nothing, so
+  a comparison that raises unwinds through it harmlessly.
+
+  Include this file after defining:
+
+    SORT_NAME             prefix for the generated functions
+    SORT_ELEM             element type
+    SORT_LESS(a, b, arg)  true when element a sorts before element b
+
+  SORT_LESS need not be a consistent ordering: Array#sort hands it a block
+  that may return anything at all.  The sort terminates and stays within
+  the range whatever it answers, though of course the result is only
+  sorted if it does describe an ordering.
+
+  It defines
+
+    static void SORT_NAME##_sort(SORT_ELEM *begin, SORT_ELEM *end, void *arg)
+
+  and undefines the three inputs, so a translation unit may include it
+  once per instantiation.  The comparison is expanded inline, which is
+  the point: a sort reached through a function pointer cannot inline its
+  comparison, and for Ruby's element types the comparison is most of the
+  cost.
+
+**********************************************************************/
+
+#ifndef SORT_NAME
+# error SORT_NAME must be defined before including sort_template.h
+#endif
+#ifndef SORT_ELEM
+# error SORT_ELEM must be defined before including sort_template.h
+#endif
+#ifndef SORT_LESS
+# error SORT_LESS must be defined before including sort_template.h
+#endif
+
+#define SORT_CAT1(x, y) x ## y
+#define SORT_CAT(x, y) SORT_CAT1(x, y)
+#define SORT_FUNC(suffix) SORT_CAT(SORT_NAME, suffix)
+
+#define sort_less(a, b) SORT_LESS(a, b, arg)
+#define sort_swap(a, b) do { \
+    SORT_ELEM sort_swap_tmp = (a); (a) = (b); (b) = sort_swap_tmp; \
+} while (0)
+/* Median of the three elements pointed at, as a pointer to one of them. */
+#define sort_med3(a, b, c) (sort_less(*(a), *(b)) ? \
+                            (sort_less(*(b), *(c)) ? (b) : sort_less(*(c), *(a)) ? (a) : (c)) : \
+                            (sort_less(*(c), *(b)) ? (b) : sort_less(*(a), *(c)) ? (a) : (c)))
+
+/* Threshold below which insertion sort beats partitioning. */
+#define SORT_INSERTION_MAX 16
+
+/* Array#sort lets the block return anything it likes, so SORT_LESS need not be
+ * a consistent ordering and the pivot cannot be relied on to stop a partition
+ * scan.  Every scan below is bounded instead.  A separate unbounded variant for
+ * the comparisons Ruby controls measured about 1% faster, which is not worth a
+ * second path through the partition that no test for a lying comparator
+ * reaches. */
+
+static void
+SORT_FUNC(_insertion_sort)(SORT_ELEM *begin, SORT_ELEM *end, void *arg)
+{
+    for (SORT_ELEM *index = begin + 1; index < end; index++) {
+        SORT_ELEM tmp = *index;
+        SORT_ELEM *j = index;
+        while (j > begin && sort_less(tmp, j[-1])) {
+            *j = j[-1];
+            j--;
+        }
+        *j = tmp;
+    }
+}
+
+static inline void
+SORT_FUNC(_heap_down)(SORT_ELEM *begin, size_t offset, size_t len, void *arg)
+{
+    size_t c;
+    SORT_ELEM tmp = begin[offset];
+    while ((c = (offset << 1) + 1) <= len) {
+        if (c < len && sort_less(begin[c], begin[c+1])) {
+            c++;
+        }
+        if (!sort_less(tmp, begin[c])) break;
+        begin[offset] = begin[c];
+        offset = c;
+    }
+    begin[offset] = tmp;
+}
+
+static void
+SORT_FUNC(_heap_sort)(SORT_ELEM *begin, SORT_ELEM *end, void *arg)
+{
+    size_t n = end - begin;
+    if (n < 2) return;
+
+    for (size_t offset = n >> 1; offset > 0;) {
+        SORT_FUNC(_heap_down)(begin, --offset, n-1, arg);
+    }
+    for (size_t offset = n-1; offset > 0;) {
+        sort_swap(*begin, begin[offset]);
+        SORT_FUNC(_heap_down)(begin, 0, --offset, arg);
+    }
+}
+
+static void
+SORT_FUNC(_quick_sort)(SORT_ELEM *begin, SORT_ELEM *end, size_t d, void *arg)
+{
+    if (end - begin <= SORT_INSERTION_MAX) {
+        SORT_FUNC(_insertion_sort)(begin, end, arg);
+        return;
+    }
+    if (d == 0) {
+        /* Partitioning has gone quadratic; fall back to guaranteed O(n log n). */
+        SORT_FUNC(_heap_sort)(begin, end, arg);
+        return;
+    }
+
+    /* Pivot selection, widening with the range exactly as ruby_qsort does in
+     * util.c.  Median of three is not enough: on input made of a few ascending
+     * runs it keeps choosing a near-minimum, and on random input the resulting
+     * imbalance costs comparisons, which is the whole budget when the
+     * comparison is a Ruby call. */
+    size_t n = end - begin;
+    SORT_ELEM *m = begin + (n >> 1);
+    SORT_ELEM *lo, *hi;
+
+    if (n >= 200) {
+        size_t s = n >> 3;
+        lo = sort_med3(begin + s, begin + 2*s, begin + 3*s);
+        hi = sort_med3(m + s, m + 2*s, m + 3*s);
+    }
+    else if (n >= 60) {
+        size_t s = n >> 2;
+        lo = begin + s;
+        hi = m + s;
+    }
+    else {
+        lo = begin;
+        hi = end - 1;
+    }
+
+    SORT_ELEM x = *sort_med3(lo, m, hi);
+    SORT_ELEM *i = begin;
+    SORT_ELEM *j = end - 1;
+
+    do {
+        while (i < end - 1 && sort_less(*i, x)) i++;
+        while (j > begin && sort_less(x, *j)) j--;
+        if (i <= j) {
+            sort_swap(*i, *j);
+            i++;
+            j--;
+        }
+    } while (i <= j);
+    j++;
+
+    /* A consistent comparison leaves the two halves covering the range with at
+     * most one element of overlap.  More than that means the comparison is not
+     * an ordering, and recursing would repeat most of the range on both sides.
+     * Heapsort reaches an answer whatever the comparison does. */
+    if ((i - begin) + (end - j) > (end - begin) + 1) {
+        SORT_FUNC(_heap_sort)(begin, end, arg);
+        return;
+    }
+
+    if (end - j > 1)   SORT_FUNC(_quick_sort)(j, end, d-1, arg);
+    if (i - begin > 1) SORT_FUNC(_quick_sort)(begin, i, d-1, arg);
+}
+
+/**
+ * Sort [begin, end) in place.
+ * @param[in,out] begin  First element.
+ * @param[in]     end    One past the last element.
+ * @param[in]     arg    Opaque context handed to SORT_LESS.
+ */
+static void
+SORT_FUNC(_sort)(SORT_ELEM *begin, SORT_ELEM *end, void *arg)
+{
+    size_t n = end - begin;
+    if (n < 2) return;
+
+    /* Ordered input is common enough to be worth one pass to find, and both
+     * orderings are then free.  The descending case reverses only when every
+     * adjacent pair is strictly descending, so no equal elements have their
+     * order disturbed by it. */
+    SORT_ELEM *p = begin + 1;
+    while (p < end && !sort_less(*p, *(p-1))) p++;
+    if (p == end) return;
+
+    if (p == begin + 1) {
+        SORT_ELEM *q = begin + 2;
+        while (q < end && sort_less(*q, *(q-1))) q++;
+        if (q == end) {
+            for (SORT_ELEM *l = begin, *r = end - 1; l < r; l++, r--) {
+                sort_swap(*l, *r);
+            }
+            return;
+        }
+    }
+
+    size_t d = CHAR_BIT * sizeof(n) - nlz_intptr(n) - 1;
+    SORT_FUNC(_quick_sort)(begin, end, d << 1, arg);
+}
+
+#undef SORT_INSERTION_MAX
+#undef sort_med3
+#undef sort_swap
+#undef sort_less
+#undef SORT_FUNC
+#undef SORT_CAT
+#undef SORT_CAT1
+#undef SORT_LESS
+#undef SORT_ELEM
+#undef SORT_NAME

--- a/test/ruby/test_array.rb
+++ b/test/ruby/test_array.rb
@@ -1823,6 +1823,58 @@ class TestArray < Test::Unit::TestCase
     assert_equal(@cls[], @cls[].sort)
   end
 
+  # Shapes that take different routes through the sort: the ordered ones are
+  # detected up front, and the sizes straddle the switch from insertion sort to
+  # partitioning and the widening pivot selection.
+  def test_sort_shapes
+    [1, 2, 16, 17, 59, 60, 199, 200, 1000].each do |n|
+      sorted = (1..n).to_a
+      {
+        ascending: sorted,
+        descending: sorted.reverse,
+        equal: [7] * n,
+        two_runs: sorted.each_slice((n + 1) / 2).to_a.inject(:+),
+        random: sorted.shuffle(random: Random.new(n)),
+      }.each do |shape, a|
+        assert_equal(a.dup.sort_by {|x| x }, @cls[*a].sort, "#{shape} n=#{n}")
+        assert_equal(a.dup.sort_by {|x| -x }, @cls[*a].sort {|x, y| y <=> x },
+                     "#{shape} n=#{n} with block")
+      end
+    end
+  end
+
+  def test_sort_with_duplicates_keeps_every_element
+    a = @cls[*(1..500).map {|i| i % 7 }]
+    assert_equal(a.tally, a.sort.tally)
+    assert_equal(a.sort, a.sort.sort)
+  end
+
+  # A block may return anything at all, so the comparison is not necessarily an
+  # ordering.  Sorting must still terminate without reading outside the array.
+  def test_sort_with_inconsistent_block
+    [17, 60, 200, 1000].each do |n|
+      a = @cls[*(1..n).to_a]
+      assert_equal(n, a.sort { -1 }.size, "n=#{n}")
+      assert_equal(n, a.sort { 1 }.size, "n=#{n}")
+      assert_equal(n, a.sort { 0 }.size, "n=#{n}")
+      r = Random.new(n)
+      assert_equal(n, a.sort { r.rand(-1..1) }.size, "n=#{n} random")
+    end
+  end
+
+  # The comparison raising must unwind cleanly, leaving the array usable.  On
+  # glibc this used to escape qsort_r by longjmp and strand its scratch buffer.
+  def test_sort_raising_comparison
+    a = @cls[*(1..1000).to_a.shuffle(random: Random.new(1))]
+    b = a.dup
+    assert_raise(ArgumentError) { b.sort! {|x, y| raise ArgumentError if x > 500; x <=> y } }
+    assert_equal(a.size, b.size)
+    assert_equal(a.sort, b.sort)
+
+    c = @cls[*(1..1000).to_a.shuffle(random: Random.new(2))] << nil
+    assert_raise(ArgumentError) { c.sort }
+  end
+
   def test_sort!
     a = @cls[ 4, 1, 2, 3 ]
     assert_equal(@cls[1, 2, 3, 4], a.sort!)

--- a/test/ruby/test_enum.rb
+++ b/test/ruby/test_enum.rb
@@ -665,6 +665,34 @@ class TestEnumerable < Test::Unit::TestCase
     assert_equal([13, 14], [20, 32, 32, 21, 30, 25, 29, 13, 14].min_by(2) {|x| x})
   end
 
+  # min/max with an argument sort the collected candidates, at sizes straddling
+  # the insertion-sort threshold and both pivot-selection widenings.
+  def test_nmin_shapes
+    [1, 2, 17, 60, 200, 1000].each do |n|
+      a = (1..n).to_a.shuffle(random: Random.new(n))
+      [1, 2, n / 2 + 1, n].uniq.each do |k|
+        assert_equal(a.sort.first(k), a.min(k), "n=#{n} k=#{k}")
+        assert_equal(a.sort.reverse.first(k), a.max(k), "n=#{n} k=#{k}")
+        assert_equal(a.sort.reverse.first(k), a.min_by(k) {|x| -x }, "n=#{n} k=#{k}")
+        assert_equal(a.sort.first(k), a.max_by(k) {|x| -x }, "n=#{n} k=#{k}")
+        assert_equal(a.sort.reverse.first(k), a.min(k) {|x, y| y <=> x }, "n=#{n} k=#{k}")
+      end
+    end
+  end
+
+  # A block may return anything, so the comparison need not be an ordering.
+  # This must terminate without reading outside the buffer.
+  def test_nmin_with_inconsistent_block
+    [17, 200, 1000].each do |n|
+      a = (1..n).to_a
+      assert_equal(n / 2, a.min(n / 2) { -1 }.size, "n=#{n}")
+      assert_equal(n / 2, a.max(n / 2) { 1 }.size, "n=#{n}")
+      assert_equal(n / 2, a.min(n / 2) { 0 }.size, "n=#{n}")
+      r = Random.new(n)
+      assert_equal(n / 2, a.min(n / 2) { r.rand(-1..1) }.size, "n=#{n} random")
+    end
+  end
+
   def test_max_by
     assert_equal(1, @obj.max_by {|x| -x })
     cond = ->(x, i) { -x }


### PR DESCRIPTION
Implements the direction agreed in [Bug #20203], where Matz said "give it a try" at the February dev meeting. The ticket is still open and unassigned, so I picked it up — @XrXr, @ko1, you were both asked to take it there; happy to hand this over or close it if either of you already has work in progress.

`Array#sort`, `Array#sort!` and `Enumerable#sort` reached libc's `qsort_r` through `ruby_qsort`, as did `Enumerable#sort_by` whenever its keys were not all Fixnum or all Float, and `Enumerable#min`/`#max` when given an argument. That left ordering, performance and memory safety up to the platform. A comparison that raises leaves `qsort` by `longjmp`, and on glibc the scratch buffer it allocated is never freed — an unbounded leak of roughly half the array's bytes per raised sort. No custom comparator is needed to reach it; one `nil` among the elements is enough. Passing a comparator that longjmps is undefined behaviour, so this is Ruby's to avoid rather than glibc's to fix. glibc still allocates that buffer: the introsort patch that would have removed it was reverted before 2.39, and current `stdlib/qsort.c` mergesorts into a `malloc`'d buffer with a heapsort fallback.

## Approach

`Enumerable#sort_by` has had an allocation-free introsort since [Feature #19643], used when every key is a Fixnum or every key is a Float. This moves it to `sort_template.h`, parameterised on the element type and the comparison, and instantiates it for bare `VALUE`s with and without a block, and for the key/value pairs that `sort_by` and `nmin_run` build. Neither `array.c` nor `enum.c` refers to `ruby_qsort` any more.

Expanding the comparison inline is the point: behind `qsort_r`'s function pointer it never could be. Nothing on these paths allocates now, so a raising comparison unwinds harmlessly.

This deviates from the plan in the ticket, which was to route to `ruby_qsort` — the `util.c` qs6. That measured about 20% slower on random input than the introsort, so the introsort seemed the better target. Numbers below.

## Three deviations from the `enum.c` original

**Every scan is bounded** rather than relying on the pivot as a sentinel, and a partition whose halves overlap falls back to heapsort. `Array#sort` lets a block return anything at all, and a comparison that is not an ordering otherwise walks off the array — `spec/ruby/core/array/sort_spec.rb:88` (`a.sort { -1 }`) segfaults without this. This is the same defect Qualys reported in glibc's own `qsort` on 2024-01-30, present from glibc 1.04 through 2.38, and their fix was likewise a `tmp_ptr > base_ptr &&` bound. Worth knowing before anyone reads the bounds as redundant.

**Pivot selection widens with the range**, as `ruby_qsort` already did at `util.c:393`. Median of three chose near-minimum pivots on input made of a few ascending runs, costing 114 ns/element there and 20% more comparisons on random input.

**The pre-pass recognises a descending run** as well as an ascending one.

## Measurements

N=1M on macOS/arm64 against 4.0.6, ns per element, lower is better:

| shape | this PR | 4.0.6 |
|---|---|---|
| int random | 74.7 | 96.4 |
| int sorted | 2.2 | 5.1 |
| int reversed | 2.5 | 21.7 |
| int two ascending runs | 36.2 | 51.8 |
| int all equal | 1.7 | 2.7 |
| string random | 241 | 244 |
| float random | 184 | 192 |
| with a block | 724 | 691 |
| `sort_by` over Fixnum keys | 94.7 | 91.6 |

Sorting the 200k candidates out of `Enumerable#min`, whole-array: Integers 19.5 vs 21.5 ms, Strings 79.9 vs 71.7 ms.

The slower cases — with a block, `sort_by` over Fixnum keys, and `min` over Strings — are all paths where a Ruby call dominates each comparison, and all of it is comparison *count*: this makes about 13% more comparisons than Apple's `qsort`, which uses a three-way partition and an insertion-sort shortcut that this does not. That seems the most promising next step, along with extending the `sort_by` uniformity check beyond Fixnum and Float to String.

`benchmark/array_sort_shapes.yml` is added because every existing sort benchmark uses shuffled input only — there was no sorted, reversed, two-run or all-equal case for `Array#sort` anywhere.

## Scope and caveats

- `dir.c` and `compile.c` still use `ruby_qsort`, deliberately. Neither comparator can run Ruby or raise, so the `longjmp` this addresses cannot happen there: `dir.c` sorts `rb_dirent_t *` with `strcmp`, and `compile.c` sorts `struct outer_variable_pair` — which does hold `VALUE`s — with `rb_str_cmp`, which is pure.
- **I could not reproduce the original crash.** macOS never takes glibc's `malloc` path, so the `TestEnumerable` failures in [Bug #20203] do not occur here. The fix is structural — there is no scratch buffer left to double-free — but it would be worth someone running this under the GCC 14 configuration that surfaced it.
- The POSIX constraint that "the comparison function shall not alter the contents of the array" dissolves rather than gets fixed: we no longer call a POSIX function, so whether the sort tolerates GC compaction rewriting elements mid-comparison becomes Ruby's own invariant. It does tolerate it in testing — `GC.compact` inside a comparison over 3000 elements sorts correctly, as does fiber reentry out of a comparison — but that is observation, not proof.
- **Tie ordering changes on every platform.** [Bug #11379] settled this as unspecified, with nobu noting there that the divergence existed precisely "because `qsort_r()` of glibc is used instead of `ruby_qsort()`".

## Testing

`make test-all`, `make btest` and `make test-spec` all pass — 36077 tests, 2065 bootstrap tests, and 33072 examples across 3455 files, with no failures or errors. New tests in `test/ruby/test_array.rb` and `test/ruby/test_enum.rb` cover the ordered/equal/two-run/random shapes at sizes straddling the insertion-sort threshold and both pivot-selection widenings, inconsistent blocks (`-1`, `1`, `0`, random) for both `sort` and `min`/`max` with an argument, and a raising comparison leaving the array intact.
