### PR TITLE
Bump the vcpkg builtin-baseline for the gmp msys2 404 [Backport to ruby_4_0]

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -7,5 +7,5 @@
     "openssl",
     "zlib"
   ],
-  "builtin-baseline": "cd61e1e26a038e82d6550a3ebbe0fbbfe7da78e3"
+  "builtin-baseline": "7f3781e19cc7d4e4882a4caec01668c6f7b5c163"
 }


### PR DESCRIPTION
Backport of commit 0f024f53b09 from master. The gmp portfile at the current baseline downloads `autoconf2.71-2.71-3-any.pkg.tar.zst` from msys2 mirrors by a pinned URL, but msys2 has rotated the package to `-4`, so every mirror returns 404 and Windows CI on `ruby_4_0` fails to build gmp whenever the vcpkg binary cache misses, e.g. https://github.com/ruby/ruby/actions/runs/32658995757/job/97242672735. The new baseline includes microsoft/vcpkg@37bb045f3c, which updates the URL.
