### PR TITLE
Fix Ractor._activated: don't use Module#prepend

### DIFF
--- a/ractor.rb
+++ b/ractor.rb
@@ -541,9 +541,9 @@ class Ractor
   # internal method
   def self._require feature # :nodoc:
     if main?
-      super feature
+      require(feature)
     else
-      Primitive.ractor_require feature
+      Primitive.ractor_require(feature)
     end
   end
 
@@ -552,17 +552,22 @@ class Ractor
 
     # internal method that is called when the first "Ractor.new" is called
     def _activated # :nodoc:
-      Kernel.prepend Module.new{|m|
-        m.set_temporary_name '<RactorRequire>'
-
-        def require feature # :nodoc: -- otherwise RDoc outputs it as a class method
+      return if defined?(@__ractor_require_alias_activated)
+      # Put this in Object so that it comes before Rubygems require (which
+      # may have code that is not ractor-safe). Gems that hijack require
+      # should define their require in the Kernel module.
+      Object.module_eval do
+        alias_method :__ractor_original_require, :require
+        def require(feature) # :nodoc:
           if Ractor.main?
             super
           else
-            Ractor._require feature
+            Ractor._require(feature)
           end
         end
-      }
+        private :require
+      end
+      @__ractor_require_alias_activated = true
     end
   end
 

--- a/test/ruby/test_ractor.rb
+++ b/test/ruby/test_ractor.rb
@@ -354,6 +354,98 @@ class TestRactor < Test::Unit::TestCase
     RUBY
   end
 
+  # Ex: Rubygems redefines require before single-ractor mode is cancelled. The redefined require
+  # from a gem like rubygems should run in the main Ractor regardless of whether the gem is loaded
+  # before or after single ractor mode is cancelled.
+  #
+  # Uses assert_separately rather than assert_ractor: these tests must start out in single-ractor
+  # mode, and assert_ractor cancels it by creating a Ractor before the test body runs.
+  def test_redefined_require_before_single_ractor_mode_cancelled
+    assert_separately([], __FILE__, __LINE__, <<-'RUBY')
+      Warning[:experimental] = false
+      refute defined?(Gem), "rubygems must not be loaded"
+      refute Object.private_method_defined?(:__ractor_original_require), "must still be in single-ractor mode"
+
+      require "tempfile"
+      require "pathname"
+      f = Tempfile.new(["file_to_require_from_ractor", ".rb"])
+      f.write("")
+      f.flush
+      old = $-w; $-w = nil
+      class << Ractor
+        alias __orig_ractor_require _require
+        def _require(feature)
+          (Ractor.current[:required] ||= []) << [self.inspect, __method__, feature.to_s]
+          __orig_ractor_require(feature)
+        end
+      end
+      module Kernel
+        alias some_original_require require
+        def require(feature)
+          (Ractor.current[:required] ||= []) << [self.inspect, __method__, feature.to_s]
+          some_original_require(feature)
+        end
+      end
+      $-w = old
+      result = Ractor.new(f.path) do |path|
+        require Pathname.new(path)
+        Ractor.current[:required]
+      end.value
+      assert_equal [["Ractor", :_require, f.path]], result
+      assert_equal ["nil", :require, f.path], Ractor.current[:required]&.first
+    RUBY
+  end
+
+  # Ex: Rubygems redefines require after single-ractor mode is cancelled. The redefined require
+  # from a gem like rubygems should run in the main Ractor regardless of whether the gem is loaded
+  # before or after single ractor mode is cancelled.
+  #
+  # Uses assert_separately rather than assert_ractor: these tests must start out in single-ractor
+  # mode, and assert_ractor cancels it by creating a Ractor before the test body runs.
+  def test_redefined_require_after_single_ractor_mode_cancelled
+    assert_separately([], __FILE__, __LINE__, <<-'RUBY')
+      Warning[:experimental] = false
+      refute defined?(Gem), "rubygems must not be loaded"
+      refute Object.private_method_defined?(:__ractor_original_require), "must still be in single-ractor mode"
+
+      require "tempfile"
+      require "pathname"
+      f = Tempfile.new(["file_to_require_from_ractor", ".rb"])
+      f.write("")
+      f.flush
+      old = $-w; $-w = nil
+      class << Ractor
+        alias __orig_ractor_require _require
+        def _require(feature)
+          (Ractor.current[:required] ||= []) << [self.inspect, __method__, feature.to_s]
+          __orig_ractor_require(feature)
+        end
+      end
+      $-w = old
+      result = Ractor.new(f.path) do |path|
+        require Pathname.new(path)
+        Ractor.current[:required]
+      end.value
+      assert_equal [["Ractor", :_require, f.path]], result
+      assert_nil Ractor.current[:required]
+      old = $-w; $-w = nil
+      module Kernel
+        alias some_original_require require
+        def require(feature)
+          (Ractor.current[:required] ||= []) << [self.inspect, __method__, feature.to_s]
+          some_original_require(feature)
+        end
+      end
+      $-w = old
+      result = Ractor.new(f.path) do |path|
+        require Pathname.new(path)
+        Ractor.current[:required]
+      end.value
+      assert_equal [["Ractor", :_require, f.path]], result
+      assert_equal ["nil", :require, f.path], Ractor.current[:required]&.first
+    RUBY
+  end
+
   # [Bug #21398]
   def test_port_receive_dnt_with_port_send
     omit 'unstable on windows and macos-14' if RUBY_PLATFORM =~ /mswin|mingw|darwin/


### PR DESCRIPTION
Use aliasing instead of Module#prepend with super to redefine `require` when coming out of single ractor mode. There are bad interactions between Module#prepend and aliasing and we have seen bugs related to this in Rails CI: https://bugs.ruby-lang.org/issues/22263.

This should fix the issue we saw in Rails CI but doesn't fix the overall design issue with Module#prepend and aliasing.

Define the `require` method on `Object` so that it acts like a prepend, which is necessary if the redefined require (from Rubygems, Zeitwerk, etc.) happens after we leave single-ractor mode.