### PR TITLE
Defer unloading box-local extension DLLs on Windows

### DIFF
--- a/box.c
+++ b/box.c
@@ -65,7 +65,6 @@ bool ruby_box_crashed = false; // extern, changed only in vm.c
 
 VALUE rb_resolve_feature_path(VALUE klass, VALUE fname);
 static VALUE rb_box_inspect(VALUE obj);
-static void cleanup_all_local_extensions(VALUE libmap);
 
 void
 rb_box_set_gem_flags(rb_box_gem_flags_t *flags)
@@ -302,8 +301,6 @@ box_entry_free(void *ptr)
     if (box->classext_cow_classes) {
         st_foreach(box->classext_cow_classes, free_classext_for_box, (st_data_t)box);
     }
-
-    cleanup_all_local_extensions(box->ruby_dln_libmap);
 
     free_box_st_tables(ptr);
     SIZED_FREE(box);
@@ -808,24 +805,48 @@ rb_box_cleanup_local_extension(VALUE cleanup)
     (void)p;
 }
 
-static int
-cleanup_local_extension_i(VALUE key, VALUE value, VALUE arg)
+#if defined(_WIN32)
+struct box_local_ext_list {
+    struct box_local_ext_list *next;
+    HMODULE handle;
+};
+static struct box_local_ext_list *box_local_exts;
+#endif
+
+void
+rb_box_defer_unload_local_extension(void *handle)
 {
 #if defined(_WIN32)
-    HMODULE h = (HMODULE)NUM2PTR(value);
-    WCHAR module_path[MAXPATHLEN];
-    DWORD len = GetModuleFileNameW(h, module_path, numberof(module_path));
-
-    FreeLibrary(h);
-    if (len > 0 && len < numberof(module_path)) DeleteFileW(module_path);
+    /* A box-local copy of an extension DLL must stay loaded as long as
+     * objects created by it can be finalized; unloading is deferred to
+     * rb_box_unload_local_extensions after the objspace is destructed.
+     * The loaded copy cannot be deleted on Windows, so the file is also
+     * removed there instead of in box_ext_cleanup_free. */
+    struct box_local_ext_list *ext = malloc(sizeof(struct box_local_ext_list));
+    if (!ext) return;
+    ext->handle = (HMODULE)handle;
+    ext->next = box_local_exts;
+    box_local_exts = ext;
 #endif
-    return ST_DELETE;
 }
 
-static void
-cleanup_all_local_extensions(VALUE libmap)
+void
+rb_box_unload_local_extensions(void)
 {
-    rb_hash_foreach(libmap, cleanup_local_extension_i, 0);
+#if defined(_WIN32)
+    struct box_local_ext_list *ext = box_local_exts;
+    box_local_exts = NULL;
+    while (ext) {
+        struct box_local_ext_list *next = ext->next;
+        WCHAR module_path[MAXPATHLEN];
+        DWORD len = GetModuleFileNameW(ext->handle, module_path, numberof(module_path));
+
+        FreeLibrary(ext->handle);
+        if (len > 0 && len < numberof(module_path)) DeleteFileW(module_path);
+        free(ext);
+        ext = next;
+    }
+#endif
 }
 
 VALUE

--- a/internal/box.h
+++ b/internal/box.h
@@ -90,6 +90,8 @@ VALUE rb_get_box_object(rb_box_t *ns);
 
 VALUE rb_box_local_extension(VALUE box, VALUE fname, VALUE path, VALUE *cleanup);
 void rb_box_cleanup_local_extension(VALUE cleanup);
+void rb_box_defer_unload_local_extension(void *handle);
+void rb_box_unload_local_extensions(void);
 
 void rb_initialize_mandatory_boxes(void);
 void rb_box_init_done(void);

--- a/load.c
+++ b/load.c
@@ -1224,6 +1224,7 @@ load_ext(VALUE path, VALUE fname)
     void *handle = dln_load_feature(RSTRING_PTR(loaded), RSTRING_PTR(fname));
     if (cleanup) {
         rb_box_cleanup_local_extension(cleanup);
+        rb_box_defer_unload_local_extension(handle);
     }
     RB_GC_GUARD(loaded);
     RB_GC_GUARD(fname);

--- a/test/rubygems/test_gem_command.rb
+++ b/test/rubygems/test_gem_command.rb
@@ -403,8 +403,6 @@ ERROR:  Possible alternatives: non_existent_with_hint
 
   def test_gem_cli_runs_under_ruby_box
     omit "Ruby::Box is not available" unless defined?(Ruby::Box)
-    # A boxed subprocess crashes with SIGSEGV during finalization on Windows
-    omit "Ruby::Box is unstable on Windows" if Gem.win_platform?
     # Ruby 4.0 resolves Gem::NameTuple from the root box and fails autoload
     omit "Ruby::Box is too unstable before 4.1" if Gem.ruby_version < Gem::Version.new("4.1.0.a")
 

--- a/vm.c
+++ b/vm.c
@@ -3584,6 +3584,8 @@ ruby_vm_destruct(rb_vm_t *vm)
             rb_yjit_free_at_exit();
 #endif
         }
+
+        rb_box_unload_local_extensions();
     }
     RUBY_FREE_LEAVE("vm");
     return 0;


### PR DESCRIPTION
A boxed process on Windows crashes with SIGSEGV at exit when objects created by a C extension are still alive there. For extensions like `openssl`, `fiddle`, and `win32ole`, just requiring them inside a box is enough, since their Init leaves such objects behind. This is what the RUBY_BOX gem CLI canary caught (https://github.com/ruby/ruby/actions/runs/32933358242/job/98069763490). Minimal reproduction is `RUBY_BOX=1 ruby -e "require 'openssl'"`.

On Unix, a box-local copy of a C extension is unlinked right after loading and its dlopen handle stays alive for the lifetime of the process. On Windows, a loaded DLL cannot be deleted, so `box_entry_free` called `FreeLibrary` before deleting the copy. During `rb_objspace_call_finalizer` the box entry can be freed before other T_DATA objects, and finalizing them afterwards dereferences the `rb_data_type_t` in the unloaded DLL.

This change aligns Windows with the Unix lifetime. Copied DLLs stay loaded until `ruby_vm_destruct` and are unloaded and deleted there, after the objspace is gone. Also reverts the canary skip added in #18508.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
