### PR TITLE
[DOC] Fix UnboundMethod#bind owner documentation

### DIFF
--- a/proc.c
+++ b/proc.c
@@ -3454,9 +3454,9 @@ convert_umethod_to_method_components(const struct METHOD *data, VALUE recv, VALU
  *  call-seq:
  *     umeth.bind(obj) -> method
  *
- *  Bind <i>umeth</i> to <i>obj</i>. If Klass was the class from which
- *  <i>umeth</i> was obtained, <code>obj.kind_of?(Klass)</code> must
- *  be true.
+ *  Bind <i>umeth</i> to <i>obj</i>. If <i>umeth</i>'s owner is a class,
+ *  <i>obj</i> must be an instance of that class or one of its subclasses.
+ *  If the owner is a module, <i>obj</i> may be any object.
  *
  *     class A
  *       def test
@@ -3470,6 +3470,7 @@ convert_umethod_to_method_components(const struct METHOD *data, VALUE recv, VALU
  *
  *
  *     um = B.instance_method(:test)
+ *     um.owner #=> A
  *     bm = um.bind(C.new)
  *     bm.call
  *     bm = um.bind(B.new)
@@ -3481,8 +3482,7 @@ convert_umethod_to_method_components(const struct METHOD *data, VALUE recv, VALU
  *
  *     In test, class = C
  *     In test, class = B
- *     prog.rb:16:in `bind': bind argument must be an instance of B (TypeError)
- *     	from prog.rb:16
+ *     In test, class = A
  */
 
 static VALUE


### PR DESCRIPTION
The `UnboundMethod#bind` documentation currently describes the binding constraint in terms of the class used to obtain the method. The implementation instead uses the method's owner, and allows methods owned by modules to be bound to any object.

This updates the wording and corrects the example: `B.instance_method(:test)` is owned by `A`, so binding it to `A.new` succeeds.

Verification:

- Generated the RDoc for `proc.c`
- Ran the documented class and module binding examples
