### PR TITLE
ZJIT: Stop generating a new stub after invalidation

### DIFF
--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -273,9 +273,26 @@ pub fn invalidate_iseq_version(cb: &mut CodeBlock, iseq: IseqPtr, version: &mut 
 pub fn gen_iseq_call(cb: &mut CodeBlock, iseq_call: &IseqCallRef) -> Result<(), CompileError> {
     trace_compile_phase("compile_stub", || {
         // Compile a function stub
-        let stub_ptr = gen_function_stub(cb, iseq_call.clone()).inspect_err(|err| {
-            debug!("{err:?}: gen_function_stub failed: {}", iseq_get_location(iseq_call.iseq.get(), 0));
-        })?;
+        let stub_ptr = match iseq_call.stub_addr.get() {
+            // When gen_iseq_call() is called from invalidation and therefore this IseqCall has been
+            // compiled before, reuse the address of the previously-compiled stub.
+            Some(stub_ptr) => {
+                // gen_function_stub leaked one Rc reference into the stub's baked IseqCall pointer,
+                // and the previous function_stub_hit consumed it. Restore one leaked reference for
+                // the next stub hit's Rc::from_raw to reclaim.
+                unsafe { Rc::increment_strong_count(Rc::as_ptr(iseq_call)); }
+                stub_ptr
+            }
+            // When gen_iseq_call() is called from gen_iseq_body() and this IseqCall is compiled for
+            // the first time, generate a function stub and remember the address in the IseqCall.
+            None => {
+                let stub_ptr = gen_function_stub(cb, iseq_call.clone()).inspect_err(|err| {
+                    debug!("{err:?}: gen_function_stub failed: {}", iseq_get_location(iseq_call.iseq.get(), 0));
+                })?;
+                iseq_call.stub_addr.set(Some(stub_ptr));
+                stub_ptr
+            }
+        };
 
         // Update the JIT-to-JIT call to call the stub
         let stub_addr = stub_ptr.raw_ptr(cb);
@@ -4339,6 +4356,9 @@ pub struct IseqCall {
 
     /// Position where the call instruction ends (exclusive)
     end_addr: Cell<Option<CodePtr>>,
+
+    /// Address of the function stub generated for this call, if already compiled.
+    stub_addr: Cell<Option<CodePtr>>,
 }
 
 pub type IseqCallRef = Rc<IseqCall>;
@@ -4350,6 +4370,7 @@ impl IseqCall {
             iseq: Cell::new(iseq),
             start_addr: Cell::new(None),
             end_addr: Cell::new(None),
+            stub_addr: Cell::new(None),
             jit_entry_idx,
             argc,
         };

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -4358,6 +4358,7 @@ pub struct IseqCall {
     end_addr: Cell<Option<CodePtr>>,
 
     /// Address of the function stub generated for this call, if already compiled.
+    // TODO(alan): Remove with removal of without_locals(), as this caching means `IseqCall` is never freed.
     stub_addr: Cell<Option<CodePtr>>,
 }
 

--- a/zjit/src/codegen_tests.rs
+++ b/zjit/src/codegen_tests.rs
@@ -1106,7 +1106,7 @@ fn test_no_ep_escape_patch_point_after_send_does_not_repeat_send() {
 }
 
 #[test]
-fn test_no_ep_escape_side_exit_restores_locals() {
+fn test_no_ep_escape_side_exit_restores_locals_while_oom() {
     // A regression test for stub compilation failures on OOM. Functions patched by NoEPEscape
     // is unsafe to enter (FrameState uses without_locals() and doesn't spill the entry state),
     // so even under OOM, the re-stub after invalidation must succeed.

--- a/zjit/src/codegen_tests.rs
+++ b/zjit/src/codegen_tests.rs
@@ -6,7 +6,7 @@ use crate::backend::lir::Assembler;
 use crate::codegen::max_iseq_versions;
 use crate::cruby::*;
 use crate::hir::{Insn, iseq_to_hir};
-use crate::options::{get_option, rb_zjit_prepare_options, set_call_threshold, set_inline_threshold, set_max_versions};
+use crate::options::{get_option, rb_zjit_prepare_options, set_call_threshold, set_inline_threshold, set_max_versions, set_mem_bytes};
 use crate::payload::IseqVersion;
 use crate::hir::tests::hir_build_tests::assert_contains_opcode;
 use crate::payload::*;
@@ -1103,6 +1103,41 @@ fn test_no_ep_escape_patch_point_after_send_does_not_repeat_send() {
     "#);
     assert_contains_opcode("test", YARVINSN_send);
     assert_snapshot!(assert_compiles_allowing_exits("[test, test, test]"), @"[1, 2, 3]");
+}
+
+#[test]
+fn test_no_ep_escape_side_exit_restores_locals() {
+    // A regression test for stub compilation failures on OOM. Functions patched by NoEPEscape
+    // is unsafe to enter (FrameState uses without_locals() and doesn't spill the entry state),
+    // so even under OOM, the re-stub after invalidation must succeed.
+    set_mem_bytes(2 * 1024 * 1024);
+    set_inline_threshold(0);
+    set_call_threshold(2);
+    assert_snapshot!(inspect(r#"
+        class Foo
+          def initialize = @perm = 7
+          def callee(esc, local_to_spill = "spilled", perm = @perm)
+            binding if esc
+            local_to_spill
+          end
+        end
+        def kaller(foo, esc) = foo.callee(esc)
+
+        foo = Foo.new
+        300.times { kaller(foo, false) } # compile callee (with its NoEPEscape patch point) and the kaller->callee edge
+
+        # Fill the code region so the re-stub after the EP escape fails with OutOfMemory.
+        1000.times do |i|
+          body = (0...25).map { |k| "u#{k} = #{i} + #{k}; s += u#{k}" }.join("; ")
+          eval "def big#{i}(a = 1); s = 0; #{body}; s; end"
+        end
+        1000.times { |i| 2.times { send(:"big#{i}") } }
+
+        kaller(foo, true) # escape callee's EP; the kaller->callee re-stub OOMs
+        # Re-enter the patched callee. Each call must still return "spilled"; on the buggy
+        # build local_to_spill is read from a stale stack slot and comes back as junk.
+        300.times.all? { kaller(foo, false) == "spilled" }
+    "#), @"true");
 }
 
 #[test]

--- a/zjit/src/options.rs
+++ b/zjit/src/options.rs
@@ -666,6 +666,13 @@ pub fn set_inline_threshold(inline_threshold: InlineThreshold) {
     unsafe { OPTIONS.as_mut().unwrap().inline_threshold = inline_threshold; }
 }
 
+/// Set --zjit-mem-size for testing. It's used to force OOM in tests.
+#[cfg(test)]
+pub fn set_mem_bytes(mem_bytes: usize) {
+    rb_zjit_prepare_options();
+    unsafe { OPTIONS.as_mut().unwrap().mem_bytes = mem_bytes; }
+}
+
 /// Enable --zjit-stats for testing
 #[cfg(test)]
 pub fn enable_zjit_stats() {


### PR DESCRIPTION
This PR fixes random CI failures like [this](https://github.com/ruby/ruby/actions/runs/32989418502/job/98243186363).

Since NoEPEscape PatchPoint uses FrameState `without_locals()` https://github.com/ruby/ruby/pull/14448, entering already-invalidated code is unsafe (such code doesn't spill entry-state locals on the invalidated patch point, which would not be a problem for on-stack code that should have spilled locals before a non-leaf call). https://github.com/ruby/ruby/pull/16558 fixed interpreter entries, and https://github.com/ruby/ruby/pull/18315 fixed JIT entries. JIT entries, however, were not fully fixed because OOM may fail re-stubs. This PR fixes that case.

## Memory usage

On lobsters, `code_region_bytes` is decreased by 41KB, and `zjit_alloc_bytes` is increased by 62KB. So an increase of 21KB out of 35.9MB (+0.06%). I think the 0.06% increase is acceptable, and better code locality might be rather favorable.

### Before

```
code_region_bytes:     15,540,224
zjit_alloc_bytes:      20,343,960
```

### After

```
code_region_bytes:     15,499,264
zjit_alloc_bytes:      20,405,576
```