### PR TITLE
fix array splicing when source has a shared buffer with another array

### DIFF
--- a/array.c
+++ b/array.c
@@ -2328,6 +2328,16 @@ rb_ary_splice(VALUE ary, long beg, long len, const VALUE *rptr, long rlen)
     {
         const VALUE *optr = RARRAY_CONST_PTR(ary);
         rofs = (rptr >= optr && rptr < optr + olen) ? rptr - optr : -1;
+        if (rofs != -1 && ARY_SHARED_P(ary) && rptr + rlen > optr + olen) {
+            /* The source overlaps the storage of ary, but reaches past ary's
+             * own elements: ary shares that storage with a longer array (see
+             * ary_make_shared).  Rebasing rptr onto the storage ary ends up
+             * with below would then read uninitialized slots, so give ary
+             * private storage now and keep reading from the shared storage,
+             * which the other array keeps alive. */
+            rb_ary_modify(ary);
+            rofs = -1;
+        }
     }
 
     if (beg >= olen) {

--- a/test/ruby/test_array.rb
+++ b/test/ruby/test_array.rb
@@ -670,6 +670,45 @@ class TestArray < Test::Unit::TestCase
     assert_equal(:ok, a.last)
   end
 
+  # Long enough that the array cannot be embedded, so `dup` shares the buffer
+  # instead of copying it.
+  SHARED_BUF_LEN = 200
+
+  def shared_buf_src
+    (0...SHARED_BUF_LEN).map {|i| "e#{i}"}
+  end
+
+  def test_concat_shared_longer_than_self
+    # `dup` makes both arrays share one buffer, so `b` and `a` start out with
+    # the same data pointer; `pop` then leaves `b` shorter than `a`.
+    src = shared_buf_src
+    a = @cls[*src]
+    b = a.dup
+    b.pop
+    assert_equal(src[0..-2] + src, b.concat(a))
+    GC.start
+    assert_equal(src.last, b.last)
+  end
+
+  def test_aset_shared_longer_than_self
+    src = shared_buf_src
+
+    a = @cls[*src]
+    b = a.dup
+    b.pop
+    b[0, 0] = a
+    assert_equal(src + src[0..-2], b)
+
+    a = @cls[*src]
+    c = a.dup
+    c.pop
+    c[5, 2] = a
+    assert_equal(src[0, 5] + src + src[0..-2][7..], c)
+
+    GC.start
+    assert_equal(src[0..-2].last, c.last)
+  end
+
   def test_count
     a = @cls[1, 2, 3, 1, 2]
     assert_equal(5, a.count)


### PR DESCRIPTION
certain modification operations, like `#pop`, keep the shared buffer, which then corrupts operations like `#concat`, which pass unitialized malloc memory to the destination array, when the concat'd array shares a buffer with src.

Simplest reproduction:

```ruby
a = (0...200).map { |i| "s#{i}" }
b = a.dup      # a and b now share ONE buffer
b.pop          # b is 199 long, a is 200
b.concat(a)
p b.last       #=> false   (expected "s199")
```

this condition only triggers for arrays too big to embed.

This changeset was built using claude, after observing a succession of crashes on an upgrade of an app to 4.0.6 on `Set#add`. An initial harness was created around the reproduction of that issue (shared below, crashed every time for me), after which the LLM bruteforced until narrowing down to the splice operation patched in this PR.

```ruby
require 'set'

def old_adj(m)
  hs = Hash.new{|h,k|h[k]=[]}
   m.each_with_object(hs) do |x,a|
     a[x[:from]] << x[:to]
   end
end

def new_adj(m)
  d= Hash.new{|h,k|h[k]=Set.new}
  m.each {|x| d[x[:from]] << x[:to] }
  d.each_with_object(Hash.new{|h,k|h[k]=[]}) do |(f,t),a|
    a[f] = t.to_a
  end
end

def walk(ids, adj)
  ids.to_h do |s|
    r=Set.new; st=adj[s].dup
    until st.empty?
      nd=st.pop
      next if r.include?(nd)
      r << nd
      st.concat(adj[nd])
    end
    [s,r]
  end
end

srand 20260821

600.times do |i|
  n = 1 + rand(18)
  ids = (0...n).map{|k|"n#{k}"}
  edges = []

  (rand(40) + 1).times do
    a=ids.sample
    b=ids.sample
    (1 + rand(12)).times { edges << { from: a, to: b } }
  end
  if i % 5 == 0
    edges << { from: ids.first, to: ids.first }
  end
  ids << "orphan#{i}" if i % 7 == 0

  walk(ids, old_adj(edges))
  walk(ids, new_adj(edges))   # both walks, NO comparison
end

puts "twowalk done"

```