### PR TITLE
Make IO::Buffer slices retain their root buffer

### DIFF
--- a/io_buffer.c
+++ b/io_buffer.c
@@ -1741,8 +1741,9 @@ rb_io_buffer_slice(struct rb_io_buffer *buffer, VALUE self, size_t offset, size_
     slice->base = (char*)buffer->base + offset;
     slice->size = length;
 
-    // The source should be the root buffer:
-    if (buffer->source != Qnil) {
+    // Slices retain their root buffer. If this buffer is already a slice,
+    // retain its root directly rather than building a chain of slices:
+    if (rb_typeddata_is_kind_of(buffer->source, &rb_io_buffer_type)) {
         RB_OBJ_WRITE(instance, &slice->source, buffer->source);
     }
     else {
@@ -1758,8 +1759,9 @@ rb_io_buffer_slice(struct rb_io_buffer *buffer, VALUE self, size_t offset, size_
  *  Produce another IO::Buffer which is a slice (or view into) the current one
  *  starting at +offset+ bytes and going for +length+ bytes.
  *
- *  The slicing happens without copying of memory, and the slice keeps being
- *  associated with the original buffer's source (string, or file), if any.
+ *  The slicing happens without copying memory. The slice retains its root
+ *  buffer and becomes invalid if that root is freed, transferred, resized so
+ *  that the slice is outside its bounds, or otherwise invalidated.
  *
  *  If the offset is not given, it will be zero. If the offset is negative, it
  *  will raise an ArgumentError.

--- a/spec/ruby/core/io/buffer/for_spec.rb
+++ b/spec/ruby/core/io/buffer/for_spec.rb
@@ -59,6 +59,20 @@ describe "IO::Buffer.for" do
       @buffer.should.null?
     end
 
+    ruby_version_is "4.1" do
+      it "invalidates slices when the block ends" do
+        slice = nil
+
+        IO::Buffer.for(@string) do |buffer|
+          slice = buffer.slice(0, 2)
+          slice.should.valid?
+        end
+
+        slice.should_not.valid?
+        -> { slice.get_string }.should.raise(IO::Buffer::InvalidatedError)
+      end
+    end
+
     context "if string is not frozen" do
       it "creates a modifiable string-backed buffer" do
         IO::Buffer.for(@string) do |buffer|

--- a/spec/ruby/core/io/buffer/valid_spec.rb
+++ b/spec/ruby/core/io/buffer/valid_spec.rb
@@ -83,12 +83,24 @@ describe "IO::Buffer#valid?" do
       end
     end
 
-    it "is true for a slice of a freed string-backed buffer while string is alive" do
-      @buffer = IO::Buffer.for("alive")
-      slice = @buffer.slice(0, 2)
-      slice.valid?.should == true
-      @buffer.free
-      slice.valid?.should == true
+    ruby_version_is ""..."4.1" do
+      it "is true for a slice of a freed string-backed buffer while string is alive" do
+        @buffer = IO::Buffer.for("alive")
+        slice = @buffer.slice(0, 2)
+        slice.valid?.should == true
+        @buffer.free
+        slice.valid?.should == true
+      end
+    end
+
+    ruby_version_is "4.1" do
+      it "is false for a slice of a freed string-backed buffer" do
+        @buffer = IO::Buffer.for("alive")
+        slice = @buffer.slice(0, 2)
+        slice.valid?.should == true
+        @buffer.free
+        slice.valid?.should == false
+      end
     end
 
     # There probably should be a test with a garbage-collected string,

--- a/test/ruby/test_io_buffer.rb
+++ b/test/ruby/test_io_buffer.rb
@@ -396,6 +396,33 @@ class TestIOBuffer < Test::Unit::TestCase
     assert_equal "Hello World", hello
   end
 
+  def test_string_backed_slice_is_invalidated_when_root_is_freed
+    buffer = IO::Buffer.for("Hello World")
+    slice = buffer.slice(0, 5)
+
+    assert_predicate slice, :valid?
+    buffer.free
+    refute_predicate slice, :valid?
+    assert_raise(IO::Buffer::InvalidatedError) {slice.get_string}
+  ensure
+    slice&.free unless slice&.null?
+    buffer&.free unless buffer&.null?
+  end
+
+  def test_string_backed_slice_escaping_block_is_invalidated
+    slice = nil
+
+    IO::Buffer.for(+"Hello World") do |buffer|
+      slice = buffer.slice(0, 5)
+      assert_predicate slice, :valid?
+    end
+
+    refute_predicate slice, :valid?
+    assert_raise(IO::Buffer::InvalidatedError) {slice.get_string}
+  ensure
+    slice&.free unless slice&.null?
+  end
+
   def test_transfer
     hello = %w"Hello World".join(" ")
     buffer = IO::Buffer.for(hello)


### PR DESCRIPTION
## Summary

- Make slices retain their root `IO::Buffer` rather than an external source directly.
- Keep nested slices pointing directly to the root, avoiding a chain of slices.
- Invalidate string-backed slices when their root is freed, including slices escaping an `IO::Buffer.for` block.

## Motivation

A slice of a string-backed buffer currently retains the String directly. Freeing the root buffer therefore leaves the slice appearing valid while the String remains alive. In the block form of `IO::Buffer.for`, this also allows a slice to escape after the temporary root buffer has been freed and the String unlocked.

Retaining the root buffer makes the lifetime relationship explicit and gives string-backed slices the same invalidation behavior as internal and mapped buffers.

## Testing

- `make test-all TESTS=test/ruby/test_io_buffer.rb`
- `make test-spec MSPECOPT=spec/ruby/core/io/buffer`
