### PR TITLE
Avoid unsafe zero-length IO::Buffer operations

### DIFF
--- a/include/ruby/io/buffer.h
+++ b/include/ruby/io/buffer.h
@@ -92,8 +92,9 @@ VALUE rb_io_buffer_free(VALUE self);
 // not exactly one.
 VALUE rb_io_buffer_free_locked(VALUE self);
 
-// Access the internal buffer and flags. Validates the pointers.
-// The points may not remain valid if the source buffer is manipulated.
+// Access the internal buffer and flags. Validates the pointers. If the returned
+// base is NULL, the returned size is always zero.
+// The pointers may not remain valid if the source buffer is manipulated.
 // Consider using rb_io_buffer_lock if needed.
 enum rb_io_buffer_flags rb_io_buffer_get_bytes(VALUE self, void **base, size_t *size);
 void rb_io_buffer_get_bytes_for_reading(VALUE self, const void **base, size_t *size);

--- a/io_buffer.c
+++ b/io_buffer.c
@@ -2095,6 +2095,12 @@ rb_io_buffer_compare(VALUE self, VALUE other)
         return RB_INT2NUM(1);
     }
 
+    if (size1 == 0) {
+        return RB_INT2NUM(0);
+    }
+
+    RUBY_ASSERT(ptr1 != NULL);
+    RUBY_ASSERT(ptr2 != NULL);
     return RB_INT2NUM(memcmp(ptr1, ptr2, size1));
 }
 
@@ -2808,6 +2814,10 @@ io_buffer_memmove(struct rb_io_buffer *buffer, size_t offset, const void *source
         rb_raise(rb_eArgError, "The computed source range exceeds the size of the source buffer!");
     }
 
+    if (length == 0) return;
+
+    RUBY_ASSERT(base != NULL);
+    RUBY_ASSERT(source_base != NULL);
     struct io_buffer_memmove_arguments arguments = {
         .destination = (unsigned char*)base+offset,
         .source = (unsigned char*)source_base+source_offset,
@@ -3072,6 +3082,9 @@ rb_io_buffer_clear(VALUE self, uint8_t value, size_t offset, size_t length)
 
     io_buffer_validate_range(buffer, offset, length);
 
+    if (length == 0) return;
+
+    RUBY_ASSERT(base != NULL);
     memset((char*)base + offset, value, length);
 }
 
@@ -3258,8 +3271,11 @@ rb_io_buffer_read(VALUE self, VALUE io, size_t length, size_t offset)
     size_t size;
     io_buffer_get_bytes_for_writing(buffer, &base, &size);
 
-    base = (unsigned char*)base + offset;
     size = size - offset;
+    if (size == 0) return SIZET2NUM(0);
+
+    RUBY_ASSERT(base != NULL);
+    base = (unsigned char*)base + offset;
 
     struct io_buffer_read_internal_argument argument = {
         .descriptor = descriptor,
@@ -3280,7 +3296,8 @@ rb_io_buffer_read(VALUE self, VALUE io, size_t length, size_t offset)
  *  If +length+ is not given or +nil+, it defaults to the size of the buffer
  *  minus the offset, i.e. the entire buffer.
  *
- *  If +length+ is zero, exactly one <tt>read</tt> operation will occur.
+ *  If +length+ is zero, exactly one <tt>read</tt> operation will occur, unless
+ *  there is no available space in the buffer at +offset+.
  *
  *  If +offset+ is not given, it defaults to zero, i.e. the beginning of the
  *  buffer.
@@ -3376,8 +3393,11 @@ rb_io_buffer_pread(VALUE self, VALUE io, rb_off_t from, size_t length, size_t of
     size_t size;
     io_buffer_get_bytes_for_writing(buffer, &base, &size);
 
-    base = (unsigned char*)base + offset;
     size = size - offset;
+    if (size == 0) return SIZET2NUM(0);
+
+    RUBY_ASSERT(base != NULL);
+    base = (unsigned char*)base + offset;
 
     struct io_buffer_pread_internal_argument argument = {
         .descriptor = descriptor,
@@ -3400,7 +3420,8 @@ rb_io_buffer_pread(VALUE self, VALUE io, rb_off_t from, size_t length, size_t of
  *  If +length+ is not given or +nil+, it defaults to the size of the buffer
  *  minus the offset, i.e. the entire buffer.
  *
- *  If +length+ is zero, exactly one <tt>pread</tt> operation will occur.
+ *  If +length+ is zero, exactly one <tt>pread</tt> operation will occur,
+ *  unless there is no available space in the buffer at +offset+.
  *
  *  If +offset+ is not given, it defaults to zero, i.e. the beginning of the
  *  buffer.
@@ -3497,8 +3518,11 @@ rb_io_buffer_write(VALUE self, VALUE io, size_t length, size_t offset)
     size_t size;
     io_buffer_get_bytes_for_reading(buffer, &base, &size);
 
-    base = (unsigned char*)base + offset;
     size = size - offset;
+    if (size == 0) return SIZET2NUM(0);
+
+    RUBY_ASSERT(base != NULL);
+    base = (const unsigned char*)base + offset;
 
     struct io_buffer_write_internal_argument argument = {
         .descriptor = descriptor,
@@ -3519,7 +3543,8 @@ rb_io_buffer_write(VALUE self, VALUE io, size_t length, size_t offset)
  *  If +length+ is not given or +nil+, it defaults to the size of the buffer
  *  minus the offset, i.e. the entire buffer.
  *
- *  If +length+ is zero, exactly one <tt>write</tt> operation will occur.
+ *  If +length+ is zero, exactly one <tt>write</tt> operation will occur,
+ *  unless there are no available bytes in the buffer at +offset+.
  *
  *  If +offset+ is not given, it defaults to zero, i.e. the beginning of the
  *  buffer.
@@ -3608,8 +3633,11 @@ rb_io_buffer_pwrite(VALUE self, VALUE io, rb_off_t from, size_t length, size_t o
     size_t size;
     io_buffer_get_bytes_for_reading(buffer, &base, &size);
 
-    base = (unsigned char*)base + offset;
     size = size - offset;
+    if (size == 0) return SIZET2NUM(0);
+
+    RUBY_ASSERT(base != NULL);
+    base = (const unsigned char*)base + offset;
 
     struct io_buffer_pwrite_internal_argument argument = {
         .descriptor = descriptor,
@@ -3640,7 +3668,8 @@ rb_io_buffer_pwrite(VALUE self, VALUE io, rb_off_t from, size_t length, size_t o
  *  If +length+ is not given or +nil+, it defaults to the size of the buffer
  *  minus the offset, i.e. the entire buffer.
  *
- *  If +length+ is zero, exactly one <tt>pwrite</tt> operation will occur.
+ *  If +length+ is zero, exactly one <tt>pwrite</tt> operation will occur,
+ *  unless there are no available bytes in the buffer at +offset+.
  *
  *  If +offset+ is not given, it defaults to zero, i.e. the beginning of the
  *  buffer.
@@ -4096,6 +4125,9 @@ io_buffer_bit_count(int argc, VALUE *argv, VALUE self)
     size_t size;
     io_buffer_get_bytes_for_reading(buffer, &base, &size);
 
+    if (length == 0) return SIZET2NUM(0);
+
+    RUBY_ASSERT(base != NULL);
     size_t count = memory_bit_count((const unsigned char *)base + offset, length);
 
     return SIZET2NUM(count);

--- a/test/ruby/test_io_buffer.rb
+++ b/test/ruby/test_io_buffer.rb
@@ -427,9 +427,11 @@ class TestIOBuffer < Test::Unit::TestCase
   def test_compare_zero_length
     buffer1 = IO::Buffer.new(0)
     buffer2 = IO::Buffer.new(1)
+    buffer3 = IO::Buffer.new(0)
 
     assert_negative buffer1 <=> buffer2
     assert_positive buffer2 <=> buffer1
+    assert_equal 0, buffer1 <=> buffer3
   end
 
   def test_slice
@@ -887,6 +889,13 @@ class TestIOBuffer < Test::Unit::TestCase
     assert_raise(ArgumentError) {buffer.clear(0, SIZE_MAX-7, 10)}
   end
 
+  def test_clear_zero_length
+    buffer = IO::Buffer.new(0)
+
+    assert_same buffer, buffer.clear
+    assert_predicate buffer, :empty?
+  end
+
   def test_invalidation
     input, output = IO.pipe
 
@@ -1016,6 +1025,31 @@ class TestIOBuffer < Test::Unit::TestCase
 
     io.seek(0)
     assert_equal "ello", io.read(4)
+  ensure
+    io.close!
+  end
+
+  def test_zero_length_io
+    io = Tempfile.new
+
+    assert_zero_length_io = proc do |buffer, offset = 0|
+      assert_equal 0, buffer.read(io, 0, offset)
+      assert_equal 0, buffer.pread(io, 0, 0, offset)
+      assert_equal 0, buffer.write(io, 0, offset)
+      assert_equal 0, buffer.pwrite(io, 0, 0, offset)
+    end
+
+    buffer = IO::Buffer.new(0)
+    assert_predicate buffer, :null?
+    assert_zero_length_io.call(buffer)
+
+    IO::Buffer.for("") do |buffer|
+      refute_predicate buffer, :null?
+      assert_zero_length_io.call(buffer)
+    end
+
+    buffer = IO::Buffer.new(8)
+    assert_zero_length_io.call(buffer, buffer.size)
   ensure
     io.close!
   end


### PR DESCRIPTION
Several `IO::Buffer` operations support the canonical empty `{NULL, 0}` state at the Ruby level, but their C implementations could still perform pointer arithmetic on `NULL` or pass null pointers to memory functions for zero-length ranges.

This change makes those empty-range paths explicit while preserving their validation and ordinary observable behavior:

- return directly for zero-length comparison, copy, clear, and bit counting after validation
- return zero from native read, pread, write, and pwrite when no buffer capacity remains at the requested offset
- assert that a positive-size span always has a non-null base before pointer arithmetic
- document that the C byte-access APIs return size zero whenever their base is null
- retain the existing single-operation behavior for `length == 0` when buffer capacity is available
- cover null empty buffers, non-null empty buffers, and end-of-buffer offsets

Tests:

- `make test-all TESTS=../ruby-io-buffer-zero-length/test/ruby/test_io_buffer.rb`
- `make test-spec MSPECOPT=../ruby-io-buffer-zero-length/spec/ruby/core/io/buffer`