### PR TITLE
Ractor, GC: retire two "in flight" names

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -4137,11 +4137,8 @@ rb_gc_vm_refresh_zombie_pages(void)
     vm->gc.zombie_total_pages = total;
 }
 
-/* Incremental marking only runs single-objspace; vm_insert_ractor0 calls this just
- * before a second Ractor becomes visible so any cycle in progress finishes; a settle
- * cannot resume, nor inheritance extend, another objspace's partial mark. */
 void
-rb_gc_finish_in_flight_gc(void)
+rb_gc_rest(void)
 {
     rb_gc_impl_gc_rest(rb_gc_get_objspace());
 }

--- a/internal/gc.h
+++ b/internal/gc.h
@@ -312,7 +312,7 @@ void rb_gc_zombie_objspaces_atfork(void);
 void rb_gc_disable_holders_atfork(void);
 void rb_gc_atfork_global_locks(void);
 void rb_gc_stash_cleanup_objspace(void);
-void rb_gc_finish_in_flight_gc(void);
+void rb_gc_rest(void);
 bool rb_gc_during_global_gc_p(void);
 bool rb_gc_single_objspace_p(void);
 const char *rb_obj_info(VALUE obj);

--- a/ractor.c
+++ b/ractor.c
@@ -516,10 +516,11 @@ vm_insert_ractor0(rb_vm_t *vm, rb_ractor_t *r, bool single_ractor_mode)
     RUBY_DEBUG_LOG("r:%u ractor.cnt:%u++", r->pub.id, vm->ractor.cnt);
     VM_ASSERT(single_ractor_mode || RB_VM_LOCKED_P());
 
-    /* Just before the process goes multi-objspace.  Incremental marking only runs in a
-     * single-objspace world, so finish any cycle in progress before the count changes. */
+    /* Incremental marking only runs in a single-objspace world, and nothing later can
+     * finish another objspace's partial mark, so end any cycle in progress before a
+     * second Ractor becomes visible. */
     if (vm->ractor.cnt == 1) {
-        rb_gc_finish_in_flight_gc();
+        rb_gc_rest();
     }
 
     ccan_list_add_tail(&vm->ractor.set, &r->vmlr_node);

--- a/ractor.c
+++ b/ractor.c
@@ -306,11 +306,11 @@ ractor_mark(void *ptr)
      * both the set and zombie_objspaces (orphan-merged) this marker is its only cover. */
     rb_gc_mark(r->sync.default_port_value);
     /* A single-objspace impl (mmtk) has no zombie_objspaces and no pin/shref bits, so
-     * the root scan cannot reach a terminated Ractor's legacy value, queue or in-flight
-     * payloads; and no shref rule forbids following them from the wrapper. */
+     * the root scan cannot reach a terminated Ractor's queue, in-flight payloads or
+     * join value; and no shref rule forbids following them from the wrapper. */
     if (!rb_gc_multi_objspace_p()) {
         ractor_mark_unshareable_parts(r);
-        rb_ractor_mark_in_flight_for_single_objspace(r);
+        rb_ractor_mark_terminated_join_value(r);
     }
 }
 

--- a/ractor_core.h
+++ b/ractor_core.h
@@ -159,7 +159,6 @@ struct rb_ractor_struct {
 /* Mark the GC roots held in Ractor r's C structs (from the root scan in gc.c). */
 void rb_ractor_mark_local_roots(rb_ractor_t *r);
 void rb_ractor_mark_terminated_join_value(rb_ractor_t *r);
-void rb_ractor_mark_in_flight_for_single_objspace(rb_ractor_t *r);
 
 /* Move src's registered_marks to dst and leave src empty (on join or when an orphan
  * is absorbed).  An absorb can run during a GC sweep, so the implementation uses raw

--- a/ractor_sync.c
+++ b/ractor_sync.c
@@ -825,15 +825,6 @@ ractor_sync_mark(rb_ractor_t *r)
     }
 }
 
-/* A single-objspace impl (mmtk) has no pin or shref bits and no zombie_objspaces, so
- * plain marking from the wrapper keeps these alive; the default GC covers the same set
- * with its pins and its zombie scan. */
-void
-rb_ractor_mark_in_flight_for_single_objspace(rb_ractor_t *r)
-{
-    rb_gc_mark(r->sync.legacy);
-}
-
 static int
 ractor_sync_free_ports_i(st_data_t _key, st_data_t val, st_data_t _args)
 {


### PR DESCRIPTION
Two functions carried "in flight" in their names for different reasons, and neither needs the word.

`rb_gc_finish_in_flight_gc` → `rb_gc_rest`. It is a one-line wrapper around `rb_gc_impl_gc_rest`, and every other layer of the same call already says "gc rest" (`gc_rest` in gc/default/default.c, `rb_gc_impl_gc_rest` across the modular GC boundary). The wrapper exists only because ractor.c cannot call `rb_gc_impl_*` itself, so it should not rename the operation on the way out.

`rb_ractor_mark_in_flight_for_single_objspace` is dropped. Since the in-flight pins went away it marked `r->sync.legacy` and nothing else, which is what `rb_ractor_mark_terminated_join_value` next to it already does — two functions over one field, and the surviving one names it correctly. The single-objspace branch now calls that one.

One behaviour change: `rb_ractor_mark_terminated_join_value` also `pins. sync.legacy` is a C-struct slot with no compaction update hook anywhere, so pinning is the treatment it needs; the plain `rb_gc_mark` it replaces was the weaker of the two. The branch is `!rb_gc_multi_objspace_p()`, so this is the mmtk path.

ractor.c includes ractor_sync.c, so the removed function was local to one translation unit and its ractor_core.h declaration goes with it.