### PR TITLE
ZJIT: Simplify indexing block and instruction vectors

### DIFF
--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -2941,7 +2941,7 @@ impl Assembler
             StackMapEntry::Opnd(Opnd::UImm(value)) => !VALUE(*value as usize).special_const_p(),
             StackMapEntry::Opnd(Opnd::VReg { idx, .. }) => {
                 matches!(
-                    intervals[idx.to_usize()].assigned.get().expect("StackMap VReg should have an allocation"),
+                    intervals[*idx].assigned.get().expect("StackMap VReg should have an allocation"),
                     Allocation::Reg(_)
                 )
             }

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -83,7 +83,7 @@ impl JITState {
 
     /// Retrieve the output of a given instruction that has been compiled
     fn get_opnd(&self, insn_id: InsnId) -> lir::Opnd {
-        self.opnds[insn_id.to_usize()].unwrap_or_else(|| panic!("Failed to get_opnd({insn_id})"))
+        self.opnds[insn_id].unwrap_or_else(|| panic!("Failed to get_opnd({insn_id})"))
     }
 
     /// Get the ISEQ for the version currently being compiled.
@@ -467,7 +467,7 @@ fn gen_function(cb: &mut CodeBlock, iseq: IseqPtr, version: IseqVersionRef, func
                 // Param does not have operands, so fake a ResolvedInsnId.
                 match crate::hir::ResolvedInsnId(insn_id).insn(function) {
                     Insn::Param => {
-                        jit.opnds[insn_id.to_usize()] = Some(gen_param(&mut asm, idx));
+                        jit.opnds[insn_id] = Some(gen_param(&mut asm, idx));
                     },
                     insn => unreachable!("Non-param insn found in block.params: {insn:?}"),
                 }
@@ -480,7 +480,7 @@ fn gen_function(cb: &mut CodeBlock, iseq: IseqPtr, version: IseqVersionRef, func
                     let insn_id = function.find_id(insn_id);
                     // Param does not have operands, so fake a ResolvedInsnId.
                     if let &Insn::LoadArg { idx, .. } = crate::hir::ResolvedInsnId(insn_id).insn(function) {
-                        jit.opnds[insn_id.to_usize()] = Some(gen_param(&mut asm, idx as usize));
+                        jit.opnds[insn_id] = Some(gen_param(&mut asm, idx as usize));
                     }
                 }
             }
@@ -811,7 +811,7 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
     assert!(insn.has_output(), "Cannot write LIR output of HIR instruction with no output: {insn}");
 
     // If the instruction has an output, remember it in jit.opnds
-    jit.opnds[insn_id.to_usize()] = Some(out_opnd);
+    jit.opnds[insn_id] = Some(out_opnd);
 
     Ok(())
 }

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -438,7 +438,7 @@ fn gen_function(cb: &mut CodeBlock, iseq: IseqPtr, version: IseqVersionRef, func
             // Skip the entries superblock -- it's an internal CFG artifact
             if block_id == function.entries_block { continue; }
             let lir_block_id = asm.new_block(block_id, function.is_entry_block(block_id), rpo_idx);
-            hir_to_lir[block_id.to_usize()] = Some(lir_block_id);
+            hir_to_lir[block_id] = Some(lir_block_id);
         }
 
         // Compile each basic block
@@ -447,7 +447,7 @@ fn gen_function(cb: &mut CodeBlock, iseq: IseqPtr, version: IseqVersionRef, func
             if block_id == function.entries_block { continue; }
             // Set the current block to the LIR block that corresponds to this
             // HIR block.
-            let lir_block_id = hir_to_lir[block_id.to_usize()].unwrap();
+            let lir_block_id = hir_to_lir[block_id].unwrap();
             asm.set_current_block(lir_block_id);
 
             // Write a label to jump to the basic block
@@ -493,8 +493,8 @@ fn gen_function(cb: &mut CodeBlock, iseq: IseqPtr, version: IseqVersionRef, func
                 let result = match &insn {
                     Insn::CondBranch { val, if_true, if_false } => {
                         let val_opnd = jit.get_opnd(*val);
-                        let true_target = hir_to_lir[if_true.target.to_usize()].unwrap();
-                        let false_target = hir_to_lir[if_false.target.to_usize()].unwrap();
+                        let true_target = hir_to_lir[if_true.target].unwrap();
+                        let false_target = hir_to_lir[if_false.target].unwrap();
 
                         let true_branch = lir::BranchEdge {
                             target: true_target,
@@ -514,7 +514,7 @@ fn gen_function(cb: &mut CodeBlock, iseq: IseqPtr, version: IseqVersionRef, func
                         Ok(())
                     }
                     Insn::Jump(target) => {
-                        let lir_target = hir_to_lir[target.target.to_usize()].unwrap();
+                        let lir_target = hir_to_lir[target.target].unwrap();
                         let branch_edge = lir::BranchEdge {
                             target: lir_target,
                             args: target.args.iter().map(|insn_id| jit.get_opnd(*insn_id)).collect()

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -93,15 +93,9 @@ impl std::fmt::Display for InsnId {
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, PartialOrd, Ord)]
 pub struct BlockId(pub u32);
 
-impl IntoUsize for BlockId {
-    fn to_usize(self) -> usize {
-        self.0.to_usize()
-    }
-}
-
 impl From<BlockId> for usize {
     fn from(val: BlockId) -> Self {
-        val.to_usize()
+        val.0.to_usize()
     }
 }
 
@@ -109,6 +103,28 @@ impl From<usize> for BlockId {
     fn from(val: usize) -> Self {
         BlockId(val.try_into().expect("BlockId should fit in u32"))
     }
+}
+
+impl<T> std::ops::Index<BlockId> for [T] {
+    type Output = T;
+    #[inline]
+    fn index(&self, i: BlockId) -> &T { &self[usize::from(i)] }
+}
+
+impl<T> std::ops::IndexMut<BlockId> for [T] {
+    #[inline]
+    fn index_mut(&mut self, i: BlockId) -> &mut T { &mut self[usize::from(i)] }
+}
+
+impl<T> std::ops::Index<BlockId> for Vec<T> {
+    type Output = T;
+    #[inline]
+    fn index(&self, i: BlockId) -> &T { &self[usize::from(i)] }
+}
+
+impl<T> std::ops::IndexMut<BlockId> for Vec<T> {
+    #[inline]
+    fn index_mut(&mut self, i: BlockId) -> &mut T { &mut self[usize::from(i)] }
 }
 
 impl std::fmt::Display for BlockId {
@@ -3048,9 +3064,9 @@ impl Function {
         let is_param = matches!(insn, Insn::Param);
         let id = self.new_insn(insn);
         if is_param {
-            self.blocks[block.to_usize()].params.push(id);
+            self.blocks[block].params.push(id);
         } else {
-            self.blocks[block.to_usize()].insns.push(id);
+            self.blocks[block].insns.push(id);
         }
         id
     }
@@ -3190,7 +3206,7 @@ impl Function {
 
     // Add an instruction to an SSA block
     fn push_insn_id(&mut self, block: BlockId, insn_id: InsnId) -> InsnId {
-        self.blocks[block.to_usize()].insns.push(insn_id);
+        self.blocks[block].insns.push(insn_id);
         insn_id
     }
 
@@ -3281,7 +3297,7 @@ impl Function {
         // produces no value, and `make_equal_to` asserts `has_output()`. So the instruction stored
         // at this id is always the terminator itself, and reading it by reference matches what
         // `find` would return.
-        let terminator = &self.insns[*self.blocks[block.to_usize()].insns.last().unwrap()];
+        let terminator = &self.insns[*self.blocks[block].insns.last().unwrap()];
 
         let (first, second, rest): (Option<BlockId>, Option<BlockId>, &[BlockId]) = match terminator {
             Insn::CondBranch { if_true, if_false, .. } => (Some(if_true.target), Some(if_false.target), &[]),
@@ -3302,12 +3318,12 @@ impl Function {
 
     /// Return a reference to the Block at the given index.
     pub fn block(&self, block_id: BlockId) -> &Block {
-        &self.blocks[block_id.to_usize()]
+        &self.blocks[block_id]
     }
 
     /// Return a reference to the entry block.
     pub fn entry_block(&self) -> &Block {
-        &self.blocks[self.entry_block.to_usize()]
+        &self.blocks[self.entry_block]
     }
 
     /// Return the number of blocks
@@ -3655,7 +3671,7 @@ impl Function {
     /// Copy self.param_types to the param types of jit_entry_blocks.
     fn copy_param_types(&mut self) {
         for jit_entry_block in self.jit_entry_blocks.iter() {
-            let entry_params = self.blocks[jit_entry_block.to_usize()].params.iter();
+            let entry_params = self.blocks[*jit_entry_block].params.iter();
             let param_types = self.param_types.iter();
             assert!(
                 param_types.len() >= entry_params.len(),
@@ -3717,7 +3733,7 @@ impl Function {
         // includes reachable blocks. Any blocks not present in `rpo` default to `usize::MAX`.
         let mut rpo_order = vec![usize::MAX; self.blocks.len()];
         for (idx, &block_id) in rpo.iter().enumerate() {
-            rpo_order[block_id.to_usize()] = idx;
+            rpo_order[block_id] = idx;
         }
         loop {
             let mut changed = false;
@@ -3725,8 +3741,8 @@ impl Function {
             let mut num_instructions = 0;
             for (rpo_index, &block) in rpo.iter().enumerate() {
                 if !reachable.get(block) { continue; }
-                for i in 0..self.blocks[block.to_usize()].insns.len() {
-                    let insn_id = self.blocks[block.to_usize()].insns[i];
+                for i in 0..self.blocks[block].insns.len() {
+                    let insn_id = self.blocks[block].insns[i];
                     if self.insns[insn_id].counts_against_inlining_budget() {
                         num_instructions += 1;
                     }
@@ -3742,19 +3758,19 @@ impl Function {
                                 // params of `target` itself).
                                 let arg_types: Vec<Type> = if_true.args.iter().map(|a| self.type_of(*a)).collect();
                                 for (idx, arg_type) in arg_types.into_iter().enumerate() {
-                                    let param = self.blocks[if_true.target.to_usize()].params[idx];
+                                    let param = self.blocks[if_true.target].params[idx];
                                     changed |= set_type!(param, self.type_of(param).union(arg_type));
                                 }
-                                traversed_back_edge |= rpo_order[if_true.target.to_usize()] <= rpo_index;
+                                traversed_back_edge |= rpo_order[if_true.target] <= rpo_index;
                             }
                             if self.type_of(*val).could_be(Type::from_cbool(false)) {
                                 reachable.insert(if_false.target);
                                 let arg_types: Vec<Type> = if_false.args.iter().map(|a| self.type_of(*a)).collect();
                                 for (idx, arg_type) in arg_types.into_iter().enumerate() {
-                                    let param = self.blocks[if_false.target.to_usize()].params[idx];
+                                    let param = self.blocks[if_false.target].params[idx];
                                     changed |= set_type!(param, self.type_of(param).union(arg_type));
                                 }
-                                traversed_back_edge |= rpo_order[if_false.target.to_usize()] <= rpo_index;
+                                traversed_back_edge |= rpo_order[if_false.target] <= rpo_index;
                             }
                             continue;
                         }
@@ -3762,10 +3778,10 @@ impl Function {
                             reachable.insert(target);
                             let arg_types: Vec<Type> = args.iter().map(|a| self.type_of(*a)).collect();
                             for (idx, arg_type) in arg_types.into_iter().enumerate() {
-                                let param = self.blocks[target.to_usize()].params[idx];
+                                let param = self.blocks[target].params[idx];
                                 changed |= set_type!(param, self.type_of(param).union(arg_type));
                             }
-                            traversed_back_edge |= rpo_order[target.to_usize()] <= rpo_index;
+                            traversed_back_edge |= rpo_order[target] <= rpo_index;
                             continue;
                         }
                         Insn::Entries { targets } => {
@@ -4391,8 +4407,8 @@ impl Function {
         if let Some(replacement) = (props.inline)(self, tmp_block, recv, &args, state) {
             // Copy contents of tmp_block to block
             assert_ne!(block, tmp_block);
-            let insns = std::mem::take(&mut self.blocks[tmp_block.to_usize()].insns);
-            self.blocks[block.to_usize()].insns.extend(insns);
+            let insns = std::mem::take(&mut self.blocks[tmp_block].insns);
+            self.blocks[block].insns.extend(insns);
             self.count(block, Counter::inline_cfunc_optimized_send_count);
             if self.type_of(replacement).bit_equal(types::Any) {
                 // Not set yet; infer type
@@ -4460,8 +4476,8 @@ impl Function {
     /// Also try and inline constant caches, specialize object allocations, and more.
     fn type_specialize(&mut self) {
         for block in self.reverse_post_order() {
-            let old_insns = std::mem::take(&mut self.blocks[block.to_usize()].insns);
-            assert!(self.blocks[block.to_usize()].insns.is_empty());
+            let old_insns = std::mem::take(&mut self.blocks[block].insns);
+            assert!(self.blocks[block].insns.is_empty());
             for insn_id in old_insns {
                 let resolved = self.resolve(insn_id);
                 match resolved.insn(self) {
@@ -4893,8 +4909,8 @@ impl Function {
                                             if let Some(replacement) = (props.inline)(fun, tmp_block, recv, &args, state) {
                                                 // Copy contents of tmp_block to block
                                                 assert_ne!(block, tmp_block);
-                                                let insns = std::mem::take(&mut fun.blocks[tmp_block.to_usize()].insns);
-                                                fun.blocks[block.to_usize()].insns.extend(insns);
+                                                let insns = std::mem::take(&mut fun.blocks[tmp_block].insns);
+                                                fun.blocks[block].insns.extend(insns);
                                                 fun.count(block, Counter::inline_cfunc_optimized_send_count);
                                                 fun.make_equal_to(send_insn_id, replacement);
                                                 if fun.type_of(replacement).bit_equal(types::Any) {
@@ -4960,8 +4976,8 @@ impl Function {
                                             if let Some(replacement) = (props.inline)(fun, tmp_block, recv, &args, state) {
                                                 // Copy contents of tmp_block to block
                                                 assert_ne!(block, tmp_block);
-                                                let insns = std::mem::take(&mut fun.blocks[tmp_block.to_usize()].insns);
-                                                fun.blocks[block.to_usize()].insns.extend(insns);
+                                                let insns = std::mem::take(&mut fun.blocks[tmp_block].insns);
+                                                fun.blocks[block].insns.extend(insns);
                                                 fun.count(block, Counter::inline_cfunc_optimized_send_count);
                                                 fun.make_equal_to(send_insn_id, replacement);
                                                 if fun.type_of(replacement).bit_equal(types::Any) {
@@ -5242,8 +5258,8 @@ impl Function {
                                     if let Some(replacement) = (props.inline)(self, tmp_block, recv, &args, state) {
                                         // Copy contents of tmp_block to block
                                         assert_ne!(block, tmp_block);
-                                        let insns = std::mem::take(&mut self.blocks[tmp_block.to_usize()].insns);
-                                        self.blocks[block.to_usize()].insns.extend(insns);
+                                        let insns = std::mem::take(&mut self.blocks[tmp_block].insns);
+                                        self.blocks[block].insns.extend(insns);
                                         self.count(block, Counter::inline_cfunc_optimized_send_count);
                                         self.make_equal_to(insn_id, replacement);
                                         if self.type_of(replacement).bit_equal(types::Any) {
@@ -5292,8 +5308,8 @@ impl Function {
                                     if let Some(replacement) = (props.inline)(self, tmp_block, recv, &args, state) {
                                         // Copy contents of tmp_block to block
                                         assert_ne!(block, tmp_block);
-                                        let insns = std::mem::take(&mut self.blocks[tmp_block.to_usize()].insns);
-                                        self.blocks[block.to_usize()].insns.extend(insns);
+                                        let insns = std::mem::take(&mut self.blocks[tmp_block].insns);
+                                        self.blocks[block].insns.extend(insns);
                                         self.count(block, Counter::inline_cfunc_optimized_send_count);
                                         self.make_equal_to(insn_id, replacement);
                                         if self.type_of(replacement).bit_equal(types::Any) {
@@ -5470,14 +5486,14 @@ impl Function {
             // inlinable SendDirect in the same block still gets a chance.
             let mut search_start = 0;
             loop {
-                let Some(offset) = self.blocks[block.to_usize()].insns[search_start..].iter()
+                let Some(offset) = self.blocks[block].insns[search_start..].iter()
                     .position(|&id| self.is_send_direct(id))
                 else {
                     break;
                 };
                 let send_pos = search_start + offset;
 
-                let send_insn_id = self.blocks[block.to_usize()].insns[send_pos];
+                let send_insn_id = self.blocks[block].insns[send_pos];
                 let send = self.resolve(send_insn_id);
                 let Insn::SendDirect(data) = send.insn(self)
                 else {
@@ -5591,7 +5607,7 @@ impl Function {
                 // constants land in `block` at the correct position (after the
                 // pre-Send body, before the PushLightweightFrame and Jump we add
                 // last).
-                let tail = self.blocks[block.to_usize()].insns.split_off(send_pos);
+                let tail = self.blocks[block].insns.split_off(send_pos);
                 debug_assert!(self.is_send_direct(tail[0]));
 
                 let omitted_opt_num = opt_num - passed_opt_num;
@@ -5626,7 +5642,7 @@ impl Function {
                 //     same value back to the runtime frame so a resuming interpreter sees
                 //     the correct bitmask.
                 //   * any remaining non-parameter locals are nil-initialized.
-                let callee_body_params: Vec<InsnId> = self.blocks[callee_entry_body_block.to_usize()].params.clone();
+                let callee_body_params: Vec<InsnId> = self.blocks[callee_entry_body_block].params.clone();
 
                 // First param is self.
                 if !callee_body_params.is_empty() {
@@ -5667,7 +5683,7 @@ impl Function {
                 // Clear the callee body entry block's params since we've aliased
                 // them via make_equal_to rather than passing them as branch
                 // arguments. This keeps validation happy (the Jump passes 0 args).
-                self.blocks[callee_entry_body_block.to_usize()].params.clear();
+                self.blocks[callee_entry_body_block].params.clear();
 
                 // Set up the continuation block: a single Param merges all return
                 // values jumped in from the callee's leaves, then PopLightweightFrame
@@ -6066,8 +6082,8 @@ impl Function {
             return;
         }
         for block in self.reverse_post_order() {
-            let old_insns = std::mem::take(&mut self.blocks[block.to_usize()].insns);
-            assert!(self.blocks[block.to_usize()].insns.is_empty());
+            let old_insns = std::mem::take(&mut self.blocks[block].insns);
+            assert!(self.blocks[block].insns.is_empty());
             for insn_id in old_insns {
                 match self.resolve(insn_id).insn(self) {
                     &Insn::Send { state, reason: SendFallbackReason::SendNoProfiles, .. } => {
@@ -6123,7 +6139,7 @@ impl Function {
         }
 
         fn block_terminator(fun: &Function, block_id: BlockId) -> InsnId {
-            *fun.blocks[block_id.to_usize() as usize].insns().last().unwrap()
+            *fun.blocks[block_id].insns().last().unwrap()
         }
 
         macro_rules! edges_of {
@@ -6161,11 +6177,11 @@ impl Function {
         // We only need to update blocks that have params. (Blocks without params cannot be improved)
         let blocks_receiving_params: Vec<BlockId> = blocks.iter().copied()
             .filter(|&block_id|
-                self.blocks[block_id.to_usize()].params().len() != 0)
+                self.blocks[block_id].params().len() != 0)
             .collect();
 
         // Create a vec to represent trivial indices
-        let max_params = blocks.iter().copied().map(|id| self.blocks[id.to_usize()].params.len()).max().unwrap_or(0);
+        let max_params = blocks.iter().copied().map(|id| self.blocks[id].params.len()).max().unwrap_or(0);
         let mut trivial_indices: Vec<usize> = Vec::with_capacity(max_params);
 
         let mut changed = true;
@@ -6185,10 +6201,10 @@ impl Function {
                     for (i, param) in params.iter().enumerate() {
                         let param = self.find_id(*param);
                         // If the param is the same as passed into the block, it is a self loop and provides no new predecessor information.
-                        if param == self.find_id(self.blocks[block_id.to_usize()].params[i]) {
+                        if param == self.find_id(self.blocks[*block_id].params[i]) {
                             continue
                         }
-                        param_values[block_id.to_usize()][i].update(param);
+                        param_values[*block_id][i].update(param);
                     }
                 }
             }
@@ -6199,7 +6215,7 @@ impl Function {
             // 2. Remove trivial params from the basic block definition
             // 3. Remove trivial params from each CondBranch and Jump that targets the basic block that was just updated
             for block_id in &blocks_receiving_params {
-                let block_preds = &param_values[block_id.to_usize()];
+                let block_preds = &param_values[*block_id];
                 trivial_indices.clear();
                 for (idx, state) in block_preds.iter().enumerate() {
                     if let ParamValue::One(_) = state {
@@ -6210,13 +6226,13 @@ impl Function {
                 // Replace uses of the trivial params with the concretized value
                 for param_index in &trivial_indices {
                     if let ParamValue::One(insn_id) = block_preds[*param_index] {
-                        self.make_equal_to(self.blocks[block_id.to_usize()].params[*param_index], insn_id);
+                        self.make_equal_to(self.blocks[*block_id].params[*param_index], insn_id);
                         changed = true;
                     }
                 }
 
                 // Update the block
-                prune_vec_by_indices(&mut self.blocks[block_id.to_usize()].params, &trivial_indices);
+                prune_vec_by_indices(&mut self.blocks[*block_id].params, &trivial_indices);
 
                 // Update the terminators (basic blocks can only branch at the terminator. This is where block params are passed)
                 for jump_block_id in &blocks_sending_params {
@@ -6234,7 +6250,7 @@ impl Function {
     fn optimize_load_store(&mut self) {
         for block in self.reverse_post_order() {
             let mut compile_time_heap: HashMap<(InsnId, i32), InsnId>  = HashMap::new();
-            let old_insns = std::mem::take(&mut self.blocks[block.to_usize()].insns);
+            let old_insns = std::mem::take(&mut self.blocks[block].insns);
             let mut new_insns = Vec::with_capacity(old_insns.len());
             for insn_id in old_insns {
                 let replacement_insn: InsnId = match self.resolve(insn_id).insn(self) {
@@ -6301,7 +6317,7 @@ impl Function {
                 };
                 new_insns.push(replacement_insn);
             }
-            self.blocks[block.to_usize()].insns = new_insns;
+            self.blocks[block].insns = new_insns;
         }
     }
 
@@ -6342,9 +6358,9 @@ impl Function {
         let mut rewrite_maps: Vec<Option<HashMap<InsnId, InsnId>>> = vec![None; self.blocks.len()];
         let dominators = Dominators::new(self);
         for &block in dominators.cfi.reverse_post_order() {
-            let mut rewrite_map = rewrite_maps[dominators.idom(block).to_usize()].clone().unwrap_or_else(|| HashMap::new());
-            for i in 0..self.blocks[block.to_usize()].insns.len() {
-                let insn_id = self.blocks[block.to_usize()].insns[i];
+            let mut rewrite_map = rewrite_maps[dominators.idom(block)].clone().unwrap_or_else(|| HashMap::new());
+            for i in 0..self.blocks[block].insns.len() {
+                let insn_id = self.blocks[block].insns[i];
                 let canonical_id = self.union_find.borrow().find_const(insn_id);
 
                 let union_find = &self.union_find;
@@ -6367,7 +6383,7 @@ impl Function {
                     _ => {}
                 }
             }
-            rewrite_maps[block.to_usize()] = Some(rewrite_map);
+            rewrite_maps[block] = Some(rewrite_map);
         }
 
         crate::stats::trace_compile_phase("infer_types", || self.infer_types());
@@ -6387,7 +6403,7 @@ impl Function {
         // This would require 1) fixpointing, 2) worklist, or 3) (slightly less powerful) calling a
         // function-level infer_types after each pruned branch.
         for block in self.reverse_post_order() {
-            let old_insns = std::mem::take(&mut self.blocks[block.to_usize()].insns);
+            let old_insns = std::mem::take(&mut self.blocks[block].insns);
             let mut new_insns = Vec::with_capacity(old_insns.len());
             for insn_id in old_insns {
                 let replacement_id = match self.resolve(insn_id).insn(self) {
@@ -6715,7 +6731,7 @@ impl Function {
                     break;
                 }
             }
-            self.blocks[block.to_usize()].insns = new_insns;
+            self.blocks[block].insns = new_insns;
         }
     }
 
@@ -6727,7 +6743,7 @@ impl Function {
         // Find all of the instructions that have side effects, are control instructions, or are
         // otherwise necessary to keep around
         for block_id in &rpo {
-            for insn_id in &self.blocks[block_id.to_usize()].insns {
+            for insn_id in &self.blocks[*block_id].insns {
                 if !&self.insns[*insn_id].is_elidable() {
                     worklist.push_back(*insn_id);
                 }
@@ -6745,12 +6761,12 @@ impl Function {
         }
         // Now remove all unnecessary instructions
         for block_id in &rpo {
-            self.blocks[block_id.to_usize()].insns.retain(|&insn_id| necessary.get(insn_id));
+            self.blocks[*block_id].insns.retain(|&insn_id| necessary.get(insn_id));
         }
     }
 
     fn absorb_dst_block(&mut self, num_in_edges: &[u32], block: BlockId) -> bool {
-        let Some(&terminator_id) = self.blocks[block.to_usize()].insns.last()
+        let Some(&terminator_id) = self.blocks[block].insns.last()
             else { return false };
         let &mut Insn::Jump(ref mut edge) = self.resolve(terminator_id).insn_mut(self)
             else { return false };
@@ -6758,7 +6774,7 @@ impl Function {
             // Can't absorb self
             return false;
         }
-        if num_in_edges[edge.target.to_usize()] != 1 {
+        if num_in_edges[edge.target] != 1 {
             // Can't absorb block if it's the target of more than one branch
             return false;
         }
@@ -6768,16 +6784,16 @@ impl Function {
         // Drop the borrow of edge, which drops the borrow of self, which allows us to mutate self
         // again.
         let _ = edge;
-        let params = std::mem::take(&mut self.blocks[target.to_usize()].params);
+        let params = std::mem::take(&mut self.blocks[target].params);
         assert_eq!(args.len(), params.len());
         for (arg, param) in args.iter().zip(params) {
             self.make_equal_to(param, *arg);
         }
         // Remove branch instruction
-        self.blocks[block.to_usize()].insns.pop();
+        self.blocks[block].insns.pop();
         // Move target instructions into block
-        let target_insns = std::mem::take(&mut self.blocks[target.to_usize()].insns);
-        self.blocks[block.to_usize()].insns.extend(target_insns);
+        let target_insns = std::mem::take(&mut self.blocks[target].insns);
+        self.blocks[block].insns.extend(target_insns);
         true
     }
 
@@ -6790,7 +6806,7 @@ impl Function {
         let mut num_in_edges = vec![0; self.blocks.len()];
         for block in self.reverse_post_order() {
             for target in self.successors(block) {
-                num_in_edges[target.to_usize()] += 1;
+                num_in_edges[target] += 1;
             }
         }
         let mut changed = false;
@@ -6798,7 +6814,7 @@ impl Function {
             let mut iter_changed = false;
             for block in self.reverse_post_order() {
                 // Ignore transient empty blocks
-                if self.blocks[block.to_usize()].insns.is_empty() { continue; }
+                if self.blocks[block].insns.is_empty() { continue; }
                 loop {
                     let absorbed = self.absorb_dst_block(&num_in_edges, block);
                     if !absorbed { break; }
@@ -6819,7 +6835,7 @@ impl Function {
     fn remove_redundant_patch_points(&mut self) {
         for block_id in self.reverse_post_order() {
             let mut seen = HashSet::new();
-            let insns = std::mem::take(&mut self.blocks[block_id.to_usize()].insns);
+            let insns = std::mem::take(&mut self.blocks[block_id].insns);
             let mut new_insns = Vec::with_capacity(insns.len());
             for insn_id in insns {
                 // PatchPoint is never in union-find and it does not have operands, so fake a
@@ -6834,7 +6850,7 @@ impl Function {
                 }
                 new_insns.push(insn_id);
             }
-            self.blocks[block_id.to_usize()].insns = new_insns;
+            self.blocks[block_id].insns = new_insns;
         }
     }
 
@@ -6844,7 +6860,7 @@ impl Function {
     fn remove_duplicate_check_interrupts(&mut self) {
         for block_id in self.reverse_post_order() {
             let mut seen = false;
-            let insns = std::mem::take(&mut self.blocks[block_id.to_usize()].insns);
+            let insns = std::mem::take(&mut self.blocks[block_id].insns);
             let mut new_insns = Vec::with_capacity(insns.len());
             for insn_id in insns {
                 let insn = &self.insns[insn_id];
@@ -6856,7 +6872,7 @@ impl Function {
                 }
                 new_insns.push(insn_id);
             }
-            self.blocks[block_id.to_usize()].insns = new_insns;
+            self.blocks[block_id].insns = new_insns;
         }
     }
 
@@ -6927,7 +6943,7 @@ impl Function {
             // First, find the (PushInlineFrame, PopInlineFrame) pairs to elide.
             let mut elided_pairs: Vec<(InsnId, InsnId)> = Vec::new();
             let mut pending_pushes: Vec<PendingPush> = Vec::new();
-            for &insn_id in &self.blocks[block_id.to_usize()].insns {
+            for &insn_id in &self.blocks[block_id].insns {
                 match self.find_ref(insn_id) {
                     Insn::PushInlineFrame { .. } => {
                         pending_pushes.push(PendingPush { push_id: insn_id, frame_observed: false });
@@ -6976,7 +6992,7 @@ impl Function {
                 rewrites.insert(push_id, replacement);
                 rewrites.insert(pop_id, None);
             }
-            self.blocks[block_id.to_usize()].insns.retain_mut(|insn_id| {
+            self.blocks[block_id].insns.retain_mut(|insn_id| {
                 match rewrites.get(insn_id) {
                     Some(Some(replacement)) => {
                         *insn_id = *replacement;
@@ -7071,8 +7087,8 @@ impl Function {
             .insert("id", id.0)
             .insert("loopDepth", loop_depth)
             .insert("attributes", Json::array(attributes))
-            .insert("predecessors", Json::array(predecessors.iter().map(|x| x.to_usize()).collect::<Vec<usize>>()))
-            .insert("successors", Json::array(successors.iter().map(|x| x.to_usize()).collect::<Vec<usize>>()))
+            .insert("predecessors", Json::array(predecessors.iter().map(|x| usize::from(*x)).collect::<Vec<usize>>()))
+            .insert("successors", Json::array(successors.iter().map(|x| usize::from(*x)).collect::<Vec<usize>>()))
             .insert("instructions", Json::array(instructions))
             .build()
     }
@@ -7108,7 +7124,7 @@ impl Function {
         // Push each block from the iteration in reverse post order to `hir_blocks`.
         for block_id in self.reverse_post_order() {
             // Create the block with instructions.
-            let block = &self.blocks[block_id.to_usize()];
+            let block = &self.blocks[block_id];
             let predecessors = cfi.predecessors(block_id);
             let successors = cfi.successors(block_id);
             let mut instructions = Vec::new();
@@ -7304,7 +7320,7 @@ impl Function {
     /// 3. Every block must have a terminator.
     fn validate_block_terminators_and_jumps(&self) -> Result<(), ValidationError> {
         let check_edge = |block_id: BlockId, edge: &BranchEdge| -> Result<(), ValidationError> {
-            let target_len = self.blocks[edge.target.to_usize()].params.len();
+            let target_len = self.blocks[edge.target].params.len();
             let args_len = edge.args.len();
             if target_len != args_len {
                 return Err(ValidationError::MismatchedBlockArity(block_id, target_len, args_len));
@@ -7313,7 +7329,7 @@ impl Function {
         };
 
         for block_id in self.reverse_post_order() {
-            let insns = &self.blocks[block_id.to_usize()].insns;
+            let insns = &self.blocks[block_id].insns;
             for (idx, insn_id) in insns.iter().enumerate() {
                 // No need for resolve(): we only look at edge targets/arity and terminators.
                 let insn = self.find_ref(*insn_id);
@@ -7359,27 +7375,27 @@ impl Function {
         // starts with nothing defined.
         for &block in &rpo {
             if block == self.entries_block {
-                assigned_in[block.to_usize()] = Some(InsnSet::with_capacity(self.insns.len()));
+                assigned_in[block] = Some(InsnSet::with_capacity(self.insns.len()));
             } else {
                 let mut all_ones = InsnSet::with_capacity(self.insns.len());
                 all_ones.insert_all();
-                assigned_in[block.to_usize()] = Some(all_ones);
+                assigned_in[block] = Some(all_ones);
             }
         }
         let mut worklist = VecDeque::with_capacity(self.num_blocks());
         worklist.push_back(self.entries_block);
         while let Some(block) = worklist.pop_front() {
-            let mut assigned = assigned_in[block.to_usize()].clone().unwrap();
-            for &param in &self.blocks[block.to_usize()].params {
+            let mut assigned = assigned_in[block].clone().unwrap();
+            for &param in &self.blocks[block].params {
                 assigned.insert(param);
             }
-            for &insn_id in &self.blocks[block.to_usize()].insns {
+            for &insn_id in &self.blocks[block].insns {
                 let insn_id = self.union_find.borrow().find_const(insn_id);
                 // No need for resolve(): we only look at jump targets here, and the
                 // operand check below resolves each operand itself.
                 let insn = self.find_ref(insn_id);
                 let mut propagate = |target: BlockId| -> Result<(), ValidationError> {
-                    let Some(block_in) = assigned_in[target.to_usize()].as_mut() else {
+                    let Some(block_in) = assigned_in[target].as_mut() else {
                         return Err(ValidationError::JumpTargetNotInRPO(target));
                     };
                     if block_in.intersect_with(&assigned) {
@@ -7407,11 +7423,11 @@ impl Function {
         }
         // Check that each instruction's operands are assigned
         for &block in &rpo {
-            let mut assigned = assigned_in[block.to_usize()].clone().unwrap();
-            for &param in &self.blocks[block.to_usize()].params {
+            let mut assigned = assigned_in[block].clone().unwrap();
+            for &param in &self.blocks[block].params {
                 assigned.insert(param);
             }
-            for &insn_id in &self.blocks[block.to_usize()].insns {
+            for &insn_id in &self.blocks[block].insns {
                 let insn_id = self.union_find.borrow().find_const(insn_id);
                 self.insns[insn_id].try_for_each_operand(|operand| {
                     let operand = self.union_find.borrow().find_const(operand);
@@ -7432,7 +7448,7 @@ impl Function {
     fn validate_insn_uniqueness(&self) -> Result<(), ValidationError> {
         let mut seen = InsnSet::with_capacity(self.insns.len());
         for block_id in self.reverse_post_order() {
-            for &insn_id in &self.blocks[block_id.to_usize()].insns {
+            for &insn_id in &self.blocks[block_id].insns {
                 let insn_id = self.union_find.borrow().find_const(insn_id);
                 if !seen.insert(insn_id) {
                     return Err(ValidationError::DuplicateInstruction(block_id, insn_id));
@@ -7794,7 +7810,7 @@ impl Function {
     /// Check that insn types match the expected types for each instruction.
     fn validate_types(&self) -> Result<(), ValidationError> {
         for block_id in self.reverse_post_order() {
-            for &insn_id in &self.blocks[block_id.to_usize()].insns {
+            for &insn_id in &self.blocks[block_id].insns {
                 self.validate_insn_type(insn_id)?;
             }
         }
@@ -7987,9 +8003,9 @@ impl<'a> std::fmt::Display for FunctionPrinter<'a> {
                 continue;
             }
             write!(f, "{block_id}(")?;
-            if !fun.blocks[block_id.to_usize()].params.is_empty() {
+            if !fun.blocks[block_id].params.is_empty() {
                 let mut sep = "";
-                for param in &fun.blocks[block_id.to_usize()].params {
+                for param in &fun.blocks[block_id].params {
                     write!(f, "{sep}{param}")?;
                     let insn_type = fun.type_of(*param);
                     if !insn_type.is_subtype(types::Empty) {
@@ -7999,7 +8015,7 @@ impl<'a> std::fmt::Display for FunctionPrinter<'a> {
                 }
             }
             writeln!(f, "):")?;
-            for insn_id in &fun.blocks[block_id.to_usize()].insns {
+            for insn_id in &fun.blocks[block_id].insns {
                 let insn = fun.find(*insn_id);
                 if !self.display_snapshot_and_tp_patchpoints &&
                     matches!(insn, Insn::Snapshot {..} | Insn::PatchPoint { invariant: Invariant::NoTracePoint, .. }) {
@@ -10741,13 +10757,13 @@ impl Dominators {
         // Map BlockId -> RPO index for O(1) lookup in intersect.
         let mut rpo_order = vec![usize::MAX; num_blocks];
         for (idx, &block) in rpo.iter().enumerate() {
-            rpo_order[block.to_usize()] = idx;
+            rpo_order[block] = idx;
         }
 
         // Initialize idom: root's idom is itself, everything else is undefined.
         let mut idoms = vec![IDOM_NONE; num_blocks];
         let root = f.entries_block;
-        idoms[root.to_usize()] = root;
+        idoms[root] = root;
 
         let mut changed = true;
         while changed {
@@ -10759,7 +10775,7 @@ impl Dominators {
                 let preds = cfi.predecessors(block);
                 let mut new_idom = IDOM_NONE;
                 for &p in preds {
-                    if idoms[p.to_usize()] != IDOM_NONE {
+                    if idoms[p] != IDOM_NONE {
                         new_idom = p;
                         break;
                     }
@@ -10769,13 +10785,13 @@ impl Dominators {
                 // Intersect with remaining processed predecessors.
                 for &p in preds {
                     if p == new_idom { continue; }
-                    if idoms[p.to_usize()] != IDOM_NONE {
+                    if idoms[p] != IDOM_NONE {
                         new_idom = Self::intersect(&idoms, &rpo_order, p, new_idom);
                     }
                 }
 
-                if idoms[block.to_usize()] != new_idom {
-                    idoms[block.to_usize()] = new_idom;
+                if idoms[block] != new_idom {
+                    idoms[block] = new_idom;
                     changed = true;
                 }
             }
@@ -10788,11 +10804,11 @@ impl Dominators {
     /// Uses RPO indices: a node with a *lower* RPO index is *higher* in the tree.
     fn intersect(idoms: &[BlockId], rpo_order: &[usize], mut b1: BlockId, mut b2: BlockId) -> BlockId {
         while b1 != b2 {
-            while rpo_order[b1.to_usize()] > rpo_order[b2.to_usize()] {
-                b1 = idoms[b1.to_usize()];
+            while rpo_order[b1] > rpo_order[b2] {
+                b1 = idoms[b1];
             }
-            while rpo_order[b2.to_usize()] > rpo_order[b1.to_usize()] {
-                b2 = idoms[b2.to_usize()];
+            while rpo_order[b2] > rpo_order[b1] {
+                b2 = idoms[b2];
             }
         }
         b1
@@ -10800,7 +10816,7 @@ impl Dominators {
 
     /// Return the immediate dominator of `block`.
     pub fn idom(&self, block: BlockId) -> BlockId {
-        self.idoms[block.to_usize()]
+        self.idoms[block]
     }
 
     /// Return true if `left` is dominated by `right`.

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -49,15 +49,9 @@ use crate::options::INLINE_BUDGET_UNLIMITED;
 #[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug)]
 pub struct InsnId(pub u32);
 
-impl IntoUsize for InsnId {
-    fn to_usize(self) -> usize {
-        self.0.to_usize()
-    }
-}
-
 impl From<InsnId> for usize {
     fn from(val: InsnId) -> Self {
-        val.to_usize()
+        val.0.to_usize()
     }
 }
 
@@ -65,6 +59,28 @@ impl From<usize> for InsnId {
     fn from(val: usize) -> Self {
         InsnId(val.try_into().expect("InsnId should fit in u32"))
     }
+}
+
+impl<T> std::ops::Index<InsnId> for [T] {
+    type Output = T;
+    #[inline]
+    fn index(&self, i: InsnId) -> &T { &self[usize::from(i)] }
+}
+
+impl<T> std::ops::IndexMut<InsnId> for [T] {
+    #[inline]
+    fn index_mut(&mut self, i: InsnId) -> &mut T { &mut self[usize::from(i)] }
+}
+
+impl<T> std::ops::Index<InsnId> for Vec<T> {
+    type Output = T;
+    #[inline]
+    fn index(&self, i: InsnId) -> &T { &self[usize::from(i)] }
+}
+
+impl<T> std::ops::IndexMut<InsnId> for Vec<T> {
+    #[inline]
+    fn index_mut(&mut self, i: InsnId) -> &mut T { &mut self[usize::from(i)] }
 }
 
 impl std::fmt::Display for InsnId {
@@ -2755,14 +2771,14 @@ impl ResolvedInsnId {
     /// union-find). Assumes the operands are resolved through union-find already. Use
     /// [`Function::resolve`] to resolve operands before calling this.
     pub fn insn_mut(self, fun: &mut Function) -> &mut Insn {
-        &mut fun.insns[self.0.to_usize()]
+        &mut fun.insns[self.0]
     }
 
     /// Return a reference to the instruction at `insn_id` (after resolving via union-find).
     /// Assumes the operands are resolved through union-find already. Use [`Function::resolve`] to
     /// resolve operands before calling this.
     pub fn insn(self, fun: &Function) -> &Insn {
-        &fun.insns[self.0.to_usize()]
+        &fun.insns[self.0]
     }
 }
 
@@ -3228,7 +3244,7 @@ impl Function {
     /// and locals, the way [`Function::frame_state`] does.
     fn frame_depth(&self, insn_id: InsnId) -> InlineDepth {
         let insn_id = self.union_find.borrow().find_const(insn_id);
-        match &self.insns[insn_id.to_usize()] {
+        match &self.insns[insn_id] {
             Insn::Snapshot { state } => state.depth,
             insn => panic!("Unexpected non-Snapshot {insn} when looking up frame depth"),
         }
@@ -3265,7 +3281,7 @@ impl Function {
         // produces no value, and `make_equal_to` asserts `has_output()`. So the instruction stored
         // at this id is always the terminator itself, and reading it by reference matches what
         // `find` would return.
-        let terminator = &self.insns[self.blocks[block.to_usize()].insns.last().unwrap().to_usize()];
+        let terminator = &self.insns[*self.blocks[block.to_usize()].insns.last().unwrap()];
 
         let (first, second, rest): (Option<BlockId>, Option<BlockId>, &[BlockId]) = match terminator {
             Insn::CondBranch { if_true, if_false, .. } => (Some(if_true.target), Some(if_false.target), &[]),
@@ -3399,7 +3415,7 @@ impl Function {
             };
         }
         let insn_id = find!(insn_id);
-        let mut result = self.insns[insn_id.to_usize()].clone();
+        let mut result = self.insns[insn_id].clone();
         result.for_each_operand_mut(&mut |operand: &mut InsnId| {
             *operand = find!(*operand);
         });
@@ -3411,7 +3427,7 @@ impl Function {
     /// to have been resolved first, so the returned instruction's operands may be stale. Use it
     /// when the caller only inspects the opcode, or resolves the operands itself.
     pub fn find_ref(&self, insn_id: InsnId) -> &Insn {
-        &self.insns[self.find_id(insn_id).to_usize()]
+        &self.insns[self.find_id(insn_id)]
     }
 
     /// Make the operands of the instruction at `find(insn_id)` point to the current representative
@@ -3427,7 +3443,7 @@ impl Function {
     pub fn resolve(&mut self, insn_id: InsnId) -> ResolvedInsnId {
         let union_find = self.union_find.borrow();
         let insn_id = union_find.find_const(insn_id);
-        self.insns[insn_id.to_usize()].for_each_operand_mut(&mut |operand: &mut InsnId| {
+        self.insns[insn_id].for_each_operand_mut(&mut |operand: &mut InsnId| {
             *operand = union_find.find_const(*operand);
         });
         ResolvedInsnId(insn_id)
@@ -3438,7 +3454,7 @@ impl Function {
         use Insn::*;
         // Always set the reason: convert_no_profile_sends depends on it to identify
         // sends that should be converted to side exits for exit-based recompilation.
-        match self.insns.get_mut(insn_id.to_usize()).unwrap() {
+        match &mut self.insns[insn_id] {
             Send { reason, .. }
             | SendForward { reason, .. }
             | InvokeSuper { reason, .. }
@@ -3451,17 +3467,17 @@ impl Function {
 
     /// Replace `insn` with the new instruction `replacement`, which will get appended to `insns`.
     fn make_equal_to(&mut self, insn: InsnId, replacement: InsnId) {
-        assert!(self.insns[insn.to_usize()].has_output(),
+        assert!(self.insns[insn].has_output(),
                 "Don't use make_equal_to for instruction with no output");
-        assert!(self.insns[replacement.to_usize()].has_output(),
+        assert!(self.insns[replacement].has_output(),
                 "Can't replace instruction that has output with instruction that has no output");
         // Don't push it to the block
         self.union_find.borrow_mut().make_equal_to(insn, replacement);
     }
 
     pub fn type_of(&self, insn: InsnId) -> Type {
-        assert!(self.insns[insn.to_usize()].has_output());
-        self.insn_types[self.union_find.borrow_mut().find(insn).to_usize()]
+        assert!(self.insns[insn].has_output());
+        self.insn_types[self.union_find.borrow_mut().find(insn)]
     }
 
     /// Check if the type of `insn` is a subtype of `ty`.
@@ -3470,8 +3486,8 @@ impl Function {
     }
 
     fn infer_type(&self, insn: InsnId) -> Type {
-        assert!(self.insns[insn.to_usize()].has_output());
-        match &self.insns[insn.to_usize()] {
+        assert!(self.insns[insn].has_output());
+        match &self.insns[insn] {
             Insn::Param => unimplemented!("params should not be present in block.insns"),
             Insn::LoadArg { val_type, .. } => *val_type,
             Insn::SetGlobal { .. } | Insn::Jump(_) | Insn::Entries { .. } | Insn::EntryPoint { .. }
@@ -3483,7 +3499,7 @@ impl Function {
             | Insn::CheckInterrupts { .. } | Insn::BreakPoint | Insn::Unreachable
             | Insn::StoreField { .. } | Insn::WriteBarrier { .. } | Insn::HashAset { .. } | Insn::ArrayAset { .. }
             | Insn::PushInlineFrame { .. } | Insn::PopInlineFrame { .. } =>
-                panic!("Cannot infer type of instruction with no output: {}. See Insn::has_output().", self.insns[insn.to_usize()]),
+                panic!("Cannot infer type of instruction with no output: {}. See Insn::has_output().", self.insns[insn]),
             Insn::Const { val: Const::Value(val) } => Type::from_value(*val),
             Insn::Const { val: Const::CBool(val) } => Type::from_cbool(*val),
             Insn::Const { val: Const::CInt8(val) } => Type::from_cint(types::CInt8, *val as i64),
@@ -3647,7 +3663,7 @@ impl Function {
             );
             for (param, param_type) in std::iter::zip(entry_params, param_types) {
                 // We know that function parameters are BasicObject or some subclass
-                self.insn_types[param.to_usize()] = *param_type;
+                self.insn_types[*param] = *param_type;
             }
         }
     }
@@ -3668,11 +3684,11 @@ impl Function {
             ($insn:expr, $new_type:expr) => {{
                 let insn = $insn;
                 let new_type = $new_type;
-                let old_type = self.insn_types[self.union_find.borrow_mut().find(insn).to_usize()];
+                let old_type = self.insn_types[self.union_find.borrow_mut().find(insn)];
                 if old_type.bit_equal(new_type) {
                     false
                 } else {
-                    self.insn_types[insn.to_usize()] = new_type;
+                    self.insn_types[insn] = new_type;
                     true
                 }
             }};
@@ -3711,12 +3727,12 @@ impl Function {
                 if !reachable.get(block) { continue; }
                 for i in 0..self.blocks[block.to_usize()].insns.len() {
                     let insn_id = self.blocks[block.to_usize()].insns[i];
-                    if self.insns[insn_id.to_usize()].counts_against_inlining_budget() {
+                    if self.insns[insn_id].counts_against_inlining_budget() {
                         num_instructions += 1;
                     }
                     // Instructions without output, including branch instructions, can't be targets
                     // of make_equal_to, so we don't need find() here.
-                    let insn_type = match &self.insns[insn_id.to_usize()] {
+                    let insn_type = match &self.insns[insn_id] {
                         Insn::CondBranch { val, if_true, if_false } => {
                             assert!(!self.type_of(*val).bit_equal(types::Empty));
                             if self.type_of(*val).could_be(Type::from_cbool(true)) {
@@ -3773,7 +3789,7 @@ impl Function {
 
     fn chase_insn(&self, insn: InsnId) -> InsnId {
         let id = self.union_find.borrow().find_const(insn);
-        match self.insns[id.to_usize()] {
+        match self.insns[id] {
             Insn::GuardType { val, .. }
             | Insn::GuardBitEquals { val, .. }
             | Insn::GuardAnyBitSet { val, .. }
@@ -4207,7 +4223,7 @@ impl Function {
 
     pub fn guard_type_recompile(&mut self, block: BlockId, val: InsnId, guard_type: Type, state: InsnId, recompile: Recompile) -> InsnId {
         let result = self.push_insn(block, Insn::GuardType { val, guard_type, state, recompile: Some(recompile) });
-        self.insn_types[result.to_usize()] = self.infer_type(result);
+        self.insn_types[result] = self.infer_type(result);
         result
     }
 
@@ -4380,7 +4396,7 @@ impl Function {
             self.count(block, Counter::inline_cfunc_optimized_send_count);
             if self.type_of(replacement).bit_equal(types::Any) {
                 // Not set yet; infer type
-                self.insn_types[replacement.to_usize()] = self.infer_type(replacement);
+                self.insn_types[replacement] = self.infer_type(replacement);
             }
             self.remove_block(tmp_block);
             return replacement;
@@ -4593,7 +4609,7 @@ impl Function {
                             // Add GuardType for profiled receiver
                             if let Some(profiled_type) = profiled_type {
                                 recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: Some(Recompile) });
-                                self.insn_types[recv.to_usize()] = self.infer_type(recv);
+                                self.insn_types[recv] = self.infer_type(recv);
                             }
 
                             let SendDirectArgs { state: send_state, args: send_args, kw_bits, jit_entry_idx } =
@@ -4883,7 +4899,7 @@ impl Function {
                                                 fun.make_equal_to(send_insn_id, replacement);
                                                 if fun.type_of(replacement).bit_equal(types::Any) {
                                                     // Not set yet; infer type
-                                                    fun.insn_types[replacement.to_usize()] = fun.infer_type(replacement);
+                                                    fun.insn_types[replacement] = fun.infer_type(replacement);
                                                 }
                                                 fun.remove_block(tmp_block);
                                                 return Ok(());
@@ -4894,7 +4910,7 @@ impl Function {
                                                 fun.count(block, Counter::inline_cfunc_optimized_send_count);
                                                 let owner = unsafe { (*cme).owner };
                                                 let ccall = fun.push_insn(block, Insn::CCall { cfunc: cfunc_ptr, recv, args, name, owner, return_type, elidable });
-                                                fun.insn_types[ccall.to_usize()] = fun.infer_type(ccall);
+                                                fun.insn_types[ccall] = fun.infer_type(ccall);
                                                 fun.make_equal_to(send_insn_id, ccall);
                                                 return Ok(());
                                             }
@@ -4916,7 +4932,7 @@ impl Function {
                                             elidable,
                                             block: blockiseq.map(BlockHandler::BlockIseq),
                                         })));
-                                        fun.insn_types[ccall.to_usize()] = fun.infer_type(ccall);
+                                        fun.insn_types[ccall] = fun.infer_type(ccall);
                                         fun.make_equal_to(send_insn_id, ccall);
                                         Ok(())
                                     }
@@ -4950,7 +4966,7 @@ impl Function {
                                                 fun.make_equal_to(send_insn_id, replacement);
                                                 if fun.type_of(replacement).bit_equal(types::Any) {
                                                     // Not set yet; infer type
-                                                    fun.insn_types[replacement.to_usize()] = fun.infer_type(replacement);
+                                                    fun.insn_types[replacement] = fun.infer_type(replacement);
                                                 }
                                                 fun.remove_block(tmp_block);
                                                 return Ok(());
@@ -4961,7 +4977,7 @@ impl Function {
                                                 fun.count(block, Counter::inline_cfunc_optimized_send_count);
                                                 let owner = unsafe { (*cme).owner };
                                                 let ccall = fun.push_insn(block, Insn::CCall { cfunc: cfunc_ptr, recv, args, name, owner, return_type, elidable });
-                                                fun.insn_types[ccall.to_usize()] = fun.infer_type(ccall);
+                                                fun.insn_types[ccall] = fun.infer_type(ccall);
                                                 fun.make_equal_to(send_insn_id, ccall);
                                                 return Ok(());
                                             }
@@ -4983,7 +4999,7 @@ impl Function {
                                             elidable,
                                             block: blockiseq.map(BlockHandler::BlockIseq),
                                         })));
-                                        fun.insn_types[ccall.to_usize()] = fun.infer_type(ccall);
+                                        fun.insn_types[ccall] = fun.infer_type(ccall);
                                         fun.make_equal_to(send_insn_id, ccall);
                                         Ok(())
                                     }
@@ -5014,12 +5030,12 @@ impl Function {
                         let method = unsafe { rb_vm_ci_mid((*cd).ci) };
                         self.push_insn(block, Insn::PatchPoint { invariant: Invariant::MethodRedefined { klass: class, method, cme }, state });
                         let replacement = self.push_insn(block, Insn::Const { val: Const::CBool(is_expected_cfunc) });
-                        self.insn_types[replacement.to_usize()] = self.infer_type(replacement);
+                        self.insn_types[replacement] = self.infer_type(replacement);
                         self.make_equal_to(insn_id, replacement);
                     }
                     &Insn::ObjectAlloc { val, state } => {
                         if let Some(replacement) = self.try_inline_object_alloc(block, val, state) {
-                            self.insn_types[replacement.to_usize()] = self.infer_type(replacement);
+                            self.insn_types[replacement] = self.infer_type(replacement);
                             self.make_equal_to(insn_id, replacement);
                         } else {
                             self.push_insn_id(block, insn_id);
@@ -5034,7 +5050,7 @@ impl Function {
                             let high_fix = self.coerce_to(block, high, types::Fixnum, state);
                             let replacement = self.push_insn(block, Insn::NewRangeFixnum { low: low_fix, high: high_fix, flag, state });
                             self.make_equal_to(insn_id, replacement);
-                            self.insn_types[replacement.to_usize()] = self.infer_type(replacement);
+                            self.insn_types[replacement] = self.infer_type(replacement);
                         } else {
                             self.push_insn_id(block, insn_id);
                         };
@@ -5232,7 +5248,7 @@ impl Function {
                                         self.make_equal_to(insn_id, replacement);
                                         if self.type_of(replacement).bit_equal(types::Any) {
                                             // Not set yet; infer type
-                                            self.insn_types[replacement.to_usize()] = self.infer_type(replacement);
+                                            self.insn_types[replacement] = self.infer_type(replacement);
                                         }
                                         self.remove_block(tmp_block);
                                         continue;
@@ -5282,7 +5298,7 @@ impl Function {
                                         self.make_equal_to(insn_id, replacement);
                                         if self.type_of(replacement).bit_equal(types::Any) {
                                             // Not set yet; infer type
-                                            self.insn_types[replacement.to_usize()] = self.infer_type(replacement);
+                                            self.insn_types[replacement] = self.infer_type(replacement);
                                         }
                                         self.remove_block(tmp_block);
                                         continue;
@@ -6122,12 +6138,12 @@ impl Function {
 
         fn outgoing_edges(fun: &Function, block_id: BlockId) -> impl Iterator<Item = &BranchEdge> {
             let insn_id = block_terminator(fun, block_id);
-            edges_of!(&fun.insns[insn_id.to_usize()])
+            edges_of!(&fun.insns[insn_id])
         }
 
         fn outgoing_edges_mut(fun: &mut Function, block_id: BlockId) -> impl Iterator<Item = &mut BranchEdge> {
             let insn_id = block_terminator(fun, block_id);
-            edges_of!(&mut fun.insns[insn_id.to_usize()])
+            edges_of!(&mut fun.insns[insn_id])
         }
 
         // Instantiate the domain for abstract interpretation.
@@ -6332,14 +6348,14 @@ impl Function {
                 let canonical_id = self.union_find.borrow().find_const(insn_id);
 
                 let union_find = &self.union_find;
-                self.insns[canonical_id.to_usize()].for_each_operand_mut(|operand| {
+                self.insns[canonical_id].for_each_operand_mut(|operand| {
                     let canon = union_find.borrow().find_const(*operand);
                     *operand = rewrite_map.get(&canon).copied().unwrap_or(canon);
                 });
 
                 // For the binary guards only `left` is registered because their infer_type is
                 // type_of(left).
-                match &self.insns[canonical_id.to_usize()] {
+                match &self.insns[canonical_id] {
                     Insn::GuardType      { val:  src, .. }
                     | Insn::GuardBitEquals { val:  src, .. }
                     | Insn::GuardAnyBitSet { val:  src, .. }
@@ -6541,11 +6557,11 @@ impl Function {
                             // quotient towards negative infinity, so this holds for all fixnums.
                             (None, Some(d)) if is_power_of_two(d) => {
                                 let shift = self.new_insn(Insn::Const { val: Const::Value(VALUE::fixnum_from_isize(d.trailing_zeros() as isize)) });
-                                self.insn_types[shift.to_usize()] = self.infer_type(shift);
+                                self.insn_types[shift] = self.infer_type(shift);
                                 new_insns.push(shift);
                                 let replacement = self.new_insn(Insn::FixnumRShift { left, right: shift });
                                 self.make_equal_to(insn_id, replacement);
-                                self.insn_types[replacement.to_usize()] = self.infer_type(replacement);
+                                self.insn_types[replacement] = self.infer_type(replacement);
                                 new_insns.push(replacement);
                                 continue;
                             }
@@ -6569,11 +6585,11 @@ impl Function {
                             // in [0, d), which matches two's complement AND for all fixnums.
                             (None, Some(d)) if is_power_of_two(d) => {
                                 let mask = self.new_insn(Insn::Const { val: Const::Value(VALUE::fixnum_from_isize((d - 1) as isize)) });
-                                self.insn_types[mask.to_usize()] = self.infer_type(mask);
+                                self.insn_types[mask] = self.infer_type(mask);
                                 new_insns.push(mask);
                                 let replacement = self.new_insn(Insn::FixnumAnd { left, right: mask });
                                 self.make_equal_to(insn_id, replacement);
-                                self.insn_types[replacement.to_usize()] = self.infer_type(replacement);
+                                self.insn_types[replacement] = self.infer_type(replacement);
                                 new_insns.push(replacement);
                                 continue;
                             }
@@ -6688,14 +6704,14 @@ impl Function {
                 };
                 // If we're adding a new instruction, mark the two equivalent in the union-find and
                 // do an incremental flow typing of the new instruction.
-                if insn_id != replacement_id && self.insns[replacement_id.to_usize()].has_output() {
+                if insn_id != replacement_id && self.insns[replacement_id].has_output() {
                     self.make_equal_to(insn_id, replacement_id);
-                    self.insn_types[replacement_id.to_usize()] = self.infer_type(replacement_id);
+                    self.insn_types[replacement_id] = self.infer_type(replacement_id);
                 }
                 new_insns.push(replacement_id);
                 // If we've just folded an IfTrue into a Jump, for example, don't bother copying
                 // over unreachable instructions afterward.
-                if self.insns[replacement_id.to_usize()].is_terminator() {
+                if self.insns[replacement_id].is_terminator() {
                     break;
                 }
             }
@@ -6712,7 +6728,7 @@ impl Function {
         // otherwise necessary to keep around
         for block_id in &rpo {
             for insn_id in &self.blocks[block_id.to_usize()].insns {
-                if !&self.insns[insn_id.to_usize()].is_elidable() {
+                if !&self.insns[*insn_id].is_elidable() {
                     worklist.push_back(*insn_id);
                 }
             }
@@ -6723,7 +6739,7 @@ impl Function {
             if necessary.get(insn_id) { continue; }
             necessary.insert(insn_id);
             let insn_id = self.union_find.borrow().find_const(insn_id);
-            self.insns[insn_id.to_usize()].for_each_operand(|operand| {
+            self.insns[insn_id].for_each_operand(|operand| {
                 worklist.push_back(self.union_find.borrow().find_const(operand));
             });
         }
@@ -6831,7 +6847,7 @@ impl Function {
             let insns = std::mem::take(&mut self.blocks[block_id.to_usize()].insns);
             let mut new_insns = Vec::with_capacity(insns.len());
             for insn_id in insns {
-                let insn = &self.insns[insn_id.to_usize()];
+                let insn = &self.insns[insn_id];
                 if matches!(insn, Insn::CheckInterrupts { .. }) {
                     if seen { continue; }
                     seen = true;
@@ -6872,7 +6888,7 @@ impl Function {
         let mut references_snapshot = false;
         insn.for_each_operand(|opnd| {
             let opnd = self.union_find.borrow().find_const(opnd);
-            if matches!(&self.insns[opnd.to_usize()], Insn::Snapshot { .. }) {
+            if matches!(&self.insns[opnd], Insn::Snapshot { .. }) {
                 references_snapshot = true;
             }
         });
@@ -7397,14 +7413,14 @@ impl Function {
             }
             for &insn_id in &self.blocks[block.to_usize()].insns {
                 let insn_id = self.union_find.borrow().find_const(insn_id);
-                self.insns[insn_id.to_usize()].try_for_each_operand(|operand| {
+                self.insns[insn_id].try_for_each_operand(|operand| {
                     let operand = self.union_find.borrow().find_const(operand);
                     if !assigned.get(operand) {
                         return Err(ValidationError::OperandNotDefined(block, insn_id, operand));
                     }
                     Ok(())
                 })?;
-                if self.insns[insn_id.to_usize()].has_output() {
+                if self.insns[insn_id].has_output() {
                     assigned.insert(insn_id);
                 }
             }
@@ -9142,7 +9158,7 @@ fn add_iseq_to_hir(
                                 let zjit_module = VALUE(state::ZJIT_MODULE.load(Ordering::Relaxed));
                                 let lookedup_module = rb_const_lookup(rb_cRubyVM, ID!(ZJIT));
                                 if !lookedup_module.is_null() && (*lookedup_module).value == zjit_module {
-                                    fun.insn_types[result.to_usize()] = Type::from_value(zjit_module);
+                                    fun.insn_types[result] = Type::from_value(zjit_module);
                                 }
                             }
                         }

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -2761,7 +2761,7 @@ mod hir_opt_tests {
 
         function.eliminate_dead_code();
 
-        let insns = &function.blocks[block.to_usize()].insns;
+        let insns = &function.blocks[block].insns;
         assert!(insns.contains(&comment));
         assert!(!insns.contains(&dead_const));
     }


### PR DESCRIPTION
This PR implements `std::ops::{Index,IndexMut}` for `BlockId` and `InsnId` so we don't need to explicitly call `IntoUsize::to_usize` whenever we want to index into a slice or a `Vec`.  We applied a similar clean-up for `VRegId` in #17580. I think this makes the HIR code easier to read.