### PR TITLE
hash.c: avoid signed integer overflow in ar_hint_first_match SWAR splat

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -661,7 +661,7 @@ ar_hint_first_match(ar_hint_t needle, VALUE haystack)
 {
     // Common SWAR technique.
     // First XOR all bytes so that matching ones are set to 0x00.
-    VALUE search_mask = AR_HINT_BASE_MASK * needle;
+    VALUE search_mask = (VALUE)AR_HINT_BASE_MASK * needle;
     VALUE matches = haystack ^ search_mask;
 
     // Then turns 0x00 into 0x80, and any other bytes into 0x00.


### PR DESCRIPTION
Hi,
I ran into this UBsan report in oss-fuzz's CI: https://github.com/google/oss-fuzz/pull/16072

```
hash.c:664:43: runtime error: signed integer overflow: 72340172838076673 * 131 cannot be represented in type 'long'
```

You can reproduce this by running `make CC=clang CFLAGS="-fsanitize=signed-integer-overflow"`

UBsan flags this because the `AR_HINT_BASE_MASK` constant is implicitly typed as long:

https://github.com/ruby/ruby/blob/b4322d90201dcedea39670d77bf3bbb697b872bc/hash.c#L664

Notably, with an unsigned cast, this line can't overflow (`AR_HINT_BASE_MASK` is `0x0101..0101`). `VALUE` is always an unsigned type.
The SWAR code was introduced fairly recently (7da70f17736d).

Thanks!