### PR TITLE
Cache templates of the branch/method coverage results

### DIFF
--- a/ext/coverage/coverage.c
+++ b/ext/coverage/coverage.c
@@ -22,6 +22,25 @@ static VALUE cme2counter = Qnil;
 static VALUE me_set = Qnil;
 
 /*
+ * Method coverage result template:
+ *   method_tmpl_by_path: { path => { key => me or [me, ...] } }
+ * Each peek dups the per-path template and replaces the values with the
+ * call counts.  me_set and cme2counter are append-only and iterate in
+ * insertion order, so only the entries after the ones already seen are added.
+ */
+static VALUE method_tmpl_by_path = Qnil;
+static long method_tmpl_n_me_set = 0;
+static long method_tmpl_n_cme2counter = 0;
+
+static void
+method_template_reset(void)
+{
+    method_tmpl_by_path = Qnil;
+    method_tmpl_n_me_set = 0;
+    method_tmpl_n_cme2counter = 0;
+}
+
+/*
  *  call-seq: Coverage.supported?(mode) -> true or false
  *
  *  Returns true if coverage measurement is supported for the given mode.
@@ -120,6 +139,7 @@ rb_coverage_setup(int argc, VALUE *argv, VALUE klass)
         cme2counter = Qnil;
         me_set = Qnil;
     }
+    method_template_reset();
 
     coverages = rb_get_coverages();
     if (!RTEST(coverages)) {
@@ -305,30 +325,130 @@ branch_coverage(VALUE branches)
     return a.result;
 }
 
+struct method_template_add_arg {
+    long skip;
+    long i;
+    int check_me_set;   /* skip the entries in me_set (they are already added) */
+};
+
 static void
-method_coverage_i(const struct rb_coverage_method_data *method, void *data)
+method_template_add(VALUE me)
 {
-    VALUE ncoverages = *(VALUE *)data;
-    VALUE ncoverage = rb_hash_aref(ncoverages, method->path);
+    struct rb_coverage_method_data d;
+    VALUE tmpl, key, mes;
 
-    if (!NIL_P(ncoverage)) {
-        VALUE methods = rb_hash_aref(ncoverage, ID2SYM(rb_intern("methods")));
-        VALUE key = rb_ary_new_from_args(6, method->owner, method->method_id,
-                                         method->first_lineno, method->first_column,
-                                         method->last_lineno, method->last_column);
-        VALUE rcount = method->count;
-        VALUE previous = rb_hash_aref(methods, key);
+    if (!rb_coverage_method_data_of(me, Qnil, &d)) return;
 
-        if (NIL_P(rcount)) rcount = LONG2FIX(0);
-        if (NIL_P(previous)) previous = LONG2FIX(0);
-        if (!POSFIXABLE(FIX2LONG(rcount) + FIX2LONG(previous))) {
-            rcount = LONG2FIX(FIXNUM_MAX);
-        }
-        else {
-            rcount = LONG2FIX(FIX2LONG(rcount) + FIX2LONG(previous));
-        }
-        rb_hash_aset(methods, key, rcount);
+    tmpl = rb_hash_lookup(method_tmpl_by_path, d.path);
+    if (NIL_P(tmpl)) {
+        tmpl = rb_hash_new();
+        rb_hash_aset(method_tmpl_by_path, d.path, tmpl);
     }
+    key = rb_ary_new_from_args(6, d.owner, d.method_id,
+                               d.first_lineno, d.first_column,
+                               d.last_lineno, d.last_column);
+    rb_ary_freeze(key);
+    mes = rb_hash_lookup(tmpl, key);
+    if (NIL_P(mes)) {
+        rb_hash_aset(tmpl, key, me);
+    }
+    else if (RB_TYPE_P(mes, T_ARRAY)) {
+        rb_ary_push(mes, me);
+    }
+    else {
+        VALUE ary = rb_ary_hidden_new(2);
+        rb_ary_push(ary, mes);
+        rb_ary_push(ary, me);
+        rb_hash_aset(tmpl, key, ary);
+    }
+}
+
+static int
+method_template_add_i(VALUE me, VALUE value, VALUE data)
+{
+    struct method_template_add_arg *arg = (struct method_template_add_arg *)data;
+    if (arg->i++ >= arg->skip) {
+        if (arg->check_me_set && RTEST(rb_hash_lookup2(me_set, me, Qfalse))) return ST_CONTINUE;
+        method_template_add(me);
+    }
+    return ST_CONTINUE;
+}
+
+static void
+method_template_update(void)
+{
+    struct method_template_add_arg arg;
+
+    if (NIL_P(method_tmpl_by_path)) {
+        method_tmpl_by_path = rb_hash_new();
+        method_tmpl_n_me_set = 0;
+        method_tmpl_n_cme2counter = 0;
+    }
+    if (RTEST(me_set) && RHASH_SIZE(me_set) > (size_t)method_tmpl_n_me_set) {
+        arg.skip = method_tmpl_n_me_set;
+        arg.i = 0;
+        arg.check_me_set = 0;
+        rb_hash_foreach(me_set, method_template_add_i, (VALUE)&arg);
+        method_tmpl_n_me_set = arg.i;
+    }
+    if (RTEST(cme2counter) && RHASH_SIZE(cme2counter) > (size_t)method_tmpl_n_cme2counter) {
+        arg.skip = method_tmpl_n_cme2counter;
+        arg.i = 0;
+        arg.check_me_set = RTEST(me_set);
+        rb_hash_foreach(cme2counter, method_template_add_i, (VALUE)&arg);
+        method_tmpl_n_cme2counter = arg.i;
+    }
+}
+
+static int
+method_fill_check(st_data_t key, st_data_t value, st_data_t argp, int error)
+{
+    return ST_REPLACE;
+}
+
+static long
+method_call_count(VALUE me)
+{
+    VALUE c = rb_hash_lookup2(cme2counter, me, Qnil);
+    return FIXNUM_P(c) ? FIX2LONG(c) : 0;
+}
+
+/* methods: {key => me or [me, ...]} -> {key => count}, where count is the
+ * sum of the call counts of all the method entries sharing the key
+ * (methods redefined at the same location) */
+static int
+method_fill_count(st_data_t *key, st_data_t *value, st_data_t argp, int existing)
+{
+    VALUE mes = (VALUE)*value;
+    long count;
+    if (RB_TYPE_P(mes, T_ARRAY)) {
+        long i;
+        count = 0;
+        for (i = 0; i < RARRAY_LEN(mes); i++) {
+            count += method_call_count(RARRAY_AREF(mes, i));
+            if (!POSFIXABLE(count)) count = FIXNUM_MAX;
+        }
+    }
+    else {
+        count = method_call_count(mes);
+    }
+    *value = (st_data_t)LONG2FIX(count);
+    return ST_CONTINUE;
+}
+
+static VALUE
+method_coverage(VALUE path)
+{
+    VALUE tmpl = rb_hash_lookup(method_tmpl_by_path, path);
+    VALUE methods;
+    if (NIL_P(tmpl)) {
+        methods = rb_hash_new();
+    }
+    else {
+        methods = rb_hash_dup(tmpl);
+        rb_hash_stlike_foreach_with_replace(methods, method_fill_check, method_fill_count, 0);
+    }
+    return methods;
 }
 
 static int
@@ -360,7 +480,7 @@ coverage_peek_result_i(st_data_t key, st_data_t val, st_data_t h)
         }
 
         if (current_mode & COVERAGE_TARGET_METHODS) {
-            rb_hash_aset(h, ID2SYM(rb_intern("methods")), rb_hash_new());
+            rb_hash_aset(h, ID2SYM(rb_intern("methods")), method_coverage(path));
         }
 
         coverage = h;
@@ -391,11 +511,10 @@ rb_coverage_peek_result(VALUE klass)
         rb_raise(rb_eRuntimeError, "coverage measurement is not enabled");
     }
 
-    rb_hash_foreach(coverages, coverage_peek_result_i, ncoverages);
-
     if (current_mode & COVERAGE_TARGET_METHODS) {
-        rb_coverage_each_method(method_coverage_i, &ncoverages);
+        method_template_update();
     }
+    rb_hash_foreach(coverages, coverage_peek_result_i, ncoverages);
 
     rb_hash_freeze(ncoverages);
     return ncoverages;
@@ -472,6 +591,7 @@ rb_coverage_result(int argc, VALUE *argv, VALUE klass)
         rb_reset_coverages();
         cme2counter = Qnil;
         me_set = Qnil;
+        method_template_reset();
         current_state = IDLE;
     }
     return ncoverages;
@@ -737,4 +857,5 @@ Init_coverage(void)
     rb_define_module_function(rb_mCoverage, "running?", rb_coverage_running, 0);
     rb_global_variable(&cme2counter);
     rb_global_variable(&me_set);
+    rb_global_variable(&method_tmpl_by_path);
 }

--- a/ext/coverage/coverage.c
+++ b/ext/coverage/coverage.c
@@ -186,11 +186,16 @@ struct branch_coverage_result_builder
     int id;
     VALUE result;
     VALUE children;
-    VALUE counters;
 };
 
+/*
+ * Branch coverage result template, cached in branches[2]:
+ *   { base_key => { target_key => counter_index } }
+ * Each peek dups it and replaces the indexes with the counters, which avoids
+ * hashing the array keys again and again.
+ */
 static int
-branch_coverage_ii(VALUE _key, VALUE branch, VALUE v)
+branch_template_ii(VALUE _key, VALUE branch, VALUE v)
 {
     struct branch_coverage_result_builder *b = (struct branch_coverage_result_builder *) v;
 
@@ -199,14 +204,16 @@ branch_coverage_ii(VALUE _key, VALUE branch, VALUE v)
     VALUE target_first_column = RARRAY_AREF(branch, 2);
     VALUE target_last_lineno = RARRAY_AREF(branch, 3);
     VALUE target_last_column = RARRAY_AREF(branch, 4);
-    long counter_idx = FIX2LONG(RARRAY_AREF(branch, 5));
-    rb_hash_aset(b->children, rb_ary_new_from_args(6, target_label, LONG2FIX(b->id++), target_first_lineno, target_first_column, target_last_lineno, target_last_column), RARRAY_AREF(b->counters, counter_idx));
+    VALUE counter_idx = RARRAY_AREF(branch, 5);
+    VALUE key = rb_ary_new_from_args(6, target_label, LONG2FIX(b->id++), target_first_lineno, target_first_column, target_last_lineno, target_last_column);
+    rb_ary_freeze(key);
+    rb_hash_aset(b->children, key, counter_idx);
 
     return ST_CONTINUE;
 }
 
 static int
-branch_coverage_i(VALUE _key, VALUE branch_base, VALUE v)
+branch_template_i(VALUE _key, VALUE branch_base, VALUE v)
 {
     struct branch_coverage_result_builder *b = (struct branch_coverage_result_builder *) v;
 
@@ -217,26 +224,85 @@ branch_coverage_i(VALUE _key, VALUE branch_base, VALUE v)
     VALUE base_last_column = RARRAY_AREF(branch_base, 4);
     VALUE branches = RARRAY_AREF(branch_base, 5);
     VALUE children = rb_hash_new();
-    rb_hash_aset(b->result, rb_ary_new_from_args(6, base_type, LONG2FIX(b->id++), base_first_lineno, base_first_column, base_last_lineno, base_last_column), children);
+    VALUE key = rb_ary_new_from_args(6, base_type, LONG2FIX(b->id++), base_first_lineno, base_first_column, base_last_lineno, base_last_column);
+    rb_ary_freeze(key);
+    rb_hash_aset(b->result, key, children);
     b->children = children;
-    rb_hash_foreach(branches, branch_coverage_ii, v);
+    rb_hash_foreach(branches, branch_template_ii, v);
 
+    return ST_CONTINUE;
+}
+
+/* returns [template, nbases, ntargets] */
+static VALUE
+branch_template(VALUE branches)
+{
+    VALUE structure = RARRAY_AREF(branches, 0);
+    VALUE counters = RARRAY_AREF(branches, 1);
+    long nbases = RHASH_SIZE(structure);
+    long ntargets = RARRAY_LEN(counters);
+    VALUE cache = RARRAY_LEN(branches) > 2 ? RARRAY_AREF(branches, 2) : Qnil;
+
+    if (!NIL_P(cache) &&
+        FIX2LONG(RARRAY_AREF(cache, 1)) == nbases &&
+        FIX2LONG(RARRAY_AREF(cache, 2)) == ntargets) {
+        return RARRAY_AREF(cache, 0);
+    }
+    else {
+        struct branch_coverage_result_builder b;
+        b.id = 0;
+        b.result = rb_hash_new();
+        rb_hash_foreach(structure, branch_template_i, (VALUE)&b);
+        cache = rb_ary_hidden_new(3);
+        rb_ary_push(cache, b.result);
+        rb_ary_push(cache, LONG2FIX(nbases));
+        rb_ary_push(cache, LONG2FIX(ntargets));
+        rb_ary_store(branches, 2, cache);
+        return b.result;
+    }
+}
+
+static int
+branch_fill_check(st_data_t key, st_data_t value, st_data_t argp, int error)
+{
+    return ST_REPLACE;
+}
+
+/* children: {target_key => counter_index} -> {target_key => counter} */
+static int
+branch_fill_counter(st_data_t *key, st_data_t *value, st_data_t argp, int existing)
+{
+    VALUE counters = (VALUE)argp;
+    *value = (st_data_t)RARRAY_AREF(counters, FIX2LONG((VALUE)*value));
+    return ST_CONTINUE;
+}
+
+struct branch_fill_arg
+{
+    VALUE result;
+    VALUE counters;
+};
+
+/* result: {base_key => children_template} -> {base_key => filled copy of children} */
+static int
+branch_fill_children(st_data_t *key, st_data_t *value, st_data_t argp, int existing)
+{
+    struct branch_fill_arg *a = (struct branch_fill_arg *)argp;
+    VALUE children = rb_hash_dup((VALUE)*value);
+    rb_hash_stlike_foreach_with_replace(children, branch_fill_check, branch_fill_counter, (st_data_t)a->counters);
+    RB_OBJ_WRITE(a->result, value, children);
     return ST_CONTINUE;
 }
 
 static VALUE
 branch_coverage(VALUE branches)
 {
-    VALUE structure = RARRAY_AREF(branches, 0);
-
-    struct branch_coverage_result_builder b;
-    b.id = 0;
-    b.result = rb_hash_new();
-    b.counters = RARRAY_AREF(branches, 1);
-
-    rb_hash_foreach(structure, branch_coverage_i, (VALUE)&b);
-
-    return b.result;
+    struct branch_fill_arg a;
+    VALUE template = branch_template(branches);
+    a.counters = RARRAY_AREF(branches, 1);
+    a.result = rb_hash_dup(template);
+    rb_hash_stlike_foreach_with_replace(a.result, branch_fill_check, branch_fill_children, (st_data_t)&a);
+    return a.result;
 }
 
 static void

--- a/internal/coverage.h
+++ b/internal/coverage.h
@@ -41,6 +41,7 @@ void rb_reset_coverages(void);
 void rb_resume_coverages(void);
 void rb_suspend_coverages(void);
 void rb_coverage_each_method(rb_coverage_method_callback callback, void *data);
+bool rb_coverage_method_data_of(VALUE me, VALUE count, struct rb_coverage_method_data *out);
 
 RUBY_SYMBOL_EXPORT_END
 

--- a/internal/hash.h
+++ b/internal/hash.h
@@ -84,7 +84,6 @@ VALUE rb_hash_rehash(VALUE hash);
 int rb_hash_add_new_element(VALUE hash, VALUE key, VALUE val);
 VALUE rb_hash_set_pair(VALUE hash, VALUE pair);
 int rb_hash_stlike_delete(VALUE hash, st_data_t *pkey, st_data_t *pval);
-int rb_hash_stlike_foreach_with_replace(VALUE hash, st_foreach_check_callback_func *func, st_update_callback_func *replace, st_data_t arg);
 int rb_hash_stlike_update(VALUE hash, st_data_t key, st_update_callback_func *func, st_data_t arg);
 bool rb_hash_default_unredefined(VALUE hash);
 VALUE rb_hash_alloc_fixed_size(VALUE klass, st_index_t size);
@@ -108,6 +107,7 @@ RUBY_SYMBOL_EXPORT_BEGIN
 VALUE rb_hash_delete_entry(VALUE hash, VALUE key);
 VALUE rb_ident_hash_new(void);
 int rb_hash_stlike_foreach(VALUE hash, st_foreach_callback_func *func, st_data_t arg);
+int rb_hash_stlike_foreach_with_replace(VALUE hash, st_foreach_check_callback_func *func, st_update_callback_func *replace, st_data_t arg);
 RUBY_SYMBOL_EXPORT_END
 
 VALUE rb_hash_new_with_bulk_insert(long argc, const VALUE *argv);

--- a/test/coverage/test_coverage.rb
+++ b/test/coverage/test_coverage.rb
@@ -320,6 +320,46 @@ def test_branch_coverage_for_eval_repeated
     end;
   end
 
+  def test_peek_result_methods_after_eval_adds_methods
+    assert_in_out_err(["-W0", *ARGV], <<-"end;", ["1", "2", "1", "3", "1", "false"], [])
+      Coverage.start(eval: true, methods: true)
+
+      eval(<<-RUBY, TOPLEVEL_BINDING, "test.rb", 1)
+      class Foo
+        def foo; end
+      end
+      RUBY
+
+      Foo.new.foo
+      r1 = Coverage.peek_result["test.rb"][:methods]
+      p r1.size
+
+      # A later eval with the same path adds new methods to the same file,
+      # and redefining a method at the same location shares the key
+      eval(<<-RUBY, TOPLEVEL_BINDING, "test.rb", 10)
+      class Foo
+        def bar; end
+      end
+      RUBY
+      eval(<<-RUBY, TOPLEVEL_BINDING, "test.rb", 1)
+      class Foo
+        def foo; end
+      end
+      RUBY
+
+      Foo.new.foo
+      Foo.new.foo
+      Foo.new.bar
+      r2 = Coverage.peek_result["test.rb"][:methods]
+      p r2.size
+      # the earlier snapshot must not be affected
+      p r1.size
+      p r2[[Foo, :foo, 2, 8, 2, 20]]
+      p r2[[Foo, :bar, 11, 8, 11, 20]]
+      p r1.equal?(r2)
+    end;
+  end
+
   def test_eval_negative_lineno
     assert_in_out_err(ARGV, <<-"end;", ["[1, 1, 1]"], [])
       Coverage.start(eval: true, lines: true)

--- a/test/coverage/test_coverage.rb
+++ b/test/coverage/test_coverage.rb
@@ -256,7 +256,7 @@ class TestCoverage < Test::Unit::TestCase
     end;
   end
 
-  def test_branch_coverage_for_eval_repeated
+def test_branch_coverage_for_eval_repeated
     assert_in_out_err(["-W0", *ARGV], <<-"end;", ["2", "2", "[[0, 1], [0, 2]]"], [])
       Coverage.start(eval: true, branches: true)
 
@@ -281,6 +281,42 @@ class TestCoverage < Test::Unit::TestCase
       r = Coverage.peek_result["test.rb"][:branches]
       p r.size
       p r.values.map {|targets| targets.values.sort }.sort
+    end;
+  end
+
+  def test_peek_result_branches_after_eval_adds_branches
+    assert_in_out_err(ARGV, <<-"end;", ["1", "1", "2", "3", "1", "false"], [])
+      Coverage.start(eval: true, branches: true)
+
+      sum = ->(r) { r.sum {|_, targets| targets.sum {|_, count| count } } }
+
+      eval(<<-RUBY, TOPLEVEL_BINDING, "test.rb", 1)
+      def foo(x)
+        x ? 1 : 2
+      end
+      RUBY
+
+      foo(true)
+      r1 = Coverage.peek_result["test.rb"][:branches]
+      p r1.size
+      p sum[r1]
+
+      # A later eval with the same path adds new branches to the same file,
+      # and the cached result template must be refreshed accordingly
+      eval(<<-RUBY, TOPLEVEL_BINDING, "test.rb", 10)
+      def bar(x)
+        x ? 1 : 2
+      end
+      RUBY
+
+      foo(true)
+      bar(false)
+      r2 = Coverage.peek_result["test.rb"][:branches]
+      p r2.size
+      p sum[r2]
+      # the earlier snapshot must not be affected
+      p sum[r1]
+      p r1.equal?(r2)
     end;
   end
 

--- a/thread.c
+++ b/thread.c
@@ -6274,27 +6274,38 @@ struct method_coverage_arg {
     void *data;
 };
 
-static void
-method_coverage_call(const rb_method_entry_t *me, VALUE count,
-                     struct method_coverage_arg *arg)
+/* Fills *out for the method entry `me_v` and returns true, or returns false
+ * if the method entry is not a subject of method coverage (aliases,
+ * complemented entries, and methods without a source location). */
+bool
+rb_coverage_method_data_of(VALUE me_v, VALUE count, struct rb_coverage_method_data *out)
 {
+    const rb_method_entry_t *me = (const rb_method_entry_t *)me_v;
     VALUE location[5];
     const rb_method_entry_t *resolved_me = rb_resolve_me_location(me, location);
 
     if (me != resolved_me || RB_TYPE_P(me->owner, T_ICLASS) ||
-        FIX2LONG(location[1]) <= 0) return;
+        FIX2LONG(location[1]) <= 0) return false;
 
-    struct rb_coverage_method_data method = {
-        .owner = me->owner,
-        .method_id = ID2SYM(me->def->original_id),
-        .path = location[0],
-        .first_lineno = location[1],
-        .first_column = location[2],
-        .last_lineno = location[3],
-        .last_column = location[4],
-        .count = count,
-    };
-    arg->callback(&method, arg->data);
+    out->owner = me->owner;
+    out->method_id = ID2SYM(me->def->original_id);
+    out->path = location[0];
+    out->first_lineno = location[1];
+    out->first_column = location[2];
+    out->last_lineno = location[3];
+    out->last_column = location[4];
+    out->count = count;
+    return true;
+}
+
+static void
+method_coverage_call(const rb_method_entry_t *me, VALUE count,
+                     struct method_coverage_arg *arg)
+{
+    struct rb_coverage_method_data method;
+    if (rb_coverage_method_data_of((VALUE)me, count, &method)) {
+        arg->callback(&method, arg->data);
+    }
 }
 
 static int


### PR DESCRIPTION
`Coverage.peek_result` rebuilds the branch and method coverage results on every call, and hashing their array keys dominates the cost. SimpleCov wants to call `peek_result` around every test ([Bug #22250]), so this is paid thousands of times per run.

Build a template of each result once (branch structures are immutable; `me_set`/`cme2counter` are append-only), and let each peek just dup it and fill in the counters without rehashing the keys.

* 40k branch sites: 40 ms -> 3.5 ms per peek
* 10k methods: 24 ms -> 0.7 ms per peek
* rack's test suite with SimpleCov's per-test tracking: 30 s -> 8.4 s

The results are identical; the key arrays are now frozen and shared.