### PR TITLE
Introduce an improved allocator interface

### DIFF
--- a/array.c
+++ b/array.c
@@ -716,13 +716,6 @@ ary_alloc_heap(VALUE klass)
 }
 
 static VALUE
-empty_ary_alloc(VALUE klass)
-{
-    RUBY_DTRACE_CREATE_HOOK(ARRAY, 0);
-    return ary_alloc_embed(klass, 0);
-}
-
-static VALUE
 ary_new(VALUE klass, long capa)
 {
     RUBY_ASSERT(ruby_thread_has_gvl_p());
@@ -751,6 +744,23 @@ ary_new(VALUE klass, long capa)
     }
 
     return ary;
+}
+
+static VALUE
+empty_ary_alloc2(VALUE klass, VALUE src)
+{
+    RUBY_DTRACE_CREATE_HOOK(ARRAY, 0);
+    if (UNDEF_P(src)) {
+        return ary_alloc_embed(klass, 0);
+    }
+    RUBY_ASSERT(RB_TYPE_P(src, T_ARRAY));
+    return ary_new(klass, RARRAY_LEN(src));
+}
+
+static VALUE
+empty_ary_alloc(VALUE klass)
+{
+    return empty_ary_alloc2(klass, Qundef);
 }
 
 VALUE
@@ -9034,7 +9044,7 @@ Init_Array(void)
     rb_cArray  = rb_define_class("Array", rb_cObject);
     rb_include_module(rb_cArray, rb_mEnumerable);
 
-    rb_define_alloc_func(rb_cArray, empty_ary_alloc);
+    rb_define_copy_alloc_func(rb_cArray, empty_ary_alloc2, empty_ary_alloc);
     rb_define_singleton_method(rb_cArray, "new", rb_ary_s_new, -1);
     rb_define_singleton_method(rb_cArray, "[]", rb_ary_s_create, -1);
     rb_define_singleton_method(rb_cArray, "try_convert", rb_ary_s_try_convert, 1);

--- a/class.c
+++ b/class.c
@@ -687,10 +687,9 @@ class_boot_boxable(VALUE super, bool boxable)
 
     class_associate_super(klass, super, true);
     if (super && !UNDEF_P(super)) {
-        RCLASS_SET_ALLOCATOR(klass, RCLASS_ALLOCATOR(super));
+        RCLASS_INHERIT_ALLOCATOR(klass, super);
         rb_class_set_initialized(klass);
     }
-
     return (VALUE)klass;
 }
 

--- a/hash.c
+++ b/hash.c
@@ -1603,11 +1603,22 @@ rb_hash_alloc_copy(VALUE klass, VALUE src)
 }
 
 static VALUE
-empty_hash_alloc(VALUE klass)
+empty_hash_alloc2(VALUE klass, VALUE src)
 {
     RUBY_DTRACE_CREATE_HOOK(HASH, 0);
 
-    return hash_alloc_capa(klass, 0);
+    if (UNDEF_P(src)) {
+        return hash_alloc_capa(klass, 0);
+    }
+
+    RUBY_ASSERT(RB_TYPE_P(src, T_HASH));
+    return hash_alloc_capa(klass, RHASH_SIZE(src));
+}
+
+static VALUE
+empty_hash_alloc(VALUE klass)
+{
+    return empty_hash_alloc2(klass, Qundef);
 }
 
 static VALUE
@@ -7686,7 +7697,7 @@ Init_Hash(void)
 
     rb_include_module(rb_cHash, rb_mEnumerable);
 
-    rb_define_alloc_func(rb_cHash, empty_hash_alloc);
+    rb_define_copy_alloc_func(rb_cHash, empty_hash_alloc2, empty_hash_alloc);
     rb_define_singleton_method(rb_cHash, "[]", rb_hash_s_create, -1);
     rb_define_singleton_method(rb_cHash, "try_convert", rb_hash_s_try_convert, 1);
     rb_define_method(rb_cHash, "initialize_copy", rb_hash_replace, 1);

--- a/internal/class.h
+++ b/internal/class.h
@@ -56,7 +56,17 @@ struct rb_classext_struct {
     const VALUE refined_class;
     union {
         struct {
+            /**
+             * Old-style allocator. The function receive the class of the object
+             * to allocate and returns a new object.
+             */
             rb_alloc_func_t allocator;
+            /**
+             * New-style allocator. The function the class of the object to allocate
+             * and an optional reference to the object that has to be duped or cloned.
+             * When not copying a previous object, the reference is set to `Qundef`.
+             */
+            rb_copy_alloc_func_t copy_allocator;
         } class;
         struct {
             VALUE attached_object;
@@ -600,7 +610,9 @@ static inline rb_alloc_func_t
 RCLASS_ALLOCATOR(VALUE klass)
 {
     RBIMPL_ASSERT_TYPE(klass, T_CLASS);
-    RUBY_ASSERT(!RCLASS_SINGLETON_P(klass));
+    if (RCLASS_SINGLETON_P(klass)) {
+        return 0;
+    }
     return RCLASS_EXT_PRIME(klass)->as.class.allocator;
 }
 
@@ -610,6 +622,31 @@ RCLASS_SET_ALLOCATOR(VALUE klass, rb_alloc_func_t allocator)
     RUBY_ASSERT(RB_TYPE_P(klass, T_CLASS));
     RUBY_ASSERT(!RCLASS_SINGLETON_P(klass));
     RCLASS_EXT_PRIME(klass)->as.class.allocator = allocator; // Allocator is set only on the initial definition
+}
+
+static inline rb_copy_alloc_func_t
+RCLASS_COPY_ALLOCATOR(VALUE klass)
+{
+    RBIMPL_ASSERT_TYPE(klass, T_CLASS);
+    if (RCLASS_SINGLETON_P(klass)) {
+        return 0;
+    }
+    return RCLASS_EXT_PRIME(klass)->as.class.copy_allocator;
+}
+
+static inline void
+RCLASS_SET_COPY_ALLOCATOR(VALUE klass, rb_copy_alloc_func_t allocator)
+{
+    RUBY_ASSERT(RB_TYPE_P(klass, T_CLASS));
+    RUBY_ASSERT(!RCLASS_SINGLETON_P(klass));
+    RCLASS_EXT_PRIME(klass)->as.class.copy_allocator = allocator; // Allocator is set only on the initial definition
+}
+
+static inline void
+RCLASS_INHERIT_ALLOCATOR(VALUE klass, VALUE super)
+{
+    RCLASS_EXT_PRIME(klass)->as.class.allocator = RCLASS_ALLOCATOR(super);
+    RCLASS_EXT_PRIME(klass)->as.class.copy_allocator = RCLASS_COPY_ALLOCATOR(super);
 }
 
 static inline void

--- a/internal/object.h
+++ b/internal/object.h
@@ -12,6 +12,7 @@
 
 /* object.c */
 
+VALUE rb_obj_alloc_copy(VALUE obj);
 VALUE rb_class_allocate_instance(VALUE klass);
 VALUE rb_class_allocate_instance_capa(VALUE klass, uint8_t /* attr_index_t */ max_iv_count);
 VALUE rb_class_search_ancestor(VALUE klass, VALUE super);

--- a/internal/vm.h
+++ b/internal/vm.h
@@ -101,6 +101,10 @@ struct rb_iseq_struct;
 const struct rb_callcache *rb_vm_search_method_slowpath(const struct rb_callinfo *ci, VALUE klass);
 
 /* vm_method.c */
+typedef VALUE (*rb_copy_alloc_func_t)(VALUE klass, VALUE other);
+rb_alloc_func_t rb_get_raw_alloc_func(VALUE klass);
+void rb_define_copy_alloc_func(VALUE klass, rb_copy_alloc_func_t copy_func, rb_alloc_func_t alloc_func);
+void rb_init_alloc_func(VALUE klass);
 int rb_ec_obj_respond_to(struct rb_execution_context_struct *ec, VALUE obj, ID id, int priv);
 
 /* vm_dump.c */

--- a/object.c
+++ b/object.c
@@ -543,10 +543,20 @@ rb_obj_clone_setup(VALUE obj, VALUE clone, VALUE kwfreeze)
     return clone;
 }
 
+VALUE
+rb_obj_alloc_copy(VALUE obj)
+{
+    VALUE klass = rb_obj_class(obj);
+    if (klass && RCLASS_COPY_ALLOCATOR(klass)) {
+        return RCLASS_COPY_ALLOCATOR(klass)(klass, obj);
+    }
+    return rb_obj_alloc(klass);
+}
+
 static VALUE
 mutable_obj_clone(VALUE obj, VALUE kwfreeze)
 {
-    VALUE clone = rb_obj_alloc(rb_obj_class(obj));
+    VALUE clone = rb_obj_alloc_copy(obj);
     return rb_obj_clone_setup(obj, clone, kwfreeze);
 }
 
@@ -608,21 +618,11 @@ rb_obj_dup_setup(VALUE obj, VALUE dup)
 VALUE
 rb_obj_dup(VALUE obj)
 {
-    VALUE dup;
-
     if (special_object_p(obj)) {
         return obj;
     }
 
-    switch (OBJ_BUILTIN_TYPE(obj)) {
-      case T_HASH:
-        dup = rb_hash_alloc_copy(rb_obj_class(obj), obj);
-        break;
-      default:
-        dup = rb_obj_alloc(rb_obj_class(obj));
-        break;
-    }
-
+    VALUE dup = rb_obj_alloc_copy(obj);
     return rb_obj_dup_setup(obj, dup);
 }
 
@@ -2220,7 +2220,7 @@ rb_class_initialize(int argc, VALUE *argv, VALUE klass)
     }
     rb_class_set_super(klass, super);
     RCLASS_SET_MAX_IV_COUNT(klass, RCLASS_MAX_IV_COUNT(super));
-    RCLASS_SET_ALLOCATOR(klass, RCLASS_ALLOCATOR(super));
+    RCLASS_INHERIT_ALLOCATOR(klass, super);
     rb_make_metaclass(klass, RBASIC(super)->klass);
     rb_class_inherited(super, klass);
     rb_mod_initialize_exec(klass);
@@ -2236,8 +2236,23 @@ rb_undefined_alloc(VALUE klass)
              klass);
 }
 
-static rb_alloc_func_t class_get_alloc_func(VALUE klass);
-static VALUE class_call_alloc_func(rb_alloc_func_t allocator, VALUE klass);
+static rb_alloc_func_t
+class_get_alloc_func(VALUE klass)
+{
+    rb_alloc_func_t allocator;
+
+    if (!RCLASS_INITIALIZED_P(klass)) {
+        rb_raise(rb_eTypeError, "can't instantiate uninitialized class");
+    }
+    if (RCLASS_SINGLETON_P(klass)) {
+        rb_raise(rb_eTypeError, "can't create instance of singleton class");
+    }
+    allocator = rb_get_alloc_func(klass);
+    if (!allocator) {
+        rb_undefined_alloc(klass);
+    }
+    return allocator;
+}
 
 /*
  *  call-seq:
@@ -2265,26 +2280,23 @@ static VALUE
 rb_class_alloc(VALUE klass)
 {
     RBIMPL_ASSERT_TYPE(klass, T_CLASS);
-    rb_alloc_func_t allocator = class_get_alloc_func(klass);
-    return class_call_alloc_func(allocator, klass);
-}
 
-static rb_alloc_func_t
-class_get_alloc_func(VALUE klass)
-{
-    rb_alloc_func_t allocator;
+    RUBY_DTRACE_CREATE_HOOK(OBJECT, rb_class2name(klass));
 
-    if (!RCLASS_INITIALIZED_P(klass)) {
-        rb_raise(rb_eTypeError, "can't instantiate uninitialized class");
+    VALUE obj;
+
+    rb_copy_alloc_func_t copy_allocator = RCLASS_COPY_ALLOCATOR(klass);
+    if (copy_allocator) {
+        obj = copy_allocator(klass, Qundef);
     }
-    if (RCLASS_SINGLETON_P(klass)) {
-        rb_raise(rb_eTypeError, "can't create instance of singleton class");
+    else {
+        rb_alloc_func_t allocator = class_get_alloc_func(klass);
+        obj= allocator(klass);
     }
-    allocator = rb_get_alloc_func(klass);
-    if (!allocator) {
-        rb_undefined_alloc(klass);
-    }
-    return allocator;
+
+    RUBY_ASSERT(rb_obj_class(obj) == rb_class_real(klass));
+
+    return obj;
 }
 
 // Might return NULL.
@@ -2294,19 +2306,6 @@ rb_zjit_class_get_alloc_func(VALUE klass)
     assert(RCLASS_INITIALIZED_P(klass));
     assert(!RCLASS_SINGLETON_P(klass));
     return rb_get_alloc_func(klass);
-}
-
-static VALUE
-class_call_alloc_func(rb_alloc_func_t allocator, VALUE klass)
-{
-    VALUE obj;
-
-    RUBY_DTRACE_CREATE_HOOK(OBJECT, rb_class2name(klass));
-
-    obj = (*allocator)(klass);
-
-    RUBY_ASSERT(rb_obj_class(obj) == rb_class_real(klass));
-    return obj;
 }
 
 VALUE

--- a/ractor.c
+++ b/ractor.c
@@ -3376,7 +3376,7 @@ ractor_native_shallow_copy(VALUE obj)
 
     switch (BUILTIN_TYPE(obj)) {
       case T_OBJECT:
-        copy = rb_obj_alloc(rb_obj_class(obj));
+        copy = rb_obj_alloc_copy(obj);
         rb_obj_copy_ivar(copy, obj);
         break;
       case T_STRING:
@@ -3389,11 +3389,11 @@ ractor_native_shallow_copy(VALUE obj)
         copy = rb_hash_dup(obj);
         break;
       case T_STRUCT:
-        copy = rb_obj_alloc(rb_obj_class(obj));
+        copy = rb_obj_alloc_copy(obj);
         rb_struct_init_copy(copy, obj);
         break;
       case T_MATCH:
-        copy = rb_obj_alloc(rb_obj_class(obj));
+        copy = rb_obj_alloc_copy(obj);
         rb_match_init_copy(copy, obj);
         break;
       case T_DATA:

--- a/vm_method.c
+++ b/vm_method.c
@@ -1779,20 +1779,59 @@ propagate_alloc_func(VALUE subclass, VALUE arg)
         !RCLASS_SINGLETON_P(subclass) &&
         !FL_TEST_RAW(subclass, RCLASS_ALLOCATOR_DEFINED)) {
         RCLASS_SET_ALLOCATOR(subclass, (rb_alloc_func_t)arg);
+        RCLASS_SET_COPY_ALLOCATOR(subclass, NULL);
         rb_class_foreach_subclass(subclass, propagate_alloc_func, arg);
     }
 }
 
 void
-rb_define_alloc_func(VALUE klass, VALUE (*func)(VALUE))
+rb_define_alloc_func(VALUE klass, rb_alloc_func_t func)
 {
     Check_Type(klass, T_CLASS);
     if (RCLASS_SINGLETON_P(klass)) {
         rb_raise(rb_eTypeError, "can't define an allocator for a singleton class");
     }
     RCLASS_SET_ALLOCATOR(klass, func);
+    RCLASS_SET_COPY_ALLOCATOR(klass, NULL);
     FL_SET_RAW(klass, RCLASS_ALLOCATOR_DEFINED);
     rb_class_foreach_subclass(klass, propagate_alloc_func, (VALUE)func);
+}
+
+struct propagate_copy_alloc_func_args {
+    rb_alloc_func_t alloc_func;
+    rb_copy_alloc_func_t copy_alloc_func;
+};
+
+static void
+propagate_copy_alloc_func(VALUE subclass, VALUE arg)
+{
+    if (RB_TYPE_P(subclass, T_CLASS) &&
+        !RCLASS_SINGLETON_P(subclass) &&
+        !FL_TEST_RAW(subclass, RCLASS_ALLOCATOR_DEFINED)) {
+
+        struct propagate_copy_alloc_func_args *args = (struct propagate_copy_alloc_func_args *)arg;
+        RCLASS_SET_ALLOCATOR(subclass, args->alloc_func);
+        RCLASS_SET_COPY_ALLOCATOR(subclass, args->copy_alloc_func);
+        rb_class_foreach_subclass(subclass, propagate_copy_alloc_func, arg);
+    }
+}
+
+void
+rb_define_copy_alloc_func(VALUE klass, rb_copy_alloc_func_t copy_func, rb_alloc_func_t func)
+{
+    Check_Type(klass, T_CLASS);
+    if (RCLASS_SINGLETON_P(klass)) {
+        rb_raise(rb_eTypeError, "can't define a copy allocator for a singleton class");
+    }
+    RCLASS_SET_ALLOCATOR(klass, func);
+    RCLASS_SET_COPY_ALLOCATOR(klass, copy_func);
+    FL_SET_RAW(klass, RCLASS_ALLOCATOR_DEFINED);
+
+    struct propagate_copy_alloc_func_args args = {
+        .alloc_func = func,
+        .copy_alloc_func = copy_func,
+    };
+    rb_class_foreach_subclass(klass, propagate_copy_alloc_func, (VALUE)&args);
 }
 
 void
@@ -1811,8 +1850,53 @@ rb_get_alloc_func(VALUE klass)
 
     rb_alloc_func_t allocator = RCLASS_ALLOCATOR(klass);
     if (allocator == UNDEF_ALLOC_FUNC) return 0;
-    RUBY_ASSERT(allocator);
-    return allocator;
+    if (allocator) {
+        return allocator;
+    }
+
+    VALUE *superclasses = RCLASS_SUPERCLASSES(klass);
+    size_t depth = RCLASS_SUPERCLASS_DEPTH(klass);
+
+    for (size_t i = depth; i > 0; i--) {
+        klass = superclasses[i - 1];
+        RBIMPL_ASSERT_TYPE(klass, T_CLASS);
+
+        allocator = RCLASS_ALLOCATOR(klass);
+        if (allocator == UNDEF_ALLOC_FUNC) break;
+        if (allocator) return allocator;
+    }
+    return 0;
+}
+
+void
+rb_init_alloc_func(VALUE klass)
+{
+    RBIMPL_ASSERT_TYPE(klass, T_CLASS);
+
+    if (RCLASS_ALLOCATOR(klass)) {
+        return;
+    }
+
+    VALUE *superclasses = RCLASS_SUPERCLASSES(klass);
+    size_t depth = RCLASS_SUPERCLASS_DEPTH(klass);
+
+    for (size_t i = depth; i > 0; i--) {
+        VALUE superclass = superclasses[i - 1];
+        RBIMPL_ASSERT_TYPE(superclass, T_CLASS);
+
+        rb_alloc_func_t allocator = RCLASS_ALLOCATOR(superclass);
+        if (allocator) {
+            RCLASS_SET_ALLOCATOR(klass, allocator);
+            return;
+        }
+
+        rb_copy_alloc_func_t allocator2 = RCLASS_COPY_ALLOCATOR(superclass);
+        if (allocator2) {
+            RCLASS_SET_COPY_ALLOCATOR(klass, allocator2);
+            return;
+        }
+    }
+
 }
 
 const rb_method_entry_t *


### PR DESCRIPTION
Ref: https://bugs.ruby-lang.org/issues/21852

The current API has several shortcomings and assumptions that no longer holds.

For instance, it takes a single Class argument, this made sense years ago when all objects slots were of fixed size, but now that we have variable width allocation, the allocator needs more information than that to do it's job properly.

You can easily witness that problem with the Array class:

```ruby
>> require 'objspace'
>> ObjectSpace.memsize_of([1] * 8)
=> 80
>> ObjectSpace.memsize_of(([1] * 8).dup)
=> 104
```

Here `#dup` had to allocate a new array without any information about how large it needed to be, so it allocated the smallest possible size, and then `#initialize_copy` had to spill the array on the C heap.

This is currently worked around in various ways in different classes, some define their own `#dup` method, but then it doesn't work if `rb_obj_dup` is called from C.

Some others hooks themselves in `rb_obj_dup`, but that doesn't scale.

Another problem that this new interface solves is that it allows disabling `Class#allocate` without also disabling `Object#dup`.

Since the allocator function recieve `Qundef` as second argument on raw `Class#allocate`, it's very easy to raise an error in such case.