### PR TITLE
Don't sweep T_DATA concurrently that aren't THREAD_SAFE_FREE

### DIFF
--- a/ext/-test-/gc/tdata_non_thread_safe_free/extconf.rb
+++ b/ext/-test-/gc/tdata_non_thread_safe_free/extconf.rb
@@ -1,0 +1,2 @@
+# frozen_string_literal: false
+create_makefile("-test-/gc/tdata_non_thread_safe_free")

--- a/ext/-test-/gc/tdata_non_thread_safe_free/tdata_non_thread_safe_free.c
+++ b/ext/-test-/gc/tdata_non_thread_safe_free/tdata_non_thread_safe_free.c
@@ -1,0 +1,104 @@
+#include <ruby.h>
+#include <ruby/atomic.h>
+
+/*
+ * A T_DATA type whose free function is declared RUBY_TYPED_FREE_IMMEDIATELY but
+ * deliberately NOT RUBY_TYPED_THREAD_SAFE_FREE. Without that flag the GC must
+ * not invoke dfree concurrently with another dfree, even though Ractor-local GC
+ * lets several Ractors mark/sweep in parallel. A genuinely non-thread-safe dfree
+ * would touch shared process state without a lock and corrupt it under concurrent
+ * invocation. Here we measure the unsafe precondition by counting how many threads
+ * are inside the free at the same instant.
+ */
+
+static rb_atomic_t in_free_now;
+static rb_atomic_t max_concurrent_free;
+static rb_atomic_t total_frees;
+
+/* How long to hold the free window open, in atomic-load spins, so a concurrent
+ * free on another Ractor becomes observable. */
+#define OVERLAP_WINDOW 128
+
+static void
+non_thread_safe_free(void *ptr)
+{
+    rb_atomic_t cur = RUBY_ATOMIC_FETCH_ADD(in_free_now, 1) + 1;
+
+    rb_atomic_t prev;
+    do {
+        prev = RUBY_ATOMIC_LOAD(max_concurrent_free);
+        if (cur <= prev) break;
+    } while (RUBY_ATOMIC_CAS(max_concurrent_free, prev, cur) != prev);
+
+    for (int i = 0; i < OVERLAP_WINDOW; i++) {
+        if (RUBY_ATOMIC_LOAD(in_free_now) >= 2) break;
+    }
+
+    RUBY_ATOMIC_FETCH_SUB(in_free_now, 1);
+    RUBY_ATOMIC_FETCH_ADD(total_frees, 1);
+
+    xfree(ptr);
+}
+
+typedef struct {
+    int payload;
+} test_data;
+
+static const rb_data_type_t non_thread_safe_free_type = {
+    "tdata_non_thread_safe_free",
+    {0, non_thread_safe_free, 0},
+    0, 0,
+    RUBY_TYPED_FREE_IMMEDIATELY, /* intentionally NOT RUBY_TYPED_THREAD_SAFE_FREE */
+};
+
+static VALUE
+test_alloc(VALUE klass)
+{
+    test_data *data;
+    return TypedData_Make_Struct(klass, test_data, &non_thread_safe_free_type, data);
+}
+
+static VALUE
+test_make(VALUE klass, VALUE num)
+{
+    unsigned long i, n = NUM2ULONG(num);
+    for (i = 0; i < n; i++) {
+        test_alloc(klass);
+    }
+    return Qnil;
+}
+
+static VALUE
+test_max_concurrent_free(VALUE klass)
+{
+    return UINT2NUM(RUBY_ATOMIC_LOAD(max_concurrent_free));
+}
+
+static VALUE
+test_total_frees(VALUE klass)
+{
+    return UINT2NUM(RUBY_ATOMIC_LOAD(total_frees));
+}
+
+static VALUE
+test_reset(VALUE klass)
+{
+    RUBY_ATOMIC_SET(in_free_now, 0);
+    RUBY_ATOMIC_SET(max_concurrent_free, 0);
+    RUBY_ATOMIC_SET(total_frees, 0);
+    return Qnil;
+}
+
+void
+Init_tdata_non_thread_safe_free(void)
+{
+    rb_ext_ractor_safe(true);
+
+    VALUE mBug = rb_define_module("Bug");
+    VALUE klass = rb_define_class_under(mBug, "TDataNonThreadSafeFree", rb_cObject);
+    rb_define_alloc_func(klass, test_alloc);
+    rb_define_singleton_method(klass, "make", test_make, 1);
+    rb_define_singleton_method(klass, "max_concurrent_free", test_max_concurrent_free, 0);
+    rb_define_singleton_method(klass, "total_frees", test_total_frees, 0);
+    rb_define_singleton_method(klass, "reset", test_reset, 0);
+}

--- a/gc.c
+++ b/gc.c
@@ -123,6 +123,7 @@
 #include "vm_sync.h"
 #include "vm_callinfo.h"
 #include "ractor_core.h"
+#include "internal/ractor.h"
 #include "yjit.h"
 #include "zjit.h"
 
@@ -355,6 +356,12 @@ bool
 rb_gc_multi_ractor_p(void)
 {
     return rb_multi_ractor_p();
+}
+
+uint32_t
+rb_gc_ractor_last_id(void)
+{
+    return rb_ractor_last_id();
 }
 
 bool
@@ -714,6 +721,7 @@ typedef struct gc_function_map {
     struct rb_gc_object_metadata_entry *(*object_metadata)(void *objspace_ptr, VALUE obj);
     bool (*live_object_p)(void *objspace_ptr, const void *ptr);
     bool (*garbage_object_p)(void *objspace_ptr, VALUE obj);
+    bool (*internal_object_p)(void *objspace_ptr, VALUE obj);
     void (*set_event_hook)(void *objspace_ptr, const rb_event_flag_t event);
     void (*copy_attributes)(void *objspace_ptr, VALUE dest, VALUE obj);
 
@@ -910,6 +918,7 @@ ruby_modular_gc_init(void)
     load_modular_gc_func(object_metadata);
     load_modular_gc_func(live_object_p);
     load_modular_gc_func(garbage_object_p);
+    load_modular_gc_func(internal_object_p);
     load_modular_gc_func(set_event_hook);
     load_modular_gc_func(copy_attributes);
 
@@ -1015,6 +1024,7 @@ ruby_modular_gc_init(void)
 # define rb_gc_impl_object_metadata rb_gc_functions.object_metadata
 # define rb_gc_impl_live_object_p rb_gc_functions.live_object_p
 # define rb_gc_impl_garbage_object_p rb_gc_functions.garbage_object_p
+# define rb_gc_impl_internal_object_p rb_gc_functions.internal_object_p
 # define rb_gc_impl_set_event_hook rb_gc_functions.set_event_hook
 # define rb_gc_impl_copy_attributes rb_gc_functions.copy_attributes
 #endif
@@ -1907,6 +1917,7 @@ internal_object_p(VALUE obj)
             return 0;
           default:
             if (!RBASIC(obj)->klass) break;
+            if (rb_gc_impl_internal_object_p(rb_gc_get_objspace(), obj)) return 1;
             return 0;
         }
     }
@@ -4005,6 +4016,7 @@ static void gc_orphan_merge_job(void *unused);
 static void
 zombie_objspaces_push(rb_vm_t *vm, void *objspace, void **owner_slot, struct rb_ractor_struct *owner)
 {
+    ASSERT_vm_locking();
     if (vm->gc.zombie_objspaces_count == vm->gc.zombie_objspaces_capa) {
         size_t new_capa = vm->gc.zombie_objspaces_capa ? vm->gc.zombie_objspaces_capa * 2 : 16;
         struct rb_objspace_zombie *grown =
@@ -4083,6 +4095,7 @@ void
 rb_gc_objspace_disown(void *objspace)
 {
     if (!rb_gc_impl_multi_objspace_p()) return;
+    ASSERT_vm_locking();
     rb_vm_t *vm = GET_VM();
     bool found = false;
 
@@ -4117,6 +4130,7 @@ rb_gc_during_global_gc_p(void)
 static void
 rb_gc_vm_forget_zombie(void *objspace)
 {
+    ASSERT_vm_locking();
     rb_vm_t *vm = GET_VM();
     size_t n = vm->gc.zombie_objspaces_count;
     for (size_t i = 0; i < n; i++) {

--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -762,7 +762,6 @@ typedef struct rb_objspace {
     rb_darray(VALUE) weak_references;
     rb_postponed_job_handle_t finalize_deferred_pjob;
 
-
     int sweeping_heap_count;
 
     int fork_vm_lock_lev;
@@ -833,6 +832,17 @@ typedef struct rb_global_objspace {
         size_t n_pages, capa;
         uintptr_t lomem, himem;
     } page_index;
+
+    /* Ractor ID at the start of a single-objspace major GC; compared at sweep
+     * finish to detect whether a Ractor was spawned mid-GC. */
+    uint32_t saved_ractor_last_id;
+
+    rb_postponed_job_handle_t tdata_deferred_free_pjob;
+
+    /* Atomic count of deferred non-thread-safe T_DATA objects across all objspaces.
+     * Incremented once per object when it first dies in the defer path; reset to 0 by
+     * the deferred-free postponed job (under the barrier) and at global-GC completion. */
+    size_t tdata_deferred_free_count;
 } rb_global_objspace_t;
 
 static rb_global_objspace_t rb_global_objspace_instance;
@@ -846,6 +856,9 @@ static rb_global_objspace_t *global_objspace = NULL;
  * small Ractor's objspace is about 13 pages, so discarding many of them still stays
  * below it, while a single fat zombie crosses it. */
 #define ZOMBIE_PAGES_TRIGGER 256
+/* Trigger the deferred T_DATA free postponed job once this many have accumulated
+ * across all objspaces. */
+#define TDATA_DEFERRED_FREE_THRESHOLD (1 << 16)
 
 static void objspace_absorb(rb_objspace_t *dst, rb_objspace_t *src);
 
@@ -868,6 +881,7 @@ global_objspace_init(void)
         g->page_pool.arena_current = NULL;
         g->page_pool.arena_count = 0;
         g->page_pool.advised_count = 0;
+        g->tdata_deferred_free_pjob = POSTPONED_JOB_HANDLE_INVALID;
         g->page_pool.arenas_unmapped = 0;
 #ifdef HAVE_MMAP
         g->page_pool.os_page_size = sysconf(_SC_PAGE_SIZE);
@@ -3641,14 +3655,15 @@ objspace_each_objects_try(VALUE arg)
                     if (stop) break;
                 }
             }
-            else if (data->skip_unswept_dead &&
-                     is_lazy_sweeping(objspace) && page->flags.before_sweep) {
+            else if (data->skip_unswept_dead) {
                 /* A foreign page pending sweep: hand out the live objects one slot at a
                  * time and skip the unmarked (dead) ones the owner's sweep frees as soon
                  * as the barrier lifts. */
+                const bool page_unswept = is_lazy_sweeping(objspace) && page->flags.before_sweep;
                 bool stop = false;
                 for (uintptr_t slot = pstart; slot < pend; slot += heap->slot_size) {
-                    if (!RVALUE_MARKED(objspace, (VALUE)slot)) continue;
+                    if (page_unswept && !RVALUE_MARKED(objspace, (VALUE)slot)) continue;
+                    if (rb_gc_impl_internal_object_p(objspace, (VALUE)slot)) continue;
                     if (data->each_obj_callback &&
                         (*data->each_obj_callback)((void *)slot, (void *)(slot + heap->slot_size),
                                                    heap->slot_size, data->data)) {
@@ -4531,10 +4546,246 @@ struct gc_sweep_context {
     int empty_slots;
     /* Hoisted out of the per-slot pinned-free assert: too expensive for the sweep loop
      * as an external call. */
-    unsigned char check_pinned_free;
+    const bool check_pinned_free;
+    /* This is a parallel local sweep (multi-Ractor, not a global GC), so a non-thread-safe
+     * T_DATA dfree must be deferred to the global GC or the postponed job rather than run here. */
+    const bool defer_thread_unsafe_local_sweep;
+    bool trigger_thread_unsafe_sweep_postponed_job;
 
     struct free_region *free_region;
 };
+
+/* True when a local (per-Ractor) sweep must not free obj. Doing so would run a T_DATA
+ * dfree inline (RUBY_TYPED_FREE_IMMEDIATELY) that is not RUBY_TYPED_THREAD_SAFE_FREE.
+ * NOTE: We must free the root fiber during postmortem collection, otherwise another Ractor
+ * can collect the fiber through a major GC while we're still tearing it down. Once fibers are
+ * THREAD_SAFE_FREE, we no longer need the root fiber condition as it will be guaranteed to be
+ * collected during this time.
+ */
+static bool
+gc_obj_defer_local_free_p(rb_objspace_t *objspace, VALUE obj)
+{
+    if (BUILTIN_TYPE(obj) != T_DATA) return false;
+
+    const rb_data_type_t *type = RTYPEDDATA_TYPE(obj);
+    void (*dfree)(void *) = type->function.dfree;
+    if (!dfree || dfree == RUBY_DEFAULT_FREE) return false;
+    if (type->flags & RUBY_TYPED_THREAD_SAFE_FREE) return false;
+
+    if (type->flags & RUBY_TYPED_FREE_IMMEDIATELY) {
+        if (objspace->flags.during_postmortem) {
+            if (rb_fiber_current() == obj) {
+                return false;
+            }
+        }
+        return !FL_TEST_RAW(obj, FL_SHAREABLE);
+    }
+    else {
+        return false;
+    }
+}
+
+static void gc_tdata_deferred_free_job(void *unused);
+static void gc_tdata_deferred_free_pjob_ensure(void);
+static unsigned int gc_during_gc_get(const rb_objspace_t *objspace);
+static void gc_during_gc_set(rb_objspace_t *objspace, unsigned int v);
+static void gc_global_snapshot_objspaces(void);
+
+static void
+gc_tdata_deferred_free_pjob_ensure(void)
+{
+    if (global_objspace->tdata_deferred_free_pjob == POSTPONED_JOB_HANDLE_INVALID) {
+        global_objspace->tdata_deferred_free_pjob =
+            rb_postponed_job_preregister(0, gc_tdata_deferred_free_job, NULL);
+        if (global_objspace->tdata_deferred_free_pjob == POSTPONED_JOB_HANDLE_INVALID) {
+            rb_bug("Could not preregister postponed job for deferred T_DATA free");
+        }
+    }
+}
+
+/* -- Deferred T_DATA free postponed job --
+ *
+ * Non-thread-safe T_DATA that die during a local sweep are retained via the SHAREABLE
+ * bit (pinned_roots_mark re-marks them each local GC). The global counter tracks how
+ * many have accumulated. When it crosses TDATA_DEFERRED_FREE_THRESHOLD, this postponed
+ * job fires: it takes the VM lock + barrier (stopping all Ractors so non-thread-safe
+ * dfree is safe) and walks every objspace's shareable-bit slots, freeing the deferred
+ * T_DATA. This avoids a full global GC (with its every-ec root scan) just to reap them.
+ *
+ * This is "a global sweep minus the global mark": the barrier cost is the same, but the
+ * mark phase (root scan, C stack walk, all-objspace traversal) is skipped.
+ */
+
+static size_t
+gc_tdata_deferred_free_page(rb_objspace_t *objspace, rb_heap_t *heap, struct heap_page *page)
+{
+    uintptr_t p = page->start;
+    short slot_size = page->slot_size;
+    int total_slots = page->total_slots;
+    int bitmap_plane_count = CEILDIV(total_slots, BITS_BITLENGTH);
+    size_t freed = 0;
+    int zombie_count = 0;
+
+    int out_of_range_bits = total_slots % BITS_BITLENGTH;
+
+    struct heap_page *alloc_page = heap->newobj.alloc_using_page;
+
+    for (int j = 0; j < bitmap_plane_count; j++) {
+        bits_t shareable = page->shareable_bits[j];
+        if (out_of_range_bits != 0 && j == bitmap_plane_count - 1) {
+            shareable &= ((bits_t)1 << out_of_range_bits) - 1;
+        }
+        bits_t bitset = shareable;
+        uintptr_t pp = p;
+
+        while (bitset) {
+            if (bitset & 1) {
+                VALUE obj = (VALUE)pp;
+                asan_unpoisoning_object(obj) {
+                    /* A deferred T_DATA borrows the shareable bit without FL_SHAREABLE.
+                     * Real shareable objects have both, so !FL_SHAREABLE excludes them.
+                     * Same test as rb_gc_impl_internal_object_p. */
+                    if (BUILTIN_TYPE(obj) == T_DATA && gc_obj_defer_local_free_p(objspace, obj))
+                    {
+                        rb_gc_obj_free_vm_weak_references(obj);
+                        bool put_back_on_freelist = rb_gc_obj_free(objspace, obj);
+                        CLEAR_IN_BITMAP(GET_HEAP_SHAREABLE_BITS(obj), obj);
+                        CLEAR_IN_BITMAP(GET_HEAP_MARK_BITS(obj), obj);
+                        CLEAR_IN_BITMAP(GET_HEAP_UNCOLLECTIBLE_BITS(obj), obj);
+                        GC_ASSERT(!MARKED_IN_BITMAP(GET_HEAP_WB_UNPROTECTED_BITS(obj), obj));
+                        if (put_back_on_freelist) {
+                            RBASIC(obj)->flags = 0;
+                            RVALUE_AGE_SET_BITMAP(obj, 0);
+
+                            if (!page->flags.before_sweep) {
+                                if (page != alloc_page) {
+                                    heap_page_add_free_region(objspace, page, obj);
+                                    page->free_slots++;
+                                }
+                                else {
+                                    /* Allocator owns this page's free list. Insert into
+                                     * alloc_next_region so the slot is picked up when the
+                                     * current region is exhausted. Safe under the barrier. */
+                                    struct free_region *new_region = (struct free_region *)obj;
+                                    new_region->flags = 0;
+                                    new_region->end = (uintptr_t)obj + slot_size;
+                                    new_region->next = heap->newobj.alloc_next_region;
+                                    heap->newobj.alloc_next_region = new_region;
+                                    rb_asan_poison_object(obj);
+                                }
+                            }
+                            /* On an unswept page, skip free-list registration: the lazy
+                             * sweep will see T_NONE and register the slot itself. */
+
+                            heap->total_freed_objects++;
+                        }
+                        else {
+                            zombie_count++;
+                        }
+                        /* Count in both branches: the dfree ran regardless of zombie or not */
+                        freed++;
+                    }
+                }
+            }
+            pp += slot_size;
+            bitset >>= 1;
+        }
+        p += BITS_BITLENGTH * slot_size;
+    }
+
+    if (zombie_count > 0 && !finalizing) {
+        gc_finalize_deferred_register(objspace);
+    }
+
+    /* Update page flag: check if any shareable bits remain. */
+    bool any_shareable = false;
+    for (int j = 0; j < bitmap_plane_count; j++) {
+        if (page->shareable_bits[j]) { any_shareable = true; break; }
+    }
+    if (!any_shareable) page->flags.has_shareable_objects = FALSE;
+
+    return freed;
+}
+static void
+gc_tdata_deferred_free_objspace(void *objspace_ptr, void *data)
+{
+    rb_objspace_t *objspace = objspace_ptr;
+    size_t *freed = (size_t *)data;
+
+    for (int h = 0; h < HEAP_COUNT; h++) {
+        rb_heap_t *heap = &heaps[h];
+        struct heap_page *page;
+
+        ccan_list_for_each(&heap->pages, page, page_node) {
+            if (!page->flags.has_shareable_objects) continue;
+
+            *freed += gc_tdata_deferred_free_page(objspace, heap, page);
+        }
+    }
+}
+
+static void
+gc_tdata_deferred_free_job(void *unused)
+{
+    (void)unused;
+
+    size_t count = (size_t)RUBY_ATOMIC_VALUE_LOAD(global_objspace->tdata_deferred_free_count);
+    if (count < TDATA_DEFERRED_FREE_THRESHOLD || rb_gc_single_objspace_p()) {
+        return;
+    }
+
+    unsigned int lev = RB_GC_VM_LOCK();
+
+    if (global_objspace->tdata_deferred_free_count < TDATA_DEFERRED_FREE_THRESHOLD) {
+        RB_GC_VM_UNLOCK(lev);
+        return;
+    }
+
+    rb_gc_vm_barrier();
+
+    gc_global_snapshot_objspaces();
+    size_t n = global_objspace->global_gc.n_objspaces;
+    rb_objspace_t **objspaces = global_objspace->global_gc.objspaces;
+
+    /* Set during_gc=TRUE and init vm_context for the CURRENT objspace only.
+     * The no-alloc guard (default.c:3315-3322) checks only the allocating
+     * (=current) objspace's during_gc, and rb_gc_get_ec() reads only the
+     * current objspace's vm_context.ec. */
+    rb_objspace_t *objspace = rb_gc_get_objspace();
+    unsigned int saved_during_gc = gc_during_gc_get(objspace);
+    dont_gc_on();
+    rb_gc_initialize_vm_context(&objspace->vm_context);
+    gc_during_gc_set(objspace, TRUE);
+
+    size_t freed = 0;
+    for (size_t i = 0; i < n; i++) {
+        gc_tdata_deferred_free_objspace(objspaces[i], &freed);
+    }
+
+    // The free_count can be higher than the actual count
+    GC_ASSERT(freed <= global_objspace->tdata_deferred_free_count);
+    global_objspace->tdata_deferred_free_count = 0;
+
+    gc_during_gc_set(objspace, saved_during_gc);
+    dont_gc_off();
+
+    RB_GC_VM_UNLOCK(lev);
+}
+
+/* True for objects we don't want to include when iterating over the objspace heaps,
+ * like during `ObjectSpace.each_object`. The object can live in another objspace, in
+ * which case we return `false`. */
+bool
+rb_gc_impl_internal_object_p(void *objspace_ptr, VALUE obj)
+{
+    rb_objspace_t *objspace = objspace_ptr;
+    if (gc_foreign_object_p(objspace, obj)) {
+        return false;
+    }
+    /* Test the shareable bitmap before reading obj's flags. */
+    return MARKED_IN_BITMAP(GET_HEAP_SHAREABLE_BITS(obj), obj) &&
+           gc_obj_defer_local_free_p(objspace, obj);
+}
 
 static inline void
 gc_sweep_register_free_slot(rb_objspace_t *objspace, struct heap_page *page, struct gc_sweep_context *ctx, uintptr_t p, short slot_size)
@@ -4629,6 +4880,7 @@ gc_sweep_plane(rb_objspace_t *objspace, rb_heap_t *heap, uintptr_t p, bits_t bit
 #undef CHECK
 #endif
 
+
                 if (!rb_gc_obj_needs_cleanup_p(vp)) {
                     (void)VALGRIND_MAKE_MEM_UNDEFINED((void*)p, slot_size);
                     gc_sweep_register_free_slot(objspace, sweep_page, ctx, p, slot_size);
@@ -4636,6 +4888,22 @@ gc_sweep_plane(rb_objspace_t *objspace, rb_heap_t *heap, uintptr_t p, bits_t bit
                     ctx->freed_slots++;
                 }
                 else {
+                    if (RB_UNLIKELY(ctx->defer_thread_unsafe_local_sweep && gc_obj_defer_local_free_p(objspace, vp))) {
+                        /* Retain this slot: freeing it here might run a non-thread-safe dfree
+                        * concurrently with another Ractor's sweep. */
+                        MARK_IN_BITMAP(GET_HEAP_SHAREABLE_BITS(vp), vp);
+                        // This mark bit is transient but necessary. It's unset in gc_sweep_page's gc_setup_mark_bits.
+                        MARK_IN_BITMAP(GET_HEAP_MARK_BITS(vp), vp);
+                        sweep_page->flags.has_shareable_objects = TRUE;
+                        size_t count = RUBY_ATOMIC_SIZE_FETCH_ADD(global_objspace->tdata_deferred_free_count, 1) + 1;
+                        if (count >= TDATA_DEFERRED_FREE_THRESHOLD) {
+                            ctx->trigger_thread_unsafe_sweep_postponed_job = true;
+                        }
+                        break;
+                    }
+                    // During single objspace sweeping, it's possible that we sweep some of these deferred TDATA objects.
+                    // That's fine, we don't want to add extra branches just to subtract from `tdata_deferred_free_count`.
+                    // Overcount is okay, the count is more of a hint.
                     gc_report(2, objspace, "page_sweep: free %p\n", (void *)p);
 
                     rb_gc_obj_free_vm_weak_references(vp);
@@ -5062,6 +5330,10 @@ gc_sweep_finish(rb_objspace_t *objspace)
         /* gc_marks_finish retains ~2/3 of empty pages in objspace->empty_pages for reuse,
          * only the excess reaches the pool. */
         page_pool_reclaim(global_objspace);
+
+        if (rb_gc_ractor_last_id() == global_objspace->saved_ractor_last_id) {
+            global_objspace->tdata_deferred_free_count = 0;
+        }
     }
 
     for (int i = 0; i < HEAP_COUNT; i++) {
@@ -5114,7 +5386,11 @@ gc_sweep_step(rb_objspace_t *objspace, rb_heap_t *heap)
      * ran the pinned walk.  The current world state would misfire: a single-world
      * cycle leaves dead shareable objects unmarked and its sweep can straddle the switch
      * to multi-objspace.  A global GC's exact mark does not pin, so it is excluded. */
-    const unsigned char check_pinned_free = objspace->last_cycle_pinned;
+    const bool check_pinned_free = objspace->last_cycle_pinned;
+
+    const bool defer_thread_unsafe_local_sweep =
+        rb_gc_multi_ractor_p() && !objspace->flags.during_global_gc;
+    bool trigger_thread_unsafe_sweep_postponed_job = false;
 
     do {
         RUBY_DEBUG_LOG("sweep_page:%p", (void *)sweep_page);
@@ -5125,9 +5401,12 @@ gc_sweep_step(rb_objspace_t *objspace, rb_heap_t *heap)
             .freed_slots = 0,
             .empty_slots = 0,
             .check_pinned_free = check_pinned_free,
+            .defer_thread_unsafe_local_sweep = defer_thread_unsafe_local_sweep,
+            .trigger_thread_unsafe_sweep_postponed_job = trigger_thread_unsafe_sweep_postponed_job,
         };
         gc_sweep_page(objspace, heap, &ctx);
         int free_slots = ctx.freed_slots + ctx.empty_slots;
+        trigger_thread_unsafe_sweep_postponed_job = ctx.trigger_thread_unsafe_sweep_postponed_job;
 
         RUBY_DTRACE_GC_HOOK(SWEEP_PAGE, ctx.page->slot_size, ctx.final_slots, ctx.freed_slots, ctx.empty_slots);
 
@@ -5173,6 +5452,12 @@ gc_sweep_step(rb_objspace_t *objspace, rb_heap_t *heap)
             sweep_page->free_next = NULL;
         }
     } while ((sweep_page = heap->sweeping_page));
+
+    if (trigger_thread_unsafe_sweep_postponed_job) {
+        gc_report(2, objspace, "thread-unsafe sweep postponed job triggered\n");
+        // Trigger on current EC
+        rb_postponed_job_trigger(global_objspace->tdata_deferred_free_pjob);
+    }
 
     if (!heap->sweeping_page) {
         objspace->sweeping_heap_count--;
@@ -6530,10 +6815,17 @@ verify_internal_consistency_i(void *page_start, void *page_end, size_t stride,
                 data->parent = obj;
                 data->parent_shareable = sh_bit;
 
+                /* A dead non-thread-safe T_DATA is retained until the global GC. It borrows
+                 * the shareable bit and looks live, but its children were not pinned and
+                 * may already be gone, so the child-graph checks below do not apply. */
+                bool deferred_retained = sh_bit && gc_obj_defer_local_free_p(objspace, obj);
+
                 /* Bitmap invariants: a page's shareable bit matches FL_SHAREABLE
                  * exactly, and a shref record only ever points at an unshareable
-                 * object. */
-                if (sh_bit != !!RB_FL_TEST_RAW(obj, RUBY_FL_SHAREABLE)) {
+                 * object.  A deferred non-thread-safe T_DATA borrows the shareable
+                 * bit without the flag to survive local sweeps until a global GC. */
+                if (sh_bit != !!RB_FL_TEST_RAW(obj, RUBY_FL_SHAREABLE) &&
+                        !deferred_retained) {
                     fprintf(stderr, "verify_internal_consistency_i: shareable bit %d "
                             "disagrees with FL_SHAREABLE on %s\n", (int)sh_bit, rb_obj_info(obj));
                     data->err_count++;
@@ -6546,7 +6838,7 @@ verify_internal_consistency_i(void *page_start, void *page_end, size_t stride,
 
                 /* Normally, we don't expect T_MOVED objects to be in the heap.
                 * But they can stay alive on the stack, */
-                if (!gc_object_moved_p(objspace, obj)) {
+                if (!gc_object_moved_p(objspace, obj) && !deferred_retained) {
                     /* moved slots don't have children */
                     rb_objspace_reachable_objects_from(obj, check_children_i, (void *)data);
                 }
@@ -6555,7 +6847,7 @@ verify_internal_consistency_i(void *page_start, void *page_end, size_t stride,
                 if (RVALUE_OLD_P(objspace, obj)) data->old_object_count++;
                 if (RVALUE_WB_UNPROTECTED(objspace, obj) && RVALUE_UNCOLLECTIBLE(objspace, obj)) data->remembered_shady_count++;
 
-                if (!is_marking(objspace) && RVALUE_OLD_P(objspace, obj)) {
+                if (!is_marking(objspace) && RVALUE_OLD_P(objspace, obj) && !deferred_retained) {
                     /* reachable objects from an oldgen object should be old or (young with remember) */
                     data->parent = obj;
                     rb_objspace_reachable_objects_from(obj, check_generation_i, (void *)data);
@@ -6565,7 +6857,7 @@ verify_internal_consistency_i(void *page_start, void *page_end, size_t stride,
                     rb_gc_verify_shareable(obj);
                 }
 
-                if (is_incremental_marking(objspace)) {
+                if (is_incremental_marking(objspace) && !deferred_retained) {
                     if (RVALUE_BLACK_P(objspace, obj)) {
                         /* reachable objects from black objects should be black or grey objects */
                         data->parent = obj;
@@ -8334,6 +8626,10 @@ gc_start_body(rb_objspace_t *objspace, unsigned int reason, bool allow_global)
 
     if (objspace->flags.immediate_sweep) reason |= GPR_FLAG_IMMEDIATE_SWEEP;
 
+    if (do_full_mark && rb_gc_single_objspace_p()) {
+        global_objspace->saved_ractor_last_id = rb_gc_ractor_last_id();
+    }
+
     /* Enter after during_compacting is decided: gc_local_gc_holds_vm_lock reads it. */
     unsigned int lock_lev;
     gc_enter(objspace, gc_enter_event_start, &lock_lev);
@@ -9233,6 +9529,8 @@ gc_start_global(rb_objspace_t *driver, unsigned int reason, bool compact, bool a
         if (new_limit < SHAREABLE_OBJECTS_LIMIT_MIN) new_limit = SHAREABLE_OBJECTS_LIMIT_MIN;
         objspace->shareable_objects_limit = new_limit;
     }
+
+    global_objspace->tdata_deferred_free_count = 0; /* The global sweep freed all deferred T_DATA */
     driver->profile.count++;
 
     /* step 10 */
@@ -12539,6 +12837,8 @@ rb_gc_impl_objspace_init(void *objspace_ptr)
     if (objspace->finalize_deferred_pjob == POSTPONED_JOB_HANDLE_INVALID) {
         rb_bug("Could not preregister postponed job for GC");
     }
+
+    gc_tdata_deferred_free_pjob_ensure();
 
     /* A standard RVALUE (RBasic + embedded VALUEs + debug overhead) must fit
      * in at least one pool.  In debug builds RVALUE_OVERHEAD can push this

--- a/gc/gc.h
+++ b/gc/gc.h
@@ -106,6 +106,7 @@ MODULAR_GC_FN void rb_gc_save_machine_context(void);
 MODULAR_GC_FN void rb_gc_mark_roots(void *objspace, const char **categoryp);
 MODULAR_GC_FN bool rb_gc_multi_ractor_p(void);
 MODULAR_GC_FN bool rb_gc_ever_multi_ractor_p(void);
+MODULAR_GC_FN uint32_t rb_gc_ractor_last_id(void);
 /* Process-wide GC disable flag (GC.disable / rb_gc_disable).  Every GC trigger in
  * an impl checks it, so disabling stops automatic GC in every Ractor.  The
  * per-objspace switch is objspace->flags.dont_gc. */

--- a/gc/gc_impl.h
+++ b/gc/gc_impl.h
@@ -170,6 +170,7 @@ GC_IMPL_FN const char *rb_gc_impl_active_gc_name(void);
 GC_IMPL_FN struct rb_gc_object_metadata_entry *rb_gc_impl_object_metadata(void *objspace_ptr, VALUE obj);
 GC_IMPL_FN bool rb_gc_impl_live_object_p(void *objspace_ptr, const void *ptr);
 GC_IMPL_FN bool rb_gc_impl_garbage_object_p(void *objspace_ptr, VALUE obj);
+GC_IMPL_FN bool rb_gc_impl_internal_object_p(void *objspace_ptr, VALUE obj);
 GC_IMPL_FN void rb_gc_impl_set_event_hook(void *objspace_ptr, const rb_event_flag_t event);
 GC_IMPL_FN void rb_gc_impl_copy_attributes(void *objspace_ptr, VALUE dest, VALUE obj);
 

--- a/gc/mmtk/mmtk.c
+++ b/gc/mmtk/mmtk.c
@@ -1792,6 +1792,12 @@ rb_gc_impl_garbage_object_p(void *objspace_ptr, VALUE obj)
     return false;
 }
 
+bool
+rb_gc_impl_internal_object_p(void *objspace_ptr, VALUE obj)
+{
+    return false;
+}
+
 void rb_gc_impl_set_event_hook(void *objspace_ptr, const rb_event_flag_t event) { }
 
 void

--- a/gc/wbcheck/wbcheck.c
+++ b/gc/wbcheck/wbcheck.c
@@ -1952,6 +1952,12 @@ rb_gc_impl_garbage_object_p(void *objspace_ptr, VALUE obj)
     return !result;
 }
 
+bool
+rb_gc_impl_internal_object_p(void *objspace_ptr, VALUE obj)
+{
+    return false;
+}
+
 void
 rb_gc_impl_set_event_hook(void *objspace_ptr, const rb_event_flag_t event)
 {

--- a/internal/ractor.h
+++ b/internal/ractor.h
@@ -2,6 +2,7 @@
 #define INTERNAL_RACTOR_H
 
 void rb_ractor_ensure_main_ractor(const char *msg);
+uint32_t rb_ractor_last_id(void);
 
 RUBY_SYMBOL_EXPORT_BEGIN
 RUBY_SYMBOL_EXPORT_END

--- a/ractor.c
+++ b/ractor.c
@@ -513,6 +513,12 @@ ractor_next_id(void)
     return id;
 }
 
+uint32_t
+rb_ractor_last_id(void)
+{
+    return (uint32_t)RUBY_ATOMIC_LOAD(ractor_last_id);
+}
+
 static void
 vm_insert_ractor0(rb_vm_t *vm, rb_ractor_t *r, bool single_ractor_mode)
 {
@@ -546,6 +552,7 @@ cancel_single_ractor_mode(void)
     rb_yjit_invalidate_single_ractor();
     rb_zjit_invalidate_single_ractor();
 
+    ASSERT_vm_unlocking();
     rb_funcall(rb_cRactor, rb_intern("_activated"), 0);
 }
 

--- a/test/-ext-/gc/test_tdata_non_thread_safe_free.rb
+++ b/test/-ext-/gc/test_tdata_non_thread_safe_free.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: false
+require 'test/unit'
+
+class TestTDataNonThreadSafeFree < Test::Unit::TestCase
+  def test_non_thread_safe_dfree_is_not_called_concurrently
+    assert_ractor(<<~'RUBY', require: "-test-/gc/tdata_non_thread_safe_free")
+      RACTORS = 8
+      ITERS = 20
+      BATCH = 10000
+
+      # TODO: use GC.start once a `global: false` option is available
+      ractors = RACTORS.times.map do
+        Ractor.new do
+          ITERS.times { Bug::TDataNonThreadSafeFree.make(BATCH) }
+          :done
+        end
+      end
+      ractors.each(&:value)
+
+      max = Bug::TDataNonThreadSafeFree.max_concurrent_free
+      total = Bug::TDataNonThreadSafeFree.total_frees
+
+      assert_operator total, :>, 0, "expected objects to actually be freed"
+      assert_operator max, :==, 1,
+        "non-thread-safe dfree ran concurrently (BUG!): observed #{max} simultaneous " \
+        "frees across #{total} total; Ractor-local GC must not invoke a dfree " \
+        "for types lacking RUBY_TYPED_THREAD_SAFE_FREE"
+    RUBY
+  end
+
+  def test_deferred_free_postponed_job
+    # Create enough non-thread-safe T_DATA across multiple Ractors to exceed the
+    # threshold (65536), triggering the postponed job that sweeps them under the
+    # VM barrier without a full global GC.
+    assert_ractor(<<~'RUBY', require: "-test-/gc/tdata_non_thread_safe_free")
+      Bug::TDataNonThreadSafeFree.reset
+
+      RACTORS = 4
+      BATCH = 20000
+      ITERS = 10
+
+      ractors = RACTORS.times.map do
+        Ractor.new do
+          ITERS.times { Bug::TDataNonThreadSafeFree.make(BATCH) }
+          :done
+        end
+      end
+      ractors.each(&:value)
+      assert_operator Bug::TDataNonThreadSafeFree.total_frees, :>, 0,
+        "A postponed job should have fired and freed deferred tdatas (conservative GC)"
+
+      max = Bug::TDataNonThreadSafeFree.max_concurrent_free
+      assert_operator max, :==, 1,
+        "non-thread-safe dfree ran concurrently under the barrier (BUG!): " \
+        "observed #{max} simultaneous frees"
+    RUBY
+  end
+
+  def test_single_ractor_freed_by_major_gc
+    assert_ractor(<<~'RUBY',  require: "-test-/gc/tdata_non_thread_safe_free")
+      Bug::TDataNonThreadSafeFree.reset
+
+      ITERS = 10
+      BATCH = 50_000
+
+      ITERS.times { Bug::TDataNonThreadSafeFree.make(BATCH) }
+      4.times { GC.start }
+
+      total = Bug::TDataNonThreadSafeFree.total_frees
+      assert_operator total, :>, 0,
+        "expected a single-Ractor major GC to free non-thread-safe T_DATA"
+    RUBY
+  end
+
+  def test_multi_ractor_under_threshold_no_postponed_job
+    assert_ractor(<<~'RUBY', require: "-test-/gc/tdata_non_thread_safe_free")
+      Bug::TDataNonThreadSafeFree.reset
+
+      r = Ractor.new { receive }
+
+      BATCH = 30_000
+      before = GC.stat(:count)
+      Bug::TDataNonThreadSafeFree.make(BATCH)
+      after = GC.stat(:count)
+
+      if before == after
+        total = Bug::TDataNonThreadSafeFree.total_frees
+        assert_operator total, :==, 0, "If didn't hit threshold, shouldn't trigger postponed job"
+      end
+      r.send(nil); r.join
+    RUBY
+  end
+
+  def test_multi_ractor_to_single_ractor_major_should_collect
+    assert_ractor(<<~'RUBY', require: "-test-/gc/tdata_non_thread_safe_free")
+      Bug::TDataNonThreadSafeFree.reset
+
+      r = Ractor.new { receive }
+
+      BATCH = 30_000
+      before = GC.stat(:count)
+      Bug::TDataNonThreadSafeFree.make(BATCH)
+      after = GC.stat(:count)
+
+      if before == after
+        total = Bug::TDataNonThreadSafeFree.total_frees
+        assert_operator total, :==, 0, "If didn't hit threshold, shouldn't trigger postponed job"
+      end
+
+      r.send(nil); r.value
+      3.times { GC.start } # single-ractor major GCs
+      total = Bug::TDataNonThreadSafeFree.total_frees
+      assert_operator total, :>, 0,
+        "expected a single-Ractor major GC to free non-thread-safe T_DATA"
+    RUBY
+  end
+
+  def test_multi_ractor_global_gc_should_collect
+    assert_ractor(<<~'RUBY', require: "-test-/gc/tdata_non_thread_safe_free")
+      Bug::TDataNonThreadSafeFree.reset
+
+      r = Ractor.new { receive }
+
+      BATCH = 30_000
+      before = GC.stat(:count)
+      Bug::TDataNonThreadSafeFree.make(BATCH)
+      after = GC.stat(:count)
+
+      if before == after
+        total = Bug::TDataNonThreadSafeFree.total_frees
+        assert_operator total, :==, 0, "If didn't hit threshold, shouldn't trigger postponed job"
+      end
+
+      3.times { GC.start } # global GCs
+      total = Bug::TDataNonThreadSafeFree.total_frees
+      assert_operator total, :>, 0,
+        "expected a multi-ractor global GC to free non-thread-safe T_DATA"
+      r.send(nil); r.join
+    RUBY
+  end
+end


### PR DESCRIPTION
If an object's type can't be freed concurrently (not thread safe) and there are multiple Ractors running, wait until a certain amount accumulate (2^16) and then run a postponed job to clean them up under the VM barrier. Global GC will also clean up any remaining deferred T_DATA if one runs. If a transition to single objspace happens, they
will be collected again in normal GCs (major and minor).

The implementation uses the shareable_bit for this purpose. It sets this bit on the T_DATA object during sweeping and skips sweeping it. This keeps it unswept, but allows its references to be swept.