### PR TITLE
Ractor: reach a terminated Ractor's join value through its wrapper

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -3279,15 +3279,13 @@ rb_gc_mark_roots(void *objspace, const char **categoryp)
         }
         /* A Ractor that terminated (left vm->ractor.set) but whose struct is not freed
          * still owns rb_gc_register_mark_object pins.  Keep them alive until
-         * ractor_free hands them to main; an orphan (owner == NULL) was moved above. */
+         * ractor_free hands them to main; an orphan (owner == NULL) was moved above.
+         * The join value is not rooted here: ractor_mark marks it from the wrapper. */
         for (size_t i = 0; i < vm->gc.zombie_objspaces_count; i++) {
             rb_ractor_t *owner = vm->gc.zombie_objspaces[i].owner;
             if (owner) {
                 rb_gc_mark_vm_stack_values((long)owner->registered_marks_cnt,
                                            owner->registered_marks);
-                /* Keep a terminated Ractor's join value (read by Ractor#value) alive
-                 * without depending on wrapper reachability.  Threads are not walked. */
-                rb_ractor_mark_terminated_join_value(owner);
             }
         }
 

--- a/ractor.c
+++ b/ractor.c
@@ -312,6 +312,13 @@ ractor_mark(void *ptr)
         ractor_mark_unshareable_parts(r);
         rb_ractor_mark_in_flight_for_single_objspace(r);
     }
+    else if (rb_gc_during_global_gc_p()) {
+        /* The join value is only of use to whoever can still call Ractor#value, which
+         * means holding this wrapper, so mark it as the wrapper's child rather than as a
+         * root.  A global GC stops the world and marks every objspace together, which is
+         * what lets the shareable wrapper reach an unshareable value at all. */
+        rb_ractor_mark_terminated_join_value(r);
+    }
 }
 
 /* Mark the GC roots reachable from Ractor r's C structs.  A local GC cannot rely on the


### PR DESCRIPTION
The root scan marked r->sync.legacy for every zombie objspace, deliberately "without depending on wrapper reachability".  That makes the value a GC root, and a Ractor whose return value can reach the Ractor object roots itself:

  Ractor.new { Ractor.current }.join

Nothing else names either one, but the value is a root, the value reaches the wrapper, so the wrapper never dies, so ractor_free never runs, rb_gc_objspace_disown is never called, and the objspace stays in zombie_objspaces for the life of the process.  The count never returning to zero also holds rb_gc_single_objspace_p() false forever, which is the gate on page_pool_reclaim, so the page pool stops returning arenas to the OS.  A Ractor::Port, an array, an ivar -- any path from the value back to the wrapper does it; 10000 rounds of the line above leave 10001 live Ractors.

The value is of use only to whoever can still call Ractor#value, and that means holding the wrapper, so mark it as the wrapper's child instead.  A self-referential pair is then ordinary garbage, and the transitive case (one Ractor's value naming another) falls out of normal tracing rather than needing a pass that iterates to a fixpoint.

Only during a global GC: it stops the world and marks every objspace together, which is what lets the shareable wrapper reach an unshareable value.  A local GC must not, and never did -- the zombie scan this replaces also ran only in a global GC.

  300 rounds of the line above       10001 -> 1 live Ractors
  8000 rounds with a dropped message 2.3 GB -> 216 MB, and it now plateaus
                                     (287 MB at 20000, 288 MB at 40000)

Verified with RUBY_DEBUG=1: bootstraptest/test_ractor.rb, the GC and Ractor unit tests, GC.verify_internal_consistency after holding 100 terminated Ractors across GC.compact (their values, including self-references, all still readable), and the same under GC.stress.