### PR TITLE
Retry TestGc#test_stat_heap_constraints once

### DIFF
--- a/test/ruby/test_gc.rb
+++ b/test/ruby/test_gc.rb
@@ -302,6 +302,13 @@ class TestGc < Test::Unit::TestCase
     assert_equal stat[:heap_available_slots], stat_heap_sum[:heap_eden_slots]
     assert_equal stat[:total_allocated_objects], stat_heap_sum[:total_allocated_objects]
     assert_equal stat[:total_freed_objects], stat_heap_sum[:total_freed_objects]
+  rescue Test::Unit::AssertionFailedError
+    # GC.stat and GC.stat_heap are separate reads of the same counters, so
+    # anything allocated between them makes the two disagree.  An accounting
+    # bug disagrees on the retry too.
+    raise if @retried
+    @retried = true
+    retry
   end
 
   def test_page_pool_stat_consistency


### PR DESCRIPTION
The test reads `GC.stat` and `GC.stat_heap` separately and asserts that the per-heap values sum to the totals.  Both come from the same counters (`objspace_live_slots()` is the sum of the per-heap live slots, and so on), so they only disagree when something allocated or freed between the two reads:

```
TestGc#test_stat_heap_constraints [test/ruby/test_gc.rb:298]:
<243163> expected but was
<243164>.
```

Two adjacent statements are a wide enough window.  A call site allocates its inline caches the first time it runs, and

```ruby
GC.stat(stat)
GC.stat_heap(nil, stat_heap)
```

has a constant reference and a call on each line.  Calling six methods with the same body but distinct call sites allocates three objects on each first call, all `imemo_constcache` and `imemo_callcache`; calling one of them a second time allocates nothing:

```
cold call site: total_allocated +3  imemo=[[:imemo_constcache, 2]]   (six methods, identical)
warm call site: total_allocated +0  imemo=[]
```

The warm-up loop the test already has covers that particular case, and a quiet single-threaded process shows no mismatch in 100,000 rounds.  What allocated in the failing CI run is not identified: that job runs with `--yjit-call-threshold=1`, so the second iteration, the one that is compared, is the first to run as compiled code.

Running the pair in a loop with a background allocating thread reproduces the failure, 7 mismatches in 200,000 rounds; reading the pair again leaves 0.  Disabling GC does not help (7 in 200,000): the reads disagree over an allocation, not over a collection.

So retry the test once instead of leaving it flaky.  An accounting bug fails the retry too, so this keeps what the test checks.

Seen on YJIT macOS with `--yjit-call-threshold=1`:
https://github.com/ruby/ruby/actions/runs/32472080033/job/96740787745
