### PR TITLE
Preserve IO::Buffer read-only state when resizing

### DIFF
--- a/io_buffer.c
+++ b/io_buffer.c
@@ -2003,7 +2003,8 @@ io_buffer_resize_copy(VALUE self, struct rb_io_buffer *buffer, size_t size)
 {
     // Slow path:
     struct rb_io_buffer resized;
-    io_buffer_initialize(self, &resized, NULL, size, io_flags_for_size(size), Qnil);
+    enum rb_io_buffer_flags flags = io_flags_for_size(size) | (buffer->flags & RB_IO_BUFFER_READONLY);
+    io_buffer_initialize(self, &resized, NULL, size, flags, Qnil);
 
     if (buffer->base) {
         size_t preserve = buffer->size;

--- a/spec/ruby/core/io/buffer/resize_spec.rb
+++ b/spec/ruby/core/io/buffer/resize_spec.rb
@@ -115,6 +115,14 @@ describe "IO::Buffer#resize" do
     @buffer.size.should == 1
   end
 
+  it "preserves read-only access when the allocation is replaced" do
+    @buffer = IO::Buffer.new(IO::Buffer::PAGE_SIZE, IO::Buffer::MAPPED | IO::Buffer::READONLY)
+    @buffer.resize(16)
+
+    @buffer.should.readonly?
+    -> { @buffer.set_string("test") }.should.raise(IO::Buffer::AccessError, "Buffer is not writable!")
+  end
+
   ruby_version_is "4.1" do
     it "raises FrozenError without resizing a frozen buffer" do
       buffer = IO::Buffer.new(4)


### PR DESCRIPTION
On platforms with `mremap`, resizing preserves the existing buffer flags as part of the allocation. The copy fallback instead initialized a fresh allocation using only size-derived flags, which dropped `IO::Buffer::READONLY` and could make a read-only buffer writable after resizing.

Preserve `READONLY` when the fallback replaces the allocation. Allocation strategy flags such as `MAPPED`, `SHARED`, and `PRIVATE` are intentionally not retained: `resize(size)` may change the allocation strategy, while a future flags argument could provide an explicit way to control that behavior.

The regression spec uses a mapped read-only buffer and shrinks it so macOS exercises the copy fallback.

Tests:

- `make -j4 test-all TESTS=../ruby-io-buffer-preserve-readonly-resize/test/ruby/test_io_buffer.rb`
- `make test-spec MSPECOPT=../ruby-io-buffer-preserve-readonly-resize/spec/ruby/core/io/buffer/resize_spec.rb`