### PR TITLE
[Bug #22260] Preserve the box of a TOP/CLASS env in isolated procs

### DIFF
--- a/test/ruby/test_box.rb
+++ b/test/ruby/test_box.rb
@@ -1281,4 +1281,17 @@ class TestBox < Test::Unit::TestCase
       Module.new.include?(Module.new)
     end;
   end
+
+  def test_method_call_in_isolated_proc_from_class_frame
+    # A TOP/CLASS local env stores its box in the SPECVAL slot (VM_ENV_BOX);
+    # Ractor.make_shareable's env copy must preserve it, or any method call
+    # inside the isolated proc dereferences a NULL box and crashes the VM.
+    assert_separately([ENV_ENABLE_BOX], __FILE__, __LINE__, "#{<<~"begin;"}\n#{<<~'end;'}", ignore_stderr: true)
+    begin;
+      module BoxIsolatedProcTest
+        PROC = Ractor.make_shareable(->(x){ x.to_s })
+      end
+      assert_equal "42", BoxIsolatedProcTest::PROC.call(42)
+    end;
+  end
 end

--- a/vm.c
+++ b/vm.c
@@ -1529,6 +1529,13 @@ env_copy(const VALUE *src_ep, VALUE read_only_variables)
         RB_OBJ_WRITTEN(copied_env, Qundef, new_prev_env);
         VM_ENV_FLAGS_UNSET(ep, VM_ENV_FLAG_LOCAL);
     }
+    else if (VM_ENV_BOXED_P(src_ep)) {
+        // A TOP/CLASS local env stores its box, not a block handler, in the
+        // SPECVAL slot (VM_ENV_BOX). Preserve it: method lookup inside the
+        // isolated proc reads the box back via rb_current_box(), and a
+        // cleared slot dereferences a NULL box.
+        ep[VM_ENV_DATA_INDEX_SPECVAL] = src_ep[VM_ENV_DATA_INDEX_SPECVAL];
+    }
     else {
         ep[VM_ENV_DATA_INDEX_SPECVAL] = VM_BLOCK_HANDLER_NONE;
     }


### PR DESCRIPTION
## Summary

`env_copy()` writes `VM_BLOCK_HANDLER_NONE` into the SPECVAL slot of every local env, but a TOP/CLASS env keeps its box there (`VM_ENV_BOX`). A Proc defined at a class/module body and isolated by `Ractor.make_shareable` loses its box, so under `RUBY_BOX=1` the first method call inside it dereferences a NULL box and crashes:

```console
$ RUBY_BOX=1 ruby -e 'module M; L = Ractor.make_shareable(->(*a){ Rational(*a) }); end; p M::L.call(3, 4)'
-e:1: [BUG] Segmentation fault at 0x0000000000000000
```

This change copies the SPECVAL slot through for TOP/CLASS envs and adds a regression test. The test segfaults before the fix and passes after it.

This resolves [Bug #22260](https://bugs.ruby-lang.org/issues/22260).
