### PR TITLE
Process.warmup: recompute allocatable_bytes

### DIFF
--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -9518,9 +9518,6 @@ rb_gc_impl_prepare_heap(void *objspace_ptr)
 {
     rb_objspace_t *objspace = objspace_ptr;
 
-    size_t orig_total_slots = objspace_available_slots(objspace);
-    size_t orig_allocatable_bytes = objspace->heap_pages.allocatable_bytes;
-
     rb_gc_impl_each_objects(objspace, gc_set_candidate_object_i, objspace_ptr);
 
     double orig_max_free_slots = gc_params.heap_free_slots_max_ratio;
@@ -9534,11 +9531,15 @@ rb_gc_impl_prepare_heap(void *objspace_ptr)
     heap_pages_free_unused_pages(objspace_ptr);
     GC_ASSERT(heap_pages_freeable_pages == 0);
     GC_ASSERT(objspace->empty_pages_count == 0);
-    objspace->heap_pages.allocatable_bytes = orig_allocatable_bytes;
 
-    size_t total_slots = objspace_available_slots(objspace);
-    if (orig_total_slots > total_slots) {
-        objspace->heap_pages.allocatable_bytes += (orig_total_slots - total_slots) * heaps[0].slot_size;
+    // Process.warmup is meant to be called at the end of the boot sequence, which is commonly allocation
+    // heavy and result in GC limits raising significantly, but it's not indicative of the limits needed
+    // for runtime.
+    // Recompute the allocatable_bytes limit based on `gc_params.heap_init_bytes`.
+    GC_ASSERT(objspace->heap_pages.allocatable_bytes == 0);
+    for (int i = 0; i < HEAP_COUNT; i++) {
+        rb_heap_t *heap = &heaps[i];
+        heap_allocatable_bytes_expand(objspace, heap, heap->empty_slots, heap->total_slots, heap->slot_size);
     }
 
 #if defined(HAVE_MALLOC_TRIM) && !defined(RUBY_ALTERNATIVE_MALLOC_HEADER)


### PR DESCRIPTION
A problem I ran into in production, is that the boot sequence, which tend to be allocation heavy, would cause the `allocatable_bytes` (or previous version equivalent) to grow much higher than what the application runtime actually needs.

This resulted in GC not triggering for a long time, with the adverse effect of a unreasonably high memory usage and infrequent but long GC pauses to sweep dozens of requests worth of garbage.

I worked around that problem by explictly tuning the `INIT_SLOT_SIZE*` environment variables, to curb that growth. It works OK but is high maintaince as it needs to be retuned frequently as the application shape changes.

Overall I think the the boot sequence isn't a good indicator of the heap size the application will need at runtime (particularly for monolith type applications).

Hence it is desirable to somewhat "reset" (or recompute) the heap limits at end of boot. If we somehow undershoot, it will correct itself quickly after a few GC, which is preferable to overshooting.

```ruby
def to_mib(bytes) = "#{(bytes / 1024.0 / 1024).round(1)}MiB"
puts "heap_allocatable_bytes: #{to_mib(GC.stat[:heap_allocatable_bytes])}"
keep = 2_000_000.times.map { Object.new }
garbage = 10_000_000.times.map { Object.new }
garbage.clear
puts "heap_allocatable_bytes: #{to_mib(GC.stat[:heap_allocatable_bytes])}"
Process.warmup
puts "heap_allocatable_bytes: #{to_mib(GC.stat[:heap_allocatable_bytes])}"
```

master:

```
heap_allocatable_bytes: 0.0MiB
heap_allocatable_bytes: 79.2MiB
heap_allocatable_bytes: 372.1MiB
```

this branch:

```
heap_allocatable_bytes: 0.0MiB
heap_allocatable_bytes: 79.2MiB
heap_allocatable_bytes: 57.1MiB
```

NB: I'm not particularly convinced the algorithm in this patch is the ideal one, there's likely a better one people more familiar than me with the GC could come up with.

cc @peterzhu2118 as we discussed this yesterday.
cc @eightbitraptor as you may have insights here.