### PR TITLE
Use stable keys for the branch coverage structure

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -628,17 +628,28 @@ setup_branch(const rb_code_location_t *loc, const char *type, VALUE structure, V
 }
 
 static VALUE
-decl_branch_base(rb_iseq_t *iseq, VALUE key, const rb_code_location_t *loc, const char *type)
+decl_branch_base(rb_iseq_t *iseq, int node_id, const rb_code_location_t *loc, const char *type)
 {
     if (!branch_coverage_valid_p(iseq, loc->beg_pos.lineno)) return Qundef;
 
     /*
-     * if !structure[node]
-     *   structure[node] = [type, first_lineno, first_column, last_lineno, last_column, branches = {}]
+     * A branch base is keyed by [source_hash (in two halves), node_id, first_lineno],
+     * which identifies the branch node stably even across (re-)evals against
+     * the same path.
+     *
+     * if !structure[key]
+     *   structure[key] = [type, first_lineno, first_column, last_lineno, last_column, branches = {}]
      * else
-     *   branches = structure[node][5]
+     *   branches = structure[key][5]
      * end
      */
+    uint64_t source_hash = ISEQ_BODY(iseq)->source_hash;
+    VALUE key = rb_ary_new_from_args(4,
+        ULONG2NUM((unsigned long)(source_hash >> 32)),
+        ULONG2NUM((unsigned long)(source_hash & 0xffffffff)),
+        INT2FIX(node_id),
+        INT2FIX(loc->beg_pos.lineno));
+    rb_ary_freeze(key);
 
     VALUE structure = RARRAY_AREF(ISEQ_BRANCH_COVERAGE(iseq), 0);
     VALUE branch_base = rb_hash_aref(structure, key);
@@ -7082,7 +7093,7 @@ compile_if(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, int 
     ADD_SEQ(ret, cond_seq);
 
     if (then_label->refcnt && else_label->refcnt) {
-        branches = decl_branch_base(iseq, PTR2NUM(node), nd_code_loc(node), type == NODE_IF ? "if" : "unless");
+        branches = decl_branch_base(iseq, nd_node_id(node), nd_code_loc(node), type == NODE_IF ? "if" : "unless");
     }
 
     if (then_label->refcnt) {
@@ -7162,7 +7173,7 @@ compile_case(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const orig_nod
 
     CHECK(COMPILE(head, "case base", RNODE_CASE(node)->nd_head));
 
-    branches = decl_branch_base(iseq, PTR2NUM(node), nd_code_loc(node), "case");
+    branches = decl_branch_base(iseq, nd_node_id(node), nd_code_loc(node), "case");
 
     node = RNODE_CASE(node)->nd_body;
     EXPECT_NODE("NODE_CASE", node, NODE_WHEN, COMPILE_NG);
@@ -7267,7 +7278,7 @@ compile_case2(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const orig_no
     VALUE branches = Qfalse;
     int branch_id = 0;
 
-    branches = decl_branch_base(iseq, PTR2NUM(orig_node), nd_code_loc(orig_node), "case");
+    branches = decl_branch_base(iseq, nd_node_id(orig_node), nd_code_loc(orig_node), "case");
 
     INIT_ANCHOR(body_seq);
     endlabel = NEW_LABEL(nd_line(node));
@@ -8266,7 +8277,7 @@ compile_case3(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const orig_no
     INIT_ANCHOR(body_seq);
     INIT_ANCHOR(cond_seq);
 
-    branches = decl_branch_base(iseq, PTR2NUM(node), nd_code_loc(node), "case");
+    branches = decl_branch_base(iseq, nd_node_id(node), nd_code_loc(node), "case");
 
     node = RNODE_CASE3(node)->nd_body;
     EXPECT_NODE("NODE_CASE3", node, NODE_IN, COMPILE_NG);
@@ -8470,7 +8481,7 @@ compile_loop(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, in
     if (tmp_label) ADD_LABEL(ret, tmp_label);
 
     ADD_LABEL(ret, redo_label);
-    branches = decl_branch_base(iseq, PTR2NUM(node), nd_code_loc(node), type == NODE_WHILE ? "while" : "until");
+    branches = decl_branch_base(iseq, nd_node_id(node), nd_code_loc(node), type == NODE_WHILE ? "while" : "until");
 
     const NODE *const coverage_node = RNODE_WHILE(node)->nd_body ? RNODE_WHILE(node)->nd_body : node;
     add_trace_branch_coverage(
@@ -9113,7 +9124,7 @@ qcall_branch_start(rb_iseq_t *iseq, LINK_ANCHOR *const recv, VALUE *branches, co
     LABEL *else_label = NEW_LABEL(nd_line(line_node));
     VALUE br = 0;
 
-    br = decl_branch_base(iseq, PTR2NUM(node), nd_code_loc(node), "&.");
+    br = decl_branch_base(iseq, nd_node_id(node), nd_code_loc(node), "&.");
     *branches = br;
     ADD_INSN(recv, line_node, dup);
     ADD_INSNL(recv, line_node, branchnil, else_label);

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -1148,7 +1148,7 @@ pm_compile_conditional(rb_iseq_t *iseq, const pm_node_location_t *node_location,
 
     if (then_label->refcnt && else_label->refcnt && PM_BRANCH_COVERAGE_P(iseq)) {
         conditional_location = pm_code_location(scope_node, node);
-        branches = decl_branch_base(iseq, PTR2NUM(node), &conditional_location, type == PM_IF_NODE ? "if" : "unless");
+        branches = decl_branch_base(iseq, (int) node->node_id, &conditional_location, type == PM_IF_NODE ? "if" : "unless");
     }
 
     if (then_label->refcnt) {
@@ -1278,7 +1278,7 @@ pm_compile_loop(rb_iseq_t *iseq, const pm_node_location_t *node_location, pm_nod
     // Establish branch coverage for the loop.
     if (PM_BRANCH_COVERAGE_P(iseq)) {
         rb_code_location_t loop_location = pm_code_location(scope_node, node);
-        VALUE branches = decl_branch_base(iseq, PTR2NUM(node), &loop_location, type == PM_WHILE_NODE ? "while" : "until");
+        VALUE branches = decl_branch_base(iseq, (int) node->node_id, &loop_location, type == PM_WHILE_NODE ? "while" : "until");
 
         rb_code_location_t branch_location = statements != NULL ? pm_code_location(scope_node, (const pm_node_t *) statements) : loop_location;
         add_trace_branch_coverage(iseq, ret, &branch_location, branch_location.beg_pos.column, 0, "body", branches);
@@ -3789,7 +3789,7 @@ pm_compile_call(rb_iseq_t *iseq, const pm_call_node_t *call_node, LINK_ANCHOR *c
                 .end_pos = { .lineno = end_location.line, .column = end_location.column }
             };
 
-            branches = decl_branch_base(iseq, PTR2NUM(call_node), &code_location, "&.");
+            branches = decl_branch_base(iseq, (int) call_node->base.node_id, &code_location, "&.");
         }
 
         PUSH_INSN(ret, location, dup);
@@ -7640,7 +7640,7 @@ pm_compile_case_node(rb_iseq_t *iseq, const pm_case_node_t *cast, const pm_node_
 
         if (PM_BRANCH_COVERAGE_P(iseq)) {
             case_location = pm_code_location(scope_node, (const pm_node_t *) cast);
-            branches = decl_branch_base(iseq, PTR2NUM(cast), &case_location, "case");
+            branches = decl_branch_base(iseq, (int) cast->base.node_id, &case_location, "case");
         }
 
         // Loop through each clauses in the case node and compile each of
@@ -7727,7 +7727,7 @@ pm_compile_case_node(rb_iseq_t *iseq, const pm_case_node_t *cast, const pm_node_
 
         if (PM_BRANCH_COVERAGE_P(iseq)) {
             case_location = pm_code_location(scope_node, (const pm_node_t *) cast);
-            branches = decl_branch_base(iseq, PTR2NUM(cast), &case_location, "case");
+            branches = decl_branch_base(iseq, (int) cast->base.node_id, &case_location, "case");
         }
 
         // This is the label where everything will fall into if none of the
@@ -7899,7 +7899,7 @@ pm_compile_case_match_node(rb_iseq_t *iseq, const pm_case_match_node_t *node, co
 
     if (PM_BRANCH_COVERAGE_P(iseq)) {
         case_location = pm_code_location(scope_node, (const pm_node_t *) node);
-        branches = decl_branch_base(iseq, PTR2NUM(node), &case_location, "case");
+        branches = decl_branch_base(iseq, (int) node->base.node_id, &case_location, "case");
     }
 
     // If there is only one pattern, then the behavior changes a bit. It

--- a/test/coverage/test_coverage.rb
+++ b/test/coverage/test_coverage.rb
@@ -256,6 +256,34 @@ class TestCoverage < Test::Unit::TestCase
     end;
   end
 
+  def test_branch_coverage_for_eval_repeated
+    assert_in_out_err(["-W0", *ARGV], <<-"end;", ["2", "2", "[[0, 1], [0, 2]]"], [])
+      Coverage.start(eval: true, branches: true)
+
+      code = <<-RUBY
+      def foo(x)
+        x ? 1 : 2
+      end
+      RUBY
+
+      # Evaluating different code at the same path yields separate entries
+      eval(code, TOPLEVEL_BINDING, "test.rb", 1)
+      eval(code.sub("foo", "bar"), TOPLEVEL_BINDING, "test.rb", 10)
+      foo(true)
+      r = Coverage.peek_result["test.rb"][:branches]
+      p r.size
+
+      # Re-evaluating the very same code accumulates the counters instead of
+      # adding duplicated entries
+      eval(code, TOPLEVEL_BINDING, "test.rb", 1)
+      foo(true)
+      bar(false)
+      r = Coverage.peek_result["test.rb"][:branches]
+      p r.size
+      p r.values.map {|targets| targets.values.sort }.sort
+    end;
+  end
+
   def test_eval_negative_lineno
     assert_in_out_err(ARGV, <<-"end;", ["[1, 1, 1]"], [])
       Coverage.start(eval: true, lines: true)

--- a/thread.c
+++ b/thread.c
@@ -6443,7 +6443,7 @@ rb_default_coverage(int n)
         branches = rb_ary_hidden_new_fill(2);
         /* internal data structures for branch coverage:
          *
-         * { branch base node =>
+         * { branch base key (see decl_branch_base) =>
          *     [base_type, base_first_lineno, base_first_column, base_last_lineno, base_last_column, {
          *       branch target id =>
          *         [target_type, target_first_lineno, target_first_column, target_last_lineno, target_last_column, target_counter_index],
@@ -6453,10 +6453,10 @@ rb_default_coverage(int n)
          * }
          *
          * Example:
-         * { NODE_CASE =>
+         * { [source_hash, node_id, lineno] =>
          *     [1, 0, 4, 3, {
-         *       NODE_WHEN => [2, 8, 2, 9, 0],
-         *       NODE_WHEN => [3, 8, 3, 9, 1],
+         *       0 => [2, 8, 2, 9, 0],
+         *       1 => [3, 8, 3, 9, 1],
          *       ...
          *     }],
          *   ...


### PR DESCRIPTION
The branch coverage structure was keyed by the address of the AST node, which is needed to let multiple compilations of the same node (e.g., an ensure clause) share one entry [Bug #16967].  However, ASTs are freed after compilation, so when code is eval'ed against the same path, a reused node address could merge unrelated branches into one entry, nondeterministically.

Key the structure by [source_hash, node_id, first_lineno] instead. This is deterministic: different code eval'ed at the same path always gets separate entries, and re-evaluating the very same code at the same path and line accumulates the counters, like line coverage does.