### PR TITLE
ZJIT: Elide inline frames containing only `Snapshot`s

### DIFF
--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -7085,9 +7085,18 @@ impl Function {
     /// * It must not reference a FrameState `Snapshot` operand: a side exit
     ///   materializes the enclosing inlined frame, and effects don't model
     ///   deopt for otherwise pure instructions like `FixnumAdd`.
+    ///   (`Snapshot` instructions themselves are exempt: they are inert data
+    ///   that cannot side-exit, so they should not prevent elision.)
     /// * `LoadSP` reads the frame-dependent SP register despite having empty
     ///   effects, so it's excluded explicitly.
     fn can_elide_enclosing_frame(&self, insn: &Insn) -> bool {
+        // A `Snapshot` only matters as the deopt state of an instruction
+        // that can side-exit. It shouldn't prevent elision on its own.
+        // Side-exiting instructions will block elision when they're scanned.
+        // TODO (nirvdrum 2026-09-02) Replace this specific instruction check with a check of the instruction's effects.
+        if matches!(insn, Insn::Snapshot { .. }) {
+            return true;
+        }
         // TODO: Model LoadSP as reading from the control frame and drop this
         // special case.
         if matches!(insn, Insn::LoadSP) {

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -2147,6 +2147,49 @@ mod hir_opt_tests {
     }
 
     #[test]
+    fn test_eliminate_empty_inline_frames_with_dead_snapshot() {
+        eval("
+            def add(a, b) = a + b
+            def test = add(1, 2) + add(3, 4)
+            test
+        ");
+
+        // `add` is inlined at both call sites, giving two `PushInlineFrame`/`PopInlineFrame`
+        // pairs. The first pair keeps `add`'s `PatchPoint` and `CheckInterrupts`, which the
+        // deduplication passes leave on the earliest copy, so it has real work between it. The
+        // second pair's body is optimized away entirely, yet the pair still isn't eliminated,
+        // because it encloses the `Snapshot`s that body left behind. `Snapshot`s aren't printed
+        // out, so that pair looks empty below even though the pass doesn't treat it as empty.
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:3:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          Jump bb3(v1)
+        bb2():
+          EntryPoint JIT(0)
+          v4:BasicObject = LoadArg :self@0
+          Jump bb3(v4)
+        bb3(v6:BasicObject):
+          v11:Fixnum[1] = Const Value(1)
+          v13:Fixnum[2] = Const Value(2)
+          PatchPoint MethodRedefined(Object@0x1000, add@0x1008, cme:0x1010)
+          v32:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
+          PushInlineFrame :add, v32 (0x1038), num_args=2
+          PatchPoint MethodRedefined(Integer@0x1058, +@0x1060, cme:0x1068)
+          v88:Fixnum[3] = Const Value(3)
+          CheckInterrupts
+          PopInlineFrame
+          v18:Fixnum[3] = Const Value(3)
+          v20:Fixnum[4] = Const Value(4)
+          PushInlineFrame :add, v32 (0x1038), num_args=2
+          PopInlineFrame
+          v90:Fixnum[10] = Const Value(10)
+          Return v90
+        ");
+    }
+
+    #[test]
     fn test_call_with_correct_and_too_many_args_for_method() {
         eval("
             def target(a = 1, b = 2, c = 3, d = 4) = [a, b, c, d]

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -2156,10 +2156,8 @@ mod hir_opt_tests {
 
         // `add` is inlined at both call sites, giving two `PushInlineFrame`/`PopInlineFrame`
         // pairs. The first pair keeps `add`'s `PatchPoint` and `CheckInterrupts`, which the
-        // deduplication passes leave on the earliest copy, so it has real work between it. The
-        // second pair's body is optimized away entirely, yet the pair still isn't eliminated,
-        // because it encloses the `Snapshot`s that body left behind. `Snapshot`s aren't printed
-        // out, so that pair looks empty below even though the pass doesn't treat it as empty.
+        // deduplication passes leave on the earliest copy, so it has real work between it and
+        // survives. The second pair and its body are optimized away entirely.
         assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
         bb1():
@@ -2179,10 +2177,6 @@ mod hir_opt_tests {
           PatchPoint MethodRedefined(Integer@0x1058, +@0x1060, cme:0x1068)
           v88:Fixnum[3] = Const Value(3)
           CheckInterrupts
-          PopInlineFrame
-          v18:Fixnum[3] = Const Value(3)
-          v20:Fixnum[4] = Const Value(4)
-          PushInlineFrame :add, v32 (0x1038), num_args=2
           PopInlineFrame
           v90:Fixnum[10] = Const Value(10)
           Return v90


### PR DESCRIPTION
This PR builds upon #18231.

While digging into some inlining examples I noticed seemingly empty `PushInlineFrame`/`PopInlineFrame` pairs in the HIR output. Digging in, it turns out they're not really empty, but rather hold `Snapshot`s leftover from an inlined body that was optimized away (we don't print out `Snapshot`s by default). `can_elide_enclosing_frame` (introduced in #18231) rejects any instruction that references a `Snapshot` operand because those may side-exit. But, in an inlined frame the `Snapshot` will reference its `caller`, which is another `Snapshot`, and that was being caught by the check.
However, we know `Snapshot` cannot side-exit, so when all we're left with is a chain of `Snapshot`s we can ignore all of them, freeing us up to elide the inline frame.

We already track how many times execution would have passed through an elided pair via `empty_inline_frame_count`, so the run time impact of these do-nothing pairs falls out of `--zjit-stats` directly:

| benchmark | master | branch |
|---|---:|---:|
| `keyword_args` | 0 | 10,499,797 |
| `chunky-png` | 0 | 1,458 |
| `hexapdf` | 2,413 | 6,423 |
| `lobsters` | 239 | 239 |
| `liquid-render` | 0 | 0 |

These numbers scale with iteration count. I ran with `WARMUP_ITRS=1 MIN_BENCH_ITRS=2`.

I was also curious how many pairs this actually elides at compile time, which we don't track today. For that I added a temporary counter (not included in this PR):

| benchmark | master | branch |
|---|---:|---:|
| `keyword_args` | 0 | 7 |
| `chunky-png` | 0 | 4 |
| `hexapdf` | 2 | 5 |

So, a very small number of sites are able to remove inline frames, but that can translate into a much larger number on a hot path at run time.

As for wall clock time, we have:

| benchmark | master (ms) | branch (ms) | master/branch |
|---|---:|---:|---:|
| `keyword_args` | 6.74 | 1.66 | **4.05** |
| `lobsters` | 352.99 | 341.51 | 1.03 |
| `chunky-png` | 176.88 | 175.38 | 1.01 |
| `liquid-render` | 40.24 | 40.39 | 0.99 |
| `hexapdf` | 753.58 | 760.20 | 0.99 |

The `keyword_args` benchmark is the largest beneficiary. For the other benchmarks, any gains or losses are within the margin of error. While the lobsters number looks promising, I get the same 3% gain over the base branch with inlining disabled. I'm not sure why that is, but it's not a gain from this change.

While this PR doesn't really affect big applications, it's nice not having these empty inline frames cluttering the HIR output.
