### PR TITLE
Shrink lvar_states in iseq

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -1864,14 +1864,14 @@ update_lvar_state(const rb_iseq_t *iseq, int level, int idx)
         iseq = ISEQ_BODY(iseq)->parent_iseq;
     }
 
-    enum lvar_state *states = ISEQ_BODY(iseq)->lvar_states;
+    uint8_t *states = ISEQ_BODY(iseq)->lvar_states;
     int table_idx = ISEQ_BODY(iseq)->local_table_size - idx;
-    switch (states[table_idx]) {
+    switch (iseq_lvar_state_get(states, table_idx)) {
       case lvar_uninitialized:
-        states[table_idx] = lvar_initialized;
+        iseq_lvar_state_set(states, table_idx, lvar_initialized);
         break;
       case lvar_initialized:
-        states[table_idx] = lvar_reassigned;
+        iseq_lvar_state_set(states, table_idx, lvar_reassigned);
         break;
       case lvar_reassigned:
         /* nothing */
@@ -1885,13 +1885,13 @@ static int
 iseq_set_parameters_lvar_state(const rb_iseq_t *iseq)
 {
     for (unsigned int i=0; i<ISEQ_BODY(iseq)->param.size; i++) {
-        ISEQ_BODY(iseq)->lvar_states[i] = lvar_initialized;
+        iseq_lvar_state_set(ISEQ_BODY(iseq)->lvar_states, i, lvar_initialized);
     }
 
     int lead_num = ISEQ_BODY(iseq)->param.lead_num;
     int opt_num = ISEQ_BODY(iseq)->param.opt_num;
     for (int i=0; i<opt_num; i++) {
-        ISEQ_BODY(iseq)->lvar_states[lead_num + i] = lvar_uninitialized;
+        iseq_lvar_state_set(ISEQ_BODY(iseq)->lvar_states, lead_num + i, lvar_uninitialized);
     }
 
     return COMPILE_OK;
@@ -2257,13 +2257,7 @@ iseq_set_local_table(rb_iseq_t *iseq, const rb_ast_id_table_t *tbl, const NODE *
         MEMCPY(ids, tbl->ids + offset, ID, size);
         ISEQ_BODY(iseq)->local_table = ids;
 
-        enum lvar_state *states = ALLOC_N(enum lvar_state, size);
-        // fprintf(stderr, "iseq:%p states:%p size:%d\n", iseq, states, (int)size);
-        for (unsigned int i=0; i<size; i++) {
-            states[i] = lvar_uninitialized;
-            // fprintf(stderr, "id:%s\n", rb_id2name(ISEQ_BODY(iseq)->local_table[i]));
-        }
-        ISEQ_BODY(iseq)->lvar_states = states;
+        ISEQ_BODY(iseq)->lvar_states = ZALLOC_N(uint8_t, ISEQ_LVAR_STATES_BUFLEN(size));
     }
     ISEQ_BODY(iseq)->local_table_size = size;
 
@@ -12616,7 +12610,7 @@ typedef uint32_t ibf_offset_t;
 
 #define IBF_MAJOR_VERSION ISEQ_MAJOR_VERSION
 #ifdef RUBY_DEVEL
-#define IBF_DEVEL_VERSION 6
+#define IBF_DEVEL_VERSION 7
 #define IBF_MINOR_VERSION (ISEQ_MINOR_VERSION * 10000 + IBF_DEVEL_VERSION)
 #else
 #define IBF_MINOR_VERSION ISEQ_MINOR_VERSION
@@ -13443,12 +13437,12 @@ static ibf_offset_t
 ibf_dump_lvar_states(struct ibf_dump *dump, const rb_iseq_t *iseq)
 {
     const struct rb_iseq_constant_body *const body = ISEQ_BODY(iseq);
-    const int size = body->local_table_size;
-    IBF_W_ALIGN(enum lvar_state);
-    return ibf_dump_write(dump, body->lvar_states, sizeof(enum lvar_state) * (body->lvar_states ? size : 0));
+    const int size = ISEQ_LVAR_STATES_BUFLEN(body->local_table_size);
+    IBF_W_ALIGN(uint8_t);
+    return ibf_dump_write(dump, body->lvar_states, sizeof(uint8_t) * (body->lvar_states ? size : 0));
 }
 
-static enum lvar_state *
+static uint8_t *
 ibf_load_lvar_states(const struct ibf_load *load, ibf_offset_t lvar_states_offset, int size, const ID *local_table)
 {
     if (local_table == rb_iseq_shared_exc_local_tbl ||
@@ -13456,7 +13450,7 @@ ibf_load_lvar_states(const struct ibf_load *load, ibf_offset_t lvar_states_offse
         return NULL;
     }
     else {
-        enum lvar_state *states = IBF_R(lvar_states_offset, enum lvar_state, size);
+        uint8_t *states = IBF_R(lvar_states_offset, uint8_t, ISEQ_LVAR_STATES_BUFLEN(size));
         return states;
     }
 }

--- a/iseq.c
+++ b/iseq.c
@@ -231,7 +231,7 @@ rb_iseq_free(const rb_iseq_t *iseq)
         if (LIKELY(body->local_table != rb_iseq_shared_exc_local_tbl)) {
             SIZED_FREE_N(body->local_table, body->local_table_size);
         }
-        SIZED_FREE_N(body->lvar_states, body->local_table_size);
+        SIZED_FREE_N(body->lvar_states, ISEQ_LVAR_STATES_BUFLEN(body->local_table_size));
 
         compile_data_free(ISEQ_COMPILE_DATA(iseq));
         if (body->outer_variables) rb_id_table_free(body->outer_variables);
@@ -544,7 +544,7 @@ rb_iseq_memsize(const rb_iseq_t *iseq)
         size += body->iseq_size * sizeof(VALUE);
         size += body->insns_info.size * (sizeof(struct iseq_insn_info_entry) + sizeof(unsigned int));
         size += body->local_table_size * sizeof(ID); // body->local_table
-        if (body->lvar_states) size += body->local_table_size * sizeof(enum lvar_state);
+        if (body->lvar_states) size += ISEQ_LVAR_STATES_BUFLEN(body->local_table_size) * sizeof(uint8_t);
         size += ISEQ_MBITS_BUFLEN(body->iseq_size) * ISEQ_MBITS_SIZE;
         if (body->catch_table) {
             size += iseq_catch_table_bytes(body->catch_table->size);

--- a/iseq.h
+++ b/iseq.h
@@ -26,6 +26,26 @@ RUBY_EXTERN const int ruby_api_version[];
 #define ISEQ_MBITS_SET_P(buf, i) ((buf[(i) / ISEQ_MBITS_BITLENGTH] >> ((i) % ISEQ_MBITS_BITLENGTH)) & 0x1)
 #define ISEQ_MBITS_BUFLEN(size) roomof(size, ISEQ_MBITS_BITLENGTH)
 
+#define ISEQ_LVAR_STATE_BITS 2
+#define ISEQ_LVAR_STATES_PER_BYTE (CHAR_BIT / ISEQ_LVAR_STATE_BITS)
+#define ISEQ_LVAR_STATES_BUFLEN(size) roomof(size, ISEQ_LVAR_STATES_PER_BYTE)
+STATIC_ASSERT(lvar_state_fits_in_iseq_lvar_state_bits, lvar_reassigned < (1 << ISEQ_LVAR_STATE_BITS));
+
+static inline enum lvar_state
+iseq_lvar_state_get(const uint8_t *buf, unsigned int i)
+{
+    const unsigned int shift = (i % ISEQ_LVAR_STATES_PER_BYTE) * ISEQ_LVAR_STATE_BITS;
+    return (enum lvar_state)((buf[i / ISEQ_LVAR_STATES_PER_BYTE] >> shift) & ((1 << ISEQ_LVAR_STATE_BITS) - 1));
+}
+
+static inline void
+iseq_lvar_state_set(uint8_t *buf, unsigned int i, enum lvar_state state)
+{
+    uint8_t *const byte = &buf[i / ISEQ_LVAR_STATES_PER_BYTE];
+    const unsigned int shift = (i % ISEQ_LVAR_STATES_PER_BYTE) * ISEQ_LVAR_STATE_BITS;
+    *byte = (*byte & ~(((1 << ISEQ_LVAR_STATE_BITS) - 1) << shift)) | ((uint8_t)state << shift);
+}
+
 #ifndef USE_ISEQ_NODE_ID
 #define USE_ISEQ_NODE_ID 1
 #endif

--- a/vm.c
+++ b/vm.c
@@ -1495,7 +1495,7 @@ env_copy(const VALUE *src_ep, VALUE read_only_variables)
             for (unsigned int j=0; j<body->local_table_size; j++) {
                 if (id == body->local_table[j]) {
                     // check reassignment
-                    if (body->lvar_states[j] == lvar_reassigned) {
+                    if (iseq_lvar_state_get(body->lvar_states, j) == lvar_reassigned) {
                         VALUE name = rb_id2str(id);
                         VALUE msg = rb_sprintf("cannot make a shareable Proc because "
                                                "the outer variable '%" PRIsVALUE "' may be reassigned.", name);

--- a/vm_core.h
+++ b/vm_core.h
@@ -410,6 +410,12 @@ enum rb_builtin_attr {
 typedef VALUE (*rb_jit_func_t)(struct rb_execution_context_struct *, struct rb_control_frame_struct *);
 typedef VALUE (*rb_zjit_func_t)(struct rb_execution_context_struct *, struct rb_control_frame_struct *, rb_jit_func_t);
 
+enum lvar_state {
+    lvar_uninitialized,
+    lvar_initialized,
+    lvar_reassigned,
+};
+
 struct rb_iseq_constant_body {
     enum rb_iseq_type type;
 
@@ -507,11 +513,7 @@ struct rb_iseq_constant_body {
 
     const ID *local_table;		/* must free */
 
-    enum lvar_state {
-        lvar_uninitialized,
-        lvar_initialized,
-        lvar_reassigned,
-    } *lvar_states;
+    uint8_t *lvar_states;
 
     /* catch table */
     struct iseq_catch_table *catch_table;

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -1267,10 +1267,6 @@ pub struct rb_iseq_constant_body_iseq_insn_info {
     pub size: ::std::os::raw::c_uint,
     pub succ_index_table: *mut succ_index_table,
 }
-pub const lvar_uninitialized: rb_iseq_constant_body_lvar_state = 0;
-pub const lvar_initialized: rb_iseq_constant_body_lvar_state = 1;
-pub const lvar_reassigned: rb_iseq_constant_body_lvar_state = 2;
-pub type rb_iseq_constant_body_lvar_state = u32;
 #[repr(C)]
 pub struct rb_iseq_constant_body__bindgen_ty_1 {
     pub flip_count: rb_snum_t,


### PR DESCRIPTION
lvar_states only has 3 states, but an enum uses 4 bytes. This commit shrinks lvar_states to use only 2 bits (0.25 bytes), which means we save 3.75 bytes for every local variable in an iseq.

We can see that for this script:

```ruby
def foo
  a = 1
  b = 1
  c = 1
  d = 1
end

iseq = RubyVM::InstructionSequence.of(method(:foo))
puts ObjectSpace.memsize_of(iseq)
```

It outputs 736 before this commit, and 721 now, which is 15 bytes saved over the 4 local variables.