### PR TITLE
Make empty IO::Buffer slices valid

### DIFF
--- a/io_buffer.c
+++ b/io_buffer.c
@@ -1007,17 +1007,19 @@ io_buffer_validate_slice(VALUE source, void *base, size_t size)
         rb_io_buffer_get_bytes(source, &source_base, &source_size);
     }
 
-    // Source is invalid:
-    if (source_base == NULL) return 0;
+    uintptr_t source_address = (uintptr_t)source_base;
+    uintptr_t address = (uintptr_t)base;
 
     // Base is out of range:
-    if (base < source_base) return 0;
+    if (address < source_address) return 0;
 
-    const void *source_end = (char*)source_base + source_size;
-    const void *end = (char*)base + size;
+    uintptr_t offset = address - source_address;
 
-    // End is out of range:
-    if (end > source_end) return 0;
+    // Base is beyond the end of the source:
+    if (offset > source_size) return 0;
+
+    // End is beyond the end of the source:
+    if (size > source_size - (size_t)offset) return 0;
 
     // It seems okay:
     return 1;
@@ -1788,7 +1790,7 @@ rb_io_buffer_slice(struct rb_io_buffer *buffer, VALUE self, size_t offset, size_
     struct rb_io_buffer *slice = get_io_buffer(instance);
 
     slice->flags |= (buffer->flags & RB_IO_BUFFER_READONLY);
-    slice->base = (char*)buffer->base + offset;
+    slice->base = buffer->base ? (char*)buffer->base + offset : NULL;
     slice->size = length;
 
     // Slices retain their root buffer. If this buffer is already a slice,
@@ -3014,7 +3016,9 @@ io_buffer_get_string(int argc, VALUE *argv, VALUE self)
 
     io_buffer_validate_range(buffer, offset, length);
 
-    return rb_enc_str_new((const char*)base + offset, length, encoding);
+    const char *data = base ? (const char*)base + offset : NULL;
+
+    return rb_enc_str_new(data, length, encoding);
 }
 
 /*

--- a/spec/ruby/core/io/buffer/valid_spec.rb
+++ b/spec/ruby/core/io/buffer/valid_spec.rb
@@ -50,6 +50,39 @@ describe "IO::Buffer#valid?" do
       slice.valid?.should == true
     end
 
+    ruby_version_is "4.1" do
+      it "is true for an empty slice of an empty buffer" do
+        @buffer = IO::Buffer.new(0)
+        slice = @buffer.slice(0, 0)
+
+        slice.valid?.should == true
+        slice.get_string.should == ""
+      end
+
+      it "tracks whether its empty range exists in the source" do
+        @buffer = IO::Buffer.new(0)
+        slice = @buffer.slice(0, 0)
+
+        slice.valid?.should == true
+
+        @buffer.resize(1)
+        slice.valid?.should == false
+        -> { slice.get_string }.should.raise(IO::Buffer::InvalidatedError)
+
+        @buffer.resize(0)
+        slice.valid?.should == true
+        slice.get_string.should == ""
+      end
+
+      it "is false when its empty range no longer belongs to the source" do
+        @buffer = IO::Buffer.new(1)
+        slice = @buffer.slice(1, 0)
+
+        @buffer.resize(0)
+        slice.valid?.should == false
+      end
+    end
+
     context "when buffer is resized" do
       it "is false when slice becomes outside the buffer" do
         @buffer = IO::Buffer.new(4)


### PR DESCRIPTION
## Summary

- Reuse `rb_io_buffer_get_bytes` to validate and obtain the root source range.
- Validate empty and non-empty slices with the same integer range calculation.
- Avoid null-pointer arithmetic when creating empty slices and strings.
- Use overflow-safe range checks for recorded addresses.

This makes an empty slice of a valid empty buffer behave as an empty view:

```ruby
root = IO::Buffer.new(0)
slice = root.slice(0, 0)

slice.valid?     # => true
slice.get_string # => ""
```

Validity remains range-based: if the source range disappears the slice becomes invalid, and if the same empty range exists again it can become valid again.

## Tests

- `make test-all TESTS=../ruby-io-buffer-empty-slice-validity/test/ruby/test_io_buffer.rb`
- `make test-spec MSPECOPT=../ruby-io-buffer-empty-slice-validity/spec/ruby/core/io/buffer`