### PR TITLE
Acquire IO::Buffer bytes after resolving encoding

### DIFF
--- a/io_buffer.c
+++ b/io_buffer.c
@@ -3255,10 +3255,6 @@ io_buffer_get_string(int argc, VALUE *argv, VALUE self)
     size_t offset, length;
     struct rb_io_buffer *buffer = io_buffer_extract_offset_length(self, argc, argv, &offset, &length);
 
-    const void *base;
-    size_t size;
-    io_buffer_get_bytes_for_reading(buffer, &base, &size);
-
     rb_encoding *encoding;
     if (argc >= 3) {
         encoding = rb_find_encoding(argv[2]);
@@ -3268,6 +3264,10 @@ io_buffer_get_string(int argc, VALUE *argv, VALUE self)
     }
 
     io_buffer_validate_range(buffer, offset, length);
+
+    const void *base;
+    size_t size;
+    io_buffer_get_bytes_for_reading(buffer, &base, &size);
 
     const char *data = base ? (const char*)base + offset : NULL;
 

--- a/test/ruby/test_io_buffer.rb
+++ b/test/ruby/test_io_buffer.rb
@@ -973,6 +973,22 @@ class TestIOBuffer < Test::Unit::TestCase
     end
   end
 
+  def test_get_string_resolves_encoding_before_accessing_buffer
+    buffer = IO::Buffer.for("hello").dup
+    transferred = nil
+
+    encoding = Object.new
+    encoding.define_singleton_method(:to_str) do
+      transferred = buffer.transfer
+      buffer.resize(5)
+      buffer.set_string("world")
+      "UTF-8"
+    end
+
+    assert_equal "world", buffer.get_string(0, 5, encoding)
+    assert_equal "hello", transferred.get_string
+  end
+
   def test_zero_length_get_string
     buffer = IO::Buffer.new.slice(0, 0)
     assert_equal "", buffer.get_string


### PR DESCRIPTION
This supersedes #18493 with the narrower concrete fix identified during that work.

## Summary

Resolve the requested encoding before acquiring the raw `IO::Buffer` pointer in `IO::Buffer#get_string`.

Encoding coercion can execute Ruby code. If that code transfers or reallocates the receiver, the previously acquired pointer becomes stale even though the receiver remains valid. Acquiring the bytes after coercion and range validation ensures `get_string` reads from the current allocation.

The regression test transfers the original allocation during encoding coercion, replaces it with different content of the same size, and verifies that `get_string` reads the replacement.

## Testing

`make -j4 test-all TESTS=../ruby-io-buffer-critical-sections/test/ruby/test_io_buffer.rb`

157 tests, 1094 assertions, 0 failures, 0 errors.