### PR TITLE
Don't record EP escape in JIT when not enabled

### DIFF
--- a/iseq.c
+++ b/iseq.c
@@ -192,14 +192,14 @@ rb_iseq_free(const rb_iseq_t *iseq)
         iseq_clear_ic_references(iseq);
         struct rb_iseq_constant_body *const body = ISEQ_BODY(iseq);
 #if USE_YJIT
-        rb_yjit_iseq_free(iseq);
+        if (rb_yjit_enabled_p) rb_yjit_iseq_free(iseq);
         if (FL_TEST_RAW((VALUE)iseq, ISEQ_TRANSLATED)) {
             RUBY_ASSERT(rb_yjit_live_iseq_count > 0);
             rb_yjit_live_iseq_count--;
         }
 #endif
 #if USE_ZJIT
-        rb_zjit_iseq_free(iseq);
+        if (rb_zjit_enabled_p) rb_zjit_iseq_free(iseq);
 #endif
         SIZED_FREE_N(body->iseq_encoded, body->iseq_size);
         SIZED_FREE_N(body->insns_info.body, body->insns_info.size);

--- a/vm.c
+++ b/vm.c
@@ -1140,8 +1140,8 @@ vm_make_env_each(const rb_execution_context_t * const ec, rb_control_frame_t *co
     // are no longer useful and can slow down Ractors.
     if (VM_FRAME_RUBYFRAME_P(cfp) &&
         !rbimpl_atomic_load(&ISEQ_BODY(iseq)->jit_ep_escape_recorded, RBIMPL_ATOMIC_RELAXED)) {
-        rb_yjit_invalidate_ep_is_bp(iseq);
-        rb_zjit_invalidate_no_ep_escape(iseq);
+        if (rb_yjit_enabled_p) rb_yjit_invalidate_ep_is_bp(iseq);
+        if (rb_zjit_enabled_p) rb_zjit_invalidate_no_ep_escape(iseq);
     }
 
     /*

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -1997,7 +1997,7 @@ eval_string_with_cref(VALUE self, VALUE src, rb_cref_t *cref, VALUE file, int li
 
     // EP is not escaped to the heap here, but captured and reused by another frame.
     // ZJIT's locals are incompatible with it unlike YJIT's, so invalidate the ISEQ for ZJIT.
-    rb_zjit_invalidate_no_ep_escape(CFP_ISEQ(cfp));
+    if (rb_zjit_enabled_p) rb_zjit_invalidate_no_ep_escape(CFP_ISEQ(cfp));
 
     iseq = eval_make_iseq(src, file, line, &block);
     if (!iseq) {

--- a/yjit/src/invariants.rs
+++ b/yjit/src/invariants.rs
@@ -573,11 +573,6 @@ pub extern "C" fn rb_yjit_invalidate_no_singleton_class(klass: VALUE) {
 /// equal to base pointer.
 #[no_mangle]
 pub extern "C" fn rb_yjit_invalidate_ep_is_bp(iseq: IseqPtr) {
-    // Skip tracking EP escapes on boot. We don't need to invalidate anything during boot.
-    if unsafe { INVARIANTS.is_none() } {
-        return;
-    }
-
     with_vm_lock(src_loc!(), || {
         // If an EP escape for this ISEQ is detected for the first time, invalidate all blocks
         // associated to the ISEQ. The iseq flag records the escape, so the map keeps only

--- a/zjit/src/invariants.rs
+++ b/zjit/src/invariants.rs
@@ -194,11 +194,6 @@ pub extern "C" fn rb_zjit_bop_redefined(klass: RedefinitionFlag, bop: ruby_basic
 /// equal to base pointer.
 #[unsafe(no_mangle)]
 pub extern "C" fn rb_zjit_invalidate_no_ep_escape(iseq: IseqPtr) {
-    // Skip tracking EP escapes on boot. We don't need to invalidate anything during boot.
-    if !ZJITState::has_instance() {
-        return;
-    }
-
     with_vm_lock(src_loc!(), || {
         // Remember that this ISEQ may escape EP
         unsafe { rb_jit_iseq_mark_ep_escape_recorded(iseq) };


### PR DESCRIPTION
We shouldn't record JIT information before the JIT is actually enabled.

This change doesn't seem to affect ZJIT or YJIT performance beyond the margin of error:

    ZJIT:

      --------------  ------------  ------------  --------------  -------------
      bench            master (ms)   branch (ms)  branch 1st itr  master/branch
      activerecord     50.1 ± 7.4%   49.0 ± 5.7%           0.948          1.022
      chunky-png      164.2 ± 2.1%  166.8 ± 2.8%           0.985          0.985
      erubi-rails     247.0 ± 2.8%  264.6 ± 2.2%           0.945          0.934
      hexapdf         571.3 ± 1.0%  565.4 ± 1.2%           0.959          1.010
      liquid-c        17.6 ± 13.1%  19.2 ± 12.9%           0.976          0.920
      liquid-compile  15.7 ± 11.0%   15.6 ± 7.5%           0.978          1.003
      liquid-il        79.8 ± 2.0%   78.2 ± 2.2%           0.993          1.021
      liquid-render    32.3 ± 6.8%   32.3 ± 6.3%           1.001          0.999
      lobsters        243.8 ± 4.9%  242.8 ± 4.7%           0.976          1.004
      mail             38.8 ± 3.1%   39.5 ± 5.1%           0.993          0.982
      psych-load      612.4 ± 1.5%  610.0 ± 1.9%           1.001          1.004
      railsbench      343.8 ± 2.9%  350.8 ± 2.2%           0.991          0.980
      rubocop         50.0 ± 10.6%  51.2 ± 12.0%           1.019          0.978
      ruby-lsp         42.9 ± 3.8%   43.2 ± 3.7%           0.974          0.993
      sequel           18.5 ± 6.6%   18.7 ± 6.6%           1.021          0.991
      shipit          344.3 ± 1.3%  339.8 ± 3.4%           0.981          1.013
      --------------  ------------  ------------  --------------  -------------

    YJIT:

      --------------  ------------  ------------  --------------  -------------
      bench            master (ms)   branch (ms)  branch 1st itr  master/branch
      activerecord     42.6 ± 7.7%   40.6 ± 5.5%           1.099          1.048
      chunky-png      164.7 ± 1.3%  164.8 ± 1.1%           1.060          0.999
      erubi-rails     256.7 ± 3.3%  241.3 ± 2.3%           1.035          1.064
      hexapdf         445.6 ± 1.0%  444.6 ± 1.0%           1.012          1.002
      liquid-c        16.4 ± 11.2%  16.7 ± 13.3%           1.037          0.986
      liquid-compile  14.5 ± 11.5%   14.3 ± 7.8%           0.990          1.011
      liquid-il        74.9 ± 2.6%   73.4 ± 3.6%           0.993          1.021
      liquid-render    23.1 ± 8.9%   23.3 ± 8.7%           1.001          0.992
      lobsters        239.9 ± 9.9%  238.7 ± 9.3%           0.989          1.005
      mail             29.2 ± 4.6%   30.0 ± 5.8%           0.977          0.973
      psych-load      515.5 ± 1.2%  511.5 ± 0.7%           0.973          1.008
      railsbench      317.4 ± 2.2%  317.9 ± 2.5%           1.008          0.998
      rubocop         42.1 ± 18.5%  42.0 ± 14.4%           1.052          1.004
      ruby-lsp         41.5 ± 3.8%   41.6 ± 3.8%           1.013          0.998
      sequel           18.5 ± 6.6%   18.2 ± 5.4%           1.150          1.018
      shipit          282.8 ± 3.8%  285.5 ± 5.2%           1.000          0.991
      --------------  ------------  ------------  --------------  -------------