### PR TITLE
Fixes to callcache use from ZJIT

### DIFF
--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -2308,9 +2308,9 @@ vm_search_method_slowpath0(VALUE cd_owner, struct rb_call_data *cd, VALUE klass)
     return cc;
 }
 
-ALWAYS_INLINE(static const struct rb_callcache *vm_search_method_fastpath(const struct rb_control_frame_struct *reg_cfp, struct rb_call_data *cd, VALUE klass));
-static const struct rb_callcache *
-vm_search_method_fastpath(const struct rb_control_frame_struct *reg_cfp, struct rb_call_data *cd, VALUE klass)
+ALWAYS_INLINE(static bool vm_cc_hit_p(const struct rb_call_data *cd, VALUE klass));
+static bool
+vm_cc_hit_p(const struct rb_call_data *cd, VALUE klass)
 {
     const struct rb_callcache *cc = cd->cc;
 
@@ -2325,7 +2325,7 @@ vm_search_method_fastpath(const struct rb_control_frame_struct *reg_cfp, struct 
                       (vm_ci_flag(cd->ci) & VM_CALL_SUPER) ||         // search_super w/ define_method
                       vm_cc_cme(cc)->called_id == vm_ci_mid(cd->ci)); // cme->called_id == ci->mid
 
-            return cc;
+            return true;
         }
         RB_DEBUG_COUNTER_INC(mc_inline_miss_invalidated);
     }
@@ -2333,6 +2333,17 @@ vm_search_method_fastpath(const struct rb_control_frame_struct *reg_cfp, struct 
         RB_DEBUG_COUNTER_INC(mc_inline_miss_klass);
     }
 #endif
+
+    return false;
+}
+
+ALWAYS_INLINE(static const struct rb_callcache *vm_search_method_fastpath(const struct rb_control_frame_struct *reg_cfp, struct rb_call_data *cd, VALUE klass));
+static const struct rb_callcache *
+vm_search_method_fastpath(const struct rb_control_frame_struct *reg_cfp, struct rb_call_data *cd, VALUE klass)
+{
+    if (vm_cc_hit_p(cd, klass)) {
+        return cd->cc;
+    }
 
     return vm_search_method_slowpath0((VALUE)CFP_ISEQ(reg_cfp), cd, klass);
 }
@@ -2352,9 +2363,12 @@ const struct rb_callable_method_entry_struct *
 rb_zjit_vm_search_method(VALUE cd_owner, struct rb_call_data *cd, VALUE recv)
 {
     // Called from ZJIT with the compile-time iseq, which may differ from
-    // the iseq on the current CFP. Use the slowpath to avoid stale caches.
+    // the iseq on the current CFP.
     VALUE klass = CLASS_OF(recv);
-    const struct rb_callcache *cc = vm_search_method_slowpath0(cd_owner, cd, klass);
+    const struct rb_callcache *cc = cd->cc;
+    if (!vm_cc_hit_p(cd, klass)) {
+        cc = vm_search_method_slowpath0(cd_owner, cd, klass);
+    }
     return vm_cc_cme(cc);
 }
 
@@ -2431,11 +2445,7 @@ rb_zjit_cme_is_cfunc(const rb_callable_method_entry_t *me, const cfunc_type func
 int
 rb_vm_method_cfunc_is(const rb_iseq_t *iseq, CALL_DATA cd, VALUE recv, cfunc_type func)
 {
-    // Called from ZJIT with the compile-time iseq, which may differ from
-    // the iseq on the current CFP. Use the slowpath to avoid stale caches.
-    VALUE klass = CLASS_OF(recv);
-    const struct rb_callcache *cc = vm_search_method_slowpath0((VALUE)iseq, cd, klass);
-    const struct rb_callable_method_entry_struct *cme = vm_cc_cme(cc);
+    const struct rb_callable_method_entry_struct *cme = rb_zjit_vm_search_method((VALUE)iseq, cd, recv);
     return check_cfunc(cme, func);
 }
 

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -2251,6 +2251,15 @@ rb_vm_search_method_slowpath(const struct rb_callinfo *ci, VALUE klass)
     return cc;
 }
 
+#if VM_CHECK_MODE > 0
+static bool
+vm_cd_owned_by_iseq_p(const struct rb_call_data *cd, const rb_iseq_t *iseq)
+{
+    const struct rb_iseq_constant_body *body = ISEQ_BODY(iseq);
+    return cd >= body->call_data && cd < body->call_data + body->ci_size;
+}
+#endif
+
 static const struct rb_callcache *
 vm_search_method_slowpath0(VALUE cd_owner, struct rb_call_data *cd, VALUE klass)
 {
@@ -2265,6 +2274,10 @@ vm_search_method_slowpath0(VALUE cd_owner, struct rb_call_data *cd, VALUE klass)
 
     const struct rb_callcache *empty_cc = &vm_empty_cc;
     if (cd_owner && cc != empty_cc) {
+        // invokesuper dispatches with a cd on the machine stack, which has no
+        // owning iseq to remember and keeps its ci out of the GC.
+        VM_ASSERT(!vm_ci_markable(cd->ci) ||
+                  vm_cd_owned_by_iseq_p(cd, (const rb_iseq_t *)cd_owner));
         RB_OBJ_WRITTEN(cd_owner, Qundef, cc);
     }
 

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -2308,12 +2308,10 @@ vm_search_method_slowpath0(VALUE cd_owner, struct rb_call_data *cd, VALUE klass)
     return cc;
 }
 
-ALWAYS_INLINE(static bool vm_cc_hit_p(const struct rb_call_data *cd, VALUE klass));
+ALWAYS_INLINE(static bool vm_cc_hit_p(const struct rb_callcache *cc, const struct rb_call_data *cd, VALUE klass));
 static bool
-vm_cc_hit_p(const struct rb_call_data *cd, VALUE klass)
+vm_cc_hit_p(const struct rb_callcache *cc, const struct rb_call_data *cd, VALUE klass)
 {
-    const struct rb_callcache *cc = cd->cc;
-
     VM_ASSERT_TYPE2(klass, T_CLASS, T_ICLASS);
 
 #if OPT_INLINE_METHOD_CACHE
@@ -2341,8 +2339,9 @@ ALWAYS_INLINE(static const struct rb_callcache *vm_search_method_fastpath(const 
 static const struct rb_callcache *
 vm_search_method_fastpath(const struct rb_control_frame_struct *reg_cfp, struct rb_call_data *cd, VALUE klass)
 {
-    if (vm_cc_hit_p(cd, klass)) {
-        return cd->cc;
+    const struct rb_callcache *cc = cd->cc;
+    if (vm_cc_hit_p(cc, cd, klass)) {
+        return cc;
     }
 
     return vm_search_method_slowpath0((VALUE)CFP_ISEQ(reg_cfp), cd, klass);
@@ -2366,7 +2365,7 @@ rb_zjit_vm_search_method(VALUE cd_owner, struct rb_call_data *cd, VALUE recv)
     // the iseq on the current CFP.
     VALUE klass = CLASS_OF(recv);
     const struct rb_callcache *cc = cd->cc;
-    if (!vm_cc_hit_p(cd, klass)) {
+    if (!vm_cc_hit_p(cc, cd, klass)) {
         cc = vm_search_method_slowpath0(cd_owner, cd, klass);
     }
     return vm_cc_cme(cc);

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -4933,7 +4933,8 @@ impl Function {
                     }
                     &Insn::IsMethodCfunc { val, cd, cfunc, state } if self.type_of(val).ruby_object_known() => {
                         let class = self.type_of(val).ruby_object().unwrap();
-                        let cme = unsafe { rb_zjit_vm_search_method(self.iseq.into(), cd as *mut rb_call_data, class) };
+                        let cd_owner = self.frame_state_iseq(state);
+                        let cme = unsafe { rb_zjit_vm_search_method(cd_owner.into(), cd as *mut rb_call_data, class) };
                         let is_expected_cfunc = unsafe { rb_zjit_cme_is_cfunc(cme, cfunc as *const c_void) };
                         let method = unsafe { rb_vm_ci_mid((*cd).ci) };
                         self.push_insn(block, Insn::PatchPoint { invariant: Invariant::MethodRedefined { klass: class, method, cme }, state });


### PR DESCRIPTION
When investigating the object-new benchmark in Ractors, I found that the profiler reported the majority of our time in `vm_ci_packed_p`. I believe this is because we were constantly writing into the cd->cc field causing false sharing.

I also noticed when trying to double check correctness that with inlining (I think?) in one case when used at compile time we were passing the wrong iseq to rb_zjit_vm_search_method which could potentially cause the wrong write barrier to be fired.