### PR TITLE
Make `IO::Buffer` I/O operations single-transfer and composable.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -50,6 +50,16 @@ Note: We're only listing outstanding class updates.
       binary representation of a non-negative integer (its population count).
       [[Feature #20163]]
 
+* IO::Buffer
+
+    * `read`, `write`, `pread`, and `pwrite` now perform one IO operation using
+      `(offset, length)`, where `length` is the maximum transfer size. Short
+      transfers are returned directly.
+
+    * The corresponding fiber scheduler hooks are no longer experimental and
+      now use the same `(offset, length)` argument order and single-operation
+      semantics.
+
 * Kernel
 
     * `Kernel#autoload_relative` and `Module#autoload_relative` are added.

--- a/doc/language/fiber.md
+++ b/doc/language/fiber.md
@@ -83,19 +83,37 @@ class Scheduler
   end
 
   # Read from the given io into the specified buffer.
-  # WARNING: Experimental hook! Do not use in production code!
   # @parameter io [IO] The io to read from.
   # @parameter buffer [IO::Buffer] The buffer to read into.
-  # @parameter length [Integer] The minimum amount to read.
-  def io_read(io, buffer, length)
+  # @parameter offset [Integer] The offset in the buffer to read to.
+  # @parameter length [Integer] The maximum amount to read in one operation.
+  def io_read(io, buffer, offset, length)
+  end
+
+  # Read from the given io at the specified position into the specified buffer.
+  # @parameter io [IO] The io to read from.
+  # @parameter buffer [IO::Buffer] The buffer to read into.
+  # @parameter from [Integer] The position in the io to read from.
+  # @parameter offset [Integer] The offset in the buffer to read to.
+  # @parameter length [Integer] The maximum amount to read in one operation.
+  def io_pread(io, buffer, from, offset, length)
   end
 
   # Write from the given buffer into the specified IO.
-  # WARNING: Experimental hook! Do not use in production code!
   # @parameter io [IO] The io to write to.
   # @parameter buffer [IO::Buffer] The buffer to write from.
-  # @parameter length [Integer] The minimum amount to write.
-  def io_write(io, buffer, length)
+  # @parameter offset [Integer] The offset in the buffer to write from.
+  # @parameter length [Integer] The maximum amount to write in one operation.
+  def io_write(io, buffer, offset, length)
+  end
+
+  # Write from the given buffer to the specified position in the given io.
+  # @parameter io [IO] The io to write to.
+  # @parameter buffer [IO::Buffer] The buffer to write from.
+  # @parameter from [Integer] The position in the io to write to.
+  # @parameter offset [Integer] The offset in the buffer to write from.
+  # @parameter length [Integer] The maximum amount to write in one operation.
+  def io_pwrite(io, buffer, from, offset, length)
   end
 
   # Sleep the current task for the specified duration, or forever if not

--- a/include/ruby/fiber/scheduler.h
+++ b/include/ruby/fiber/scheduler.h
@@ -24,7 +24,8 @@
 RBIMPL_SYMBOL_EXPORT_BEGIN()
 
 // Version 3: Adds support for `fiber_interrupt`.
-#define RUBY_FIBER_SCHEDULER_VERSION 3
+// Version 4: IO hooks use single-transfer `(offset, length)` semantics.
+#define RUBY_FIBER_SCHEDULER_VERSION 4
 
 struct timeval;
 struct rb_thread_struct;
@@ -292,12 +293,12 @@ VALUE rb_fiber_scheduler_io_selectv(VALUE scheduler, int argc, VALUE *argv);
  * @param[in]   scheduler    Target scheduler.
  * @param[in]   io           An io object to read from.
  * @param[in]   buffer       The buffer to read to.
- * @param[in]   length       The minimum number of bytes to read.
- * @param[in]   offset       The offset in the buffer to read from.
+ * @param[in]   offset       The offset in the buffer to read to.
+ * @param[in]   length       The maximum number of bytes to read in one operation.
  * @retval      RUBY_Qundef  `scheduler` doesn't have `#io_read`.
  * @return      otherwise    What `scheduler.io_read` returns `[-errno, size]`.
  */
-VALUE rb_fiber_scheduler_io_read(VALUE scheduler, VALUE io, VALUE buffer, size_t length, size_t offset);
+VALUE rb_fiber_scheduler_io_read(VALUE scheduler, VALUE io, VALUE buffer, size_t offset, size_t length);
 
 /**
  * Non-blocking write to the passed IO.
@@ -305,12 +306,12 @@ VALUE rb_fiber_scheduler_io_read(VALUE scheduler, VALUE io, VALUE buffer, size_t
  * @param[in]   scheduler    Target scheduler.
  * @param[in]   io           An io object to write to.
  * @param[in]   buffer       The buffer to write from.
- * @param[in]   length       The minimum number of bytes to write.
  * @param[in]   offset       The offset in the buffer to write from.
+ * @param[in]   length       The maximum number of bytes to write in one operation.
  * @retval      RUBY_Qundef  `scheduler` doesn't have `#io_write`.
  * @return      otherwise    What `scheduler.io_write` returns `[-errno, size]`.
  */
-VALUE rb_fiber_scheduler_io_write(VALUE scheduler, VALUE io, VALUE buffer, size_t length, size_t offset);
+VALUE rb_fiber_scheduler_io_write(VALUE scheduler, VALUE io, VALUE buffer, size_t offset, size_t length);
 
 /**
  * Non-blocking read from the passed IO at the specified offset.
@@ -319,12 +320,12 @@ VALUE rb_fiber_scheduler_io_write(VALUE scheduler, VALUE io, VALUE buffer, size_
  * @param[in]   io           An io object to read from.
  * @param[in]   from         The offset to read from.
  * @param[in]   buffer       The buffer to read to.
- * @param[in]   length       The minimum number of bytes to read.
  * @param[in]   offset       The offset in the buffer to read to.
+ * @param[in]   length       The maximum number of bytes to read in one operation.
  * @retval      RUBY_Qundef  `scheduler` doesn't have `#io_read`.
  * @return      otherwise    What `scheduler.io_read` returns.
  */
-VALUE rb_fiber_scheduler_io_pread(VALUE scheduler, VALUE io, rb_off_t from, VALUE buffer, size_t length, size_t offset);
+VALUE rb_fiber_scheduler_io_pread(VALUE scheduler, VALUE io, rb_off_t from, VALUE buffer, size_t offset, size_t length);
 
 /**
  * Non-blocking write to the passed IO at the specified offset.
@@ -333,12 +334,12 @@ VALUE rb_fiber_scheduler_io_pread(VALUE scheduler, VALUE io, rb_off_t from, VALU
  * @param[in]   io           An io object to write to.
  * @param[in]   from         The offset to write to.
  * @param[in]   buffer       The buffer to write from.
- * @param[in]   length       The minimum number of bytes to write.
  * @param[in]   offset       The offset in the buffer to write from.
+ * @param[in]   length       The maximum number of bytes to write in one operation.
  * @retval      RUBY_Qundef  `scheduler` doesn't have `#io_write`.
  * @return      otherwise    What `scheduler.io_write` returns.
  */
-VALUE rb_fiber_scheduler_io_pwrite(VALUE scheduler, VALUE io, rb_off_t from, VALUE buffer, size_t length, size_t offset);
+VALUE rb_fiber_scheduler_io_pwrite(VALUE scheduler, VALUE io, rb_off_t from, VALUE buffer, size_t offset, size_t length);
 
 /**
  * Non-blocking read from the passed IO using a native buffer.
@@ -346,12 +347,11 @@ VALUE rb_fiber_scheduler_io_pwrite(VALUE scheduler, VALUE io, rb_off_t from, VAL
  * @param[in]   scheduler    Target scheduler.
  * @param[in]   io           An io object to read from.
  * @param[in]   base         The memory to read to.
- * @param[in]   size         Size of the memory.
- * @param[in]   length       The minimum number of bytes to read.
+ * @param[in]   size         The maximum number of bytes to read in one operation.
  * @retval      RUBY_Qundef  `scheduler` doesn't have `#io_read`.
  * @return      otherwise    What `scheduler.io_read` returns.
  */
-VALUE rb_fiber_scheduler_io_read_memory(VALUE scheduler, VALUE io, void *base, size_t size, size_t length);
+VALUE rb_fiber_scheduler_io_read_memory(VALUE scheduler, VALUE io, void *base, size_t size);
 
 /**
  * Non-blocking write to the passed IO using a native buffer.
@@ -359,12 +359,11 @@ VALUE rb_fiber_scheduler_io_read_memory(VALUE scheduler, VALUE io, void *base, s
  * @param[in]   scheduler    Target scheduler.
  * @param[in]   io           An io object to write to.
  * @param[in]   base         The memory to write from.
- * @param[in]   size         Size of the memory.
- * @param[in]   length       The minimum number of bytes to write.
+ * @param[in]   size         The maximum number of bytes to write in one operation.
  * @retval      RUBY_Qundef  `scheduler` doesn't have `#io_write`.
  * @return      otherwise    What `scheduler.io_write` returns.
  */
-VALUE rb_fiber_scheduler_io_write_memory(VALUE scheduler, VALUE io, const void *base, size_t size, size_t length);
+VALUE rb_fiber_scheduler_io_write_memory(VALUE scheduler, VALUE io, const void *base, size_t size);
 
 /**
  * Non-blocking pread from the passed IO using a native buffer.
@@ -373,12 +372,11 @@ VALUE rb_fiber_scheduler_io_write_memory(VALUE scheduler, VALUE io, const void *
  * @param[in]   io           An io object to read from.
  * @param[in]   from         The offset to read from.
  * @param[in]   base         The memory to read to.
- * @param[in]   size         Size of the memory.
- * @param[in]   length       The minimum number of bytes to read.
+ * @param[in]   size         The maximum number of bytes to read in one operation.
  * @retval      RUBY_Qundef  `scheduler` doesn't have `#io_read`.
  * @return      otherwise    What `scheduler.io_read` returns.
  */
-VALUE rb_fiber_scheduler_io_pread_memory(VALUE scheduler, VALUE io, rb_off_t from, void *base, size_t size, size_t length);
+VALUE rb_fiber_scheduler_io_pread_memory(VALUE scheduler, VALUE io, rb_off_t from, void *base, size_t size);
 
 /**
  * Non-blocking pwrite to the passed IO using a native buffer.
@@ -387,12 +385,11 @@ VALUE rb_fiber_scheduler_io_pread_memory(VALUE scheduler, VALUE io, rb_off_t fro
  * @param[in]   io           An io object to write to.
  * @param[in]   from         The offset to write from.
  * @param[in]   base         The memory to write from.
- * @param[in]   size         Size of the memory.
- * @param[in]   length       The minimum number of bytes to write.
+ * @param[in]   size         The maximum number of bytes to write in one operation.
  * @retval      RUBY_Qundef  `scheduler` doesn't have `#io_write`.
  * @return      otherwise    What `scheduler.io_write` returns.
  */
-VALUE rb_fiber_scheduler_io_pwrite_memory(VALUE scheduler, VALUE io, rb_off_t from, const void *base, size_t size, size_t length);
+VALUE rb_fiber_scheduler_io_pwrite_memory(VALUE scheduler, VALUE io, rb_off_t from, const void *base, size_t size);
 
 /**
  * Non-blocking close the given IO.

--- a/include/ruby/io/buffer.h
+++ b/include/ruby/io/buffer.h
@@ -21,7 +21,8 @@ RBIMPL_SYMBOL_EXPORT_BEGIN()
 // WARNING: This entire interface is experimental and may change in the future!
 #define RB_IO_BUFFER_EXPERIMENTAL 1
 
-#define RUBY_IO_BUFFER_VERSION 2
+// Version 3: IO operations use single-transfer `(offset, length)` semantics.
+#define RUBY_IO_BUFFER_VERSION 3
 
 // The `IO::Buffer` class.
 RUBY_EXTERN VALUE rb_cIOBuffer;
@@ -107,11 +108,12 @@ VALUE rb_io_buffer_transfer(VALUE self);
 void rb_io_buffer_resize(VALUE self, size_t size);
 void rb_io_buffer_clear(VALUE self, uint8_t value, size_t offset, size_t length);
 
-// The length is the minimum required length.
-VALUE rb_io_buffer_read(VALUE self, VALUE io, size_t length, size_t offset);
-VALUE rb_io_buffer_pread(VALUE self, VALUE io, rb_off_t from, size_t length, size_t offset);
-VALUE rb_io_buffer_write(VALUE self, VALUE io, size_t length, size_t offset);
-VALUE rb_io_buffer_pwrite(VALUE self, VALUE io, rb_off_t from, size_t length, size_t offset);
+// The length is the maximum transfer length. Each function performs one
+// logical IO operation and may return a short result.
+VALUE rb_io_buffer_read(VALUE self, VALUE io, size_t offset, size_t length);
+VALUE rb_io_buffer_pread(VALUE self, VALUE io, rb_off_t from, size_t offset, size_t length);
+VALUE rb_io_buffer_write(VALUE self, VALUE io, size_t offset, size_t length);
+VALUE rb_io_buffer_pwrite(VALUE self, VALUE io, rb_off_t from, size_t offset, size_t length);
 
 RBIMPL_SYMBOL_EXPORT_END()
 

--- a/io.c
+++ b/io.c
@@ -1298,7 +1298,7 @@ rb_io_read_memory(rb_io_t *fptr, void *buf, size_t count)
     rb_thread_t *th = GET_THREAD();
     VALUE scheduler = rb_fiber_scheduler_current_for_threadptr(th);
     if (scheduler != Qnil) {
-        VALUE result = rb_fiber_scheduler_io_read_memory(scheduler, fptr->self, buf, count, 0);
+        VALUE result = rb_fiber_scheduler_io_read_memory(scheduler, fptr->self, buf, count);
 
         if (!UNDEF_P(result)) {
             return rb_fiber_scheduler_io_result_apply(result);
@@ -1332,7 +1332,7 @@ rb_io_write_memory(rb_io_t *fptr, const void *buf, size_t count)
     rb_thread_t *th = GET_THREAD();
     VALUE scheduler = rb_fiber_scheduler_current_for_threadptr(th);
     if (scheduler != Qnil) {
-        VALUE result = rb_fiber_scheduler_io_write_memory(scheduler, fptr->self, buf, count, 0);
+        VALUE result = rb_fiber_scheduler_io_write_memory(scheduler, fptr->self, buf, count);
 
         if (!UNDEF_P(result)) {
             return rb_fiber_scheduler_io_result_apply(result);
@@ -1371,7 +1371,7 @@ rb_writev_internal(rb_io_t *fptr, const struct iovec *iov, int iovcnt)
     VALUE scheduler = rb_fiber_scheduler_current_for_threadptr(th);
     if (scheduler != Qnil) {
         // This path assumes at least one `iov`:
-        VALUE result = rb_fiber_scheduler_io_write_memory(scheduler, fptr->self, iov[0].iov_base, iov[0].iov_len, 0);
+        VALUE result = rb_fiber_scheduler_io_write_memory(scheduler, fptr->self, iov[0].iov_base, iov[0].iov_len);
 
         if (!UNDEF_P(result)) {
             return rb_fiber_scheduler_io_result_apply(result);
@@ -1425,7 +1425,7 @@ io_flush_buffer_sync(void *arg)
 static inline VALUE
 io_flush_buffer_fiber_scheduler(VALUE scheduler, rb_io_t *fptr)
 {
-    VALUE ret = rb_fiber_scheduler_io_write_memory(scheduler, fptr->self, fptr->wbuf.ptr+fptr->wbuf.off, fptr->wbuf.len, 0);
+    VALUE ret = rb_fiber_scheduler_io_write_memory(scheduler, fptr->self, fptr->wbuf.ptr+fptr->wbuf.off, fptr->wbuf.len);
     if (!UNDEF_P(ret)) {
         ssize_t result = rb_fiber_scheduler_io_result_apply(ret);
         if (result > 0) {
@@ -3471,7 +3471,7 @@ io_read_memory_call(VALUE arg)
 
     VALUE scheduler = rb_fiber_scheduler_current();
     if (scheduler != Qnil) {
-        VALUE result = rb_fiber_scheduler_io_read_memory(scheduler, iis->fptr->self, iis->buf, iis->capa, 0);
+        VALUE result = rb_fiber_scheduler_io_read_memory(scheduler, iis->fptr->self, iis->buf, iis->capa);
 
         if (!UNDEF_P(result)) {
             // This is actually returned as a pseudo-VALUE and later cast to a long:
@@ -6229,7 +6229,7 @@ pread_internal_call(VALUE _arg)
 
     VALUE scheduler = rb_fiber_scheduler_current();
     if (scheduler != Qnil) {
-        VALUE result = rb_fiber_scheduler_io_pread_memory(scheduler, arg->io->self, arg->offset, arg->buf, arg->count, 0);
+        VALUE result = rb_fiber_scheduler_io_pread_memory(scheduler, arg->io->self, arg->offset, arg->buf, arg->count);
 
         if (!UNDEF_P(result)) {
             return rb_fiber_scheduler_io_result_apply(result);
@@ -6320,7 +6320,7 @@ pwrite_internal_call(VALUE _arg)
 
     VALUE scheduler = rb_fiber_scheduler_current();
     if (scheduler != Qnil) {
-        VALUE result = rb_fiber_scheduler_io_pwrite_memory(scheduler, arg->io->self, arg->offset, arg->buf, arg->count, 0);
+        VALUE result = rb_fiber_scheduler_io_pwrite_memory(scheduler, arg->io->self, arg->offset, arg->buf, arg->count);
 
         if (!UNDEF_P(result)) {
             return rb_fiber_scheduler_io_result_apply(result);

--- a/io_buffer.c
+++ b/io_buffer.c
@@ -479,42 +479,10 @@ io_buffer_default_length(const struct rb_io_buffer *buffer, size_t offset)
     return buffer->size - offset;
 }
 
-// Extract the optional length and offset arguments, returning the buffer.
-// The length and offset are optional, but if they are provided, they must be
-// positive integers. If the length is not provided, the default length is
-// computed from the buffer size and offset. If the offset is not provided, it
-// defaults to zero.
-static inline struct rb_io_buffer *
-io_buffer_extract_length_offset(VALUE self, int argc, VALUE argv[], size_t *length, size_t *offset)
-{
-    struct rb_io_buffer *buffer = get_io_buffer(self);
-
-    if (argc >= 2 && !NIL_P(argv[1])) {
-        *offset = io_buffer_extract_offset(argv[1]);
-    }
-    else {
-        *offset = 0;
-    }
-
-    if (argc >= 1 && !NIL_P(argv[0])) {
-        *length = io_buffer_extract_length(argv[0]);
-    }
-    else {
-        *length = io_buffer_default_length(buffer, *offset);
-    }
-
-    return buffer;
-}
-
 // Extract the optional offset and length arguments, returning the buffer.
-// Similar to `io_buffer_extract_length_offset` but with the order of arguments
-// reversed.
-//
-// After much consideration, I decided to accept both forms.
-// The `(offset, length)` order is more natural when referring about data,
-// while the `(length, offset)` order is more natural when referring to
-// read/write operations. In many cases, with the latter form, `offset`
-// is usually not supplied.
+// The offset and length are optional, but if they are provided, they must be
+// positive integers. If the offset is not provided, it defaults to zero. If
+// the length is not provided, it defaults to the buffer size minus the offset.
 static inline struct rb_io_buffer *
 io_buffer_extract_offset_length(VALUE self, int argc, VALUE argv[], size_t *offset, size_t *length)
 {
@@ -3331,76 +3299,50 @@ io_buffer_blocking_region(VALUE io, struct rb_io_buffer *buffer, rb_blocking_fun
 struct io_buffer_read_internal_argument {
     // The file descriptor to read from:
     int descriptor;
-    // The base pointer to read from:
+    // The base pointer to read into:
     char *base;
-    // The size of the buffer:
-    size_t size;
-    // The minimum number of bytes to read:
+    // The maximum number of bytes to read:
     size_t length;
 };
 
 static VALUE
 io_buffer_read_internal(void *_argument)
 {
-    size_t total = 0;
     struct io_buffer_read_internal_argument *argument = _argument;
+    ssize_t result = read(argument->descriptor, argument->base, argument->length);
 
-    while (true) {
-        ssize_t result = read(argument->descriptor, argument->base, argument->size);
-
-        if (result < 0) {
-            return rb_fiber_scheduler_io_result(result, errno);
-        }
-        else if (result == 0) {
-            return rb_fiber_scheduler_io_result(total, 0);
-        }
-        else {
-            total += result;
-
-            if (total >= argument->length) {
-                return rb_fiber_scheduler_io_result(total, 0);
-            }
-
-            argument->base = argument->base + result;
-            argument->size = argument->size - result;
-        }
-    }
+    return rb_fiber_scheduler_io_result(result, errno);
 }
 
 VALUE
-rb_io_buffer_read(VALUE self, VALUE io, size_t length, size_t offset)
+rb_io_buffer_read(VALUE self, VALUE io, size_t offset, size_t length)
 {
     io = rb_io_get_io(io);
 
+    struct rb_io_buffer *buffer = get_io_buffer(self);
+    io_buffer_validate_for_writing(buffer);
+    io_buffer_validate_range(buffer, offset, length);
+
+    if (length == 0) return SIZET2NUM(0);
+
     VALUE scheduler = rb_fiber_scheduler_current();
     if (scheduler != Qnil) {
-        VALUE result = rb_fiber_scheduler_io_read(scheduler, io, self, length, offset);
+        VALUE result = rb_fiber_scheduler_io_read(scheduler, io, self, offset, length);
 
         if (!UNDEF_P(result)) {
             return result;
         }
     }
 
-    struct rb_io_buffer *buffer = get_io_buffer(self);
-
-    io_buffer_validate_range(buffer, offset, length);
-
-    int descriptor = rb_io_descriptor(io);
-
-    void * base;
+    void *base;
     size_t size;
     io_buffer_get_bytes_for_writing(buffer, &base, &size);
 
-    size = size - offset;
-    if (size == 0) return SIZET2NUM(0);
-
     RUBY_ASSERT(base != NULL);
-    base = (unsigned char*)base + offset;
 
     struct io_buffer_read_internal_argument argument = {
-        .descriptor = descriptor,
-        .base = base,
-        .size = size,
+        .descriptor = rb_io_descriptor(io),
+        .base = (char*)base + offset,
         .length = length,
     };
 
@@ -3408,26 +3350,22 @@ rb_io_buffer_read(VALUE self, VALUE io, size_t length, size_t offset)
 }
 
 /*
- *  call-seq: read(io, [length, [offset]]) -> read length or -errno
+ *  call-seq: read(io, [offset, [length]]) -> read length or -errno
  *
- *  Read at least +length+ bytes from the +io+, into the buffer starting at
- *  +offset+. If an error occurs, return <tt>-errno</tt>.
- *
- *  If +length+ is not given or +nil+, it defaults to the size of the buffer
- *  minus the offset, i.e. the entire buffer.
- *
- *  If +length+ is zero, exactly one <tt>read</tt> operation will occur, unless
- *  there is no available space in the buffer at +offset+.
+ *  Perform one read operation of at most +length+ bytes from +io+ into the
+ *  buffer starting at +offset+. A short read is a normal result. If an error
+ *  occurs, return <tt>-errno</tt>.
  *
  *  If +offset+ is not given, it defaults to zero, i.e. the beginning of the
- *  buffer.
+ *  buffer. If +length+ is not given, it defaults to the size of the buffer
+ *  minus the offset. A zero length is a no-op.
  *
  *    IO::Buffer.for('test') do |buffer|
  *      p buffer
  *      # =>
  *      # <IO::Buffer 0x00007fca40087c38+4 SLICE>
  *      # 0x00000000  74 65 73 74         test
- *      buffer.read(File.open('/dev/urandom', 'rb'), 2)
+ *      buffer.read(File.open('/dev/urandom', 'rb'), 0, 2)
  *      p buffer
  *      # =>
  *      # <IO::Buffer 0x00007f3bc65f2a58+4 EXTERNAL SLICE>
@@ -3441,110 +3379,79 @@ io_buffer_read(int argc, VALUE *argv, VALUE self)
 
     VALUE io = argv[0];
 
-    size_t length, offset;
-    io_buffer_extract_length_offset(self, argc-1, argv+1, &length, &offset);
+    size_t offset, length;
+    io_buffer_extract_offset_length(self, argc-1, argv+1, &offset, &length);
 
-    return rb_io_buffer_read(self, io, length, offset);
+    return rb_io_buffer_read(self, io, offset, length);
 }
 
 struct io_buffer_pread_internal_argument {
     // The file descriptor to read from:
     int descriptor;
-    // The base pointer to read from:
+    // The base pointer to read into:
     char *base;
-    // The size of the buffer:
-    size_t size;
-    // The minimum number of bytes to read:
+    // The maximum number of bytes to read:
     size_t length;
-    // The offset to read from:
-    off_t offset;
+    // The position to read from:
+    off_t from;
 };
 
 static VALUE
 io_buffer_pread_internal(void *_argument)
 {
-    size_t total = 0;
     struct io_buffer_pread_internal_argument *argument = _argument;
+    ssize_t result = pread(argument->descriptor, argument->base, argument->length, argument->from);
 
-    while (true) {
-        ssize_t result = pread(argument->descriptor, argument->base, argument->size, argument->offset);
-
-        if (result < 0) {
-            return rb_fiber_scheduler_io_result(result, errno);
-        }
-        else if (result == 0) {
-            return rb_fiber_scheduler_io_result(total, 0);
-        }
-        else {
-            total += result;
-
-            if (total >= argument->length) {
-                return rb_fiber_scheduler_io_result(total, 0);
-            }
-
-            argument->base = argument->base + result;
-            argument->size = argument->size - result;
-            argument->offset = argument->offset + result;
-        }
-    }
+    return rb_fiber_scheduler_io_result(result, errno);
 }
 
 VALUE
-rb_io_buffer_pread(VALUE self, VALUE io, rb_off_t from, size_t length, size_t offset)
+rb_io_buffer_pread(VALUE self, VALUE io, rb_off_t from, size_t offset, size_t length)
 {
     io = rb_io_get_io(io);
 
+    struct rb_io_buffer *buffer = get_io_buffer(self);
+    io_buffer_validate_for_writing(buffer);
+    io_buffer_validate_range(buffer, offset, length);
+
+    if (length == 0) return SIZET2NUM(0);
+
     VALUE scheduler = rb_fiber_scheduler_current();
     if (scheduler != Qnil) {
-        VALUE result = rb_fiber_scheduler_io_pread(scheduler, io, from, self, length, offset);
+        VALUE result = rb_fiber_scheduler_io_pread(scheduler, io, from, self, offset, length);
 
         if (!UNDEF_P(result)) {
             return result;
         }
     }
 
-    struct rb_io_buffer *buffer = get_io_buffer(self);
-
-    io_buffer_validate_range(buffer, offset, length);
-
-    int descriptor = rb_io_descriptor(io);
-
-    void * base;
+    void *base;
     size_t size;
     io_buffer_get_bytes_for_writing(buffer, &base, &size);
 
-    size = size - offset;
-    if (size == 0) return SIZET2NUM(0);
-
     RUBY_ASSERT(base != NULL);
-    base = (unsigned char*)base + offset;
 
     struct io_buffer_pread_internal_argument argument = {
-        .descriptor = descriptor,
-        .base = base,
-        .size = size,
+        .descriptor = rb_io_descriptor(io),
+        .base = (char*)base + offset,
         .length = length,
-        .offset = from,
+        .from = from,
     };
 
     return io_buffer_blocking_region(io, buffer, io_buffer_pread_internal, &argument);
 }
 
 /*
- *  call-seq: pread(io, from, [length, [offset]]) -> read length or -errno
+ *  call-seq: pread(io, from, [offset, [length]]) -> read length or -errno
  *
- *  Read at least +length+ bytes from the +io+ starting at the specified +from+
- *  position, into the buffer starting at +offset+. If an error occurs,
- *  return <tt>-errno</tt>.
- *
- *  If +length+ is not given or +nil+, it defaults to the size of the buffer
- *  minus the offset, i.e. the entire buffer.
- *
- *  If +length+ is zero, exactly one <tt>pread</tt> operation will occur,
- *  unless there is no available space in the buffer at +offset+.
+ *  Perform one read operation of at most +length+ bytes from +io+ at +from+
+ *  into the buffer starting at +offset+. A short read is a normal result and
+ *  the IO's current position is not modified. If an error occurs, return
+ *  <tt>-errno</tt>.
  *
  *  If +offset+ is not given, it defaults to zero, i.e. the beginning of the
- *  buffer.
+ *  buffer. If +length+ is not given, it defaults to the size of the buffer
+ *  minus the offset. A zero length is a no-op.
  *
  *    IO::Buffer.for('test') do |buffer|
  *      p buffer
@@ -3569,10 +3476,10 @@ io_buffer_pread(int argc, VALUE *argv, VALUE self)
     VALUE io = argv[0];
     rb_off_t from = NUM2OFFT(argv[1]);
 
-    size_t length, offset;
-    io_buffer_extract_length_offset(self, argc-2, argv+2, &length, &offset);
+    size_t offset, length;
+    io_buffer_extract_offset_length(self, argc-2, argv+2, &offset, &length);
 
-    return rb_io_buffer_pread(self, io, from, length, offset);
+    return rb_io_buffer_pread(self, io, from, offset, length);
 }
 
 struct io_buffer_write_internal_argument {
@@ -3580,74 +3487,47 @@ struct io_buffer_write_internal_argument {
     int descriptor;
     // The base pointer to write from:
     const char *base;
-    // The size of the buffer:
-    size_t size;
-    // The minimum length to write:
+    // The maximum number of bytes to write:
     size_t length;
 };
 
 static VALUE
 io_buffer_write_internal(void *_argument)
 {
-    size_t total = 0;
     struct io_buffer_write_internal_argument *argument = _argument;
+    ssize_t result = write(argument->descriptor, argument->base, argument->length);
 
-    while (true) {
-        ssize_t result = write(argument->descriptor, argument->base, argument->size);
-
-        if (result < 0) {
-            return rb_fiber_scheduler_io_result(result, errno);
-        }
-        else if (result == 0) {
-            return rb_fiber_scheduler_io_result(total, 0);
-        }
-        else {
-            total += result;
-
-            if (total >= argument->length) {
-                return rb_fiber_scheduler_io_result(total, 0);
-            }
-
-            argument->base = argument->base + result;
-            argument->size = argument->size - result;
-        }
-    }
+    return rb_fiber_scheduler_io_result(result, errno);
 }
 
 VALUE
-rb_io_buffer_write(VALUE self, VALUE io, size_t length, size_t offset)
+rb_io_buffer_write(VALUE self, VALUE io, size_t offset, size_t length)
 {
     io = rb_io_get_write_io(rb_io_get_io(io));
 
+    struct rb_io_buffer *buffer = get_io_buffer(self);
+    io_buffer_validate_range(buffer, offset, length);
+
+    if (length == 0) return SIZET2NUM(0);
+
     VALUE scheduler = rb_fiber_scheduler_current();
     if (scheduler != Qnil) {
-        VALUE result = rb_fiber_scheduler_io_write(scheduler, io, self, length, offset);
+        VALUE result = rb_fiber_scheduler_io_write(scheduler, io, self, offset, length);
 
         if (!UNDEF_P(result)) {
             return result;
         }
     }
 
-    struct rb_io_buffer *buffer = get_io_buffer(self);
-
-    io_buffer_validate_range(buffer, offset, length);
-
-    int descriptor = rb_io_descriptor(io);
-
-    const void * base;
+    const void *base;
     size_t size;
     io_buffer_get_bytes_for_reading(buffer, &base, &size);
 
-    size = size - offset;
-    if (size == 0) return SIZET2NUM(0);
-
     RUBY_ASSERT(base != NULL);
-    base = (const unsigned char*)base + offset;
 
     struct io_buffer_write_internal_argument argument = {
-        .descriptor = descriptor,
-        .base = base,
-        .size = size,
+        .descriptor = rb_io_descriptor(io),
+        .base = (const char*)base + offset,
         .length = length,
     };
 
@@ -3655,22 +3535,18 @@ rb_io_buffer_write(VALUE self, VALUE io, size_t length, size_t offset)
 }
 
 /*
- *  call-seq: write(io, [length, [offset]]) -> written length or -errno
+ *  call-seq: write(io, [offset, [length]]) -> written length or -errno
  *
- *  Write at least +length+ bytes from the buffer starting at +offset+, into the +io+.
- *  If an error occurs, return <tt>-errno</tt>.
- *
- *  If +length+ is not given or +nil+, it defaults to the size of the buffer
- *  minus the offset, i.e. the entire buffer.
- *
- *  If +length+ is zero, exactly one <tt>write</tt> operation will occur,
- *  unless there are no available bytes in the buffer at +offset+.
+ *  Perform one write operation of at most +length+ bytes to +io+ from the
+ *  buffer starting at +offset+. A short write is a normal result. If an error
+ *  occurs, return <tt>-errno</tt>.
  *
  *  If +offset+ is not given, it defaults to zero, i.e. the beginning of the
- *  buffer.
+ *  buffer. If +length+ is not given, it defaults to the size of the buffer
+ *  minus the offset. A zero length is a no-op.
  *
  *    out = File.open('output.txt', 'wb')
- *    IO::Buffer.for('1234567').write(out, 3)
+ *    IO::Buffer.for('1234567').write(out, 0, 3)
  *
  *  This leads to +123+ being written into <tt>output.txt</tt>
  */
@@ -3681,10 +3557,10 @@ io_buffer_write(int argc, VALUE *argv, VALUE self)
 
     VALUE io = argv[0];
 
-    size_t length, offset;
-    io_buffer_extract_length_offset(self, argc-1, argv+1, &length, &offset);
+    size_t offset, length;
+    io_buffer_extract_offset_length(self, argc-1, argv+1, &offset, &length);
 
-    return rb_io_buffer_write(self, io, length, offset);
+    return rb_io_buffer_write(self, io, offset, length);
 }
 
 struct io_buffer_pwrite_internal_argument {
@@ -3692,113 +3568,73 @@ struct io_buffer_pwrite_internal_argument {
     int descriptor;
     // The base pointer to write from:
     const char *base;
-    // The size of the buffer:
-    size_t size;
-    // The minimum length to write:
+    // The maximum number of bytes to write:
     size_t length;
-    // The offset to write to:
-    off_t offset;
+    // The position to write to:
+    off_t from;
 };
 
 static VALUE
 io_buffer_pwrite_internal(void *_argument)
 {
-    size_t total = 0;
     struct io_buffer_pwrite_internal_argument *argument = _argument;
+    ssize_t result = pwrite(argument->descriptor, argument->base, argument->length, argument->from);
 
-    while (true) {
-        ssize_t result = pwrite(argument->descriptor, argument->base, argument->size, argument->offset);
-
-        if (result < 0) {
-            return rb_fiber_scheduler_io_result(result, errno);
-        }
-        else if (result == 0) {
-            return rb_fiber_scheduler_io_result(total, 0);
-        }
-        else {
-            total += result;
-
-            if (total >= argument->length) {
-                return rb_fiber_scheduler_io_result(total, 0);
-            }
-
-            argument->base = argument->base + result;
-            argument->size = argument->size - result;
-            argument->offset = argument->offset + result;
-        }
-    }
+    return rb_fiber_scheduler_io_result(result, errno);
 }
 
 VALUE
-rb_io_buffer_pwrite(VALUE self, VALUE io, rb_off_t from, size_t length, size_t offset)
+rb_io_buffer_pwrite(VALUE self, VALUE io, rb_off_t from, size_t offset, size_t length)
 {
     io = rb_io_get_write_io(rb_io_get_io(io));
 
+    struct rb_io_buffer *buffer = get_io_buffer(self);
+    io_buffer_validate_range(buffer, offset, length);
+
+    if (length == 0) return SIZET2NUM(0);
+
     VALUE scheduler = rb_fiber_scheduler_current();
     if (scheduler != Qnil) {
-        VALUE result = rb_fiber_scheduler_io_pwrite(scheduler, io, from, self, length, offset);
+        VALUE result = rb_fiber_scheduler_io_pwrite(scheduler, io, from, self, offset, length);
 
         if (!UNDEF_P(result)) {
             return result;
         }
     }
 
-    struct rb_io_buffer *buffer = get_io_buffer(self);
-
-    io_buffer_validate_range(buffer, offset, length);
-
-    int descriptor = rb_io_descriptor(io);
-
-    const void * base;
+    const void *base;
     size_t size;
     io_buffer_get_bytes_for_reading(buffer, &base, &size);
 
-    size = size - offset;
-    if (size == 0) return SIZET2NUM(0);
-
     RUBY_ASSERT(base != NULL);
-    base = (const unsigned char*)base + offset;
 
     struct io_buffer_pwrite_internal_argument argument = {
-        .descriptor = descriptor,
-
-        // Move the base pointer to the offset:
-        .base = base,
-
-        // And the size to the length of buffer we want to read:
-        .size = size,
-
-        // And the length of the buffer we want to write:
+        .descriptor = rb_io_descriptor(io),
+        .base = (const char*)base + offset,
         .length = length,
-
-        // And the offset in the file we want to write from:
-        .offset = from,
+        .from = from,
     };
 
     return io_buffer_blocking_region(io, buffer, io_buffer_pwrite_internal, &argument);
 }
 
 /*
- *  call-seq: pwrite(io, from, [length, [offset]]) -> written length or -errno
+ *  call-seq: pwrite(io, from, [offset, [length]]) -> written length or -errno
  *
- *  Write at least +length+ bytes from the buffer starting at +offset+, into
- *  the +io+ starting at the specified +from+ position. If an error occurs,
- *  return <tt>-errno</tt>.
- *
- *  If +length+ is not given or +nil+, it defaults to the size of the buffer
- *  minus the offset, i.e. the entire buffer.
- *
- *  If +length+ is zero, exactly one <tt>pwrite</tt> operation will occur,
- *  unless there are no available bytes in the buffer at +offset+.
+ *  Perform one write operation of at most +length+ bytes to +io+ at +from+
+ *  from the buffer starting at +offset+. A short write is a normal result and
+ *  the IO's current position is not modified. If an error occurs, return
+ *  <tt>-errno</tt>.
  *
  *  If +offset+ is not given, it defaults to zero, i.e. the beginning of the
- *  buffer.
+ *  buffer. If +length+ is not given, it defaults to the size of the buffer
+ *  minus the offset. A zero length is a no-op.
  *
  *  If the +from+ position is beyond the end of the file, the gap will be
  *  filled with null (0 value) bytes.
  *
  *    out = File.open('output.txt', File::RDWR) # open for read/write, no truncation
- *    IO::Buffer.for('1234567').pwrite(out, 2, 3, 1)
+ *    IO::Buffer.for('1234567').pwrite(out, 2, 1, 3)
  *
  *  This leads to +234+ (3 bytes, starting from position 1) being written into
  *  <tt>output.txt</tt>, starting from file position 2.
@@ -3811,10 +3647,10 @@ io_buffer_pwrite(int argc, VALUE *argv, VALUE self)
     VALUE io = argv[0];
     rb_off_t from = NUM2OFFT(argv[1]);
 
-    size_t length, offset;
-    io_buffer_extract_length_offset(self, argc-2, argv+2, &length, &offset);
+    size_t offset, length;
+    io_buffer_extract_offset_length(self, argc-2, argv+2, &offset, &length);
 
-    return rb_io_buffer_pwrite(self, io, from, length, offset);
+    return rb_io_buffer_pwrite(self, io, from, offset, length);
 }
 
 static inline void
@@ -4460,6 +4296,9 @@ Init_IO_Buffer(void)
 #endif
 
     RUBY_IO_BUFFER_DEFAULT_SIZE = io_buffer_default_size(RUBY_IO_BUFFER_PAGE_SIZE);
+
+    /* The IO::Buffer interface version. */
+    rb_define_const(rb_cIOBuffer, "VERSION", INT2NUM(RUBY_IO_BUFFER_VERSION));
 
     /* The operating system page size. Used for efficient page-aligned memory allocations. */
     rb_define_const(rb_cIOBuffer, "PAGE_SIZE", SIZET2NUM(RUBY_IO_BUFFER_PAGE_SIZE));

--- a/scheduler.c
+++ b/scheduler.c
@@ -790,29 +790,24 @@ VALUE rb_fiber_scheduler_io_selectv(VALUE scheduler, int argc, VALUE *argv)
 
 /*
  *  Document-method: Fiber::Scheduler#io_read
- *  call-seq: io_read(io, buffer, length, offset) -> read length or -errno
+ *  call-seq: io_read(io, buffer, offset, length) -> read length or -errno
  *
- *  Invoked by IO#read or IO#Buffer.read to read +length+ bytes from +io+ into a
- *  specified +buffer+ (see IO::Buffer) at the given +offset+.
+ *  Invoked by IO#read or IO::Buffer#read to perform one read of at most
+ *  +length+ bytes from +io+ into a specified +buffer+ (see IO::Buffer),
+ *  starting at the given +offset+.
  *
- *  The +length+ argument is the "minimum length to be read". If the IO buffer
- *  size is 8KiB, but the +length+ is +1024+ (1KiB), up to 8KiB might be read,
- *  but at least 1KiB will be. Generally, the only case where less data than
- *  +length+ will be read is if there is an error reading the data.
+ *  A short read is returned directly. Specifying a +length+ of 0 returns 0
+ *  without performing a read.
  *
- *  Specifying a +length+ of 0 is valid and means try reading at least once and
- *  return any available data.
- *
- *  Suggested implementation should try to read from +io+ in a non-blocking
- *  manner and call #io_wait if the +io+ is not ready (which will yield control
- *  to other fibers).
+ *  The implementation should perform one non-blocking read and return
+ *  <tt>-EAGAIN</tt> if +io+ is not ready. The caller can then wait and retry as
+ *  appropriate.
  *
  *  See IO::Buffer for an interface available to return data.
  *
  *  Expected to return number of bytes read, or, in case of an error,
  *  <tt>-errno</tt> (negated number corresponding to system's error code).
  *
- *  The method should be considered _experimental_.
  */
 static VALUE
 fiber_scheduler_io_read(VALUE _argument) {
@@ -822,14 +817,14 @@ fiber_scheduler_io_read(VALUE _argument) {
 }
 
 VALUE
-rb_fiber_scheduler_io_read(VALUE scheduler, VALUE io, VALUE buffer, size_t length, size_t offset)
+rb_fiber_scheduler_io_read(VALUE scheduler, VALUE io, VALUE buffer, size_t offset, size_t length)
 {
     if (!rb_respond_to(scheduler, id_io_read)) {
         return RUBY_Qundef;
     }
 
     VALUE arguments[] = {
-        scheduler, io, buffer, SIZET2NUM(length), SIZET2NUM(offset)
+        scheduler, io, buffer, SIZET2NUM(offset), SIZET2NUM(length)
     };
 
     if (rb_respond_to(scheduler, id_fiber_interrupt)) {
@@ -841,17 +836,16 @@ rb_fiber_scheduler_io_read(VALUE scheduler, VALUE io, VALUE buffer, size_t lengt
 
 /*
  *  Document-method: Fiber::Scheduler#io_pread
- *  call-seq: io_pread(io, buffer, from, length, offset) -> read length or -errno
+ *  call-seq: io_pread(io, buffer, from, offset, length) -> read length or -errno
  *
- *  Invoked by IO#pread or IO::Buffer#pread to read +length+ bytes from +io+
- *  at offset +from+ into a specified +buffer+ (see IO::Buffer) at the given
- *  +offset+.
+ *  Invoked by IO#pread or IO::Buffer#pread to perform one read of at most
+ *  +length+ bytes from +io+ at offset +from+ into a specified +buffer+ (see
+ *  IO::Buffer), starting at the given +offset+.
  *
  *  This method is semantically the same as #io_read, but it allows to specify
  *  the offset to read from and is often better for asynchronous IO on the same
  *  file.
  *
- *  The method should be considered _experimental_.
  */
 static VALUE
 fiber_scheduler_io_pread(VALUE _argument) {
@@ -861,14 +855,14 @@ fiber_scheduler_io_pread(VALUE _argument) {
 }
 
 VALUE
-rb_fiber_scheduler_io_pread(VALUE scheduler, VALUE io, rb_off_t from, VALUE buffer, size_t length, size_t offset)
+rb_fiber_scheduler_io_pread(VALUE scheduler, VALUE io, rb_off_t from, VALUE buffer, size_t offset, size_t length)
 {
     if (!rb_respond_to(scheduler, id_io_pread)) {
         return RUBY_Qundef;
     }
 
     VALUE arguments[] = {
-        scheduler, io, buffer, OFFT2NUM(from), SIZET2NUM(length), SIZET2NUM(offset)
+        scheduler, io, buffer, OFFT2NUM(from), SIZET2NUM(offset), SIZET2NUM(length)
     };
 
     if (rb_respond_to(scheduler, id_fiber_interrupt)) {
@@ -880,23 +874,18 @@ rb_fiber_scheduler_io_pread(VALUE scheduler, VALUE io, rb_off_t from, VALUE buff
 
 /*
  *  Document-method: Fiber::Scheduler#io_write
- *  call-seq: io_write(io, buffer, length, offset) -> written length or -errno
+ *  call-seq: io_write(io, buffer, offset, length) -> written length or -errno
  *
- *  Invoked by IO#write or IO::Buffer#write to write +length+ bytes to +io+ from
- *  from a specified +buffer+ (see IO::Buffer) at the given +offset+.
+ *  Invoked by IO#write or IO::Buffer#write to perform one write of at most
+ *  +length+ bytes to +io+ from a specified +buffer+ (see IO::Buffer), starting
+ *  at the given +offset+.
  *
- *  The +length+ argument is the "minimum length to be written". If the IO
- *  buffer size is 8KiB, but the +length+ specified is 1024 (1KiB), at most 8KiB
- *  will be written, but at least 1KiB will be. Generally, the only case where
- *  less data than +length+ will be written is if there is an error writing the
- *  data.
+ *  A short write is returned directly. Specifying a +length+ of 0 returns 0
+ *  without performing a write.
  *
- *  Specifying a +length+ of 0 is valid and means try writing at least once, as
- *  much data as possible.
- *
- *  Suggested implementation should try to write to +io+ in a non-blocking
- *  manner and call #io_wait if the +io+ is not ready (which will yield control
- *  to other fibers).
+ *  The implementation should perform one non-blocking write and return
+ *  <tt>-EAGAIN</tt> if +io+ is not ready. The caller can then wait and retry as
+ *  appropriate.
  *
  *  See IO::Buffer for an interface available to get data from buffer
  *  efficiently.
@@ -904,7 +893,6 @@ rb_fiber_scheduler_io_pread(VALUE scheduler, VALUE io, rb_off_t from, VALUE buff
  *  Expected to return number of bytes written, or, in case of an error,
  *  <tt>-errno</tt> (negated number corresponding to system's error code).
  *
- *  The method should be considered _experimental_.
  */
 static VALUE
 fiber_scheduler_io_write(VALUE _argument) {
@@ -914,14 +902,14 @@ fiber_scheduler_io_write(VALUE _argument) {
 }
 
 VALUE
-rb_fiber_scheduler_io_write(VALUE scheduler, VALUE io, VALUE buffer, size_t length, size_t offset)
+rb_fiber_scheduler_io_write(VALUE scheduler, VALUE io, VALUE buffer, size_t offset, size_t length)
 {
     if (!rb_respond_to(scheduler, id_io_write)) {
         return RUBY_Qundef;
     }
 
     VALUE arguments[] = {
-        scheduler, io, buffer, SIZET2NUM(length), SIZET2NUM(offset)
+        scheduler, io, buffer, SIZET2NUM(offset), SIZET2NUM(length)
     };
 
     if (rb_respond_to(scheduler, id_fiber_interrupt)) {
@@ -933,17 +921,15 @@ rb_fiber_scheduler_io_write(VALUE scheduler, VALUE io, VALUE buffer, size_t leng
 
 /*
  *  Document-method: Fiber::Scheduler#io_pwrite
- *  call-seq: io_pwrite(io, buffer, from, length, offset) -> written length or -errno
+ *  call-seq: io_pwrite(io, buffer, from, offset, length) -> written length or -errno
  *
- *  Invoked by IO#pwrite or IO::Buffer#pwrite to write +length+ bytes to +io+
- *  at offset +from+ into a specified +buffer+ (see IO::Buffer) at the given
- *  +offset+.
+ *  Invoked by IO#pwrite or IO::Buffer#pwrite to perform one write of at most
+ *  +length+ bytes to +io+ at offset +from+ from a specified +buffer+ (see
+ *  IO::Buffer), starting at the given +offset+.
  *
  *  This method is semantically the same as #io_write, but it allows to specify
  *  the offset to write to and is often better for asynchronous IO on the same
  *  file.
- *
- *  The method should be considered _experimental_.
  *
  */
 static VALUE
@@ -954,7 +940,7 @@ fiber_scheduler_io_pwrite(VALUE _argument) {
 }
 
 VALUE
-rb_fiber_scheduler_io_pwrite(VALUE scheduler, VALUE io, rb_off_t from, VALUE buffer, size_t length, size_t offset)
+rb_fiber_scheduler_io_pwrite(VALUE scheduler, VALUE io, rb_off_t from, VALUE buffer, size_t offset, size_t length)
 {
 
 
@@ -963,7 +949,7 @@ rb_fiber_scheduler_io_pwrite(VALUE scheduler, VALUE io, rb_off_t from, VALUE buf
     }
 
     VALUE arguments[] = {
-        scheduler, io, buffer, OFFT2NUM(from), SIZET2NUM(length), SIZET2NUM(offset)
+        scheduler, io, buffer, OFFT2NUM(from), SIZET2NUM(offset), SIZET2NUM(length)
     };
 
     if (rb_respond_to(scheduler, id_fiber_interrupt)) {
@@ -974,11 +960,11 @@ rb_fiber_scheduler_io_pwrite(VALUE scheduler, VALUE io, rb_off_t from, VALUE buf
 }
 
 VALUE
-rb_fiber_scheduler_io_read_memory(VALUE scheduler, VALUE io, void *base, size_t size, size_t length)
+rb_fiber_scheduler_io_read_memory(VALUE scheduler, VALUE io, void *base, size_t size)
 {
     VALUE buffer = rb_io_buffer_new_locked(base, size, 0);
 
-    VALUE result = rb_fiber_scheduler_io_read(scheduler, io, buffer, length, 0);
+    VALUE result = rb_fiber_scheduler_io_read(scheduler, io, buffer, 0, size);
 
     rb_io_buffer_free_locked(buffer);
 
@@ -986,11 +972,11 @@ rb_fiber_scheduler_io_read_memory(VALUE scheduler, VALUE io, void *base, size_t 
 }
 
 VALUE
-rb_fiber_scheduler_io_write_memory(VALUE scheduler, VALUE io, const void *base, size_t size, size_t length)
+rb_fiber_scheduler_io_write_memory(VALUE scheduler, VALUE io, const void *base, size_t size)
 {
     VALUE buffer = rb_io_buffer_new_locked((void*)base, size, RB_IO_BUFFER_READONLY);
 
-    VALUE result = rb_fiber_scheduler_io_write(scheduler, io, buffer, length, 0);
+    VALUE result = rb_fiber_scheduler_io_write(scheduler, io, buffer, 0, size);
 
     rb_io_buffer_free_locked(buffer);
 
@@ -998,11 +984,11 @@ rb_fiber_scheduler_io_write_memory(VALUE scheduler, VALUE io, const void *base, 
 }
 
 VALUE
-rb_fiber_scheduler_io_pread_memory(VALUE scheduler, VALUE io, rb_off_t from, void *base, size_t size, size_t length)
+rb_fiber_scheduler_io_pread_memory(VALUE scheduler, VALUE io, rb_off_t from, void *base, size_t size)
 {
     VALUE buffer = rb_io_buffer_new_locked(base, size, 0);
 
-    VALUE result = rb_fiber_scheduler_io_pread(scheduler, io, from, buffer, length, 0);
+    VALUE result = rb_fiber_scheduler_io_pread(scheduler, io, from, buffer, 0, size);
 
     rb_io_buffer_free_locked(buffer);
 
@@ -1010,11 +996,11 @@ rb_fiber_scheduler_io_pread_memory(VALUE scheduler, VALUE io, rb_off_t from, voi
 }
 
 VALUE
-rb_fiber_scheduler_io_pwrite_memory(VALUE scheduler, VALUE io, rb_off_t from, const void *base, size_t size, size_t length)
+rb_fiber_scheduler_io_pwrite_memory(VALUE scheduler, VALUE io, rb_off_t from, const void *base, size_t size)
 {
     VALUE buffer = rb_io_buffer_new_locked((void*)base, size, RB_IO_BUFFER_READONLY);
 
-    VALUE result = rb_fiber_scheduler_io_pwrite(scheduler, io, from, buffer, length, 0);
+    VALUE result = rb_fiber_scheduler_io_pwrite(scheduler, io, from, buffer, 0, size);
 
     rb_io_buffer_free_locked(buffer);
 

--- a/test/fiber/scheduler.rb
+++ b/test/fiber/scheduler.rb
@@ -371,116 +371,28 @@ end
 # This scheduler class implements `io_read` and `io_write` hooks which require
 # `IO::Buffer`.
 class IOBufferScheduler < Scheduler
-  EAGAIN = -Errno::EAGAIN::Errno
-
-  def io_read(io, buffer, length, offset)
-    total = 0
+  def io_read(io, buffer, offset, length)
     io.nonblock = true
 
-    while true
-      result = blocking{buffer.read(io, 0, offset)}
-
-      if result > 0
-        total += result
-        offset += result
-        break if total >= length
-      elsif result == 0
-        break
-      elsif result == EAGAIN
-        if length > 0
-          self.io_wait(io, IO::READABLE, nil)
-        else
-          return result
-        end
-      elsif result < 0
-        return result
-      end
-    end
-
-    return total
+    blocking{buffer.read(io, offset, length)}
   end
 
-  def io_write(io, buffer, length, offset)
-    total = 0
+  def io_write(io, buffer, offset, length)
     io.nonblock = true
 
-    while true
-      result = blocking{buffer.write(io, 0, offset)}
-
-      if result > 0
-        total += result
-        offset += result
-        break if total >= length
-      elsif result == 0
-        break
-      elsif result == EAGAIN
-        if length > 0
-          self.io_wait(io, IO::WRITABLE, nil)
-        else
-          return result
-        end
-      elsif result < 0
-        return result
-      end
-    end
-
-    return total
+    blocking{buffer.write(io, offset, length)}
   end
 
-  def io_pread(io, buffer, from, length, offset)
-    total = 0
+  def io_pread(io, buffer, from, offset, length)
     io.nonblock = true
 
-    while true
-      result = blocking{buffer.pread(io, from, 0, offset)}
-
-      if result > 0
-        total += result
-        offset += result
-        from += result
-        break if total >= length
-      elsif result == 0
-        break
-      elsif result == EAGAIN
-        if length > 0
-          self.io_wait(io, IO::READABLE, nil)
-        else
-          return result
-        end
-      elsif result < 0
-        return result
-      end
-    end
-
-    return total
+    blocking{buffer.pread(io, from, offset, length)}
   end
 
-  def io_pwrite(io, buffer, from, length, offset)
-    total = 0
+  def io_pwrite(io, buffer, from, offset, length)
     io.nonblock = true
 
-    while true
-      result = blocking{buffer.pwrite(io, from, 0, offset)}
-
-      if result > 0
-        total += result
-        offset += result
-        from += result
-        break if total >= length
-      elsif result == 0
-        break
-      elsif result == EAGAIN
-        if length > 0
-          self.io_wait(io, IO::WRITABLE, nil)
-        else
-          return result
-        end
-      elsif result < 0
-        return result
-      end
-    end
-
-    return total
+    blocking{buffer.pwrite(io, from, offset, length)}
   end
 
   def blocking(&block)
@@ -493,24 +405,24 @@ class IOScheduler < Scheduler
     @operations ||= []
   end
 
-  def io_write(io, buffer, length, offset)
+  def io_write(io, buffer, offset, length)
     descriptor = io.fileno
-    string = buffer.get_string
+    string = buffer.get_string(offset, length)
 
     self.operations << [:io_write, descriptor, string]
 
     Fiber.blocking do
-      buffer.write(io, 0, offset)
+      buffer.write(io, offset, length)
     end
   end
 end
 
 class IOErrorScheduler < Scheduler
-  def io_read(io, buffer, length, offset)
+  def io_read(io, buffer, offset, length)
     return -Errno::EBADF::Errno
   end
 
-  def io_write(io, buffer, length, offset)
+  def io_write(io, buffer, offset, length)
     return -Errno::EINVAL::Errno
   end
 end

--- a/test/fiber/test_io_buffer.rb
+++ b/test/fiber/test_io_buffer.rb
@@ -132,11 +132,11 @@ class TestFiberIOBuffer < Test::Unit::TestCase
     destination_buffer = IO::Buffer.new(source_buffer.size)
 
     # Test non-scheduler code path:
-    source_buffer.write(o, source_buffer.size)
-    destination_buffer.read(i, source_buffer.size)
+    source_buffer.write(o, 0, source_buffer.size)
+    destination_buffer.read(i, 0, source_buffer.size)
     assert_equal source_buffer, destination_buffer
 
-    # Test scheduler code path:
+    # Test with a scheduler installed:
     destination_buffer.clear
 
     thread = Thread.new do
@@ -144,14 +144,43 @@ class TestFiberIOBuffer < Test::Unit::TestCase
       Fiber.set_scheduler scheduler
 
       Fiber.schedule do
-        source_buffer.write(o, source_buffer.size)
-        destination_buffer.read(i, source_buffer.size)
+        source_buffer.write(o, 0, source_buffer.size)
+        destination_buffer.read(i, 0, source_buffer.size)
       end
     end
 
     thread.join
 
     assert_equal source_buffer, destination_buffer
+  ensure
+    i&.close
+    o&.close
+  end
+
+  def test_io_buffer_read_write_offset_and_length
+    omit "UNIXSocket is not defined!" unless defined?(UNIXSocket)
+
+    i, o = UNIXSocket.pair
+    source_buffer = IO::Buffer.for("xHELLOy")
+    destination_buffer = IO::Buffer.new(9)
+    written = read = nil
+
+    thread = Thread.new do
+      scheduler = IOBufferScheduler.new
+      Fiber.set_scheduler scheduler
+
+      Fiber.schedule do
+        written = source_buffer.write(o, 1, 5)
+        o.close_write
+        read = destination_buffer.read(i, 2, 5)
+      end
+    end
+
+    thread.join
+
+    assert_equal 5, written
+    assert_equal 5, read
+    assert_equal "HELLO", destination_buffer.get_string(2, 5)
   ensure
     i&.close
     o&.close
@@ -173,11 +202,11 @@ class TestFiberIOBuffer < Test::Unit::TestCase
     destination_buffer = IO::Buffer.new(source_buffer.size)
 
     # Test non-scheduler code path:
-    source_buffer.pwrite(file, 1, source_buffer.size)
-    destination_buffer.pread(file, 1, source_buffer.size)
+    source_buffer.pwrite(file, 1, 0, source_buffer.size)
+    destination_buffer.pread(file, 1, 0, source_buffer.size)
     assert_equal source_buffer, destination_buffer
 
-    # Test scheduler code path:
+    # Test with a scheduler installed:
     destination_buffer.clear
     file.truncate(0)
 
@@ -186,14 +215,42 @@ class TestFiberIOBuffer < Test::Unit::TestCase
       Fiber.set_scheduler scheduler
 
       Fiber.schedule do
-        source_buffer.pwrite(file, 1, source_buffer.size)
-        destination_buffer.pread(file, 1, source_buffer.size)
+        source_buffer.pwrite(file, 1, 0, source_buffer.size)
+        destination_buffer.pread(file, 1, 0, source_buffer.size)
       end
     end
 
     thread.join
 
     assert_equal source_buffer, destination_buffer
+  ensure
+    file&.close!
+  end
+
+  def test_io_buffer_pread_pwrite_from_offset_and_length
+    file = Tempfile.new("test_io_buffer_pread_pwrite_from_offset_and_length")
+
+    omit "Non-blocking file IO is not supported" unless nonblockable?(file)
+
+    source_buffer = IO::Buffer.for("xHELLOy")
+    destination_buffer = IO::Buffer.new(9)
+    written = read = nil
+
+    thread = Thread.new do
+      scheduler = IOBufferScheduler.new
+      Fiber.set_scheduler scheduler
+
+      Fiber.schedule do
+        written = source_buffer.pwrite(file, 3, 1, 5)
+        read = destination_buffer.pread(file, 3, 2, 5)
+      end
+    end
+
+    thread.join
+
+    assert_equal 5, written
+    assert_equal 5, read
+    assert_equal "HELLO", destination_buffer.get_string(2, 5)
   ensure
     file&.close!
   end

--- a/test/ruby/test_io_buffer.rb
+++ b/test/ruby/test_io_buffer.rb
@@ -23,6 +23,10 @@ class TestIOBuffer < Test::Unit::TestCase
     assert(value > 0, "Expected #{value} to be positive!")
   end
 
+  def test_version
+    assert_equal 3, IO::Buffer::VERSION
+  end
+
   def test_flags
     assert_equal 1, IO::Buffer::EXTERNAL
     assert_equal 2, IO::Buffer::INTERNAL
@@ -1129,7 +1133,7 @@ class TestIOBuffer < Test::Unit::TestCase
     input2.nonblock = false
     buffer = IO::Buffer.new(2)
 
-    thread1 = Thread.new {buffer.read(input1, 1, 0)}
+    thread1 = Thread.new {buffer.read(input1, 0, 1)}
     thread2 = Thread.new {buffer.read(input2, 1, 1)}
 
     Thread.pass until thread1.stop? && thread2.stop?
@@ -1178,18 +1182,31 @@ class TestIOBuffer < Test::Unit::TestCase
     end
   end
 
-  def test_read_with_with_length
+  def test_read_with_length
     hello_world_tempfile do |io|
       buffer = IO::Buffer.new(128)
-      buffer.read(io, 5)
+      buffer.read(io, 0, 5)
       assert_equal "Hello", buffer.get_string(0, 5)
     end
   end
 
-  def test_read_with_with_offset
+  def test_read_returns_short_result
+    input, output = IO.pipe
+    input.nonblock = true
+    output.write("abc")
+
+    buffer = IO::Buffer.new(5)
+    assert_equal 3, buffer.read(input, 0, 5)
+    assert_equal "abc", buffer.get_string(0, 3)
+  ensure
+    input&.close
+    output&.close
+  end
+
+  def test_read_with_offset
     hello_world_tempfile do |io|
       buffer = IO::Buffer.new(128)
-      buffer.read(io, nil, 6)
+      buffer.read(io, 6)
       assert_equal "Hello", buffer.get_string(6, 5)
     end
   end
@@ -1198,7 +1215,7 @@ class TestIOBuffer < Test::Unit::TestCase
     hello_world_tempfile(100) do |io|
       buffer = IO::Buffer.new(1024)
       # Only read 24 bytes from the file, as we are starting at offset 1000 in the buffer.
-      assert_equal 24, buffer.read(io, 0, 1000)
+      assert_equal 24, buffer.read(io, 1000)
       assert_equal "Hello World", buffer.get_string(1000, 11)
     end
   end
@@ -1221,7 +1238,7 @@ class TestIOBuffer < Test::Unit::TestCase
 
     buffer = IO::Buffer.new(5)
     buffer.set_string("Hello")
-    buffer.write(io, 4, 1)
+    buffer.write(io, 1, 4)
 
     io.seek(0)
     assert_equal "ello", io.read(4)
@@ -1233,10 +1250,10 @@ class TestIOBuffer < Test::Unit::TestCase
     io = Tempfile.new
 
     assert_zero_length_io = proc do |buffer, offset = 0|
-      assert_equal 0, buffer.read(io, 0, offset)
-      assert_equal 0, buffer.pread(io, 0, 0, offset)
-      assert_equal 0, buffer.write(io, 0, offset)
-      assert_equal 0, buffer.pwrite(io, 0, 0, offset)
+      assert_equal 0, buffer.read(io, offset, 0)
+      assert_equal 0, buffer.pread(io, 0, offset, 0)
+      assert_equal 0, buffer.write(io, offset, 0)
+      assert_equal 0, buffer.pwrite(io, 0, offset, 0)
     end
 
     buffer = IO::Buffer.new(0)
@@ -1260,7 +1277,7 @@ class TestIOBuffer < Test::Unit::TestCase
     io.seek(0)
 
     buffer = IO::Buffer.new(128)
-    buffer.pread(io, 6, 5)
+    buffer.pread(io, 6, 0, 5)
 
     assert_equal "World", buffer.get_string(0, 5)
     assert_equal 0, io.tell
@@ -1274,7 +1291,7 @@ class TestIOBuffer < Test::Unit::TestCase
     io.seek(0)
 
     buffer = IO::Buffer.new(128)
-    buffer.pread(io, 6, 5, 6)
+    buffer.pread(io, 6, 6, 5)
 
     assert_equal "World", buffer.get_string(6, 5)
     assert_equal 0, io.tell
@@ -1287,7 +1304,7 @@ class TestIOBuffer < Test::Unit::TestCase
 
     buffer = IO::Buffer.new(128)
     buffer.set_string("World")
-    buffer.pwrite(io, 6, 5)
+    buffer.pwrite(io, 6, 0, 5)
 
     assert_equal 0, io.tell
 
@@ -1302,7 +1319,7 @@ class TestIOBuffer < Test::Unit::TestCase
 
     buffer = IO::Buffer.new(128)
     buffer.set_string("Hello World")
-    buffer.pwrite(io, 6, 5, 6)
+    buffer.pwrite(io, 6, 6, 5)
 
     assert_equal 0, io.tell
 


### PR DESCRIPTION
## Summary

Change the `IO::Buffer#read`, `#write`, `#pread`, and `#pwrite` methods and their fiber scheduler hooks to expose composable, `read(2)`-style primitives:

- Perform one IO transfer attempt.
- Treat `length` as the maximum transfer size.
- Return short transfers directly.
- Use `(offset, length)` consistently for buffer ranges.
- Make each native-memory helper expose exactly the requested transfer span.
- Return the number of bytes transferred or `-errno`, including `-EAGAIN` when the operation would block.

For example:

```ruby
buffer.read(io, offset, length)
buffer.pread(io, from, offset, length)

scheduler.io_read(io, buffer, offset, length)
scheduler.io_pread(io, buffer, from, offset, length)
```

Higher-level `IO` operations retain responsibility for waiting and retrying when appropriate. This also preserves the immediate would-block behavior of non-blocking operations.

We recognize that changing these interfaces creates some downstream migration work. However, the hooks and corresponding `IO::Buffer` methods were explicitly experimental, and correcting them before stabilization is a net improvement: the resulting interface is simpler, consistent, and directly composable using familiar `read(2)` semantics.

Ruby 4.1 makes the four scheduler hooks non-experimental. `RUBY_FIBER_SCHEDULER_VERSION` is bumped to 4 so downstream schedulers can detect the corrected argument order and semantics. No additional `_partial` methods or hooks are introduced.

`RUBY_IO_BUFFER_VERSION` is bumped to 3 and exposed to Ruby as `IO::Buffer::VERSION`. Ruby-only consumers can detect the corrected `(offset, length)` order and single-transfer semantics with:

```ruby
IO::Buffer::VERSION >= 3
```

## Testing

- `make test` — 2,066 tests passed
- Focused IO::Buffer and fiber tests — 165 tests, 1,109 assertions passed
- Full `test/fiber` — 96 tests, 399 assertions passed