### PR TITLE
Marshal.load: Fix buffer overflow at overread of string body

### DIFF
--- a/marshal.c
+++ b/marshal.c
@@ -1487,6 +1487,10 @@ r_bytes1_buffered(long len, struct load_arg *arg)
 
         if (tmp_len > need_len) {
             buflen = tmp_len - need_len;
+            if (UNLIKELY(buflen > arg->bufsize)) {
+                arg->buf = ruby_sized_realloc_n(arg->buf, buflen, 1, arg->bufsize);
+                arg->bufsize = buflen;
+            }
             memcpy(arg->buf, RSTRING_PTR(tmp)+need_len, buflen);
             arg->buflen = buflen;
         }

--- a/test/ruby/test_marshal.rb
+++ b/test/ruby/test_marshal.rb
@@ -953,6 +953,28 @@ class TestMarshal < Test::Unit::TestCase
     assert_equal([nil, nil], Marshal.load(input))
   end
 
+  def test_load_overread_string_body
+    input = Struct.new(:bytes, :count) do
+      def initialize
+        super("\x04\x08[\x07".bytes, 0)
+      end
+
+      def getbyte
+        bytes.shift
+      end
+
+      def read(_len, _outbuf = nil)
+        self.count += 1
+        case count
+        when 1 then "\"\x06" # TYPE_STRING, length 1
+        when 2 then "a" + "0" * (1024 * 128)
+        end
+      end
+    end.new
+
+    assert_equal(["a", nil], Marshal.load(input))
+  end
+
   def test_bignum_len_overflow
     assert_raise(ArgumentError) do
       Marshal.load("\x04\x08l+\x04\x00\x00\x00\x40")


### PR DESCRIPTION
`Marshal.load` segfaults when the source is a custom IO whose `read` returns more bytes than requested and the surplus arrives while a string body is being read. The leftover copy at the end of `r_bytes1_buffered` writes into `arg->buf` without consulting `arg->bufsize`, so anything beyond `BUFSIZ` runs past the end of the allocation.

7455eb4c260 added the same guard to `r_byte1_buffered`, but that only covered the initial-byte refill path. This applies the matching `ruby_sized_realloc_n` guard to the string-body path so both callers grow the buffer before copying.

The new test reaches `r_bytes1_buffered` by having the first `read` return the type and length bytes and the second `read` over-return by 128 KiB. It faults reliably on an unpatched build, and under `libgmalloc` it traps on the guard page immediately after `arg->buf`.
