### PR TITLE
ractor: skip blocking_cnt bookkeeping on pthread

### DIFF
--- a/ractor.c
+++ b/ractor.c
@@ -1006,6 +1006,14 @@ ractor_check_blocking(rb_ractor_t *cr, unsigned int remained_thread_cnt, const c
 {
     VM_ASSERT(cr == GET_RACTOR());
 
+#ifdef RUBY_THREAD_PTHREAD_H
+    // vm->ractor.blocking_cnt is only consumed by the win32 scheduler; the
+    // pthread one must not pay a VM lock per blocking region for it.  The
+    // running<->blocking status flips stop with it (all callers), matching
+    // rb_ractor_blocking_threads_dec skipping the reverse transition.
+    return;
+#endif
+
     RUBY_DEBUG_LOG2(file, line,
                     "cr->threads.cnt:%u cr->threads.blocking_cnt:%u vm->ractor.cnt:%u vm->ractor.blocking_cnt:%u",
                     cr->threads.cnt, cr->threads.blocking_cnt,
@@ -1106,6 +1114,8 @@ rb_ractor_blocking_threads_dec(rb_ractor_t *cr, const char *file, int line)
 
     VM_ASSERT(cr == GET_RACTOR());
 
+#ifndef RUBY_THREAD_PTHREAD_H
+    // see rb_ractor_blocking_threads_inc
     if (cr->threads.cnt == cr->threads.blocking_cnt) {
         rb_vm_t *vm = GET_VM();
 
@@ -1113,6 +1123,7 @@ rb_ractor_blocking_threads_dec(rb_ractor_t *cr, const char *file, int line)
             rb_vm_ractor_blocking_cnt_dec(vm, cr, __FILE__, __LINE__);
         }
     }
+#endif
 
     cr->threads.blocking_cnt--;
 }

--- a/ractor.rb
+++ b/ractor.rb
@@ -382,7 +382,7 @@ class Ractor
     name = __builtin_cexpr! %q{ RACTOR_PTR(self)->name }
     id   = __builtin_cexpr! %q{ UINT2NUM(rb_ractor_id(RACTOR_PTR(self))) }
     status = __builtin_cexpr! %q{
-      rb_str_new2(ractor_status_str(RACTOR_PTR(self)->status_))
+      rb_str_new2(RACTOR_PTR(self)->status_ == ractor_terminated ? "terminated" : "running")
     }
     "#<Ractor:##{id}#{name ? ' '+name : ''}#{loc ? " " + loc : ''} #{status}>"
   end


### PR DESCRIPTION
rb_ractor_blocking_threads_inc/dec took the VM lock on every blocking region boundary of a ractor's last runnable thread -- for a 1-thread ractor, twice per IO operation -- to maintain vm->ractor.blocking_cnt. That counter is only consumed by the win32 scheduler, so the pthread build now skips those VM-lock sections; the per-ractor threads.blocking_cnt and the ractor creation/exit protocol stay.

Ractor#inspect's status becomes running/terminated only ("blocking" is gone).  The finer states were really the win32 scheduler's in-blocking-region flag leaking into inspect (under M:N, receive/sleep/ IO waits always showed "running" anyway, and the skip above stops the remaining flips on pthread entirely).

R ractors x 1 thread, pipe write/read round-trips each, 16-HT machine (Ryzen 9 5900HX), RUBY_MN_THREADS=1, best of 3, mean of 2 alternating same-tree runs:

           before     after
     1R      342k      356k
     4R      877k     1016k
     8R      884k      976k
    16R      835k      884k
    24R      793k      839k

The remaining ceiling is the scheduler-lock contention addressed by "thread: keep context switches off the scheduler lock"; combined, 16R reaches 3.6M rt/s.

Suggested-by: Koichi Sasada <ko1@atdot.net>