### PR TITLE
Fix autoload's require dispatch under Ruby::Box

### DIFF
--- a/test/ruby/test_box.rb
+++ b/test/ruby/test_box.rb
@@ -203,6 +203,58 @@ class TestBox < Test::Unit::TestCase
     assert_raise(NameError) { BOX_B }
   end
 
+  def test_autoload_dispatches_prepended_require
+    # Autoload must go through the `Kernel#require` decorations (Zeitwerk, RubyGems, etc.)
+    # of the box that registered the autoload, not `Ruby::Box#require` directly.
+    assert_separately([ENV_ENABLE_BOX], __FILE__, __LINE__, "#{<<~"begin;"}\n#{<<~'end;'}", ignore_stderr: true)
+    begin;
+      FEATURE = "/nonexistent/virtual_feature"
+      module Decor
+        def require(path)
+          if path == FEATURE
+            Object.const_set(:AutoloadedFromDecorator, Module.new)
+            return true
+          end
+          super
+        end
+      end
+      Kernel.prepend(Decor)
+      Object.autoload(:AutoloadedFromDecorator, FEATURE)
+      assert_kind_of Module, AutoloadedFromDecorator
+    end;
+  end
+
+  def test_autoload_dispatches_prepended_require_of_the_registered_box
+    # Even when the autoload is triggered from outside, it must be dispatched to the
+    # (decorated) `Kernel#require` of the box that registered the autoload.
+    # --enable=gems because Kernel.prepend in a box without RubyGems has a separate
+    # ancestry ordering problem, and assert_separately runs with --disable=gems.
+    assert_in_out_err([ENV_ENABLE_BOX, "--enable=gems"], "#{<<-"begin;"}\n#{<<-'end;'}") do |output, error|
+      begin;
+        box = Ruby::Box.new
+        box.eval(<<~RUBY)
+          FEATURE = "/nonexistent/box_virtual_feature"
+          module BoxDecor
+            def require(path)
+              if path == FEATURE
+                Holder.const_set(:Virtual, "decorated in \#{Ruby::Box.current.inspect}")
+                return true
+              end
+              super
+            end
+          end
+          Kernel.prepend(BoxDecor)
+          module Holder
+            autoload :Virtual, FEATURE
+          end
+        RUBY
+        puts box::Holder::Virtual
+      end;
+      assert_equal 1, output.size
+      assert_match(/\Adecorated in #<Ruby::Box:\d+,user/, output.first)
+    end
+  end
+
   def test_continuous_top_level_method_in_a_box
     setup_box
 

--- a/variable.c
+++ b/variable.c
@@ -3164,10 +3164,16 @@ autoload_apply_constants(VALUE _arguments)
 }
 
 static VALUE
+autoload_feature_require_in_box(VALUE receiver, VALUE feature)
+{
+    rb_vm_frame_flag_set_box_require(GET_EC());
+
+    return rb_funcall(receiver, rb_intern("require"), 1, feature);
+}
+
+static VALUE
 autoload_feature_require(VALUE _arguments)
 {
-    VALUE receiver = rb_vm_top_self();
-
     struct autoload_load_arguments *arguments = (struct autoload_load_arguments*)_arguments;
 
     struct autoload_const *autoload_const = arguments->autoload_const;
@@ -3175,9 +3181,6 @@ autoload_feature_require(VALUE _arguments)
 
     // We save this for later use in autoload_apply_constants:
     arguments->autoload_data = rb_check_typeddata(autoload_const->autoload_data_value, &autoload_data_type);
-
-    if (rb_box_available() && BOX_OBJ_P(autoload_box_value))
-        receiver = autoload_box_value;
 
     /*
      * Clear the global cc cache table because the require method can be different from the current
@@ -3187,7 +3190,25 @@ autoload_feature_require(VALUE _arguments)
      */
     rb_gccct_clear_table();
 
-    VALUE result = rb_funcall(receiver, rb_intern("require"), 1, arguments->autoload_data->feature);
+    VALUE feature = arguments->autoload_data->feature;
+    rb_box_t *box = NULL;
+    if (rb_box_available() && BOX_OBJ_P(autoload_box_value)) {
+        box = rb_get_box_t(autoload_box_value);
+    }
+
+    VALUE result;
+    if (box && box->top_self) {
+        /*
+         * Call `require` on the top self of the box that registered the autoload, in a frame
+         * running in that box, so that `Kernel#require` decorations in the box (RubyGems,
+         * Zeitwerk, etc.) are dispatched and the feature is loaded into that box.
+         */
+        result = rb_vm_call_cfunc_in_box(box->top_self, autoload_feature_require_in_box,
+                                         box->top_self, feature, feature, box);
+    }
+    else {
+        result = rb_funcall(rb_vm_top_self(), rb_intern("require"), 1, feature);
+    }
 
     if (RTEST(result)) {
         return rb_mutex_synchronize(autoload_mutex, autoload_apply_constants, _arguments);


### PR DESCRIPTION
With `RUBY_BOX=1`, firing an autoload calls `Ruby::Box#require` on the box that registered the autoload, which goes straight to `rb_require_string` and bypasses everything prepended to `Kernel#require` in that box (RubyGems, Zeitwerk, Bootsnap). Zeitwerk's implicit namespaces rely on the decorated `require`, so a plain Rails 8.1 app boots but fails on the first request with `LoadError` for a directory path. This is the remaining autoload part of [Bug #21830].

This change calls `require` on the registered box's top self in a frame running in that box, so the decorated method resolves while the feature is still loaded into the box that registered the autoload. `Ruby::Box#require` itself is unchanged. With this fix, `RUBY_BOX=1 bin/rails server` serves `GET /` with 200.

https://bugs.ruby-lang.org/issues/21830

This touches box internals, so I'd like a review from @tagomoris.
