### PR TITLE
Remove wrapper field in iseq

### DIFF
--- a/iseq.c
+++ b/iseq.c
@@ -407,8 +407,6 @@ rb_iseq_mark_and_move(rb_iseq_t *iseq, bool reference_updating)
 {
     RUBY_MARK_ENTER("iseq");
 
-    rb_gc_mark_and_move(&iseq->wrapper);
-
     if (ISEQ_BODY(iseq)) {
         struct rb_iseq_constant_body *body = ISEQ_BODY(iseq);
 
@@ -1721,24 +1719,11 @@ static const rb_data_type_t iseqw_data_type = {
 static VALUE
 iseqw_new(const rb_iseq_t *iseq)
 {
-    if (iseq->wrapper) {
-        if (*(const rb_iseq_t **)rb_check_typeddata(iseq->wrapper, &iseqw_data_type) != iseq) {
-            rb_raise(rb_eTypeError, "wrong iseq wrapper: %" PRIsVALUE " for %p",
-                     iseq->wrapper, (void *)iseq);
-        }
-        return iseq->wrapper;
-    }
-    else {
-        rb_iseq_t **ptr;
-        VALUE obj = TypedData_Make_Struct(rb_cISeq, rb_iseq_t *, &iseqw_data_type, ptr);
-        RB_OBJ_WRITE(obj, ptr, iseq);
-
-        /* cache a wrapper object */
-        RB_OBJ_SET_FROZEN_SHAREABLE((VALUE)obj);
-        RB_OBJ_WRITE((VALUE)iseq, &iseq->wrapper, obj);
-
-        return obj;
-    }
+    rb_iseq_t **ptr;
+    VALUE obj = TypedData_Make_Struct(rb_cISeq, rb_iseq_t *, &iseqw_data_type, ptr);
+    RB_OBJ_WRITE(obj, ptr, iseq);
+    RB_OBJ_SET_FROZEN_SHAREABLE((VALUE)obj);
+    return obj;
 }
 
 VALUE

--- a/test/ruby/test_iseq.rb
+++ b/test/ruby/test_iseq.rb
@@ -837,21 +837,6 @@ class TestISeq < Test::Unit::TestCase
     }
   end
 
-  def test_iseq_of_twice_for_same_code
-    [
-      proc{},
-      method(:test_iseq_of_twice_for_same_code),
-      RubyVM::InstructionSequence.compile("p 1"),
-      begin; raise "error"; rescue => error; error.backtrace_locations[0]; end
-    ].each{|src|
-      iseq1 = RubyVM::InstructionSequence.of(src)
-      iseq2 = RubyVM::InstructionSequence.of(src)
-
-      # ISeq objects should be same for same src
-      assert_equal iseq1.object_id, iseq2.object_id
-    }
-  end
-
   def test_iseq_builtin_to_a
     invokebuiltin = eval(EnvUtil.invoke_ruby(['-e', <<~EOS], '', true).first)
       insns = RubyVM::InstructionSequence.of([].method(:pack)).to_a.last

--- a/vm_core.h
+++ b/vm_core.h
@@ -590,11 +590,10 @@ struct rb_iseq_constant_body {
 /* typedef rb_iseq_t is in method.h */
 struct rb_iseq_struct {
     VALUE flags; /* 1 */
-    VALUE wrapper; /* 2 */
 
-    struct rb_iseq_constant_body *body;  /* 3 */
+    struct rb_iseq_constant_body *body;  /* 2 */
 
-    union { /* 4, 5 words */
+    union { /* 3, 4 words */
         struct iseq_compile_data *compile_data; /* used at compile time */
 
         struct {

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -1289,7 +1289,6 @@ pub union rb_iseq_constant_body__bindgen_ty_1 {
 #[repr(C)]
 pub struct rb_iseq_struct {
     pub flags: VALUE,
-    pub wrapper: VALUE,
     pub body: *mut rb_iseq_constant_body,
     pub aux: rb_iseq_struct__bindgen_ty_1,
 }

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -1766,7 +1766,7 @@ mod hir_opt_tests {
           PatchPoint MethodRedefined(Object@0x1000, m@0x1008, cme:0x1010)
           v20:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           PushInlineFrame :m, v20 (0x1038), num_args=1
-          PatchPoint MethodRedefined(NilClass@0x1060, nil?@0x1068, cme:0x1070)
+          PatchPoint MethodRedefined(NilClass@0x1058, nil?@0x1060, cme:0x1068)
           v52:Fixnum[0] = Const Value(0)
           CheckInterrupts
           v84:Fixnum[0] = Const Value(0)
@@ -1801,7 +1801,7 @@ mod hir_opt_tests {
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, fun_new_map@0x1010, cme:0x1018)
           v25:ArraySubclass[class_exact:C] = GuardType v10, ArraySubclass[class_exact:C] recompile
-          v26:BasicObject = SendDirect v25, 0x1040, :fun_new_map (0x1068)
+          v26:BasicObject = SendDirect v25, 0x1040, :fun_new_map (0x1060)
           PatchPoint NoEPEscape(test)
           CheckInterrupts
           Return v26
@@ -1991,7 +1991,7 @@ mod hir_opt_tests {
           PushInlineFrame :foo, v18 (0x1038), num_args=0
           v26:Fixnum[1] = Const Value(1)
           v34:Fixnum[2] = Const Value(2)
-          PatchPoint MethodRedefined(Integer@0x1060, +@0x1068, cme:0x1070)
+          PatchPoint MethodRedefined(Integer@0x1058, +@0x1060, cme:0x1068)
           v61:Fixnum[3] = Const Value(3)
           CheckInterrupts
           PopInlineFrame
@@ -2022,7 +2022,7 @@ mod hir_opt_tests {
           v20:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           PushInlineFrame :foo, v20 (0x1038), num_args=1
           v28:Fixnum[2] = Const Value(2)
-          PatchPoint MethodRedefined(Integer@0x1060, +@0x1068, cme:0x1070)
+          PatchPoint MethodRedefined(Integer@0x1058, +@0x1060, cme:0x1068)
           v54:Fixnum[5] = Const Value(5)
           CheckInterrupts
           PopInlineFrame
@@ -2053,7 +2053,7 @@ mod hir_opt_tests {
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
           v22:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           PushInlineFrame :foo, v22 (0x1038), num_args=2
-          PatchPoint MethodRedefined(Integer@0x1060, +@0x1068, cme:0x1070)
+          PatchPoint MethodRedefined(Integer@0x1058, +@0x1060, cme:0x1068)
           v47:Fixnum[7] = Const Value(7)
           CheckInterrupts
           PopInlineFrame
@@ -2097,7 +2097,7 @@ mod hir_opt_tests {
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
           v28:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           PushInlineFrame :foo, v28 (0x1038), num_args=0
-          PatchPoint StableConstantNames(0x1060, DEBUG)
+          PatchPoint StableConstantNames(0x1058, DEBUG)
           v58:NilClass = Const Value(nil)
           CheckInterrupts
           PopInlineFrame
@@ -2137,7 +2137,7 @@ mod hir_opt_tests {
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
           v28:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           PushInlineFrame :foo, v28 (0x1038), num_args=0
-          PatchPoint StableConstantNames(0x1060, CALL_BLOCK)
+          PatchPoint StableConstantNames(0x1058, CALL_BLOCK)
           v61:NilClass = Const Value(nil)
           CheckInterrupts
           PopInlineFrame
@@ -4143,16 +4143,16 @@ mod hir_opt_tests {
           v52:NilClass = Const Value(nil)
           PushInlineFrame :foo, v22 (0x1038), num_args=2
           v34:CPtr = GetEP 0
-          v35:CUInt64 = LoadField v34, :VM_ENV_DATA_INDEX_FLAGS@0x1060
+          v35:CUInt64 = LoadField v34, :VM_ENV_DATA_INDEX_FLAGS@0x1058
           v36:CBool = IsBlockParamModified v35
           CondBranch v36, bb6(), bb7()
         bb6():
-          v38:BasicObject = LoadField v34, :block@0x1061
+          v38:BasicObject = LoadField v34, :block@0x1059
           Jump bb8(v38, v38)
         bb7():
-          v40:CInt64 = LoadField v34, :VM_ENV_DATA_INDEX_SPECVAL@0x1062
+          v40:CInt64 = LoadField v34, :VM_ENV_DATA_INDEX_SPECVAL@0x105a
           v41:CInt64 = GuardAnyBitSet v40, CUInt64(1) recompile
-          v42:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1068))
+          v42:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1060))
           Jump bb8(v42, v52)
         bb8(v32:BasicObject, v33:BasicObject):
           v47:BasicObject = Send v32, :call, v11, v13 # SendFallbackReason: Send: unsupported optimized method type BlockCall
@@ -4190,10 +4190,10 @@ mod hir_opt_tests {
           v18:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           PushInlineFrame :foo, v18 (0x1038), num_args=0
           v25:CPtr = GetEP 0
-          v26:CInt64 = LoadField v25, :VM_ENV_DATA_INDEX_SPECVAL@0x1060
+          v26:CInt64 = LoadField v25, :VM_ENV_DATA_INDEX_SPECVAL@0x1058
           v27:CInt64[-4] = Const CInt64(-4)
           v28:CInt64 = IntAnd v26, v27
-          v29:BasicObject = InvokeBlockIseqDirect (0x1068), v28
+          v29:BasicObject = InvokeBlockIseqDirect (0x1060), v28
           CheckInterrupts
           PopInlineFrame
           Return v29
@@ -4229,11 +4229,11 @@ mod hir_opt_tests {
           v29:Fixnum[1] = Const Value(1)
           v31:Fixnum[2] = Const Value(2)
           v33:CPtr = GetEP 0
-          v34:CInt64 = LoadField v33, :VM_ENV_DATA_INDEX_SPECVAL@0x1060
+          v34:CInt64 = LoadField v33, :VM_ENV_DATA_INDEX_SPECVAL@0x1058
           v35:CInt64[-4] = Const CInt64(-4)
           v36:CInt64 = IntAnd v34, v35
-          v37:BasicObject = InvokeBlockIseqDirect (0x1068), v36, v29, v31
-          PatchPoint MethodRedefined(Integer@0x1090, +@0x1098, cme:0x10a0)
+          v37:BasicObject = InvokeBlockIseqDirect (0x1060), v36, v29, v31
+          PatchPoint MethodRedefined(Integer@0x1080, +@0x1088, cme:0x1090)
           v52:Fixnum = GuardType v37, Fixnum
           v53:Fixnum = FixnumAdd v11, v52
           CheckInterrupts
@@ -4322,10 +4322,10 @@ mod hir_opt_tests {
           v37:Fixnum[7] = Const Value(7)
           v39:Fixnum[8] = Const Value(8)
           v41:CPtr = GetEP 0
-          v42:CInt64 = LoadField v41, :VM_ENV_DATA_INDEX_SPECVAL@0x1060
+          v42:CInt64 = LoadField v41, :VM_ENV_DATA_INDEX_SPECVAL@0x1058
           v43:CInt64[-4] = Const CInt64(-4)
           v44:CInt64 = IntAnd v42, v43
-          v45:BasicObject = InvokeBlockIseqDirect (0x1068), v44, v25, v27, v29, v31, v33, v35, v37, v39
+          v45:BasicObject = InvokeBlockIseqDirect (0x1060), v44, v25, v27, v29, v31, v33, v35, v37, v39
           CheckInterrupts
           PopInlineFrame
           Return v45
@@ -4685,7 +4685,7 @@ mod hir_opt_tests {
           v44:BasicObject = CCallWithFrame v43, :Kernel#lambda@0x1040, block=0x1048
           v22:CPtr = GetEP 0
           v23:BasicObject = LoadField v22, :a@0x1000
-          PatchPoint MethodRedefined(Object@0x1008, foo@0x1070, cme:0x1078)
+          PatchPoint MethodRedefined(Object@0x1008, foo@0x1068, cme:0x1070)
           v34:CPtr = GetEP 0
           v35:BasicObject = LoadField v34, :a@0x1000
           CheckInterrupts
@@ -4719,8 +4719,8 @@ mod hir_opt_tests {
           v24:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           v25:ArrayExact = NewArray v11, v13, v15
           PushInlineFrame :foo, v24 (0x1038), num_args=1
-          PatchPoint NoSingletonClass(Array@0x1060)
-          PatchPoint MethodRedefined(Array@0x1060, length@0x1068, cme:0x1070)
+          PatchPoint NoSingletonClass(Array@0x1058)
+          PatchPoint MethodRedefined(Array@0x1058, length@0x1060, cme:0x1068)
           v49:CInt64 = ArrayLength v25
           v50:Fixnum = BoxFixnum v49
           CheckInterrupts
@@ -4759,8 +4759,8 @@ mod hir_opt_tests {
           v32:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           v33:ArrayExact = NewArray v11, v13, v15, v17, v19, v21, v23
           PushInlineFrame :foo, v32 (0x1038), num_args=1
-          PatchPoint NoSingletonClass(Array@0x1060)
-          PatchPoint MethodRedefined(Array@0x1060, length@0x1068, cme:0x1070)
+          PatchPoint NoSingletonClass(Array@0x1058)
+          PatchPoint MethodRedefined(Array@0x1058, length@0x1060, cme:0x1068)
           v57:CInt64 = ArrayLength v33
           v58:Fixnum = BoxFixnum v57
           CheckInterrupts
@@ -4795,15 +4795,15 @@ mod hir_opt_tests {
           v24:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           v25:ArrayExact = NewArray v11, v13, v15
           PushInlineFrame :foo, v24 (0x1038), num_args=1
-          PatchPoint NoSingletonClass(Array@0x1060)
-          PatchPoint MethodRedefined(Array@0x1060, length@0x1068, cme:0x1070)
+          PatchPoint NoSingletonClass(Array@0x1058)
+          PatchPoint MethodRedefined(Array@0x1058, length@0x1060, cme:0x1068)
           v55:CInt64 = ArrayLength v25
           v56:Fixnum = BoxFixnum v55
           v38:CPtr = GetEP 0
-          v39:CInt64 = LoadField v38, :VM_ENV_DATA_INDEX_SPECVAL@0x1098
+          v39:CInt64 = LoadField v38, :VM_ENV_DATA_INDEX_SPECVAL@0x1090
           v40:CInt64[-4] = Const CInt64(-4)
           v41:CInt64 = IntAnd v39, v40
-          v42:BasicObject = InvokeBlockIseqDirect (0x10a0), v41, v56
+          v42:BasicObject = InvokeBlockIseqDirect (0x1098), v41, v56
           CheckInterrupts
           PopInlineFrame
           Return v42
@@ -4838,20 +4838,20 @@ mod hir_opt_tests {
           v57:NilClass = Const Value(nil)
           PushInlineFrame :foo, v24 (0x1038), num_args=1
           v37:CPtr = GetEP 0
-          v38:CUInt64 = LoadField v37, :VM_ENV_DATA_INDEX_FLAGS@0x1060
+          v38:CUInt64 = LoadField v37, :VM_ENV_DATA_INDEX_FLAGS@0x1058
           v39:CBool = IsBlockParamModified v38
           CondBranch v39, bb6(), bb7()
         bb6():
-          v41:BasicObject = LoadField v37, :block@0x1061
+          v41:BasicObject = LoadField v37, :block@0x1059
           Jump bb8(v41, v41)
         bb7():
-          v43:CInt64 = LoadField v37, :VM_ENV_DATA_INDEX_SPECVAL@0x1062
+          v43:CInt64 = LoadField v37, :VM_ENV_DATA_INDEX_SPECVAL@0x105a
           v44:CInt64 = GuardAnyBitSet v43, CUInt64(1) recompile
-          v45:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1068))
+          v45:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1060))
           Jump bb8(v45, v57)
         bb8(v35:BasicObject, v36:BasicObject):
-          PatchPoint NoSingletonClass(Array@0x1070)
-          PatchPoint MethodRedefined(Array@0x1070, length@0x1078, cme:0x1080)
+          PatchPoint NoSingletonClass(Array@0x1068)
+          PatchPoint MethodRedefined(Array@0x1068, length@0x1070, cme:0x1078)
           v66:CInt64 = ArrayLength v25
           v67:Fixnum = BoxFixnum v66
           v52:BasicObject = Send v35, :call, v67 # SendFallbackReason: Send: unsupported optimized method type BlockCall
@@ -4888,11 +4888,11 @@ mod hir_opt_tests {
           v26:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           v27:ArrayExact = NewArray v13, v15
           PushInlineFrame :foo, v26 (0x1038), num_args=3
-          PatchPoint NoSingletonClass(Array@0x1060)
-          PatchPoint MethodRedefined(Array@0x1060, length@0x1068, cme:0x1070)
+          PatchPoint NoSingletonClass(Array@0x1058)
+          PatchPoint MethodRedefined(Array@0x1058, length@0x1060, cme:0x1068)
           v61:CInt64 = ArrayLength v27
           v62:Fixnum = BoxFixnum v61
-          PatchPoint MethodRedefined(Integer@0x1098, +@0x10a0, cme:0x10a8)
+          PatchPoint MethodRedefined(Integer@0x1090, +@0x1098, cme:0x10a0)
           v66:Fixnum = FixnumAdd v62, v11
           v70:Fixnum = FixnumAdd v66, v17
           CheckInterrupts
@@ -4928,11 +4928,11 @@ mod hir_opt_tests {
           v25:ArrayExact = NewArray v11, v13
           v47:Fixnum[0] = Const Value(0)
           PushInlineFrame :foo, v24 (0x1038), num_args=2
-          PatchPoint NoSingletonClass(Array@0x1060)
-          PatchPoint MethodRedefined(Array@0x1060, length@0x1068, cme:0x1070)
+          PatchPoint NoSingletonClass(Array@0x1058)
+          PatchPoint MethodRedefined(Array@0x1058, length@0x1060, cme:0x1068)
           v56:CInt64 = ArrayLength v25
           v57:Fixnum = BoxFixnum v56
-          PatchPoint MethodRedefined(Integer@0x1098, +@0x10a0, cme:0x10a8)
+          PatchPoint MethodRedefined(Integer@0x1090, +@0x1098, cme:0x10a0)
           v61:Fixnum = FixnumAdd v57, v15
           CheckInterrupts
           PopInlineFrame
@@ -4967,11 +4967,11 @@ mod hir_opt_tests {
           v24:Fixnum[40] = Const Value(40)
           v46:Fixnum[0] = Const Value(0)
           PushInlineFrame :foo, v22 (0x1038), num_args=2
-          PatchPoint NoSingletonClass(Array@0x1060)
-          PatchPoint MethodRedefined(Array@0x1060, length@0x1068, cme:0x1070)
+          PatchPoint NoSingletonClass(Array@0x1058)
+          PatchPoint MethodRedefined(Array@0x1058, length@0x1060, cme:0x1068)
           v55:CInt64 = ArrayLength v23
           v56:Fixnum = BoxFixnum v55
-          PatchPoint MethodRedefined(Integer@0x1098, +@0x10a0, cme:0x10a8)
+          PatchPoint MethodRedefined(Integer@0x1090, +@0x1098, cme:0x10a0)
           v60:Fixnum = FixnumAdd v56, v24
           CheckInterrupts
           PopInlineFrame
@@ -5069,7 +5069,7 @@ mod hir_opt_tests {
           v22:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           PushInlineFrame :foo, v22 (0x1038), num_args=2
           v31:Fixnum[80] = Const Value(80)
-          PatchPoint MethodRedefined(Integer@0x1060, +@0x1068, cme:0x1070)
+          PatchPoint MethodRedefined(Integer@0x1058, +@0x1060, cme:0x1068)
           v67:Fixnum[110] = Const Value(110)
           CheckInterrupts
           PopInlineFrame
@@ -5366,9 +5366,9 @@ mod hir_opt_tests {
           v21:StaticSymbol[:k] = Const Value(VALUE(0x1038))
           v22:HashExact = NewHash v21: v11
           PushInlineFrame :foo, v20 (0x1040), num_args=1
-          PatchPoint NoSingletonClass(Hash@0x1068)
-          PatchPoint MethodRedefined(Hash@0x1068, class@0x1070, cme:0x1078)
-          v44:ClassSubclass[Hash@0x1068] = Const Value(VALUE(0x1068))
+          PatchPoint NoSingletonClass(Hash@0x1060)
+          PatchPoint MethodRedefined(Hash@0x1060, class@0x1068, cme:0x1070)
+          v44:ClassSubclass[Hash@0x1060] = Const Value(VALUE(0x1060))
           CheckInterrupts
           PopInlineFrame
           Return v44
@@ -5871,7 +5871,7 @@ mod hir_opt_tests {
           v38:Fixnum[0] = Const Value(0)
           PushInlineFrame :foo, v18 (0x1038), num_args=1
           v30:Fixnum[1] = Const Value(1)
-          PatchPoint MethodRedefined(Integer@0x1060, +@0x1068, cme:0x1070)
+          PatchPoint MethodRedefined(Integer@0x1058, +@0x1060, cme:0x1068)
           v47:Fixnum[2] = Const Value(2)
           CheckInterrupts
           PopInlineFrame
@@ -6169,12 +6169,12 @@ mod hir_opt_tests {
           PatchPoint MethodRedefined(C@0x1008, initialize@0x1038, cme:0x1040)
           PushInlineFrame :initialize, v45 (0x1068), num_args=1
           PatchPoint SingleRactorMode
-          v63:CShape = LoadField v45, :shape_id@0x1090
-          v64:CShape[0x1091] = GuardBitEquals v63, CShape(0x1091) recompile
-          StoreField v45, :@x@0x1092, v15
+          v63:CShape = LoadField v45, :shape_id@0x1088
+          v64:CShape[0x1089] = GuardBitEquals v63, CShape(0x1089) recompile
+          StoreField v45, :@x@0x108a, v15
           WriteBarrier v45, v15
-          v67:CShape[0x1093] = Const CShape(0x1093)
-          StoreField v45, :shape_id@0x1090, v67
+          v67:CShape[0x108b] = Const CShape(0x108b)
+          StoreField v45, :shape_id@0x1088, v67
           CheckInterrupts
           PopInlineFrame
           Return v45
@@ -6275,12 +6275,12 @@ mod hir_opt_tests {
           v41:ObjectSubclass[class_exact:Factory] = GuardType v12, ObjectSubclass[class_exact:Factory] recompile
           PushInlineFrame :new, v41 (0x1048), num_args=0
           v48:NilClass = Const Value(nil)
-          PatchPoint StableConstantNames(0x1070, Object)
-          v51:ClassSubclass[Object@0x1078] = Const Value(VALUE(0x1078))
-          PatchPoint MethodRedefined(Object@0x1078, new@0x1018, cme:0x1080)
-          v84:ObjectExact = ObjectAllocClass Object:VALUE(0x1078)
-          PatchPoint NoSingletonClass(Object@0x1078)
-          PatchPoint MethodRedefined(Object@0x1078, initialize@0x10a8, cme:0x10b0)
+          PatchPoint StableConstantNames(0x1068, Object)
+          v51:ClassSubclass[Object@0x1070] = Const Value(VALUE(0x1070))
+          PatchPoint MethodRedefined(Object@0x1070, new@0x1018, cme:0x1078)
+          v84:ObjectExact = ObjectAllocClass Object:VALUE(0x1070)
+          PatchPoint NoSingletonClass(Object@0x1070)
+          PatchPoint MethodRedefined(Object@0x1070, initialize@0x10a0, cme:0x10a8)
           CheckInterrupts
           PopInlineFrame
           Return v84
@@ -6346,11 +6346,11 @@ mod hir_opt_tests {
           PushInlineFrame :initialize, v42 (0x1068), num_args=1
           v62:TrueClass = Const Value(true)
           v80:CPtr = GetEP 0
-          v81:CUInt64 = LoadField v80, :VM_ENV_DATA_INDEX_FLAGS@0x1090
+          v81:CUInt64 = LoadField v80, :VM_ENV_DATA_INDEX_FLAGS@0x1088
           v82:CBool = IsBlockParamModified v81
           CondBranch v82, bb11(), bb12()
         bb11():
-          v84:BasicObject = LoadField v80, :block@0x1091
+          v84:BasicObject = LoadField v80, :block@0x1089
           Jump bb13(v84)
         bb12():
           v86:BasicObject = GetBlockParam :block, l0, EP@4
@@ -6768,7 +6768,7 @@ mod hir_opt_tests {
           PopInlineFrame
           Return v76
         bb4():
-          v50:StaticSymbol[:skip] = Const Value(VALUE(0x1068))
+          v50:StaticSymbol[:skip] = Const Value(VALUE(0x1060))
           CheckInterrupts
           Return v50
         ");
@@ -11081,7 +11081,7 @@ mod hir_opt_tests {
           v11:ArrayExact = ArrayDup v10
           PatchPoint NoSingletonClass(Array@0x1008)
           PatchPoint MethodRedefined(Array@0x1008, map@0x1010, cme:0x1018)
-          v22:BasicObject = SendDirect v11, 0x1040, :map (0x1068)
+          v22:BasicObject = SendDirect v11, 0x1040, :map (0x1060)
           CheckInterrupts
           Return v22
         ");
@@ -11279,10 +11279,10 @@ mod hir_opt_tests {
           PushInlineFrame :foo, v18 (0x1038), num_args=0
           v25:Fixnum[1] = Const Value(1)
           v27:CPtr = GetEP 0
-          v28:CInt64 = LoadField v27, :VM_ENV_DATA_INDEX_SPECVAL@0x1060
+          v28:CInt64 = LoadField v27, :VM_ENV_DATA_INDEX_SPECVAL@0x1058
           v29:CInt64[-4] = Const CInt64(-4)
           v30:CInt64 = IntAnd v28, v29
-          v31:BasicObject = InvokeBlockIseqDirect (0x1068), v30, v25
+          v31:BasicObject = InvokeBlockIseqDirect (0x1060), v30, v25
           CheckInterrupts
           PopInlineFrame
           Return v31
@@ -11317,14 +11317,14 @@ mod hir_opt_tests {
           v71:NilClass = Const Value(nil)
           PushInlineFrame :foo, v18 (0x1038), num_args=0
           v28:CPtr = GetEP 0
-          v29:CUInt64 = LoadField v28, :VM_ENV_DATA_INDEX_FLAGS@0x1060
+          v29:CUInt64 = LoadField v28, :VM_ENV_DATA_INDEX_FLAGS@0x1058
           v30:CBool = IsBlockParamModified v29
           CondBranch v30, bb7(), bb8()
         bb7():
-          v32:BasicObject = LoadField v28, :blk@0x1061
+          v32:BasicObject = LoadField v28, :blk@0x1059
           Jump bb9(v32, v32)
         bb8():
-          v34:CInt64 = LoadField v28, :VM_ENV_DATA_INDEX_SPECVAL@0x1062
+          v34:CInt64 = LoadField v28, :VM_ENV_DATA_INDEX_SPECVAL@0x105a
           v35:CInt64[0] = GuardBitEquals v34, CInt64(0) recompile
           v36:NilClass = Const Value(nil)
           Jump bb9(v36, v71)
@@ -11333,16 +11333,16 @@ mod hir_opt_tests {
           CondBranch v39, bb10(), bb6()
         bb10():
           v46:CPtr = GetEP 0
-          v47:CUInt64 = LoadField v46, :VM_ENV_DATA_INDEX_FLAGS@0x1060
+          v47:CUInt64 = LoadField v46, :VM_ENV_DATA_INDEX_FLAGS@0x1058
           v48:CBool = IsBlockParamModified v47
           CondBranch v48, bb11(), bb12()
         bb11():
-          v50:BasicObject = LoadField v46, :blk@0x1061
+          v50:BasicObject = LoadField v46, :blk@0x1059
           Jump bb13(v50, v50)
         bb12():
-          v52:CInt64 = LoadField v46, :VM_ENV_DATA_INDEX_SPECVAL@0x1062
+          v52:CInt64 = LoadField v46, :VM_ENV_DATA_INDEX_SPECVAL@0x105a
           v53:CInt64 = GuardAnyBitSet v52, CUInt64(1) recompile
-          v54:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1068))
+          v54:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1060))
           Jump bb13(v54, v27)
         bb13(v44:BasicObject, v45:BasicObject):
           v57:BasicObject = Send v44, :call # SendFallbackReason: Send: no profile data available
@@ -17337,7 +17337,7 @@ mod hir_opt_tests {
           v21:RubyValue = LoadField v18, :VM_ENV_DATA_INDEX_SPECVAL@0x1048
           v22:FalseClass = GuardBitEquals v21, Value(false)
           PushInlineFrame :foo, v6 (0x1050), num_args=0
-          v29:StringExact[VALUE(0x1078)] = Const Value(VALUE(0x1078))
+          v29:StringExact[VALUE(0x1070)] = Const Value(VALUE(0x1070))
           v30:StringExact = StringCopy v29
           CheckInterrupts
           PopInlineFrame
@@ -17412,13 +17412,13 @@ mod hir_opt_tests {
           v32:FalseClass = GuardBitEquals v31, Value(false)
           PushInlineFrame :foo, v9 (0x1058), num_args=1
           v45:Fixnum[2] = Const Value(2)
-          PatchPoint MethodRedefined(Integer@0x1080, *@0x1088, cme:0x1090)
+          PatchPoint MethodRedefined(Integer@0x1078, *@0x1080, cme:0x1088)
           v59:Fixnum = GuardType v10, Fixnum recompile
           v60:Fixnum = FixnumMult v59, v45
           CheckInterrupts
           PopInlineFrame
           v18:Fixnum[1] = Const Value(1)
-          PatchPoint MethodRedefined(Integer@0x1080, +@0x10b8, cme:0x10c0)
+          PatchPoint MethodRedefined(Integer@0x1078, +@0x10b0, cme:0x10b8)
           v37:Fixnum = FixnumAdd v60, v18
           Return v37
         ");
@@ -17818,7 +17818,7 @@ mod hir_opt_tests {
           SetLocal :other_block, l0, EP@3, v43
           v30:CPtr = GetEP 0
           v31:BasicObject = LoadField v30, :other_block@0x1002
-          v33:BasicObject = InvokeSuper v42, 0x1070, v31 # SendFallbackReason: super: complex argument passing to `super` call
+          v33:BasicObject = InvokeSuper v42, 0x1068, v31 # SendFallbackReason: super: complex argument passing to `super` call
           CheckInterrupts
           Return v33
         ");
@@ -18571,14 +18571,14 @@ mod hir_opt_tests {
           SetLocal :sep, l0, EP@5, v131
           Jump bb8(v90, v131, v92, v93)
         bb8(v98:BasicObject, v99:BasicObject, v100:BasicObject, v101:BasicObject):
-          PatchPoint StableConstantNames(0x1078, CONST)
-          v106:HashExact[VALUE(0x1080)] = Const Value(VALUE(0x1080))
+          PatchPoint StableConstantNames(0x1070, CONST)
+          v106:HashExact[VALUE(0x1078)] = Const Value(VALUE(0x1078))
           SetLocal :kwsplat, l0, EP@3, v106
           v111:CPtr = GetEP 0
           v112:BasicObject = LoadField v111, :list@0x1001
           v114:CPtr = GetEP 0
           v115:BasicObject = LoadField v114, :iter_method@0x1005
-          v117:BasicObject = Send v112, 0x1088, :__send__, v115 # SendFallbackReason: Send: unsupported method type Optimized
+          v117:BasicObject = Send v112, 0x1080, :__send__, v115 # SendFallbackReason: Send: unsupported method type Optimized
           v118:CPtr = GetEP 0
           v119:BasicObject = LoadField v118, :list@0x1001
           v120:BasicObject = LoadField v118, :sep@0x1002
@@ -18667,7 +18667,7 @@ mod hir_opt_tests {
           PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
           v18:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           PushInlineFrame :foo, v18 (0x1038), num_args=0
-          v27:StringExact[VALUE(0x1060)] = Const Value(VALUE(0x1060))
+          v27:StringExact[VALUE(0x1058)] = Const Value(VALUE(0x1058))
           CheckInterrupts
           PopInlineFrame
           Return v27
@@ -18741,10 +18741,10 @@ mod hir_opt_tests {
           v92:CInt64 = UnboxFixnum v65
           v93:BasicObject = ArrayAref v11, v92
           v95:CPtr = GetEP 0
-          v96:CInt64 = LoadField v95, :VM_ENV_DATA_INDEX_SPECVAL@0x1068
+          v96:CInt64 = LoadField v95, :VM_ENV_DATA_INDEX_SPECVAL@0x1060
           v97:CInt64[-4] = Const CInt64(-4)
           v98:CInt64 = IntAnd v96, v97
-          v99:BasicObject = InvokeBlockIseqDirect (0x1070), v98, v93
+          v99:BasicObject = InvokeBlockIseqDirect (0x1068), v98, v93
           v103:Fixnum[1] = Const Value(1)
           v104:Fixnum = FixnumAdd v65, v103
           PatchPoint NoEPEscape(each)
@@ -18981,13 +18981,13 @@ mod hir_opt_tests {
           PatchPoint MethodRedefined(Object@0x1008, greet_recompile@0x1010, cme:0x1018)
           v42:ObjectSubclass[class_exact*:Object@VALUE(0x1008)] = GuardType v9, ObjectSubclass[class_exact*:Object@VALUE(0x1008)] recompile
           PushInlineFrame :greet_recompile, v42 (0x1040), num_args=1
-          PatchPoint MethodRedefined(Integer@0x1068, to_s@0x1070, cme:0x1078)
-          v63:StringExact = CCallVariadic v22, :Integer#to_s@0x10a0
+          PatchPoint MethodRedefined(Integer@0x1060, to_s@0x1068, cme:0x1070)
+          v63:StringExact = CCallVariadic v22, :Integer#to_s@0x1098
           CheckInterrupts
           PopInlineFrame
           Return v63
         bb4():
-          v34:StringExact[VALUE(0x10a8)] = Const Value(VALUE(0x10a8))
+          v34:StringExact[VALUE(0x10a0)] = Const Value(VALUE(0x10a0))
           v35:StringExact = StringCopy v34
           CheckInterrupts
           Return v35
@@ -20316,7 +20316,7 @@ mod hir_opt_tests {
           PatchPoint MethodRedefined(Object@0x1008, double@0x1010, cme:0x1018)
           v23:ObjectSubclass[class_exact*:Object@VALUE(0x1008)] = GuardType v9, ObjectSubclass[class_exact*:Object@VALUE(0x1008)] recompile
           PushInlineFrame :double, v23 (0x1040), num_args=1
-          PatchPoint MethodRedefined(Integer@0x1068, +@0x1070, cme:0x1078)
+          PatchPoint MethodRedefined(Integer@0x1060, +@0x1068, cme:0x1070)
           v45:Fixnum = GuardType v10, Fixnum recompile
           v47:Fixnum = FixnumAdd v45, v45
           CheckInterrupts
@@ -20364,7 +20364,7 @@ mod hir_opt_tests {
           v23:ObjectSubclass[class_exact*:Object@VALUE(0x1008)] = GuardType v9, ObjectSubclass[class_exact*:Object@VALUE(0x1008)] recompile
           PushInlineFrame :clamp_nonneg, v23 (0x1040), num_args=1
           v32:Fixnum[0] = Const Value(0)
-          PatchPoint MethodRedefined(Integer@0x1068, <@0x1070, cme:0x1078)
+          PatchPoint MethodRedefined(Integer@0x1060, <@0x1068, cme:0x1070)
           v62:Fixnum = GuardType v10, Fixnum recompile
           v63:BoolExact = FixnumLt v62, v32
           v37:CBool = Test v63
@@ -20481,7 +20481,7 @@ mod hir_opt_tests {
           v23:ObjectSubclass[class_exact*:Object@VALUE(0x1008)] = GuardType v9, ObjectSubclass[class_exact*:Object@VALUE(0x1008)] recompile
           PushInlineFrame :add_one, v23 (0x1040), num_args=1
           v32:Fixnum[1] = Const Value(1)
-          PatchPoint MethodRedefined(Integer@0x1068, +@0x1070, cme:0x1078)
+          PatchPoint MethodRedefined(Integer@0x1060, +@0x1068, cme:0x1070)
           v46:Fixnum = GuardType v10, Fixnum recompile
           v47:Fixnum = FixnumAdd v46, v32
           CheckInterrupts
@@ -20542,8 +20542,8 @@ mod hir_opt_tests {
           PatchPoint MethodRedefined(Object@0x1008, outer@0x1010, cme:0x1018)
           v23:ObjectSubclass[class_exact*:Object@VALUE(0x1008)] = GuardType v9, ObjectSubclass[class_exact*:Object@VALUE(0x1008)] recompile
           PushInlineFrame :outer, v23 (0x1040), num_args=1
-          PatchPoint MethodRedefined(Object@0x1008, inner@0x1068, cme:0x1070)
-          v44:BasicObject = SendDirect v23, 0x0, :inner (0x1098), v10
+          PatchPoint MethodRedefined(Object@0x1008, inner@0x1060, cme:0x1068)
+          v44:BasicObject = SendDirect v23, 0x0, :inner (0x1090), v10
           CheckInterrupts
           PopInlineFrame
           Return v44
@@ -20646,7 +20646,7 @@ mod hir_opt_tests {
           PushInlineFrame :add_opts, v23 (0x1040), num_args=1
           v32:Fixnum[10] = Const Value(10)
           v41:Fixnum[100] = Const Value(100)
-          PatchPoint MethodRedefined(Integer@0x1068, +@0x1070, cme:0x1078)
+          PatchPoint MethodRedefined(Integer@0x1060, +@0x1068, cme:0x1070)
           v71:Fixnum = GuardType v10, Fixnum recompile
           v72:Fixnum = FixnumAdd v71, v32
           v76:Fixnum = FixnumAdd v72, v41
@@ -20702,7 +20702,7 @@ mod hir_opt_tests {
           v25:ObjectSubclass[class_exact*:Object@VALUE(0x1008)] = GuardType v9, ObjectSubclass[class_exact*:Object@VALUE(0x1008)] recompile
           PushInlineFrame :add_opts, v25 (0x1040), num_args=2
           v34:Fixnum[100] = Const Value(100)
-          PatchPoint MethodRedefined(Integer@0x1068, +@0x1070, cme:0x1078)
+          PatchPoint MethodRedefined(Integer@0x1060, +@0x1068, cme:0x1070)
           v63:Fixnum = GuardType v10, Fixnum recompile
           v64:Fixnum = FixnumAdd v63, v16
           v68:Fixnum = FixnumAdd v64, v34
@@ -20739,7 +20739,7 @@ mod hir_opt_tests {
           v18:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           v40:NilClass = Const Value(nil)
           PushInlineFrame :callee, v18 (0x1038), num_args=0
-          v26:StaticSymbol[:default] = Const Value(VALUE(0x1060))
+          v26:StaticSymbol[:default] = Const Value(VALUE(0x1058))
           CheckInterrupts
           PopInlineFrame
           Return v26
@@ -20826,7 +20826,7 @@ mod hir_opt_tests {
           v23:ObjectSubclass[class_exact*:Object@VALUE(0x1008)] = GuardType v9, ObjectSubclass[class_exact*:Object@VALUE(0x1008)] recompile
           PushInlineFrame :maybe_rescue, v23 (0x1040), num_args=1
           v32:Fixnum[1] = Const Value(1)
-          PatchPoint MethodRedefined(Integer@0x1068, +@0x1070, cme:0x1078)
+          PatchPoint MethodRedefined(Integer@0x1060, +@0x1068, cme:0x1070)
           v47:Fixnum = GuardType v10, Fixnum recompile
           v48:Fixnum = FixnumAdd v47, v32
           CheckInterrupts
@@ -20923,22 +20923,22 @@ mod hir_opt_tests {
           PatchPoint MethodRedefined(Child@0x1008, greet@0x1010, cme:0x1018)
           v23:ObjectSubclass[class_exact:Child] = GuardType v10, ObjectSubclass[class_exact:Child] recompile
           PushInlineFrame :greet, v23 (0x1040), num_args=0
-          PatchPoint MethodRedefined(Parent@0x1068, greet@0x1010, cme:0x1070)
+          PatchPoint MethodRedefined(Parent@0x1060, greet@0x1010, cme:0x1068)
           v47:CPtr = GetEP 0
-          v48:RubyValue = LoadField v47, :VM_ENV_DATA_INDEX_ME_CREF@0x1098
+          v48:RubyValue = LoadField v47, :VM_ENV_DATA_INDEX_ME_CREF@0x1090
           v49:CallableMethodEntry[VALUE(0x1018)] = GuardBitEquals v48, Value(VALUE(0x1018))
-          v50:RubyValue = LoadField v47, :VM_ENV_DATA_INDEX_SPECVAL@0x1099
+          v50:RubyValue = LoadField v47, :VM_ENV_DATA_INDEX_SPECVAL@0x1091
           v51:FalseClass = GuardBitEquals v50, Value(false)
-          PushInlineFrame :greet, v23 (0x10a0), num_args=0
-          v63:StringExact[VALUE(0x10c8)] = Const Value(VALUE(0x10c8))
+          PushInlineFrame :greet, v23 (0x1098), num_args=0
+          v63:StringExact[VALUE(0x10b8)] = Const Value(VALUE(0x10b8))
           v64:StringExact = StringCopy v63
           CheckInterrupts
           PopInlineFrame
-          v33:StringExact[VALUE(0x10d0)] = Const Value(VALUE(0x10d0))
+          v33:StringExact[VALUE(0x10c0)] = Const Value(VALUE(0x10c0))
           v34:StringExact = StringCopy v33
-          PatchPoint NoSingletonClass(String@0x10d8)
-          PatchPoint MethodRedefined(String@0x10d8, +@0x10e0, cme:0x10e8)
-          v57:BasicObject = CCallWithFrame v64, :String#+@0x1110, v34
+          PatchPoint NoSingletonClass(String@0x10c8)
+          PatchPoint MethodRedefined(String@0x10c8, +@0x10d0, cme:0x10d8)
+          v57:BasicObject = CCallWithFrame v64, :String#+@0x1100, v34
           CheckInterrupts
           PopInlineFrame
           Return v57
@@ -20990,7 +20990,7 @@ mod hir_opt_tests {
           PatchPoint MethodRedefined(Object@0x1008, add_opts@0x1010, cme:0x1018)
           v27:ObjectSubclass[class_exact*:Object@VALUE(0x1008)] = GuardType v9, ObjectSubclass[class_exact*:Object@VALUE(0x1008)] recompile
           PushInlineFrame :add_opts, v27 (0x1040), num_args=3
-          PatchPoint MethodRedefined(Integer@0x1068, +@0x1070, cme:0x1078)
+          PatchPoint MethodRedefined(Integer@0x1060, +@0x1068, cme:0x1070)
           v55:Fixnum = GuardType v10, Fixnum recompile
           v56:Fixnum = FixnumAdd v55, v16
           v60:Fixnum = FixnumAdd v56, v18
@@ -21046,7 +21046,7 @@ mod hir_opt_tests {
           v23:ObjectSubclass[class_exact*:Object@VALUE(0x1008)] = GuardType v9, ObjectSubclass[class_exact*:Object@VALUE(0x1008)] recompile
           PushInlineFrame :add_opt_post, v23 (0x1040), num_args=1
           v31:Fixnum[10] = Const Value(10)
-          PatchPoint MethodRedefined(Integer@0x1068, +@0x1070, cme:0x1078)
+          PatchPoint MethodRedefined(Integer@0x1060, +@0x1068, cme:0x1070)
           v56:Fixnum = GuardType v10, Fixnum
           v57:Fixnum = FixnumAdd v31, v56
           CheckInterrupts
@@ -21102,7 +21102,7 @@ mod hir_opt_tests {
           v25:ObjectSubclass[class_exact*:Object@VALUE(0x1008)] = GuardType v9, ObjectSubclass[class_exact*:Object@VALUE(0x1008)] recompile
           PushInlineFrame :add_lead_opt_post, v25 (0x1040), num_args=2
           v34:Fixnum[10] = Const Value(10)
-          PatchPoint MethodRedefined(Integer@0x1068, +@0x1070, cme:0x1078)
+          PatchPoint MethodRedefined(Integer@0x1060, +@0x1068, cme:0x1070)
           v63:Fixnum = GuardType v10, Fixnum recompile
           v64:Fixnum = FixnumAdd v63, v34
           v68:Fixnum = FixnumAdd v64, v16
@@ -21155,7 +21155,7 @@ mod hir_opt_tests {
           v25:ObjectSubclass[class_exact*:Object@VALUE(0x1008)] = GuardType v9, ObjectSubclass[class_exact*:Object@VALUE(0x1008)] recompile
           v43:Fixnum[0] = Const Value(0)
           PushInlineFrame :add_kw, v25 (0x1040), num_args=2
-          PatchPoint MethodRedefined(Integer@0x1068, +@0x1070, cme:0x1078)
+          PatchPoint MethodRedefined(Integer@0x1060, +@0x1068, cme:0x1070)
           v50:Fixnum = GuardType v10, Fixnum recompile
           v51:Fixnum = FixnumAdd v50, v16
           CheckInterrupts
@@ -21207,7 +21207,7 @@ mod hir_opt_tests {
           v25:ObjectSubclass[class_exact*:Object@VALUE(0x1008)] = GuardType v9, ObjectSubclass[class_exact*:Object@VALUE(0x1008)] recompile
           v43:Fixnum[0] = Const Value(0)
           PushInlineFrame :add_optkw, v25 (0x1040), num_args=2
-          PatchPoint MethodRedefined(Integer@0x1068, +@0x1070, cme:0x1078)
+          PatchPoint MethodRedefined(Integer@0x1060, +@0x1068, cme:0x1070)
           v50:Fixnum = GuardType v10, Fixnum recompile
           v51:Fixnum = FixnumAdd v50, v16
           CheckInterrupts
@@ -21259,7 +21259,7 @@ mod hir_opt_tests {
           v24:Fixnum[10] = Const Value(10)
           v43:Fixnum[0] = Const Value(0)
           PushInlineFrame :add_optkw, v23 (0x1040), num_args=2
-          PatchPoint MethodRedefined(Integer@0x1068, +@0x1070, cme:0x1078)
+          PatchPoint MethodRedefined(Integer@0x1060, +@0x1068, cme:0x1070)
           v50:Fixnum = GuardType v10, Fixnum recompile
           v51:Fixnum = FixnumAdd v50, v24
           CheckInterrupts
@@ -21314,11 +21314,11 @@ mod hir_opt_tests {
           v61:Fixnum[0] = Const Value(0)
           PushInlineFrame :add_kws, v27 (0x1040), num_args=3
           v40:Fixnum[100] = Const Value(100)
-          PatchPoint MethodRedefined(Integer@0x1068, *@0x1070, cme:0x1078)
+          PatchPoint MethodRedefined(Integer@0x1060, *@0x1068, cme:0x1070)
           v68:Fixnum = GuardType v10, Fixnum recompile
           v69:Fixnum = FixnumMult v68, v40
           v82:Fixnum[20] = Const Value(20)
-          PatchPoint MethodRedefined(Integer@0x1068, +@0x10a0, cme:0x10a8)
+          PatchPoint MethodRedefined(Integer@0x1060, +@0x1098, cme:0x10a0)
           v77:Fixnum = FixnumAdd v69, v82
           v81:Fixnum = FixnumAdd v77, v16
           CheckInterrupts
@@ -21376,12 +21376,12 @@ mod hir_opt_tests {
           CondBranch v36, bb6(v24), bb7()
         bb7():
           v42:Fixnum[2] = Const Value(2)
-          PatchPoint MethodRedefined(Integer@0x1068, *@0x1070, cme:0x1078)
+          PatchPoint MethodRedefined(Integer@0x1060, *@0x1068, cme:0x1070)
           v70:Fixnum = GuardType v10, Fixnum recompile
           v71:Fixnum = FixnumMult v70, v42
           Jump bb6(v71)
         bb6(v50:NilClass|Fixnum):
-          PatchPoint MethodRedefined(Integer@0x1068, +@0x10a0, cme:0x10a8)
+          PatchPoint MethodRedefined(Integer@0x1060, +@0x1098, cme:0x10a0)
           v74:Fixnum = GuardType v10, Fixnum recompile
           v75:Fixnum = GuardType v50, Fixnum
           v76:Fixnum = FixnumAdd v74, v75
@@ -21437,7 +21437,7 @@ mod hir_opt_tests {
           PatchPoint MethodRedefined(Object@0x1008, add_lead_opt_post@0x1010, cme:0x1018)
           v27:ObjectSubclass[class_exact*:Object@VALUE(0x1008)] = GuardType v9, ObjectSubclass[class_exact*:Object@VALUE(0x1008)] recompile
           PushInlineFrame :add_lead_opt_post, v27 (0x1040), num_args=3
-          PatchPoint MethodRedefined(Integer@0x1068, +@0x1070, cme:0x1078)
+          PatchPoint MethodRedefined(Integer@0x1060, +@0x1068, cme:0x1070)
           v55:Fixnum = GuardType v10, Fixnum recompile
           v56:Fixnum = FixnumAdd v55, v16
           v60:Fixnum = FixnumAdd v56, v18
@@ -21493,10 +21493,10 @@ mod hir_opt_tests {
           v25:ObjectSubclass[class_exact*:Object@VALUE(0x1008)] = GuardType v9, ObjectSubclass[class_exact*:Object@VALUE(0x1008)] recompile
           PushInlineFrame :with_yield, v25 (0x1040), num_args=1
           v34:CPtr = GetEP 0
-          v35:CInt64 = LoadField v34, :VM_ENV_DATA_INDEX_SPECVAL@0x1068
+          v35:CInt64 = LoadField v34, :VM_ENV_DATA_INDEX_SPECVAL@0x1060
           v36:CInt64[-4] = Const CInt64(-4)
           v37:CInt64 = IntAnd v35, v36
-          v38:BasicObject = InvokeBlockIseqDirect (0x1070), v37, v10
+          v38:BasicObject = InvokeBlockIseqDirect (0x1068), v37, v10
           CheckInterrupts
           PopInlineFrame
           PatchPoint NoEPEscape(test)
@@ -21550,16 +21550,16 @@ mod hir_opt_tests {
           v53:NilClass = Const Value(nil)
           PushInlineFrame :with_block_param, v25 (0x1040), num_args=1
           v36:CPtr = GetEP 0
-          v37:CUInt64 = LoadField v36, :VM_ENV_DATA_INDEX_FLAGS@0x1068
+          v37:CUInt64 = LoadField v36, :VM_ENV_DATA_INDEX_FLAGS@0x1060
           v38:CBool = IsBlockParamModified v37
           CondBranch v38, bb6(), bb7()
         bb6():
-          v40:BasicObject = LoadField v36, :block@0x1069
+          v40:BasicObject = LoadField v36, :block@0x1061
           Jump bb8(v40, v40)
         bb7():
-          v42:CInt64 = LoadField v36, :VM_ENV_DATA_INDEX_SPECVAL@0x106a
+          v42:CInt64 = LoadField v36, :VM_ENV_DATA_INDEX_SPECVAL@0x1062
           v43:CInt64 = GuardAnyBitSet v42, CUInt64(1) recompile
-          v44:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1070))
+          v44:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1068))
           Jump bb8(v44, v53)
         bb8(v34:BasicObject, v35:BasicObject):
           v48:BasicObject = Send v34, :call, v10 # SendFallbackReason: Send: unsupported optimized method type BlockCall
@@ -21614,16 +21614,16 @@ mod hir_opt_tests {
           v54:NilClass = Const Value(nil)
           PushInlineFrame :callee, v25 (0x1040), num_args=1
           v38:CPtr = GetEP 0
-          v39:CUInt64 = LoadField v38, :VM_ENV_DATA_INDEX_FLAGS@0x1068
+          v39:CUInt64 = LoadField v38, :VM_ENV_DATA_INDEX_FLAGS@0x1060
           v40:CBool = IsBlockParamModified v39
           CondBranch v40, bb6(), bb7()
         bb6():
-          v42:BasicObject = LoadField v38, :block@0x1069
+          v42:BasicObject = LoadField v38, :block@0x1061
           Jump bb8(v42, v42)
         bb7():
-          v44:CInt64 = LoadField v38, :VM_ENV_DATA_INDEX_SPECVAL@0x106a
+          v44:CInt64 = LoadField v38, :VM_ENV_DATA_INDEX_SPECVAL@0x1062
           v45:CInt64 = GuardAnyBitSet v44, CUInt64(1) recompile
-          v46:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1070))
+          v46:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1068))
           Jump bb8(v46, v54)
         bb8(v36:BasicObject, v37:BasicObject):
           v49:BasicObject = Send v25, &block, :inner, v10, v36 # SendFallbackReason: Send: block argument is not nil
@@ -21690,22 +21690,22 @@ mod hir_opt_tests {
           PatchPoint MethodRedefined(Point@0x1008, initialize@0x1038, cme:0x1040)
           PushInlineFrame :initialize, v85 (0x1068), num_args=2
           PatchPoint SingleRactorMode
-          v117:CShape = LoadField v85, :shape_id@0x1090
-          v118:CShape[0x1091] = GuardBitEquals v117, CShape(0x1091) recompile
-          StoreField v85, :@x@0x1092, v15
+          v117:CShape = LoadField v85, :shape_id@0x1088
+          v118:CShape[0x1089] = GuardBitEquals v117, CShape(0x1089) recompile
+          StoreField v85, :@x@0x108a, v15
           WriteBarrier v85, v15
-          v121:CShape[0x1093] = Const CShape(0x1093)
-          StoreField v85, :shape_id@0x1090, v121
+          v121:CShape[0x108b] = Const CShape(0x108b)
+          StoreField v85, :shape_id@0x1088, v121
           PatchPoint NoEPEscape(initialize)
           PatchPoint SingleRactorMode
-          StoreField v85, :@y@0x1094, v17
+          StoreField v85, :@y@0x108c, v17
           WriteBarrier v85, v17
-          v136:CShape[0x1095] = Const CShape(0x1095)
-          StoreField v85, :shape_id@0x1090, v136
+          v136:CShape[0x108d] = Const CShape(0x108d)
+          StoreField v85, :shape_id@0x1088, v136
           CheckInterrupts
           PopInlineFrame
           v42:NilClass = Const Value(nil)
-          PatchPoint StableConstantNames(0x1098, Point)
+          PatchPoint StableConstantNames(0x1090, Point)
           v45:ClassSubclass[Point@0x1008] = Const Value(VALUE(0x1008))
           v47:Fixnum[1] = Const Value(1)
           v49:Fixnum[2] = Const Value(2)
@@ -21715,30 +21715,30 @@ mod hir_opt_tests {
           PatchPoint MethodRedefined(Point@0x1008, initialize@0x1038, cme:0x1040)
           PushInlineFrame :initialize, v95 (0x1068), num_args=2
           PatchPoint SingleRactorMode
-          v157:CShape = LoadField v95, :shape_id@0x1090
-          v158:CShape[0x1091] = GuardBitEquals v157, CShape(0x1091) recompile
-          StoreField v95, :@x@0x1092, v47
+          v157:CShape = LoadField v95, :shape_id@0x1088
+          v158:CShape[0x1089] = GuardBitEquals v157, CShape(0x1089) recompile
+          StoreField v95, :@x@0x108a, v47
           WriteBarrier v95, v47
-          v161:CShape[0x1093] = Const CShape(0x1093)
-          StoreField v95, :shape_id@0x1090, v161
+          v161:CShape[0x108b] = Const CShape(0x108b)
+          StoreField v95, :shape_id@0x1088, v161
           PatchPoint NoEPEscape(initialize)
           PatchPoint SingleRactorMode
-          StoreField v95, :@y@0x1094, v49
+          StoreField v95, :@y@0x108c, v49
           WriteBarrier v95, v49
-          v176:CShape[0x1095] = Const CShape(0x1095)
-          StoreField v95, :shape_id@0x1090, v176
+          v176:CShape[0x108d] = Const CShape(0x108d)
+          StoreField v95, :shape_id@0x1088, v176
           CheckInterrupts
           PopInlineFrame
           PatchPoint NoSingletonClass(Point@0x1008)
-          PatchPoint MethodRedefined(Point@0x1008, ==@0x10a0, cme:0x10a8)
-          PushInlineFrame :==, v85 (0x10d0), num_args=1
+          PatchPoint MethodRedefined(Point@0x1008, ==@0x1098, cme:0x10a0)
+          PushInlineFrame :==, v85 (0x10c8), num_args=1
           PatchPoint SingleRactorMode
-          v195:CShape = LoadField v85, :shape_id@0x1090
-          v196:CShape[0x1095] = GuardBitEquals v195, CShape(0x1095) recompile
-          v197:BasicObject = LoadField v85, :@x@0x1092
+          v195:CShape = LoadField v85, :shape_id@0x1088
+          v196:CShape[0x108d] = GuardBitEquals v195, CShape(0x108d) recompile
+          v197:BasicObject = LoadField v85, :@x@0x108a
           PatchPoint NoEPEscape(==)
-          PatchPoint MethodRedefined(Point@0x1008, x@0x10f8, cme:0x1100)
-          PatchPoint MethodRedefined(Integer@0x1128, ==@0x10a0, cme:0x1130)
+          PatchPoint MethodRedefined(Point@0x1008, x@0x10e8, cme:0x10f0)
+          PatchPoint MethodRedefined(Integer@0x1118, ==@0x1098, cme:0x1120)
           v253:Fixnum = GuardType v197, Fixnum recompile
           v255:BoolExact = FixnumEq v253, v47
           v208:CBool = Test v255
@@ -21746,16 +21746,16 @@ mod hir_opt_tests {
           CondBranch v208, bb19(), bb18(v209)
         bb19():
           PatchPoint SingleRactorMode
-          v216:CShape = LoadField v85, :shape_id@0x1090
-          v217:CShape[0x1095] = GuardBitEquals v216, CShape(0x1095) recompile
-          v218:BasicObject = LoadField v85, :@y@0x1094
+          v216:CShape = LoadField v85, :shape_id@0x1088
+          v217:CShape[0x108d] = GuardBitEquals v216, CShape(0x108d) recompile
+          v218:BasicObject = LoadField v85, :@y@0x108c
           PatchPoint NoEPEscape(==)
           PatchPoint NoSingletonClass(Point@0x1008)
-          PatchPoint MethodRedefined(Point@0x1008, y@0x1158, cme:0x1160)
-          v260:CShape = LoadField v95, :shape_id@0x1090
-          v261:CShape[0x1095] = GuardBitEquals v260, CShape(0x1095) recompile
-          v262:BasicObject = LoadField v95, :@y@0x1094
-          PatchPoint MethodRedefined(Integer@0x1128, ==@0x10a0, cme:0x1130)
+          PatchPoint MethodRedefined(Point@0x1008, y@0x1148, cme:0x1150)
+          v260:CShape = LoadField v95, :shape_id@0x1088
+          v261:CShape[0x108d] = GuardBitEquals v260, CShape(0x108d) recompile
+          v262:BasicObject = LoadField v95, :@y@0x108c
+          PatchPoint MethodRedefined(Integer@0x1118, ==@0x1098, cme:0x1120)
           v265:Fixnum = GuardType v218, Fixnum recompile
           v266:Fixnum = GuardType v262, Fixnum
           v267:BoolExact = FixnumEq v265, v266

--- a/zjit/src/hir/tests.rs
+++ b/zjit/src/hir/tests.rs
@@ -212,9 +212,9 @@ mod snapshot_tests {
           v44:Fixnum[0] = Const Value(0)
           v27:Any = Snapshot FrameState { pc: 0x1008, stack: [], locals: [] }
           PushInlineFrame :foo, v24 (0x1048), num_args=3
-          v38:Any = Snapshot FrameState { pc: 0x1070, stack: [v13, v15, v11], locals: [a=v13, b=v15, c=v11, ID(0)=v44], caller: v27 }
+          v38:Any = Snapshot FrameState { pc: 0x1068, stack: [v13, v15, v11], locals: [a=v13, b=v15, c=v11, ID(0)=v44], caller: v27 }
           v39:ArrayExact = NewArray v13, v15, v11
-          v40:Any = Snapshot FrameState { pc: 0x1078, stack: [v39], locals: [a=v13, b=v15, c=v11, ID(0)=v44], caller: v27 }
+          v40:Any = Snapshot FrameState { pc: 0x1070, stack: [v39], locals: [a=v13, b=v15, c=v11, ID(0)=v44], caller: v27 }
           CheckInterrupts
           PopInlineFrame
           Return v39
@@ -252,9 +252,9 @@ mod snapshot_tests {
           v39:Fixnum[0] = Const Value(0)
           v24:Any = Snapshot FrameState { pc: 0x1008, stack: [], locals: [] }
           PushInlineFrame :foo, v22 (0x1048), num_args=2
-          v33:Any = Snapshot FrameState { pc: 0x1070, stack: [v11, v13], locals: [a=v11, b=v13, ID(0)=v39], caller: v24 }
+          v33:Any = Snapshot FrameState { pc: 0x1068, stack: [v11, v13], locals: [a=v11, b=v13, ID(0)=v39], caller: v24 }
           v34:ArrayExact = NewArray v11, v13
-          v35:Any = Snapshot FrameState { pc: 0x1078, stack: [v34], locals: [a=v11, b=v13, ID(0)=v39], caller: v24 }
+          v35:Any = Snapshot FrameState { pc: 0x1070, stack: [v34], locals: [a=v11, b=v13, ID(0)=v39], caller: v24 }
           CheckInterrupts
           PopInlineFrame
           Return v34
@@ -299,9 +299,9 @@ mod snapshot_tests {
           v64:Fixnum[0] = Const Value(0)
           v37:Any = Snapshot FrameState { pc: 0x1008, stack: [], locals: [] }
           PushInlineFrame :foo, v34 (0x1048), num_args=8
-          v58:Any = Snapshot FrameState { pc: 0x1070, stack: [v19, v21, v17, v15, v11, v13, v23, v25], locals: [five=v11, six=v13, a=v19, b=v21, c=v17, d=v15, e=v23, f=v25, ID(0)=v64], caller: v37 }
+          v58:Any = Snapshot FrameState { pc: 0x1068, stack: [v19, v21, v17, v15, v11, v13, v23, v25], locals: [five=v11, six=v13, a=v19, b=v21, c=v17, d=v15, e=v23, f=v25, ID(0)=v64], caller: v37 }
           v59:ArrayExact = NewArray v19, v21, v17, v15, v11, v13, v23, v25
-          v60:Any = Snapshot FrameState { pc: 0x1078, stack: [v59], locals: [five=v11, six=v13, a=v19, b=v21, c=v17, d=v15, e=v23, f=v25, ID(0)=v64], caller: v37 }
+          v60:Any = Snapshot FrameState { pc: 0x1070, stack: [v59], locals: [five=v11, six=v13, a=v19, b=v21, c=v17, d=v15, e=v23, f=v25, ID(0)=v64], caller: v37 }
           CheckInterrupts
           PopInlineFrame
           Return v59
@@ -2141,7 +2141,7 @@ pub(crate) mod hir_build_tests {
           v25:BasicObject = Send v10, 0x1000, :foo # SendFallbackReason: Uncategorized(send)
           PatchPoint NoEPEscape(test)
           v28:CPtr = LoadSP
-          v29:BasicObject = LoadField v28, :a@0x1028
+          v29:BasicObject = LoadField v28, :a@0x1020
           PatchPoint NoEPEscape(test)
           v38:BasicObject = Send v29, :+, v20 # SendFallbackReason: Uncategorized(opt_plus)
           CheckInterrupts
@@ -2217,8 +2217,8 @@ pub(crate) mod hir_build_tests {
           PatchPoint NoEPEscape(test)
           v18:CPtr = LoadSP
           v19:BasicObject = LoadField v18, :block@0x1000
-          PatchPoint StableConstantNames(0x1030, ::RubyVM::ZJIT)
-          v24:ModuleSubclass[RubyVM::ZJIT@0x1038] = Const Value(VALUE(0x1038))
+          PatchPoint StableConstantNames(0x1028, ::RubyVM::ZJIT)
+          v24:ModuleSubclass[RubyVM::ZJIT@0x1030] = Const Value(VALUE(0x1030))
           SideExit DirectiveInduced
         ");
     }
@@ -2257,8 +2257,8 @@ pub(crate) mod hir_build_tests {
           v17:Fixnum[1] = Const Value(1)
           v22:BasicObject = Send v11, 0x1008, :consume # SendFallbackReason: Uncategorized(send)
           PatchPoint NoEPEscape(test)
-          PatchPoint StableConstantNames(0x1030, ::RubyVM::ZJIT)
-          v29:ModuleSubclass[RubyVM::ZJIT@0x1038] = Const Value(VALUE(0x1038))
+          PatchPoint StableConstantNames(0x1028, ::RubyVM::ZJIT)
+          v29:ModuleSubclass[RubyVM::ZJIT@0x1030] = Const Value(VALUE(0x1030))
           SideExit DirectiveInduced
         ");
     }
@@ -2295,16 +2295,16 @@ pub(crate) mod hir_build_tests {
           v15:BasicObject = Send v9, 0x1008, :consume # SendFallbackReason: Uncategorized(send)
           PatchPoint NoEPEscape(test)
           v24:CPtr = GetEP 0
-          v25:CUInt64 = LoadField v24, :VM_ENV_DATA_INDEX_FLAGS@0x1030
+          v25:CUInt64 = LoadField v24, :VM_ENV_DATA_INDEX_FLAGS@0x1028
           v26:CBool = IsBlockParamModified v25
           CondBranch v26, bb4(), bb5()
         bb4():
-          v28:BasicObject = LoadField v24, :&@0x1031
+          v28:BasicObject = LoadField v24, :&@0x1029
           Jump bb6(v28, v28)
         bb5():
-          v30:CInt64 = LoadField v24, :VM_ENV_DATA_INDEX_SPECVAL@0x1032
+          v30:CInt64 = LoadField v24, :VM_ENV_DATA_INDEX_SPECVAL@0x102a
           v31:CInt64 = GuardAnyBitSet v30, CUInt64(1) recompile
-          v32:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1038))
+          v32:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1030))
           Jump bb6(v32, v10)
         bb6(v22:BasicObject, v23:BasicObject):
           v35:BasicObject = Send v9, &block, :consume, v22 # SendFallbackReason: Uncategorized(send)
@@ -2350,7 +2350,7 @@ pub(crate) mod hir_build_tests {
           v25:BasicObject = Send v10, 0x1000, :foo # SendFallbackReason: Uncategorized(send)
           PatchPoint NoEPEscape(test)
           v28:CPtr = LoadSP
-          v29:BasicObject = LoadField v28, :a@0x1028
+          v29:BasicObject = LoadField v28, :a@0x1020
           PatchPoint NoEPEscape(test)
           v38:BasicObject = Send v29, :+, v20 # SendFallbackReason: Uncategorized(opt_plus)
           CheckInterrupts


### PR DESCRIPTION
We keep a singleton of iseq wrappers (RubyVM::InstructionSequence). However, this is rarely used and causes 8 bytes to be wasted on all iseq objects. Since we now have the 32-byte slot size in the default GC, we can save that memory.