### PR TITLE
[Backport 3.3] Handle spurious wakeups in Thread#join

### DIFF
--- a/test/fiber/scheduler.rb
+++ b/test/fiber/scheduler.rb
@@ -114,7 +114,7 @@ class Scheduler
         end
 
         ready.each do |fiber|
-          fiber.resume
+          fiber.resume if fiber.alive?
         end
       end
     end

--- a/thread.c
+++ b/thread.c
@@ -1047,23 +1047,28 @@ thread_join_sleep(VALUE arg)
     while (!thread_finished(target_th)) {
         VALUE scheduler = rb_fiber_scheduler_current();
 
-        if (scheduler != Qnil) {
-            rb_fiber_scheduler_block(scheduler, target_th->self, p->timeout);
-            // Check if the target thread is finished after blocking:
-            if (thread_finished(target_th)) break;
-            // Otherwise, a timeout occurred:
-            else return Qfalse;
-        }
-        else if (!limit) {
-            sleep_forever(th, SLEEP_DEADLOCKABLE | SLEEP_ALLOW_SPURIOUS | SLEEP_NO_CHECKINTS);
+        if (!limit) {
+            if (scheduler != Qnil) {
+                rb_fiber_scheduler_block(scheduler, target_th->self, Qnil);
+            }
+            else {
+                sleep_forever(th, SLEEP_DEADLOCKABLE | SLEEP_ALLOW_SPURIOUS | SLEEP_NO_CHECKINTS);
+            }
         }
         else {
             if (hrtime_update_expire(limit, end)) {
                 RUBY_DEBUG_LOG("timeout target_th:%u", rb_th_serial(target_th));
                 return Qfalse;
             }
-            th->status = THREAD_STOPPED;
-            native_sleep(th, limit);
+
+            if (scheduler != Qnil) {
+                VALUE timeout = rb_float_new(hrtime2double(*limit));
+                rb_fiber_scheduler_block(scheduler, target_th->self, timeout);
+            }
+            else {
+                th->status = THREAD_STOPPED;
+                native_sleep(th, limit);
+            }
         }
         RUBY_VM_CHECK_INTS_BLOCKING(th->ec);
         th->status = THREAD_RUNNABLE;


### PR DESCRIPTION
Backports f0cf4dce65ba7bf3dc6787e10b88e08b411e2c92 from #13532 to ruby_3_3.

An untimed Thread#join running under a Fiber scheduler could treat a spurious scheduler wakeup as a timeout. Thread#value could consequently return nil while the target thread was still alive.

The conflict resolution retains the Ruby 3.3 branch-specific thread I/O implementation and uses Fiber#resume in its scheduler test helper.

Tested on arm64 macOS:

    make test-all TESTS=../test/fiber/test_thread.rb
    7 tests, 21 assertions, 0 failures, 0 errors, 0 skips

Ruby 3.4 backport: #18503