### PR TITLE
[DOC] Correct wording and formatting issues in contributing documentation

### DIFF
--- a/doc/contributing/building_ruby.md
+++ b/doc/contributing/building_ruby.md
@@ -298,7 +298,7 @@ The compiled Ruby will now automatically crash with a report and a backtrace
 if ASAN detects a memory safety issue. To run Ruby's test suite under ASAN,
 issue the following command. Note that this will take quite a long time (over
 two hours on my laptop); the `RUBY_TEST_TIMEOUT_SCALE` and
-`SYNTAX_SUGEST_TIMEOUT` variables are required to make sure tests don't
+`SYNTAX_SUGGEST_TIMEOUT` variables are required to make sure tests don't
 spuriously fail with timeouts when in fact they're just slow.
 
 ```sh

--- a/doc/contributing/documentation_guide.md
+++ b/doc/contributing/documentation_guide.md
@@ -347,7 +347,7 @@ Alternatives:
     - Example {source}[https://github.com/ruby/ruby/blob/34d802f32f00df1ac0220b62f72605827c16bad8/file.c#L6570-L6596].
     - Corresponding {output}[rdoc-ref:File@ReadWrite+Mode].
 
-- (Markdown format only): A {Github Flavored Markdown (GFM) table}[https://github.github.com/gfm/#tables-extension-],
+- (Markdown format only): A {GitHub Flavored Markdown (GFM) table}[https://github.github.com/gfm/#tables-extension-],
   using special formatting for the text:
 
     - Example {source}[https://github.com/ruby/ruby/blob/34d802f32f00df1ac0220b62f72605827c16bad8/doc/contributing/glossary.md?plain=1].

--- a/doc/contributing/making_changes_to_ruby.md
+++ b/doc/contributing/making_changes_to_ruby.md
@@ -23,6 +23,6 @@ Use the following style for commit messages:
 
 ## CI
 
-GitHub actions will run on each pull request.
+GitHub Actions will run on each pull request.
 
 There is [a CI that runs on master](https://rubyci.org/). It has broad coverage of different systems and architectures, such as Solaris SPARC and macOS.


### PR DESCRIPTION
### description
- Fix the environmental variable `SYNTAX_SUGEST_TIMEOUT` into `SYNTAX_SUGGEST_TIMEOUT`
- Fix the incorrect capitalization of the proper noun. (Github ==> GitHub, GitHub actions ==> GitHub Actions)

### file changes
Original:
[doc/contributing/building_ruby.md](https://github.com/ruby/ruby/blob/master/doc/contributing/building_ruby.md)
[doc/contributing/documentation_guide.md](https://github.com/ruby/ruby/blob/master/doc/contributing/documentation_guide.md)
[doc/contributing/making_changes_to_ruby.md](https://github.com/ruby/ruby/blob/master/doc/contributing/making_changes_to_ruby.md)

### why
To correct typographical errors, improving overall project quality and preventing developer confusion.