### PR TITLE
Guard `Net::HTTPHeader#content_length` spec by version

### DIFF
--- a/spec/ruby/library/net-http/httpheader/content_length_spec.rb
+++ b/spec/ruby/library/net-http/httpheader/content_length_spec.rb
@@ -19,12 +19,26 @@ describe "Net::HTTPHeader#content_length" do
   it "returns the value of the 'Content-Length' header entry as an Integer" do
     @headers["Content-Length"] = "123"
     @headers.content_length.should.eql?(123)
+  end
 
-    @headers["Content-Length"] = "123valid"
-    @headers.content_length.should.eql?(123)
+  ruby_version_is ""..."4.1" do
+    it "ignores the parts of the 'Content-Length' header entry around the digits" do
+      @headers["Content-Length"] = "123valid"
+      @headers.content_length.should.eql?(123)
 
-    @headers["Content-Length"] = "valid123"
-    @headers.content_length.should.eql?(123)
+      @headers["Content-Length"] = "valid123"
+      @headers.content_length.should.eql?(123)
+    end
+  end
+
+  ruby_version_is "4.1" do
+    it "raises a Net::HTTPHeaderSyntaxError if the 'Content-Length' header entry is not entirely digits" do
+      @headers["Content-Length"] = "123valid"
+      -> { @headers.content_length }.should.raise(Net::HTTPHeaderSyntaxError)
+
+      @headers["Content-Length"] = "valid123"
+      -> { @headers.content_length }.should.raise(Net::HTTPHeaderSyntaxError)
+    end
   end
 end
 


### PR DESCRIPTION
`test-spec` fails on master because the spec still expects `Content-Length` values such as `123valid` and `valid123` to yield `123`, while strict parsing now raises `Net::HTTPHeaderSyntaxError` for anything that is not entirely digits.

I split that example so the lenient result stays under `ruby_version_is ""..."4.1"` and the raise is asserted under `ruby_version_is "4.1"`. `Net::HTTPHeader#content_length=` is untouched since it still goes through `len.to_i`.

Verified both branches of the guard: 4.1.0dev with this tree's `lib` on the load path, and 4.0.6 with its own `net/http`.
