### PR TITLE
Unify jit_payload in iseq_constant_body

### DIFF
--- a/iseq.c
+++ b/iseq.c
@@ -474,13 +474,7 @@ rb_iseq_mark_and_move(rb_iseq_t *iseq, bool reference_updating)
          * compile/invalidate). Iseqs are born shareable, so a multi-Ractor local GC
          * never traverses them. */
         const bool jit_payload_lock_p = rb_gc_multi_objspace_p();
-        bool jit_payload_p = false;
-# if USE_YJIT
-        if (body->yjit_payload != NULL) jit_payload_p = true;
-# endif
-# if USE_ZJIT
-        if (body->zjit_payload != NULL) jit_payload_p = true;
-# endif
+        bool jit_payload_p = body->jit_payload != NULL;
 #endif
         if (reference_updating) {
 #if USE_YJIT || USE_ZJIT
@@ -488,19 +482,19 @@ rb_iseq_mark_and_move(rb_iseq_t *iseq, bool reference_updating)
                 if (jit_payload_lock_p) {
                     RB_VM_LOCKING_NO_BARRIER() {
 # if USE_YJIT
-                        rb_yjit_iseq_update_references(iseq);
+                        if (rb_yjit_enabled_p) rb_yjit_iseq_update_references(iseq);
 # endif
 # if USE_ZJIT
-                        rb_zjit_iseq_update_references(body->zjit_payload);
+                        if (rb_zjit_enabled_p) rb_zjit_iseq_update_references(body->jit_payload);
 # endif
                     }
                 }
                 else {
 # if USE_YJIT
-                    rb_yjit_iseq_update_references(iseq);
+                    if (rb_yjit_enabled_p) rb_yjit_iseq_update_references(iseq);
 # endif
 # if USE_ZJIT
-                    rb_zjit_iseq_update_references(body->zjit_payload);
+                    if (rb_zjit_enabled_p) rb_zjit_iseq_update_references(body->jit_payload);
 # endif
                 }
             }
@@ -514,19 +508,19 @@ rb_iseq_mark_and_move(rb_iseq_t *iseq, bool reference_updating)
                     if (jit_payload_lock_p) {
                         RB_VM_LOCKING_NO_BARRIER() {
 # if USE_YJIT
-                            rb_yjit_iseq_mark(body->yjit_payload);
+                            if (rb_yjit_enabled_p) rb_yjit_iseq_mark(body->jit_payload);
 # endif
 # if USE_ZJIT
-                            rb_zjit_iseq_mark(body->zjit_payload);
+                            if (rb_zjit_enabled_p) rb_zjit_iseq_mark(body->jit_payload);
 # endif
                         }
                     }
                     else {
 # if USE_YJIT
-                        rb_yjit_iseq_mark(body->yjit_payload);
+                        if (rb_yjit_enabled_p) rb_yjit_iseq_mark(body->jit_payload);
 # endif
 # if USE_ZJIT
-                        rb_zjit_iseq_mark(body->zjit_payload);
+                        if (rb_zjit_enabled_p) rb_zjit_iseq_mark(body->jit_payload);
 # endif
                     }
                 }

--- a/jit.c
+++ b/jit.c
@@ -611,6 +611,27 @@ rb_jit_vm_unlock(unsigned int *recursive_lock_level, const char *file, int line)
     rb_vm_lock_leave(recursive_lock_level, file, line);
 }
 
+void *
+rb_iseq_get_jit_payload(const rb_iseq_t *iseq)
+{
+    RUBY_ASSERT_ALWAYS(IMEMO_TYPE_P(iseq, imemo_iseq));
+    if (ISEQ_BODY(iseq)) {
+        return ISEQ_BODY(iseq)->jit_payload;
+    }
+    else {
+        return NULL;
+    }
+}
+
+void
+rb_iseq_set_jit_payload(const rb_iseq_t *iseq, void *payload)
+{
+    RUBY_ASSERT_ALWAYS(IMEMO_TYPE_P(iseq, imemo_iseq));
+    RUBY_ASSERT_ALWAYS(ISEQ_BODY(iseq));
+    RUBY_ASSERT_ALWAYS(NULL == ISEQ_BODY(iseq)->jit_payload);
+    ISEQ_BODY(iseq)->jit_payload = payload;
+}
+
 void
 rb_iseq_reset_jit_func(const rb_iseq_t *iseq)
 {

--- a/vm_core.h
+++ b/vm_core.h
@@ -572,18 +572,12 @@ struct rb_iseq_constant_body {
     rb_jit_func_t jit_exception;
     // Number of calls on jit_exec_exception()
     long unsigned jit_exception_calls;
+    void *jit_payload;
 #endif
 
 #if USE_YJIT
-    // YJIT stores some data on each iseq.
-    void *yjit_payload;
     // Used to estimate how frequently this ISEQ gets called
     uint64_t yjit_calls_at_interv;
-#endif
-
-#if USE_ZJIT
-    // ZJIT stores some data on each iseq.
-    void *zjit_payload;
 #endif
 
     // Hash of the source this iseq was compiled from, or 0 if it is

--- a/yjit.c
+++ b/yjit.c
@@ -193,29 +193,6 @@ rb_full_cfunc_return(rb_execution_context_t *ec, VALUE return_value)
     ec->cfp->sp++;
 }
 
-// TODO(alan): consider using an opaque pointer for the payload rather than a void pointer
-void *
-rb_iseq_get_yjit_payload(const rb_iseq_t *iseq)
-{
-    RUBY_ASSERT_ALWAYS(IMEMO_TYPE_P(iseq, imemo_iseq));
-    if (ISEQ_BODY(iseq)) {
-        return ISEQ_BODY(iseq)->yjit_payload;
-    }
-    else {
-        // Body is NULL when constructing the iseq.
-        return NULL;
-    }
-}
-
-void
-rb_iseq_set_yjit_payload(const rb_iseq_t *iseq, void *payload)
-{
-    RUBY_ASSERT_ALWAYS(IMEMO_TYPE_P(iseq, imemo_iseq));
-    RUBY_ASSERT_ALWAYS(ISEQ_BODY(iseq));
-    RUBY_ASSERT_ALWAYS(NULL == ISEQ_BODY(iseq)->yjit_payload);
-    ISEQ_BODY(iseq)->yjit_payload = payload;
-}
-
 // This is defined only as a named struct inside rb_iseq_constant_body.
 // By giving it a separate typedef, we make it nameable by rust-bindgen.
 // Bindgen's temp/anon name isn't guaranteed stable.

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -242,7 +242,7 @@ fn main() {
         .allowlist_function("rb_object_shape_count")
         .allowlist_function("rb_ivar_get_at")
         .allowlist_function("rb_ivar_get_at_no_ractor_check")
-        .allowlist_function("rb_iseq_(get|set)_yjit_payload")
+        .allowlist_function("rb_iseq_(get|set)_jit_payload")
         .allowlist_function("rb_iseq_pc_at_idx")
         .allowlist_function("rb_iseq_opcode_at_pc")
         .allowlist_function("rb_jit_reserve_addr_space")

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -1806,7 +1806,7 @@ impl IseqPayload {
 /// Get the payload for an iseq. For safety it's up to the caller to ensure the returned `&mut`
 /// upholds aliasing rules and that the argument is a valid iseq.
 pub fn get_iseq_payload(iseq: IseqPtr) -> Option<&'static mut IseqPayload> {
-    let payload = unsafe { rb_iseq_get_yjit_payload(iseq) };
+    let payload = unsafe { rb_iseq_get_jit_payload(iseq) };
     let payload: *mut IseqPayload = payload.cast();
     unsafe { payload.as_mut() }
 }
@@ -1816,7 +1816,7 @@ pub fn get_or_create_iseq_payload(iseq: IseqPtr) -> &'static mut IseqPayload {
     type VoidPtr = *mut c_void;
 
     let payload_non_null = unsafe {
-        let payload = rb_iseq_get_yjit_payload(iseq);
+        let payload = rb_iseq_get_jit_payload(iseq);
         if payload.is_null() {
             // Increment the compiled iseq count
             incr_counter!(compiled_iseq_count);
@@ -1827,7 +1827,7 @@ pub fn get_or_create_iseq_payload(iseq: IseqPtr) -> &'static mut IseqPayload {
             // We allocate in those cases anyways.
             let new_payload = IseqPayload::default();
             let new_payload = Box::into_raw(Box::new(new_payload));
-            rb_iseq_set_yjit_payload(iseq, new_payload as VoidPtr);
+            rb_iseq_set_jit_payload(iseq, new_payload as VoidPtr);
 
             new_payload
         } else {
@@ -1904,7 +1904,7 @@ pub extern "C" fn rb_yjit_iseq_free(iseq: IseqPtr) {
     iseq_free_invariants(iseq);
 
     let payload = {
-        let payload = unsafe { rb_iseq_get_yjit_payload(iseq) };
+        let payload = unsafe { rb_iseq_get_jit_payload(iseq) };
         if payload.is_null() {
             // Nothing to free.
             return;
@@ -2032,7 +2032,7 @@ pub extern "C" fn rb_yjit_iseq_mark(payload: *mut c_void) {
 /// This is a mirror of [rb_yjit_iseq_mark].
 #[no_mangle]
 pub extern "C" fn rb_yjit_iseq_update_references(iseq: IseqPtr) {
-    let payload = unsafe { rb_iseq_get_yjit_payload(iseq) };
+    let payload = unsafe { rb_iseq_get_jit_payload(iseq) };
     let payload = if payload.is_null() {
         // Nothing to update.
         return;

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -1254,8 +1254,6 @@ extern "C" {
     ) -> VALUE;
     pub fn rb_c_method_tracing_currently_enabled(ec: *const rb_execution_context_t) -> bool;
     pub fn rb_full_cfunc_return(ec: *mut rb_execution_context_t, return_value: VALUE);
-    pub fn rb_iseq_get_yjit_payload(iseq: *const rb_iseq_t) -> *mut ::std::os::raw::c_void;
-    pub fn rb_iseq_set_yjit_payload(iseq: *const rb_iseq_t, payload: *mut ::std::os::raw::c_void);
     pub fn rb_get_symbol_id(namep: VALUE) -> ID;
     pub fn rb_yjit_builtin_function(iseq: *const rb_iseq_t) -> *const rb_builtin_function;
     pub fn rb_vm_base_ptr(cfp: *mut rb_control_frame_struct) -> *mut VALUE;
@@ -1403,6 +1401,8 @@ extern "C" {
         file: *const ::std::os::raw::c_char,
         line: ::std::os::raw::c_int,
     );
+    pub fn rb_iseq_get_jit_payload(iseq: *const rb_iseq_t) -> *mut ::std::os::raw::c_void;
+    pub fn rb_iseq_set_jit_payload(iseq: *const rb_iseq_t, payload: *mut ::std::os::raw::c_void);
     pub fn rb_iseq_reset_jit_func(iseq: *const rb_iseq_t);
     pub fn rb_jit_get_page_size() -> u32;
     pub fn rb_jit_reserve_addr_space(mem_size: u32) -> *mut u8;

--- a/zjit.c
+++ b/zjit.c
@@ -141,30 +141,6 @@ rb_zjit_iseq_insn_set(const rb_iseq_t *iseq, unsigned int insn_idx, enum ruby_vm
     ISEQ_BODY(iseq)->iseq_encoded[insn_idx] = (VALUE)insn_table[bare_insn];
 }
 
-// Get profiling information for ISEQ
-void *
-rb_iseq_get_zjit_payload(const rb_iseq_t *iseq)
-{
-    RUBY_ASSERT_ALWAYS(IMEMO_TYPE_P(iseq, imemo_iseq));
-    if (ISEQ_BODY(iseq)) {
-        return ISEQ_BODY(iseq)->zjit_payload;
-    }
-    else {
-        // Body is NULL when constructing the iseq.
-        return NULL;
-    }
-}
-
-// Set profiling information for ISEQ
-void
-rb_iseq_set_zjit_payload(const rb_iseq_t *iseq, void *payload)
-{
-    RUBY_ASSERT_ALWAYS(IMEMO_TYPE_P(iseq, imemo_iseq));
-    RUBY_ASSERT_ALWAYS(ISEQ_BODY(iseq));
-    RUBY_ASSERT_ALWAYS(NULL == ISEQ_BODY(iseq)->zjit_payload);
-    ISEQ_BODY(iseq)->zjit_payload = payload;
-}
-
 void
 rb_zjit_print_exception(void)
 {

--- a/zjit/bindgen/src/main.rs
+++ b/zjit/bindgen/src/main.rs
@@ -303,7 +303,7 @@ fn main() {
         .allowlist_type("rb_iseq_type")
         .allowlist_type("rb_event_flag_t")
         .allowlist_function("rb_object_shape_count")
-        .allowlist_function("rb_iseq_(get|set)_zjit_payload")
+        .allowlist_function("rb_iseq_(get|set)_jit_payload")
         .allowlist_function("rb_iseq_pc_at_idx")
         .allowlist_function("rb_iseq_opcode_at_pc")
         .allowlist_function("rb_iseq_bare_opcode_at_pc")

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -2450,8 +2450,6 @@ unsafe extern "C" {
         insn_idx: ::std::os::raw::c_uint,
         bare_insn: ruby_vminsn_type,
     );
-    pub fn rb_iseq_get_zjit_payload(iseq: *const rb_iseq_t) -> *mut ::std::os::raw::c_void;
-    pub fn rb_iseq_set_zjit_payload(iseq: *const rb_iseq_t, payload: *mut ::std::os::raw::c_void);
     pub fn rb_zjit_print_exception();
     pub fn rb_zjit_singleton_class_p(klass: VALUE) -> bool;
     pub fn rb_zjit_defined_ivar(obj: VALUE, id: ID, pushval: VALUE) -> VALUE;
@@ -2579,6 +2577,8 @@ unsafe extern "C" {
         file: *const ::std::os::raw::c_char,
         line: ::std::os::raw::c_int,
     );
+    pub fn rb_iseq_get_jit_payload(iseq: *const rb_iseq_t) -> *mut ::std::os::raw::c_void;
+    pub fn rb_iseq_set_jit_payload(iseq: *const rb_iseq_t, payload: *mut ::std::os::raw::c_void);
     pub fn rb_iseq_reset_jit_func(iseq: *const rb_iseq_t);
     pub fn rb_jit_get_page_size() -> u32;
     pub fn rb_jit_reserve_addr_space(mem_size: u32) -> *mut u8;

--- a/zjit/src/payload.rs
+++ b/zjit/src/payload.rs
@@ -110,7 +110,7 @@ pub fn get_or_create_iseq_payload_ptr(iseq: IseqPtr) -> *mut IseqPayload {
     type VoidPtr = *mut c_void;
 
     unsafe {
-        let payload = rb_iseq_get_zjit_payload(iseq);
+        let payload = rb_iseq_get_jit_payload(iseq);
         if payload.is_null() {
             // Allocate a new payload with Box and transfer ownership to the GC.
             // We drop the payload with Box::from_raw when the GC frees the ISEQ and calls us.
@@ -118,7 +118,7 @@ pub fn get_or_create_iseq_payload_ptr(iseq: IseqPtr) -> *mut IseqPayload {
             // We allocate in those cases anyways.
             let new_payload = IseqPayload::new();
             let new_payload = Box::into_raw(Box::new(new_payload));
-            rb_iseq_set_zjit_payload(iseq, new_payload as VoidPtr);
+            rb_iseq_set_jit_payload(iseq, new_payload as VoidPtr);
 
             new_payload
         } else {


### PR DESCRIPTION
We cannot have YJIT and ZJIT enabled at the same time, so we can use a single jit_payload pointer in iseq_constant_body to reduce the size by 8 bytes.