### PR TITLE
Ractor: drop a port queue once nothing can name it

### DIFF
--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -2848,3 +2848,18 @@ assert_equal '[[:obj, true], [:str, true], [:strct, true]]', %q{
   [o, s, st].each { |x| r.send(x, move: true) }
   r.value.inspect
 }
+
+# A port that is still reachable keeps its queue, whether or not it was closed.  (Dropping
+# the queue of a port that is gone is not fixed for mmtk, so that case is a test-all one
+# that omits itself: see test_port_queue_dropped_when_port_unreachable.)
+assert_equal '[[0, 1, 2], [:a, :b]]', %q{
+  taken = 3.times.map do |i|
+    port = Ractor::Port.new
+    Ractor.new(port, i) { |p, n| p << n; nil }.join
+    port
+  end
+  closed = Ractor::Port.new
+  closed.send(:a); closed.send(:b); closed.close
+  6.times { GC.start }
+  [taken.map(&:receive), [closed.receive, closed.receive]]
+}

--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -7113,7 +7113,7 @@ gc_marks_finish(rb_objspace_t *objspace)
     }
 
     // TODO: refactor so we don't need to call this
-    rb_ractor_finish_marking();
+    rb_ractor_finish_marking(is_full_marking(objspace));
 
     gc_event_hook(objspace, RUBY_INTERNAL_EVENT_GC_END_MARK);
 }
@@ -9065,7 +9065,7 @@ gc_start_global(rb_objspace_t *driver, unsigned int reason, bool compact, bool a
     /* This cycle's root pass over every Ractor has swept the deleted ractor-local keys out of
      * each storage.  Free the key structs while still inside the barrier (a local GC never
      * can; see rb_ractor_finish_marking). */
-    rb_ractor_finish_marking();
+    rb_ractor_finish_marking(true);
 
     gc_marking_exit(driver);
 

--- a/gc/gc.h
+++ b/gc/gc.h
@@ -133,7 +133,7 @@ MODULAR_GC_FN void rb_gc_print_backtrace();
 RUBY_SYMBOL_EXPORT_END
 #endif
 
-void rb_ractor_finish_marking(void);
+void rb_ractor_finish_marking(bool full_mark);
 
 // -------------------Private section begin------------------------
 // Functions in this section are private to the default GC and gc.c

--- a/ractor.c
+++ b/ractor.c
@@ -3671,7 +3671,7 @@ rb_ractor_local_storage_ptr_set(rb_ractor_local_key_t key, void *ptr)
 #define DEFAULT_KEYS_CAPA 0x10
 
 void
-rb_ractor_finish_marking(void)
+rb_ractor_finish_marking(bool full_mark)
 {
     /* A freed key's struct may only be released by a collection that purged every
      * Ractor's storage with no other marker running: a global GC, or a single objspace.
@@ -3684,6 +3684,8 @@ rb_ractor_finish_marking(void)
      * zombie_objspaces only marks the join slot): purge here, under the barrier, before
      * the struct is freed, or a later ractor_free reads a freed key. */
     rb_vm_t *vm = GET_VM();
+    rb_ractor_t *r;
+
     for (size_t zi = 0; zi < vm->gc.zombie_objspaces_count; zi++) {
         rb_ractor_t *owner = vm->gc.zombie_objspaces[zi].owner;
         if (owner == NULL || owner->local_storage == NULL) continue;
@@ -3697,6 +3699,16 @@ rb_ractor_finish_marking(void)
     if (freed_ractor_local_keys.capa > DEFAULT_KEYS_CAPA) {
         freed_ractor_local_keys.capa = DEFAULT_KEYS_CAPA;
         SIZED_REALLOC_N(freed_ractor_local_keys.keys, rb_ractor_local_key_t, DEFAULT_KEYS_CAPA, freed_ractor_local_keys.capa);
+    }
+
+    /* Under a minor mark an unmarked port is not a dead one. */
+    if (full_mark) {
+        ccan_list_for_each(&vm->ractor.set, r, vmlr_node) {
+            rb_ractor_reap_dead_ports(r);
+        }
+        if (vm->ractor.cnt == 0 && vm->ractor.main_ractor) {
+            rb_ractor_reap_dead_ports(vm->ractor.main_ractor);
+        }
     }
 }
 

--- a/ractor_core.h
+++ b/ractor_core.h
@@ -159,6 +159,7 @@ struct rb_ractor_struct {
 /* Mark the GC roots held in Ractor r's C structs (from the root scan in gc.c). */
 void rb_ractor_mark_local_roots(rb_ractor_t *r);
 void rb_ractor_mark_terminated_join_value(rb_ractor_t *r);
+void rb_ractor_reap_dead_ports(rb_ractor_t *r);
 
 /* Move src's registered_marks to dst and leave src empty (on join or when an orphan
  * is absorbed).  An absorb can run during a GC sweep, so the implementation uses raw
@@ -229,7 +230,7 @@ VALUE rb_ractor_ensure_shareable(VALUE obj, VALUE name);
 st_table *rb_ractor_targeted_hooks(rb_ractor_t *cr);
 
 RUBY_SYMBOL_EXPORT_BEGIN
-void rb_ractor_finish_marking(void);
+void rb_ractor_finish_marking(bool full_mark);
 
 bool rb_ractor_shareable_p_continue(VALUE obj);
 

--- a/ractor_sync.c
+++ b/ractor_sync.c
@@ -28,6 +28,8 @@ static void ractor_off_queue_remove(struct ractor_basket *b);
 void rb_ractor_courier_mark(struct rb_ractor_courier *c);
 struct rb_ractor_courier *rb_ractor_courier_build_copy(VALUE obj, struct rb_ractor_courier **slot);
 
+static void ractor_port_note_alive(const struct ractor_port *rp);
+
 static void
 ractor_port_mark(void *ptr)
 {
@@ -35,6 +37,13 @@ ractor_port_mark(void *ptr)
 
     if (rp->r) {
         rb_gc_mark(rp->r->pub.self);
+
+        /* Only a mark that covers every objspace can call a port dead.  Ask the single
+         * objspace first: it answers without the VM, which a GC worker thread cannot
+         * reach (mmtk marks from several of them). */
+        if (rb_gc_single_objspace_p() || rb_gc_during_global_gc_p()) {
+            ractor_port_note_alive(rp);
+        }
     }
 }
 
@@ -342,6 +351,7 @@ ractor_mark_off_queue_baskets(rb_ractor_t *r)
 struct ractor_queue {
     struct ccan_list_head set;
     bool closed;
+    bool alive;  /* its Ractor::Port is still reachable; see the reap below */
 };
 
 static void
@@ -349,6 +359,7 @@ ractor_queue_init(struct ractor_queue *rq)
 {
     ccan_list_head_init(&rq->set);
     rq->closed = false;
+    rq->alive = true;
 }
 
 static struct ractor_queue *
@@ -357,6 +368,19 @@ ractor_queue_new(void)
     struct ractor_queue *rq = ALLOC(struct ractor_queue);
     ractor_queue_init(rq);
     return rq;
+}
+
+static void
+ractor_port_note_alive(const struct ractor_port *rp)
+{
+    struct ractor_queue *rq;
+
+    if (rp->r->sync.ports && st_lookup(rp->r->sync.ports, rp->id_, (st_data_t *)&rq)) {
+        /* Several markers can reach the same port at once (mmtk marks from its GC worker
+         * threads), but they all store the same value and the reap reads it once marking
+         * is over. */
+        rq->alive = true;
+    }
 }
 
 static void
@@ -605,6 +629,32 @@ ractor_close_port(rb_execution_context_t *ec, rb_ractor_t *cr, const struct ract
     RACTOR_UNLOCK_SELF(cr);
 
     return rq != NULL;
+}
+
+/* A port is the only way to receive from its queue, so a queue whose port is gone is
+ * unreachable -- but the table is keyed by id, so no sweep finds it.  Mark and sweep the
+ * table itself: ractor_port_mark sets the flag, this clears it for the next cycle. */
+static int
+ractor_reap_dead_ports_i(st_data_t port_id, st_data_t val, st_data_t dat)
+{
+    struct ractor_queue *rq = (struct ractor_queue *)val;
+
+    if (rq->alive) {
+        rq->alive = false;
+        return ST_CONTINUE;
+    }
+    else {
+        ractor_queue_free(rq);
+        return ST_DELETE;
+    }
+}
+
+void
+rb_ractor_reap_dead_ports(rb_ractor_t *r)
+{
+    if (r->sync.ports) {
+        st_foreach(r->sync.ports, ractor_reap_dead_ports_i, 0);
+    }
 }
 
 static int

--- a/test/ruby/test_ractor.rb
+++ b/test/ruby/test_ractor.rb
@@ -794,4 +794,20 @@ class TestRactor < Test::Unit::TestCase
       assert_equal :ok, r.value
     RUBY
   end
+  def test_port_queue_dropped_when_port_unreachable
+    omit 'not fixed for mmtk: it never calls rb_ractor_finish_marking, where the reap runs' unless GC.config[:implementation] == 'default'
+    assert_ractor(<<~'RUBY')
+      200.times do
+        port = Ractor::Port.new
+        Ractor.new(port) { |p| p << Ractor::Port.new; nil }.join
+      end
+      8.times { GC.start }
+      # A dropped message holding a port used to root the sending Ractor, and with it
+      # that Ractor's whole objspace, for the life of the process: every one of the 200
+      # survived.  A few of the last still can -- the reap needs a second full mark, and
+      # a conservative stack scan holds whatever it holds -- so this is not exact.
+      assert_operator ObjectSpace.each_object(Ractor).count, :<, 20
+    RUBY
+  end
+
 end


### PR DESCRIPTION
A port's queue lives in the receiving Ractor's table keyed by the port id, so nothing ties it to the Ractor::Port object: when the port becomes unreachable the queue stays, and so does every message left in it.  Nobody can receive them -- receiving needs the port -- but they are still GC roots.

A message reaching a Ractor makes that permanent.  Port#<< of a port is the natural shape of a credit token, and a token nobody takes holds the sender's port, which marks the sender's Ractor object, which keeps its objspace in zombie_objspaces for the life of the process:

  20.times { feed = Ractor::Port.new
             Ractor.new(feed) { |f| f << Ractor::Port.new; nil }.join }
  5.times { GC.start }
  ObjectSpace.each_object(Ractor).count   # 21 before, 1 after

Mark and sweep the table itself.  ractor_port_mark notes the ids a reachable port still carries, and rb_ractor_finish_marking drops the queues nobody noted, which is where the ractor-local keys are already reaped for the same reason.  Both run only where an unmarked port really is dead: after a mark that covered every objspace -- a global GC or a full single-objspace one -- which is also when the world is stopped enough to read the table without the owner's lock.  Hence the new argument to rb_ractor_finish_marking: a minor mark leaves live old objects unmarked.

A queue starts named so that one created between its port being marked and the reap, which incremental marking allows, is not taken for an orphan.  It costs the queue one more cycle before it goes.

  2000 rounds, dropping one message each, KB of RSS retained per round:

    payload           before   after
    Integer            13.0     13.3
    Ractor::Port      leaks     14.3
    shareable 10KB     89.1     62.5

The last row is not retention: the payload is collected (0 of 500 strings survive), but the reap only runs in a global GC, so between two of them the dropped messages hold pages.  Collecting every 20 rounds instead brings it to 1.5 KB.

ractor-pipeline, which sends credit tokens this way, over 60 pipelines: 455MB growing by 5.6MB each to 272MB growing by 1.5MB, with the library unchanged.