### PR TITLE
Raise subprocess timeout in TestArgf#test_inplace_bug_17117

### DIFF
--- a/test/ruby/test_argf.rb
+++ b/test/ruby/test_argf.rb
@@ -383,7 +383,7 @@ class TestArgf < Test::Unit::TestCase
   end
 
   def test_inplace_bug_17117
-    assert_in_out_err(["-", @t1.path], "#{<<~"{#"}#{<<~'};'}")
+    assert_in_out_err(["-", @t1.path], "#{<<~"{#"}#{<<~'};'}", timeout: 60)
     {#
       #!/usr/bin/ruby -pi.bak
       BEGIN {


### PR DESCRIPTION
`TestArgf#test_inplace_bug_17117` timed out on the macOS `--repeat-count=2` job: https://github.com/ruby/ruby/actions/runs/32345364008/job/96352871123. The subprocess allocates one million strings to reproduce the `ARGF.inplace` corruption from [Bug #17117], which normally finishes well under a second but can exceed the default 10 second limit (scaled to 100 seconds on that job) when the runner is overloaded at the end of a `test-all` run. The same test is already excluded on MMTk debug builds for timing out. This raises the timeout for this test to 60 seconds.

[Bug #17117]: https://bugs.ruby-lang.org/issues/17117
