### PR TITLE
thread: shard the io-wait bookkeeping by fd

### DIFF
--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -3299,18 +3299,26 @@ static struct {
     } wheel[TIMER_WHEEL_LEVELS];
     uint64_t wheel_cursor_tick; // slots for ticks <= this are drained
     rb_hrtime_t next_expiry;   // never later than the earliest deadline
-    struct ccan_list_head waiting_untimed;
-    pthread_mutex_t waiting_lock;
+    pthread_mutex_t waiting_lock; // the wheel and the flags of fd-less timed waits
+
+    /* The fd map entries and the flags of io waits are guarded per fd by a
+     * shard lock, so unrelated fds register and wake in parallel.  Whoever
+     * clears an io wait's flags under its shard owns the wakeup.  Lock order:
+     * shard -> waiting_lock -> wake_pending_lock, never the other way. */
+#define IO_WAIT_SHARDS 16
+    pthread_mutex_t fd_shard_locks[IO_WAIT_SHARDS];
 
     // signaled when wake_pending clears on a thread; see timer_thread_wake_fence
+    pthread_mutex_t wake_pending_lock;
     rb_nativethread_cond_t wake_pending_cond;
 #endif
 
 #if (HAVE_SYS_EPOLL_H || HAVE_SYS_EVENT_H) && USE_MN_THREADS
-    // fd -> struct rb_fd_waiters, in chunks so entries never move.
-    // Protected by waiting_lock.
-    struct rb_fd_waiters **fdmap_chunks;
-    unsigned int fdmap_nchunks;
+    // fd -> struct rb_fd_waiters, in chunks so entries never move.  The chunk
+    // table installs slots by CAS (chunks span shards); entry state is guarded
+    // by the fd's shard lock.
+#define FDMAP_MAX_CHUNKS 1024 // fds up to FDMAP_MAX_CHUNKS * FDMAP_CHUNK_SIZE
+    struct rb_fd_waiters *fdmap_chunks[FDMAP_MAX_CHUNKS];
 #endif
 } timer_th = {
     .created_fork_gen = 0,
@@ -3539,6 +3547,21 @@ rb_thread_create_timer_thread(void)
             RUBY_DEBUG_LOG("forked child process");
 
             CLOSE_INVALIDATE_PAIR(timer_th.comm_fds);
+#if USE_MN_THREADS
+            // The parent's waiters do not exist in the child, and the armings
+            // belong to the closed event backend: a stale entry would satisfy
+            // fd_waiters_arm's want == armed_flags check and never arm the new
+            // backend (a lost wake the old dynamic map also had).
+            for (unsigned int ci = 0; ci < FDMAP_MAX_CHUNKS; ci++) {
+                struct rb_fd_waiters *chunk = timer_th.fdmap_chunks[ci];
+                if (chunk == NULL) continue;
+                for (unsigned int i = 0; i < FDMAP_CHUNK_SIZE; i++) {
+                    ccan_list_head_init(&chunk[i].waiters);
+                    chunk[i].armed_flags = 0;
+                    chunk[i].generation++;
+                }
+            }
+#endif
 #if HAVE_SYS_EPOLL_H && USE_MN_THREADS
             close_invalidate(&timer_th.event_fd, "close event_fd");
 #elif HAVE_SYS_EVENT_H && USE_MN_THREADS
@@ -3561,8 +3584,11 @@ rb_thread_create_timer_thread(void)
         }
         timer_th.wheel_cursor_tick = timer_wheel_tick(rb_hrtime_now());
         timer_th.next_expiry = TIMER_WHEEL_NO_EXPIRY;
-        ccan_list_head_init(&timer_th.waiting_untimed);
         rb_native_mutex_initialize(&timer_th.waiting_lock);
+        for (int i = 0; i < IO_WAIT_SHARDS; i++) {
+            rb_native_mutex_initialize(&timer_th.fd_shard_locks[i]);
+        }
+        rb_native_mutex_initialize(&timer_th.wake_pending_lock);
         rb_native_cond_initialize(&timer_th.wake_pending_cond);
 #endif
 

--- a/thread_pthread.h
+++ b/thread_pthread.h
@@ -95,8 +95,9 @@ struct rb_thread_sched_item {
     struct rb_thread_sched_waiting waiting_reason;
     uint32_t event_serial;
 
-    // the timer thread has a wake pending for this thread; under waiting_lock
-    bool wake_pending;
+    // wakes pending on this thread (timer thread or an fd shard claim);
+    // under timer_th.wake_pending_lock
+    uint32_t wake_pending_cnt;
 
     // parked on its own condvar with a deadline; under the sched lock (see
     // ubf_waiting).  Always false for an M:N thread: its deadline lives on the

--- a/thread_pthread_mn.c
+++ b/thread_pthread_mn.c
@@ -23,6 +23,23 @@ thread_sched_waiting_thread(struct rb_thread_sched_waiting *w)
     }
 }
 
+#define FD_WAIT_IO_MASK (thread_sched_waiting_io_read | thread_sched_waiting_io_write)
+
+// Guards the fd map entries and the flags of io waits for its fds.  Whoever
+// clears an io wait's flags under its shard owns that wakeup.
+// Lock order: shard -> waiting_lock -> wake_pending_lock.
+static void
+fd_shard_lock(int fd)
+{
+    rb_native_mutex_lock(&timer_th.fd_shard_locks[(unsigned int)fd % IO_WAIT_SHARDS]);
+}
+
+static void
+fd_shard_unlock(int fd)
+{
+    rb_native_mutex_unlock(&timer_th.fd_shard_locks[(unsigned int)fd % IO_WAIT_SHARDS]);
+}
+
 #define TIMER_WHEEL_NO_EXPIRY RB_HRTIME_MAX
 #ifndef TIMER_WHEEL_TICK_MS
 #define TIMER_WHEEL_TICK_MS 1 // L0 slot width; coarser trades sleep accuracy for fewer drains
@@ -178,20 +195,13 @@ timer_wheel_drain(rb_hrtime_t now, uint64_t now_tick, struct ccan_list_head *exp
             struct rb_thread_sched_waiting *w;
             while ((w = ccan_list_pop(&pending, struct rb_thread_sched_waiting, node)) != NULL) {
                 if (timer_thread_check_exceed(w->data.timeout, now)) {
-                    rb_thread_t *th = thread_sched_waiting_thread(w);
+                    RUBY_DEBUG_LOG("expired th:%u", rb_th_serial(thread_sched_waiting_thread(w)));
 
-                    RUBY_DEBUG_LOG("wakeup th:%u", rb_th_serial(th));
-
-#if HAVE_SYS_EPOLL_H || HAVE_SYS_EVENT_H
-                    // An fd+timeout waiter is also on its fd's waiter list.
-                    timer_thread_unregister_waiting(th, w->data.fd, w->flags);
-#endif
-                    /* flags stay set until the wakeup below takes them under
-                     * the lock: a waiter whose flags are already cleared may
+                    /* flags stay set until the wakeup takes them under the
+                     * owning lock (the fd shard for io waits, this one
+                     * otherwise): a waiter whose flags are already cleared may
                      * run and re-register through this same `w`, which would
                      * relink the node we are still holding on `expired`. */
-                    w->data.result = 0;
-
                     ccan_list_add_tail(expired, &w->node);
                 }
                 else {
@@ -263,39 +273,48 @@ timer_thread_wakeup_thread(rb_thread_t *th, uint32_t event_serial)
 // One thread the timer thread is about to wake, with the serial it was armed at.
 struct timer_wake { rb_thread_t *th; uint32_t serial; };
 
-// Mark each thread while a wake is pending for it, so a dying thread can wait
-// (timer_thread_wake_fence).  Set under waiting_lock before the lock is dropped.
+// Count a pending wake against a thread, so a dying thread can wait them out
+// (timer_thread_wake_fence).  A count, not a flag: an expiry hold and an fd
+// event's wake can be pending on one thread at once.  Take it while the lock
+// that pinned the thread (shard or waiting_lock) is still held.
 static void
-timer_wake_pending_set(struct timer_wake *batch, int n)
+timer_wake_pending_inc(rb_thread_t *th)
 {
-    for (int i = 0; i < n; i++) {
-        batch[i].th->sched.wake_pending = true;
-    }
+    rb_native_mutex_lock(&timer_th.wake_pending_lock);
+    th->sched.wake_pending_cnt++;
+    rb_native_mutex_unlock(&timer_th.wake_pending_lock);
+}
+
+static void
+timer_wake_pending_dec(rb_thread_t *th)
+{
+    rb_native_mutex_lock(&timer_th.wake_pending_lock);
+    VM_ASSERT(th->sched.wake_pending_cnt > 0);
+    th->sched.wake_pending_cnt--;
+    rb_native_cond_broadcast(&timer_th.wake_pending_cond);
+    rb_native_mutex_unlock(&timer_th.wake_pending_lock);
 }
 
 static void
 timer_wake_pending_clear(struct timer_wake *batch, int n)
 {
-    rb_native_mutex_lock(&timer_th.waiting_lock);
     for (int i = 0; i < n; i++) {
-        batch[i].th->sched.wake_pending = false;
+        timer_wake_pending_dec(batch[i].th);
     }
-    rb_native_cond_broadcast(&timer_th.wake_pending_cond);
-    rb_native_mutex_unlock(&timer_th.waiting_lock);
 }
 
-// Wait out a pending wake before a thread is freed: it would touch freed memory,
-// or wake a reused thread whose first serial matches the stale entry.
+// Wait out pending wakes before a thread is freed: they would touch freed
+// memory, or wake a reused thread whose first serial matches a stale entry.
 static void
 timer_thread_wake_fence(rb_thread_t *th)
 {
     if (!TIMER_THREAD_CREATED_P()) return;
 
-    rb_native_mutex_lock(&timer_th.waiting_lock);
-    while (th->sched.wake_pending) {
-        rb_native_cond_wait(&timer_th.wake_pending_cond, &timer_th.waiting_lock);
+    rb_native_mutex_lock(&timer_th.wake_pending_lock);
+    while (th->sched.wake_pending_cnt > 0) {
+        rb_native_cond_wait(&timer_th.wake_pending_cond, &timer_th.wake_pending_lock);
     }
-    rb_native_mutex_unlock(&timer_th.waiting_lock);
+    rb_native_mutex_unlock(&timer_th.wake_pending_lock);
 }
 
 static void
@@ -312,6 +331,8 @@ timer_thread_check_timeout(rb_vm_t *vm)
 
     while (more) {
         int n = 0;
+        struct { rb_thread_t *th; uint32_t serial; int fd; } io_claims[TIMEOUT_WAKE_BATCH];
+        int n_io = 0;
 
         rb_native_mutex_lock(&timer_th.waiting_lock);
         {
@@ -321,18 +342,37 @@ timer_thread_check_timeout(rb_vm_t *vm)
             }
 
             struct rb_thread_sched_waiting *w;
-            while (n < TIMEOUT_WAKE_BATCH &&
+            while (n + n_io < TIMEOUT_WAKE_BATCH &&
                    (w = ccan_list_pop(&expired, struct rb_thread_sched_waiting, node)) != NULL) {
                 // Name the thread and its serial here, then release it: once the
                 // flags are clear the thread may run and re-register through `w`,
                 // and a serial read after that would match the new registration.
-                batch[n].th = thread_sched_waiting_thread(w);
-                batch[n].serial = w->data.event_serial;
-                w->flags = thread_sched_waiting_none;
-                n++;
+                // the pop leaves the node dangling; a concurrent claimer's
+                // wheel del (under this lock) must find it self-linked
+                ccan_list_node_init(&w->node);
+
+                if (w->flags & FD_WAIT_IO_MASK) {
+                    // The fd shard owns these flags; claim below, once this
+                    // lock is dropped.  The pending count pins the thread: it
+                    // was parked when we popped its node (a claimed entry
+                    // leaves the wheel before its thread can wake).
+                    io_claims[n_io].th = thread_sched_waiting_thread(w);
+                    io_claims[n_io].serial = w->data.event_serial;
+                    io_claims[n_io].fd = w->data.fd;
+                    timer_wake_pending_inc(io_claims[n_io].th);
+                    n_io++;
+                }
+                else {
+                    // pin before the flags clear; see timer_thread_wake_fd_waiters
+                    batch[n].th = thread_sched_waiting_thread(w);
+                    batch[n].serial = w->data.event_serial;
+                    timer_wake_pending_inc(batch[n].th);
+                    w->flags = thread_sched_waiting_none;
+                    w->data.result = 0;
+                    n++;
+                }
             }
             more = !ccan_list_empty(&expired);
-            timer_wake_pending_set(batch, n);
         }
         rb_native_mutex_unlock(&timer_th.waiting_lock);
 
@@ -340,26 +380,77 @@ timer_thread_check_timeout(rb_vm_t *vm)
             timer_thread_wakeup_thread(batch[i].th, batch[i].serial);
         }
         timer_wake_pending_clear(batch, n);
+
+        // The io entries race the fd event and the ubf for their flags.
+        for (int i = 0; i < n_io; i++) {
+            rb_thread_t *th = io_claims[i].th;
+            int fd = io_claims[i].fd;
+            bool claimed = false;
+
+            fd_shard_lock(fd);
+            {
+                struct rb_thread_sched_waiting *w = &th->sched.waiting_reason;
+
+                if (w->flags != thread_sched_waiting_none &&
+                    w->data.event_serial == io_claims[i].serial) {
+                    VM_ASSERT(w->data.fd == fd);
+                    timer_thread_unregister_waiting(th, fd, w->flags);
+                    w->flags = thread_sched_waiting_none;
+                    w->data.result = 0;
+                    claimed = true;
+                }
+            }
+            fd_shard_unlock(fd);
+
+            if (claimed) {
+                timer_thread_wakeup_thread(th, io_claims[i].serial);
+            }
+            timer_wake_pending_dec(th);
+        }
     }
 }
 
 static bool
 timer_thread_cancel_waiting(rb_thread_t *th)
 {
-    bool canceled = false;
+    struct rb_thread_sched_waiting *w = &th->sched.waiting_reason;
 
-    rb_native_mutex_lock(&timer_th.waiting_lock);
-    {
-        if (th->sched.waiting_reason.flags) {
-            canceled = true;
-            timer_wheel_del(&th->sched.waiting_reason);
-            timer_thread_unregister_waiting(th, th->sched.waiting_reason.data.fd, th->sched.waiting_reason.flags);
-            th->sched.waiting_reason.flags = thread_sched_waiting_none;
+    while (1) {
+        // Racy routing read; the claim is re-verified under the owning lock.
+        enum thread_sched_waiting_flag flags = w->flags;
+
+        if (flags == thread_sched_waiting_none) {
+            return false;
         }
-    }
-    rb_native_mutex_unlock(&timer_th.waiting_lock);
+        else if (flags & FD_WAIT_IO_MASK) {
+            int fd = w->data.fd;
 
-    return canceled;
+            fd_shard_lock(fd);
+            if ((w->flags & FD_WAIT_IO_MASK) && w->data.fd == fd) {
+                if (w->flags & thread_sched_waiting_timeout) {
+                    rb_native_mutex_lock(&timer_th.waiting_lock);
+                    timer_wheel_del(w);
+                    rb_native_mutex_unlock(&timer_th.waiting_lock);
+                }
+                timer_thread_unregister_waiting(th, fd, w->flags);
+                w->flags = thread_sched_waiting_none;
+                fd_shard_unlock(fd);
+                return true;
+            }
+            fd_shard_unlock(fd);
+        }
+        else {
+            rb_native_mutex_lock(&timer_th.waiting_lock);
+            if (w->flags && !(w->flags & FD_WAIT_IO_MASK)) {
+                timer_wheel_del(w);
+                w->flags = thread_sched_waiting_none;
+                rb_native_mutex_unlock(&timer_th.waiting_lock);
+                return true;
+            }
+            rb_native_mutex_unlock(&timer_th.waiting_lock);
+        }
+        // lost the routing race; look again
+    }
 }
 
 static void
@@ -1041,52 +1132,45 @@ native_thread_create_shared(rb_thread_t *th)
 /// -- a reader and a writer on one socket -- so the backend is armed with their
 /// union, and an event is dispatched to every waiter it concerns.
 
-#define FD_WAIT_IO_MASK (thread_sched_waiting_io_read | thread_sched_waiting_io_write)
+// (FD_WAIT_IO_MASK and the fd shard helpers are defined near the top.)
 
 #define FDMAP_CHUNK_BITS 10
 #define FDMAP_CHUNK_SIZE (1u << FDMAP_CHUNK_BITS)
 #define FDMAP_CHUNK_MASK (FDMAP_CHUNK_SIZE - 1)
 
-// timer_th.waiting_lock must be held.
+// Callable under any fd shard lock: a chunk spans every shard, so the chunk
+// table is not guarded by them; slots install by CAS and are never freed.
 static struct rb_fd_waiters *
 fd_waiters_lookup(int fd, bool create)
 {
     if (fd < 0) return NULL;
 
     unsigned int ci = (unsigned int)fd >> FDMAP_CHUNK_BITS;
+    if (ci >= FDMAP_MAX_CHUNKS) return NULL; // the caller falls back to a blocking wait
 
-    if (ci >= timer_th.fdmap_nchunks) {
+    struct rb_fd_waiters *chunk = RUBY_ATOMIC_PTR_LOAD(timer_th.fdmap_chunks[ci]);
+
+    if (chunk == NULL) {
         if (!create) return NULL;
 
-        unsigned int n = timer_th.fdmap_nchunks ? timer_th.fdmap_nchunks : 8;
-        while (n <= ci) n *= 2;
-
-        // Only the chunk pointers are reallocated; the entries themselves never
-        // move, so the list heads inside them stay valid.
-        struct rb_fd_waiters **chunks = realloc(timer_th.fdmap_chunks, sizeof(*chunks) * n);
-        if (chunks == NULL) rb_bug("fd_waiters_lookup: realloc failed");
-
-        for (unsigned int i = timer_th.fdmap_nchunks; i < n; i++) chunks[i] = NULL;
-        timer_th.fdmap_chunks = chunks;
-        timer_th.fdmap_nchunks = n;
-    }
-
-    if (timer_th.fdmap_chunks[ci] == NULL) {
-        if (!create) return NULL;
-
-        struct rb_fd_waiters *chunk = calloc(FDMAP_CHUNK_SIZE, sizeof(*chunk));
+        chunk = calloc(FDMAP_CHUNK_SIZE, sizeof(*chunk));
         if (chunk == NULL) rb_bug("fd_waiters_lookup: calloc failed");
 
         for (unsigned int i = 0; i < FDMAP_CHUNK_SIZE; i++) {
             ccan_list_head_init(&chunk[i].waiters);
         }
-        timer_th.fdmap_chunks[ci] = chunk;
+
+        struct rb_fd_waiters *prev = RUBY_ATOMIC_PTR_CAS(timer_th.fdmap_chunks[ci], NULL, chunk);
+        if (prev != NULL) {
+            free(chunk); // another shard installed it first
+            chunk = prev;
+        }
     }
 
-    return &timer_th.fdmap_chunks[ci][(unsigned int)fd & FDMAP_CHUNK_MASK];
+    return &chunk[(unsigned int)fd & FDMAP_CHUNK_MASK];
 }
 
-// timer_th.waiting_lock must be held.
+// The fd's shard lock must be held.
 static uint32_t
 fd_waiters_union(struct rb_fd_waiters *e)
 {
@@ -1112,7 +1196,7 @@ fd_event_tag(int fd, uint32_t generation)
 
 // Make the backend match `want`.  Returns false if the fd cannot be registered
 // at all (closed, or unsupported by the backend), leaving the entry untouched.
-// timer_th.waiting_lock must be held.
+// The fd's shard lock must be held.
 static bool
 fd_waiters_arm(int fd, struct rb_fd_waiters *e, uint32_t want)
 {
@@ -1247,17 +1331,15 @@ verify_waiting_list(void)
             VM_ASSERT(occupied == !ccan_list_empty(&lv->slots[slot]));
 
             ccan_list_for_each(&lv->slots[slot], w, node) {
-                VM_ASSERT(w->flags & thread_sched_waiting_timeout);
-                VM_ASSERT(w->data.timeout != 0);
+                // an io entry's flags belong to its fd shard: do not read them here
+                if (!(w->flags & FD_WAIT_IO_MASK)) {
+                    VM_ASSERT(w->flags & thread_sched_waiting_timeout);
+                    VM_ASSERT(w->data.timeout != 0);
+                }
                 VM_ASSERT(w->wheel_lvl == lvl);
                 VM_ASSERT(w->wheel_slot == slot);
             }
         }
-    }
-
-    ccan_list_for_each(&timer_th.waiting_untimed, w, node) {
-        VM_ASSERT(!(w->flags & thread_sched_waiting_timeout));
-        VM_ASSERT(w->data.timeout == 0);
     }
 #endif
 }
@@ -1359,66 +1441,85 @@ timer_thread_register_waiting(rb_thread_t *th, int fd, enum thread_sched_waiting
         VM_ASSERT(fd >= 0);
     }
 
-    rb_native_mutex_lock(&timer_th.waiting_lock);
-    {
-        if (flags & FD_WAIT_IO_MASK) {
-            VM_ASSERT(th != NULL);
-
+    if (flags & FD_WAIT_IO_MASK) {
+        fd_shard_lock(fd);
+        {
             struct rb_fd_waiters *e = fd_waiters_lookup(fd, true);
+
+            if (e == NULL) { // fd beyond the map: fall back to a blocking wait
+                fd_shard_unlock(fd);
+                return timer_thread_unavailable;
+            }
 
             // Arm the union of what this fd's waiters want, so a second waiter
             // on the same fd extends the arming instead of colliding with it.
             if (!fd_waiters_arm(fd, e, fd_waiters_union(e) | (uint32_t)(flags & FD_WAIT_IO_MASK))) {
-                rb_native_mutex_unlock(&timer_th.waiting_lock);
+                fd_shard_unlock(fd);
                 return timer_thread_unavailable;
             }
 
-            ccan_list_add_tail(&e->waiters, &th->sched.waiting_reason.fd_node);
-            RUBY_DEBUG_LOG("armed fd:%d want:%u", fd, e->armed_flags);
-        }
+            if (th) {
+                ccan_list_add_tail(&e->waiters, &th->sched.waiting_reason.fd_node);
 
-        if (th) {
-            VM_ASSERT(th->sched.waiting_reason.flags == thread_sched_waiting_none);
-
-            // setup waiting information
-            {
+                VM_ASSERT(th->sched.waiting_reason.flags == thread_sched_waiting_none);
                 th->sched.waiting_reason.flags = flags;
                 th->sched.waiting_reason.data.timeout = abs;
                 th->sched.waiting_reason.data.fd = fd;
                 th->sched.waiting_reason.data.result = 0;
                 th->sched.waiting_reason.data.event_serial = event_serial;
-            }
 
-            if (abs == 0) { // no timeout
-                VM_ASSERT(!(flags & thread_sched_waiting_timeout));
-                ccan_list_add_tail(&timer_th.waiting_untimed, &th->sched.waiting_reason.node);
-            }
-            else {
-                RUBY_DEBUG_LOG("abs:%lu", (unsigned long)abs);
-                VM_ASSERT(flags & thread_sched_waiting_timeout);
+                if (abs != 0) {
+                    RUBY_DEBUG_LOG("abs:%lu", (unsigned long)abs);
+                    VM_ASSERT(flags & thread_sched_waiting_timeout);
 
-                rb_hrtime_t prev_expiry = timer_th.next_expiry;
-                timer_wheel_insert(&th->sched.waiting_reason);
-
-                verify_waiting_list();
-
-                if (timer_th.next_expiry < prev_expiry) {
-                    // an earlier deadline than the timer thread is armed for
-                    timer_thread_wakeup_force();
+                    rb_native_mutex_lock(&timer_th.waiting_lock);
+                    {
+                        rb_hrtime_t prev_expiry = timer_th.next_expiry;
+                        timer_wheel_insert(&th->sched.waiting_reason);
+                        verify_waiting_list();
+                        if (timer_th.next_expiry < prev_expiry) {
+                            // an earlier deadline than the timer thread is armed for
+                            timer_thread_wakeup_force();
+                        }
+                    }
+                    rb_native_mutex_unlock(&timer_th.waiting_lock);
                 }
             }
+            RUBY_DEBUG_LOG("armed fd:%d want:%u", fd, e->armed_flags);
         }
-        else {
-            VM_ASSERT(abs == 0);
-        }
+        fd_shard_unlock(fd);
     }
-    rb_native_mutex_unlock(&timer_th.waiting_lock);
+    else if (th) {
+        // fd-less timed wait: the wheel lock owns it end to end
+        VM_ASSERT(abs != 0 && (flags & thread_sched_waiting_timeout));
+
+        rb_native_mutex_lock(&timer_th.waiting_lock);
+        {
+            VM_ASSERT(th->sched.waiting_reason.flags == thread_sched_waiting_none);
+            th->sched.waiting_reason.flags = flags;
+            th->sched.waiting_reason.data.timeout = abs;
+            th->sched.waiting_reason.data.fd = fd;
+            th->sched.waiting_reason.data.result = 0;
+            th->sched.waiting_reason.data.event_serial = event_serial;
+
+            rb_hrtime_t prev_expiry = timer_th.next_expiry;
+            timer_wheel_insert(&th->sched.waiting_reason);
+            verify_waiting_list();
+            if (timer_th.next_expiry < prev_expiry) {
+                timer_thread_wakeup_force();
+            }
+        }
+        rb_native_mutex_unlock(&timer_th.waiting_lock);
+    }
+    else {
+        VM_ASSERT(abs == 0);
+    }
 
     return timer_thread_registered;
 }
 
 // Drop `th` from its fd's waiter list and re-arm the backend for whoever is
-// left.  timer_th.waiting_lock must be held.
+// left.  The fd's shard lock must be held.
 static void
 timer_thread_unregister_waiting(rb_thread_t *th, int fd, enum thread_sched_waiting_flag flags)
 {
@@ -1502,11 +1603,11 @@ timer_thread_wake_fd_waiters(int fd, uint32_t generation, uint32_t wake_flags, i
 
     if (wake_flags == 0) return;
 
-    for (;;) {
+    while (1) {
         int n = 0;
         bool more = false;
 
-        rb_native_mutex_lock(&timer_th.waiting_lock);
+        fd_shard_lock(fd);
         {
             struct rb_fd_waiters *e = fd_waiters_lookup(fd, false);
 
@@ -1524,25 +1625,34 @@ timer_thread_wake_fd_waiters(int fd, uint32_t generation, uint32_t wake_flags, i
                     }
 
                     ccan_list_del_init(&w->fd_node);
-                    timer_wheel_del(w); // also leaves the timer wheel
+
+                    if (w->flags & thread_sched_waiting_timeout) {
+                        // also leaves the timer wheel (or the expiry pass's
+                        // batch, whose claim will then find the flags gone)
+                        rb_native_mutex_lock(&timer_th.waiting_lock);
+                        timer_wheel_del(w);
+                        rb_native_mutex_unlock(&timer_th.waiting_lock);
+                    }
+
+                    // The pin must be visible before the flags clear: a waiter
+                    // that sees the clear may skip parking, finish and die,
+                    // and the fence only waits on the pending count.
+                    batch[n].th = thread_sched_waiting_thread(w);
+                    batch[n].serial = w->data.event_serial;
+                    timer_wake_pending_inc(batch[n].th);
+                    n++;
 
                     w->flags = thread_sched_waiting_none;
                     w->data.fd = -1;
                     w->data.result = result;
-
-                    batch[n].th = thread_sched_waiting_thread(w);
-                    batch[n].serial = w->data.event_serial;
-                    n++;
                 }
 
                 // Re-arm for whoever is still waiting on this fd (nothing, if
                 // they all just woke up).
                 fd_waiters_arm(fd, e, fd_waiters_union(e));
             }
-
-            timer_wake_pending_set(batch, n);
         }
-        rb_native_mutex_unlock(&timer_th.waiting_lock);
+        fd_shard_unlock(fd);
 
         for (int i = 0; i < n; i++) {
             timer_thread_wakeup_thread(batch[i].th, batch[i].serial);


### PR DESCRIPTION
Every io wait took timer_th.waiting_lock to register and again to wake: one global lock serialized the fd map, the epoll_ctl calls made under it, the timer wheel and the wake-pending flags, across all fds.

Split the ownership:
- an fd's waiter list, arming state and the flags of its io waits move under one of 16 fd shard locks; unrelated fds register and wake in parallel, and the epoll_ctl calls leave the global lock entirely
- waiting_lock keeps the wheel and fd-less timed waits
- wake_pending becomes a count under its own small lock, so an expiry hold and an fd event's wake can pin one thread at once
- the untimed waiter list is dropped (its only reader was a VM_ASSERT pass), so untimed io waits touch no global lock at all
- the fd map's chunk table becomes a fixed array with CAS-installed chunks, since chunks span shards

An io+timeout wait is registered in both structures; whoever clears its flags under the fd shard owns the wakeup.  The expiry pass pops wheel nodes under waiting_lock, pins the thread with the pending count, and claims under the shard by (serial, fd) -- lock order is always shard -> waiting_lock -> wake_pending_lock.

R ractor pairs (1 thread each) ping-ponging over pipes with blocking reads, total round-trips/sec, 16-HT machine (Ryzen 9 5900HX), RUBY_MN_THREADS=1, mean of 2 alternating same-tree runs:

                before    after
     8 pairs      63k      134k
    16 pairs      64k      143k

Messaging without fds (port ping-pong pairs) is unchanged.

A thread-heavy shape (256 threads in few ractors doing memcached round trips) is unchanged: its wakes stay inside each ractor's readyq and the old lock was not saturated there.