### PR TITLE
[backport ruby_4_0] Register clones with their superclass's subclass list

### DIFF
--- a/class.c
+++ b/class.c
@@ -1128,6 +1128,13 @@ rb_mod_init_copy(VALUE clone, VALUE orig)
         rb_class_update_superclasses(clone);
     }
 
+    if (RB_TYPE_P(clone, T_CLASS)) {
+        VALUE super = RCLASS_SUPER(clone);
+        if (super && RB_TYPE_P(super, T_ICLASS)) {
+            class_switch_superclass(rb_class_superclass(clone), clone);
+        }
+    }
+
     return clone;
 }
 

--- a/test/ruby/test_class.rb
+++ b/test/ruby/test_class.rb
@@ -820,6 +820,20 @@ class TestClass < Test::Unit::TestCase
     end
   end
 
+  def test_subclasses_includes_clone
+    c = Class.new
+    with_include = Class.new(c) { include Module.new }
+    with_prepend = Class.new(c) { prepend Module.new }
+    plain = Class.new(c)
+
+    bug22190 = '[ruby-core:126038] [Bug #22190]'
+    clones = [with_include, with_prepend, plain].flat_map {|k| [k.clone, k.dup]}
+    subclasses = c.subclasses
+    clones.each do |k|
+      assert_equal(1, subclasses.count(k), "#{bug22190} expected #{k.inspect} to appear in subclasses exactly once")
+    end
+  end
+
   def test_attached_object
     c = Class.new
     sc = c.singleton_class


### PR DESCRIPTION
Since a2531ba29303fab468c8084c07149040a7871219, class_associate_super()
maintains subclass lists only for direct T_CLASS -> T_CLASS links. When
a class that includes or prepends a module is cloned, rb_mod_init_copy()
connects the clone (or its origin) to a T_ICLASS, so the clone was never
added to its real superclass's subclass list and Class#subclasses did
not return it.

Register the clone with its superclass explicitly after the chain is
built. rb_class_superclass() can be used because the superclass table
is already up to date at this point and the superclass always exists
(the root class cannot be cloned). Clones of classes without modules
are registered by class_associate_super() as before.

[Backport #22190]

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
