### PR TITLE
Update rbs to 4.2.0

### DIFF
--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -16,8 +16,8 @@ net-imap            0.6.6   https://github.com/ruby/net-imap
 net-smtp            0.5.1   https://github.com/ruby/net-smtp
 matrix              0.4.3   https://github.com/ruby/matrix
 prime               0.1.4   https://github.com/ruby/prime
-rbs                 4.0.3   https://github.com/ruby/rbs
-typeprof            0.32.0  https://github.com/ruby/typeprof
+rbs                 4.2.0   https://github.com/ruby/rbs
+typeprof            0.32.0  https://github.com/ruby/typeprof b950f910c6b6e4736988637f46a1ae256384c9f7
 debug               1.11.1  https://github.com/ruby/debug 6510cfbc7496c55ebbefa437a25c17ca58f7c5eb
 racc                1.8.1   https://github.com/ruby/racc
 mutex_m             0.3.0   https://github.com/ruby/mutex_m

--- a/tool/rbs_skip_tests
+++ b/tool/rbs_skip_tests
@@ -35,6 +35,7 @@ NetInstanceTest depending on external resources
 TestHTTPRequest depending on external resources
 TestSingletonNetHTTPResponse depending on external resources
 TestInstanceNetHTTPResponse depending on external resources
+test_URI_open(OpenURISingletonTest) depending on external resources
 
 test_TOPDIR(RbConfigSingletonTest) `TOPDIR` is `nil` during CI while RBS type is declared as `String`
 

--- a/tool/rbs_skip_tests
+++ b/tool/rbs_skip_tests
@@ -25,6 +25,7 @@ test_collection_install__mutex_m__config__stdlib_source(RBS::CliTest) running te
 test_collection_install__mutex_m__dependency_no_bundled(RBS::CliTest) running tests without Bundler
 test_collection_install__mutex_m__no_bundled(RBS::CliTest) running tests without Bundler
 test_collection_install__mutex_m__rbs_dependency_and__gem_dependency(RBS::CliTest) running tests without Bundler
+test_collection_install__nongem_stdlib_no_warning(RBS::CliTest) running tests without Bundler
 test_collection_install_frozen(RBS::CliTest) running tests without Bundler
 test_collection_install_gemspec(RBS::CliTest) running tests without Bundler
 test_collection_update(RBS::CliTest) running tests without Bundler

--- a/tool/rbs_skip_tests_windows
+++ b/tool/rbs_skip_tests_windows
@@ -17,6 +17,15 @@ test_confstr(EtcSingletonTest)
 # NameError: uninitialized constant Etc::SC_ARG_MAX
 test_sysconf(EtcSingletonTest)
 
+# NameError: uninitialized constant Etc::Group
+test_each(EtcGroupSingletonTest)
+
+# NameError: uninitialized constant Etc::PC_PIPE_BUF
+test_pathconf(IOInstanceTest)
+
+# `Etc::Passwd.each` returns the class itself instead of an Enumerator because getpwent() is unavailable
+test_each(EtcPasswdSingletonTest)
+
 # Errno::EACCES: Permission denied @ apply2files - C:/a/_temp/d20250813-10156-udw6rx/chmod
 test_chmod(FileInstanceTest)
 test_chmod(FileInstanceTest)
@@ -70,9 +79,6 @@ test_parse_config(OpenSSLConfigSingletonTest)
 test_each(OpenSSLConfigTest)
 test_lookup_and_set(OpenSSLConfigTest)
 test_sections(OpenSSLConfigTest)
-
-# OpenSSL::SSL::SSLError: SSL_connect returned=1 errno=0 peeraddr=185.199.108.153:443 state=error: certificate verify failed (unable to get local issuer certificate)
-test_URI_open(OpenURISingletonTest)
 
 # ArgumentError: both textmode and binmode specified
 test_binwrite(PathnameInstanceTest)

--- a/tool/update-bundled_gems.rb
+++ b/tool/update-bundled_gems.rb
@@ -5,7 +5,7 @@ BEGIN {
   # STDOUT is not usable in inplace edit mode
   output = $-i ? STDOUT : STDERR
   # Gems to skip auto-updating (e.g. when a new major version breaks CI)
-  pinned = %w[rbs]
+  pinned = %w[]
 }
 output = STDERR if ARGF.file == STDIN
 END {


### PR DESCRIPTION
The `bundled_gems` workflow has failed every day since 2026-08-16 because rbs 4.0.3's `test/stdlib/Ripper_test.rb` raises `uninitialized constant Ripper` on current master. ruby/rbs fixed that by requiring `ripper` in the stdlib tests, and the fix ships in 4.2.0.

typeprof 0.32.0 never finishes `TypeProf::Core::GlobalEnv#load_core_rbs` against rbs 4.2.0 and times out after 600 seconds in CI, so I pinned it to a typeprof master revision that has already moved to RBS 4.2. The new `test_collection_install__nongem_stdlib_no_warning` test is skipped because rbs's `bundle_install` helper runs whatever `bundle` comes first on `PATH`, which in ruby CI is setup-ruby's 3.1.7 loading the build tree's `rbconfig.rb`. A fix for that is in progress in ruby/rbs.

rbs has been pinned out of `tool/update-bundled_gems.rb` since March 2026, when the 4.0 series was breaking CI. With 4.2.0 green I removed the pin.

Closes #18384
