### PR TITLE
[Backport #22223] Check SO_ERROR after waiting for nonblocking connect

### DIFF
--- a/ext/socket/lib/socket.rb
+++ b/ext/socket/lib/socket.rb
@@ -63,6 +63,13 @@ class Addrinfo
         when :wait_writable
           sock.wait_writable(timeout) or
             raise Errno::ETIMEDOUT, "user specified timeout for #{self.ip_address}:#{self.ip_port}"
+          # Check SO_ERROR instead of relying on the connect_nonblock retry;
+          # some kernels (e.g. Darwin 27) answer the retry connect(2) with
+          # EISCONN even when the connection has failed.  [Bug #22223]
+          err = sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_ERROR).int
+          unless err.zero?
+            raise SystemCallError.new("connect(2) for #{self.ip_address}:#{self.ip_port}", err)
+          end
         end while true
       else
         sock.connect(self)

--- a/test/socket/test_socket.rb
+++ b/test/socket/test_socket.rb
@@ -624,6 +624,16 @@ class TestSocket < Test::Unit::TestCase
     sock.close if sock && ! sock.closed?
   end
 
+  def test_connect_timeout_connection_refused
+    server = TCPServer.new("127.0.0.1", 0)
+    port = server.addr[1]
+    server.close
+
+    assert_raise(Errno::ECONNREFUSED) do
+      Socket.tcp("127.0.0.1", port, connect_timeout: 5)
+    end
+  end unless /mswin|mingw/ =~ RUBY_PLATFORM
+
   def test_getifaddrs
     begin
       list = Socket.getifaddrs


### PR DESCRIPTION
Darwin 27 answers the retry connect(2) on a refused nonblocking socket
with EISCONN, so the retry idiom in Addrinfo#connect_internal returned
an unconnected socket. SO_ERROR still holds the real error, so consult
it after wait_writable, as wait_connectable() in init.c already does.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
