### PR TITLE
ZJIT: Add codegen test for Fixnum#<< overflow side exit

### DIFF
--- a/zjit/src/codegen_tests.rs
+++ b/zjit/src/codegen_tests.rs
@@ -2833,6 +2833,29 @@ fn test_opt_minus_overflow() {
 }
 
 #[test]
+fn test_fixnum_lshift() {
+    assert_snapshot!(inspect("
+        def test(a) = a << 3
+        test(1) # profile opt_ltlt
+
+        [test(5), test(0), test(-5)]
+    "), @"[40, 0, -40]");
+}
+
+#[test]
+fn test_fixnum_lshift_overflow() {
+    assert_snapshot!(inspect("
+        def test(a) = a << 3
+        test(1) # profile opt_ltlt
+
+        r1 = test(1 << 60)
+        r2 = test(-(1 << 60))
+
+        [r1, r2]
+    "), @"[9223372036854775808, -9223372036854775808]");
+}
+
+#[test]
 fn test_opt_eq() {
     eval("
         def test(a, b) = a == b


### PR DESCRIPTION
Add codegen tests for the Fixnum left shift fastpath and its overflow side exit.