### PR TITLE
Bump the vcpkg builtin-baseline for the gmp msys2 404

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -7,5 +7,5 @@
     "openssl",
     "zlib"
   ],
-  "builtin-baseline": "9e593bb18ea69cc5095e012465dcd675a822ed0d"
+  "builtin-baseline": "7f3781e19cc7d4e4882a4caec01668c6f7b5c163"
 }


### PR DESCRIPTION
The gmp portfile at the previous baseline downloads autoconf2.71-2.71-3-any.pkg.tar.zst from msys2 mirrors by a pinned URL, but msys2 has rotated the package to -4, so every mirror returns 404 and Windows CI fails to build gmp whenever the vcpkg binary cache misses. The new baseline includes microsoft/vcpkg@37bb045f3c, which updates the URL.