### PR TITLE
[Backport #22257] Fix stale super cache on prepend after include

### DIFF
--- a/class.c
+++ b/class.c
@@ -1960,6 +1960,7 @@ rb_prepend_module(VALUE klass, VALUE module)
         VALUE klass_origin = RCLASS_ORIGIN(klass);
         struct rb_id_table *klass_m_tbl = RCLASS_M_TBL(klass);
         struct rb_id_table *klass_origin_m_tbl = RCLASS_M_TBL(klass_origin);
+        VALUE new_origins = 0;
         while (iclass) {
             /* During lazy sweeping, iclass->klass could be a dead object that
              * has not yet been swept. */
@@ -1974,12 +1975,22 @@ rb_prepend_module(VALUE klass, VALUE module)
                     RCLASS_SET_INCLUDER(origin, RCLASS_INCLUDER(subclass));
                     RCLASS_WRITE_ORIGIN(subclass, origin);
                     RICLASS_SET_ORIGIN_SHARED_MTBL(origin);
+                    if (!new_origins) new_origins = rb_ary_hidden_new(1);
+                    rb_ary_push(new_origins, origin);
                 }
                 include_modules_at(subclass, subclass, module, FALSE);
             }
 
             iclass = iclass->next;
         }
+        /* Register after the loop. Registering during it would visit the
+         * new iclass and prepend module into it a second time. */
+        if (new_origins) {
+            for (long i = 0; i < RARRAY_LEN(new_origins); i++) {
+                rb_module_add_to_subclasses_list(klass, RARRAY_AREF(new_origins, i));
+            }
+        }
+        RB_GC_GUARD(new_origins);
     }
 }
 

--- a/test/ruby/test_super.rb
+++ b/test/ruby/test_super.rb
@@ -667,6 +667,38 @@ class TestSuper < Test::Unit::TestCase
     assert_equal(:test, c.new.test)
   end
 
+  def test_super_with_prepended_module_after_include_method_caching
+    m = Module.new do
+      def test
+        :m
+      end
+    end
+
+    c = Class.new { include m }
+
+    m.prepend(Module.new do
+      def test
+        super
+      end
+    end)
+
+    # prime the super call-site cache through the prepended module
+    assert_equal(:m, c.new.test)
+
+    m.class_eval do
+      begin
+        verbose_bak, $VERBOSE = $VERBOSE, nil
+        def test
+          :redefined
+        end
+      ensure
+        $VERBOSE = verbose_bak
+      end
+    end
+
+    assert_equal(:redefined, c.new.test)
+  end
+
   class TestFor_super_with_modified_rest_parameter_base
     def foo *args
       args


### PR DESCRIPTION
Prepending a module to a module that already has includers backfills an origin iclass into each includer's ancestor chain using rb_prepend_module.

The backfilled iclass is never added to a subclasses list, so rb_clear_method_cache can't reach it when one of the module's methods is later redefined.

Calling super through a call site that has cached the backfilled iclass calls the old entry, even though it should be redefined.

```ruby
module M; def foo; :m; end; end
class D; include M; end
M.prepend(Module.new { def foo; super; end })
D.new.foo                          # prime the super cache
M.send(:define_method, :foo) { :hooked }
D.new.foo                          # => got :m, expected :hooked
```

This commit makes sure that the backfilled iclass is registered in the subclasses list.