### PR TITLE
Resize IO::Buffer slices without reallocating

### DIFF
--- a/io_buffer.c
+++ b/io_buffer.c
@@ -345,13 +345,19 @@ get_io_buffer(VALUE self)
     return buffer;
 }
 
+static bool
+io_buffer_slice_p(struct rb_io_buffer *buffer)
+{
+    return rb_typeddata_is_kind_of(buffer->source, &rb_io_buffer_type);
+}
+
 // Return the buffer which owns the lock count. A slice backed by another
 // buffer shares that source buffer's lock count. Other external sources, such
 // as strings, manage their own lifetime and do not share buffer lock state.
 static struct rb_io_buffer *
 io_buffer_lock_owner(struct rb_io_buffer *buffer)
 {
-    if (rb_typeddata_is_kind_of(buffer->source, &rb_io_buffer_type)) {
+    if (io_buffer_slice_p(buffer)) {
         return get_io_buffer(buffer->source);
     }
 
@@ -1775,7 +1781,7 @@ rb_io_buffer_slice(struct rb_io_buffer *buffer, VALUE self, size_t offset, size_
 
     // Slices retain their root buffer. If this buffer is already a slice,
     // retain its root directly rather than building a chain of slices:
-    if (rb_typeddata_is_kind_of(buffer->source, &rb_io_buffer_type)) {
+    if (io_buffer_slice_p(buffer)) {
         RB_OBJ_WRITE(instance, &slice->source, buffer->source);
     }
     else {
@@ -1911,10 +1917,51 @@ io_buffer_resize_copy(VALUE self, struct rb_io_buffer *buffer, size_t size)
     *buffer = resized;
 }
 
+static void
+io_buffer_resize_slice(struct rb_io_buffer *slice, size_t size)
+{
+    struct rb_io_buffer *source = get_io_buffer(slice->source);
+
+    if (!io_buffer_validate(source)) {
+        rb_raise(rb_eIOBufferInvalidatedError, "Buffer is invalid!");
+    }
+
+    if (source->base == NULL || slice->base == NULL) {
+        rb_raise(rb_eIOBufferInvalidatedError, "Buffer is invalid!");
+    }
+
+    uintptr_t source_address = (uintptr_t)source->base;
+    uintptr_t slice_address = (uintptr_t)slice->base;
+
+    if (slice_address < source_address) {
+        rb_raise(rb_eIOBufferInvalidatedError, "Buffer is invalid!");
+    }
+
+    uintptr_t offset = slice_address - source_address;
+
+    if (offset > source->size) {
+        rb_raise(rb_eIOBufferInvalidatedError, "Buffer is invalid!");
+    }
+
+    if (size > source->size - (size_t)offset) {
+        rb_raise(rb_eArgError, "Resized slice exceeds its source buffer!");
+    }
+
+    // Validate the requested range rather than the current range so that
+    // shrinking a slice can restore its validity after the source shrinks.
+    slice->size = size;
+}
+
 void
 rb_io_buffer_resize(VALUE self, size_t size)
 {
     struct rb_io_buffer *buffer = get_io_buffer(self);
+
+    if (io_buffer_slice_p(buffer)) {
+        // Resizing a slice only changes the view, not the locked allocation.
+        io_buffer_resize_slice(buffer, size);
+        return;
+    }
 
     io_buffer_validate_for_reading(buffer);
 
@@ -1986,8 +2033,14 @@ rb_io_buffer_resize(VALUE self, size_t size)
  *    # #<IO::Buffer 0x0000555f5d1a1630+8 INTERNAL>
  *    # 0x00000000  74 65 73 74 00 00 00 00                         test....
  *
- *  External buffer (created with ::for), and locked buffer
- *  can not be resized.
+ *  When the buffer is a slice, resizing changes the size of the view without
+ *  modifying the source buffer or allocating new storage. The resized view
+ *  must remain within the source buffer. Growing the view exposes the existing
+ *  bytes in the source; they are not cleared. Because the source allocation
+ *  does not change, a slice can be resized while its source is locked.
+ *
+ *  External owning buffers (created with ::for), and locked owning buffers
+ *  cannot be resized.
  */
 static VALUE
 io_buffer_resize(VALUE self, VALUE size)

--- a/spec/ruby/core/io/buffer/resize_spec.rb
+++ b/spec/ruby/core/io/buffer/resize_spec.rb
@@ -143,9 +143,72 @@ describe "IO::Buffer#resize" do
     -> { @buffer.resize(10.0) }.should.raise(TypeError, "not an Integer")
   end
 
-  context "with a slice of a buffer" do
-    # Current behavior of slice resizing seems unintended (it's undocumented, too).
-    # It either creates a completely new buffer, or breaks the slice on size 0.
-    it "needs to be reviewed for spec completeness"
+  ruby_version_is "4.1" do
+    context "with a slice of a buffer" do
+      it "changes the size of the view without modifying the source" do
+        @buffer = IO::Buffer.for("abcdef").dup
+        slice = @buffer.slice(2, 2)
+
+        slice.resize(4).should.equal?(slice)
+        slice.get_string.should == "cdef"
+        @buffer.get_string.should == "abcdef"
+
+        slice.resize(1)
+        slice.get_string.should == "c"
+      end
+
+      it "does not allocate when resized to zero" do
+        @buffer = IO::Buffer.for("abcdef").dup
+        slice = @buffer.slice(2, 2)
+
+        slice.resize(0)
+        slice.should_not.null?
+        slice.should.empty?
+        slice.should.valid?
+
+        slice.resize(4)
+        slice.get_string.should == "cdef"
+      end
+
+      it "raises ArgumentError when the resized view exceeds the source" do
+        @buffer = IO::Buffer.for("abcdef").dup
+        slice = @buffer.slice(2, 2)
+
+        -> { slice.resize(5) }.should.raise(
+          ArgumentError,
+          "Resized slice exceeds its source buffer!"
+        )
+
+        slice.get_string.should == "cd"
+      end
+
+      it "can be resized while the source allocation is locked" do
+        @buffer = IO::Buffer.for("abcdef").dup
+        slice = @buffer.slice(2, 2)
+
+        slice.locked do
+          slice.resize(4)
+          slice.get_string.should == "cdef"
+        end
+      end
+
+      it "preserves read-only access" do
+        @buffer = IO::Buffer.for("abcdef")
+        slice = @buffer.slice(2, 2)
+
+        slice.resize(4)
+        slice.should.readonly?
+        slice.get_string.should == "cdef"
+      end
+
+      it "uses the retained root buffer as the boundary for nested slices" do
+        @buffer = IO::Buffer.for("abcdef").dup
+        parent = @buffer.slice(1, 2)
+        slice = parent.slice(1, 1)
+
+        slice.resize(4)
+        slice.get_string.should == "cdef"
+      end
+    end
   end
 end

--- a/test/ruby/test_io_buffer.rb
+++ b/test/ruby/test_io_buffer.rb
@@ -326,11 +326,64 @@ class TestIOBuffer < Test::Unit::TestCase
     slice = buffer.slice(0, 8)
 
     slice.resize(0)
-    assert_predicate slice, :null?
+    refute_predicate slice, :null?
+    assert_predicate slice, :empty?
+    assert_predicate slice, :valid?
     assert_equal 64, buffer.size
 
     slice.resize(1)
     assert_equal 1, slice.size
+    assert_predicate slice, :valid?
+  end
+
+  def test_resize_slice_changes_view
+    buffer = IO::Buffer.for("abcdef").dup
+    slice = buffer.slice(2, 2)
+
+    assert_same slice, slice.resize(4)
+    assert_equal "cdef", slice.get_string
+
+    slice.set_string("X")
+    assert_equal "abXdef", buffer.get_string
+
+    slice.resize(1)
+    assert_equal "X", slice.get_string
+  end
+
+  def test_resize_slice_beyond_source
+    buffer = IO::Buffer.for("abcdef").dup
+    slice = buffer.slice(2, 2)
+
+    error = assert_raise(ArgumentError) do
+      slice.resize(5)
+    end
+
+    assert_equal "Resized slice exceeds its source buffer!", error.message
+    assert_equal 2, slice.size
+    assert_equal "cd", slice.get_string
+  end
+
+  def test_resize_locked_slice
+    buffer = IO::Buffer.for("abcdef").dup
+    slice = buffer.slice(2, 2)
+
+    slice.locked do
+      slice.resize(4)
+      assert_equal "cdef", slice.get_string
+
+      assert_raise(IO::Buffer::LockedError) do
+        buffer.resize(8)
+      end
+    end
+  end
+
+  def test_resize_nested_slice_uses_root_bounds
+    buffer = IO::Buffer.for("abcdef").dup
+    parent = buffer.slice(1, 2)
+    slice = parent.slice(1, 1)
+
+    slice.resize(4)
+    assert_equal "cdef", slice.get_string
   end
 
   def test_resize_zero_external


### PR DESCRIPTION
## Summary

Change `IO::Buffer#resize` for slices so it adjusts the view size rather than allocating an independent buffer.

A slice now:

- retains its base address, source, and access flags;
- can grow or shrink within the current bounds of its retained root buffer;
- exposes existing source bytes when grown, without clearing them;
- remains a view when resized to zero;
- can be resized while the source allocation is locked, because the allocation does not move or change;
- raises `ArgumentError` if the requested range exceeds the source;
- raises `IO::Buffer::InvalidatedError` if its anchor no longer exists in the source.

Nested slices continue to use their retained root buffer as their boundary.

Previously, resizing a slice to a non-zero size silently copied it into a new owned allocation, while resizing it to zero freed the view. RubySpec already marked that behavior as unintended and unspecified.

## Testing

- `test/ruby/test_io_buffer.rb`: 111 tests, 882 assertions, 0 failures, 0 errors.
- `spec/ruby/core/io/buffer`: 195 examples, 382 expectations, 0 failures, 0 errors.