### PR TITLE
Raise YJIT’s `case` specialization limit to 256

### DIFF
--- a/test/ruby/test_yjit.rb
+++ b/test/ruby/test_yjit.rb
@@ -1223,6 +1223,26 @@ class TestYJIT < Test::Unit::TestCase
     RUBY
   end
 
+  def test_opt_case_dispatch_all_byte_values
+    branches = 256.times.map { |value| "when #{value} then #{value}" }.join("\n")
+    assert_compiles(<<~RUBY, exits: :any, result: :ok)
+      def case_dispatch(value)
+        case value
+        #{branches}
+        end
+      end
+
+      values = (0...256).to_a
+      return :wrong_result unless values.map { |value| case_dispatch(value) } == values
+
+      stats = RubyVM::YJIT.runtime_stats
+      return :early_fallback if stats[:all_stats] && !stats[:num_opt_case_dispatch_megamorphic].zero?
+      return :wrong_else unless 2.times.map { case_dispatch(256) } == [nil, nil]
+      return :ok unless stats[:all_stats]
+      RubyVM::YJIT.runtime_stats[:num_opt_case_dispatch_megamorphic].positive? ? :ok : :missing_fallback
+    RUBY
+  end
+
   def test_code_gc
     assert_compiles(code_gc_helpers + <<~'RUBY', exits: :any, result: :ok)
       return :not_paged unless add_pages(100) # prepare freeable pages

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -2875,7 +2875,7 @@ fn jit_chain_guard(
     jcc: JCCKinds,
     jit: &mut JITState,
     asm: &mut Assembler,
-    depth_limit: u8,
+    depth_limit: u16,
     counter: Counter,
 ) {
     let target0_gen_fn = match jcc {
@@ -2902,22 +2902,22 @@ fn jit_chain_guard(
 }
 
 // up to 8 different shapes for each
-pub const GET_IVAR_MAX_DEPTH: u8 = 8;
+pub const GET_IVAR_MAX_DEPTH: u16 = 8;
 
 // up to 8 different shapes for each
-pub const SET_IVAR_MAX_DEPTH: u8 = 8;
+pub const SET_IVAR_MAX_DEPTH: u16 = 8;
 
 // hashes and arrays
-pub const OPT_AREF_MAX_CHAIN_DEPTH: u8 = 2;
+pub const OPT_AREF_MAX_CHAIN_DEPTH: u16 = 2;
 
 // expandarray
-pub const EXPANDARRAY_MAX_CHAIN_DEPTH: u8 = 4;
+pub const EXPANDARRAY_MAX_CHAIN_DEPTH: u16 = 4;
 
 // up to 5 different methods for send
-pub const SEND_MAX_DEPTH: u8 = 5;
+pub const SEND_MAX_DEPTH: u16 = 5;
 
-// up to 20 different offsets for case-when
-pub const CASE_WHEN_MAX_DEPTH: u8 = 20;
+// Specialize every value of a byte-sized case expression
+pub const CASE_WHEN_MAX_DEPTH: u16 = 256;
 
 pub const MAX_SPLAT_LENGTH: i32 = 127;
 
@@ -2928,7 +2928,7 @@ pub const MAX_SPLAT_LENGTH: i32 = 127;
 fn gen_get_ivar(
     jit: &mut JITState,
     asm: &mut Assembler,
-    max_chain_depth: u8,
+    max_chain_depth: u16,
     comptime_receiver: VALUE,
     ivar_name: ID,
     recv: Opnd,
@@ -4982,7 +4982,7 @@ fn jit_guard_known_klass(
     obj_opnd: Opnd,
     insn_opnd: YARVOpnd,
     sample_instance: VALUE,
-    max_chain_depth: u8,
+    max_chain_depth: u16,
     counter: Counter,
 ) {
     let known_klass = sample_instance.class_of();

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -460,8 +460,10 @@ impl fmt::Debug for RegMapping {
     }
 }
 
-/// Maximum value of the chain depth (should fit in 5 bits)
-const CHAIN_DEPTH_MAX: u8 = 0b11111; // 31
+/// Maximum value of the chain depth (should fit in 9 bits)
+const CHAIN_DEPTH_MAX: u16 = 256;
+const DEFERRED_FLAG: u8 = 1 << 0;
+const RETURN_LANDING_FLAG: u8 = 1 << 1;
 
 /// Code generation context
 /// Contains information we can use to specialize/optimize code
@@ -478,14 +480,11 @@ pub struct Context {
     reg_mapping: RegMapping,
 
     // Depth of this block in the sidechain (eg: inline-cache chain)
-    // 6 bits, max 63
-    chain_depth: u8,
+    // 9 bits, max 256
+    chain_depth: u16,
 
-    // Whether this code is the target of a JIT-to-JIT Ruby return ([Self::is_return_landing])
-    is_return_landing: bool,
-
-    // Whether the compilation of this code has been deferred ([Self::is_deferred])
-    is_deferred: bool,
+    // Return-landing and deferred flags
+    flags: u8,
 
     // Type we track for self
     self_type: Type,
@@ -580,9 +579,9 @@ impl BitVector {
         self.push_uint(val as u64, 8);
     }
 
-    fn push_u5(&mut self, val: u8) {
-        assert!(val <= 0b11111);
-        self.push_uint(val as u64, 5);
+    fn push_u9(&mut self, val: u16) {
+        assert!(val <= 0b1_1111_1111);
+        self.push_uint(val as u64, 9);
     }
 
     fn push_u4(&mut self, val: u8) {
@@ -654,8 +653,8 @@ impl BitVector {
         self.read_uint(bit_idx, 8) as u8
     }
 
-    fn read_u5(&self, bit_idx: &mut usize) -> u8 {
-        self.read_uint(bit_idx, 5) as u8
+    fn read_u9(&self, bit_idx: &mut usize) -> u16 {
+        self.read_uint(bit_idx, 9) as u16
     }
 
     fn read_u4(&self, bit_idx: &mut usize) -> u8 {
@@ -1053,17 +1052,17 @@ impl Context {
             }
         }
 
-        bits.push_bool(self.is_deferred);
-        bits.push_bool(self.is_return_landing);
+        bits.push_bool(self.is_deferred());
+        bits.push_bool(self.is_return_landing());
 
         // The chain depth is most often 0 or 1
         if self.chain_depth < 2 {
             bits.push_u1(0);
-            bits.push_u1(self.chain_depth);
+            bits.push_u1(self.chain_depth.try_into().unwrap());
 
         } else {
             bits.push_u1(1);
-            bits.push_u5(self.chain_depth);
+            bits.push_u9(self.chain_depth);
         }
 
         // Encode the self type if known
@@ -1154,13 +1153,17 @@ impl Context {
             }
         }
 
-        ctx.is_deferred = bits.read_bool(&mut idx);
-        ctx.is_return_landing = bits.read_bool(&mut idx);
+        if bits.read_bool(&mut idx) {
+            ctx.flags |= DEFERRED_FLAG;
+        }
+        if bits.read_bool(&mut idx) {
+            ctx.flags |= RETURN_LANDING_FLAG;
+        }
 
         if bits.read_u1(&mut idx) == 0 {
-            ctx.chain_depth = bits.read_u1(&mut idx)
+            ctx.chain_depth = bits.read_u1(&mut idx).into()
         } else {
-            ctx.chain_depth = bits.read_u5(&mut idx)
+            ctx.chain_depth = bits.read_u9(&mut idx);
         }
 
         loop {
@@ -2577,13 +2580,13 @@ impl Context {
         self.reg_mapping = reg_mapping;
     }
 
-    pub fn get_chain_depth(&self) -> u8 {
+    pub fn get_chain_depth(&self) -> u16 {
         self.chain_depth
     }
 
     pub fn reset_chain_depth_and_defer(&mut self) {
         self.chain_depth = 0;
-        self.is_deferred = false;
+        self.flags &= !DEFERRED_FLAG;
     }
 
     pub fn increment_chain_depth(&mut self) {
@@ -2594,23 +2597,23 @@ impl Context {
     }
 
     pub fn set_as_return_landing(&mut self) {
-        self.is_return_landing = true;
+        self.flags |= RETURN_LANDING_FLAG;
     }
 
     pub fn clear_return_landing(&mut self) {
-        self.is_return_landing = false;
+        self.flags &= !RETURN_LANDING_FLAG;
     }
 
     pub fn is_return_landing(&self) -> bool {
-        self.is_return_landing
+        self.flags & RETURN_LANDING_FLAG != 0
     }
 
     pub fn mark_as_deferred(&mut self) {
-        self.is_deferred = true;
+        self.flags |= DEFERRED_FLAG;
     }
 
     pub fn is_deferred(&self) -> bool {
-        self.is_deferred
+        self.flags & DEFERRED_FLAG != 0
     }
 
     /// Get an operand for the adjusted stack pointer address
@@ -4373,6 +4376,7 @@ mod tests {
         // Check that we can store types in 4 bits,
         // and all local types in 32 bits
         assert_eq!(mem::size_of::<Type>(), 1);
+        assert_eq!(mem::size_of::<Context>(), 56);
         assert!(Type::BlockParamProxy as usize <= 0b1111);
         assert!(MAX_CTX_LOCALS * 4 <= 32);
     }

--- a/yjit/src/log.rs
+++ b/yjit/src/log.rs
@@ -46,7 +46,7 @@ impl Log {
         }
     }
 
-    pub fn add_block_with_chain_depth(block_id: BlockId, chain_depth: u8) {
+    pub fn add_block_with_chain_depth(block_id: BlockId, chain_depth: u16) {
         if !Self::has_instance() {
             return;
         }


### PR DESCRIPTION
## Background

YJIT currently specializes up to 20 observed Fixnum values at an `opt_case_dispatch` site. Once a case sees more than 20 values, it compiles the generic `===` branch sequence instead. This is particularly expensive for bytecode decoders and other byte-sized dispatch tables.

## Benchmarks

On a synthetic Liquid VM decoder stream with 36 evenly mixed opcodes and 3.6 million decoded instructions:

```
threshold 20    0.0933s
threshold 256   0.0777s  (16.7% faster)
```

Generated inline code also decreased from 41.6 KiB to 28.6 KiB because YJIT no longer compiles the long fallback chain.

## Fix

Raise the case dispatch specialization limit to 256. Chain depth now uses `u16`, while the return-landing and deferred booleans share one byte so `Context` remains 56 bytes. The compact encoding for depths 0 and 1 is unchanged; larger depths use nine bits.

The megamorphic fallback remains at depth 256. This also adds a 256-arm case test covering both the specialization limit and fallback.

cc: @tenderlove 
