### PR TITLE
ZJIT: Split OperandTooLarge out of TooManyArgsForLir

### DIFF
--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -767,7 +767,11 @@ pub enum SendFallbackReason {
     SendBlockArgNotNil,
     CCallWithFrameTooManyArgs,
     ObjToStringNotString,
+    /// Too many arguments in a C call to fit in C ABI registers.
     TooManyArgsForLir,
+    /// An operand doesn't fit in the integer type that encodes it,
+    /// e.g. an argument count that overflows IseqCall's u16.
+    OperandTooLarge,
     /// The Proc object for a BMETHOD is not defined by an ISEQ. (See `enum rb_block_type`.)
     BmethodNonIseqProc,
     /// Caller supplies too few or too many arguments than what the callee's parameters expects.
@@ -838,6 +842,7 @@ impl Display for SendFallbackReason {
             CCallWithFrameTooManyArgs => write!(f, "CCallWithFrame: too many arguments"),
             ObjToStringNotString => write!(f, "ObjToString: result is not a string"),
             TooManyArgsForLir => write!(f, "Too many arguments for LIR"),
+            OperandTooLarge => write!(f, "Operand doesn't fit in its encoding"),
             BmethodNonIseqProc => write!(f, "Bmethod: Proc object is not defined by an ISEQ"),
             ArgcParamMismatch => write!(f, "Argument count does not match parameter count"),
             ComplexArgPass => write!(f, "Complex argument passing"),
@@ -2702,7 +2707,7 @@ fn can_direct_send(iseq: *const rb_iseq_t, ci: *const rb_callinfo, args: &[InsnI
 
     // IseqCall stores the JIT entry index and argc as u16.
     if u16::try_from(send_argc).is_err() {
-        return Err(SendDirectFailure::new(TooManyArgsForLir));
+        return Err(SendDirectFailure::new(OperandTooLarge));
     }
 
     Ok(())
@@ -4017,7 +4022,7 @@ impl Function {
         // rest packing changes the SendDirect argument count.
         // See: vm_args.c's setup_parameters_complex and args_setup_opt_parameters.
         let passed_opt_num = (positional_argc - min_positional_argc).min(opt_num);
-        let jit_entry_idx = passed_opt_num.try_into().map_err(|_| TooManyArgsForLir)?;
+        let jit_entry_idx = passed_opt_num.try_into().map_err(|_| OperandTooLarge)?;
 
         // Methods without *rest still need the jit_entry_idx computed above,
         // but their positional args do not need repacking.
@@ -4704,7 +4709,7 @@ impl Function {
                                     {
                                         let native_index = (index as i64) * (SIZEOF_VALUE as i64);
                                         if native_index > (i32::MAX as i64) {
-                                            self.set_dynamic_send_reason(insn_id, TooManyArgsForLir);
+                                            self.set_dynamic_send_reason(insn_id, OperandTooLarge);
                                             self.push_insn_id(block, insn_id); continue;
                                         }
                                     }

--- a/zjit/src/stats.rs
+++ b/zjit/src/stats.rs
@@ -258,6 +258,7 @@ make_counters! {
         send_fallback_send_cfunc_not_variadic,
         send_fallback_send_not_optimized_method_type_optimized,
         send_fallback_too_many_args_for_lir,
+        send_fallback_operand_too_large,
         send_fallback_send_bop_redefined,
         send_fallback_send_operands_not_fixnum,
         send_fallback_send_polymorphic_fallback,
@@ -682,6 +683,7 @@ pub fn send_fallback_counter(reason: crate::hir::SendFallbackReason) -> Counter 
         SendNotOptimizedMethodTypeOptimized(_)
                                                   => send_fallback_send_not_optimized_method_type_optimized,
         TooManyArgsForLir                         => send_fallback_too_many_args_for_lir,
+        OperandTooLarge                           => send_fallback_operand_too_large,
         SendBopRedefined                          => send_fallback_send_bop_redefined,
         SendOperandsNotFixnum                     => send_fallback_send_operands_not_fixnum,
         SendPolymorphicFallback                   => send_fallback_send_polymorphic_fallback,


### PR DESCRIPTION
This PR renames some of the `TooManyArgsForLir` send fallback reasons to `OperandTooLarge`.

Some of these fallback reasons are not really about the C ABI, which `TooManyArgsForLir` was originally used for. Even if we used C ABI stack slots for everything, those send fallback will not go away. To avoid confusion, I want to rename those unrelated things to `OperandTooLarge`. The remaining `TooManyArgsForLir` is only C method calls.