### PR TITLE
Keep a timer-thread wake batch from naming a freed thread

### DIFF
--- a/thread.c
+++ b/thread.c
@@ -836,6 +836,9 @@ thread_start_func_2(rb_thread_t *th, VALUE *stack_start)
 
 #if defined(USE_MN_THREADS) && USE_MN_THREADS
     if (th_has_coroutine(th)) {
+        // wait out any pending wake while th and its Ractor are still alive
+        rb_thread_wake_fence(th);
+
         // Run the coroutine thread's epilogue here, while th is still valid;
         // co_start then only makes the final transfer (see
         // coroutine_thread_terminated in thread_pthread_mn.c).

--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -334,6 +334,7 @@ static void ractor_sched_enq(rb_vm_t *vm, rb_ractor_t *r);
 static void timer_thread_wakeup(void);
 static void timer_thread_wakeup_locked(rb_vm_t *vm);
 static void timer_thread_wakeup_force(void);
+static void timer_thread_wake_fence(struct rb_thread_struct *th);
 static bool ractor_sched_timeout_arm(rb_thread_t *th, const rb_hrtime_t *rel);
 static bool ractor_sched_timeout_disarm(rb_thread_t *th);
 static void thread_sched_switch(rb_thread_t *cth, rb_thread_t *next_th);
@@ -1112,6 +1113,9 @@ thread_sched_to_dead_common(struct rb_thread_sched *sched, rb_thread_t *th)
 static void
 thread_sched_to_dead(struct rb_thread_sched *sched, rb_thread_t *th)
 {
+    // wait out any pending wake here, while th's Ractor is still alive
+    timer_thread_wake_fence(th);
+
     thread_sched_lock(sched, th);
     {
         thread_sched_to_dead_common(sched, th);
@@ -2667,8 +2671,15 @@ thread_sched_reclaim(struct coroutine_context *dead_co)
 #endif
 
 void
+rb_thread_wake_fence(rb_thread_t *th)
+{
+    timer_thread_wake_fence(th);
+}
+
+void
 rb_threadptr_sched_free(rb_thread_t *th)
 {
+    timer_thread_wake_fence(th);
 #if USE_MN_THREADS
     if (th->sched.malloc_stack) {
         // has dedicated
@@ -3181,6 +3192,9 @@ static struct {
     rb_hrtime_t next_expiry;   // never later than the earliest deadline
     struct ccan_list_head waiting_untimed;
     pthread_mutex_t waiting_lock;
+
+    // signaled when wake_pending clears on a thread; see timer_thread_wake_fence
+    rb_nativethread_cond_t wake_pending_cond;
 #endif
 
 #if (HAVE_SYS_EPOLL_H || HAVE_SYS_EVENT_H) && USE_MN_THREADS
@@ -3405,6 +3419,7 @@ rb_thread_create_timer_thread(void)
         timer_th.next_expiry = TIMER_WHEEL_NO_EXPIRY;
         ccan_list_head_init(&timer_th.waiting_untimed);
         rb_native_mutex_initialize(&timer_th.waiting_lock);
+        rb_native_cond_initialize(&timer_th.wake_pending_cond);
 #endif
 
         // open communication channel

--- a/thread_pthread.h
+++ b/thread_pthread.h
@@ -103,6 +103,9 @@ struct rb_thread_sched_item {
     struct rb_thread_sched_waiting waiting_reason;
     uint32_t event_serial;
 
+    // the timer thread has a wake pending for this thread; under waiting_lock
+    bool wake_pending;
+
     bool malloc_stack;
     void *context_stack;
     size_t context_stack_size;
@@ -230,5 +233,6 @@ RUBY_EXTERN native_tls_key_t ruby_current_ec_key;
 struct rb_ractor_struct;
 void rb_ractor_sched_wait(struct rb_execution_context_struct *ec, struct rb_ractor_struct *cr, rb_unblock_function_t *ubf, void *ptr);
 void rb_ractor_sched_wakeup(struct rb_ractor_struct *r, struct rb_thread_struct *th);
+void rb_thread_wake_fence(struct rb_thread_struct *th);
 
 #endif /* RUBY_THREAD_PTHREAD_H */

--- a/thread_pthread_mn.c
+++ b/thread_pthread_mn.c
@@ -260,6 +260,44 @@ timer_thread_wakeup_thread(rb_thread_t *th, uint32_t event_serial)
 
 #define TIMEOUT_WAKE_BATCH 16
 
+// One thread the timer thread is about to wake, with the serial it was armed at.
+struct timer_wake { rb_thread_t *th; uint32_t serial; };
+
+// Mark each thread while a wake is pending for it, so a dying thread can wait
+// (timer_thread_wake_fence).  Set under waiting_lock before the lock is dropped.
+static void
+timer_wake_pending_set(struct timer_wake *batch, int n)
+{
+    for (int i = 0; i < n; i++) {
+        batch[i].th->sched.wake_pending = true;
+    }
+}
+
+static void
+timer_wake_pending_clear(struct timer_wake *batch, int n)
+{
+    rb_native_mutex_lock(&timer_th.waiting_lock);
+    for (int i = 0; i < n; i++) {
+        batch[i].th->sched.wake_pending = false;
+    }
+    rb_native_cond_broadcast(&timer_th.wake_pending_cond);
+    rb_native_mutex_unlock(&timer_th.waiting_lock);
+}
+
+// Wait out a pending wake before a thread is freed: it would touch freed memory,
+// or wake a reused thread whose first serial matches the stale entry.
+static void
+timer_thread_wake_fence(rb_thread_t *th)
+{
+    if (!TIMER_THREAD_CREATED_P()) return;
+
+    rb_native_mutex_lock(&timer_th.waiting_lock);
+    while (th->sched.wake_pending) {
+        rb_native_cond_wait(&timer_th.wake_pending_cond, &timer_th.waiting_lock);
+    }
+    rb_native_mutex_unlock(&timer_th.waiting_lock);
+}
+
 static void
 timer_thread_check_timeout(rb_vm_t *vm)
 {
@@ -269,7 +307,7 @@ timer_thread_check_timeout(rb_vm_t *vm)
 
     ccan_list_head_init(&expired);
 
-    struct timeout_wake { rb_thread_t *th; uint32_t serial; } batch[TIMEOUT_WAKE_BATCH];
+    struct timer_wake batch[TIMEOUT_WAKE_BATCH];
     bool more = true;
 
     while (more) {
@@ -294,12 +332,14 @@ timer_thread_check_timeout(rb_vm_t *vm)
                 n++;
             }
             more = !ccan_list_empty(&expired);
+            timer_wake_pending_set(batch, n);
         }
         rb_native_mutex_unlock(&timer_th.waiting_lock);
 
         for (int i = 0; i < n; i++) {
             timer_thread_wakeup_thread(batch[i].th, batch[i].serial);
         }
+        timer_wake_pending_clear(batch, n);
     }
 }
 
@@ -1452,7 +1492,7 @@ event_wait(rb_vm_t *vm)
 static void
 timer_thread_wake_fd_waiters(int fd, uint32_t generation, uint32_t wake_flags, int result)
 {
-    struct { rb_thread_t *th; uint32_t serial; } batch[FD_WAKE_BATCH];
+    struct timer_wake batch[FD_WAKE_BATCH];
 
     if (wake_flags == 0) return;
 
@@ -1493,12 +1533,15 @@ timer_thread_wake_fd_waiters(int fd, uint32_t generation, uint32_t wake_flags, i
                 // they all just woke up).
                 fd_waiters_arm(fd, e, fd_waiters_union(e));
             }
+
+            timer_wake_pending_set(batch, n);
         }
         rb_native_mutex_unlock(&timer_th.waiting_lock);
 
         for (int i = 0; i < n; i++) {
             timer_thread_wakeup_thread(batch[i].th, batch[i].serial);
         }
+        timer_wake_pending_clear(batch, n);
 
         if (!more) break;
     }
@@ -1696,6 +1739,12 @@ static int
 timer_wheel_timeout(int timeout)
 {
     return timeout; // no M:N threads, no timed waiters
+}
+
+static void
+timer_thread_wake_fence(rb_thread_t *th)
+{
+    // no timer wheel, no wake batches
 }
 
 static void


### PR DESCRIPTION
The timer thread delivers expiry and fd wakeups in batches: it collects {thread, serial} pairs under timer_th.waiting_lock, releases the lock (the scheduler lock a wakeup takes must not nest inside it), and then wakes each thread.  Unlinking an entry is what releases its thread, so from that moment the thread can be woken by somebody else, exit and be freed while the batch still holds a bare pointer to it.  Waking it then dereferences a freed thread, and crashes when the Ractor holding it was torn down:

```
  [BUG] Segmentation fault at 0x0000000000000138
  timer_thread_check_timeout -> timer_thread_wakeup_thread
  -> rb_native_mutex_lock(&TH_SCHED(th)->lock_)   # th->ractor is NULL
```

The serial captured in the batch does not help, and can even match again: a thread struct reused from the freed one starts counting event serials from zero, so its first timed wait matches serial 1 held in a stale batch entry, and the timer wakes a thread whose wheel entry is still armed:

  Assertion Failed: thread_sched_wait_running_turn:
      th->sched.waiting_reason.flags == thread_sched_waiting_none

Both reproduce on a loop of Ractors that die while one of their threads sits in a timed receive, in ~15 rounds of 400.  They only became reachable when e1bce29aac cut a dying Ractor's teardown from one second to well under a millisecond: the batch window used to be dwarfed by the teardown time.

Holding waiting_lock across the wakes would close the window but deadlock: arming a timer takes the scheduler lock and then waiting_lock, so a wake taking the scheduler lock under waiting_lock inverts the order.  So mark the threads instead.  When the timer thread publishes a batch it sets in_wake_batch on each thread, under waiting_lock; when it has woken them all it clears the marks and broadcasts.  A dying thread checks its own mark and waits on the cond until it clears, fencing twice:

Once when it leaves the scheduler for good (thread_sched_to_dead, and the coroutine epilogue in thread_start_func_2).  This is the fence that matters for a dying Ractor: a stale wakeup reaches the Ractor through TH_SCHED(), and the rb_ractor_t can be collected as soon as the Ractor is unlinked, so the wait must happen while it is still alive.  Nothing re-arms the thread after this point, so no later batch can name it.

Once more when the rb_thread_t itself is freed (rb_threadptr_sched_free), as a backstop for frees that do not come through a thread's own exit.

The wait is bounded by one batch of at most 16 wakeups, and the fence takes only waiting_lock, which the timer thread never holds while it wakes, so the two cannot deadlock.