### PR TITLE
Invalidate CCs on cc_table_dup and avoid clearing valid CCs from iseqs on mark

### DIFF
--- a/internal/gc.h
+++ b/internal/gc.h
@@ -230,6 +230,11 @@ void rb_gc_after_fork(rb_pid_t pid);
     if (_obj != (VALUE)*(ptr)) *(ptr) = (void *)_obj; \
 } while (0)
 
+#define rb_gc_move_ptr(ptr) do { \
+    VALUE _obj = rb_gc_location((VALUE)*(ptr)); \
+    if (_obj != (VALUE)*(ptr)) *(ptr) = (void *)_obj; \
+} while (0)
+
 RUBY_SYMBOL_EXPORT_BEGIN
 /* exports for objspace module */
 void rb_objspace_reachable_objects_from(VALUE obj, void (func)(VALUE, void *), void *data);

--- a/iseq.c
+++ b/iseq.c
@@ -392,7 +392,7 @@ static bool
 cc_is_active(const struct rb_callcache *cc, bool reference_updating)
 {
     if (cc) {
-        if (cc == rb_vm_empty_cc() || rb_vm_empty_cc_for_super()) {
+        if (cc == rb_vm_empty_cc() || cc == rb_vm_empty_cc_for_super()) {
             return false;
         }
 

--- a/iseq.c
+++ b/iseq.c
@@ -389,28 +389,12 @@ rb_iseq_mark_and_move_each_body_value(const rb_iseq_t *iseq, VALUE *original_ise
 }
 
 static bool
-cc_is_active(const struct rb_callcache *cc, bool reference_updating)
+cc_is_active(const struct rb_callcache *cc)
 {
-    if (cc) {
-        if (cc == rb_vm_empty_cc() || cc == rb_vm_empty_cc_for_super()) {
-            return false;
-        }
+    RUBY_ASSERT(cc);
+    RUBY_ASSERT(vm_cc_markable(cc));
 
-        if (reference_updating) {
-            cc = (const struct rb_callcache *)rb_gc_location((VALUE)cc);
-        }
-
-        if (vm_cc_markable(cc) && vm_cc_valid(cc)) {
-            const struct rb_callable_method_entry_struct *cme = vm_cc_cme(cc);
-            if (reference_updating) {
-                cme = (const struct rb_callable_method_entry_struct *)rb_gc_location((VALUE)cme);
-            }
-            if (!METHOD_ENTRY_INVALIDATED(cme)) {
-                return true;
-            }
-        }
-    }
-    return false;
+    return vm_cc_valid(cc) && !METHOD_ENTRY_INVALIDATED(vm_cc_cme(cc));
 }
 
 void
@@ -435,16 +419,30 @@ rb_iseq_mark_and_move(rb_iseq_t *iseq, bool reference_updating)
         if (body->mandatory_only_iseq) rb_gc_mark_and_move_ptr(&body->mandatory_only_iseq);
 
         if (body->call_data) {
+            struct rb_call_data *cds = body->call_data;
             for (unsigned int i = 0; i < body->ci_size; i++) {
-                struct rb_call_data *cds = body->call_data;
 
                 if (cds[i].ci) rb_gc_mark_and_move_ptr(&cds[i].ci);
 
-                if (cc_is_active(cds[i].cc, reference_updating)) {
-                    rb_gc_mark_and_move_ptr(&cds[i].cc);
+                const struct rb_callcache *cc = cds[i].cc;
+                if (!cc || cc == rb_vm_empty_cc() || cc == rb_vm_empty_cc_for_super()) {
+                    // No need for marking, reference updating, or clearing
+                    // We also want to avoid reassigning to improve CoW
+                    continue;
                 }
-                else if (cds[i].cc != rb_vm_empty_cc()) {
-                    cds[i].cc = rb_vm_empty_cc();
+
+                if (reference_updating) {
+                    rb_gc_move_ptr(&cds[i].cc);
+                }
+                else {
+                    if (cc_is_active(cc)) {
+                        rb_gc_mark_movable((VALUE)cc);
+                    }
+                    else {
+                        // Either the CC or CME has been invalidated. Replace
+                        // it with the empty CC so that it can be GC'd.
+                        cds[i].cc = rb_vm_empty_cc();
+                    }
                 }
             }
         }

--- a/vm_method.c
+++ b/vm_method.c
@@ -140,6 +140,8 @@ rb_vm_cc_table_create(size_t capa)
     return rb_managed_id_table_create(&cc_table_type, capa);
 }
 
+static void vm_ccs_invalidate(struct rb_class_cc_entries *ccs);
+
 static enum rb_id_table_iterator_result
 vm_cc_table_dup_i(ID key, VALUE old_ccs_ptr, void *data)
 {
@@ -147,8 +149,13 @@ vm_cc_table_dup_i(ID key, VALUE old_ccs_ptr, void *data)
     struct rb_class_cc_entries *old_ccs = (struct rb_class_cc_entries *)old_ccs_ptr;
 
     if (METHOD_ENTRY_INVALIDATED(old_ccs->cme)) {
-        // Invalidated CME. This entry will be removed from the old table on
-        // the next GC mark, so it's unsafe (and undesirable) to copy
+        // At this point, old_ccs is valid and hasn't been freed.
+        // However once we allocate below, mark_cc_entry_i may free the entries
+        // If this is invalidated, we should avoid the copy, and invalidate the CCs
+        // since later we will CAS the new cc_table, disconnecting old_ccs and it
+        // may not be marked.
+        // We don't want to copy this anyways since it's invalidated.
+        vm_ccs_invalidate(old_ccs);
         return ID_TABLE_CONTINUE;
     }
 
@@ -187,6 +194,7 @@ vm_ccs_invalidate(struct rb_class_cc_entries *ccs)
 {
     for (int i=0; i<ccs->len; i++) {
         const struct rb_callcache *cc = ccs->entries[i].cc;
+        if (cc->klass == Qundef) continue; // already invalidated
         VM_ASSERT(!vm_cc_super_p(cc) && !vm_cc_refinement_p(cc));
         vm_cc_invalidate(cc);
     }


### PR DESCRIPTION
This fixes two dormant bugs

This reverts https://github.com/ruby/ruby/pull/16147, reapplying https://github.com/ruby/ruby/pull/16140

I believe the CC bug reported on 4.0 (https://bugs.ruby-lang.org/issues/22242) was the cause of the crashes last time we tried this. That bug has since been made dormant on HEAD by using a weak reference for cc->cme. This applies an additional fix (that we will backport to 4.0 as it doesn't have that weak reference)