### PR TITLE
Document dynamic IO::Buffer slice validity

### DIFF
--- a/io_buffer.c
+++ b/io_buffer.c
@@ -1316,10 +1316,17 @@ rb_io_buffer_size(VALUE self)
 /*
  *  call-seq: valid? -> true or false
  *
- *  Returns whether the buffer buffer is accessible.
+ *  Returns whether the buffer's recorded memory range currently exists within
+ *  its source. A buffer which is not a slice is always valid, including a null
+ *  buffer.
  *
- *  A buffer becomes invalid if it is a slice of another buffer (or string)
- *  which has been freed or re-allocated at a different address.
+ *  A slice can become invalid if its source is freed, transferred, shrunk past
+ *  the slice, or reallocated at a different address. Validity is dynamic: if
+ *  the source later contains the same address range again, the slice becomes
+ *  valid again.
+ *
+ *  #valid?, #null? and #empty? describe independent properties. For example,
+ *  an invalid slice can still have a non-null address and a non-zero size.
  */
 static VALUE
 rb_io_buffer_valid_p(VALUE self)
@@ -1332,8 +1339,11 @@ rb_io_buffer_valid_p(VALUE self)
 /*
  *  call-seq: null? -> true or false
  *
- *  If the buffer was freed with #free, transferred with #transfer, or was
- *  never allocated in the first place.
+ *  Returns whether the buffer has no recorded base address.
+ *
+ *  A buffer is null if it was freed with #free, transferred with #transfer, or
+ *  was never allocated in the first place. A zero-sized buffer or slice may
+ *  have a non-null address, so #null? and #empty? are distinct properties.
  *
  *    buffer = IO::Buffer.new(0)
  *    buffer.null? #=> true
@@ -1354,9 +1364,11 @@ rb_io_buffer_null_p(VALUE self)
 /*
  *  call-seq: empty? -> true or false
  *
- *  If the buffer has 0 size: it is created by ::new with size 0, or with ::for
- *  from an empty string. (Note that empty files can't be mapped, so the buffer
- *  created with ::map will never be empty.)
+ *  Returns whether the buffer has zero size.
+ *
+ *  A buffer can be empty but have a non-null address, for example a zero-sized
+ *  slice or a buffer created with ::for from an empty string. Therefore
+ *  #empty? does not imply #null?.
  */
 static VALUE
 rb_io_buffer_empty_p(VALUE self)

--- a/spec/ruby/core/io/buffer/empty_spec.rb
+++ b/spec/ruby/core/io/buffer/empty_spec.rb
@@ -24,4 +24,13 @@ describe "IO::Buffer#empty?" do
     @buffer = IO::Buffer.new(4)
     @buffer.slice(3, 0).empty?.should == true
   end
+
+  it "is false for an invalid slice with a non-zero size" do
+    @buffer = IO::Buffer.new(4)
+    slice = @buffer.slice(0, 2)
+    @buffer.free
+
+    slice.valid?.should == false
+    slice.empty?.should == false
+  end
 end

--- a/spec/ruby/core/io/buffer/null_spec.rb
+++ b/spec/ruby/core/io/buffer/null_spec.rb
@@ -24,4 +24,13 @@ describe "IO::Buffer#null?" do
     @buffer = IO::Buffer.new(4)
     @buffer.slice(3, 0).null?.should == false
   end
+
+  it "is false for an invalid slice with a recorded address" do
+    @buffer = IO::Buffer.new(4)
+    slice = @buffer.slice(0, 2)
+    @buffer.free
+
+    slice.valid?.should == false
+    slice.null?.should == false
+  end
 end

--- a/spec/ruby/core/io/buffer/valid_spec.rb
+++ b/spec/ruby/core/io/buffer/valid_spec.rb
@@ -73,6 +73,25 @@ describe "IO::Buffer#valid?" do
       slice.valid?.should == false
     end
 
+    it "is independent of null? and empty?" do
+      @buffer = IO::Buffer.new(4)
+      slice = @buffer.slice(0, 2)
+      @buffer.free
+
+      slice.valid?.should == false
+      slice.null?.should == false
+      slice.empty?.should == false
+    end
+
+    it "can be true for a non-null empty slice" do
+      @buffer = IO::Buffer.new(4)
+      slice = @buffer.slice(2, 0)
+
+      slice.valid?.should == true
+      slice.null?.should == false
+      slice.empty?.should == true
+    end
+
     it "is false for a slice of a freed file-backed buffer" do
       File.open(__FILE__, "r") do |file|
         @buffer = IO::Buffer.map(file, nil, 0, IO::Buffer::READONLY)


### PR DESCRIPTION
## Summary

- Document that a slice is valid when its recorded address range currently exists within its source.
- Clarify that slice validity is dynamic and independent from `null?` and `empty?`.
- Add RubySpec coverage for invalid non-null/non-empty slices and valid non-null empty slices.

This documents the existing range-based model; it does not change slice validation or introduce generation-based permanent invalidation.

## Testing

- `make test-spec MSPECOPT=../ruby-io-buffer-dynamic-slice-validity/spec/ruby/core/io/buffer`