### PR TITLE
Normalize empty IO::Buffer state

### DIFF
--- a/io_buffer.c
+++ b/io_buffer.c
@@ -191,6 +191,7 @@ io_buffer_zero(struct rb_io_buffer *buffer)
 {
     buffer->base = NULL;
     buffer->size = 0;
+    buffer->flags = 0;
     buffer->lock_count = 0;
 #if defined(_WIN32)
     buffer->mapping = NULL;
@@ -259,13 +260,6 @@ io_buffer_free(struct rb_io_buffer *buffer)
         // if (RB_TYPE_P(buffer->source, T_STRING)) {
         //     rb_str_unlocktmp(buffer->source);
         // }
-
-        buffer->base = NULL;
-
-        buffer->size = 0;
-        buffer->flags = 0;
-        buffer->lock_count = 0;
-        buffer->source = Qnil;
     }
 
 #if defined(_WIN32)
@@ -277,6 +271,8 @@ io_buffer_free(struct rb_io_buffer *buffer)
         buffer->mapping = NULL;
     }
 #endif
+
+    io_buffer_zero(buffer);
 }
 
 static void

--- a/test/ruby/test_io_buffer.rb
+++ b/test/ruby/test_io_buffer.rb
@@ -453,6 +453,16 @@ class TestIOBuffer < Test::Unit::TestCase
     transferred = buffer.transfer
     assert_equal "Hello World", transferred.get_string
     assert_predicate buffer, :null?
+    assert_predicate buffer, :empty?
+    assert_predicate buffer, :valid?
+    refute_predicate buffer, :external?
+    refute_predicate buffer, :internal?
+    refute_predicate buffer, :mapped?
+    refute_predicate buffer, :shared?
+    refute_predicate buffer, :private?
+    refute_predicate buffer, :readonly?
+    assert_equal "", buffer.get_string
+    assert_equal 0, buffer.set_string("")
     assert_raise IO::Buffer::AccessError do
       transferred.set_string("Goodbye")
     end


### PR DESCRIPTION
## Summary

- Clear allocation flags whenever an `IO::Buffer` is reset.
- Use the same reset helper after `free`, including when the buffer is already null.
- Ensure the source of `transfer` becomes a canonical valid, empty buffer.

Previously, transferring a string-backed buffer cleared its address and size but preserved flags such as `EXTERNAL` and `READONLY`. The source therefore reported both `null?` and `readonly?`, and even a zero-length write raised `IO::Buffer::AccessError`.

After this change, `free` and the source side of `transfer` consistently produce `{base = NULL, size = 0, flags = 0, lock_count = 0, source = nil}`.

## Testing

`make test-all TESTS=/Users/samuel/Developer/samuel-williams-shopify/ruby-io-buffer-resize-zero/test/ruby/test_io_buffer.rb`

107 tests, 860 assertions, 0 failures, 0 errors.