### PR TITLE
Array#flatten: optimize the common `*args.flatten` pattern

### DIFF
--- a/array.c
+++ b/array.c
@@ -6837,6 +6837,22 @@ flatten(VALUE ary, int level)
     return result;
 }
 
+static inline VALUE
+single_nested_array(VALUE ary)
+{
+    // Fast path for the common variadic argument pattern:
+    // def foo(*args)
+    //   args.flatten!
+    //   ...
+    if (RARRAY_LEN(ary) == 1) {
+        VALUE first = RARRAY_AREF(ary, 0);
+        if (RB_TYPE_P(first, T_ARRAY) && CLASS_OF(first) == rb_cArray) {
+            return first;
+        }
+    }
+    return 0;
+}
+
 /*
  *  call-seq:
  *    flatten!(depth = nil) -> self or nil
@@ -6883,11 +6899,24 @@ rb_ary_flatten_bang(int argc, VALUE *argv, VALUE ary)
     if (!NIL_P(lv)) level = NUM2INT(lv);
     if (level == 0) return Qnil;
 
-    result = flatten(ary, level);
-    if (result == ary) {
-        return Qnil;
+    VALUE child = single_nested_array(ary);
+    if (child) {
+        if (level == 1) {
+            result = child;
+        }
+        else {
+            if (level > 1) level--;
+            result = flatten(child, level);
+        }
     }
-    if (!(mod = ARY_EMBED_P(result))) rb_ary_freeze(result);
+    else {
+        result = flatten(ary, level);
+        if (result == ary) {
+            return Qnil;
+        }
+    }
+
+    if (!(mod = ARY_EMBED_P(result) && result != child)) rb_ary_freeze(result);
     rb_ary_replace(ary, result);
     if (mod) ARY_SET_EMBED_LEN(result, 0);
 
@@ -6940,9 +6969,22 @@ rb_ary_flatten(int argc, VALUE *argv, VALUE ary)
         if (level == 0) return ary_make_shared_copy(ary);
     }
 
-    result = flatten(ary, level);
-    if (result == ary) {
-        result = ary_make_shared_copy(ary);
+    VALUE child = single_nested_array(ary);
+    if (child) {
+        if (level == 1) {
+            result = child;
+        }
+        else {
+            level--;
+            result = flatten(child, level);
+        }
+    }
+    else {
+        result = flatten(ary, level);
+    }
+
+    if (result == ary || result == child) {
+        return ary_make_shared_copy(result);
     }
 
     return result;

--- a/benchmark/array_flatten.yml
+++ b/benchmark/array_flatten.yml
@@ -4,16 +4,26 @@ prelude: |
   small_pairs_ary = [[1, 2]] * 5
   large_pairs_ary = [[1, 2]] * 100
   mostly_flat_ary = 100.times.to_a.push([101, 102])
+  small_nested_ary = [small_flat_ary]
+  large_nested_ary = [large_flat_ary]
 
 benchmark:
   small_flat_ary.flatten: small_flat_ary.flatten
-  small_flat_ary.flatten!: small_flat_ary.flatten!
+  small_flat_ary.flatten!: small_flat_ary.dup.flatten!
   large_flat_ary.flatten: large_flat_ary.flatten
-  large_flat_ary.flatten!: large_flat_ary.flatten!
+  large_flat_ary.flatten!: large_flat_ary.dup.flatten!
   small_pairs_ary.flatten: small_pairs_ary.flatten
   small_pairs_ary.flatten!: small_pairs_ary.dup.flatten!
   large_pairs_ary.flatten: large_pairs_ary.flatten
   large_pairs_ary.flatten!: large_pairs_ary.dup.flatten!
   mostly_flat_ary.flatten: mostly_flat_ary.flatten
   mostly_flat_ary.flatten!: mostly_flat_ary.dup.flatten!
+  small_nested_ary.flatten: small_nested_ary.flatten
+  small_nested_ary.flatten!: small_nested_ary.dup.flatten!
+  large_nested_ary.flatten: large_nested_ary.flatten
+  large_nested_ary.flatten!: large_nested_ary.dup.flatten!
+  small_nested_ary.flatten(1): small_nested_ary.flatten(1)
+  small_nested_ary.flatten!(1): small_nested_ary.dup.flatten!(1)
+  large_nested_ary.flatten(1): large_nested_ary.flatten(1)
+  large_nested_ary.flatten!(1): large_nested_ary.dup.flatten!(1)
 loop_count: 10000


### PR DESCRIPTION
A common Ruby idiom for variadic methods is to flatten the argument list so that it can be called with either variadic arguments or an Array.

e.g. from the sqlite3 gem:

```ruby
def bind_params(*bind_vars)
  bind_vars.flatten.each do |var|
  # ...
```

However, as soon as `flatten` encounter another array, it has to protect against recursion, which requires allocating an expensive identity Hash.
So this pattern has a relatively high cost when called with a single array argument (e.g. `bind_params [1, 2, 3]`).

We can specialize for that common case without noticeably impacting other usages of `Array#flatten`:

|                              |compare-ruby|built-ruby|
|:-----------------------------|-----------:|---------:|
|small_flat_ary.flatten        |      7.547M|    7.974M|
|                              |           -|     1.06x|
|small_flat_ary.flatten!       |      6.031M|    6.105M|
|                              |           -|     1.01x|
|large_flat_ary.flatten        |    465.896k|  485.861k|
|                              |           -|     1.04x|
|large_flat_ary.flatten!       |    455.872k|  478.103k|
|                              |           -|     1.05x|
|small_pairs_ary.flatten       |      1.327M|    1.407M|
|                              |           -|     1.06x|
|small_pairs_ary.flatten!      |      1.165M|    1.153M|
|                              |       1.01x|         -|
|large_pairs_ary.flatten       |     96.612k|   96.976k|
|                              |           -|     1.00x|
|large_pairs_ary.flatten!      |     94.108k|   97.289k|
|                              |           -|     1.03x|
|mostly_flat_ary.flatten       |    399.648k|  417.327k|
|                              |           -|     1.04x|
|mostly_flat_ary.flatten!      |    378.315k|  395.946k|
|                              |           -|     1.05x|
|small_nested_ary.flatten      |      2.513M|    7.788M|
|                              |           -|     3.10x|
|small_nested_ary.flatten!     |      2.024M|    5.914M|
|                              |           -|     2.92x|
|large_nested_ary.flatten      |    341.635k|  485.319k|
|                              |           -|     1.42x|
|large_nested_ary.flatten!     |    329.837k|  475.014k|
|                              |           -|     1.44x|
|small_nested_ary.flatten(1)   |      9.497M|   61.350M|
|                              |           -|     6.46x|
|small_nested_ary.flatten!(1)  |      5.136M|   17.668M|
|                              |           -|     3.44x|
|large_nested_ary.flatten(1)   |      1.575M|   60.241M|
|                              |           -|    38.26x|
|large_nested_ary.flatten!(1)  |      1.369M|   16.835M|
|                              |           -|    12.30x|