### PR TITLE
hash.c: add a substition hint

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -431,7 +431,8 @@ RHASH_AR_TABLE_MAX_BOUND(VALUE h)
 #define RHASH_AR_TABLE_MISS RHASH_AR_TABLE_MAX_SIZE
 
 #define RHASH_AR_TABLE_REF(hash, n) (&RHASH_AR_TABLE(hash)->pairs[n])
-#define RHASH_AR_CLEARED_HINT 0xff
+#define RHASH_AR_CLEARED_HINT 0x00
+#define RHASH_AR_SUBSTITUTION_HINT 0x01
 
 static inline st_hash_t
 ar_do_hash(VALUE hash, st_data_t key)
@@ -445,7 +446,8 @@ ar_do_hash(VALUE hash, st_data_t key)
 static inline ar_hint_t
 ar_do_hash_hint(st_hash_t hash_value)
 {
-    return (ar_hint_t)hash_value;
+    ar_hint_t hint = (ar_hint_t)hash_value;
+    return hint == RHASH_AR_CLEARED_HINT ? RHASH_AR_SUBSTITUTION_HINT : hint;
 }
 
 static inline ar_hint_t
@@ -474,19 +476,10 @@ ar_clear_entry(VALUE hash, unsigned int index)
     ar_hint_set_hint(hash, index, RHASH_AR_CLEARED_HINT);
 }
 
-static inline int
+static inline bool
 ar_cleared_entry(VALUE hash, unsigned int index)
 {
-    if (ar_hint(hash, index) == RHASH_AR_CLEARED_HINT) {
-        /* RHASH_AR_CLEARED_HINT is only a hint, not mean cleared entry,
-         * so you need to check key == Qundef
-         */
-        ar_table_pair *pair = RHASH_AR_TABLE_REF(hash, index);
-        return UNDEF_P(pair->key);
-    }
-    else {
-        return FALSE;
-    }
+    return ar_hint(hash, index) == RHASH_AR_CLEARED_HINT;
 }
 
 static inline void

--- a/spec/ruby/core/array/uniq_spec.rb
+++ b/spec/ruby/core/array/uniq_spec.rb
@@ -34,8 +34,8 @@ describe "Array#uniq" do
     y = mock('1')
     y.should_not_receive(:eql?)
 
-    x.should_receive(:hash).at_least(1).and_return(0)
-    y.should_receive(:hash).at_least(1).and_return(1)
+    x.should_receive(:hash).at_least(1).and_return(8)
+    y.should_receive(:hash).at_least(1).and_return(9)
 
     [x, y].uniq.should == [x, y]
   end
@@ -155,9 +155,9 @@ describe "Array#uniq!" do
 
   it "compares elements first with hash" do
     x = mock('0')
-    x.should_receive(:hash).at_least(1).and_return(0)
+    x.should_receive(:hash).at_least(1).and_return(8)
     y = mock('0')
-    y.should_receive(:hash).at_least(1).and_return(0)
+    y.should_receive(:hash).at_least(1).and_return(8)
 
     a = [x, y]
     a.uniq!
@@ -170,8 +170,8 @@ describe "Array#uniq!" do
     y = mock('1')
     y.should_not_receive(:eql?)
 
-    x.should_receive(:hash).at_least(1).and_return(0)
-    y.should_receive(:hash).at_least(1).and_return(1)
+    x.should_receive(:hash).at_least(1).and_return(8)
+    y.should_receive(:hash).at_least(1).and_return(9)
 
     a = [x, y]
     a.uniq!

--- a/spec/ruby/core/enumerable/uniq_spec.rb
+++ b/spec/ruby/core/enumerable/uniq_spec.rb
@@ -33,8 +33,8 @@ describe 'Enumerable#uniq' do
     y = mock('1')
     y.should_not_receive(:eql?)
 
-    x.should_receive(:hash).at_least(1).and_return(0)
-    y.should_receive(:hash).at_least(1).and_return(1)
+    x.should_receive(:hash).at_least(1).and_return(8)
+    y.should_receive(:hash).at_least(1).and_return(9)
 
     [x, y].to_enum.uniq.should == [x, y]
   end

--- a/spec/ruby/core/hash/element_reference_spec.rb
+++ b/spec/ruby/core/hash/element_reference_spec.rb
@@ -84,11 +84,11 @@ describe "Hash#[]" do
   it "does not compare keys with different #hash values via #eql?" do
     x = mock('x')
     x.should_not_receive(:eql?)
-    x.stub!(:hash).and_return(0)
+    x.stub!(:hash).and_return(7)
 
     y = mock('y')
     y.should_not_receive(:eql?)
-    y.stub!(:hash).and_return(1)
+    y.stub!(:hash).and_return(8)
 
     { y => 1 }[x].should == nil
   end

--- a/spec/ruby/core/hash/rehash_spec.rb
+++ b/spec/ruby/core/hash/rehash_spec.rb
@@ -5,8 +5,8 @@ describe "Hash#rehash" do
   it "reorganizes the Hash by recomputing all key hash codes" do
     k1 = Object.new
     k2 = Object.new
-    def k1.hash; 0; end
-    def k2.hash; 1; end
+    def k1.hash; 5; end
+    def k2.hash; 6; end
 
     h = {}
     h[k1] = :v1

--- a/spec/ruby/core/hash/shared/eql.rb
+++ b/spec/ruby/core/hash/shared/eql.rb
@@ -32,8 +32,8 @@ describe :hash_eql, shared: true do
     x.should_not_receive(:eql?)
     y.should_not_receive(:eql?)
 
-    x.should_receive(:hash).any_number_of_times.and_return(0)
-    y.should_receive(:hash).any_number_of_times.and_return(1)
+    x.should_receive(:hash).any_number_of_times.and_return(5)
+    y.should_receive(:hash).any_number_of_times.and_return(6)
 
     { x => 1 }.send(@method, { y => 1 }).should == false
   end


### PR DESCRIPTION
By guaranteeing that hints can't match `RHASH_AR_CLEARED_HINT` we can save on checking the key for `UNDEF_P` in a bunch of places.