### PR TITLE
[Bug #22090] Resolve classes in the caller's box in Marshal.load

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -9379,6 +9379,9 @@ compile_builtin_attr_symbol(rb_iseq_t *iseq, VALUE symbol)
     else if (rb_streql_lit(string, "without_interrupts")) {
         ISEQ_BODY(iseq)->builtin_attrs |= BUILTIN_ATTR_WITHOUT_INTERRUPTS;
     }
+    else if (rb_streql_lit(string, "caller_box")) {
+        ISEQ_BODY(iseq)->builtin_attrs |= BUILTIN_ATTR_CALLER_BOX;
+    }
     else {
         return COMPILE_NG;
     }

--- a/compile.c
+++ b/compile.c
@@ -9379,8 +9379,8 @@ compile_builtin_attr_symbol(rb_iseq_t *iseq, VALUE symbol)
     else if (rb_streql_lit(string, "without_interrupts")) {
         ISEQ_BODY(iseq)->builtin_attrs |= BUILTIN_ATTR_WITHOUT_INTERRUPTS;
     }
-    else if (rb_streql_lit(string, "caller_box")) {
-        ISEQ_BODY(iseq)->builtin_attrs |= BUILTIN_ATTR_CALLER_BOX;
+    else if (rb_streql_lit(string, "caller_user_box")) {
+        ISEQ_BODY(iseq)->builtin_attrs |= BUILTIN_ATTR_CALLER_USER_BOX;
     }
     else {
         return COMPILE_NG;

--- a/marshal.rb
+++ b/marshal.rb
@@ -31,6 +31,7 @@ module Marshal
   #    # => [1039360, 1039380, 1039360, 1039380] -- only 2 different objects, object_ids repeating
   #
   def self.load(source, proc = nil, freeze: false)
+    Primitive.attr! :caller_box
     Primitive.marshal_load(source, proc, freeze)
   end
 

--- a/marshal.rb
+++ b/marshal.rb
@@ -31,7 +31,7 @@ module Marshal
   #    # => [1039360, 1039380, 1039360, 1039380] -- only 2 different objects, object_ids repeating
   #
   def self.load(source, proc = nil, freeze: false)
-    Primitive.attr! :caller_box
+    Primitive.attr! :caller_user_box
     Primitive.marshal_load(source, proc, freeze)
   end
 

--- a/test/ruby/test_box.rb
+++ b/test/ruby/test_box.rb
@@ -439,6 +439,35 @@ class TestBox < Test::Unit::TestCase
       assert_equal 42, 42.itself
     end;
   end
+
+  def test_marshal_round_trip_in_main_box
+    assert_separately([ENV_ENABLE_BOX], __FILE__, __LINE__, "#{<<~"begin;"}\n#{<<~'end;'}", ignore_stderr: true)
+    begin;
+      class BoxMarshalFoo
+        attr_reader :value
+        def initialize(value)
+          @value = value
+        end
+      end
+      obj = Marshal.load(Marshal.dump(BoxMarshalFoo.new(42))) # [Bug #22090]
+      assert_instance_of BoxMarshalFoo, obj
+      assert_equal 42, obj.value
+      assert_instance_of BoxMarshalFoo, Marshal.load(Marshal.dump(BoxMarshalFoo.new(1)), freeze: true)
+    end;
+  end
+
+  def test_marshal_resolves_classes_in_the_caller_box
+    setup_box
+
+    obj = @box.eval("class BoxMarshalBar; end; Marshal.load(Marshal.dump(BoxMarshalBar.new))")
+    assert_equal "BoxMarshalBar", obj.class.name
+
+    # a class defined only in the box is invisible from the main box
+    dump = @box.eval("Marshal.dump(BoxMarshalBar.new)")
+    assert_raise_with_message(ArgumentError, /undefined class\/module BoxMarshalBar/) do
+      Marshal.load(dump)
+    end
+  end
 end
 
 class TestBoxDescendantsMain

--- a/test/ruby/test_box.rb
+++ b/test/ruby/test_box.rb
@@ -456,7 +456,7 @@ class TestBox < Test::Unit::TestCase
     end;
   end
 
-  def test_marshal_resolves_classes_in_the_caller_box
+  def test_marshal_resolves_classes_in_the_caller_user_box
     setup_box
 
     obj = @box.eval("class BoxMarshalBar; end; Marshal.load(Marshal.dump(BoxMarshalBar.new))")
@@ -467,6 +467,16 @@ class TestBox < Test::Unit::TestCase
     assert_raise_with_message(ArgumentError, /undefined class\/module BoxMarshalBar/) do
       Marshal.load(dump)
     end
+  end
+
+  def test_marshal_skips_root_box_frames_in_the_caller_stack
+    assert_separately([ENV_ENABLE_BOX], __FILE__, __LINE__, "#{<<~"begin;"}\n#{<<~'end;'}", ignore_stderr: true)
+    begin;
+      class BoxMarshalBaz; end
+      # the proc runs in the root box, where BoxMarshalBaz is invisible
+      loader = Ruby::Box.root.eval("->(dump) { Marshal.load(dump) }")
+      assert_instance_of BoxMarshalBaz, loader.call(Marshal.dump(BoxMarshalBaz.new))
+    end;
   end
 end
 

--- a/tool/mk_builtin_loader.rb
+++ b/tool/mk_builtin_loader.rb
@@ -7,7 +7,7 @@ require_relative 'ruby_vm/helpers/c_escape'
 
 SUBLIBS = {}
 REQUIRED = {}
-BUILTIN_ATTRS = %w[leaf inline_block use_block c_trace without_interrupts]
+BUILTIN_ATTRS = %w[leaf inline_block use_block c_trace without_interrupts caller_box]
 
 module CompileWarning
   @@warnings = 0

--- a/tool/mk_builtin_loader.rb
+++ b/tool/mk_builtin_loader.rb
@@ -7,7 +7,7 @@ require_relative 'ruby_vm/helpers/c_escape'
 
 SUBLIBS = {}
 REQUIRED = {}
-BUILTIN_ATTRS = %w[leaf inline_block use_block c_trace without_interrupts caller_box]
+BUILTIN_ATTRS = %w[leaf inline_block use_block c_trace without_interrupts caller_user_box]
 
 module CompileWarning
   @@warnings = 0

--- a/vm.c
+++ b/vm.c
@@ -3307,6 +3307,31 @@ rb_vm_frame_flag_set_box_require(const rb_execution_context_t *ec)
     VM_ENV_FLAGS_SET(ec->cfp->ep, VM_FRAME_FLAG_BOX_REQUIRE);
 }
 
+static const rb_box_t *current_box_on_cfp(const rb_execution_context_t *ec, const rb_control_frame_t *cfp);
+
+/**
+ * Returns the nearest user box in the caller frames, or NULL if there is none.
+ *
+ * Builtin methods written in Ruby are defined in the master box, so their own
+ * frame tells nothing about the caller. Those marked with
+ * `Primitive.attr! :caller_user_box` need the box owning the caller code, and the
+ * frames in between may belong to the master or the root box, e.g. when another
+ * builtin method or a proc made in the root box calls them.
+ */
+static const rb_box_t *
+caller_user_box_on_cfp(const rb_execution_context_t *ec, const rb_control_frame_t *cfp)
+{
+    const rb_control_frame_t * const eocfp = RUBY_VM_END_CONTROL_FRAME(ec);
+
+    while (RUBY_VM_VALID_CONTROL_FRAME_P(cfp, eocfp)) {
+        const rb_box_t *box = current_box_on_cfp(ec, cfp);
+        if (BOX_USER_P(box))
+            return box;
+        cfp = RUBY_VM_PREVIOUS_CONTROL_FRAME(cfp);
+    }
+    return NULL;
+}
+
 static const rb_box_t *
 current_box_on_cfp(const rb_execution_context_t *ec, const rb_control_frame_t *cfp)
 {
@@ -3321,12 +3346,12 @@ current_box_on_cfp(const rb_execution_context_t *ec, const rb_control_frame_t *c
         VM_BOX_ASSERT(cme, "cme should be valid");
         VM_BOX_ASSERT(cme->def, "cme->def shold be valid");
         if (cme->def->type == VM_METHOD_TYPE_ISEQ &&
-            (ISEQ_BODY(cme->def->body.iseq.iseqptr)->builtin_attrs & BUILTIN_ATTR_CALLER_BOX)) {
-            // Builtin methods with `Primitive.attr! :caller_box` operate on the caller box,
-            // just like CFUNC frames. See the comment in VM_EP_RUBY_LEP().
+            (ISEQ_BODY(cme->def->body.iseq.iseqptr)->builtin_attrs & BUILTIN_ATTR_CALLER_USER_BOX)) {
             const rb_control_frame_t *owner_cfp = rb_vm_search_cf_from_ep(ec, cfp, lep);
             if (owner_cfp) {
-                return current_box_on_cfp(ec, RUBY_VM_PREVIOUS_CONTROL_FRAME(owner_cfp));
+                box = caller_user_box_on_cfp(ec, RUBY_VM_PREVIOUS_CONTROL_FRAME(owner_cfp));
+                if (box)
+                    return box;
             }
         }
         return cme->def->box;

--- a/vm.c
+++ b/vm.c
@@ -3320,6 +3320,15 @@ current_box_on_cfp(const rb_execution_context_t *ec, const rb_control_frame_t *c
         cme = check_method_entry(lep[VM_ENV_DATA_INDEX_ME_CREF], TRUE);
         VM_BOX_ASSERT(cme, "cme should be valid");
         VM_BOX_ASSERT(cme->def, "cme->def shold be valid");
+        if (cme->def->type == VM_METHOD_TYPE_ISEQ &&
+            (ISEQ_BODY(cme->def->body.iseq.iseqptr)->builtin_attrs & BUILTIN_ATTR_CALLER_BOX)) {
+            // Builtin methods with `Primitive.attr! :caller_box` operate on the caller box,
+            // just like CFUNC frames. See the comment in VM_EP_RUBY_LEP().
+            const rb_control_frame_t *owner_cfp = rb_vm_search_cf_from_ep(ec, cfp, lep);
+            if (owner_cfp) {
+                return current_box_on_cfp(ec, RUBY_VM_PREVIOUS_CONTROL_FRAME(owner_cfp));
+            }
+        }
         return cme->def->box;
     }
     else if (VM_ENV_FRAME_TYPE_P(lep, VM_FRAME_MAGIC_TOP) || VM_ENV_FRAME_TYPE_P(lep, VM_FRAME_MAGIC_CLASS)) {

--- a/vm_core.h
+++ b/vm_core.h
@@ -404,6 +404,8 @@ enum rb_builtin_attr {
     BUILTIN_ATTR_C_TRACE = 0x08,
     // The iseq uses noint branch/jump opcodes that skip interrupt checking.
     BUILTIN_ATTR_WITHOUT_INTERRUPTS = 0x10,
+    // The iseq operates on its caller's box, like C functions do.
+    BUILTIN_ATTR_CALLER_BOX = 0x20,
 };
 
 typedef VALUE (*rb_jit_func_t)(struct rb_execution_context_struct *, struct rb_control_frame_struct *);

--- a/vm_core.h
+++ b/vm_core.h
@@ -404,8 +404,8 @@ enum rb_builtin_attr {
     BUILTIN_ATTR_C_TRACE = 0x08,
     // The iseq uses noint branch/jump opcodes that skip interrupt checking.
     BUILTIN_ATTR_WITHOUT_INTERRUPTS = 0x10,
-    // The iseq operates on its caller's box, like C functions do.
-    BUILTIN_ATTR_CALLER_BOX = 0x20,
+    // The iseq operates on the nearest user box in its caller frames.
+    BUILTIN_ATTR_CALLER_USER_BOX = 0x20,
 };
 
 typedef VALUE (*rb_jit_func_t)(struct rb_execution_context_struct *, struct rb_control_frame_struct *);

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -486,6 +486,7 @@ pub const BUILTIN_ATTR_SINGLE_NOARG_LEAF: rb_builtin_attr = 2;
 pub const BUILTIN_ATTR_INLINE_BLOCK: rb_builtin_attr = 4;
 pub const BUILTIN_ATTR_C_TRACE: rb_builtin_attr = 8;
 pub const BUILTIN_ATTR_WITHOUT_INTERRUPTS: rb_builtin_attr = 16;
+pub const BUILTIN_ATTR_CALLER_BOX: rb_builtin_attr = 32;
 pub type rb_builtin_attr = u32;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -486,7 +486,7 @@ pub const BUILTIN_ATTR_SINGLE_NOARG_LEAF: rb_builtin_attr = 2;
 pub const BUILTIN_ATTR_INLINE_BLOCK: rb_builtin_attr = 4;
 pub const BUILTIN_ATTR_C_TRACE: rb_builtin_attr = 8;
 pub const BUILTIN_ATTR_WITHOUT_INTERRUPTS: rb_builtin_attr = 16;
-pub const BUILTIN_ATTR_CALLER_BOX: rb_builtin_attr = 32;
+pub const BUILTIN_ATTR_CALLER_USER_BOX: rb_builtin_attr = 32;
 pub type rb_builtin_attr = u32;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -641,6 +641,7 @@ pub const BUILTIN_ATTR_SINGLE_NOARG_LEAF: rb_builtin_attr = 2;
 pub const BUILTIN_ATTR_INLINE_BLOCK: rb_builtin_attr = 4;
 pub const BUILTIN_ATTR_C_TRACE: rb_builtin_attr = 8;
 pub const BUILTIN_ATTR_WITHOUT_INTERRUPTS: rb_builtin_attr = 16;
+pub const BUILTIN_ATTR_CALLER_BOX: rb_builtin_attr = 32;
 pub type rb_builtin_attr = u32;
 pub type rb_jit_func_t = ::std::option::Option<
     unsafe extern "C" fn(

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -641,7 +641,7 @@ pub const BUILTIN_ATTR_SINGLE_NOARG_LEAF: rb_builtin_attr = 2;
 pub const BUILTIN_ATTR_INLINE_BLOCK: rb_builtin_attr = 4;
 pub const BUILTIN_ATTR_C_TRACE: rb_builtin_attr = 8;
 pub const BUILTIN_ATTR_WITHOUT_INTERRUPTS: rb_builtin_attr = 16;
-pub const BUILTIN_ATTR_CALLER_BOX: rb_builtin_attr = 32;
+pub const BUILTIN_ATTR_CALLER_USER_BOX: rb_builtin_attr = 32;
 pub type rb_builtin_attr = u32;
 pub type rb_jit_func_t = ::std::option::Option<
     unsafe extern "C" fn(


### PR DESCRIPTION
With `RUBY_BOX=1`, `Marshal.load(Marshal.dump(Foo.new))` fails with `ArgumentError: undefined class/module Foo` even within a single process. This breaks Marshal usage at runtime in general, including more than a dozen RubyGems test failures under Ruby::Box.

`Marshal.load` is a builtin method written in Ruby (`marshal.rb`), so it is defined in the master box and the box resolution stops at its frame, resolving dumped class names where user classes are invisible. `Marshal.dump` is a C function and already operates on the caller's box.

This PR adds `Primitive.attr! :caller_user_box`, which makes a builtin Ruby method resolve in the nearest user box in its caller frames, and applies it to `Marshal.load`. The walk skips root box frames too, since a proc made in the root box can sit right below `Marshal.load`. Since this changes the box core resolution, I'd like a review from @tagomoris.

https://bugs.ruby-lang.org/issues/22090

Generated with [Claude Code](https://claude.com/claude-code)
