### PR TITLE
Fix memory leak in symbol_id_entry_directory

### DIFF
--- a/symbol.c
+++ b/symbol.c
@@ -235,6 +235,7 @@ id_entry_dir_free(void *ptr)
 {
     struct id_entry_dir *dir = ptr;
     SIZED_FREE_N(dir->entries, dir->capa);
+    xfree(dir);
 }
 
 static size_t


### PR DESCRIPTION
symbol_id_entry_directory is not an embedded TypedData, so we need to free the allocated id_entry_dir as well.