### PR TITLE
[Bug #22264] Warn for duplicate keys after leading keyword splat

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -6607,13 +6607,11 @@ assocs		: assoc
                             assocs = tail;
                         }
                         else if (tail) {
-                            if (RNODE_LIST(assocs)->nd_head) {
-                                NODE *n = RNODE_LIST(tail)->nd_next;
-                                if (!RNODE_LIST(tail)->nd_head && nd_type_p(n, NODE_LIST) &&
-                                    nd_type_p((n = RNODE_LIST(n)->nd_head), NODE_HASH)) {
-                                    /* DSTAR */
-                                    tail = RNODE_HASH(n)->nd_head;
-                                }
+                            NODE *n = RNODE_LIST(tail)->nd_next;
+                            if (!RNODE_LIST(tail)->nd_head && nd_type_p(n, NODE_LIST) &&
+                                nd_type_p((n = RNODE_LIST(n)->nd_head), NODE_HASH)) {
+                                /* DSTAR */
+                                tail = RNODE_HASH(n)->nd_head;
                             }
                             if (tail) {
                                 assocs = list_concat(assocs, tail);

--- a/test/ruby/test_literal.rb
+++ b/test/ruby/test_literal.rb
@@ -521,6 +521,10 @@ class TestRubyLiteral < Test::Unit::TestCase
     ) do |key|
       assert_warning(/key #{Regexp.quote(eval(key).inspect)} is duplicated/) { eval("{#{key} => :bar, #{key} => :foo}") }
     end
+
+    assert_warning(/key :foo is duplicated/, "[Bug #22264]") do
+      eval("{**{}, foo: :bar, **{foo: :foo}}")
+    end
   end
 
   def test_hash_frozen_key_id


### PR DESCRIPTION
Leading keyword splats must not suppress duplicate literal key warnings.