### PR TITLE
[Bug #22219] Respect frozen IO::Buffer lifecycle state

### DIFF
--- a/io_buffer.c
+++ b/io_buffer.c
@@ -235,7 +235,7 @@ io_buffer_initialize(VALUE self, struct rb_io_buffer *buffer, void *base, size_t
 }
 
 static void
-io_buffer_free(struct rb_io_buffer *buffer)
+io_buffer_release(struct rb_io_buffer *buffer)
 {
     if (buffer->base) {
         if (buffer->flags & RB_IO_BUFFER_INTERNAL) {
@@ -264,9 +264,9 @@ io_buffer_free(struct rb_io_buffer *buffer)
 
 #if defined(_WIN32)
     if (buffer->mapping) {
-        if (RB_IO_BUFFER_DEBUG) fprintf(stderr, "io_buffer_free:CloseHandle -> %p\n", buffer->mapping);
+        if (RB_IO_BUFFER_DEBUG) fprintf(stderr, "io_buffer_release:CloseHandle -> %p\n", buffer->mapping);
         if (!CloseHandle(buffer->mapping)) {
-            fprintf(stderr, "io_buffer_free:GetLastError -> %lu\n", GetLastError());
+            fprintf(stderr, "io_buffer_release:GetLastError -> %lu\n", GetLastError());
         }
         buffer->mapping = NULL;
     }
@@ -309,7 +309,7 @@ rb_io_buffer_type_free(void *_buffer)
 {
     struct rb_io_buffer *buffer = _buffer;
 
-    io_buffer_free(buffer);
+    io_buffer_release(buffer);
 }
 
 static size_t
@@ -1659,6 +1659,20 @@ rb_io_buffer_locked(VALUE self)
     return rb_ensure(rb_yield, self, rb_io_buffer_locked_ensure, self);
 }
 
+VALUE
+rb_io_buffer_free(VALUE self)
+{
+    struct rb_io_buffer *buffer = get_io_buffer(self);
+
+    if (io_buffer_locked(buffer)) {
+        rb_raise(rb_eIOBufferLockedError, "Buffer is locked!");
+    }
+
+    io_buffer_release(buffer);
+
+    return self;
+}
+
 /*
  *  call-seq: free -> self
  *
@@ -1684,19 +1698,20 @@ rb_io_buffer_locked(VALUE self)
  *    buffer.get_string # => ""
  *
  *    buffer.get_value(:U8, 0) # raises ArgumentError
+ *
+ *  A frozen buffer cannot be freed, as that would release the memory its
+ *  contents live in:
+ *
+ *    buffer = IO::Buffer.for('test').freeze
+ *    buffer.free
+ *    # in `free': can't modify frozen IO::Buffer (FrozenError)
  */
-VALUE
-rb_io_buffer_free(VALUE self)
+static VALUE
+io_buffer_free(VALUE self)
 {
-    struct rb_io_buffer *buffer = get_io_buffer(self);
+    rb_check_frozen(self);
 
-    if (io_buffer_locked(buffer)) {
-        rb_raise(rb_eIOBufferLockedError, "Buffer is locked!");
-    }
-
-    io_buffer_free(buffer);
-
-    return self;
+    return rb_io_buffer_free(self);
 }
 
 VALUE rb_io_buffer_free_locked(VALUE self)
@@ -1712,7 +1727,7 @@ VALUE rb_io_buffer_free_locked(VALUE self)
     }
 
     io_buffer_unlock(buffer);
-    io_buffer_free(buffer);
+    io_buffer_release(buffer);
 
     return self;
 }
@@ -1928,7 +1943,7 @@ io_buffer_resize_copy(VALUE self, struct rb_io_buffer *buffer, size_t size)
         io_buffer_resize_clear(buffer, resized.base, size);
     }
 
-    io_buffer_free(buffer);
+    io_buffer_release(buffer);
     *buffer = resized;
 }
 
@@ -1994,7 +2009,7 @@ rb_io_buffer_resize(VALUE self, size_t size)
     }
 
     if (size == 0) {
-        io_buffer_free(buffer);
+        io_buffer_release(buffer);
         return;
     }
 
@@ -2055,11 +2070,13 @@ rb_io_buffer_resize(VALUE self, size_t size)
  *  does not change, a slice can be resized while its source is locked.
  *
  *  External owning buffers (created with ::for), and locked owning buffers
- *  cannot be resized.
+ *  cannot be resized. Frozen buffers cannot be resized.
  */
 static VALUE
 io_buffer_resize(VALUE self, VALUE size)
 {
+    rb_check_frozen(self);
+
     rb_io_buffer_resize(self, io_buffer_extract_size(size));
 
     return self;
@@ -4325,7 +4342,7 @@ Init_IO_Buffer(void)
     rb_define_method(rb_cIOBuffer, "<=>", rb_io_buffer_compare, 1);
     rb_define_method(rb_cIOBuffer, "resize", io_buffer_resize, 1);
     rb_define_method(rb_cIOBuffer, "clear", io_buffer_clear, -1);
-    rb_define_method(rb_cIOBuffer, "free", rb_io_buffer_free, 0);
+    rb_define_method(rb_cIOBuffer, "free", io_buffer_free, 0);
 
     rb_include_module(rb_cIOBuffer, rb_mComparable);
 

--- a/io_buffer.c
+++ b/io_buffer.c
@@ -1883,24 +1883,6 @@ io_buffer_slice(int argc, VALUE *argv, VALUE self)
     return rb_io_buffer_slice(buffer, self, offset, length);
 }
 
-/*
- *  call-seq: transfer -> new_io_buffer
- *
- *  Transfers ownership of the underlying memory to a new buffer, causing the
- *  current buffer to become uninitialized.
- *
- *    buffer = IO::Buffer.for('test')
- *    other = buffer.transfer
- *    other
- *    # =>
- *    # #<IO::Buffer 0x00007f136a15f7b0+4 EXTERNAL READONLY SLICE>
- *    # 0x00000000  74 65 73 74                                     test
- *    buffer
- *    # =>
- *    # #<IO::Buffer 0x0000000000000000+0 NULL EXTERNAL READONLY>
- *    buffer.null?
- *    # => true
- */
 VALUE
 rb_io_buffer_transfer(VALUE self)
 {
@@ -1918,6 +1900,39 @@ rb_io_buffer_transfer(VALUE self)
     io_buffer_zero(buffer);
 
     return instance;
+}
+
+/*
+ *  call-seq: transfer -> new_io_buffer
+ *
+ *  Transfers ownership of the underlying memory to a new buffer, causing the
+ *  current buffer to become uninitialized.
+ *
+ *    buffer = IO::Buffer.for('test')
+ *    other = buffer.transfer
+ *    other
+ *    # =>
+ *    # #<IO::Buffer 0x00007f136a15f7b0+4 EXTERNAL READONLY SLICE>
+ *    # 0x00000000  74 65 73 74                                     test
+ *    buffer
+ *    # =>
+ *    # #<IO::Buffer 0x0000000000000000+0 NULL EXTERNAL READONLY>
+ *    buffer.null?
+ *    # => true
+ *
+ *  A frozen buffer cannot transfer ownership, as that would leave it
+ *  uninitialized:
+ *
+ *    buffer = IO::Buffer.for('test').freeze
+ *    buffer.transfer
+ *    # in `transfer': can't modify frozen IO::Buffer (FrozenError)
+ */
+static VALUE
+io_buffer_transfer(VALUE self)
+{
+    rb_check_frozen(self);
+
+    return rb_io_buffer_transfer(self);
 }
 
 static void
@@ -4290,7 +4305,7 @@ Init_IO_Buffer(void)
     rb_define_method(rb_cIOBuffer, "size", rb_io_buffer_size, 0);
     rb_define_method(rb_cIOBuffer, "valid?", rb_io_buffer_valid_p, 0);
 
-    rb_define_method(rb_cIOBuffer, "transfer", rb_io_buffer_transfer, 0);
+    rb_define_method(rb_cIOBuffer, "transfer", io_buffer_transfer, 0);
 
     /* Indicates that the memory in the buffer is owned by someone else. See #external? for more details. */
     rb_define_const(rb_cIOBuffer, "EXTERNAL", RB_INT2NUM(RB_IO_BUFFER_EXTERNAL));

--- a/spec/ruby/core/io/buffer/free_spec.rb
+++ b/spec/ruby/core/io/buffer/free_spec.rb
@@ -81,6 +81,26 @@ describe "IO::Buffer#free" do
     end
   end
 
+  ruby_version_is "4.1" do
+    it "raises FrozenError without freeing a frozen buffer" do
+      buffer = IO::Buffer.new(4)
+      buffer.set_string("test")
+      buffer.freeze
+
+      -> { buffer.free }.should.raise(FrozenError)
+      buffer.null?.should == false
+      buffer.get_string.should == "test"
+    end
+
+    it "allows internal cleanup after a buffer is frozen inside .for" do
+      string = +"test"
+      buffer = IO::Buffer.for(string, &:freeze)
+
+      buffer.null?.should == true
+      (string << "!").should == "test!"
+    end
+  end
+
   it "is disallowed while locked, raising IO::Buffer::LockedError" do
     buffer = IO::Buffer.new(4)
     buffer.locked do

--- a/spec/ruby/core/io/buffer/resize_spec.rb
+++ b/spec/ruby/core/io/buffer/resize_spec.rb
@@ -115,6 +115,18 @@ describe "IO::Buffer#resize" do
     @buffer.size.should == 1
   end
 
+  ruby_version_is "4.1" do
+    it "raises FrozenError without resizing a frozen buffer" do
+      buffer = IO::Buffer.new(4)
+      buffer.set_string("test")
+      buffer.freeze
+
+      -> { buffer.resize(8) }.should.raise(FrozenError)
+      buffer.size.should == 4
+      buffer.get_string.should == "test"
+    end
+  end
+
   it "always clears extra memory" do
     @buffer = IO::Buffer.new(4)
     @buffer.set_string("test")

--- a/spec/ruby/core/io/buffer/transfer_spec.rb
+++ b/spec/ruby/core/io/buffer/transfer_spec.rb
@@ -81,6 +81,18 @@ describe "IO::Buffer#transfer" do
     @buffer.null?.should == false
   end
 
+  ruby_version_is "4.1" do
+    it "raises FrozenError without transferring a frozen buffer" do
+      buffer = IO::Buffer.new(4)
+      buffer.set_string("test")
+      buffer.freeze
+
+      -> { buffer.transfer }.should.raise(FrozenError)
+      buffer.null?.should == false
+      buffer.get_string.should == "test"
+    end
+  end
+
   it "is disallowed while locked, raising IO::Buffer::LockedError" do
     @buffer = IO::Buffer.new(4)
     @buffer.locked do

--- a/test/ruby/test_io_buffer.rb
+++ b/test/ruby/test_io_buffer.rb
@@ -610,6 +610,32 @@ class TestIOBuffer < Test::Unit::TestCase
     assert_equal "Ciao! World", hello
   end
 
+  def test_transfer_frozen
+    buffer = IO::Buffer.new(4)
+    buffer.set_string("test")
+    buffer.freeze
+
+    assert_raise(FrozenError) do
+      buffer.transfer
+    end
+
+    refute_predicate buffer, :null?
+    assert_equal "test", buffer.get_string
+  end
+
+  def test_transfer_frozen_external
+    string = "Hello World".freeze
+    buffer = IO::Buffer.for(string)
+    buffer.freeze
+
+    assert_raise(FrozenError) do
+      buffer.transfer
+    end
+
+    refute_predicate buffer, :null?
+    assert_equal string, buffer.get_string
+  end
+
   def test_counted_locking
     buffer = IO::Buffer.new(128)
 

--- a/test/ruby/test_io_buffer.rb
+++ b/test/ruby/test_io_buffer.rb
@@ -404,6 +404,79 @@ class TestIOBuffer < Test::Unit::TestCase
     end
   end
 
+  def test_resize_after_free
+    buffer = IO::Buffer.new(4)
+    buffer.set_string("test")
+    buffer.free
+    assert_predicate buffer, :null?
+
+    buffer.resize(8)
+    assert_equal 8, buffer.size
+    refute_predicate buffer, :null?
+  end
+
+  def test_free_frozen
+    buffer = IO::Buffer.new(4)
+    buffer.set_string("test")
+    buffer.freeze
+
+    assert_raise(FrozenError) do
+      buffer.free
+    end
+
+    refute_predicate buffer, :null?
+    assert_equal "test", buffer.get_string
+  end
+
+  def test_free_frozen_external
+    string = "Hello World".freeze
+    buffer = IO::Buffer.for(string)
+    buffer.freeze
+
+    assert_raise(FrozenError) do
+      buffer.free
+    end
+
+    refute_predicate buffer, :null?
+    assert_equal string, buffer.get_string
+  end
+
+  def test_free_frozen_in_block
+    string = +"Hello World"
+
+    buffer = IO::Buffer.for(string, &:freeze)
+    assert_predicate buffer, :null?
+
+    # The string is no longer locked by the buffer:
+    assert_equal "Hello World!", string << "!"
+  end
+
+  def test_resize_frozen
+    buffer = IO::Buffer.new(4)
+    buffer.set_string("test")
+    buffer.freeze
+
+    assert_raise(FrozenError) do
+      buffer.resize(8)
+    end
+
+    assert_equal 4, buffer.size
+    assert_equal "test", buffer.get_string
+  end
+
+  def test_resize_frozen_external
+    string = "Hello World".freeze
+    buffer = IO::Buffer.for(string)
+    buffer.freeze
+
+    assert_raise(FrozenError) do
+      buffer.resize(8)
+    end
+
+    assert_equal string.bytesize, buffer.size
+    assert_equal string, buffer.get_string
+  end
+
   def test_compare_same_size
     buffer1 = IO::Buffer.new(1)
     assert_equal buffer1, buffer1


### PR DESCRIPTION
## Summary

- Raise `FrozenError` when Ruby code calls `IO::Buffer#free`, `#resize`, or `#transfer` on a frozen buffer.
- Keep the public C APIs unrestricted so internal lifetime cleanup, including cleanup after `IO::Buffer.for`, can still release resources safely.
- Add documentation, core tests, and RubySpecs covering the frozen behavior and preservation of buffer contents.

This consolidates and rebases #18129 and #18130 by @himura467 onto the current implementation. The original commit authorship is preserved.

[Bug #22219]