### PR TITLE
Add missing fields in rb_iseq_memsize

### DIFF
--- a/iseq.c
+++ b/iseq.c
@@ -543,7 +543,7 @@ rb_iseq_memsize(const rb_iseq_t *iseq)
         size += sizeof(struct rb_iseq_constant_body);
         size += body->iseq_size * sizeof(VALUE);
         size += body->insns_info.size * (sizeof(struct iseq_insn_info_entry) + sizeof(unsigned int));
-        size += body->local_table_size * sizeof(ID);
+        size += body->local_table_size * sizeof(ID); // body->local_table
         size += ISEQ_MBITS_BUFLEN(body->iseq_size) * ISEQ_MBITS_SIZE;
         if (body->catch_table) {
             size += iseq_catch_table_bytes(body->catch_table->size);

--- a/iseq.c
+++ b/iseq.c
@@ -544,6 +544,7 @@ rb_iseq_memsize(const rb_iseq_t *iseq)
         size += body->iseq_size * sizeof(VALUE);
         size += body->insns_info.size * (sizeof(struct iseq_insn_info_entry) + sizeof(unsigned int));
         size += body->local_table_size * sizeof(ID); // body->local_table
+        if (body->lvar_states) size += body->local_table_size * sizeof(enum lvar_state);
         size += ISEQ_MBITS_BUFLEN(body->iseq_size) * ISEQ_MBITS_SIZE;
         if (body->catch_table) {
             size += iseq_catch_table_bytes(body->catch_table->size);

--- a/iseq.c
+++ b/iseq.c
@@ -552,6 +552,8 @@ rb_iseq_memsize(const rb_iseq_t *iseq)
         size += (body->param.opt_num + 1) * sizeof(VALUE);
         size += param_keyword_size(body->param.keyword);
 
+        if (body->outer_variables) size += rb_id_table_memsize(body->outer_variables);
+
         /* body->is_entries */
         size += ISEQ_IS_SIZE(body) * sizeof(union iseq_inline_storage_entry);
 


### PR DESCRIPTION
`lvar_states` and `outer_variables` are not accounted for in `rb_iseq_memsize`.