### PR TITLE
Keep the original PATH in the EnvUtil.find_executable test

### DIFF
--- a/tool/test/test_find_executable.rb
+++ b/tool/test/test_find_executable.rb
@@ -9,7 +9,7 @@ class TestFindExecutable < Test::Unit::TestCase
     ruby = RbConfig.ruby
     command = File.basename(ruby, RbConfig::CONFIG["EXEEXT"])
     original_path = ENV["PATH"]
-    ENV["PATH"] = File.dirname(ruby)
+    ENV["PATH"] = File.dirname(ruby) + File::PATH_SEPARATOR + original_path
 
     found = EnvUtil.find_executable(command, "--version") do |output|
       output.start_with?("ruby ")


### PR DESCRIPTION
MinGW (UCRT64) CI on `master` has been failing since b02fceb08e added `tool/test/test_find_executable.rb`. The test replaces `PATH` with only the build directory before spawning `ruby.exe --version`. On MSYS2 UCRT64 the ruby DLL links the shared `libgmp-10.dll`, which the Windows DLL loader resolves via `PATH`, so the child process fails to start and `EnvUtil.find_executable` returns nil. CLANGARM64 passes because gmp is not detected there. Prepend the build directory to the original `PATH` instead. `EnvUtil.find_executable` scans `PATH` entries in order, so the build ruby is still found first.
