### PR TITLE
[Feature #21700] Expose IO::Buffer mapping alignment

### DIFF
--- a/include/ruby/io/buffer.h
+++ b/include/ruby/io/buffer.h
@@ -29,6 +29,9 @@ RUBY_EXTERN VALUE rb_cIOBuffer;
 // The operating system page size.
 RUBY_EXTERN size_t RUBY_IO_BUFFER_PAGE_SIZE;
 
+// The alignment required for file mapping offsets.
+RUBY_EXTERN size_t RUBY_IO_BUFFER_MAP_ALIGNMENT;
+
 // The default buffer size, usually a (small) multiple of the page size.
 // Can be overridden by the RUBY_IO_BUFFER_DEFAULT_SIZE environment variable.
 RUBY_EXTERN size_t RUBY_IO_BUFFER_DEFAULT_SIZE;

--- a/io_buffer.c
+++ b/io_buffer.c
@@ -30,6 +30,7 @@ VALUE rb_eIOBufferInvalidatedError;
 VALUE rb_eIOBufferMaskError;
 
 size_t RUBY_IO_BUFFER_PAGE_SIZE;
+size_t RUBY_IO_BUFFER_MAP_ALIGNMENT;
 size_t RUBY_IO_BUFFER_DEFAULT_SIZE;
 
 #ifdef _WIN32
@@ -818,6 +819,19 @@ rb_io_buffer_new_locked(void *base, size_t size, enum rb_io_buffer_flags flags)
 VALUE
 rb_io_buffer_map(VALUE io, size_t size, rb_off_t offset, enum rb_io_buffer_flags flags)
 {
+    if (UNLIKELY(offset < 0)) {
+        rb_raise(rb_eArgError,
+                 "Offset (%" PRIsVALUE ") can't be negative!",
+                 OFFT2NUM(offset));
+    }
+
+    if (UNLIKELY((uintmax_t)offset % RUBY_IO_BUFFER_MAP_ALIGNMENT != 0)) {
+        rb_raise(rb_eArgError,
+                 "Offset (%" PRIsVALUE ") must be a multiple of IO::Buffer::MAP_ALIGNMENT (%" PRIuSIZE ")!",
+                 OFFT2NUM(offset),
+                 RUBY_IO_BUFFER_MAP_ALIGNMENT);
+    }
+
     VALUE instance = rb_io_buffer_type_allocate(rb_cIOBuffer);
 
     struct rb_io_buffer *buffer = get_io_buffer(instance);
@@ -835,9 +849,10 @@ rb_io_buffer_map(VALUE io, size_t size, rb_off_t offset, enum rb_io_buffer_flags
  *  Create an IO::Buffer for reading from +file+ by memory-mapping the file.
  *  +file+ should be a +File+ instance, opened for reading or reading and writing.
  *
- *  Optional +size+ and +offset+ of mapping can be specified.
- *  Trying to map an empty file or specify +size+ of 0 will raise an error.
- *  Valid values for +offset+ are system-dependent.
+ *  Optional +size+ and +offset+ of mapping can be specified. The +offset+ must
+ *  be a multiple of IO::Buffer::MAP_ALIGNMENT. The +size+ does not need to be
+ *  aligned. Trying to map an empty file or specify +size+ of 0 will raise an
+ *  error.
  *
  *  By default, the buffer is writable and expects the file to be writable.
  *  It is also shared, so several processes can use the same mapping.
@@ -937,10 +952,9 @@ io_buffer_map(int argc, VALUE *argv, VALUE klass)
             size = (size_t)(file_size - offset);
         }
         else if (UNLIKELY((size_t)(file_size - offset) < size)) {
-            size_t maximum_page_count =
-                (file_size - size) / RUBY_IO_BUFFER_PAGE_SIZE;
             size_t maximum_offset =
-                RUBY_IO_BUFFER_PAGE_SIZE * maximum_page_count;
+                (file_size - size) / RUBY_IO_BUFFER_MAP_ALIGNMENT *
+                RUBY_IO_BUFFER_MAP_ALIGNMENT;
             rb_raise(rb_eArgError,
                      "Offset (%" PRIsVALUE ") can't be larger than "
                      "%" PRIuSIZE " for requested size (%" PRIuSIZE ")",
@@ -4353,14 +4367,19 @@ Init_IO_Buffer(void)
     SYSTEM_INFO info;
     GetSystemInfo(&info);
     RUBY_IO_BUFFER_PAGE_SIZE = info.dwPageSize;
+    RUBY_IO_BUFFER_MAP_ALIGNMENT = info.dwAllocationGranularity;
 #else /* not WIN32 */
     RUBY_IO_BUFFER_PAGE_SIZE = sysconf(_SC_PAGESIZE);
+    RUBY_IO_BUFFER_MAP_ALIGNMENT = RUBY_IO_BUFFER_PAGE_SIZE;
 #endif
 
     RUBY_IO_BUFFER_DEFAULT_SIZE = io_buffer_default_size(RUBY_IO_BUFFER_PAGE_SIZE);
 
     /* The operating system page size. Used for efficient page-aligned memory allocations. */
     rb_define_const(rb_cIOBuffer, "PAGE_SIZE", SIZET2NUM(RUBY_IO_BUFFER_PAGE_SIZE));
+
+    /* The alignment required for file mapping offsets. Mapping sizes do not need to be aligned. */
+    rb_define_const(rb_cIOBuffer, "MAP_ALIGNMENT", SIZET2NUM(RUBY_IO_BUFFER_MAP_ALIGNMENT));
 
     /* The default buffer size, typically a (small) multiple of the PAGE_SIZE.
        Can be explicitly specified by setting the RUBY_IO_BUFFER_DEFAULT_SIZE

--- a/spec/ruby/core/io/buffer/map_spec.rb
+++ b/spec/ruby/core/io/buffer/map_spec.rb
@@ -31,6 +31,15 @@ describe "IO::Buffer.map" do
     File.open(@big_file_name, "rb+")
   end
 
+  def open_map_aligned_file_fixture
+    unless @map_aligned_file_name
+      @map_aligned_file_name = tmp("map_aligned_file")
+      File.write(@map_aligned_file_name, "12345678" * (IO::Buffer::MAP_ALIGNMENT / 8 + 2))
+      @tmp_files << @map_aligned_file_name
+    end
+    File.open(@map_aligned_file_name, "rb+")
+  end
+
   after :each do
     @buffer&.free
     @buffer = nil
@@ -179,8 +188,32 @@ describe "IO::Buffer.map" do
   end
 
   context "with size and offset arguments" do
-    # Neither Windows nor macOS have clear, stable behavior with non-zero offset.
-    # https://bugs.ruby-lang.org/issues/21700
+    ruby_version_is "4.1" do
+      it "maps a file from an offset aligned to MAP_ALIGNMENT" do
+        @file = open_map_aligned_file_fixture
+        @buffer = IO::Buffer.map(@file, 14, IO::Buffer::MAP_ALIGNMENT)
+
+        @buffer.size.should == 14
+        @buffer.get_string(0, 14).should == "12345678123456"
+      end
+
+      it "maps the rest of a file from an offset aligned to MAP_ALIGNMENT" do
+        @file = open_map_aligned_file_fixture
+        @buffer = IO::Buffer.map(@file, nil, IO::Buffer::MAP_ALIGNMENT)
+
+        @buffer.get_string(0, 1).should == "1"
+        @buffer.size.should == (@file.size - IO::Buffer::MAP_ALIGNMENT)
+      end
+
+      it "raises ArgumentError if offset is not aligned to MAP_ALIGNMENT" do
+        @file = open_fixture
+        message = "Offset (1) must be a multiple of IO::Buffer::MAP_ALIGNMENT (#{IO::Buffer::MAP_ALIGNMENT})!"
+
+        -> { IO::Buffer.map(@file, 1, 1) }.should.raise(ArgumentError, message)
+      end
+    end
+
+    # Before MAP_ALIGNMENT was exposed, these offsets were only portable to Linux.
     platform_is :linux do
       context "if offset is an allowed value for system call" do
         it "maps the span specified by size starting from the offset" do
@@ -252,10 +285,10 @@ describe "IO::Buffer.map" do
 
     ruby_version_is "4.1" do
       it "raises ArgumentError if offset+size is larger than file size" do
-        @file = open_big_file_fixture
+        @file = open_map_aligned_file_fixture
         size = 17
-        maximum_page_size = 0
-        -> { IO::Buffer.map(@file, size, IO::Buffer::PAGE_SIZE) }.should.raise(ArgumentError, "Offset (#{IO::Buffer::PAGE_SIZE}) can't be larger than #{maximum_page_size} for requested size (#{size})")
+        maximum_offset = 0
+        -> { IO::Buffer.map(@file, size, IO::Buffer::MAP_ALIGNMENT) }.should.raise(ArgumentError, "Offset (#{IO::Buffer::MAP_ALIGNMENT}) can't be larger than #{maximum_offset} for requested size (#{size})")
       ensure
         # Windows requires the file to be closed before deletion.
         @file.close unless @file.closed?

--- a/test/ruby/test_io_buffer.rb
+++ b/test/ruby/test_io_buffer.rb
@@ -32,6 +32,11 @@ class TestIOBuffer < Test::Unit::TestCase
     assert_equal 128, IO::Buffer::READONLY
   end
 
+  def test_map_alignment
+    assert_kind_of Integer, IO::Buffer::MAP_ALIGNMENT
+    assert_positive IO::Buffer::MAP_ALIGNMENT
+  end
+
   def test_internal_for_reading_with_string
     string = "hello"
 
@@ -211,6 +216,33 @@ class TestIOBuffer < Test::Unit::TestCase
     assert_equal Encoding::BINARY, contents.encoding
   end
 
+  def test_file_mapped_with_aligned_offset
+    alignment = IO::Buffer::MAP_ALIGNMENT
+
+    Tempfile.create do |file|
+      file.binmode
+      file.write("\0" * alignment)
+      file.write("test")
+      file.flush
+
+      buffer = IO::Buffer.map(file, 4, alignment, IO::Buffer::READONLY)
+      assert_equal "test", buffer.get_string
+    ensure
+      buffer&.free
+    end
+  end
+
+  def test_file_mapped_with_unaligned_offset
+    alignment = IO::Buffer::MAP_ALIGNMENT
+    message = "Offset (1) must be a multiple of IO::Buffer::MAP_ALIGNMENT (#{alignment})!"
+
+    File.open(__FILE__) do |file|
+      assert_raise_with_message(ArgumentError, message) do
+        IO::Buffer.map(file, 1, 1, IO::Buffer::READONLY)
+      end
+    end
+  end
+
   def test_file_mapped_size_too_large
     size = File.size(__FILE__) + 1
     file_size = File.size(__FILE__)
@@ -236,19 +268,19 @@ class TestIOBuffer < Test::Unit::TestCase
 
   def test_file_mapped_offset_too_large
     file_size = File.size(__FILE__)
-    page_count = file_size / IO::Buffer::PAGE_SIZE
-    offset = IO::Buffer::PAGE_SIZE * (page_count + 1)
+    alignment_count = file_size / IO::Buffer::MAP_ALIGNMENT
+    offset = IO::Buffer::MAP_ALIGNMENT * (alignment_count + 1)
     message = "Offset (#{offset}) can't be larger than file size (#{file_size})"
     assert_raise_with_message ArgumentError, message do
       File.open(__FILE__) {|file| IO::Buffer.map(file, nil, offset, IO::Buffer::READONLY)}
     end
 
-    if page_count > 0
-      offset = IO::Buffer::PAGE_SIZE * page_count
+    if alignment_count > 0
+      offset = IO::Buffer::MAP_ALIGNMENT * alignment_count
       available_size = file_size - offset
       size = available_size + 1
-      maximum_page_count = (file_size - size) / IO::Buffer::PAGE_SIZE
-      maximum_offset = IO::Buffer::PAGE_SIZE * maximum_page_count
+      maximum_alignment_count = (file_size - size) / IO::Buffer::MAP_ALIGNMENT
+      maximum_offset = IO::Buffer::MAP_ALIGNMENT * maximum_alignment_count
       message = "Offset (#{offset}) can't be larger than #{maximum_offset} " +
                 "for requested size (#{size})"
       assert_raise_with_message ArgumentError, message do


### PR DESCRIPTION
## Summary

- Expose IO::Buffer::MAP_ALIGNMENT and RUBY_IO_BUFFER_MAP_ALIGNMENT.
- Use dwAllocationGranularity on Windows and the page size on POSIX systems.
- Validate mapping offsets before invoking the operating-system mapping call.
- Document that mapping offsets must be aligned, while mapping sizes may be arbitrary.
- Exercise aligned and unaligned offsets in the unit tests and RubySpec.

This gives callers a portable way to choose a valid non-zero mapping offset without adding implicit aligned mapping and slicing behavior.

[Feature #21700]

## Testing

- make test-all TESTS=../ruby-io-buffer-map-alignment/test/ruby/test_io_buffer.rb
- make test-spec MSPECOPT=../ruby-io-buffer-map-alignment/spec/ruby/core/io/buffer/map_spec.rb