### PR TITLE
A forked child has one Ractor, but not one objspace

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -4183,9 +4183,12 @@ rb_gc_obj_foreign_p(VALUE obj)
 bool
 rb_gc_single_objspace_p(void)
 {
-    if (!rb_gc_impl_multi_objspace_p() || ruby_single_main_ractor) return true;
+    if (!rb_gc_impl_multi_objspace_p()) return true;
     rb_vm_t *vm = GET_VM();
-    return vm->ractor.cnt == 1 && vm->gc.zombie_objspaces_count == 0 && gc_absorbing_zombie == 0 &&
+    /* One Ractor is not one objspace: a forked child re-enters single-Ractor mode while
+     * the pre-fork Ractors' objspaces are still parked in zombie_objspaces. */
+    return (ruby_single_main_ractor != NULL || vm->ractor.cnt == 1) &&
+           vm->gc.zombie_objspaces_count == 0 && gc_absorbing_zombie == 0 &&
            !gc_absorbed_since_global_gc &&
            (vm->ractor.main_ractor == NULL ||
             vm->ractor.main_ractor->creating_child_objspace == NULL);

--- a/test/ruby/test_ractor.rb
+++ b/test/ruby/test_ractor.rb
@@ -272,6 +272,21 @@ class TestRactor < Test::Unit::TestCase
     RUBY
   end
 
+  def test_fork_child_gc_pins_shareable_objects
+    # A forked child re-enters single-Ractor mode while the Ractors it had before the
+    # fork leave their objspaces behind, so its local GC still has to pin shareable
+    # objects instead of collecting them.
+    assert_ractor(<<~'RUBY')
+      port = Ractor::Port.new
+      Ractor.new(port) { |p| p << Ractor::Port.new; Ractor.receive }
+      foreign_port = port.receive # a Port owned by, and allocated in, the other Ractor
+      pid = fork { 100_000.times { +"x" }; exit!(0) }
+      _, status = Process.waitpid2(pid)
+      assert_predicate status, :success?
+      assert_instance_of Ractor::Port, foreign_port
+    RUBY
+  end if Process.respond_to?(:fork)
+
   def test_fork_raise_isolation_error
     assert_ractor(<<~'RUBY')
       ractor = Ractor.new do


### PR DESCRIPTION
rb_gc_single_objspace_p() answered "single" as soon as ruby_single_main_ractor was set, and rb_ractor_atfork() sets it again in the child.  The pre-fork Ractors' objspaces are still parked in zombie_objspaces at that point, so the child's local GC skipped pinned_roots_mark and swept live shareable objects: a Ractor wrapper still named by a foreign Ractor::Port, or a cc in a class's cc_table. The next mark then walked freed memory.

Ask the rest of the conditions in that case too; one Ractor is not one objspace.