### PR TITLE
Fix IO::Buffer#resize(0) for mapped buffers and slices

### DIFF
--- a/io_buffer.c
+++ b/io_buffer.c
@@ -1934,6 +1934,11 @@ rb_io_buffer_resize(VALUE self, size_t size)
         rb_raise(rb_eIOBufferAccessError, "Cannot resize external buffer!");
     }
 
+    if (size == 0) {
+        io_buffer_free(buffer);
+        return;
+    }
+
 #if defined(HAVE_MREMAP) && defined(MREMAP_MAYMOVE)
     if (buffer->flags & RB_IO_BUFFER_MAPPED) {
         void *base = mremap(buffer->base, buffer->size, size, MREMAP_MAYMOVE);
@@ -1952,11 +1957,6 @@ rb_io_buffer_resize(VALUE self, size_t size)
 #endif
 
     if (buffer->flags & RB_IO_BUFFER_INTERNAL) {
-        if (size == 0) {
-            io_buffer_free(buffer);
-            return;
-        }
-
         void *base = realloc(buffer->base, size);
 
         if (!base) {

--- a/test/ruby/test_io_buffer.rb
+++ b/test/ruby/test_io_buffer.rb
@@ -315,6 +315,7 @@ class TestIOBuffer < Test::Unit::TestCase
 
     buffer.resize(0)
     assert_predicate buffer, :null?
+    assert_equal "", buffer.get_string
 
     buffer.resize(1)
     assert_equal 1, buffer.size

--- a/test/ruby/test_io_buffer.rb
+++ b/test/ruby/test_io_buffer.rb
@@ -309,6 +309,29 @@ class TestIOBuffer < Test::Unit::TestCase
     assert_equal 1, buffer.size
   end
 
+  def test_resize_zero_mapped
+    buffer = IO::Buffer.new(IO::Buffer::PAGE_SIZE)
+    assert_predicate buffer, :mapped?
+
+    buffer.resize(0)
+    assert_predicate buffer, :null?
+
+    buffer.resize(1)
+    assert_equal 1, buffer.size
+  end
+
+  def test_resize_zero_slice
+    buffer = IO::Buffer.new(64)
+    slice = buffer.slice(0, 8)
+
+    slice.resize(0)
+    assert_predicate slice, :null?
+    assert_equal 64, buffer.size
+
+    slice.resize(1)
+    assert_equal 1, slice.size
+  end
+
   def test_resize_zero_external
     buffer = IO::Buffer.for('1')
 


### PR DESCRIPTION
Handle a zero target size before entering the allocation-specific resize paths.

This prevents mapped buffers from passing zero to `mremap`, and prevents slices and non-`mremap` mapped buffers from copying an uninitialized temporary `rb_io_buffer` structure. External buffers continue to raise `IO::Buffer::AccessError` when resized.

Regression tests cover internal, mapped, sliced, and external buffers, including resizing a null buffer back to a non-zero size.

[Bug #22234]

## Testing

- `make test-all TESTS=test/ruby/test_io_buffer.rb`
- 107 tests, 849 assertions, 0 failures, 0 errors