### PR TITLE
Fail instead of spinning when a fiber scheduler writes nothing.

### DIFF
--- a/io.c
+++ b/io.c
@@ -1326,6 +1326,35 @@ rb_io_read_memory(rb_io_t *fptr, void *buf, size_t count)
     return (ssize_t)rb_io_blocking_region_wait(fptr, internal_read_func, &iis, RUBY_IO_READABLE);
 }
 
+// Zero is not a valid result for a non-empty write: a short write is positive, and a
+// would-block is a negative errno. The callers retry a zero immediately, so a scheduler
+// which transfers nothing (usually an older interface version) would spin forever:
+static ssize_t
+io_fiber_scheduler_write_result_apply(VALUE result, size_t length)
+{
+    ssize_t bytes = rb_fiber_scheduler_io_result_apply(result);
+
+    if (bytes == 0 && length > 0) {
+        char message[256];
+        snprintf(message, sizeof(message),
+                 "Fiber scheduler wrote 0 of %"PRIuSIZE" bytes: #io_write must transfer at "
+                 "least one byte or return -errno (scheduler interface version %d)",
+                 length, RUBY_FIBER_SCHEDULER_VERSION);
+
+        // `$stderr` writes through the scheduler as well, so this is the only way the
+        // message escapes a scheduler which cannot write. Once per process:
+        static rb_atomic_t reported = 0;
+        if (!ATOMIC_EXCHANGE(reported, 1)) {
+            fprintf(stderr, "warning: [pid %ld] %s\n", (long)getpid(), message);
+            fflush(stderr);
+        }
+
+        rb_raise(rb_eIOError, "%s", message);
+    }
+
+    return bytes;
+}
+
 static ssize_t
 rb_io_write_memory(rb_io_t *fptr, const void *buf, size_t count)
 {
@@ -1335,7 +1364,7 @@ rb_io_write_memory(rb_io_t *fptr, const void *buf, size_t count)
         VALUE result = rb_fiber_scheduler_io_write_memory(scheduler, fptr->self, buf, count);
 
         if (!UNDEF_P(result)) {
-            return rb_fiber_scheduler_io_result_apply(result);
+            return io_fiber_scheduler_write_result_apply(result, count);
         }
     }
 
@@ -1374,7 +1403,7 @@ rb_writev_internal(rb_io_t *fptr, const struct iovec *iov, int iovcnt)
         VALUE result = rb_fiber_scheduler_io_write_memory(scheduler, fptr->self, iov[0].iov_base, iov[0].iov_len);
 
         if (!UNDEF_P(result)) {
-            return rb_fiber_scheduler_io_result_apply(result);
+            return io_fiber_scheduler_write_result_apply(result, iov[0].iov_len);
         }
     }
 

--- a/test/fiber/scheduler.rb
+++ b/test/fiber/scheduler.rb
@@ -427,6 +427,13 @@ class IOErrorScheduler < Scheduler
   end
 end
 
+# This scheduler transfers nothing at all: neither a positive count nor a negative errno.
+class ZeroWriteScheduler < Scheduler
+  def io_write(io, buffer, offset, length)
+    return 0
+  end
+end
+
 # This scheduler has a broken implementation of `unblock`` in the sense that it
 # raises an exception. This is used to test the behavior of the scheduler when
 # unblock raises an exception.

--- a/test/fiber/test_scheduler.rb
+++ b/test/fiber/test_scheduler.rb
@@ -377,6 +377,32 @@ class TestFiberScheduler < Test::Unit::TestCase
     FileUtils.rm_f(path)
   end
 
+  # `join(10)` so that a regression fails rather than hangs:
+  def test_io_write_zero_progress
+    path = File.join(Dir.tmpdir, "ruby_test_io_write_zero_progress_#{SecureRandom.hex}")
+    error = nil
+
+    thread = Thread.new do
+      scheduler = ZeroWriteScheduler.new
+      Fiber.set_scheduler scheduler
+      Fiber.schedule do
+        File.open(path, 'w+') { it.sync = true; it << 'foo' }
+      rescue => error
+        # Ignore.
+      end
+    end
+
+    unless thread.join(10)
+      flunk "IO#write did not return: the write loop spun on a scheduler which wrote nothing."
+    end
+
+    assert_kind_of IOError, error
+    assert_include error.message, "wrote 0 of 3 bytes"
+  ensure
+    thread.kill rescue nil
+    FileUtils.rm_f(path)
+  end
+
   def test_io_write_flush_error
     path = File.join(Dir.tmpdir, "ruby_test_io_write_flush_error_#{SecureRandom.hex}")
     error = nil


### PR DESCRIPTION
`Fiber::Scheduler#io_write` returns the number of bytes written or `-errno`, and zero is only valid when `length` is zero. A scheduler which returns zero for a non-empty write has made no progress, but `io_binwrite_string` reads a zero result as "the internal buffer moved, retry" and asks again immediately, forever.

A scheduler written for interface version 3 reads the version 4 `(offset, length)` arguments the wrong way round and returns zero every time.

I found this in production with io-event 1.19.4 (I know, my bad for not updating!). Every Falcon worker spun at 100% CPU, none of them ever reported ready, and the deploy failed its health check. There is no exception and no output, so the only symptom is a stuck process, which made it hard to trace back to the scheduler at all.

- raise `IOError` from `rb_io_write_memory` and `rb_writev_internal` when the scheduler transfers nothing
- report the first stall in each process directly to `stderr`, because `$stderr` writes through the same scheduler: raising on its own is silent, an unhandled exception prints nothing at all and the process exits 0
- the new test fails on master, by timing out its thread rather than hanging the suite, and passes with the change
