### PR TITLE
[DOC] Document UnboundMethod#bind rules for class and module owners

### DIFF
--- a/proc.c
+++ b/proc.c
@@ -3454,9 +3454,9 @@ convert_umethod_to_method_components(const struct METHOD *data, VALUE recv, VALU
  *  call-seq:
  *     umeth.bind(obj) -> method
  *
- *  Bind <i>umeth</i> to <i>obj</i>. If Klass was the class from which
- *  <i>umeth</i> was obtained, <code>obj.kind_of?(Klass)</code> must
- *  be true.
+ *  Bind <i>umeth</i> to <i>obj</i>. If <i>umeth</i>'s owner is a class,
+ *  <i>obj</i> must be an instance of that class or one of its subclasses.
+ *  If the owner is a module, <i>obj</i> may be any object.
  *
  *     class A
  *       def test
@@ -3470,6 +3470,7 @@ convert_umethod_to_method_components(const struct METHOD *data, VALUE recv, VALU
  *
  *
  *     um = B.instance_method(:test)
+ *     um.owner #=> A
  *     bm = um.bind(C.new)
  *     bm.call
  *     bm = um.bind(B.new)
@@ -3477,12 +3478,22 @@ convert_umethod_to_method_components(const struct METHOD *data, VALUE recv, VALU
  *     bm = um.bind(A.new)
  *     bm.call
  *
+ *     module M
+ *       def mm
+ *         "mm on #{self.class}"
+ *       end
+ *     end
+ *
+ *     um2 = M.instance_method(:mm)
+ *     um2.owner #=> M
+ *     um2.bind(42).call #=> "mm on Integer"
+ *
  *  <em>produces:</em>
  *
  *     In test, class = C
  *     In test, class = B
- *     prog.rb:16:in `bind': bind argument must be an instance of B (TypeError)
- *     	from prog.rb:16
+ *     In test, class = A
+ *     mm on Integer
  */
 
 static VALUE


### PR DESCRIPTION
The UnboundMethod#bind documentation described the class used to obtain a method as the binding constraint, which does not match the implementation.

Update the RDoc to describe the method owner's rules for class-owned and module-owned methods, including examples of each case.