### PR TITLE
Remove IO::Buffer experimental warning

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -57,6 +57,8 @@ Note: We're only listing outstanding class updates.
 
 * IO::Buffer
 
+    * IO::Buffer and its C interface are no longer experimental.
+
     * `read`, `write`, `pread`, and `pwrite` now perform one IO operation using
       `(offset, length)`, where `length` is the maximum transfer size. Short
       transfers are returned directly.

--- a/doc/language/options.md
+++ b/doc/language/options.md
@@ -540,12 +540,7 @@ Warning[:deprecated]   = true
 Warning[:performance]  = true
 ```
 
-You can suppress a category by prefixing `no-` to the category name:
-
-```console
-$ ruby -W:no-experimental -e 'p IO::Buffer.new'
-#<IO::Buffer>
-```
+You can suppress a category by prefixing `no-` to the category name.
 
 ### `-x`: Execute Ruby Code Found in Text
 

--- a/include/ruby/io/buffer.h
+++ b/include/ruby/io/buffer.h
@@ -18,9 +18,6 @@
 
 RBIMPL_SYMBOL_EXPORT_BEGIN()
 
-// WARNING: This entire interface is experimental and may change in the future!
-#define RB_IO_BUFFER_EXPERIMENTAL 1
-
 // Version 3: IO operations use single-transfer `(offset, length)` semantics.
 #define RUBY_IO_BUFFER_VERSION 3
 

--- a/io_buffer.c
+++ b/io_buffer.c
@@ -176,22 +176,6 @@ io_buffer_map_file(struct rb_io_buffer *buffer, int descriptor, size_t size, rb_
 }
 
 static void
-io_buffer_experimental(void)
-{
-    static int warned = 0;
-
-    if (warned) return;
-
-    warned = 1;
-
-    if (rb_warning_category_enabled_p(RB_WARN_CATEGORY_EXPERIMENTAL)) {
-        rb_category_warn(RB_WARN_CATEGORY_EXPERIMENTAL,
-          "IO::Buffer is experimental and both the Ruby and C interface may change in the future!"
-        );
-    }
-}
-
-static void
 io_buffer_zero(struct rb_io_buffer *buffer)
 {
     buffer->base = NULL;
@@ -508,8 +492,6 @@ io_buffer_extract_offset_length(VALUE self, int argc, VALUE argv[], size_t *offs
 VALUE
 rb_io_buffer_type_allocate(VALUE self)
 {
-    io_buffer_experimental();
-
     struct rb_io_buffer *buffer = NULL;
     VALUE instance = TypedData_Make_Struct(self, struct rb_io_buffer, &rb_io_buffer_type, buffer);
 
@@ -4411,10 +4393,6 @@ static const rb_memory_view_entry_t io_buffer_memory_view_entry = {
  *    # => 3 -- bytes written
  *    File.read('test.txt')
  *    # => "t--- data"
- *
- *  <b>The class is experimental and the interface is subject to change, this
- *  is especially true of file mappings which may be removed entirely in
- *  the future.</b>
  */
 void
 Init_IO_Buffer(void)

--- a/test/ruby/test_io_buffer.rb
+++ b/test/ruby/test_io_buffer.rb
@@ -7,14 +7,6 @@ require '-test-/io_buffer'
 require "-test-/memory_view"
 
 class TestIOBuffer < Test::Unit::TestCase
-  experimental = Warning[:experimental]
-  begin
-    Warning[:experimental] = false
-    IO::Buffer.new(0)
-  ensure
-    Warning[:experimental] = experimental
-  end
-
   def assert_negative(value)
     assert(value < 0, "Expected #{value} to be negative!")
   end
@@ -25,6 +17,12 @@ class TestIOBuffer < Test::Unit::TestCase
 
   def test_version
     assert_equal 3, IO::Buffer::VERSION
+  end
+
+  def test_not_experimental
+    assert_warning("") do
+      IO::Buffer.new(0)
+    end
   end
 
   def test_flags


### PR DESCRIPTION
IO::Buffer has had several releases of real-world use, and Ruby 4.1 now has cohesive lifecycle, slicing, locking, mapping, and single-transfer I/O semantics.

This removes the remaining experimental status markers:

- remove the allocation-time experimental warning;
- remove the experimental warning from the class documentation;
- remove `RB_IO_BUFFER_EXPERIMENTAL` from the public C header;
- remove the test-suite warning suppression;
- remove the obsolete command-line documentation example; and
- note the stable status in NEWS.

The `RUBY_IO_BUFFER_VERSION` constant remains available for compile-time feature detection as the interface evolves.

Validation:

- `make test-all TESTS=../ruby-io-buffer-stable/test/ruby/test_io_buffer.rb`
- 147 tests, 1048 assertions, 0 failures, 0 errors.
- `make test-spec MSPECOPT=../ruby-io-buffer-stable/spec/ruby/core/io/buffer`
- 22 files, 220 examples, 435 expectations, 0 failures, 0 errors.

https://bugs.ruby-lang.org/issues/22274