### PR TITLE
hash.c: memzero hashes before allocating st_table

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -1728,6 +1728,7 @@ hash_dup_capa(VALUE hash, size_t capa)
     VALUE ret = hash_alloc_capa(rb_cHash, capa);
     if (capa > RHASH_AR_TABLE_MAX_SIZE) {
         RHASH_SET_ST_FLAG(ret);
+        RHASH_ST_CLEAR(ret); // Ensure the hash can be marked.
     }
     else {
         RUBY_ASSERT(RHASH_AR_TABLE_MAX_BOUND(ret) >= capa);


### PR DESCRIPTION
`hash_copy` will call `st_init_existing_table_with_size` which allocates and may trigger GC causing the current hash to be marked.

So we need to zero-out the `st_table` to avoid a segfault.

cc @yahonda 

NB: not including the repro as a test as it need 20+ seconds of GC stress to reproduce.