### PR TITLE
CI: Run Compilations in smaller shards

### DIFF
--- a/.github/actions/setup/compilation-source/action.yml
+++ b/.github/actions/setup/compilation-source/action.yml
@@ -1,0 +1,28 @@
+name: Set up sources for Compilations
+description: Download and extract sources prepared by the Compilations workflow.
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: compilation-source
+        path: ${{ runner.temp }}
+
+    - shell: bash
+      working-directory: ${{ github.workspace }}
+      run: tar -xf "${RUNNER_TEMP}/compilation-source.tar"
+
+    - id: gems-key
+      shell: bash
+      run: echo "hash=${HASH}" >> "${GITHUB_OUTPUT}"
+      env:
+        HASH: ${{ hashFiles('src/gems/bundled_gems') }}
+
+    - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: src/.downloaded-cache
+        key: downloaded-cache-${{ steps.gems-key.outputs.hash }}
+        restore-keys: |
+          downloaded-cache-
+          ${{ runner.os }}-${{ runner.arch }}-downloaded-cache

--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -65,277 +65,173 @@ jobs:
           compression-level: 0
           retention-days: 1
 
-  compile1:
-    name: 'omnibus compilations, #1'
-    runs-on: ubuntu-latest
+  compile:
+    name: 'omnibus compilations, #${{ matrix.shard }}'
     needs: compile-if
     if: ${{ needs.compile-if.result == 'success' }}
+    strategy:
+      fail-fast: false
+      max-parallel: 12
+      matrix:
+        shard:
+          - '01'
+          - '02'
+          - '03'
+          - '04'
+          - '05'
+          - '06'
+          - '07'
+          - '08'
+          - '09'
+          - '10'
+          - '11'
+          - '12'
+          - '13'
+          - '14'
+          - '15'
+          - '16'
+          - '17'
+          - '18'
+          - '19'
+          - '20'
+          - '21'
+          - '22'
+          - '23'
+          - '24'
+    runs-on: ubuntu-latest
     timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with: { sparse-checkout-cone-mode: false, sparse-checkout: /.github, persist-credentials: false }
       - uses: './.github/actions/setup/compilation-source'
+
       - name: 'clang 23 LTO'
-        uses: './.github/actions/compilers'
+        uses: &compilers './.github/actions/compilers'
         with:
           tag: clang-23
           with_gcc: 'clang-23 -flto=auto'
           optflags: '-O2'
         timeout-minutes: 30
-      - { uses: './.github/actions/compilers', name: 'clang 23', with: { tag: 'clang-23' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'clang 22', with: { tag: 'clang-22' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'clang 21', with: { tag: 'clang-21' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: '-O0', with: { optflags: '-O0 -march=x86-64 -mtune=generic' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'YJIT_FORCE_ENABLE', with: { cppflags: '-DYJIT_FORCE_ENABLE' }, timeout-minutes: 8 }
-      # - { uses: './.github/actions/compilers', name: '-O3', with: { optflags: '-O3 -march=x86-64 -mtune=generic', check: true } }
+        if: ${{ matrix.shard == '18' }}
+      - { uses: *compilers, name: 'clang 23', with: { tag: 'clang-23' }, timeout-minutes: 8, if: "${{ matrix.shard == '18' }}" }
+      - { uses: *compilers, name: 'clang 22', with: { tag: 'clang-22' }, timeout-minutes: 8, if: "${{ matrix.shard == '22' }}" }
+      - { uses: *compilers, name: 'clang 21', with: { tag: 'clang-21' }, timeout-minutes: 8, if: "${{ matrix.shard == '22' }}" }
+      - { uses: *compilers, name: '-O0', with: { optflags: '-O0 -march=x86-64 -mtune=generic' }, timeout-minutes: 8, if: "${{ matrix.shard == '22' }}" }
+      - { uses: *compilers, name: 'YJIT_FORCE_ENABLE', with: { cppflags: '-DYJIT_FORCE_ENABLE' }, timeout-minutes: 8, if: "${{ matrix.shard == '22' }}" }
 
-  compile2:
-    name: 'omnibus compilations, #2'
-    runs-on: ubuntu-latest
-    needs: compile-if
-    if: ${{ needs.compile-if.result == 'success' }}
-    timeout-minutes: 60
-
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with: { sparse-checkout-cone-mode: false, sparse-checkout: /.github, persist-credentials: false }
-      - uses: './.github/actions/setup/compilation-source'
       - name: 'GCC 15 LTO'
-        uses: './.github/actions/compilers'
+        uses: *compilers
         with:
           tag: gcc-15
           with_gcc: 'gcc-15 -flto=auto -ffat-lto-objects -Werror=lto-type-mismatch'
           optflags: '-O2'
           enable_shared: false
         timeout-minutes: 10
-      - { uses: './.github/actions/compilers', name: 'GCC 15', with: { tag: 'gcc-15' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'GCC 14', with: { tag: 'gcc-14' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'GCC 13', with: { tag: 'gcc-13' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'GCC 12', with: { tag: 'gcc-12' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'UNIVERSAL_PARSER', with: { cppflags: '-DUNIVERSAL_PARSER' }, timeout-minutes: 8 }
+        if: ${{ matrix.shard == '23' }}
+      - { uses: *compilers, name: 'GCC 15', with: { tag: 'gcc-15' }, timeout-minutes: 8, if: "${{ matrix.shard == '23' }}" }
+      - { uses: *compilers, name: 'GCC 14', with: { tag: 'gcc-14' }, timeout-minutes: 8, if: "${{ matrix.shard == '08' }}" }
+      - { uses: *compilers, name: 'GCC 13', with: { tag: 'gcc-13' }, timeout-minutes: 8, if: "${{ matrix.shard == '08' }}" }
+      - { uses: *compilers, name: 'GCC 12', with: { tag: 'gcc-12' }, timeout-minutes: 8, if: "${{ matrix.shard == '08' }}" }
+      - { uses: *compilers, name: 'UNIVERSAL_PARSER', with: { cppflags: '-DUNIVERSAL_PARSER' }, timeout-minutes: 8, if: "${{ matrix.shard == '08' }}" }
 
-  compile3:
-    name: 'omnibus compilations, #3'
-    runs-on: ubuntu-latest
-    needs: compile-if
-    if: ${{ needs.compile-if.result == 'success' }}
-    timeout-minutes: 60
+      - { uses: *compilers, name: 'clang 20', with: { tag: 'clang-20' }, timeout-minutes: 8, if: "${{ matrix.shard == '13' }}" }
+      - { uses: *compilers, name: 'clang 19', with: { tag: 'clang-19' }, timeout-minutes: 8, if: "${{ matrix.shard == '13' }}" }
+      - { uses: *compilers, name: 'clang 18', with: { tag: 'clang-18' }, timeout-minutes: 8, if: "${{ matrix.shard == '13' }}" }
+      - { uses: *compilers, name: 'clang 17', with: { tag: 'clang-17' }, timeout-minutes: 8, if: "${{ matrix.shard == '07' }}" }
+      - { uses: *compilers, name: 'clang 16', with: { tag: 'clang-16' }, timeout-minutes: 8, if: "${{ matrix.shard == '07' }}" }
+      - { uses: *compilers, name: 'clang 15', with: { tag: 'clang-15' }, timeout-minutes: 8, if: "${{ matrix.shard == '07' }}" }
+      - { uses: *compilers, name: 'clang 14', with: { tag: 'clang-14' }, timeout-minutes: 8, if: "${{ matrix.shard == '07' }}" }
 
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with: { sparse-checkout-cone-mode: false, sparse-checkout: /.github, persist-credentials: false }
-      - uses: './.github/actions/setup/compilation-source'
-      - { uses: './.github/actions/compilers', name: 'clang 20', with: { tag: 'clang-20' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'clang 19', with: { tag: 'clang-19' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'clang 18', with: { tag: 'clang-18' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'clang 17', with: { tag: 'clang-17' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'clang 16', with: { tag: 'clang-16' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'clang 15', with: { tag: 'clang-15' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'clang 14', with: { tag: 'clang-14' }, timeout-minutes: 8 }
-
-  compile4:
-    name: 'omnibus compilations, #4'
-    runs-on: ubuntu-latest
-    needs: compile-if
-    if: ${{ needs.compile-if.result == 'success' }}
-    timeout-minutes: 60
-
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with: { sparse-checkout-cone-mode: false, sparse-checkout: /.github, persist-credentials: false }
-      - uses: './.github/actions/setup/compilation-source'
-      - { uses: './.github/actions/compilers', name: 'clang 13', with: { tag: 'clang-13' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'clang 12', with: { tag: 'clang-12' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'clang 11', with: { tag: 'clang-11' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'clang 10', with: { tag: 'clang-10' }, timeout-minutes: 8 }
+      - { uses: *compilers, name: 'clang 13', with: { tag: 'clang-13' }, timeout-minutes: 8, if: "${{ matrix.shard == '19' }}" }
+      - { uses: *compilers, name: 'clang 12', with: { tag: 'clang-12' }, timeout-minutes: 8, if: "${{ matrix.shard == '19' }}" }
+      - { uses: *compilers, name: 'clang 11', with: { tag: 'clang-11' }, timeout-minutes: 8, if: "${{ matrix.shard == '19' }}" }
+      - { uses: *compilers, name: 'clang 10', with: { tag: 'clang-10' }, timeout-minutes: 8, if: "${{ matrix.shard == '19' }}" }
         # llvm-objcopy<=9 doesn't have --wildcard. It compiles, but leaves Rust symbols in libyjit.o and fail `make test-leaked-globals`.
-      - { uses: './.github/actions/compilers', name: 'clang 9',  with: { tag: 'clang-9',   append_configure: '--disable-yjit --disable-zjit' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'clang 8',  with: { tag: 'clang-8',   append_configure: '--disable-yjit --disable-zjit' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'clang 7',  with: { tag: 'clang-7',   append_configure: '--disable-yjit --disable-zjit' }, timeout-minutes: 8 }
+      - { uses: *compilers, name: 'clang 9', with: { tag: 'clang-9', append_configure: '--disable-yjit --disable-zjit' }, timeout-minutes: 8, if: "${{ matrix.shard == '24' }}" }
+      - { uses: *compilers, name: 'clang 8', with: { tag: 'clang-8', append_configure: '--disable-yjit --disable-zjit' }, timeout-minutes: 8, if: "${{ matrix.shard == '24' }}" }
+      - { uses: *compilers, name: 'clang 7', with: { tag: 'clang-7', append_configure: '--disable-yjit --disable-zjit' }, timeout-minutes: 8, if: "${{ matrix.shard == '24' }}" }
 
-  compile5:
-    name: 'omnibus compilations, #5'
-    runs-on: ubuntu-latest
-    needs: compile-if
-    if: ${{ needs.compile-if.result == 'success' }}
-    timeout-minutes: 60
-
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with: { sparse-checkout-cone-mode: false, sparse-checkout: /.github, persist-credentials: false }
-      - uses: './.github/actions/setup/compilation-source'
       # -Wno-strict-prototypes is necessary with clang-15 or newer, since
-      # older autoconf prior to 2.72 generate functions without prototype
-      # and -pedantic now implies strict-prototypes. Disabling the error
-      # but leaving the warning generates a lot of noise from use of
-      # ANYARGS in rb_define_method() and friends.
-      # See: https://github.com/llvm/llvm-project/commit/11da1b53d8cd3507959022cd790d5a7ad4573d94
-      - { uses: './.github/actions/compilers', name: 'C99',      with: { CFLAGS: '-std=c99 -Werror=pedantic -pedantic-errors -Wno-strict-prototypes' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'C11',   with: { CFLAGS:   '-std=c11   -Werror=pedantic -pedantic-errors -Wno-strict-prototypes' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'C17',   with: { CFLAGS:   '-std=c17   -Werror=pedantic -pedantic-errors -Wno-strict-prototypes' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'C23',   with: { CFLAGS:   '-std=c2x   -Werror=pedantic -pedantic-errors -Wno-strict-prototypes' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'C++98', with: { CXXFLAGS: '-std=c++98 -Werror=pedantic -pedantic-errors -Wno-c++11-long-long' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'C++11', with: { CXXFLAGS: '-std=c++11 -Werror=pedantic -pedantic-errors -Wno-c++11-long-long' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'C++14', with: { CXXFLAGS: '-std=c++14 -Werror=pedantic -pedantic-errors -Wno-c++11-long-long' }, timeout-minutes: 8 }
+      # older autoconf prior to 2.72 generate functions without prototype.
+      - { uses: *compilers, name: 'C99', with: { CFLAGS: '-std=c99 -Werror=pedantic -pedantic-errors -Wno-strict-prototypes' }, timeout-minutes: 8, if: "${{ matrix.shard == '12' }}" }
+      - { uses: *compilers, name: 'C11', with: { CFLAGS: '-std=c11 -Werror=pedantic -pedantic-errors -Wno-strict-prototypes' }, timeout-minutes: 8, if: "${{ matrix.shard == '12' }}" }
+      - { uses: *compilers, name: 'C17', with: { CFLAGS: '-std=c17 -Werror=pedantic -pedantic-errors -Wno-strict-prototypes' }, timeout-minutes: 8, if: "${{ matrix.shard == '12' }}" }
+      - { uses: *compilers, name: 'C23', with: { CFLAGS: '-std=c2x -Werror=pedantic -pedantic-errors -Wno-strict-prototypes' }, timeout-minutes: 8, if: "${{ matrix.shard == '12' }}" }
+      - { uses: *compilers, name: 'C++98', with: { CXXFLAGS: '-std=c++98 -Werror=pedantic -pedantic-errors -Wno-c++11-long-long' }, timeout-minutes: 8, if: "${{ matrix.shard == '20' }}" }
+      - { uses: *compilers, name: 'C++11', with: { CXXFLAGS: '-std=c++11 -Werror=pedantic -pedantic-errors -Wno-c++11-long-long' }, timeout-minutes: 8, if: "${{ matrix.shard == '20' }}" }
+      - { uses: *compilers, name: 'C++14', with: { CXXFLAGS: '-std=c++14 -Werror=pedantic -pedantic-errors -Wno-c++11-long-long' }, timeout-minutes: 8, if: "${{ matrix.shard == '20' }}" }
 
-  compile6:
-    name: 'omnibus compilations, #6'
-    runs-on: ubuntu-latest
-    needs: compile-if
-    if: ${{ needs.compile-if.result == 'success' }}
-    timeout-minutes: 60
+      - { uses: *compilers, name: 'C++20', with: { CXXFLAGS: '-std=c++20 -Werror=pedantic -pedantic-errors -Wno-c++11-long-long' }, timeout-minutes: 8, if: "${{ matrix.shard == '10' }}" }
+      - { uses: *compilers, name: 'C++23', with: { CXXFLAGS: '-std=c++23 -Werror=pedantic -pedantic-errors -Wno-c++11-long-long' }, timeout-minutes: 8, if: "${{ matrix.shard == '10' }}" }
+      - { uses: *compilers, name: 'C++26', with: { CXXFLAGS: '-std=c++26 -Werror=pedantic -pedantic-errors -Wno-c++11-long-long' }, timeout-minutes: 8, if: "${{ matrix.shard == '10' }}" }
+      - { uses: *compilers, name: 'gmp', with: { append_configure: '--with-gmp', test_all: 'ruby/test_bignum.rb', test_spec: '/github/workspace/src/spec/ruby/core/integer' }, timeout-minutes: 8, if: "${{ matrix.shard == '10' }}" }
+      - { uses: *compilers, name: 'jemalloc', with: { append_configure: '--with-jemalloc' }, timeout-minutes: 8, if: "${{ matrix.shard == '03' }}" }
+      - { uses: *compilers, name: 'valgrind', with: { append_configure: '--with-valgrind' }, timeout-minutes: 8, if: "${{ matrix.shard == '03' }}" }
+      - { uses: *compilers, name: 'coroutine=ucontext', with: { append_configure: '--with-coroutine=ucontext' }, timeout-minutes: 8, if: "${{ matrix.shard == '03' }}" }
+      - { uses: *compilers, name: 'coroutine=pthread', with: { append_configure: '--with-coroutine=pthread' }, timeout-minutes: 8, if: "${{ matrix.shard == '03' }}" }
 
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with: { sparse-checkout-cone-mode: false, sparse-checkout: /.github, persist-credentials: false }
-      - uses: './.github/actions/setup/compilation-source'
-      - { uses: './.github/actions/compilers', name: 'C++20', with: { CXXFLAGS: '-std=c++20 -Werror=pedantic -pedantic-errors -Wno-c++11-long-long' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'C++23', with: { CXXFLAGS: '-std=c++23 -Werror=pedantic -pedantic-errors -Wno-c++11-long-long' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'C++26', with: { CXXFLAGS: '-std=c++26 -Werror=pedantic -pedantic-errors -Wno-c++11-long-long' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'gmp',                 with: { append_configure: '--with-gmp', test_all: 'ruby/test_bignum.rb', test_spec: "/github/workspace/src/spec/ruby/core/integer" }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'jemalloc',            with: { append_configure: '--with-jemalloc' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'valgrind',            with: { append_configure: '--with-valgrind' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'coroutine=ucontext',  with: { append_configure: '--with-coroutine=ucontext' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'coroutine=pthread',   with: { append_configure: '--with-coroutine=pthread' }, timeout-minutes: 8 }
+      - { uses: *compilers, name: 'disable-jit', with: { append_configure: '--disable-yjit --disable-zjit' }, timeout-minutes: 8, if: "${{ matrix.shard == '02' }}" }
+      - { uses: *compilers, name: 'disable-yjit', with: { append_configure: '--disable-yjit' }, timeout-minutes: 8, if: "${{ matrix.shard == '02' }}" }
+      - { uses: *compilers, name: 'disable-zjit', with: { append_configure: '--disable-zjit' }, timeout-minutes: 8, if: "${{ matrix.shard == '02' }}" }
+      - { uses: *compilers, name: 'disable-dln', with: { append_configure: '--disable-dln' }, timeout-minutes: 8, if: "${{ matrix.shard == '02' }}" }
+      - { uses: *compilers, name: 'disable-rubygems', with: { append_configure: '--disable-rubygems' }, timeout-minutes: 8, if: "${{ matrix.shard == '02' }}" }
+      - { uses: *compilers, name: 'RUBY_DEVEL', with: { append_configure: '--enable-devel' }, timeout-minutes: 8, if: "${{ matrix.shard == '14' }}" }
+      - { uses: *compilers, name: 'OPT_THREADED_CODE=0', with: { cppflags: '-DOPT_THREADED_CODE=0' }, timeout-minutes: 8, if: "${{ matrix.shard == '14' }}" }
+      - { uses: *compilers, name: 'OPT_THREADED_CODE=1', with: { cppflags: '-DOPT_THREADED_CODE=1' }, timeout-minutes: 8, if: "${{ matrix.shard == '14' }}" }
+      - { uses: *compilers, name: 'OPT_THREADED_CODE=2', with: { cppflags: '-DOPT_THREADED_CODE=2' }, timeout-minutes: 8, if: "${{ matrix.shard == '14' }}" }
 
-  compile7:
-    name: 'omnibus compilations, #7'
-    runs-on: ubuntu-latest
-    needs: compile-if
-    if: ${{ needs.compile-if.result == 'success' }}
-    timeout-minutes: 60
+      - { uses: *compilers, name: 'NDEBUG', with: { cppflags: '-DNDEBUG' }, timeout-minutes: 8, if: "${{ matrix.shard == '15' }}" }
+      - { uses: *compilers, name: 'RUBY_DEBUG', with: { cppflags: '-DRUBY_DEBUG' }, timeout-minutes: 8, if: "${{ matrix.shard == '15' }}" }
+      - { uses: *compilers, name: 'ARRAY_DEBUG', with: { cppflags: '-DARRAY_DEBUG' }, timeout-minutes: 8, if: "${{ matrix.shard == '15' }}" }
+      - { uses: *compilers, name: 'CCAN_LIST_DEBUG', with: { cppflags: '-DCCAN_LIST_DEBUG' }, timeout-minutes: 8, if: "${{ matrix.shard == '15' }}" }
+      - { uses: *compilers, name: 'CPDEBUG=-1', with: { cppflags: '-DCPDEBUG=-1' }, timeout-minutes: 8, if: "${{ matrix.shard == '04' }}" }
+      - { uses: *compilers, name: 'ENC_DEBUG', with: { cppflags: '-DENC_DEBUG' }, timeout-minutes: 8, if: "${{ matrix.shard == '04' }}" }
+      - { uses: *compilers, name: 'VM_DEBUG_BP_CHECK', with: { cppflags: '-DVM_DEBUG_BP_CHECK' }, timeout-minutes: 8, if: "${{ matrix.shard == '04' }}" }
+      - { uses: *compilers, name: 'VM_DEBUG_VERIFY_METHOD_CACHE', with: { cppflags: '-DVM_DEBUG_VERIFY_METHOD_CACHE' }, timeout-minutes: 8, if: "${{ matrix.shard == '04' }}" }
 
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with: { sparse-checkout-cone-mode: false, sparse-checkout: /.github, persist-credentials: false }
-      - uses: './.github/actions/setup/compilation-source'
-      - { uses: './.github/actions/compilers', name: 'disable-jit',         with: { append_configure: '--disable-yjit --disable-zjit' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'disable-yjit',        with: { append_configure: '--disable-yjit' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'disable-zjit',        with: { append_configure: '--disable-zjit' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'disable-dln',         with: { append_configure: '--disable-dln' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'disable-rubygems',    with: { append_configure: '--disable-rubygems' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'RUBY_DEVEL',          with: { append_configure: '--enable-devel' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'OPT_THREADED_CODE=0',            with: { cppflags: '-DOPT_THREADED_CODE=0' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'OPT_THREADED_CODE=1',            with: { cppflags: '-DOPT_THREADED_CODE=1' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'OPT_THREADED_CODE=2',            with: { cppflags: '-DOPT_THREADED_CODE=2' }, timeout-minutes: 8 }
+      - { uses: *compilers, name: 'ID_TABLE_DEBUG', with: { cppflags: '-DID_TABLE_DEBUG' }, timeout-minutes: 8, if: "${{ matrix.shard == '17' }}" }
+      - { uses: *compilers, name: 'RGENGC_DEBUG=-1', with: { cppflags: '-DRGENGC_DEBUG=-1' }, timeout-minutes: 8, if: "${{ matrix.shard == '17' }}" }
+      - { uses: *compilers, name: 'SYMBOL_DEBUG', with: { cppflags: '-DSYMBOL_DEBUG' }, timeout-minutes: 8, if: "${{ matrix.shard == '17' }}" }
+      - { uses: *compilers, name: 'RGENGC_CHECK_MODE', with: { cppflags: '-DRGENGC_CHECK_MODE' }, timeout-minutes: 8, if: "${{ matrix.shard == '06' }}" }
+      - { uses: *compilers, name: 'VM_CHECK_MODE', with: { cppflags: '-DVM_CHECK_MODE' }, timeout-minutes: 8, if: "${{ matrix.shard == '06' }}" }
+      - { uses: *compilers, name: 'USE_EMBED_CI=0', with: { cppflags: '-DUSE_EMBED_CI=0' }, timeout-minutes: 8, if: "${{ matrix.shard == '06' }}" }
+      - { uses: *compilers, name: 'USE_FLONUM=0', with: { cppflags: '-DUSE_FLONUM=0', append_configure: '--disable-yjit --disable-zjit' }, timeout-minutes: 8, if: "${{ matrix.shard == '06' }}" }
 
-  compile8:
-    name: 'omnibus compilations, #8'
-    runs-on: ubuntu-latest
-    needs: compile-if
-    if: ${{ needs.compile-if.result == 'success' }}
-    timeout-minutes: 60
+      - { uses: *compilers, name: 'USE_LAZY_LOAD', with: { cppflags: '-DUSE_LAZY_LOAD' }, timeout-minutes: 8, if: "${{ matrix.shard == '05' }}" }
+      - { uses: *compilers, name: 'USE_RUBY_DEBUG_LOG=1', with: { cppflags: '-DUSE_RUBY_DEBUG_LOG=1' }, timeout-minutes: 8, if: "${{ matrix.shard == '05' }}" }
+      - { uses: *compilers, name: 'USE_DEBUG_COUNTER', with: { cppflags: '-DUSE_DEBUG_COUNTER=1' }, timeout-minutes: 8, if: "${{ matrix.shard == '05' }}" }
+      - { uses: *compilers, name: 'SHARABLE_MIDDLE_SUBSTRING', with: { cppflags: '-DSHARABLE_MIDDLE_SUBSTRING=1' }, timeout-minutes: 8, if: "${{ matrix.shard == '05' }}" }
+      - { uses: *compilers, name: 'DEBUG_FIND_TIME_NUMGUESS', with: { cppflags: '-DDEBUG_FIND_TIME_NUMGUESS' }, timeout-minutes: 8, if: "${{ matrix.shard == '16' }}" }
+      - { uses: *compilers, name: 'DEBUG_INTEGER_PACK', with: { cppflags: '-DDEBUG_INTEGER_PACK' }, timeout-minutes: 8, if: "${{ matrix.shard == '16' }}" }
+      - { uses: *compilers, name: 'RGENGC_PROFILE', with: { cppflags: '-DRGENGC_PROFILE' }, timeout-minutes: 8, if: "${{ matrix.shard == '16' }}" }
 
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with: { sparse-checkout-cone-mode: false, sparse-checkout: /.github, persist-credentials: false }
-      - uses: './.github/actions/setup/compilation-source'
-      - { uses: './.github/actions/compilers', name: 'NDEBUG',                         with: { cppflags: '-DNDEBUG' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'RUBY_DEBUG',                     with: { cppflags: '-DRUBY_DEBUG' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'ARRAY_DEBUG',                    with: { cppflags: '-DARRAY_DEBUG' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'CCAN_LIST_DEBUG',                with: { cppflags: '-DCCAN_LIST_DEBUG' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'CPDEBUG=-1',                     with: { cppflags: '-DCPDEBUG=-1' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'ENC_DEBUG',                      with: { cppflags: '-DENC_DEBUG' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'VM_DEBUG_BP_CHECK',              with: { cppflags: '-DVM_DEBUG_BP_CHECK' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'VM_DEBUG_VERIFY_METHOD_CACHE',   with: { cppflags: '-DVM_DEBUG_VERIFY_METHOD_CACHE' }, timeout-minutes: 8 }
+      - { uses: *compilers, name: 'GC_DEBUG_STRESS_TO_CLASS', with: { cppflags: '-DGC_DEBUG_STRESS_TO_CLASS' }, timeout-minutes: 8, if: "${{ matrix.shard == '21' }}" }
+      - { uses: *compilers, name: 'GC_DEBUG', with: { cppflags: '-DGC_DEBUG' }, timeout-minutes: 8, if: "${{ matrix.shard == '21' }}" }
+      - { uses: *compilers, name: 'GC_ENABLE_LAZY_SWEEP=0', with: { cppflags: '-DGC_ENABLE_LAZY_SWEEP=0' }, timeout-minutes: 8, if: "${{ matrix.shard == '21' }}" }
+      - { uses: *compilers, name: 'GC_PROFILE_DETAIL_MEMORY', with: { cppflags: '-DGC_PROFILE_DETAIL_MEMORY' }, timeout-minutes: 8, if: "${{ matrix.shard == '21' }}" }
+      - { uses: *compilers, name: 'GC_PROFILE_MORE_DETAIL', with: { cppflags: '-DGC_PROFILE_MORE_DETAIL' }, timeout-minutes: 8, if: "${{ matrix.shard == '09' }}" }
+      - { uses: *compilers, name: 'MALLOC_ALLOCATED_SIZE_CHECK', with: { cppflags: '-DMALLOC_ALLOCATED_SIZE_CHECK' }, timeout-minutes: 8, if: "${{ matrix.shard == '09' }}" }
+      - { uses: *compilers, name: 'RGENGC_ESTIMATE_OLDMALLOC', with: { cppflags: '-DRGENGC_ESTIMATE_OLDMALLOC' }, timeout-minutes: 8, if: "${{ matrix.shard == '09' }}" }
+      - { uses: *compilers, name: 'C++17', with: { CXXFLAGS: '-std=c++17 -Werror=pedantic -pedantic-errors -Wno-c++11-long-long' }, timeout-minutes: 8, if: "${{ matrix.shard == '09' }}" }
 
-  compile9:
-    name: 'omnibus compilations, #9'
-    runs-on: ubuntu-latest
-    needs: compile-if
-    if: ${{ needs.compile-if.result == 'success' }}
-    timeout-minutes: 60
+      - { uses: *compilers, name: 'GCC 11', with: { tag: 'gcc-11' }, timeout-minutes: 8, if: "${{ matrix.shard == '11' }}" }
+      - { uses: *compilers, name: 'GCC 10', with: { tag: 'gcc-10' }, timeout-minutes: 8, if: "${{ matrix.shard == '11' }}" }
+      - { uses: *compilers, name: 'GCC 9', with: { tag: 'gcc-9' }, timeout-minutes: 8, if: "${{ matrix.shard == '11' }}" }
+      - { uses: *compilers, name: 'GCC 8', with: { tag: 'gcc-8' }, timeout-minutes: 8, if: "${{ matrix.shard == '11' }}" }
+      - { uses: *compilers, name: 'GCC 7', with: { tag: 'gcc-7' }, timeout-minutes: 8, if: "${{ matrix.shard == '01' }}" }
+      - { uses: *compilers, name: 'ext/Setup', with: { static_exts: 'etc json/* */escape' }, timeout-minutes: 8, if: "${{ matrix.shard == '01' }}" }
+      - { uses: *compilers, name: 'enable-mkmf-verbose', with: { append_configure: '--enable-mkmf-verbose' }, timeout-minutes: 8, if: "${{ matrix.shard == '01' }}" }
+      - { uses: *compilers, name: 'HASH_DEBUG', with: { cppflags: '-DHASH_DEBUG' }, timeout-minutes: 8, if: "${{ matrix.shard == '01' }}" }
+      - { uses: *compilers, name: 'clang 6', with: { tag: 'clang-6.0', append_configure: '--disable-yjit --disable-zjit' }, timeout-minutes: 8, if: "${{ matrix.shard == '01' }}" }
 
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with: { sparse-checkout-cone-mode: false, sparse-checkout: /.github, persist-credentials: false }
-      - uses: './.github/actions/setup/compilation-source'
-      - { uses: './.github/actions/compilers', name: 'ID_TABLE_DEBUG',                 with: { cppflags: '-DID_TABLE_DEBUG' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'RGENGC_DEBUG=-1',                with: { cppflags: '-DRGENGC_DEBUG=-1' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'SYMBOL_DEBUG',                   with: { cppflags: '-DSYMBOL_DEBUG' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'RGENGC_CHECK_MODE',              with: { cppflags: '-DRGENGC_CHECK_MODE' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'VM_CHECK_MODE',                  with: { cppflags: '-DVM_CHECK_MODE' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'USE_EMBED_CI=0',                 with: { cppflags: '-DUSE_EMBED_CI=0' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'USE_FLONUM=0',                   with: { cppflags: '-DUSE_FLONUM=0', append_configure: '--disable-yjit --disable-zjit' }, timeout-minutes: 8 }
-
-  compileX:
-    name: 'omnibus compilations, #10'
-    runs-on: ubuntu-latest
-    needs: compile-if
-    if: ${{ needs.compile-if.result == 'success' }}
-    timeout-minutes: 60
-
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with: { sparse-checkout-cone-mode: false, sparse-checkout: /.github, persist-credentials: false }
-      - uses: './.github/actions/setup/compilation-source'
-      - { uses: './.github/actions/compilers', name: 'USE_LAZY_LOAD',                  with: { cppflags: '-DUSE_LAZY_LOAD' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'USE_RUBY_DEBUG_LOG=1',           with: { cppflags: '-DUSE_RUBY_DEBUG_LOG=1' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'USE_DEBUG_COUNTER',              with: { cppflags: '-DUSE_DEBUG_COUNTER=1' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'SHARABLE_MIDDLE_SUBSTRING',      with: { cppflags: '-DSHARABLE_MIDDLE_SUBSTRING=1' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'DEBUG_FIND_TIME_NUMGUESS',       with: { cppflags: '-DDEBUG_FIND_TIME_NUMGUESS' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'DEBUG_INTEGER_PACK',             with: { cppflags: '-DDEBUG_INTEGER_PACK' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'RGENGC_PROFILE',                 with: { cppflags: '-DRGENGC_PROFILE' }, timeout-minutes: 8 }
-
-  compileB:
-    name: 'omnibus compilations, #11'
-    runs-on: ubuntu-latest
-    needs: compile-if
-    if: ${{ needs.compile-if.result == 'success' }}
-    timeout-minutes: 60
-
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with: { sparse-checkout-cone-mode: false, sparse-checkout: /.github, persist-credentials: false }
-      - uses: './.github/actions/setup/compilation-source'
-      - { uses: './.github/actions/compilers', name: 'GC_DEBUG_STRESS_TO_CLASS',       with: { cppflags: '-DGC_DEBUG_STRESS_TO_CLASS' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'GC_DEBUG',                       with: { cppflags: '-DGC_DEBUG' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'GC_ENABLE_LAZY_SWEEP=0',         with: { cppflags: '-DGC_ENABLE_LAZY_SWEEP=0' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'GC_PROFILE_DETAIL_MEMORY',       with: { cppflags: '-DGC_PROFILE_DETAIL_MEMORY' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'GC_PROFILE_MORE_DETAIL',         with: { cppflags: '-DGC_PROFILE_MORE_DETAIL' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'MALLOC_ALLOCATED_SIZE_CHECK',    with: { cppflags: '-DMALLOC_ALLOCATED_SIZE_CHECK' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'RGENGC_ESTIMATE_OLDMALLOC',      with: { cppflags: '-DRGENGC_ESTIMATE_OLDMALLOC' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'C++17', with: { CXXFLAGS: '-std=c++17 -Werror=pedantic -pedantic-errors -Wno-c++11-long-long' }, timeout-minutes: 8 }
-
-  compileC:
-    name: 'omnibus compilations, #12'
-    runs-on: ubuntu-latest
-    needs: compile-if
-    if: ${{ needs.compile-if.result == 'success' }}
-    timeout-minutes: 60
-
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with: { sparse-checkout-cone-mode: false, sparse-checkout: /.github, persist-credentials: false }
-      - uses: './.github/actions/setup/compilation-source'
-      - { uses: './.github/actions/compilers', name: 'GCC 11', with: { tag: 'gcc-11' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'GCC 10', with: { tag: 'gcc-10' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'GCC 9',  with: { tag: 'gcc-9'  }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'GCC 8',  with: { tag: 'gcc-8'  }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'GCC 7',  with: { tag: 'gcc-7'  }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'ext/Setup', with: { static_exts: 'etc json/* */escape' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'enable-mkmf-verbose', with: { append_configure: '--enable-mkmf-verbose' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'HASH_DEBUG',                     with: { cppflags: '-DHASH_DEBUG' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'clang 6',  with: { tag: 'clang-6.0', append_configure: '--disable-yjit --disable-zjit' }, timeout-minutes: 8 }
 
   compilemax:
     name: 'omnibus compilations, result'
     runs-on: ubuntu-latest
     if: ${{ always() }}
     needs:
-      - 'compile1'
-      - 'compile2'
-      - 'compile3'
-      - 'compile4'
-      - 'compile5'
-      - 'compile6'
-      - 'compile7'
-      - 'compile8'
-      - 'compile9'
-      - 'compileX'
-      - 'compileB'
-      - 'compileC'
+      - 'compile'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with: { sparse-checkout-cone-mode: false, sparse-checkout: /.github, persist-credentials: false }

--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -83,7 +83,11 @@ jobs:
           with_gcc: 'clang-23 -flto=auto'
           optflags: '-O2'
         timeout-minutes: 30
+      - { uses: './.github/actions/compilers', name: 'clang 23', with: { tag: 'clang-23' }, timeout-minutes: 8 }
+      - { uses: './.github/actions/compilers', name: 'clang 22', with: { tag: 'clang-22' }, timeout-minutes: 8 }
+      - { uses: './.github/actions/compilers', name: 'clang 21', with: { tag: 'clang-21' }, timeout-minutes: 8 }
       - { uses: './.github/actions/compilers', name: '-O0', with: { optflags: '-O0 -march=x86-64 -mtune=generic' }, timeout-minutes: 8 }
+      - { uses: './.github/actions/compilers', name: 'YJIT_FORCE_ENABLE', with: { cppflags: '-DYJIT_FORCE_ENABLE' }, timeout-minutes: 8 }
       # - { uses: './.github/actions/compilers', name: '-O3', with: { optflags: '-O3 -march=x86-64 -mtune=generic', check: true } }
 
   compile2:
@@ -105,14 +109,11 @@ jobs:
           optflags: '-O2'
           enable_shared: false
         timeout-minutes: 10
-      - { uses: './.github/actions/compilers', name: 'ext/Setup', with: { static_exts: 'etc json/* */escape' }, timeout-minutes: 8 }
       - { uses: './.github/actions/compilers', name: 'GCC 15', with: { tag: 'gcc-15' }, timeout-minutes: 8 }
       - { uses: './.github/actions/compilers', name: 'GCC 14', with: { tag: 'gcc-14' }, timeout-minutes: 8 }
       - { uses: './.github/actions/compilers', name: 'GCC 13', with: { tag: 'gcc-13' }, timeout-minutes: 8 }
       - { uses: './.github/actions/compilers', name: 'GCC 12', with: { tag: 'gcc-12' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'GCC 11', with: { tag: 'gcc-11' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'GCC 10', with: { tag: 'gcc-10' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'GCC 9',  with: { tag: 'gcc-9'  }, timeout-minutes: 8 }
+      - { uses: './.github/actions/compilers', name: 'UNIVERSAL_PARSER', with: { cppflags: '-DUNIVERSAL_PARSER' }, timeout-minutes: 8 }
 
   compile3:
     name: 'omnibus compilations, #3'
@@ -152,7 +153,6 @@ jobs:
       - { uses: './.github/actions/compilers', name: 'clang 9',  with: { tag: 'clang-9',   append_configure: '--disable-yjit --disable-zjit' }, timeout-minutes: 8 }
       - { uses: './.github/actions/compilers', name: 'clang 8',  with: { tag: 'clang-8',   append_configure: '--disable-yjit --disable-zjit' }, timeout-minutes: 8 }
       - { uses: './.github/actions/compilers', name: 'clang 7',  with: { tag: 'clang-7',   append_configure: '--disable-yjit --disable-zjit' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'clang 6',  with: { tag: 'clang-6.0', append_configure: '--disable-yjit --disable-zjit' }, timeout-minutes: 8 }
 
   compile5:
     name: 'omnibus compilations, #5'
@@ -178,7 +178,6 @@ jobs:
       - { uses: './.github/actions/compilers', name: 'C++98', with: { CXXFLAGS: '-std=c++98 -Werror=pedantic -pedantic-errors -Wno-c++11-long-long' }, timeout-minutes: 8 }
       - { uses: './.github/actions/compilers', name: 'C++11', with: { CXXFLAGS: '-std=c++11 -Werror=pedantic -pedantic-errors -Wno-c++11-long-long' }, timeout-minutes: 8 }
       - { uses: './.github/actions/compilers', name: 'C++14', with: { CXXFLAGS: '-std=c++14 -Werror=pedantic -pedantic-errors -Wno-c++11-long-long' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'C++17', with: { CXXFLAGS: '-std=c++17 -Werror=pedantic -pedantic-errors -Wno-c++11-long-long' }, timeout-minutes: 8 }
 
   compile6:
     name: 'omnibus compilations, #6'
@@ -215,10 +214,11 @@ jobs:
       - { uses: './.github/actions/compilers', name: 'disable-yjit',        with: { append_configure: '--disable-yjit' }, timeout-minutes: 8 }
       - { uses: './.github/actions/compilers', name: 'disable-zjit',        with: { append_configure: '--disable-zjit' }, timeout-minutes: 8 }
       - { uses: './.github/actions/compilers', name: 'disable-dln',         with: { append_configure: '--disable-dln' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'enable-mkmf-verbose', with: { append_configure: '--enable-mkmf-verbose' }, timeout-minutes: 8 }
       - { uses: './.github/actions/compilers', name: 'disable-rubygems',    with: { append_configure: '--disable-rubygems' }, timeout-minutes: 8 }
       - { uses: './.github/actions/compilers', name: 'RUBY_DEVEL',          with: { append_configure: '--enable-devel' }, timeout-minutes: 8 }
       - { uses: './.github/actions/compilers', name: 'OPT_THREADED_CODE=0',            with: { cppflags: '-DOPT_THREADED_CODE=0' }, timeout-minutes: 8 }
+      - { uses: './.github/actions/compilers', name: 'OPT_THREADED_CODE=1',            with: { cppflags: '-DOPT_THREADED_CODE=1' }, timeout-minutes: 8 }
+      - { uses: './.github/actions/compilers', name: 'OPT_THREADED_CODE=2',            with: { cppflags: '-DOPT_THREADED_CODE=2' }, timeout-minutes: 8 }
 
   compile8:
     name: 'omnibus compilations, #8'
@@ -237,7 +237,8 @@ jobs:
       - { uses: './.github/actions/compilers', name: 'CCAN_LIST_DEBUG',                with: { cppflags: '-DCCAN_LIST_DEBUG' }, timeout-minutes: 8 }
       - { uses: './.github/actions/compilers', name: 'CPDEBUG=-1',                     with: { cppflags: '-DCPDEBUG=-1' }, timeout-minutes: 8 }
       - { uses: './.github/actions/compilers', name: 'ENC_DEBUG',                      with: { cppflags: '-DENC_DEBUG' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'GC_DEBUG',                       with: { cppflags: '-DGC_DEBUG' }, timeout-minutes: 8 }
+      - { uses: './.github/actions/compilers', name: 'VM_DEBUG_BP_CHECK',              with: { cppflags: '-DVM_DEBUG_BP_CHECK' }, timeout-minutes: 8 }
+      - { uses: './.github/actions/compilers', name: 'VM_DEBUG_VERIFY_METHOD_CACHE',   with: { cppflags: '-DVM_DEBUG_VERIFY_METHOD_CACHE' }, timeout-minutes: 8 }
 
   compile9:
     name: 'omnibus compilations, #9'
@@ -250,7 +251,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with: { sparse-checkout-cone-mode: false, sparse-checkout: /.github, persist-credentials: false }
       - uses: './.github/actions/setup/compilation-source'
-      - { uses: './.github/actions/compilers', name: 'HASH_DEBUG',                     with: { cppflags: '-DHASH_DEBUG' }, timeout-minutes: 8 }
       - { uses: './.github/actions/compilers', name: 'ID_TABLE_DEBUG',                 with: { cppflags: '-DID_TABLE_DEBUG' }, timeout-minutes: 8 }
       - { uses: './.github/actions/compilers', name: 'RGENGC_DEBUG=-1',                with: { cppflags: '-DRGENGC_DEBUG=-1' }, timeout-minutes: 8 }
       - { uses: './.github/actions/compilers', name: 'SYMBOL_DEBUG',                   with: { cppflags: '-DSYMBOL_DEBUG' }, timeout-minutes: 8 }
@@ -276,9 +276,7 @@ jobs:
       - { uses: './.github/actions/compilers', name: 'SHARABLE_MIDDLE_SUBSTRING',      with: { cppflags: '-DSHARABLE_MIDDLE_SUBSTRING=1' }, timeout-minutes: 8 }
       - { uses: './.github/actions/compilers', name: 'DEBUG_FIND_TIME_NUMGUESS',       with: { cppflags: '-DDEBUG_FIND_TIME_NUMGUESS' }, timeout-minutes: 8 }
       - { uses: './.github/actions/compilers', name: 'DEBUG_INTEGER_PACK',             with: { cppflags: '-DDEBUG_INTEGER_PACK' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'OPT_THREADED_CODE=1',            with: { cppflags: '-DOPT_THREADED_CODE=1' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'OPT_THREADED_CODE=2',            with: { cppflags: '-DOPT_THREADED_CODE=2' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'clang 21', with: { tag: 'clang-21' }, timeout-minutes: 8 }
+      - { uses: './.github/actions/compilers', name: 'RGENGC_PROFILE',                 with: { cppflags: '-DRGENGC_PROFILE' }, timeout-minutes: 8 }
 
   compileB:
     name: 'omnibus compilations, #11'
@@ -292,12 +290,13 @@ jobs:
         with: { sparse-checkout-cone-mode: false, sparse-checkout: /.github, persist-credentials: false }
       - uses: './.github/actions/setup/compilation-source'
       - { uses: './.github/actions/compilers', name: 'GC_DEBUG_STRESS_TO_CLASS',       with: { cppflags: '-DGC_DEBUG_STRESS_TO_CLASS' }, timeout-minutes: 8 }
+      - { uses: './.github/actions/compilers', name: 'GC_DEBUG',                       with: { cppflags: '-DGC_DEBUG' }, timeout-minutes: 8 }
       - { uses: './.github/actions/compilers', name: 'GC_ENABLE_LAZY_SWEEP=0',         with: { cppflags: '-DGC_ENABLE_LAZY_SWEEP=0' }, timeout-minutes: 8 }
       - { uses: './.github/actions/compilers', name: 'GC_PROFILE_DETAIL_MEMORY',       with: { cppflags: '-DGC_PROFILE_DETAIL_MEMORY' }, timeout-minutes: 8 }
       - { uses: './.github/actions/compilers', name: 'GC_PROFILE_MORE_DETAIL',         with: { cppflags: '-DGC_PROFILE_MORE_DETAIL' }, timeout-minutes: 8 }
       - { uses: './.github/actions/compilers', name: 'MALLOC_ALLOCATED_SIZE_CHECK',    with: { cppflags: '-DMALLOC_ALLOCATED_SIZE_CHECK' }, timeout-minutes: 8 }
       - { uses: './.github/actions/compilers', name: 'RGENGC_ESTIMATE_OLDMALLOC',      with: { cppflags: '-DRGENGC_ESTIMATE_OLDMALLOC' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'RGENGC_PROFILE',                 with: { cppflags: '-DRGENGC_PROFILE' }, timeout-minutes: 8 }
+      - { uses: './.github/actions/compilers', name: 'C++17', with: { CXXFLAGS: '-std=c++17 -Werror=pedantic -pedantic-errors -Wno-c++11-long-long' }, timeout-minutes: 8 }
 
   compileC:
     name: 'omnibus compilations, #12'
@@ -310,14 +309,15 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with: { sparse-checkout-cone-mode: false, sparse-checkout: /.github, persist-credentials: false }
       - uses: './.github/actions/setup/compilation-source'
-      - { uses: './.github/actions/compilers', name: 'VM_DEBUG_BP_CHECK',              with: { cppflags: '-DVM_DEBUG_BP_CHECK' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'VM_DEBUG_VERIFY_METHOD_CACHE',   with: { cppflags: '-DVM_DEBUG_VERIFY_METHOD_CACHE' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'YJIT_FORCE_ENABLE',              with: { cppflags: '-DYJIT_FORCE_ENABLE' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'UNIVERSAL_PARSER',               with: { cppflags: '-DUNIVERSAL_PARSER' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'clang 23', with: { tag: 'clang-23' }, timeout-minutes: 8 }
-      - { uses: './.github/actions/compilers', name: 'clang 22', with: { tag: 'clang-22' }, timeout-minutes: 8 }
+      - { uses: './.github/actions/compilers', name: 'GCC 11', with: { tag: 'gcc-11' }, timeout-minutes: 8 }
+      - { uses: './.github/actions/compilers', name: 'GCC 10', with: { tag: 'gcc-10' }, timeout-minutes: 8 }
+      - { uses: './.github/actions/compilers', name: 'GCC 9',  with: { tag: 'gcc-9'  }, timeout-minutes: 8 }
       - { uses: './.github/actions/compilers', name: 'GCC 8',  with: { tag: 'gcc-8'  }, timeout-minutes: 8 }
       - { uses: './.github/actions/compilers', name: 'GCC 7',  with: { tag: 'gcc-7'  }, timeout-minutes: 8 }
+      - { uses: './.github/actions/compilers', name: 'ext/Setup', with: { static_exts: 'etc json/* */escape' }, timeout-minutes: 8 }
+      - { uses: './.github/actions/compilers', name: 'enable-mkmf-verbose', with: { append_configure: '--enable-mkmf-verbose' }, timeout-minutes: 8 }
+      - { uses: './.github/actions/compilers', name: 'HASH_DEBUG',                     with: { cppflags: '-DHASH_DEBUG' }, timeout-minutes: 8 }
+      - { uses: './.github/actions/compilers', name: 'clang 6',  with: { tag: 'clang-6.0', append_configure: '--disable-yjit --disable-zjit' }, timeout-minutes: 8 }
 
   compilemax:
     name: 'omnibus compilations, result'

--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -60,11 +60,11 @@ jobs:
         with: { sparse-checkout-cone-mode: false, sparse-checkout: /.github, persist-credentials: false }
       # Set fetch-depth: 10 so that Launchable can receive commits information.
       - { uses: './.github/actions/setup/directories', with: { srcdir: 'src', builddir: 'build', makeup: true, fetch-depth: 10 } }
-      - name: 'clang 22 LTO'
+      - name: 'clang 23 LTO'
         uses: './.github/actions/compilers'
         with:
-          tag: clang-22
-          with_gcc: 'clang-22 -flto=auto'
+          tag: clang-23
+          with_gcc: 'clang-23 -flto=auto'
           optflags: '-O2'
         timeout-minutes: 30
       - { uses: './.github/actions/compilers', name: '-O0', with: { optflags: '-O0 -march=x86-64 -mtune=generic' }, timeout-minutes: 8 }

--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -35,7 +35,7 @@ env:
 # Each job is split so that they roughly take 30min to run through.
 jobs:
   compile-if:
-    name: 'omnibus compilations, trigger'
+    name: 'omnibus compilations, source'
     runs-on: ubuntu-latest
     if: >-
       ${{!(false
@@ -44,9 +44,26 @@ jobs:
       || contains(github.event.pull_request.labels.*.name, 'Documentation')
       || (github.event.pull_request.user.login == 'dependabot[bot]')
       )}}
+    timeout-minutes: 10
+
     steps:
-      - run: true
-        working-directory:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with: { sparse-checkout-cone-mode: false, sparse-checkout: /.github, persist-credentials: false }
+      # Set fetch-depth: 10 so that Launchable can receive commits information.
+      - { uses: './.github/actions/setup/directories', with: { srcdir: 'src', builddir: 'build', makeup: true, fetch-depth: 10 } }
+      - name: Archive sources
+        working-directory: ${{ github.workspace }}
+        # `.downloaded-cache` will be restored from the common cache
+        run: >-
+          tar -cf "${RUNNER_TEMP}/compilation-source.tar"
+          --exclude='src/.downloaded-cache'
+          src
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: compilation-source
+          path: ${{ runner.temp }}/compilation-source.tar
+          compression-level: 0
+          retention-days: 1
 
   compile1:
     name: 'omnibus compilations, #1'
@@ -58,8 +75,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with: { sparse-checkout-cone-mode: false, sparse-checkout: /.github, persist-credentials: false }
-      # Set fetch-depth: 10 so that Launchable can receive commits information.
-      - { uses: './.github/actions/setup/directories', with: { srcdir: 'src', builddir: 'build', makeup: true, fetch-depth: 10 } }
+      - uses: './.github/actions/setup/compilation-source'
       - name: 'clang 23 LTO'
         uses: './.github/actions/compilers'
         with:
@@ -80,7 +96,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with: { sparse-checkout-cone-mode: false, sparse-checkout: /.github, persist-credentials: false }
-      - { uses: './.github/actions/setup/directories', with: { srcdir: 'src', builddir: 'build', makeup: true, fetch-depth: 10 } }
+      - uses: './.github/actions/setup/compilation-source'
       - name: 'GCC 15 LTO'
         uses: './.github/actions/compilers'
         with:
@@ -108,7 +124,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with: { sparse-checkout-cone-mode: false, sparse-checkout: /.github, persist-credentials: false }
-      - { uses: './.github/actions/setup/directories', with: { srcdir: 'src', builddir: 'build', makeup: true, fetch-depth: 10 } }
+      - uses: './.github/actions/setup/compilation-source'
       - { uses: './.github/actions/compilers', name: 'clang 20', with: { tag: 'clang-20' }, timeout-minutes: 8 }
       - { uses: './.github/actions/compilers', name: 'clang 19', with: { tag: 'clang-19' }, timeout-minutes: 8 }
       - { uses: './.github/actions/compilers', name: 'clang 18', with: { tag: 'clang-18' }, timeout-minutes: 8 }
@@ -127,7 +143,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with: { sparse-checkout-cone-mode: false, sparse-checkout: /.github, persist-credentials: false }
-      - { uses: './.github/actions/setup/directories', with: { srcdir: 'src', builddir: 'build', makeup: true, fetch-depth: 10 } }
+      - uses: './.github/actions/setup/compilation-source'
       - { uses: './.github/actions/compilers', name: 'clang 13', with: { tag: 'clang-13' }, timeout-minutes: 8 }
       - { uses: './.github/actions/compilers', name: 'clang 12', with: { tag: 'clang-12' }, timeout-minutes: 8 }
       - { uses: './.github/actions/compilers', name: 'clang 11', with: { tag: 'clang-11' }, timeout-minutes: 8 }
@@ -148,7 +164,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with: { sparse-checkout-cone-mode: false, sparse-checkout: /.github, persist-credentials: false }
-      - { uses: './.github/actions/setup/directories', with: { srcdir: 'src', builddir: 'build', makeup: true, fetch-depth: 10 } }
+      - uses: './.github/actions/setup/compilation-source'
       # -Wno-strict-prototypes is necessary with clang-15 or newer, since
       # older autoconf prior to 2.72 generate functions without prototype
       # and -pedantic now implies strict-prototypes. Disabling the error
@@ -174,7 +190,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with: { sparse-checkout-cone-mode: false, sparse-checkout: /.github, persist-credentials: false }
-      - { uses: './.github/actions/setup/directories', with: { srcdir: 'src', builddir: 'build', makeup: true, fetch-depth: 10 } }
+      - uses: './.github/actions/setup/compilation-source'
       - { uses: './.github/actions/compilers', name: 'C++20', with: { CXXFLAGS: '-std=c++20 -Werror=pedantic -pedantic-errors -Wno-c++11-long-long' }, timeout-minutes: 8 }
       - { uses: './.github/actions/compilers', name: 'C++23', with: { CXXFLAGS: '-std=c++23 -Werror=pedantic -pedantic-errors -Wno-c++11-long-long' }, timeout-minutes: 8 }
       - { uses: './.github/actions/compilers', name: 'C++26', with: { CXXFLAGS: '-std=c++26 -Werror=pedantic -pedantic-errors -Wno-c++11-long-long' }, timeout-minutes: 8 }
@@ -194,7 +210,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with: { sparse-checkout-cone-mode: false, sparse-checkout: /.github, persist-credentials: false }
-      - { uses: './.github/actions/setup/directories', with: { srcdir: 'src', builddir: 'build', makeup: true, fetch-depth: 10 } }
+      - uses: './.github/actions/setup/compilation-source'
       - { uses: './.github/actions/compilers', name: 'disable-jit',         with: { append_configure: '--disable-yjit --disable-zjit' }, timeout-minutes: 8 }
       - { uses: './.github/actions/compilers', name: 'disable-yjit',        with: { append_configure: '--disable-yjit' }, timeout-minutes: 8 }
       - { uses: './.github/actions/compilers', name: 'disable-zjit',        with: { append_configure: '--disable-zjit' }, timeout-minutes: 8 }
@@ -214,7 +230,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with: { sparse-checkout-cone-mode: false, sparse-checkout: /.github, persist-credentials: false }
-      - { uses: './.github/actions/setup/directories', with: { srcdir: 'src', builddir: 'build', makeup: true, fetch-depth: 10 } }
+      - uses: './.github/actions/setup/compilation-source'
       - { uses: './.github/actions/compilers', name: 'NDEBUG',                         with: { cppflags: '-DNDEBUG' }, timeout-minutes: 8 }
       - { uses: './.github/actions/compilers', name: 'RUBY_DEBUG',                     with: { cppflags: '-DRUBY_DEBUG' }, timeout-minutes: 8 }
       - { uses: './.github/actions/compilers', name: 'ARRAY_DEBUG',                    with: { cppflags: '-DARRAY_DEBUG' }, timeout-minutes: 8 }
@@ -233,7 +249,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with: { sparse-checkout-cone-mode: false, sparse-checkout: /.github, persist-credentials: false }
-      - { uses: './.github/actions/setup/directories', with: { srcdir: 'src', builddir: 'build', makeup: true, fetch-depth: 10 } }
+      - uses: './.github/actions/setup/compilation-source'
       - { uses: './.github/actions/compilers', name: 'HASH_DEBUG',                     with: { cppflags: '-DHASH_DEBUG' }, timeout-minutes: 8 }
       - { uses: './.github/actions/compilers', name: 'ID_TABLE_DEBUG',                 with: { cppflags: '-DID_TABLE_DEBUG' }, timeout-minutes: 8 }
       - { uses: './.github/actions/compilers', name: 'RGENGC_DEBUG=-1',                with: { cppflags: '-DRGENGC_DEBUG=-1' }, timeout-minutes: 8 }
@@ -253,7 +269,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with: { sparse-checkout-cone-mode: false, sparse-checkout: /.github, persist-credentials: false }
-      - { uses: './.github/actions/setup/directories', with: { srcdir: 'src', builddir: 'build', makeup: true, fetch-depth: 10 } }
+      - uses: './.github/actions/setup/compilation-source'
       - { uses: './.github/actions/compilers', name: 'USE_LAZY_LOAD',                  with: { cppflags: '-DUSE_LAZY_LOAD' }, timeout-minutes: 8 }
       - { uses: './.github/actions/compilers', name: 'USE_RUBY_DEBUG_LOG=1',           with: { cppflags: '-DUSE_RUBY_DEBUG_LOG=1' }, timeout-minutes: 8 }
       - { uses: './.github/actions/compilers', name: 'USE_DEBUG_COUNTER',              with: { cppflags: '-DUSE_DEBUG_COUNTER=1' }, timeout-minutes: 8 }
@@ -274,7 +290,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with: { sparse-checkout-cone-mode: false, sparse-checkout: /.github, persist-credentials: false }
-      - { uses: './.github/actions/setup/directories', with: { srcdir: 'src', builddir: 'build', makeup: true, fetch-depth: 10 } }
+      - uses: './.github/actions/setup/compilation-source'
       - { uses: './.github/actions/compilers', name: 'GC_DEBUG_STRESS_TO_CLASS',       with: { cppflags: '-DGC_DEBUG_STRESS_TO_CLASS' }, timeout-minutes: 8 }
       - { uses: './.github/actions/compilers', name: 'GC_ENABLE_LAZY_SWEEP=0',         with: { cppflags: '-DGC_ENABLE_LAZY_SWEEP=0' }, timeout-minutes: 8 }
       - { uses: './.github/actions/compilers', name: 'GC_PROFILE_DETAIL_MEMORY',       with: { cppflags: '-DGC_PROFILE_DETAIL_MEMORY' }, timeout-minutes: 8 }
@@ -293,7 +309,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with: { sparse-checkout-cone-mode: false, sparse-checkout: /.github, persist-credentials: false }
-      - { uses: './.github/actions/setup/directories', with: { srcdir: 'src', builddir: 'build', makeup: true, fetch-depth: 10 } }
+      - uses: './.github/actions/setup/compilation-source'
       - { uses: './.github/actions/compilers', name: 'VM_DEBUG_BP_CHECK',              with: { cppflags: '-DVM_DEBUG_BP_CHECK' }, timeout-minutes: 8 }
       - { uses: './.github/actions/compilers', name: 'VM_DEBUG_VERIFY_METHOD_CACHE',   with: { cppflags: '-DVM_DEBUG_VERIFY_METHOD_CACHE' }, timeout-minutes: 8 }
       - { uses: './.github/actions/compilers', name: 'YJIT_FORCE_ENABLE',              with: { cppflags: '-DYJIT_FORCE_ENABLE' }, timeout-minutes: 8 }
@@ -328,6 +344,21 @@ jobs:
           label: 'omnibus'
           SLACK_WEBHOOK_URL: ${{ secrets.SIMPLER_ALERTS_URL }} # ruby-lang slack: ruby/simpler-alerts-bot
         if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+
+      # Reduce retained artifact storage.
+      - name: Create empty source artifact
+        run: touch compilation-source.empty
+        working-directory: ${{ runner.temp }}
+        if: ${{ always() }}
+      - name: Shrink source artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: compilation-source
+          path: ${{ runner.temp }}/compilation-source.empty
+          overwrite: true
+          retention-days: 1
+        if: ${{ always() }}
+
       - run: false
         working-directory:
         if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}


### PR DESCRIPTION
The `Compilations` workflow assigns compiler configurations to 12 fixed jobs.  Differences in runner performance and configuration timings can leave several runners idle while one long-running job determines the total workflow duration.

Prepare the generated source tree once and share it through an artifact, then run the compiler configurations as 24 smaller shards with `max-parallel: 12`.  A runner that finishes early can therefore pick up another pending shard.  The shards are ordered using recent execution times so the expected longer ones start first.

Recent successful runs on `master` after the Clang LTO improvement took 36–41 minutes, averaging about 38 minutes.  The final shard configuration completed in 34m52s:

https://github.com/nobu/ruby/actions/runs/32107656943

An earlier shard arrangement completed in 37m52s:

https://github.com/nobu/ruby/actions/runs/32096545902

GitHub-hosted runner performance still varies significantly, but smaller pending shards make it less likely that a single slow runner determines the entire workflow duration.