### PR TITLE
[Bug #21672] Validate IO::Buffer constructor flags

### DIFF
--- a/io_buffer.c
+++ b/io_buffer.c
@@ -48,6 +48,9 @@ enum {
     // This is used to validate the flags given by the user.
     RB_IO_BUFFER_FLAGS_MASK = RB_IO_BUFFER_EXTERNAL | RB_IO_BUFFER_INTERNAL | RB_IO_BUFFER_MAPPED | RB_IO_BUFFER_SHARED | RB_IO_BUFFER_PRIVATE | RB_IO_BUFFER_READONLY,
 
+    RB_IO_BUFFER_ALLOCATION_FLAGS = RB_IO_BUFFER_INTERNAL | RB_IO_BUFFER_MAPPED,
+    RB_IO_BUFFER_MAPPING_FLAGS = RB_IO_BUFFER_SHARED | RB_IO_BUFFER_PRIVATE,
+
     RB_IO_BUFFER_DEBUG = 0,
 };
 
@@ -381,6 +384,24 @@ io_buffer_extract_flags(VALUE argument)
 
     // We deliberately ignore unknown flags. Any future flags which are exposed this way should be safe to ignore.
     return flags & RB_IO_BUFFER_FLAGS_MASK;
+}
+
+static inline enum rb_io_buffer_flags
+io_buffer_flags_for_map(enum rb_io_buffer_flags flags)
+{
+    if (flags & RB_IO_BUFFER_INTERNAL) {
+        rb_raise(rb_eArgError, "IO::Buffer::INTERNAL can't be used with IO::Buffer.map!");
+    }
+
+    if (flags & RB_IO_BUFFER_EXTERNAL) {
+        rb_raise(rb_eArgError, "IO::Buffer::EXTERNAL can't be used with IO::Buffer.map!");
+    }
+
+    if ((flags & RB_IO_BUFFER_MAPPING_FLAGS) == RB_IO_BUFFER_MAPPING_FLAGS) {
+        rb_raise(rb_eArgError, "Flags can't include both IO::Buffer::SHARED and IO::Buffer::PRIVATE!");
+    }
+
+    return flags;
 }
 
 // Extract an offset argument, which must be a non-negative integer.
@@ -821,6 +842,12 @@ rb_io_buffer_map(VALUE io, size_t size, rb_off_t offset, enum rb_io_buffer_flags
  *  By default, the buffer is writable and expects the file to be writable.
  *  It is also shared, so several processes can use the same mapping.
  *
+ *  The mapping mode may be explicitly selected with IO::Buffer::SHARED or
+ *  IO::Buffer::PRIVATE, but the two flags are mutually exclusive.
+ *  IO::Buffer::MAPPED is accepted but redundant because this method always
+ *  creates a mapped buffer. IO::Buffer::INTERNAL and IO::Buffer::EXTERNAL
+ *  cannot be specified.
+ *
  *  You can pass IO::Buffer::READONLY in +flags+ argument to make a read-only buffer;
  *  this allows to work with files opened only for reading.
  *  Specifying IO::Buffer::PRIVATE in +flags+ creates a private mapping,
@@ -927,6 +954,7 @@ io_buffer_map(int argc, VALUE *argv, VALUE klass)
     if (argc >= 4) {
         flags = io_buffer_extract_flags(argv[3]);
     }
+    flags = io_buffer_flags_for_map(flags);
 
     return rb_io_buffer_map(io, size, offset, flags);
 }
@@ -942,8 +970,49 @@ io_flags_for_size(size_t size)
     return RB_IO_BUFFER_INTERNAL;
 }
 
+static inline enum rb_io_buffer_flags
+io_buffer_flags_for_new(enum rb_io_buffer_flags flags, size_t size)
+{
+    if (size == 0) {
+        // A null buffer has no allocation and therefore no allocation flags:
+        return 0;
+    }
+
+    if (!(flags & RB_IO_BUFFER_ALLOCATION_FLAGS)) {
+        if (flags & RB_IO_BUFFER_MAPPING_FLAGS) {
+            // Mapping properties imply a mapped allocation:
+            flags |= RB_IO_BUFFER_MAPPED;
+        }
+        else {
+            // No explicit allocation mode was given, so infer one from size:
+            flags |= io_flags_for_size(size);
+        }
+    }
+
+    enum rb_io_buffer_flags allocation = flags & RB_IO_BUFFER_ALLOCATION_FLAGS;
+    RUBY_ASSERT(allocation != 0);
+
+    if (allocation == RB_IO_BUFFER_ALLOCATION_FLAGS) {
+        rb_raise(rb_eArgError, "Flags can't include both IO::Buffer::INTERNAL and IO::Buffer::MAPPED!");
+    }
+
+    if (flags & RB_IO_BUFFER_EXTERNAL) {
+        rb_raise(rb_eArgError, "IO::Buffer::EXTERNAL can't be used with IO::Buffer.new!");
+    }
+
+    if ((flags & RB_IO_BUFFER_MAPPING_FLAGS) && allocation != RB_IO_BUFFER_MAPPED) {
+        rb_raise(rb_eArgError, "IO::Buffer::SHARED and IO::Buffer::PRIVATE require IO::Buffer::MAPPED!");
+    }
+
+    if ((flags & RB_IO_BUFFER_MAPPING_FLAGS) == RB_IO_BUFFER_MAPPING_FLAGS) {
+        rb_raise(rb_eArgError, "Flags can't include both IO::Buffer::SHARED and IO::Buffer::PRIVATE!");
+    }
+
+    return flags;
+}
+
 /*
- *  call-seq: IO::Buffer.new([size = DEFAULT_SIZE, [flags = 0]]) -> io_buffer
+ *  call-seq: IO::Buffer.new([size = DEFAULT_SIZE, [flags]]) -> io_buffer
  *
  *  Create a new zero-filled IO::Buffer of +size+ bytes.
  *  By default, the buffer will be _internal_: directly allocated chunk
@@ -952,6 +1021,11 @@ io_flags_for_size(size_t size)
  *  virtual memory mechanism (anonymous +mmap+ on Unix, +VirtualAlloc+
  *  on Windows). The behavior can be forced by passing IO::Buffer::MAPPED
  *  as a second parameter.
+ *
+ *  IO::Buffer::SHARED and IO::Buffer::PRIVATE imply IO::Buffer::MAPPED and are
+ *  mutually exclusive. Otherwise, if +flags+ do not include an allocation
+ *  mode, IO::Buffer::INTERNAL or IO::Buffer::MAPPED is inferred from the
+ *  requested size. The two allocation modes are mutually exclusive.
  *
  *    buffer = IO::Buffer.new(4)
  *    # =>
@@ -985,9 +1059,7 @@ rb_io_buffer_initialize(int argc, VALUE *argv, VALUE self)
     if (argc >= 2) {
         flags = io_buffer_extract_flags(argv[1]);
     }
-    else {
-        flags |= io_flags_for_size(size);
-    }
+    flags = io_buffer_flags_for_new(flags, size);
 
     io_buffer_initialize(self, buffer, NULL, size, flags, Qnil);
 

--- a/spec/ruby/core/io/buffer/initialize_spec.rb
+++ b/spec/ruby/core/io/buffer/initialize_spec.rb
@@ -81,10 +81,24 @@ describe "IO::Buffer#initialize" do
     end
 
     it "allows extra flags" do
-      @buffer = IO::Buffer.new(10, IO::Buffer::INTERNAL | IO::Buffer::SHARED | IO::Buffer::READONLY)
-      @buffer.should.internal?
+      @buffer = IO::Buffer.new(10, IO::Buffer::MAPPED | IO::Buffer::SHARED | IO::Buffer::READONLY)
+      @buffer.should.mapped?
       @buffer.should.shared?
       @buffer.should.readonly?
+    end
+
+    ruby_version_is "4.1" do
+      it "infers IO::Buffer::MAPPED from IO::Buffer::SHARED" do
+        @buffer = IO::Buffer.new(10, IO::Buffer::SHARED)
+        @buffer.should.mapped?
+        @buffer.should.shared?
+      end
+
+      it "infers IO::Buffer::MAPPED from IO::Buffer::PRIVATE" do
+        @buffer = IO::Buffer.new(10, IO::Buffer::PRIVATE)
+        @buffer.should.mapped?
+        @buffer.should.private?
+      end
     end
 
     it "ignores flags if size is 0" do
@@ -103,9 +117,46 @@ describe "IO::Buffer#initialize" do
       @buffer.should.valid?
     end
 
-    it "raises IO::Buffer::AllocationError if neither IO::Buffer::MAPPED nor IO::Buffer::INTERNAL is given" do
-      -> { IO::Buffer.new(10, IO::Buffer::READONLY) }.should.raise(IO::Buffer::AllocationError, "Could not allocate buffer!")
-      -> { IO::Buffer.new(10, 0) }.should.raise(IO::Buffer::AllocationError, "Could not allocate buffer!")
+    ruby_version_is ""..."4.1" do
+      it "raises IO::Buffer::AllocationError if neither IO::Buffer::MAPPED nor IO::Buffer::INTERNAL is given" do
+        -> { IO::Buffer.new(10, IO::Buffer::READONLY) }.should.raise(IO::Buffer::AllocationError, "Could not allocate buffer!")
+        -> { IO::Buffer.new(10, 0) }.should.raise(IO::Buffer::AllocationError, "Could not allocate buffer!")
+      end
+    end
+
+    ruby_version_is "4.1" do
+      it "infers the allocation mode if neither IO::Buffer::MAPPED nor IO::Buffer::INTERNAL is given" do
+        @buffer = IO::Buffer.new(10, IO::Buffer::READONLY)
+        @buffer.should.internal?
+        @buffer.should.readonly?
+
+        @buffer.free
+        @buffer = IO::Buffer.new(IO::Buffer::PAGE_SIZE, 0)
+        @buffer.should.mapped?
+      end
+
+      it "raises ArgumentError if both IO::Buffer::MAPPED and IO::Buffer::INTERNAL are given" do
+        flags = IO::Buffer::INTERNAL | IO::Buffer::MAPPED
+        -> { IO::Buffer.new(10, flags) }.should.raise(ArgumentError, "Flags can't include both IO::Buffer::INTERNAL and IO::Buffer::MAPPED!")
+      end
+
+      it "raises ArgumentError if IO::Buffer::EXTERNAL is given" do
+        flags = IO::Buffer::INTERNAL | IO::Buffer::EXTERNAL
+        -> { IO::Buffer.new(10, flags) }.should.raise(ArgumentError, "IO::Buffer::EXTERNAL can't be used with IO::Buffer.new!")
+      end
+
+      it "raises ArgumentError if mapping flags are given with IO::Buffer::INTERNAL" do
+        flags = IO::Buffer::INTERNAL | IO::Buffer::SHARED
+        -> { IO::Buffer.new(10, flags) }.should.raise(ArgumentError, "IO::Buffer::SHARED and IO::Buffer::PRIVATE require IO::Buffer::MAPPED!")
+
+        flags = IO::Buffer::INTERNAL | IO::Buffer::PRIVATE
+        -> { IO::Buffer.new(10, flags) }.should.raise(ArgumentError, "IO::Buffer::SHARED and IO::Buffer::PRIVATE require IO::Buffer::MAPPED!")
+      end
+
+      it "raises ArgumentError if both IO::Buffer::SHARED and IO::Buffer::PRIVATE are given" do
+        flags = IO::Buffer::SHARED | IO::Buffer::PRIVATE
+        -> { IO::Buffer.new(10, flags) }.should.raise(ArgumentError, "Flags can't include both IO::Buffer::SHARED and IO::Buffer::PRIVATE!")
+      end
     end
 
     it "raises ArgumentError if flags is negative" do

--- a/spec/ruby/core/io/buffer/map_spec.rb
+++ b/spec/ruby/core/io/buffer/map_spec.rb
@@ -284,6 +284,42 @@ describe "IO::Buffer.map" do
   end
 
   context "with flags argument" do
+    ruby_version_is "4.1" do
+      it "allows the redundant MAPPED flag" do
+        @file = open_fixture
+        @buffer = IO::Buffer.map(@file, nil, 0, IO::Buffer::MAPPED)
+
+        @buffer.should.mapped?
+        @buffer.should.shared?
+      end
+
+      it "raises ArgumentError if INTERNAL is specified" do
+        @file = open_fixture
+        -> { IO::Buffer.map(@file, nil, 0, IO::Buffer::INTERNAL) }.should.raise(
+          ArgumentError,
+          "IO::Buffer::INTERNAL can't be used with IO::Buffer.map!"
+        )
+      end
+
+      it "raises ArgumentError if EXTERNAL is specified" do
+        @file = open_fixture
+        -> { IO::Buffer.map(@file, nil, 0, IO::Buffer::EXTERNAL) }.should.raise(
+          ArgumentError,
+          "IO::Buffer::EXTERNAL can't be used with IO::Buffer.map!"
+        )
+      end
+
+      it "raises ArgumentError if both SHARED and PRIVATE are specified" do
+        @file = open_fixture
+        flags = IO::Buffer::SHARED | IO::Buffer::PRIVATE
+
+        -> { IO::Buffer.map(@file, nil, 0, flags) }.should.raise(
+          ArgumentError,
+          "Flags can't include both IO::Buffer::SHARED and IO::Buffer::PRIVATE!"
+        )
+      end
+    end
+
     context "when READONLY flag is specified" do
       it "sets readonly flag on the buffer, allowing only reads" do
         @file = open_fixture

--- a/spec/ruby/core/io/buffer/private_spec.rb
+++ b/spec/ruby/core/io/buffer/private_spec.rb
@@ -7,7 +7,7 @@ describe "IO::Buffer#private?" do
   end
 
   it "is true for a buffer created with PRIVATE flag" do
-    @buffer = IO::Buffer.new(12, IO::Buffer::INTERNAL | IO::Buffer::PRIVATE)
+    @buffer = IO::Buffer.new(12, IO::Buffer::MAPPED | IO::Buffer::PRIVATE)
     @buffer.private?.should == true
   end
 

--- a/spec/ruby/core/io/buffer/shared_spec.rb
+++ b/spec/ruby/core/io/buffer/shared_spec.rb
@@ -7,7 +7,7 @@ describe "IO::Buffer#shared?" do
   end
 
   it "is true for a buffer created with SHARED flag" do
-    @buffer = IO::Buffer.new(12, IO::Buffer::INTERNAL | IO::Buffer::SHARED)
+    @buffer = IO::Buffer.new(12, IO::Buffer::MAPPED | IO::Buffer::SHARED)
     @buffer.shared?.should == true
   end
 

--- a/test/ruby/test_io_buffer.rb
+++ b/test/ruby/test_io_buffer.rb
@@ -125,6 +125,74 @@ class TestIOBuffer < Test::Unit::TestCase
     end
   end
 
+  def test_new_invalid_flags
+    assert_raise(ArgumentError) do
+      IO::Buffer.new(128, IO::Buffer::EXTERNAL)
+    end
+
+    assert_raise(ArgumentError) do
+      IO::Buffer.new(128, IO::Buffer::INTERNAL | IO::Buffer::MAPPED)
+    end
+
+    assert_raise(ArgumentError) do
+      IO::Buffer.new(128, IO::Buffer::INTERNAL | IO::Buffer::SHARED)
+    end
+
+    assert_raise(ArgumentError) do
+      IO::Buffer.new(128, IO::Buffer::INTERNAL | IO::Buffer::PRIVATE)
+    end
+
+    assert_raise(ArgumentError) do
+      IO::Buffer.new(128, IO::Buffer::MAPPED | IO::Buffer::SHARED | IO::Buffer::PRIVATE)
+    end
+  end
+
+  def test_new_infers_allocation_mode_with_flags
+    internal = IO::Buffer.new(128, IO::Buffer::READONLY)
+    assert_predicate internal, :internal?
+    assert_predicate internal, :readonly?
+
+    mapped = IO::Buffer.new(IO::Buffer::PAGE_SIZE, IO::Buffer::READONLY)
+    assert_predicate mapped, :mapped?
+    assert_predicate mapped, :readonly?
+
+    shared = IO::Buffer.new(128, IO::Buffer::SHARED)
+    assert_predicate shared, :mapped?
+    assert_predicate shared, :shared?
+
+    private_buffer = IO::Buffer.new(128, IO::Buffer::PRIVATE)
+    assert_predicate private_buffer, :mapped?
+    assert_predicate private_buffer, :private?
+  end
+
+  def test_map_invalid_flags
+    File.open(__FILE__) do |file|
+      assert_raise(ArgumentError) do
+        IO::Buffer.map(file, nil, 0, IO::Buffer::INTERNAL)
+      end
+
+      assert_raise(ArgumentError) do
+        IO::Buffer.map(file, nil, 0, IO::Buffer::EXTERNAL)
+      end
+
+      assert_raise(ArgumentError) do
+        IO::Buffer.map(file, nil, 0, IO::Buffer::SHARED | IO::Buffer::PRIVATE)
+      end
+    end
+  end
+
+  def test_map_allows_redundant_mapped_flag
+    buffer = File.open(__FILE__) do |file|
+      IO::Buffer.map(file, nil, 0, IO::Buffer::MAPPED | IO::Buffer::READONLY)
+    end
+
+    assert_predicate buffer, :mapped?
+    assert_predicate buffer, :shared?
+    assert_predicate buffer, :readonly?
+  ensure
+    buffer&.free
+  end
+
   def test_file_mapped
     buffer = File.open(__FILE__) {|file| IO::Buffer.map(file, nil, 0, IO::Buffer::READONLY)}
     assert_equal File.size(__FILE__), buffer.size


### PR DESCRIPTION
`IO::Buffer.new` currently accepts contradictory flags such as `INTERNAL | MAPPED`. The allocation follows the first matching mode, but the resulting buffer retains both flags and may later be released using both strategies. `IO::Buffer.map` similarly accepts flags which contradict or do not apply to file mapping.

Extract the Ruby flag value once, then normalize and validate it according to the constructor:

- For `IO::Buffer.new`, infer the allocation mode from size when neither `INTERNAL` nor `MAPPED` is specified.
- Make `SHARED` and `PRIVATE` imply `MAPPED` for `IO::Buffer.new`.
- Reject contradictory allocation, ownership, and mapping flags.
- For `IO::Buffer.map`, reject `INTERNAL`, `EXTERNAL`, and `SHARED | PRIVATE`; continue accepting redundant `MAPPED` for compatibility.
- Continue ignoring flags for zero-sized buffers, which have no allocation.
- Document the allocation-mode rules and update the core tests and RubySpecs.

[Bug #21672]