### PR TITLE
Handle empty and singleton alphabets in Random::Formatter

### DIFF
--- a/lib/random/formatter.rb
+++ b/lib/random/formatter.rb
@@ -312,6 +312,11 @@ module Random::Formatter
   #   prng.choose([*'0'..'9'], 5)  #=> "27309"
   private def choose(source, n)
     size = source.size
+    if size < 2
+      return ''.dup if n <= 0
+      raise ArgumentError, "character source must not be empty" if size == 0
+      return source.values_at(0).join('') * n
+    end
     m = 1
     limit = size
     while limit * size <= 0x100000000
@@ -347,7 +352,8 @@ module Random::Formatter
   # The argument _n_ specifies the length, in characters, of the alphanumeric
   # string to be generated.
   # The argument _chars_ specifies the character list which the result is
-  # consist of.
+  # consist of. An empty character list raises ArgumentError when _n_ is positive.
+  # A character list with one entry repeats that entry without drawing random data.
   #
   # If _n_ is not specified or is nil, 16 is assumed.
   # It may be larger in the future.

--- a/lib/random/formatter.rb
+++ b/lib/random/formatter.rb
@@ -312,7 +312,7 @@ module Random::Formatter
   #   prng.choose([*'0'..'9'], 5)  #=> "27309"
   private def choose(source, n)
     size = source.size
-    raise ArgumentError, "character length must not be negative" if n.negative?
+    raise ArgumentError, "character length must not be negative" if 0 > n
     raise ArgumentError, "character source must not be empty" if size == 0
     return source.first * n if size < 2
     m = 1

--- a/lib/random/formatter.rb
+++ b/lib/random/formatter.rb
@@ -312,11 +312,9 @@ module Random::Formatter
   #   prng.choose([*'0'..'9'], 5)  #=> "27309"
   private def choose(source, n)
     size = source.size
-    if size < 2
-      return ''.dup if n <= 0
-      raise ArgumentError, "character source must not be empty" if size == 0
-      return source.values_at(0).join('') * n
-    end
+    raise ArgumentError, "character length must not be negative" if n.negative?
+    raise ArgumentError, "character source must not be empty" if size == 0
+    return source.first * n if size < 2
     m = 1
     limit = size
     while limit * size <= 0x100000000
@@ -352,7 +350,7 @@ module Random::Formatter
   # The argument _n_ specifies the length, in characters, of the alphanumeric
   # string to be generated.
   # The argument _chars_ specifies the character list which the result is
-  # consist of. An empty character list raises ArgumentError when _n_ is positive.
+  # consist of. A negative _n_ or an empty character list raises ArgumentError.
   # A character list with one entry repeats that entry without drawing random data.
   #
   # If _n_ is not specified or is nil, 16 is assumed.

--- a/lib/random/formatter.rb
+++ b/lib/random/formatter.rb
@@ -314,7 +314,7 @@ module Random::Formatter
     size = source.size
     raise ArgumentError, "character length must not be negative" if 0 > n
     raise ArgumentError, "character source must not be empty" if size == 0
-    return source.first * n if size < 2
+    return source.values_at(0).join('') * n if size < 2
     m = 1
     limit = size
     while limit * size <= 0x100000000

--- a/lib/random/formatter.rb
+++ b/lib/random/formatter.rb
@@ -313,8 +313,7 @@ module Random::Formatter
   private def choose(source, n)
     size = source.size
     raise ArgumentError, "character length must not be negative" if 0 > n
-    raise ArgumentError, "character source must not be empty" if size == 0
-    return source.values_at(0).join('') * n if size < 2
+    raise ArgumentError, "character source must contain at least two entries" if size < 2
     m = 1
     limit = size
     while limit * size <= 0x100000000
@@ -349,9 +348,9 @@ module Random::Formatter
   #
   # The argument _n_ specifies the length, in characters, of the alphanumeric
   # string to be generated.
-  # The argument _chars_ specifies the character list which the result is
-  # consist of. A negative _n_ or an empty character list raises ArgumentError.
-  # A character list with one entry repeats that entry without drawing random data.
+  # The argument _chars_ specifies the list of characters used for producing the
+  # result. A negative _n_ or a character list with fewer than two entries raises
+  # ArgumentError.
   #
   # If _n_ is not specified or is nil, 16 is assumed.
   # It may be larger in the future.

--- a/test/ruby/test_random_formatter.rb
+++ b/test/ruby/test_random_formatter.rb
@@ -142,8 +142,8 @@ module Random::Formatter
       assert_raise(ArgumentError) { @it.alphanumeric(-1) }
       assert_raise(ArgumentError) { @it.alphanumeric(0, chars: []) }
       assert_raise(ArgumentError) { @it.alphanumeric(1, chars: []) }
-      assert_equal("", @it.alphanumeric(0, chars: ["x"]))
-      assert_equal("xxx", @it.alphanumeric(3, chars: ["x"]))
+      assert_raise(ArgumentError) { @it.alphanumeric(0, chars: ["x"]) }
+      assert_raise(ArgumentError) { @it.alphanumeric(3, chars: ["x"]) }
     end
 
     def assert_in_range(range, result, mesg = nil)

--- a/test/ruby/test_random_formatter.rb
+++ b/test/ruby/test_random_formatter.rb
@@ -138,6 +138,14 @@ module Random::Formatter
       end
     end
 
+    def test_alphanumeric_small_alphabets
+      assert_raise(ArgumentError) { @it.alphanumeric(-1) }
+      assert_raise(ArgumentError) { @it.alphanumeric(0, chars: []) }
+      assert_raise(ArgumentError) { @it.alphanumeric(1, chars: []) }
+      assert_equal("", @it.alphanumeric(0, chars: ["x"]))
+      assert_equal("xxx", @it.alphanumeric(3, chars: ["x"]))
+    end
+
     def assert_in_range(range, result, mesg = nil)
       assert(range.cover?(result), build_message(mesg, "Expected #{result} to be in #{range}"))
     end


### PR DESCRIPTION
## Summary

Prevent `Random::Formatter#choose` from entering a nonterminating batching loop when the character source has fewer than two entries.

- Reject negative output lengths.
- Reject empty and singleton character sources with `ArgumentError`.
- Preserve the existing batching path and seeded output for valid alphabets.
- Clarify the public `alphanumeric` documentation.

## Reproduction

```ruby
require "random/formatter"
Random.alphanumeric(3, chars: ["x"]) # previously never returned
Random.alphanumeric(3, chars: [])    # previously never returned
```

Both cases now raise `ArgumentError`. Requiring at least two source entries also avoids presenting deterministic singleton output as random output.

## Verification

Using Ruby 4.0.6 through rbenv while loading the candidate formatter source:

- `test/ruby/test_random_formatter.rb`: **28 tests, 1,528 assertions, zero failures or errors**
- Ruby syntax check passes.
- `git diff --check` passes.
- The upstream GitHub Actions matrix is green on the preceding head; the new focused behavior change is covered by the formatter suite.

## Compatibility

Valid alphabets retain the existing selection algorithm and output behavior. Previously nonterminating invalid inputs now raise `ArgumentError`.
