### PR TITLE
Re-enable some ractor tests that were failing in CI

### DIFF
--- a/ext/-test-/thread/instrumentation/extconf.rb
+++ b/ext/-test-/thread/instrumentation/extconf.rb
@@ -1,2 +1,3 @@
 # frozen_string_literal: false
+$INCFLAGS << " -I$(topdir) -I$(top_srcdir)"
 create_makefile("-test-/thread/instrumentation")

--- a/ext/-test-/thread/instrumentation/instrumentation.c
+++ b/ext/-test-/thread/instrumentation/instrumentation.c
@@ -1,6 +1,7 @@
 #include "ruby/ruby.h"
 #include "ruby/atomic.h"
 #include "ruby/thread.h"
+#include "internal/gc.h"
 
 #ifndef RB_THREAD_LOCAL_SPECIFIER
 #  define RB_THREAD_LOCAL_SPECIFIER
@@ -19,9 +20,11 @@ static rb_atomic_t timeline_cursor;
 
 static void
 event_timeline_gc_mark(void *ptr) {
+    /* Hook sees every Ractor's threads; validate membership before marking. */
+    rb_atomic_t n = RUBY_ATOMIC_LOAD(timeline_cursor);
     rb_atomic_t cursor;
-    for (cursor = 0; cursor < timeline_cursor; cursor++) {
-        rb_gc_mark(event_timeline[cursor].thread);
+    for (cursor = 0; cursor < n; cursor++) {
+        rb_gc_mark_maybe(event_timeline[cursor].thread);
     }
 }
 
@@ -42,14 +45,12 @@ reset_timeline(void)
 static rb_event_flag_t
 find_last_event(VALUE thread)
 {
-    rb_atomic_t cursor = timeline_cursor;
-    if (cursor) {
-        do {
-            if (event_timeline[cursor].thread == thread){
-                return event_timeline[cursor].event;
-            }
-            cursor--;
-        } while (cursor > 0);
+    rb_atomic_t cursor = RUBY_ATOMIC_LOAD(timeline_cursor);
+    while (cursor > 0) {
+        cursor--;
+        if (event_timeline[cursor].thread == thread) {
+            return event_timeline[cursor].event;
+        }
     }
     return 0;
 }
@@ -166,6 +167,7 @@ event_symbol(rb_event_flag_t event)
     }
 }
 
+// NOTE: only safe when there's a single active Ractor
 static VALUE
 thread_unregister_callback(VALUE thread)
 {
@@ -174,11 +176,15 @@ thread_unregister_callback(VALUE thread)
         single_hook = NULL;
     }
 
-    VALUE events = rb_ary_new_capa(timeline_cursor);
+    rb_atomic_t n = RUBY_ATOMIC_LOAD(timeline_cursor);
+    VALUE events = rb_ary_new_capa(n);
     rb_atomic_t cursor;
-    for (cursor = 0; cursor < timeline_cursor; cursor++) {
+    for (cursor = 0; cursor < n; cursor++) {
+        VALUE th = event_timeline[cursor].thread;
+        /* Skip foreign-objspace threads: pushing them into this Array would violate containment. */
+        if (rb_objspace_foreign_object_p(th)) continue;
         VALUE pair = rb_ary_new_capa(2);
-        rb_ary_push(pair, event_timeline[cursor].thread);
+        rb_ary_push(pair, th);
         rb_ary_push(pair, event_symbol(event_timeline[cursor].event));
         rb_ary_push(events, pair);
     }

--- a/test/-ext-/thread/test_instrumentation_api.rb
+++ b/test/-ext-/thread/test_instrumentation_api.rb
@@ -134,8 +134,6 @@ class TestThreadInstrumentation < Test::Unit::TestCase
   end
 
   def test_blocking_on_ractor
-    # TODO: turn back on and fix when ractor-local GC (rlgc) lands
-    omit "this is failing CI and rlgc will change how this works so let's wait until it lands to fix it" if ENV["GITHUB_WORKFLOW"]
     assert_ractor(<<-"RUBY", require_relative: "helper", require: "-test-/thread/instrumentation")
       include ThreadInstrumentation::TestHelper
 
@@ -163,9 +161,6 @@ class TestThreadInstrumentation < Test::Unit::TestCase
   end
 
   def test_sleeping_inside_ractor
-    # TODO: turn back and fix when ractor-local GC (rlgc) lands
-    omit "This test is flaky and intermittently failing" if ENV['GITHUB_WORKFLOW']
-
     assert_ractor(<<-"RUBY", require_relative: "helper", require: "-test-/thread/instrumentation")
       include ThreadInstrumentation::TestHelper
 


### PR DESCRIPTION
I was waiting until rlgc merge in order to turn these tests back on. I also made the C extension for these tests more Ractor-safe in a post-rlgc world.