### PR TITLE
Skip the RUBY_BOX gem CLI canary on Windows

### DIFF
--- a/test/rubygems/test_gem_command.rb
+++ b/test/rubygems/test_gem_command.rb
@@ -403,6 +403,8 @@ ERROR:  Possible alternatives: non_existent_with_hint
 
   def test_gem_cli_runs_under_ruby_box
     omit "Ruby::Box is not available" unless defined?(Ruby::Box)
+    # A boxed subprocess crashes with SIGSEGV during finalization on Windows
+    omit "Ruby::Box is unstable on Windows" if Gem.win_platform?
     # Ruby 4.0 resolves Gem::NameTuple from the root box and fails autoload
     omit "Ruby::Box is too unstable before 4.1" if Gem.ruby_version < Gem::Version.new("4.1.0.a")
 


### PR DESCRIPTION
`TestGemCommand#test_gem_cli_runs_under_ruby_box` fails on Windows because the boxed subprocess dies with SIGSEGV inside `rb_objspace_call_finalizer` at exit, after `gem list` itself has finished. The crash belongs to `Ruby::Box` rather than to RubyGems and a fix is being worked on, so omit the canary on Windows until that lands.

https://github.com/ruby/ruby/actions/runs/32933358242/job/98069763490

This test comes from ruby/rubygems, so I will forward-port the same omit there.
