### PR TITLE
Reduce memory for proc objects

### DIFF
--- a/proc.c
+++ b/proc.c
@@ -309,7 +309,7 @@ rb_proc_refinements_recipe(VALUE procval)
 {
     rb_proc_t *proc;
     GetProcPtr(procval, proc);
-    if (!proc->is_refined) return Qnil;
+    if (!proc->header.is_refined) return Qnil;
     return rb_ivar_get(procval, id_refinements_recipe);
 }
 
@@ -319,7 +319,7 @@ rb_proc_set_refinements_recipe(VALUE procval, VALUE recipe)
     rb_proc_t *proc;
     GetProcPtr(procval, proc);
     rb_ivar_set(procval, id_refinements_recipe, recipe);
-    proc->is_refined = 1;
+    proc->header.is_refined = 1;
 }
 
 typedef struct {
@@ -331,9 +331,19 @@ static size_t
 proc_memsize(const void *ptr)
 {
     const rb_proc_t *proc = ptr;
-    if (proc->block.as.captured.ep == ((const cfunc_proc_t *)ptr)->env+1)
-        return sizeof(cfunc_proc_t);
-    return sizeof(rb_proc_t);
+    switch (proc->block.type) {
+      case block_type_iseq:
+      case block_type_ifunc:
+        if (proc->block.as.captured.ep == ((const cfunc_proc_t *)ptr)->env+1)
+            return sizeof(cfunc_proc_t);
+        return sizeof(rb_proc_captured_t);
+      case block_type_symbol:
+        return sizeof(rb_proc_symbol_t);
+      case block_type_proc:
+        return sizeof(rb_proc_proc_t);
+    }
+    VM_UNREACHABLE(proc_memsize);
+    return 0;
 }
 
 const rb_data_type_t ruby_proc_data_type = {
@@ -350,10 +360,26 @@ const rb_data_type_t ruby_proc_data_type = {
 #define proc_data_type ruby_proc_data_type
 
 VALUE
-rb_proc_alloc(VALUE klass)
+rb_proc_alloc(VALUE klass, enum rb_block_type block_type)
 {
-    rb_proc_t *proc;
-    return TypedData_Make_Struct(klass, rb_proc_t, &proc_data_type, proc);
+    size_t size;
+    switch (block_type) {
+      case block_type_symbol:
+        size = sizeof(rb_proc_symbol_t);
+        break;
+      case block_type_proc:
+        size = sizeof(rb_proc_proc_t);
+        break;
+      case block_type_iseq:
+      case block_type_ifunc:
+        size = sizeof(rb_proc_captured_t);
+        break;
+      default:
+        VM_UNREACHABLE(rb_proc_alloc);
+        return Qundef;
+    }
+
+    return rb_data_typed_object_zalloc(klass, size, &proc_data_type);
 }
 
 VALUE
@@ -559,7 +585,7 @@ rb_proc_refinements_cref_for_call(VALUE procval)
 {
     rb_proc_t *proc;
     GetProcPtr(procval, proc);
-    if (!proc->is_refined) return NULL;
+    if (!proc->header.is_refined) return NULL;
 
     refinement_iseq_ensure(procval, proc);
     VALUE recipe = rb_ivar_get(procval, id_refinements_recipe);
@@ -629,7 +655,7 @@ proc_refined(int argc, VALUE *argv, VALUE self)
         return self;
     }
 
-    if (vm_block_type(&src->block) != block_type_iseq || src->is_from_method) {
+    if (vm_block_type(&src->block) != block_type_iseq || src->header.is_from_method) {
         rb_raise(rb_eArgError, "can't apply refinements to a Proc without a Ruby block");
     }
 
@@ -798,7 +824,7 @@ rb_proc_lambda_p(VALUE procval)
     rb_proc_t *proc;
     GetProcPtr(procval, proc);
 
-    return RBOOL(proc->is_lambda);
+    return RBOOL(proc->header.is_lambda);
 }
 
 /* Binding */
@@ -1396,7 +1422,7 @@ cfunc_proc_new(VALUE klass, VALUE ifunc)
 
     /* self? */
     RB_OBJ_WRITE(procval, &proc->block.as.captured.code.ifunc, ifunc);
-    proc->is_lambda = TRUE;
+    proc->header.is_lambda = TRUE;
     return procval;
 }
 
@@ -1429,13 +1455,13 @@ rb_func_proc_dup(VALUE src_obj)
 static VALUE
 sym_proc_new(VALUE klass, VALUE sym)
 {
-    VALUE procval = rb_proc_alloc(klass);
+    VALUE procval = rb_proc_alloc(klass, block_type_symbol);
     rb_proc_t *proc;
     GetProcPtr(procval, proc);
 
     vm_block_type_set(&proc->block, block_type_symbol);
-    proc->is_lambda = TRUE;
-    RB_OBJ_WRITE(procval, &proc->block.as.symbol, sym);
+    proc->header.is_lambda = TRUE;
+    RB_OBJ_WRITE(procval, &proc->symbol.symbol, sym);
     return procval;
 }
 
@@ -1847,7 +1873,7 @@ rb_proc_arity(VALUE self)
     int max, min;
     GetProcPtr(self, proc);
     min = rb_vm_block_min_max_arity(&proc->block, &max);
-    return (proc->is_lambda ? min == max : max != UNLIMITED_ARGUMENTS) ? min : -min-1;
+    return (proc->header.is_lambda ? min == max : max != UNLIMITED_ARGUMENTS) ? min : -min-1;
 }
 
 static void
@@ -1897,7 +1923,7 @@ rb_block_pair_yield_optimizable(void)
             VALUE procval = block_handler;
             rb_proc_t *proc;
             GetProcPtr(procval, proc);
-            if (proc->is_lambda) return 0;
+            if (proc->header.is_lambda) return 0;
             if (min != max) return 0;
             return min > 1;
         }
@@ -1965,7 +1991,7 @@ rb_proc_get_iseq(VALUE self, int *is_proc)
 
     GetProcPtr(self, proc);
     block = &proc->block;
-    if (is_proc) *is_proc = !proc->is_lambda;
+    if (is_proc) *is_proc = !proc->header.is_lambda;
 
     switch (vm_block_type(block)) {
       case block_type_iseq:
@@ -2031,9 +2057,9 @@ proc_eq(VALUE self, VALUE other)
     GetProcPtr(self, self_proc);
     GetProcPtr(other, other_proc);
 
-    if (self_proc->is_from_method != other_proc->is_from_method ||
-            self_proc->is_lambda != other_proc->is_lambda ||
-            self_proc->is_refined != other_proc->is_refined) {
+    if (self_proc->header.is_from_method != other_proc->header.is_from_method ||
+            self_proc->header.is_lambda != other_proc->header.is_lambda ||
+            self_proc->header.is_refined != other_proc->header.is_refined) {
         return Qfalse;
     }
 
@@ -2052,7 +2078,7 @@ proc_eq(VALUE self, VALUE other)
         }
         /* a refined Proc's block iseq flips from the source to the copy on
          * the first call; compare what the Procs were built from instead */
-        if (self_proc->is_refined) {
+        if (self_proc->header.is_refined) {
             if (!refinement_recipe_eq(rb_proc_refinements_recipe(self),
                                       rb_proc_refinements_recipe(other))) {
                 return Qfalse;
@@ -2218,7 +2244,7 @@ rb_hash_proc(st_index_t hash, VALUE prc)
 
     switch (vm_block_type(&proc->block)) {
       case block_type_iseq:
-        if (proc->is_refined) {
+        if (proc->header.is_refined) {
             /* from the recipe, not the block iseq: the latter flips from the
              * source to the copy on the first call, and the hash must not */
             VALUE recipe = rb_proc_refinements_recipe(prc);
@@ -2249,8 +2275,9 @@ rb_hash_proc(st_index_t hash, VALUE prc)
 
     /* ifunc procs have their own allocated ep. If an ifunc is duplicated, they
      * will point to different ep but they should return the same hash code, so
-     * we cannot include the ep in the hash. */
-    if (vm_block_type(&proc->block) != block_type_ifunc) {
+     * we cannot include the ep in the hash.  Symbol and proc type blocks are
+     * smaller and do not have an ep at all. */
+    if (vm_block_type(&proc->block) == block_type_iseq) {
         hash = rb_hash_uint(hash, (st_index_t)proc->block.as.captured.ep);
     }
 
@@ -2370,7 +2397,7 @@ proc_to_s(VALUE self)
 {
     const rb_proc_t *proc;
     GetProcPtr(self, proc);
-    return rb_block_to_s(self, &proc->block, proc->is_lambda ? " (lambda)" : NULL);
+    return rb_block_to_s(self, &proc->block, proc->header.is_lambda ? " (lambda)" : NULL);
 }
 
 /*
@@ -3084,7 +3111,7 @@ rb_mod_define_method_with_visibility(int argc, VALUE *argv, VALUE mod, const str
         GetProcPtr(body, body_proc);
         /* A bmethod never reads the refinement cref carried on the proc;
          * reject rather than silently drop the refinements. */
-        if (body_proc->is_refined) {
+        if (body_proc->header.is_refined) {
             rb_raise(rb_eArgError,
                      "can't define a method from a Proc with refinements");
         }
@@ -3092,8 +3119,8 @@ rb_mod_define_method_with_visibility(int argc, VALUE *argv, VALUE mod, const str
         if (vm_proc_iseq(procval) != NULL) {
             rb_proc_t *proc;
             GetProcPtr(procval, proc);
-            proc->is_lambda = TRUE;
-            proc->is_from_method = TRUE;
+            proc->header.is_lambda = TRUE;
+            proc->header.is_from_method = TRUE;
         }
         rb_add_method(mod, id, VM_METHOD_TYPE_BMETHOD, (void *)procval, scope_visi->method_visi);
         if (scope_visi->module_func) {
@@ -4217,7 +4244,7 @@ method_to_proc(VALUE method)
      */
     procval = rb_block_call(rb_mRubyVMFrozenCore, idLambda, 0, 0, bmcall, method);
     GetProcPtr(procval, proc);
-    proc->is_from_method = 1;
+    proc->header.is_from_method = 1;
     return procval;
 }
 
@@ -4407,7 +4434,7 @@ proc_binding(VALUE self)
     GetProcPtr(self, proc);
     block = &proc->block;
 
-    if (proc->is_isolated) rb_raise(rb_eArgError, "Can't create Binding from isolated Proc");
+    if (proc->header.is_isolated) rb_raise(rb_eArgError, "Can't create Binding from isolated Proc");
 
   again:
     switch (vm_block_type(block)) {
@@ -4474,12 +4501,12 @@ make_curry_proc(VALUE proc, VALUE passed, VALUE arity)
     int is_lambda;
 
     GetProcPtr(proc, procp);
-    is_lambda = procp->is_lambda;
+    is_lambda = procp->header.is_lambda;
     rb_ary_freeze(passed);
     rb_ary_freeze(args);
     proc = rb_proc_new(curry, args);
     GetProcPtr(proc, procp);
-    procp->is_lambda = is_lambda;
+    procp->header.is_lambda = is_lambda;
     return proc;
 }
 
@@ -4684,7 +4711,7 @@ rb_proc_compose_to_left(VALUE self, VALUE g)
 
     if (rb_obj_is_proc(g)) {
         GetProcPtr(g, procp);
-        is_lambda = procp->is_lambda;
+        is_lambda = procp->header.is_lambda;
     }
     else {
         VM_ASSERT(rb_obj_is_method(g) || rb_obj_respond_to(g, idCall, TRUE));
@@ -4693,7 +4720,7 @@ rb_proc_compose_to_left(VALUE self, VALUE g)
 
     proc = rb_proc_new(compose, args);
     GetProcPtr(proc, procp);
-    procp->is_lambda = is_lambda;
+    procp->header.is_lambda = is_lambda;
 
     return proc;
 }
@@ -4742,11 +4769,11 @@ rb_proc_compose_to_right(VALUE self, VALUE g)
     args = rb_ary_tmp_new_from_values(0, 2, procs);
 
     GetProcPtr(self, procp);
-    is_lambda = procp->is_lambda;
+    is_lambda = procp->header.is_lambda;
 
     proc = rb_proc_new(compose, args);
     GetProcPtr(proc, procp);
-    procp->is_lambda = is_lambda;
+    procp->header.is_lambda = is_lambda;
 
     return proc;
 }
@@ -4829,7 +4856,7 @@ proc_ruby2_keywords(VALUE procval)
 
     rb_check_frozen(procval);
 
-    if (proc->is_from_method) {
+    if (proc->header.is_from_method) {
             rb_warn("Skipping set of ruby2_keywords flag for proc (proc created from method)");
             return procval;
     }
@@ -4840,7 +4867,7 @@ proc_ruby2_keywords(VALUE procval)
                 !ISEQ_BODY(proc->block.as.captured.code.iseq)->param.flags.has_post &&
                 !ISEQ_BODY(proc->block.as.captured.code.iseq)->param.flags.has_kw &&
                 !ISEQ_BODY(proc->block.as.captured.code.iseq)->param.flags.has_kwrest) {
-            if (proc->is_refined) {
+            if (proc->header.is_refined) {
                 /* on a copy of this Proc's own: the block is shared with the
                  * source Proc until the first call, and the copy installed by
                  * it may be memoized and shared with sibling Procs */

--- a/vm.c
+++ b/vm.c
@@ -1301,7 +1301,7 @@ vm_proc_create_from_captured(VALUE klass,
                              enum rb_block_type block_type,
                              int8_t is_from_method, int8_t is_lambda)
 {
-    VALUE procval = rb_proc_alloc(klass);
+    VALUE procval = rb_proc_alloc(klass, block_type);
     rb_proc_t *proc = RTYPEDDATA_DATA(procval);
 
     VM_ASSERT(VM_EP_IN_HEAP_P(GET_EC(), captured->ep));
@@ -1312,8 +1312,8 @@ vm_proc_create_from_captured(VALUE klass,
     rb_vm_block_ep_update(procval, &proc->block, captured->ep);
 
     vm_block_type_set(&proc->block, block_type);
-    proc->is_from_method = is_from_method;
-    proc->is_lambda = is_lambda;
+    proc->header.is_from_method = is_from_method;
+    proc->header.is_lambda = is_lambda;
 
     return procval;
 }
@@ -1341,14 +1341,14 @@ rb_vm_block_copy(VALUE obj, const struct rb_block *dst, const struct rb_block *s
 static VALUE
 proc_create(VALUE klass, const struct rb_block *block, int8_t is_from_method, int8_t is_lambda)
 {
-    VALUE procval = rb_proc_alloc(klass);
+    VALUE procval = rb_proc_alloc(klass, block->type);
     rb_proc_t *proc = RTYPEDDATA_DATA(procval);
 
     VM_ASSERT(VM_EP_IN_HEAP_P(GET_EC(), vm_block_ep(block)));
     rb_vm_block_copy(procval, &proc->block, block);
     vm_block_type_set(&proc->block, block->type);
-    proc->is_from_method = is_from_method;
-    proc->is_lambda = is_lambda;
+    proc->header.is_from_method = is_from_method;
+    proc->header.is_lambda = is_lambda;
 
     return procval;
 }
@@ -1366,14 +1366,14 @@ rb_proc_dup_0(VALUE self)
         procval = rb_func_proc_dup(self);
         break;
       default:
-        procval = proc_create(rb_obj_class(self), &src->block, src->is_from_method, src->is_lambda);
+        procval = proc_create(rb_obj_class(self), &src->block, src->header.is_from_method, src->header.is_lambda);
         break;
     }
 
-    if (src->is_refined) {
+    if (src->header.is_refined) {
         rb_proc_t *dst;
         GetProcPtr(procval, dst);
-        dst->is_refined = 1;
+        dst->header.is_refined = 1;
     }
 
     if (RB_OBJ_SHAREABLE_P(self)) RB_OBJ_SET_SHAREABLE(procval);
@@ -1403,7 +1403,7 @@ rb_proc_dup_with_iseq_and_recipe(VALUE self, const rb_iseq_t *iseq, VALUE recipe
     struct rb_block block = src->block;
     block.as.captured.code.iseq = iseq;
 
-    VALUE procval = proc_create(rb_obj_class(self), &block, src->is_from_method, src->is_lambda);
+    VALUE procval = proc_create(rb_obj_class(self), &block, src->header.is_from_method, src->header.is_lambda);
     rb_proc_set_refinements_recipe(procval, recipe);
 
     RB_GC_GUARD(self);
@@ -1587,19 +1587,19 @@ rb_proc_isolate_bang(VALUE self, VALUE replace_self)
     if (iseq) {
         rb_proc_t *proc = (rb_proc_t *)RTYPEDDATA_DATA(self);
 
+        if (proc->block.type != block_type_iseq) rb_raise(rb_eRuntimeError, "not supported yet");
+
         if (!UNDEF_P(replace_self)) {
             VM_ASSERT(rb_ractor_shareable_p(replace_self));
             RB_OBJ_WRITE(self, &proc->block.as.captured.self, replace_self);
         }
-
-        if (proc->block.type != block_type_iseq) rb_raise(rb_eRuntimeError, "not supported yet");
 
         if (ISEQ_BODY(iseq)->outer_variables) {
             proc_shared_outer_variables(ISEQ_BODY(iseq)->outer_variables, true, "isolate a Proc");
         }
 
         proc_isolate_env(self, proc, Qfalse);
-        proc->is_isolated = TRUE;
+        proc->header.is_isolated = TRUE;
         RB_OBJ_WRITE(self, &proc->block.as.captured.self, Qnil);
     }
 
@@ -1623,11 +1623,11 @@ rb_proc_ractor_make_shareable(VALUE self, VALUE replace_self)
     if (iseq) {
         rb_proc_t *proc = (rb_proc_t *)RTYPEDDATA_DATA(self);
 
+        if (proc->block.type != block_type_iseq) rb_raise(rb_eRuntimeError, "not supported yet");
+
         if (!UNDEF_P(replace_self)) {
             RB_OBJ_WRITE(self, &proc->block.as.captured.self, replace_self);
         }
-
-        if (proc->block.type != block_type_iseq) rb_raise(rb_eRuntimeError, "not supported yet");
 
         if (!rb_ractor_shareable_p(vm_block_self(&proc->block))) {
             rb_raise(rb_eRactorIsolationError,
@@ -1643,7 +1643,7 @@ rb_proc_ractor_make_shareable(VALUE self, VALUE replace_self)
         }
 
         proc_isolate_env(self, proc, read_only_variables);
-        proc->is_isolated = TRUE;
+        proc->header.is_isolated = TRUE;
     }
     else {
         const struct rb_block *block = vm_proc_block(self);
@@ -1896,9 +1896,9 @@ invoke_block_from_c_bh(rb_execution_context_t *ec, VALUE block_handler,
             VALUE procval = VM_BH_TO_PROC(block_handler);
             rb_proc_t *po;
             GetProcPtr(procval, po);
-            if (po->is_refined) cref = rb_proc_refinements_cref_for_call(procval);
+            if (po->header.is_refined) cref = rb_proc_refinements_cref_for_call(procval);
             if (force_blockarg == FALSE) {
-                is_lambda = po->is_lambda;
+                is_lambda = po->header.is_lambda;
             }
             block_handler = vm_block_to_block_handler(&po->block);
             goto again;
@@ -1999,7 +1999,7 @@ vm_invoke_proc(rb_execution_context_t *ec, rb_proc_t *proc, VALUE self,
                int argc, const VALUE *argv, int kw_splat, VALUE passed_block_handler,
                const rb_cref_t *cref)
 {
-    return invoke_block_from_c_proc(ec, proc, self, argc, argv, kw_splat, passed_block_handler, proc->is_lambda, cref, NULL);
+    return invoke_block_from_c_proc(ec, proc, self, argc, argv, kw_splat, passed_block_handler, proc->header.is_lambda, cref, NULL);
 }
 
 static VALUE
@@ -2018,7 +2018,7 @@ rb_vm_invoke_proc(rb_execution_context_t *ec, rb_proc_t *proc,
     VALUE self = vm_block_self(&proc->block);
     vm_block_handler_verify(passed_block_handler);
 
-    if (proc->is_from_method) {
+    if (proc->header.is_from_method) {
         return vm_invoke_bmethod(ec, proc, self, argc, argv, kw_splat, passed_block_handler, NULL);
     }
     else {
@@ -2033,7 +2033,7 @@ rb_vm_invoke_proc_with_self(rb_execution_context_t *ec, rb_proc_t *proc, VALUE s
 {
     vm_block_handler_verify(passed_block_handler);
 
-    if (proc->is_from_method) {
+    if (proc->header.is_from_method) {
         return vm_invoke_bmethod(ec, proc, self, argc, argv, kw_splat, passed_block_handler, NULL);
     }
     else {

--- a/vm_core.h
+++ b/vm_core.h
@@ -983,12 +983,12 @@ enum rb_block_type {
 };
 
 struct rb_block {
+    enum rb_block_type type : 8;
     union {
         struct rb_captured_block captured;
         VALUE symbol;
         VALUE proc;
     } as;
-    enum rb_block_type type;
 };
 
 typedef struct rb_control_frame_struct {
@@ -1386,12 +1386,43 @@ extern const rb_data_type_t ruby_proc_data_type;
     GetCoreDataFromValue((obj), rb_proc_t, &ruby_proc_data_type, (ptr))
 
 typedef struct {
-    const struct rb_block block;
+    enum rb_block_type type : 8;
     unsigned int is_from_method: 1;	/* bool */
     unsigned int is_lambda: 1;		/* bool */
     unsigned int is_isolated: 1;        /* bool */
     unsigned int is_refined: 1;         /* bool: Proc#refined */
+} rb_proc_header_t;
+
+typedef struct {
+    rb_proc_header_t header;
+    struct rb_captured_block captured;
+} rb_proc_captured_t;
+
+typedef struct {
+    rb_proc_header_t header;
+    VALUE symbol;
+} rb_proc_symbol_t;
+
+typedef struct {
+    rb_proc_header_t header;
+    VALUE proc;
+} rb_proc_proc_t;
+
+/* A Proc of any block type. */
+typedef union {
+    const struct rb_block block;
+    rb_proc_header_t header;
+    rb_proc_captured_t captured;
+    rb_proc_symbol_t symbol;
+    rb_proc_proc_t proc;
 } rb_proc_t;
+
+STATIC_ASSERT(rb_proc_captured_offset,
+    offsetof(rb_proc_captured_t, captured) == offsetof(rb_proc_t, block.as.captured));
+STATIC_ASSERT(rb_proc_symbol_offset,
+    offsetof(rb_proc_symbol_t, symbol) == offsetof(rb_proc_t, block.as.symbol));
+STATIC_ASSERT(rb_proc_proc_offset,
+    offsetof(rb_proc_proc_t, proc) == offsetof(rb_proc_t, block.as.proc));
 
 /* A refined proc's refinements recipe (see Proc#refined) lives in a hidden
  * ivar on the proc object; the accessors return nil/NULL unless is_refined is
@@ -2034,7 +2065,7 @@ VM_BH_FROM_PROC(VALUE procval)
 /* VM related object allocate functions */
 VALUE rb_thread_alloc(VALUE klass);
 VALUE rb_binding_alloc(VALUE klass);
-VALUE rb_proc_alloc(VALUE klass);
+VALUE rb_proc_alloc(VALUE klass, enum rb_block_type block_type);
 VALUE rb_proc_dup(VALUE self);
 VALUE rb_proc_dup_0(VALUE self);
 

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -2239,8 +2239,8 @@ yield_under(VALUE self, int singleton, int argc, const VALUE *argv, int kw_splat
                 VALUE procval = VM_BH_TO_PROC(block_handler);
                 rb_proc_t *po;
                 GetProcPtr(procval, po);
-                is_lambda = po->is_lambda;
-                if (po->is_refined) proc_cref = rb_proc_refinements_cref_for_call(procval);
+                is_lambda = po->header.is_lambda;
+                if (po->header.is_refined) proc_cref = rb_proc_refinements_cref_for_call(procval);
                 block_handler = vm_block_to_block_handler(&po->block);
             }
             goto again;

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -5205,7 +5205,7 @@ block_proc_is_lambda(const VALUE procval)
 
     if (procval) {
         GetProcPtr(procval, proc);
-        return proc->is_lambda;
+        return proc->header.is_lambda;
     }
     else {
         return 0;
@@ -5497,8 +5497,8 @@ vm_invoke_proc_block(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp,
         VALUE procval = VM_BH_TO_PROC(block_handler);
         rb_proc_t *po;
         GetProcPtr(procval, po);
-        if (po->is_refined) refined_procval = procval;
-        is_lambda = po->is_lambda;
+        if (po->header.is_refined) refined_procval = procval;
+        is_lambda = po->header.is_lambda;
         block_handler = vm_block_to_block_handler(&po->block);
     }
 

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -266,6 +266,7 @@ fn main() {
         .allowlist_function("rb_RSTRING_LEN")
         .allowlist_function("rb_ENCODING_GET")
         .allowlist_function("rb_jit_get_proc_ptr")
+        .allowlist_type("rb_block_type")
         .allowlist_function("rb_yjit_exit_locations_dict")
         .allowlist_function("rb_jit_icache_invalidate")
         .allowlist_function("rb_optimized_call")

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -7450,9 +7450,9 @@ fn gen_send_bmethod(
     let procv = unsafe { rb_get_def_bmethod_proc((*cme).def) };
 
     let proc = unsafe { rb_jit_get_proc_ptr(procv) };
-    let proc_block = unsafe { &(*proc).block };
+    let proc_block = unsafe { (*proc).block.as_ref() };
 
-    if proc_block.type_ != block_type_iseq {
+    if proc_block.type_() != block_type_iseq {
         return None;
     }
 

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -517,8 +517,9 @@ pub const block_type_proc: rb_block_type = 3;
 pub type rb_block_type = u32;
 #[repr(C)]
 pub struct rb_block {
+    pub _bitfield_align_1: [u8; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub as_: rb_block__bindgen_ty_1,
-    pub type_: rb_block_type,
 }
 #[repr(C)]
 pub struct rb_block__bindgen_ty_1 {
@@ -527,85 +528,148 @@ pub struct rb_block__bindgen_ty_1 {
     pub proc_: __BindgenUnionField<VALUE>,
     pub bindgen_union_field: [u64; 3usize],
 }
+impl rb_block {
+    #[inline]
+    pub fn type_(&self) -> rb_block_type {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 8u8) as u32) }
+    }
+    #[inline]
+    pub fn set_type(&mut self, val: rb_block_type) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(0usize, 8u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn new_bitfield_1(type_: rb_block_type) -> __BindgenBitfieldUnit<[u8; 1usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
+        __bindgen_bitfield_unit.set(0usize, 8u8, {
+            let type_: u32 = unsafe { ::std::mem::transmute(type_) };
+            type_ as u64
+        });
+        __bindgen_bitfield_unit
+    }
+}
 pub type rb_control_frame_t = rb_control_frame_struct;
 #[repr(C)]
-pub struct rb_proc_t {
-    pub block: rb_block,
+#[repr(align(4))]
+#[derive(Debug, Copy, Clone)]
+pub struct rb_proc_header_t {
     pub _bitfield_align_1: [u8; 0],
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
-    pub __bindgen_padding_0: [u8; 7usize],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
+    pub __bindgen_padding_0: u16,
 }
-impl rb_proc_t {
+impl rb_proc_header_t {
+    #[inline]
+    pub fn type_(&self) -> rb_block_type {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 8u8) as u32) }
+    }
+    #[inline]
+    pub fn set_type(&mut self, val: rb_block_type) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(0usize, 8u8, val as u64)
+        }
+    }
     #[inline]
     pub fn is_from_method(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(8usize, 1u8) as u32) }
     }
     #[inline]
     pub fn set_is_from_method(&mut self, val: ::std::os::raw::c_uint) {
         unsafe {
             let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(0usize, 1u8, val as u64)
+            self._bitfield_1.set(8usize, 1u8, val as u64)
         }
     }
     #[inline]
     pub fn is_lambda(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(9usize, 1u8) as u32) }
     }
     #[inline]
     pub fn set_is_lambda(&mut self, val: ::std::os::raw::c_uint) {
         unsafe {
             let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(1usize, 1u8, val as u64)
+            self._bitfield_1.set(9usize, 1u8, val as u64)
         }
     }
     #[inline]
     pub fn is_isolated(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u32) }
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(10usize, 1u8) as u32) }
     }
     #[inline]
     pub fn set_is_isolated(&mut self, val: ::std::os::raw::c_uint) {
         unsafe {
             let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(2usize, 1u8, val as u64)
+            self._bitfield_1.set(10usize, 1u8, val as u64)
         }
     }
     #[inline]
     pub fn is_refined(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(3usize, 1u8) as u32) }
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(11usize, 1u8) as u32) }
     }
     #[inline]
     pub fn set_is_refined(&mut self, val: ::std::os::raw::c_uint) {
         unsafe {
             let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(3usize, 1u8, val as u64)
+            self._bitfield_1.set(11usize, 1u8, val as u64)
         }
     }
     #[inline]
     pub fn new_bitfield_1(
+        type_: rb_block_type,
         is_from_method: ::std::os::raw::c_uint,
         is_lambda: ::std::os::raw::c_uint,
         is_isolated: ::std::os::raw::c_uint,
         is_refined: ::std::os::raw::c_uint,
-    ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
-        __bindgen_bitfield_unit.set(0usize, 1u8, {
+    ) -> __BindgenBitfieldUnit<[u8; 2usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> = Default::default();
+        __bindgen_bitfield_unit.set(0usize, 8u8, {
+            let type_: u32 = unsafe { ::std::mem::transmute(type_) };
+            type_ as u64
+        });
+        __bindgen_bitfield_unit.set(8usize, 1u8, {
             let is_from_method: u32 = unsafe { ::std::mem::transmute(is_from_method) };
             is_from_method as u64
         });
-        __bindgen_bitfield_unit.set(1usize, 1u8, {
+        __bindgen_bitfield_unit.set(9usize, 1u8, {
             let is_lambda: u32 = unsafe { ::std::mem::transmute(is_lambda) };
             is_lambda as u64
         });
-        __bindgen_bitfield_unit.set(2usize, 1u8, {
+        __bindgen_bitfield_unit.set(10usize, 1u8, {
             let is_isolated: u32 = unsafe { ::std::mem::transmute(is_isolated) };
             is_isolated as u64
         });
-        __bindgen_bitfield_unit.set(3usize, 1u8, {
+        __bindgen_bitfield_unit.set(11usize, 1u8, {
             let is_refined: u32 = unsafe { ::std::mem::transmute(is_refined) };
             is_refined as u64
         });
         __bindgen_bitfield_unit
     }
+}
+#[repr(C)]
+pub struct rb_proc_captured_t {
+    pub header: rb_proc_header_t,
+    pub captured: rb_captured_block,
+}
+#[repr(C)]
+pub struct rb_proc_symbol_t {
+    pub header: rb_proc_header_t,
+    pub symbol: VALUE,
+}
+#[repr(C)]
+pub struct rb_proc_proc_t {
+    pub header: rb_proc_header_t,
+    pub proc_: VALUE,
+}
+#[repr(C)]
+pub struct rb_proc_t {
+    pub block: __BindgenUnionField<rb_block>,
+    pub header: __BindgenUnionField<rb_proc_header_t>,
+    pub captured: __BindgenUnionField<rb_proc_captured_t>,
+    pub symbol: __BindgenUnionField<rb_proc_symbol_t>,
+    pub proc_: __BindgenUnionField<rb_proc_proc_t>,
+    pub bindgen_union_field: [u64; 4usize],
 }
 pub const VM_CHECKMATCH_TYPE_WHEN: vm_check_match_type = 1;
 pub const VM_CHECKMATCH_TYPE_CASE: vm_check_match_type = 2;

--- a/zjit/bindgen/src/main.rs
+++ b/zjit/bindgen/src/main.rs
@@ -422,6 +422,7 @@ fn main() {
         .allowlist_function("rb_get_def_iseq_ptr")
         .allowlist_function("rb_get_def_bmethod_proc")
         .allowlist_function("rb_jit_get_proc_ptr")
+        .allowlist_type("rb_block_type")
         .allowlist_function("rb_iseq_encoded_size")
         .allowlist_function("rb_get_iseq_body_total_calls")
         .allowlist_function("rb_get_iseq_body_local_iseq")

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -1656,7 +1656,7 @@ fn gen_push_inline_frame(
         // Extract EP from the Proc instance
         let procv = unsafe { rb_get_def_bmethod_proc((*cme).def) };
         let proc = unsafe { rb_jit_get_proc_ptr(procv) };
-        let proc_block = unsafe { &(*proc).block };
+        let proc_block = unsafe { (*proc).block.as_ref() };
         let capture = unsafe { proc_block.as_.captured.as_ref() };
         let bmethod_frame_type = VM_FRAME_MAGIC_BLOCK | VM_FRAME_FLAG_BMETHOD | VM_FRAME_FLAG_LAMBDA;
         // Tag the captured EP like VM_GUARDED_PREV_EP() in vm_call_iseq_bmethod()
@@ -1796,7 +1796,7 @@ fn gen_send_iseq_direct(
         // Extract EP from the Proc instance
         let procv = unsafe { rb_get_def_bmethod_proc((*cme).def) };
         let proc = unsafe { rb_jit_get_proc_ptr(procv) };
-        let proc_block = unsafe { &(*proc).block };
+        let proc_block = unsafe { (*proc).block.as_ref() };
         let capture = unsafe { proc_block.as_.captured.as_ref() };
         let bmethod_frame_type = VM_FRAME_MAGIC_BLOCK | VM_FRAME_FLAG_BMETHOD | VM_FRAME_FLAG_LAMBDA;
         // Tag the captured EP like VM_GUARDED_PREV_EP() in vm_call_iseq_bmethod()

--- a/zjit/src/cruby.rs
+++ b/zjit/src/cruby.rs
@@ -102,6 +102,7 @@ pub type RedefinitionFlag = u32;
 
 #[allow(unsafe_op_in_unsafe_fn)]
 #[allow(dead_code)]
+#[allow(non_snake_case)] // bindgen names bitfield raw accessors like `type__raw`
 #[allow(clippy::all)] // warning meant to help with reading; not useful for generated code
 mod autogened {
     use super::*;

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -1326,8 +1326,9 @@ pub const block_type_proc: rb_block_type = 3;
 pub type rb_block_type = u32;
 #[repr(C)]
 pub struct rb_block {
+    pub _bitfield_align_1: [u8; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub as_: rb_block__bindgen_ty_1,
-    pub type_: rb_block_type,
 }
 #[repr(C)]
 pub struct rb_block__bindgen_ty_1 {
@@ -1335,6 +1336,50 @@ pub struct rb_block__bindgen_ty_1 {
     pub symbol: __BindgenUnionField<VALUE>,
     pub proc_: __BindgenUnionField<VALUE>,
     pub bindgen_union_field: [u64; 3usize],
+}
+impl rb_block {
+    #[inline]
+    pub fn type_(&self) -> rb_block_type {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 8u8) as u32) }
+    }
+    #[inline]
+    pub fn set_type(&mut self, val: rb_block_type) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(0usize, 8u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn type__raw(this: *const Self) -> rb_block_type {
+        unsafe {
+            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 1usize]>>::raw_get(
+                ::std::ptr::addr_of!((*this)._bitfield_1),
+                0usize,
+                8u8,
+            ) as u32)
+        }
+    }
+    #[inline]
+    pub unsafe fn set_type_raw(this: *mut Self, val: rb_block_type) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            <__BindgenBitfieldUnit<[u8; 1usize]>>::raw_set(
+                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
+                0usize,
+                8u8,
+                val as u64,
+            )
+        }
+    }
+    #[inline]
+    pub fn new_bitfield_1(type_: rb_block_type) -> __BindgenBitfieldUnit<[u8; 1usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
+        __bindgen_bitfield_unit.set(0usize, 8u8, {
+            let type_: u32 = unsafe { ::std::mem::transmute(type_) };
+            type_ as u64
+        });
+        __bindgen_bitfield_unit
+    }
 }
 #[repr(C)]
 pub struct rb_control_frame_struct {
@@ -1348,30 +1393,64 @@ pub struct rb_control_frame_struct {
 }
 pub type rb_control_frame_t = rb_control_frame_struct;
 #[repr(C)]
-pub struct rb_proc_t {
-    pub block: rb_block,
+#[repr(align(4))]
+#[derive(Debug, Copy, Clone)]
+pub struct rb_proc_header_t {
     pub _bitfield_align_1: [u8; 0],
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
-    pub __bindgen_padding_0: [u8; 7usize],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
+    pub __bindgen_padding_0: u16,
 }
-impl rb_proc_t {
+impl rb_proc_header_t {
+    #[inline]
+    pub fn type_(&self) -> rb_block_type {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 8u8) as u32) }
+    }
+    #[inline]
+    pub fn set_type(&mut self, val: rb_block_type) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(0usize, 8u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn type__raw(this: *const Self) -> rb_block_type {
+        unsafe {
+            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 2usize]>>::raw_get(
+                ::std::ptr::addr_of!((*this)._bitfield_1),
+                0usize,
+                8u8,
+            ) as u32)
+        }
+    }
+    #[inline]
+    pub unsafe fn set_type_raw(this: *mut Self, val: rb_block_type) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            <__BindgenBitfieldUnit<[u8; 2usize]>>::raw_set(
+                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
+                0usize,
+                8u8,
+                val as u64,
+            )
+        }
+    }
     #[inline]
     pub fn is_from_method(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(8usize, 1u8) as u32) }
     }
     #[inline]
     pub fn set_is_from_method(&mut self, val: ::std::os::raw::c_uint) {
         unsafe {
             let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(0usize, 1u8, val as u64)
+            self._bitfield_1.set(8usize, 1u8, val as u64)
         }
     }
     #[inline]
     pub unsafe fn is_from_method_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 1usize]>>::raw_get(
+            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 2usize]>>::raw_get(
                 ::std::ptr::addr_of!((*this)._bitfield_1),
-                0usize,
+                8usize,
                 1u8,
             ) as u32)
         }
@@ -1380,9 +1459,9 @@ impl rb_proc_t {
     pub unsafe fn set_is_from_method_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
             let val: u32 = ::std::mem::transmute(val);
-            <__BindgenBitfieldUnit<[u8; 1usize]>>::raw_set(
+            <__BindgenBitfieldUnit<[u8; 2usize]>>::raw_set(
                 ::std::ptr::addr_of_mut!((*this)._bitfield_1),
-                0usize,
+                8usize,
                 1u8,
                 val as u64,
             )
@@ -1390,21 +1469,21 @@ impl rb_proc_t {
     }
     #[inline]
     pub fn is_lambda(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(9usize, 1u8) as u32) }
     }
     #[inline]
     pub fn set_is_lambda(&mut self, val: ::std::os::raw::c_uint) {
         unsafe {
             let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(1usize, 1u8, val as u64)
+            self._bitfield_1.set(9usize, 1u8, val as u64)
         }
     }
     #[inline]
     pub unsafe fn is_lambda_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 1usize]>>::raw_get(
+            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 2usize]>>::raw_get(
                 ::std::ptr::addr_of!((*this)._bitfield_1),
-                1usize,
+                9usize,
                 1u8,
             ) as u32)
         }
@@ -1413,9 +1492,9 @@ impl rb_proc_t {
     pub unsafe fn set_is_lambda_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
             let val: u32 = ::std::mem::transmute(val);
-            <__BindgenBitfieldUnit<[u8; 1usize]>>::raw_set(
+            <__BindgenBitfieldUnit<[u8; 2usize]>>::raw_set(
                 ::std::ptr::addr_of_mut!((*this)._bitfield_1),
-                1usize,
+                9usize,
                 1u8,
                 val as u64,
             )
@@ -1423,21 +1502,21 @@ impl rb_proc_t {
     }
     #[inline]
     pub fn is_isolated(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u32) }
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(10usize, 1u8) as u32) }
     }
     #[inline]
     pub fn set_is_isolated(&mut self, val: ::std::os::raw::c_uint) {
         unsafe {
             let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(2usize, 1u8, val as u64)
+            self._bitfield_1.set(10usize, 1u8, val as u64)
         }
     }
     #[inline]
     pub unsafe fn is_isolated_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 1usize]>>::raw_get(
+            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 2usize]>>::raw_get(
                 ::std::ptr::addr_of!((*this)._bitfield_1),
-                2usize,
+                10usize,
                 1u8,
             ) as u32)
         }
@@ -1446,9 +1525,9 @@ impl rb_proc_t {
     pub unsafe fn set_is_isolated_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
             let val: u32 = ::std::mem::transmute(val);
-            <__BindgenBitfieldUnit<[u8; 1usize]>>::raw_set(
+            <__BindgenBitfieldUnit<[u8; 2usize]>>::raw_set(
                 ::std::ptr::addr_of_mut!((*this)._bitfield_1),
-                2usize,
+                10usize,
                 1u8,
                 val as u64,
             )
@@ -1456,21 +1535,21 @@ impl rb_proc_t {
     }
     #[inline]
     pub fn is_refined(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(3usize, 1u8) as u32) }
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(11usize, 1u8) as u32) }
     }
     #[inline]
     pub fn set_is_refined(&mut self, val: ::std::os::raw::c_uint) {
         unsafe {
             let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(3usize, 1u8, val as u64)
+            self._bitfield_1.set(11usize, 1u8, val as u64)
         }
     }
     #[inline]
     pub unsafe fn is_refined_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 1usize]>>::raw_get(
+            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 2usize]>>::raw_get(
                 ::std::ptr::addr_of!((*this)._bitfield_1),
-                3usize,
+                11usize,
                 1u8,
             ) as u32)
         }
@@ -1479,9 +1558,9 @@ impl rb_proc_t {
     pub unsafe fn set_is_refined_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
             let val: u32 = ::std::mem::transmute(val);
-            <__BindgenBitfieldUnit<[u8; 1usize]>>::raw_set(
+            <__BindgenBitfieldUnit<[u8; 2usize]>>::raw_set(
                 ::std::ptr::addr_of_mut!((*this)._bitfield_1),
-                3usize,
+                11usize,
                 1u8,
                 val as u64,
             )
@@ -1489,30 +1568,59 @@ impl rb_proc_t {
     }
     #[inline]
     pub fn new_bitfield_1(
+        type_: rb_block_type,
         is_from_method: ::std::os::raw::c_uint,
         is_lambda: ::std::os::raw::c_uint,
         is_isolated: ::std::os::raw::c_uint,
         is_refined: ::std::os::raw::c_uint,
-    ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
-        __bindgen_bitfield_unit.set(0usize, 1u8, {
+    ) -> __BindgenBitfieldUnit<[u8; 2usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> = Default::default();
+        __bindgen_bitfield_unit.set(0usize, 8u8, {
+            let type_: u32 = unsafe { ::std::mem::transmute(type_) };
+            type_ as u64
+        });
+        __bindgen_bitfield_unit.set(8usize, 1u8, {
             let is_from_method: u32 = unsafe { ::std::mem::transmute(is_from_method) };
             is_from_method as u64
         });
-        __bindgen_bitfield_unit.set(1usize, 1u8, {
+        __bindgen_bitfield_unit.set(9usize, 1u8, {
             let is_lambda: u32 = unsafe { ::std::mem::transmute(is_lambda) };
             is_lambda as u64
         });
-        __bindgen_bitfield_unit.set(2usize, 1u8, {
+        __bindgen_bitfield_unit.set(10usize, 1u8, {
             let is_isolated: u32 = unsafe { ::std::mem::transmute(is_isolated) };
             is_isolated as u64
         });
-        __bindgen_bitfield_unit.set(3usize, 1u8, {
+        __bindgen_bitfield_unit.set(11usize, 1u8, {
             let is_refined: u32 = unsafe { ::std::mem::transmute(is_refined) };
             is_refined as u64
         });
         __bindgen_bitfield_unit
     }
+}
+#[repr(C)]
+pub struct rb_proc_captured_t {
+    pub header: rb_proc_header_t,
+    pub captured: rb_captured_block,
+}
+#[repr(C)]
+pub struct rb_proc_symbol_t {
+    pub header: rb_proc_header_t,
+    pub symbol: VALUE,
+}
+#[repr(C)]
+pub struct rb_proc_proc_t {
+    pub header: rb_proc_header_t,
+    pub proc_: VALUE,
+}
+#[repr(C)]
+pub struct rb_proc_t {
+    pub block: __BindgenUnionField<rb_block>,
+    pub header: __BindgenUnionField<rb_proc_header_t>,
+    pub captured: __BindgenUnionField<rb_proc_captured_t>,
+    pub symbol: __BindgenUnionField<rb_proc_symbol_t>,
+    pub proc_: __BindgenUnionField<rb_proc_proc_t>,
+    pub bindgen_union_field: [u64; 4usize],
 }
 pub const VM_CHECKMATCH_TYPE_WHEN: vm_check_match_type = 1;
 pub const VM_CHECKMATCH_TYPE_CASE: vm_check_match_type = 2;

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -4574,10 +4574,10 @@ impl Function {
                         } else if !has_block && def_type == VM_METHOD_TYPE_BMETHOD {
                             let procv = unsafe { rb_get_def_bmethod_proc((*cme).def) };
                             let proc = unsafe { rb_jit_get_proc_ptr(procv) };
-                            let proc_block = unsafe { &(*proc).block };
+                            let proc_block = unsafe { (*proc).block.as_ref() };
                             // Target ISEQ bmethods. Can't handle for example, `define_method(:foo, &:foo)`
                             // which makes a `block_type_symbol` bmethod.
-                            if proc_block.type_ != block_type_iseq {
+                            if proc_block.type_() != block_type_iseq {
                                 self.set_dynamic_send_reason(insn_id, BmethodNonIseqProc);
                                 self.push_insn_id(block, insn_id); continue;
                             }


### PR DESCRIPTION
We know the type of the proc object at allocation time, so we can allocate exactly the amount of memory needed for that type.

We can also shrink the type from a 4 byte enum since there are only 4 types of procs. This allows us to put some flags after it, which saves us 8 bytes.

This commit reduces symbol and proc procs by 24 bytes (80 bytes to 56 bytes). It also reduces iseq and ifunc procs by 8 bytes (80 bytes to 72 bytes).