### PR TITLE
ZJIT: Pass JIT-to-JIT call args on the stack

### DIFF
--- a/zjit/src/asm/arm64/mod.rs
+++ b/zjit/src/asm/arm64/mod.rs
@@ -886,12 +886,15 @@ pub fn stlxr(cb: &mut CodeBlock, rs: A64Opnd, rt: A64Opnd, rn: A64Opnd) {
 }
 
 /// STP (signed offset) - store a pair of registers to memory
+///
+/// Unlike LDP, STP with the same source register twice is well-defined
+/// (e.g. `stp xzr, xzr` is a common way to zero 16 bytes), so the pair is
+/// not asserted to be distinct.
 pub fn stp(cb: &mut CodeBlock, rt1: A64Opnd, rt2: A64Opnd, rn: A64Opnd) {
     let bytes: [u8; 4] = match (rt1, rt2, rn) {
         (A64Opnd::Reg(rt1), A64Opnd::Reg(rt2), A64Opnd::Mem(rn)) => {
             assert!(rt1.num_bits == rt2.num_bits, "Expected source registers to be the same size");
             assert!(imm_fits_bits(rn.disp.into(), 10), "The displacement must be 10 bits or less.");
-            assert_ne!(rt1.reg_no, rt2.reg_no, "Behavior is unpredictable with pairs of the same register");
 
             RegisterPair::stp(rt1.reg_no, rt2.reg_no, rn.base_reg_no, rn.disp as i16, rt1.num_bits).into()
         },
@@ -902,12 +905,13 @@ pub fn stp(cb: &mut CodeBlock, rt1: A64Opnd, rt2: A64Opnd, rn: A64Opnd) {
 }
 
 /// STP (pre-index) - store a pair of registers to memory, update the base pointer before loading it
+///
+/// Unlike LDP, STP with the same source register twice is well-defined; see [stp].
 pub fn stp_pre(cb: &mut CodeBlock, rt1: A64Opnd, rt2: A64Opnd, rn: A64Opnd) {
     let bytes: [u8; 4] = match (rt1, rt2, rn) {
         (A64Opnd::Reg(rt1), A64Opnd::Reg(rt2), A64Opnd::Mem(rn)) => {
             assert!(rt1.num_bits == rt2.num_bits, "Expected source registers to be the same size");
             assert!(imm_fits_bits(rn.disp.into(), 10), "The displacement must be 10 bits or less.");
-            assert_ne!(rt1.reg_no, rt2.reg_no, "Behavior is unpredictable with pairs of the same register");
 
             RegisterPair::stp_pre(rt1.reg_no, rt2.reg_no, rn.base_reg_no, rn.disp as i16, rt1.num_bits).into()
         },
@@ -918,12 +922,13 @@ pub fn stp_pre(cb: &mut CodeBlock, rt1: A64Opnd, rt2: A64Opnd, rn: A64Opnd) {
 }
 
 /// STP (post-index) - store a pair of registers to memory, update the base pointer after loading it
+///
+/// Unlike LDP, STP with the same source register twice is well-defined; see [stp].
 pub fn stp_post(cb: &mut CodeBlock, rt1: A64Opnd, rt2: A64Opnd, rn: A64Opnd) {
     let bytes: [u8; 4] = match (rt1, rt2, rn) {
         (A64Opnd::Reg(rt1), A64Opnd::Reg(rt2), A64Opnd::Mem(rn)) => {
             assert!(rt1.num_bits == rt2.num_bits, "Expected source registers to be the same size");
             assert!(imm_fits_bits(rn.disp.into(), 10), "The displacement must be 10 bits or less.");
-            assert_ne!(rt1.reg_no, rt2.reg_no, "Behavior is unpredictable with pairs of the same register");
 
             RegisterPair::stp_post(rt1.reg_no, rt2.reg_no, rn.base_reg_no, rn.disp as i16, rt1.num_bits).into()
         },
@@ -1820,6 +1825,14 @@ mod tests {
         let cb = compile(|cb| stp_post(cb, X10, X11, A64Opnd::new_mem(64, X12, 208)));
         assert_disasm_snapshot!(cb.disasm(), @"  0x0: stp x10, x11, [x12], #0xd0");
         assert_snapshot!(cb.hexdump(), @"8a2d8da8");
+    }
+
+    #[test]
+    fn test_stp_pre_same_reg() {
+        // Unlike LDP, storing the same register twice is well-defined.
+        let cb = compile(|cb| stp_pre(cb, X31, X31, A64Opnd::new_mem(64, X31, -16)));
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: stp xzr, xzr, [sp, #-0x10]!");
+        assert_snapshot!(cb.hexdump(), @"ff7fbfa9");
     }
 
     #[test]

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -256,6 +256,27 @@ pub use crate::backend::current::{
 
 pub static JIT_PRESERVED_REGS: &[Opnd] = &[CFP, SP, EC];
 
+/// Where the C calling convention passes an argument.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum CArgLocation {
+    /// In one of the argument registers.
+    Reg(Opnd),
+    /// In the stack slot that the caller reserves at the bottom of its frame.
+    /// The slot address depends on the reader: the caller writes it relative
+    /// to the native SP at the call, and the callee reads it from above its
+    /// return address and saved frame pointer.
+    StackSlot(usize),
+}
+
+/// Return where the C calling convention passes argument `idx`.
+pub fn c_arg_location(idx: usize) -> CArgLocation {
+    if idx < C_ARG_OPNDS.len() {
+        CArgLocation::Reg(C_ARG_OPNDS[idx])
+    } else {
+        CArgLocation::StackSlot(idx - C_ARG_OPNDS.len())
+    }
+}
+
 // Memory operand base
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Hash, Ord, PartialOrd)]
 pub enum MemBase
@@ -2575,20 +2596,23 @@ impl Assembler
             if self.basic_blocks[block_id.0].is_dummy() { continue; }
             let params = self.basic_blocks[block_id.0].parameters.clone();
 
-            // Rewrite VRegs to physical registers before sequentialization
-            // so the parcopy algorithm can detect physical register conflicts.
-            let reg_copies: Vec<parcopy::RegisterCopy<Opnd>> = params.iter().take(C_ARG_OPNDS.len()).enumerate()
+            // Rewrite VRegs to physical registers or stack slots before sequentialization
+            // so the parcopy algorithm can detect conflicts between them.
+            let copies: Vec<parcopy::RegisterCopy<Opnd>> = params.iter().enumerate()
                 .map(|(i, param)| parcopy::RegisterCopy::<Opnd> {
-                    source: C_ARG_OPNDS[i],
+                    source: match c_arg_location(i) {
+                        CArgLocation::Reg(reg) => reg,
+                        CArgLocation::StackSlot(slot) => Opnd::mem(64, NATIVE_BASE_PTR, Self::frame_size() + slot as i32 * SIZEOF_VALUE_I32),
+                    },
                     destination: Self::rewritten_opnd(*param, intervals, regs),
                 })
                 .filter(|copy| copy.source != copy.destination)
                 .collect();
 
-            debug_assert!(reg_copies.iter().all(|c| !c.source.is_vreg() && !c.destination.is_vreg()),
-                "parcopy must operate on physical registers, not VRegs");
-            let sequentialized = parcopy::sequentialize_register(&reg_copies, Opnd::Reg(SCRATCH_REG));
-            let mut moves: Vec<Insn> = sequentialized
+            debug_assert!(copies.iter().all(|c| !c.source.is_vreg() && !c.destination.is_vreg()),
+                "parcopy must operate on physical locations, not VRegs");
+            let sequentialized = parcopy::sequentialize_register(&copies, Opnd::Reg(SCRATCH_REG));
+            let moves: Vec<Insn> = sequentialized
                 .iter()
                 .map(|copy| match copy.source {
                     Opnd::Value(_) => Insn::LoadInto {
@@ -2601,19 +2625,6 @@ impl Assembler
                     },
                 })
                 .collect();
-
-            // Parameters beyond the argument registers are passed on the native
-            // stack, as specified by the C ABI: handle_caller_saved_regs() in the
-            // caller pushes them right below its frame, so with the return
-            // address and the saved frame pointer in between ([Self::frame_size]
-            // bytes on both platforms), they sit right above this frame's
-            // NATIVE_BASE_PTR. Load them after the register moves above so that
-            // no argument register is clobbered before its copy is done.
-            for (stack_idx, param) in params.iter().enumerate().skip(C_ARG_OPNDS.len())
-                .map(|(i, param)| (i - C_ARG_OPNDS.len(), param)) {
-                let src = Opnd::mem(64, NATIVE_BASE_PTR, Self::frame_size() + stack_idx as i32 * SIZEOF_VALUE_I32);
-                moves.push(Insn::Mov { dest: Self::rewritten_opnd(*param, intervals, regs), src });
-            }
 
             // Find the position after FrameSetup to insert moves. They must come
             // after FrameSetup (not before) because spilled destinations and

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -250,7 +250,7 @@ pub use crate::backend::current::{
     mem_base_reg,
     Reg,
     EC, CFP, SP,
-    NATIVE_BASE_PTR,
+    NATIVE_BASE_PTR, NATIVE_STACK_PTR,
     C_ARG_OPNDS, C_RET_OPND,
 };
 
@@ -2575,23 +2575,9 @@ impl Assembler
             if self.basic_blocks[block_id.0].is_dummy() { continue; }
             let params = self.basic_blocks[block_id.0].parameters.clone();
 
-            // JIT-to-JIT entries that would need more argument registers should
-            // be unreachable because can_direct_send() refuses to call them.
-            // Keep compiling the function body, but make the unsupported entry
-            // abort if control ever reaches it. TODO: Remove this (Shopify/ruby#916)
-            if params.len() > C_ARG_OPNDS.len() {
-                let insert_pos = self.basic_blocks[block_id.0].insns.iter()
-                    .position(|insn| matches!(insn, Insn::FrameSetup { .. }))
-                    .or_else(|| self.basic_blocks[block_id.0].insns.iter().position(|insn| matches!(insn, Insn::Label(_))).map(|idx| idx + 1))
-                    .unwrap_or(0);
-                self.basic_blocks[block_id.0].insns.insert(insert_pos, Insn::Abort);
-                self.basic_blocks[block_id.0].insn_ids.insert(insert_pos, None);
-                continue;
-            }
-
             // Rewrite VRegs to physical registers before sequentialization
             // so the parcopy algorithm can detect physical register conflicts.
-            let reg_copies: Vec<parcopy::RegisterCopy<Opnd>> = params.iter().enumerate()
+            let reg_copies: Vec<parcopy::RegisterCopy<Opnd>> = params.iter().take(C_ARG_OPNDS.len()).enumerate()
                 .map(|(i, param)| parcopy::RegisterCopy::<Opnd> {
                     source: C_ARG_OPNDS[i],
                     destination: Self::rewritten_opnd(*param, intervals, regs),
@@ -2602,7 +2588,7 @@ impl Assembler
             debug_assert!(reg_copies.iter().all(|c| !c.source.is_vreg() && !c.destination.is_vreg()),
                 "parcopy must operate on physical registers, not VRegs");
             let sequentialized = parcopy::sequentialize_register(&reg_copies, Opnd::Reg(SCRATCH_REG));
-            let moves: Vec<Insn> = sequentialized
+            let mut moves: Vec<Insn> = sequentialized
                 .iter()
                 .map(|copy| match copy.source {
                     Opnd::Value(_) => Insn::LoadInto {
@@ -2616,9 +2602,26 @@ impl Assembler
                 })
                 .collect();
 
-            // Find the position after FrameSetup to insert moves
+            // Parameters beyond the argument registers are passed on the native
+            // stack, as specified by the C ABI: handle_caller_saved_regs() in the
+            // caller pushes them right below its frame, so with the return
+            // address and the saved frame pointer in between ([Self::frame_size]
+            // bytes on both platforms), they sit right above this frame's
+            // NATIVE_BASE_PTR. Load them after the register moves above so that
+            // no argument register is clobbered before its copy is done.
+            for (stack_idx, param) in params.iter().enumerate().skip(C_ARG_OPNDS.len())
+                .map(|(i, param)| (i - C_ARG_OPNDS.len(), param)) {
+                let src = Opnd::mem(64, NATIVE_BASE_PTR, Self::frame_size() + stack_idx as i32 * SIZEOF_VALUE_I32);
+                moves.push(Insn::Mov { dest: Self::rewritten_opnd(*param, intervals, regs), src });
+            }
+
+            // Find the position after FrameSetup to insert moves. They must come
+            // after FrameSetup (not before) because spilled destinations and
+            // stack-passed parameter sources are NATIVE_BASE_PTR-relative, and
+            // NATIVE_BASE_PTR points at the caller's frame until FrameSetup.
             let insert_pos = self.basic_blocks[block_id.0].insns.iter()
                 .position(|insn| matches!(insn, Insn::FrameSetup { .. }))
+                .map(|idx| idx + 1)
                 .or_else(|| self.basic_blocks[block_id.0].insns.iter().position(|insn| matches!(insn, Insn::Label(_))).map(|idx| idx + 1))
                 .unwrap_or(0);
 
@@ -5143,18 +5146,26 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_ssa_entry_params_too_many_abort() {
+    fn test_resolve_ssa_entry_params_beyond_arg_regs_use_stack() {
         let mut asm = Assembler::new();
         let block = asm.new_block(hir::BlockId(0), true, 0);
         asm.set_current_block(block);
         let label = asm.new_label("bb0");
         asm.write_label(label);
 
-        for _ in 0..=C_ARG_OPNDS.len() {
+        let params: Vec<Opnd> = (0..=C_ARG_OPNDS.len()).map(|_| {
             let param = asm.new_vreg(64);
             asm.basic_blocks[block.0].add_parameter(param);
+            param
+        }).collect();
+        // Use every parameter so they are all live and get allocations.
+        let mut acc = params[0];
+        for &param in &params[1..] {
+            let out = asm.new_vreg(64);
+            asm.basic_blocks[block.0].push_insn(Insn::Add { left: acc, right: param, out });
+            acc = out;
         }
-        asm.basic_blocks[block.0].push_insn(Insn::CRet(Opnd::UImm(0)));
+        asm.basic_blocks[block.0].push_insn(Insn::CRet(acc));
 
         let live_in = asm.analyze_liveness();
         asm.number_instructions(0);
@@ -5165,7 +5176,16 @@ mod tests {
 
         asm.resolve_ssa(&intervals, &regs);
 
-        assert!(matches!(asm.basic_blocks[block.0].insns[1], Insn::Abort));
+        // The parameter that doesn't fit in argument registers is loaded from
+        // the caller's outgoing-argument area, right above this frame's
+        // return address and saved frame pointer.
+        let insns = &asm.basic_blocks[block.0].insns;
+        assert!(!insns.iter().any(|insn| matches!(insn, Insn::Abort)), "no entry should abort");
+        let expected_src = Opnd::mem(64, NATIVE_BASE_PTR, Assembler::frame_size());
+        assert!(
+            insns.iter().any(|insn| matches!(insn, Insn::Mov { src, .. } if *src == expected_src)),
+            "expected a load from {expected_src:?}, got: {insns:?}"
+        );
     }
 
     fn build_critical_edge() -> (Assembler, Opnd, Opnd, Opnd, Opnd, Opnd, BlockId, BlockId, BlockId) {

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -22,7 +22,7 @@ use crate::state::ZJITState;
 use crate::stats::{CompileError, exit_counter_for_compile_error, exit_counter_for_unhandled_hir_insn, incr_counter, incr_counter_by, send_fallback_counter, send_fallback_counter_for_method_type, send_fallback_counter_for_super_method_type, send_fallback_counter_ptr_for_opcode, send_fallback_counter_for_optimized_method_type};
 use crate::stats::{counter_ptr, with_time_stat, trace_compile_phase, Counter, Counter::{compile_time_ns, exit_compile_error}};
 use crate::{asm::CodeBlock, cruby::*, options::debug, virtualmem::CodePtr};
-use crate::backend::lir::{self, Assembler, C_ARG_OPNDS, C_RET_OPND, CFP, EC, NATIVE_BASE_PTR, Opnd, SP, SideExit, SideExitRecompile, SideExitTarget, StackMap, StackMapEntry, Target, asm_ccall, asm_comment};
+use crate::backend::lir::{self, Assembler, C_ARG_OPNDS, C_RET_OPND, CFP, EC, NATIVE_BASE_PTR, NATIVE_STACK_PTR, Opnd, SP, SideExit, SideExitRecompile, SideExitTarget, StackMap, StackMapEntry, Target, asm_ccall, asm_comment};
 use crate::hir::{self, iseq_to_hir, BlockId, Invariant, RangeType, SideExitReason::{self, *}, SpecialBackrefSymbol, SpecialObjectType};
 use crate::hir::{BlockHandler, CCallVariadicData, CCallWithFrameData, Const, FieldName, FrameState, Function, Insn, InsnId, Recompile, SendDirectData, SendFallbackReason, qualified_method_name};
 use crate::hir_type::{types, Type};
@@ -3937,15 +3937,26 @@ fn gen_function_stub(cb: &mut CodeBlock, iseq_call: IseqCallRef) -> Result<CodeP
 
     // If the stubbed ISEQ fails to compile, function_stub_hit exits to the
     // interpreter with this callee frame. Direct JIT-to-JIT calls pass arguments
-    // in C argument registers, so spill the packed argument locals first. The
-    // fallback path will reshape these around any optional positional gaps.
+    // in C argument registers and the rest on the native stack, so spill the
+    // packed argument locals first. The fallback path will reshape these around
+    // any optional positional gaps.
     let argc = iseq_call.argc.to_usize();
-    assert!(argc < C_ARG_OPNDS.len(), "SendDirect must fit receiver plus arguments in C argument registers");
     let local_size = unsafe { get_iseq_body_local_table_size(iseq_call.iseq.get()) }.to_usize();
     for arg_idx in 0..argc {
+        let src = if arg_idx + 1 < C_ARG_OPNDS.len() {
+            C_ARG_OPNDS[arg_idx + 1]
+        } else {
+            // The stub runs before any frame setup, so stack-passed arguments
+            // sit right above the return address (x86_64) or right at the
+            // native SP (arm64, where the return address is in a register).
+            let ret_addr_bytes = if cfg!(target_arch = "x86_64") { SIZEOF_VALUE_I32 } else { 0 };
+            let stack_arg_idx = (arg_idx + 1 - C_ARG_OPNDS.len()) as i32;
+            asm.load_into(scratch_reg, Opnd::mem(64, NATIVE_STACK_PTR, ret_addr_bytes + stack_arg_idx * SIZEOF_VALUE_I32));
+            scratch_reg
+        };
         asm.store(
             Opnd::mem(64, SP, -local_size_and_idx_to_bp_offset(local_size, arg_idx) * SIZEOF_VALUE_I32),
-            C_ARG_OPNDS[arg_idx + 1],
+            src,
         );
     }
 

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -22,7 +22,7 @@ use crate::state::ZJITState;
 use crate::stats::{CompileError, exit_counter_for_compile_error, exit_counter_for_unhandled_hir_insn, incr_counter, incr_counter_by, send_fallback_counter, send_fallback_counter_for_method_type, send_fallback_counter_for_super_method_type, send_fallback_counter_ptr_for_opcode, send_fallback_counter_for_optimized_method_type};
 use crate::stats::{counter_ptr, with_time_stat, trace_compile_phase, Counter, Counter::{compile_time_ns, exit_compile_error}};
 use crate::{asm::CodeBlock, cruby::*, options::debug, virtualmem::CodePtr};
-use crate::backend::lir::{self, Assembler, C_ARG_OPNDS, C_RET_OPND, CFP, EC, NATIVE_BASE_PTR, NATIVE_STACK_PTR, Opnd, SP, SideExit, SideExitRecompile, SideExitTarget, StackMap, StackMapEntry, Target, asm_ccall, asm_comment};
+use crate::backend::lir::{self, Assembler, CArgLocation, C_ARG_OPNDS, C_RET_OPND, CFP, EC, NATIVE_BASE_PTR, NATIVE_STACK_PTR, Opnd, SP, SideExit, SideExitRecompile, SideExitTarget, StackMap, StackMapEntry, Target, asm_ccall, asm_comment};
 use crate::hir::{self, iseq_to_hir, BlockId, Invariant, RangeType, SideExitReason::{self, *}, SpecialBackrefSymbol, SpecialObjectType};
 use crate::hir::{BlockHandler, CCallVariadicData, CCallWithFrameData, Const, FieldName, FrameState, Function, Insn, InsnId, Recompile, SendDirectData, SendFallbackReason, qualified_method_name};
 use crate::hir_type::{types, Type};
@@ -3943,16 +3943,16 @@ fn gen_function_stub(cb: &mut CodeBlock, iseq_call: IseqCallRef) -> Result<CodeP
     let argc = iseq_call.argc.to_usize();
     let local_size = unsafe { get_iseq_body_local_table_size(iseq_call.iseq.get()) }.to_usize();
     for arg_idx in 0..argc {
-        let src = if arg_idx + 1 < C_ARG_OPNDS.len() {
-            C_ARG_OPNDS[arg_idx + 1]
-        } else {
-            // The stub runs before any frame setup, so stack-passed arguments
-            // sit right above the return address (x86_64) or right at the
-            // native SP (arm64, where the return address is in a register).
-            let ret_addr_bytes = if cfg!(target_arch = "x86_64") { SIZEOF_VALUE_I32 } else { 0 };
-            let stack_arg_idx = (arg_idx + 1 - C_ARG_OPNDS.len()) as i32;
-            asm.load_into(scratch_reg, Opnd::mem(64, NATIVE_STACK_PTR, ret_addr_bytes + stack_arg_idx * SIZEOF_VALUE_I32));
-            scratch_reg
+        let src = match lir::c_arg_location(arg_idx + 1) { // +1 for self
+            CArgLocation::Reg(reg) => reg,
+            CArgLocation::StackSlot(slot) => {
+                // The stub runs before any frame setup, so stack-passed arguments
+                // sit right above the return address (x86_64) or right at the
+                // native SP (arm64, where the return address is in a register).
+                let ret_addr_bytes = if cfg!(target_arch = "x86_64") { SIZEOF_VALUE_I32 } else { 0 };
+                asm.load_into(scratch_reg, Opnd::mem(64, NATIVE_STACK_PTR, ret_addr_bytes + slot as i32 * SIZEOF_VALUE_I32));
+                scratch_reg
+            }
         };
         asm.store(
             Opnd::mem(64, SP, -local_size_and_idx_to_bp_offset(local_size, arg_idx) * SIZEOF_VALUE_I32),

--- a/zjit/src/codegen_tests.rs
+++ b/zjit/src/codegen_tests.rs
@@ -713,7 +713,7 @@ fn test_yield_inline_invocation_with_args() {
 }
 
 #[test]
-fn test_yield_with_stack_args() {
+fn test_yield_with_more_args_than_abi_registers() {
     // `self` + eight yield args don't fit in C argument registers (6 on x86_64, 8 on
     // arm64), so the direct block invocation passes the overflow arguments on the
     // native stack.
@@ -728,7 +728,7 @@ fn test_yield_with_stack_args() {
 }
 
 #[test]
-fn test_send_direct_with_stack_args() {
+fn test_send_direct_with_more_args_than_abi_registers() {
     // `self` + ten args don't fit in C argument registers (6 on x86_64, 8 on arm64),
     // so the JIT-to-JIT call passes the overflow arguments on the native stack, and
     // the callee's JIT entry loads them from above its frame.
@@ -743,7 +743,7 @@ fn test_send_direct_with_stack_args() {
 }
 
 #[test]
-fn test_send_direct_with_equal_stack_args() {
+fn test_send_direct_with_equal_args_beyond_abi_registers() {
     // A pair of adjacent stack-passed arguments that are the same zero immediate
     // (false) or the same register lowers to an STP with an identical register
     // pair on arm64, e.g. `stp xzr, xzr`, which the assembler used to reject.

--- a/zjit/src/codegen_tests.rs
+++ b/zjit/src/codegen_tests.rs
@@ -743,6 +743,22 @@ fn test_send_direct_with_stack_args() {
 }
 
 #[test]
+fn test_send_direct_with_equal_stack_args() {
+    // A pair of adjacent stack-passed arguments that are the same zero immediate
+    // (false) or the same register lowers to an STP with an identical register
+    // pair on arm64, e.g. `stp xzr, xzr`, which the assembler used to reject.
+    // On arm64, c_args[8] and c_args[9] (arguments h and i below) form a pair.
+    set_call_threshold(2);
+    eval("
+        def callee(a, b, c, d, e, f, g, h, i, j) = [a, b, c, d, e, f, g, h, i, j]
+        def test(x = 9) = [callee(1, 2, 3, 4, 5, 6, 7, false, false, 10), callee(1, 2, 3, 4, 5, 6, 7, x, x, 10)]
+        test
+        test
+    ");
+    assert_snapshot!(assert_compiles("test"), @"[[1, 2, 3, 4, 5, 6, 7, false, false, 10], [1, 2, 3, 4, 5, 6, 7, 9, 9, 10]]");
+}
+
+#[test]
 fn test_yield_inline_invocation_live_stack_below_args() {
     // A live value sits on the stack below the yield args; the no-receiver-slot SP math
     // must preserve it so `x +` sees the right operand.

--- a/zjit/src/codegen_tests.rs
+++ b/zjit/src/codegen_tests.rs
@@ -713,10 +713,10 @@ fn test_yield_inline_invocation_with_args() {
 }
 
 #[test]
-fn test_yield_with_too_many_args_for_lir() {
+fn test_yield_with_stack_args() {
     // `self` + eight yield args don't fit in C argument registers (6 on x86_64, 8 on
-    // arm64), so the direct block invocation must be rejected instead of emitting an
-    // uncompilable CCall.
+    // arm64), so the direct block invocation passes the overflow arguments on the
+    // native stack.
     set_call_threshold(2);
     eval("
         def foo = yield(1, 2, 3, 4, 5, 6, 7, 8)
@@ -725,6 +725,21 @@ fn test_yield_with_too_many_args_for_lir() {
         test
     ");
     assert_snapshot!(assert_compiles("test"), @"36");
+}
+
+#[test]
+fn test_send_direct_with_stack_args() {
+    // `self` + ten args don't fit in C argument registers (6 on x86_64, 8 on arm64),
+    // so the JIT-to-JIT call passes the overflow arguments on the native stack, and
+    // the callee's JIT entry loads them from above its frame.
+    set_call_threshold(2);
+    eval("
+        def callee(a, b, c, d, e, f, g, h, i, j) = [a, b, c, d, e, f, g, h, i, j]
+        def test = callee(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+        test
+        test
+    ");
+    assert_snapshot!(assert_compiles("test"), @"[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]");
 }
 
 #[test]

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -2690,14 +2690,8 @@ fn can_direct_send(iseq: *const rb_iseq_t, ci: *const rb_callinfo, args: &[InsnI
         return Err(SendDirectFailure::new(ArgcParamMismatch));
     }
 
-    // asm.ccall() doesn't support 6+ args. Compute the final argc after keyword setup
-    // and rest packing:
+    // Compute the final argc after keyword setup and rest packing:
     // send_argc = packed positional args + callee's total keywords (all kw slots are filled).
-    // c_argc = self + send_argc + synthetic block handler arg.
-    // Right now, the JIT entrypoint accepts the block as an param
-    // We may remove it, remove the block_arg addition to match
-    // See: https://github.com/ruby/ruby/pull/15911#discussion_r2710544982
-    let block_arg = if 0 != params.flags.has_block() { 1 } else { 0 };
     // With *rest, SendDirect receives one rest-array slot instead of each rest
     // element, so cap positional argc at required/post + filled opts + rest slot.
     let passed_opt_num = (caller_positional_i32 - min_positional).min(opt_num) as usize;
@@ -2705,12 +2699,6 @@ fn can_direct_send(iseq: *const rb_iseq_t, ci: *const rb_callinfo, args: &[InsnI
     // keyword Hash is included in the SendDirect argument count.
     let send_positional_argc = if has_rest { min_positional as usize + passed_opt_num + 1 } else { effective_positional };
     let send_argc = send_positional_argc + kw_total_num as usize;
-    let c_argc = 1 + send_argc + block_arg; // +1 for self
-
-    // TODO: Support passing arguments on the stack in C calls
-    if c_argc > C_ARG_OPNDS.len() {
-        return Err(SendDirectFailure::new(TooManyArgsForLir));
-    }
 
     // IseqCall stores the JIT entry index and argc as u16.
     if u16::try_from(send_argc).is_err() {
@@ -2991,12 +2979,6 @@ fn block_call_inlinable_iseq(iseq: IseqPtr, argc: usize) -> Result<(), SendFallb
     }
     if argc == 1 && !unsafe { rb_get_iseq_flags_ambiguous_param0(iseq) } {
         return Err(InvokeBlockNotSpecialized);
-    }
-    // The JIT-to-JIT call in gen_invoke_block_iseq_direct passes captured self plus
-    // each argument in C argument registers.
-    // TODO: Support passing arguments on the stack in C calls
-    if 1 + argc > C_ARG_OPNDS.len() {
-        return Err(TooManyArgsForLir);
     }
     if crate::codegen::block_iseq_may_throw(iseq) {
         return Err(InvokeBlockNotSpecialized);

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -4225,7 +4225,7 @@ mod hir_opt_tests {
     }
 
     #[test]
-    fn test_yield_with_stack_args_specializes() {
+    fn test_specialize_yield_with_more_args_than_abi_registers() {
         // Captured self plus eight args don't fit in C argument registers (6 on x86_64,
         // 8 on arm64); the profiled invokeblock specialization still emits
         // InvokeBlockIseqDirect, passing the overflow arguments on the stack.
@@ -4271,8 +4271,8 @@ mod hir_opt_tests {
     }
 
     #[test]
-    fn test_inlined_yield_with_stack_args_specializes() {
-        // Same as test_yield_with_stack_args_specializes, but for the guard-free
+    fn test_specialize_inlined_yield_with_more_args_than_abi_registers() {
+        // Same as test_specialize_yield_with_more_args_than_abi_registers, but for the guard-free
         // yield dispatch inside an inlined callee whose caller passes a literal block.
         let result = eval("
             def foo = yield(1, 2, 3, 4, 5, 6, 7, 8)

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -4225,10 +4225,10 @@ mod hir_opt_tests {
     }
 
     #[test]
-    fn test_yield_with_too_many_args_for_lir_falls_back() {
+    fn test_yield_with_stack_args_specializes() {
         // Captured self plus eight args don't fit in C argument registers (6 on x86_64,
-        // 8 on arm64), so the profiled invokeblock specialization must not emit
-        // InvokeBlockIseqDirect.
+        // 8 on arm64); the profiled invokeblock specialization still emits
+        // InvokeBlockIseqDirect, passing the overflow arguments on the stack.
         let result = eval("
             def foo = yield(1, 2, 3, 4, 5, 6, 7, 8)
             def test = foo { |a, b, c, d, e, f, g, h| a + b + c + d + e + f + g + h }
@@ -4255,15 +4255,24 @@ mod hir_opt_tests {
           v20:Fixnum[6] = Const Value(6)
           v22:Fixnum[7] = Const Value(7)
           v24:Fixnum[8] = Const Value(8)
-          v26:BasicObject = InvokeBlock v10, v12, v14, v16, v18, v20, v22, v24 # SendFallbackReason: Too many arguments for LIR
+          v26:CPtr = GetEP 0
+          v27:CInt64 = LoadField v26, :VM_ENV_DATA_INDEX_SPECVAL@0x1000
+          v28:CInt64[3] = Const CInt64(3)
+          v29:CInt64 = IntAnd v27, v28
+          v30:CInt64[1] = GuardBitEquals v29, CInt64(1) recompile
+          v31:CInt64[-4] = Const CInt64(-4)
+          v32:CInt64 = IntAnd v27, v31
+          v33:CPtr = LoadField v32, :code_iseq@0x1001
+          v34:CPtr[CPtr(0x1002)] = GuardBitEquals v33, CPtr(0x1002) recompile
+          v35:BasicObject = InvokeBlockIseqDirect (0x1002), v32, v10, v12, v14, v16, v18, v20, v22, v24
           CheckInterrupts
-          Return v26
+          Return v35
         ");
     }
 
     #[test]
-    fn test_inlined_yield_with_too_many_args_for_lir_falls_back() {
-        // Same as test_yield_with_too_many_args_for_lir_falls_back, but for the guard-free
+    fn test_inlined_yield_with_stack_args_specializes() {
+        // Same as test_yield_with_stack_args_specializes, but for the guard-free
         // yield dispatch inside an inlined callee whose caller passes a literal block.
         let result = eval("
             def foo = yield(1, 2, 3, 4, 5, 6, 7, 8)
@@ -4294,10 +4303,14 @@ mod hir_opt_tests {
           v35:Fixnum[6] = Const Value(6)
           v37:Fixnum[7] = Const Value(7)
           v39:Fixnum[8] = Const Value(8)
-          v41:BasicObject = InvokeBlock v25, v27, v29, v31, v33, v35, v37, v39 # SendFallbackReason: Too many arguments for LIR
+          v41:CPtr = GetEP 0
+          v42:CInt64 = LoadField v41, :VM_ENV_DATA_INDEX_SPECVAL@0x1060
+          v43:CInt64[-4] = Const CInt64(-4)
+          v44:CInt64 = IntAnd v42, v43
+          v45:BasicObject = InvokeBlockIseqDirect (0x1068), v44, v25, v27, v29, v31, v33, v35, v37, v39
           CheckInterrupts
           PopInlineFrame
-          Return v41
+          Return v45
         ");
     }
 
@@ -5245,8 +5258,9 @@ mod hir_opt_tests {
           v37:Fixnum[60] = Const Value(60)
           v39:Fixnum[70] = Const Value(70)
           v41:Fixnum[80] = Const Value(80)
-          v43:BasicObject = Send v52, :target, v27, v29, v31, v33, v35, v37, v39, v41 # SendFallbackReason: Too many arguments for LIR
-          v45:ArrayExact = NewArray v53, v56, v43
+          PatchPoint MethodRedefined(Object@0x1000, target@0x1008, cme:0x1010)
+          v59:BasicObject = SendDirect v52, 0x0, :target (0x1038), jit_entry_idx=7, v27, v29, v31, v33, v35, v37, v39, v41
+          v45:ArrayExact = NewArray v53, v56, v59
           CheckInterrupts
           Return v45
         ");

--- a/zjit/src/hir/tests.rs
+++ b/zjit/src/hir/tests.rs
@@ -293,11 +293,18 @@ mod snapshot_tests {
           v23:Fixnum[7] = Const Value(7)
           v25:Fixnum[8] = Const Value(8)
           v26:Any = Snapshot FrameState { pc: 0x1008, stack: [v6, v11, v13, v15, v17, v19, v21, v23, v25], locals: [] }
-          v27:BasicObject = Send v6, :foo, v11, v13, v15, v17, v19, v21, v23, v25 # SendFallbackReason: Too many arguments for LIR
-          v28:Any = Snapshot FrameState { pc: 0x1010, stack: [v27], locals: [] }
-          PatchPoint NoTracePoint
+          PatchPoint MethodRedefined(Object@0x1010, foo@0x1018, cme:0x1020)
+          v34:ObjectSubclass[class_exact*:Object@VALUE(0x1010)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1010)] recompile
+          v35:Any = Snapshot FrameState { pc: 0x1008, stack: [v34, v11, v13, v19, v21, v17, v15, v23, v25], locals: [] }
+          v64:Fixnum[0] = Const Value(0)
+          v37:Any = Snapshot FrameState { pc: 0x1008, stack: [], locals: [] }
+          PushInlineFrame :foo, v34 (0x1048), num_args=8
+          v58:Any = Snapshot FrameState { pc: 0x1070, stack: [v19, v21, v17, v15, v11, v13, v23, v25], locals: [five=v11, six=v13, a=v19, b=v21, c=v17, d=v15, e=v23, f=v25, ID(0)=v64], caller: v37 }
+          v59:ArrayExact = NewArray v19, v21, v17, v15, v11, v13, v23, v25
+          v60:Any = Snapshot FrameState { pc: 0x1078, stack: [v59], locals: [five=v11, six=v13, a=v19, b=v21, c=v17, d=v15, e=v23, f=v25, ID(0)=v64], caller: v37 }
           CheckInterrupts
-          Return v27
+          PopInlineFrame
+          Return v59
         ");
     }
 }


### PR DESCRIPTION
This PR uses the stack-based C argument passing added in https://github.com/ruby/ruby/pull/18285 for JIT-to-JIT calls. There are still other `TooManyArgsForLir` send fallbacks for C method calls, but they're out of scope in this PR.

## Benchmark

### Headline

The results seem positive. hexapdf, liquid-il, and rubocop are sped up.

```
before: ruby 4.1.0dev (2026-08-17T22:16:54Z master 09addc1d50) +ZJIT +PRISM [x86_64-linux]
after: ruby 4.1.0dev (2026-08-17T23:01:03Z zjit-iseq-call-sta.. b5733ca02b) +ZJIT +PRISM [x86_64-linux]

--------------  ------------  ------------  -------------  ------------
bench            before (ms)    after (ms)  after 1st itr  before/after
activerecord     65.8 ± 3.3%   65.8 ± 3.8%          1.197         1.000
chunky-png      204.2 ± 0.6%  204.9 ± 0.7%          1.002         0.997
erubi-rails     344.0 ± 2.2%  342.6 ± 2.2%          0.966         1.004
hexapdf         936.2 ± 2.2%  894.5 ± 1.9%          1.026         1.047
liquid-c        23.0 ± 10.6%  22.7 ± 11.4%          0.996         1.011
liquid-compile  18.6 ± 11.4%  18.7 ± 11.6%          1.008         0.996
liquid-il        91.5 ± 2.1%   89.0 ± 2.2%          1.011         1.028
liquid-render    43.3 ± 5.3%   43.4 ± 5.3%          1.003         0.999
lobsters        391.5 ± 5.3%  391.1 ± 4.4%          1.009         1.001
mail             53.0 ± 3.2%   53.0 ± 3.1%          1.002         1.000
psych-load      820.1 ± 1.2%  809.9 ± 1.9%          1.024         1.013
railsbench      800.9 ± 1.1%  805.1 ± 1.4%          1.006         0.995
rubocop         71.8 ± 16.1%  70.0 ± 17.2%          1.004         1.026
ruby-lsp         52.8 ± 4.4%   53.0 ± 4.2%          1.005         0.997
sequel           20.8 ± 5.9%   20.7 ± 6.2%          1.166         1.006
shipit          644.6 ± 2.1%  639.7 ± 3.2%          1.000         1.008
--------------  ------------  ------------  -------------  ------------
```

### Other

GraphQL benchmarks are sped up.

```
before: ruby 4.1.0dev (2026-08-17T22:16:54Z master 09addc1d50) +ZJIT +PRISM [x86_64-linux]
after: ruby 4.1.0dev (2026-08-17T23:01:03Z zjit-iseq-call-sta.. b5733ca02b) +ZJIT +PRISM [x86_64-linux]

--------------  ------------  ------------  -------------  ------------
bench            before (ms)    after (ms)  after 1st itr  before/after
graphql          16.7 ± 2.8%   14.8 ± 3.2%          1.008         1.129
graphql-native  143.9 ± 1.3%  129.6 ± 2.4%          1.089         1.110
--------------  ------------  ------------  -------------  ------------
```