### PR TITLE
Fix assert_not_include typo in test_box.rb

### DIFF
--- a/test/ruby/test_box.rb
+++ b/test/ruby/test_box.rb
@@ -567,7 +567,7 @@ class TestBox < Test::Unit::TestCase
     assert_equal nil, $,
 
     # used only in box
-    assert_not_include? global_variables, :$used_only_in_box
+    assert_not_include global_variables, :$used_only_in_box
     @box::UniqueGvar.write(123)
     assert_equal 123, @box::UniqueGvar.read
     assert_nil $used_only_in_box


### PR DESCRIPTION
`test_global_variables` in `test/ruby/test_box.rb` calls the nonexistent `assert_not_include?`, which raises `NoMethodError` when the suite runs with `RUBY_BOX=1`. Fix it to `assert_not_include`, matching the intent that `$used_only_in_box` is not visible in `global_variables` before the box writes to it. Verified that the test passes with `RUBY_BOX=1`.
