### PR TITLE
Replace Array#flatten{,!} internal ident hash with set

### DIFF
--- a/array.c
+++ b/array.c
@@ -6752,6 +6752,8 @@ rb_ary_count(int argc, VALUE *argv, VALUE ary)
     return LONG2NUM(n);
 }
 
+VALUE rb_ident_set_new(void);
+
 static VALUE
 flatten(VALUE ary, int level)
 {
@@ -6779,9 +6781,9 @@ flatten(VALUE ary, int level)
     rb_ary_push(stack, LONG2NUM(i + 1));
 
     if (level < 0) {
-        memo = rb_obj_hide(rb_ident_hash_new());
-        rb_hash_aset(memo, ary, Qtrue);
-        rb_hash_aset(memo, tmp, Qtrue);
+        memo = rb_obj_hide(rb_ident_set_new());
+        rb_set_add(memo, ary);
+        rb_set_add(memo, tmp);
     }
 
     ary = tmp;
@@ -6797,7 +6799,7 @@ flatten(VALUE ary, int level)
             tmp = rb_check_array_type(elt);
             if (RBASIC(result)->klass) {
                 if (RTEST(memo)) {
-                    rb_hash_clear(memo);
+                    rb_set_clear(memo);
                 }
                 rb_raise(rb_eRuntimeError, "flatten reentered");
             }
@@ -6806,11 +6808,11 @@ flatten(VALUE ary, int level)
             }
             else {
                 if (memo) {
-                    if (rb_hash_aref(memo, tmp) == Qtrue) {
-                        rb_hash_clear(memo);
+                    if (rb_set_lookup(memo, tmp)) {
+                        rb_set_clear(memo);
                         rb_raise(rb_eArgError, "tried to flatten recursive array");
                     }
-                    rb_hash_aset(memo, tmp, Qtrue);
+                    rb_set_add(memo, tmp);
                 }
                 rb_ary_push(stack, ary);
                 rb_ary_push(stack, LONG2NUM(i));
@@ -6822,7 +6824,7 @@ flatten(VALUE ary, int level)
             break;
         }
         if (memo) {
-            rb_hash_delete(memo, ary);
+            rb_set_delete(memo, ary);
         }
         tmp = rb_ary_pop(stack);
         i = NUM2LONG(tmp);
@@ -6830,7 +6832,7 @@ flatten(VALUE ary, int level)
     }
 
     if (memo) {
-        rb_hash_clear(memo);
+        rb_set_clear(memo);
     }
 
     RBASIC_SET_CLASS(result, rb_cArray);

--- a/set.c
+++ b/set.c
@@ -395,17 +395,22 @@ set_insert_wb(VALUE set, VALUE key)
 }
 
 static VALUE
-set_alloc_with_size(VALUE klass, st_index_t size)
+set_alloc_with_size_and_type(VALUE klass, st_index_t size, const struct st_hash_type *type)
 {
     VALUE set;
     struct set_object *sobj;
 
     set = TypedData_Make_Struct(klass, struct set_object, &set_data_type, sobj);
-    set_init_table_with_size(&sobj->table, &objhash, size);
+    set_init_table_with_size(&sobj->table, type, size);
 
     return set;
 }
 
+static VALUE
+set_alloc_with_size(VALUE klass, st_index_t size)
+{
+    return set_alloc_with_size_and_type(klass, size, &objhash);
+}
 
 static VALUE
 set_s_alloc(VALUE klass)
@@ -2262,6 +2267,14 @@ static VALUE
 compat_loader(VALUE self, VALUE a)
 {
     return set_i_from_hash(self, rb_ivar_get(a, id_i_hash));
+}
+
+/* Internal C-API functions */
+
+VALUE
+rb_ident_set_new(void)
+{
+    return set_alloc_with_size_and_type(rb_cSet, 0, &identhash);
 }
 
 /* C-API functions */


### PR DESCRIPTION
Should reduce memory usage when flattening an array with a large number of nested elements.