### PR TITLE
Fix prepend ancestry order in user boxes

### DIFF
--- a/class.c
+++ b/class.c
@@ -1843,6 +1843,10 @@ ensure_origin(VALUE klass)
 {
     VALUE origin = RCLASS_ORIGIN(klass);
     if (origin == klass) {
+        /* Create the box-local classext before reading m_tbl, so that the
+         * origin shares the m_tbl with the box-local iclasses of klass,
+         * as rb_prepend_module relies on that identity. */
+        rb_class_ensure_writable(klass);
         origin = class_alloc(T_ICLASS, klass);
         RCLASS_SET_M_TBL(origin, RCLASS_M_TBL(klass));
         rb_class_set_super(origin, RCLASS_SUPER(klass));

--- a/test/ruby/test_box.rb
+++ b/test/ruby/test_box.rb
@@ -582,7 +582,7 @@ class TestBox < Test::Unit::TestCase
     assert_equal nil, $,
 
     # used only in box
-    assert_not_include? global_variables, :$used_only_in_box
+    assert_not_include global_variables, :$used_only_in_box
     @box::UniqueGvar.write(123)
     assert_equal 123, @box::UniqueGvar.read
     assert_nil $used_only_in_box

--- a/test/ruby/test_box.rb
+++ b/test/ruby/test_box.rb
@@ -372,6 +372,21 @@ class TestBox < Test::Unit::TestCase
     assert_include @box::BoxedString.ancestors, String
     assert_include String.descendants, @box::BoxedString
   end
+
+  def test_prepend_to_builtin_module_in_box
+    # Use --disable-gems to keep Kernel untouched in the new box, so that
+    # the prepend below is the first copy-on-write of Kernel's classext
+    assert_separately([ENV_ENABLE_BOX, '--disable-gems'], __FILE__, __LINE__, "#{<<~"begin;"}\n#{<<~'end;'}", ignore_stderr: true)
+    begin;
+      box = Ruby::Box.new
+      box.eval('module BoxDecor; def itself; :decorated; end; end; Kernel.prepend(BoxDecor)')
+      ancestors = box.eval('Object.ancestors')
+      assert_operator ancestors.index(box::BoxDecor), :<, ancestors.index(Kernel)
+      assert_equal :decorated, box.eval('Object.new.itself')
+      assert_not_include Object.ancestors, box::BoxDecor
+      assert_equal 42, 42.itself
+    end;
+  end
 end
 
 class TestBoxDescendantsMain


### PR DESCRIPTION
In a user box created with gems disabled, prepending to a built-in module inserts it on the wrong side of the target:

```ruby
box = Ruby::Box.new
box.eval('module BoxDecor; end; Kernel.prepend(BoxDecor)')
box.eval('Object.ancestors.first(5)')
# => [Object, Ruby::Box::Loader, Kernel, BoxDecor, BasicObject]
```

`ensure_origin` reads the target's `m_tbl` before its first write creates the box-local classext, so the origin ICLASS captures the prime `m_tbl` while the subclass ICLASSes refer the box-local copy made by the CoW. The shared table check in `rb_prepend_module` then fails and the origin backfill is skipped. With gems enabled the bug is hidden because loading rubygems into the box copies `Kernel`'s classext first.

The fix creates the box-local classext before reading the `m_tbl`, which is a no-op when boxes are disabled. Also fixes a pre-existing `assert_not_include?` typo that made `test_global_variables` error under `RUBY_BOX=1`.

cc @tagomoris
