### PR TITLE
ZJIT: Reserve a label reference's bytes by writing them

### DIFF
--- a/zjit/src/asm/mod.rs
+++ b/zjit/src/asm/mod.rs
@@ -246,7 +246,12 @@ impl CodeBlock {
 
         // Move past however many bytes the instruction takes up
         if self.write_pos + num_bytes < self.mem_size {
-            self.write_pos += num_bytes;
+            // Reserve the bytes by writing them rather than by moving the cursor
+            // over them. Pages are mapped on first write, so a cursor bump alone
+            // leaves a page that cannot be mapped.
+            const RESERVED: [u8; 16] = [0; 16];
+            assert!(num_bytes <= RESERVED.len(), "label reference wants {num_bytes} bytes");
+            self.write_bytes(&RESERVED[..num_bytes]);
         } else {
             self.dropped_bytes = true; // retry emitting the Insn after next_page
         }
@@ -464,5 +469,40 @@ mod tests
 
         assert_eq!(uimm_num_bits((u32::MAX as u64) + 1), 64);
         assert_eq!(uimm_num_bits(u64::MAX), 64);
+    }
+
+    #[test]
+    fn test_label_ref_at_an_unmappable_page_sets_dropped_bytes() {
+        // Two pages of address space, but a memory limit that only lets
+        // the first page be mapped.
+        let page_size = unsafe { crate::cruby::rb_jit_get_page_size() } as usize;
+        let limit = crate::stats::zjit_alloc_bytes() + page_size + page_size / 2;
+        let virt_mem = VirtualMem::alloc(2 * page_size, Some(limit));
+        let mut cb = CodeBlock::new(Rc::new(RefCell::new(virt_mem)), false);
+
+        // Fill the mappable page up to 2 bytes below its end, so that
+        // a 5-byte jump reservation straddles into the unmappable page.
+        for _ in 0..(page_size - 2) {
+            cb.write_byte(0x90);
+        }
+        assert!(!cb.has_dropped_bytes(), "the first page must map");
+
+        // label_ref() must reserve its bytes by writing them, so that the
+        // unmappable page surfaces as dropped_bytes here, where the caller
+        // still reads it and turns it into CompileError::OutOfMemory.
+        let label = cb.new_label("over_the_page_boundary".to_string());
+        cb.label_ref(label, 5, |cb, _, _| {
+            cb.write_bytes(&[0; 5]);
+            Ok(())
+        });
+        cb.write_label(label);
+
+        // Mirror what compile_with_regs does after emit. It calls link_labels()
+        // only if emit did not go OOM. This reproduces an assertion failure in
+        // link_labels() when dropped_bytes isn't updated properly.
+        if !cb.has_dropped_bytes() {
+            cb.link_labels().unwrap();
+        }
+        assert!(cb.has_dropped_bytes(), "the reservation must discover the unmappable page");
     }
 }

--- a/zjit/src/asm/mod.rs
+++ b/zjit/src/asm/mod.rs
@@ -244,17 +244,13 @@ impl CodeBlock {
         // Keep track of the reference
         self.label_refs.push(LabelRef { pos: self.write_pos, label, num_bytes, encode: Box::new(encode) });
 
-        // Move past however many bytes the instruction takes up
-        if self.write_pos + num_bytes < self.mem_size {
-            // Reserve the bytes by writing them rather than by moving the cursor
-            // over them. Pages are mapped on first write, so a cursor bump alone
-            // leaves a page that cannot be mapped.
-            const RESERVED: [u8; 16] = [0; 16];
-            assert!(num_bytes <= RESERVED.len(), "label reference wants {num_bytes} bytes");
-            self.write_bytes(&RESERVED[..num_bytes]);
-        } else {
-            self.dropped_bytes = true; // retry emitting the Insn after next_page
-        }
+        // Move past however many bytes the instruction takes up.
+        // Reserve the bytes by writing them rather than by moving the cursor
+        // over them. Pages are mapped on first write, so a cursor bump alone
+        // leaves a page that cannot be mapped.
+        const RESERVED: [u8; 16] = [0; 16];
+        assert!(num_bytes <= RESERVED.len(), "label reference wants {num_bytes} bytes");
+        self.write_bytes(&RESERVED[..num_bytes]);
     }
 
     // Link internal label references


### PR DESCRIPTION
This PR fixes a panic in some OOM situations.

It avoids the `label_ref callback didn't write number of bytes it claimed to write upfront` assertion failure in `link_labels()`, which aborts the process when a function's last label reference straddles into a page that can no longer be mapped under `--zjit-mem-size`.

As of master, because the reservation only moves the cursor without writing, it never discovers that the page it skipped over can no longer be mapped under `--zjit-mem-size`, so `cb.dropped_bytes` stays false and emission looks successful.