### PR TITLE
ZJIT: Let ruby-bench CI show Rust backtraces

### DIFF
--- a/.github/workflows/zjit-macos.yml
+++ b/.github/workflows/zjit-macos.yml
@@ -30,6 +30,8 @@ env:
   # Work around transient crates.io download failures (curl HTTP/2 framing / partial transfer)
   CARGO_NET_RETRY: 10
   CARGO_HTTP_MULTIPLEXING: false
+  RUST_BACKTRACE: 1
+  ZJIT_RB_BUG: 1
 
 jobs:
   make:
@@ -60,8 +62,6 @@ jobs:
       RUN_OPTS: ${{ matrix.run_opts }}
       SPECOPTS: ${{ matrix.specopts }} -B../src/spec/zjit.mspec
       TESTOPTS: ${{ matrix.testopts }}
-      RUST_BACKTRACE: 1
-      ZJIT_RB_BUG: 1
 
     runs-on: macos-26
 

--- a/.github/workflows/zjit-ubuntu.yml
+++ b/.github/workflows/zjit-ubuntu.yml
@@ -30,6 +30,8 @@ env:
   # Work around transient crates.io download failures (curl HTTP/2 framing / partial transfer)
   CARGO_NET_RETRY: 10
   CARGO_HTTP_MULTIPLEXING: false
+  RUST_BACKTRACE: 1
+  ZJIT_RB_BUG: 1
 
 jobs:
   lint:
@@ -125,8 +127,6 @@ jobs:
       TESTOPTS: ${{ matrix.testopts }}
       RUBY_DEBUG: ci
       BUNDLE_JOBS: 8 # for yjit-bench
-      RUST_BACKTRACE: 1
-      ZJIT_RB_BUG: 1
 
     runs-on: ${{ matrix.runs-on || 'ubuntu-22.04' }}
 


### PR DESCRIPTION
Move `RUST_BACKTRACE=1` and `ZJIT_RB_BUG=1` from `make`'s env to workflow-global env.

When a ruby-bench job panics in Rust, because it uses `--enable-zjit=dev_nodebug`, it doesn't show a Rust backtrace. That job should also have `RUST_BACKTRACE=1` to make sure we can see one on CI logs.