### PR TITLE
thread: leave the shared pool without the scheduler lock

### DIFF
--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -1482,7 +1482,7 @@ ractor_sched_enq(rb_vm_t *vm, rb_ractor_t *r)
         // With every snt dedicated or retired, only the timer thread's
         // timeout branch can serve the entry or widen the pool: wake it
         // (a no-op unless it sleeps untimed).
-        if (vm->ractor.sched.snt_cnt == 0) {
+        if (RUBY_ATOMIC_LOAD(vm->ractor.sched.snt_cnt) == 0) {
             timer_thread_wakeup_locked(vm);
         }
 
@@ -1528,8 +1528,8 @@ ractor_sched_deq(rb_vm_t *vm, rb_ractor_t *cr)
             RUBY_DEBUG_LOG("wait grq_cnt:%d", (int)vm->ractor.sched.grq_cnt);
 
             if (SNT_IDLE_RETIRE >= 0 && ++idle_streak > SNT_IDLE_RETIRE &&
-                (int)vm->ractor.sched.snt_cnt > SNT_KEEP_MINIMUM) {
-                vm->ractor.sched.snt_cnt--;
+                (int)RUBY_ATOMIC_LOAD(vm->ractor.sched.snt_cnt) > SNT_KEEP_MINIMUM) {
+                RUBY_ATOMIC_DEC(vm->ractor.sched.snt_cnt);
                 RUBY_DEBUG_LOG("retire, snt_cnt:%d", (int)vm->ractor.sched.snt_cnt);
                 break;   // returning NULL ends this nt; see the caller
             }
@@ -1862,11 +1862,15 @@ thread_sched_atfork(struct rb_thread_sched *sched)
 
     if (th_has_dedicated_nt(th)) {
         vm->ractor.sched.snt_cnt = 0;
+#if USE_RUBY_DEBUG_LOG
         vm->ractor.sched.dnt_cnt = 1;
+#endif
     }
     else {
         vm->ractor.sched.snt_cnt = 1;
+#if USE_RUBY_DEBUG_LOG
         vm->ractor.sched.dnt_cnt = 0;
+#endif
     }
     vm->ractor.sched.running_cnt = 0;
 
@@ -2029,7 +2033,9 @@ Init_native_thread(rb_thread_t *main_th)
     main_th->nt->vm = vm;
 
     // setup mn
+#if USE_RUBY_DEBUG_LOG
     vm->ractor.sched.dnt_cnt = 1;
+#endif
 }
 
 extern int ruby_mn_threads_enabled;
@@ -2074,18 +2080,21 @@ native_thread_dedicated_inc(rb_vm_t *vm, rb_ractor_t *cr, struct rb_native_threa
     RUBY_DEBUG_LOG("nt:%d %d->%d", nt->serial, nt->dedicated, nt->dedicated + 1);
 
     if (nt->dedicated == 0) {
-        ractor_sched_lock(vm, cr);
-        {
-            vm->ractor.sched.snt_cnt--;
-            vm->ractor.sched.dnt_cnt++;
-
-            // This may have dedicated the last snt away from a pending
-            // entry whose enqueue saw snt_cnt > 0 (see ractor_sched_enq).
-            if (vm->ractor.sched.snt_cnt == 0 && vm->ractor.sched.grq_cnt > 0) {
-                timer_thread_wakeup_locked(vm);
+        // Lock-free; pairs with ractor_sched_enq (enq: grq_cnt up then read
+        // snt_cnt / here: snt_cnt down then read grq_cnt) against lost wakeups.
+        if (RUBY_ATOMIC_FETCH_SUB(vm->ractor.sched.snt_cnt, 1) == 1) {
+            // the last snt went dedicated; pending entries need the timer thread
+            ractor_sched_lock(vm, cr);
+            {
+                if (vm->ractor.sched.grq_cnt > 0) {
+                    timer_thread_wakeup_locked(vm);
+                }
             }
+            ractor_sched_unlock(vm, cr);
         }
-        ractor_sched_unlock(vm, cr);
+#if USE_RUBY_DEBUG_LOG
+        vm->ractor.sched.dnt_cnt++;
+#endif
     }
 
     nt->dedicated++;
@@ -2099,21 +2108,21 @@ native_thread_dedicated_dec(rb_vm_t *vm, rb_ractor_t *cr, struct rb_native_threa
     nt->dedicated--;
 
     if (nt->dedicated == 0) {
-        ractor_sched_lock(vm, cr);
-        {
-            /* max_cpu bounds the shared threads and this is where one rejoins
-             * them, so this is where the cap has to hold.  A thread with no room
-             * to come back to belongs to neither count until it ends. */
-            if (vm->ractor.sched.snt_cnt < vm->ractor.sched.max_cpu ||
-                (int)vm->ractor.sched.snt_cnt <= MINIMUM_SNT) {
-                vm->ractor.sched.snt_cnt++;
+        // Rejoin under the max_cpu cap; with no room this nt retires and
+        // belongs to neither count until it ends.
+        while (1) {
+            rb_atomic_t snt = RUBY_ATOMIC_LOAD(vm->ractor.sched.snt_cnt);
+            if (snt < vm->ractor.sched.max_cpu || (int)snt <= MINIMUM_SNT) {
+                if (RUBY_ATOMIC_CAS(vm->ractor.sched.snt_cnt, snt, snt + 1) == snt) break;
             }
             else {
                 nt->retiring = true;
+                break;
             }
-            vm->ractor.sched.dnt_cnt--;
         }
-        ractor_sched_unlock(vm, cr);
+#if USE_RUBY_DEBUG_LOG
+        vm->ractor.sched.dnt_cnt--;
+#endif
     }
 }
 

--- a/thread_pthread_mn.c
+++ b/thread_pthread_mn.c
@@ -824,19 +824,25 @@ native_thread_check_and_create_shared(rb_vm_t *vm)
         if (!vm->ractor.main_ractor->threads.sched.enable_mn_threads)
             schedulable_ractor_cnt--; // do not need snt for main ractor
 
-        unsigned int snt_cnt = vm->ractor.sched.snt_cnt;
-        if (((int)snt_cnt < MINIMUM_SNT) ||
-            (snt_cnt < schedulable_ractor_cnt  &&
-             snt_cnt < vm->ractor.sched.max_cpu)) {
+        // CAS keeps a concurrent rejoin from pushing snt_cnt past the cap
+        rb_atomic_t snt_cnt = RUBY_ATOMIC_LOAD(vm->ractor.sched.snt_cnt);
+        while (((int)snt_cnt < MINIMUM_SNT) ||
+               (snt_cnt < schedulable_ractor_cnt  &&
+                snt_cnt < vm->ractor.sched.max_cpu)) {
+            rb_atomic_t prev = RUBY_ATOMIC_CAS(vm->ractor.sched.snt_cnt, snt_cnt, snt_cnt + 1);
+            if (prev == snt_cnt) {
+                need_to_make = true;
+                break;
+            }
+            snt_cnt = prev;
+        }
 
+        if (need_to_make) {
             RUBY_DEBUG_LOG("added snt:%u dnt:%u ractor_cnt:%u grq_cnt:%u",
                            vm->ractor.sched.snt_cnt,
                            vm->ractor.sched.dnt_cnt,
                            vm->ractor.cnt,
                            vm->ractor.sched.grq_cnt);
-
-            vm->ractor.sched.snt_cnt++;
-            need_to_make = true;
         }
         else {
             RUBY_DEBUG_LOG("snt:%d ractor_cnt:%d", (int)vm->ractor.sched.snt_cnt, (int)vm->ractor.cnt);
@@ -852,7 +858,7 @@ native_thread_check_and_create_shared(rb_vm_t *vm)
             // Roll back, or this function would conclude forever that the
             // pool is wide enough and never try again.
             ractor_sched_lock(vm, NULL);
-            vm->ractor.sched.snt_cnt--;
+            RUBY_ATOMIC_DEC(vm->ractor.sched.snt_cnt);
             ractor_sched_unlock(vm, NULL);
             native_thread_destroy(nt);
         }

--- a/vm_core.h
+++ b/vm_core.h
@@ -749,8 +749,10 @@ typedef struct rb_vm_struct {
             bool locked;
 
             rb_nativethread_cond_t cond; // GRQ
-            unsigned int snt_cnt; // count of shared NTs
-            unsigned int dnt_cnt; // count of dedicated NTs
+            rb_atomic_t snt_cnt;  // count of shared NTs; lock-free (see native_thread_dedicated_inc)
+#if USE_RUBY_DEBUG_LOG
+            unsigned int dnt_cnt; // count of dedicated NTs; logging only, not atomic
+#endif
 
             unsigned int running_cnt;
 


### PR DESCRIPTION
native_thread_dedicated_inc/dec run on every blocking region boundary and took ractor.sched.lock each way just to move two counters.  Make snt_cnt a seq-cst atomic: leaving the pool is one FETCH_SUB, and rejoining is a CAS loop that enforces the max_cpu cap.  The lock is taken only when the last snt goes dedicated, to check grq_cnt and wake the timer thread.

The lost-wakeup gate stays sound as a store-buffer pair: ractor_sched_enq raises grq_cnt and then reads snt_cnt; dedicated_inc lowers snt_cnt and then reads grq_cnt under the lock, so at least one side sees the other.

Both increment paths (rejoin and pool widening) check the cap and then CAS, so max_cpu still holds without the lock.

dnt_cnt only ever fed one RUBY_DEBUG_LOG line, so define and update it only under USE_RUBY_DEBUG_LOG, without atomicity; nothing may read it for decisions.

R ractors x 1 thread each doing pipe write/read round-trips on a 16-HT machine (Ryzen 9 5900HX), round-trips/sec, median of repeated runs:

      R    master   patched
      1      422k      430k    +2%
      2      718k      752k    +5%
      4      933k    1,036k   +11%
      8      905k    1,111k   +23%
     16      735k    1,016k   +38%
     32      671k      955k   +42%
     64      690k      952k   +38%
    128      685k      946k   +38%

master peaks at 4 ractors and degrades under lock contention; patched peaks at 8 and holds up to 128.  Single-ractor shapes are unchanged.