### PR TITLE
ZJIT: Bump the distribution size of profiles to 8

### DIFF
--- a/zjit/src/profile.rs
+++ b/zjit/src/profile.rs
@@ -143,7 +143,7 @@ pub fn num_arguments_on_stack(cd: *const rb_call_data) -> usize {
     (unsafe { vm_ci_argc(ci) }) as usize + has_blockarg as usize
 }
 
-const DISTRIBUTION_SIZE: usize = 4;
+const DISTRIBUTION_SIZE: usize = 8;
 
 pub type TypeDistribution = Distribution<ProfiledType, DISTRIBUTION_SIZE>;
 


### PR DESCRIPTION
This PR bumps `DISTRIBUTION_SIZE` from 4 to 8.

## Why 8

I was looking at speeding at lobsters, and took a look at rubocop at a different time, and both of them have benefited from increasing the distribution size. Then, I tested a few different options, and it seemed like 8 was a nice pick for those two.

| DIST     | lobsters ms (speedup) | rubocop ms (speedup) |
|:---------|:----------------------|:---------------------|
| 4 (base) | 541.4 (1.000)         | 97.1 (1.000)         |
| 5        | 534.3 (1.013)         | 96.5 (1.006)         |
| 6        | 536.2 (1.010)         | 94.4 (1.028)         |
| 7        | 531.8 (1.018)         | 91.2 (1.064)         |
| 8        | 528.9 (1.024)         | 91.3 (1.063)         |
| 9        | 530.7 (1.020)         | 91.0 (1.066)         |
| 10       | 530.0 (1.022)         | 91.5 (1.061)         |

## Benchmark

This speeds up many of the headline benchmarks, including Rails benchmarks. Unfortunately, it didn't work in favor of all benchmarks, slowing down hexapdf and psych-load. But I want to still pick a default that prioritizes Rails over those benchmarks.

```
before: ruby 4.1.0dev (2026-08-27T19:07:46Z master f4813a34c2) +ZJIT +PRISM [x86_64-linux]
after: ruby 4.1.0dev (2026-08-27T20:25:51Z zjit-dist-size fbbb3ec044) +ZJIT +PRISM [x86_64-linux]

--------------  -------------  -------------  -------------  ------------
bench             before (ms)     after (ms)  after 1st itr  before/after
activerecord      96.5 ± 3.5%    92.3 ± 4.2%          0.870         1.045
chunky-png       283.3 ± 0.7%   281.6 ± 0.6%          1.005         1.006
erubi-rails      466.3 ± 1.9%   461.7 ± 2.2%          1.011         1.010
hexapdf         1194.4 ± 1.4%  1219.7 ± 1.2%          0.997         0.979
liquid-c          30.8 ± 9.5%    30.6 ± 9.5%          1.000         1.007
liquid-compile   25.9 ± 11.3%   25.8 ± 11.6%          0.995         1.004
liquid-il        125.4 ± 1.9%   115.2 ± 2.2%          1.049         1.089
liquid-render     58.4 ± 4.7%    55.9 ± 4.9%          1.015         1.044
lobsters         540.0 ± 4.1%   525.4 ± 4.9%          0.975         1.028
mail              74.0 ± 3.2%    72.9 ± 3.2%          1.024         1.014
psych-load      1085.9 ± 0.3%  1135.9 ± 1.5%          0.998         0.956
railsbench      1083.4 ± 1.4%  1061.2 ± 1.3%          1.070         1.021
rubocop          98.9 ± 16.0%   91.0 ± 13.2%          0.987         1.087
ruby-lsp          74.2 ± 3.8%    72.7 ± 4.0%          1.000         1.020
sequel            30.1 ± 6.5%    30.1 ± 6.8%          0.962         1.001
shipit           877.6 ± 0.8%   844.1 ± 0.7%          1.021         1.040
--------------  -------------  -------------  -------------  ------------
```

## Stats

On lobsters, it reduces the number of fallbacks due to megamorphic callsites.

```diff
-Top-20 send fallback reasons (100.0% of total 4,451,370):
+Top-20 send fallback reasons (100.0% of total 4,068,486):
               invokeblock_polymorphic_miss: 1,157,462 (26.0%)
+                          send_polymorphic:   939,028 (23.1%)
-                          send_polymorphic:   808,032 (18.2%)
-                          send_megamorphic:   561,269 (12.6%)
                invokeblock_not_specialized:   558,929 (12.6%)
               one_or_more_complex_arg_pass:   376,483 ( 8.5%)
                     send_block_arg_not_nil:   373,109 ( 8.4%)
                sendforward_not_specialized:   217,788 ( 4.9%)
                              uncategorized:   122,035 ( 2.7%)
   send_not_optimized_method_type_optimized:    97,270 ( 2.2%)
         send_not_optimized_need_permission:    83,524 ( 1.9%)
+                          send_megamorphic:    44,927 ( 1.1%)
                          super_polymorphic:    28,177 ( 0.6%)
         invokesuperforward_not_specialized:    22,240 ( 0.5%)
                    super_complex_args_pass:    14,396 ( 0.3%)
             send_not_optimized_method_type:    11,322 ( 0.3%)
                           super_from_block:    11,123 ( 0.2%)
                       singleton_class_seen:     6,389 ( 0.1%)
            super_not_optimized_method_type:     1,005 ( 0.0%)
                           send_no_profiles:       400 ( 0.0%)
                      super_call_with_block:       343 ( 0.0%)
                  send_polymorphic_fallback:        68 ( 0.0%)
```

## Memory usage
On lobsters, the total memory usage is increased by 6MB (+16.8%). This is a lot of increase. However, even with this change, the ratio of "code region size" / "alloc bytes" is still lower than YJIT (this PR's ZJIT is 1.64 whereas YJIT is 2.31).

With this larger distribution buckets, it might make more sense to allocate variable-length buckets instead of fixed-length one to reduce memory usage, but I want to scope out such changes from this PR.

### Before

```
code_region_bytes:     15,572,992
zjit_alloc_bytes:      20,218,688
```

### After

```
code_region_bytes:     15,826,944
zjit_alloc_bytes:      25,996,952
```