### PR TITLE
Make Symbol#to_proc respect the caller's box context for user boxes

### DIFF
--- a/test/ruby/test_box.rb
+++ b/test/ruby/test_box.rb
@@ -1254,6 +1254,20 @@ class TestBox < Test::Unit::TestCase
     end;
   end
 
+  def test_symbol_to_proc_uses_main_box
+    assert_separately([ENV_ENABLE_BOX], __FILE__, __LINE__, "#{<<~"begin;"}\n#{<<~'end;'}", ignore_stderr: true)
+    begin;
+      class Array
+        def main_box_only_method
+          :ok
+        end
+      end
+
+      assert_equal [:ok], [[1]].flat_map { |ary| ary.main_box_only_method }
+      assert_equal [:ok], [[1]].flat_map(&:main_box_only_method)
+    end;
+  end
+
   def test_very_basic_method_calls_and_constants
     assert_separately([ENV_ENABLE_BOX], __FILE__, __LINE__, "#{<<~"begin;"}\n#{<<~'end;'}", ignore_stderr: true)
     begin;

--- a/test/ruby/test_box.rb
+++ b/test/ruby/test_box.rb
@@ -1230,6 +1230,30 @@ class TestBox < Test::Unit::TestCase
     end;
   end
 
+  def test_symbol_to_proc_uses_current_box
+    assert_separately([ENV_ENABLE_BOX], __FILE__, __LINE__, "#{<<~"begin;"}\n#{<<~'end;'}", ignore_stderr: true)
+    begin;
+      box = Ruby::Box.new
+
+      normal, via_sym_proc = box.eval(<<~'RUBY')
+        class Array
+          def box_only_method
+            :ok
+          end
+        end
+
+        normal = [[1]].flat_map { |ary| ary.box_only_method }
+        via_sym_proc = [[1]].flat_map(&:box_only_method)
+        [normal, via_sym_proc]
+      RUBY
+
+      assert_equal [:ok], normal
+      assert_equal [:ok], via_sym_proc
+
+      assert_raise(NoMethodError) { [1].box_only_method }
+    end;
+  end
+
   def test_very_basic_method_calls_and_constants
     assert_separately([ENV_ENABLE_BOX], __FILE__, __LINE__, "#{<<~"begin;"}\n#{<<~'end;'}", ignore_stderr: true)
     begin;

--- a/vm.c
+++ b/vm.c
@@ -682,6 +682,8 @@ static void add_opt_method_entry(const rb_method_entry_t *me);
 #define VM_ASSERT_TYPE3(obj, type1, type2, type3) \
     VM_ASSERT(RB_TYPE_3_P(obj, type1, type2, type3), #obj ": %s", rb_obj_info(obj))
 
+static const rb_box_t * current_box_on_cfp(const rb_execution_context_t *ec, const rb_control_frame_t *cfp);
+
 #include "vm_insnhelper.c"
 
 #include "vm_exec.c"

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -5307,16 +5307,41 @@ vm_yield_with_symbol(rb_execution_context_t *ec,  VALUE symbol, int argc, const 
         return rb_sym_proc_call(SYM2ID(symbol), argc, argv, kw_splat, passed_proc);
     }
 
-    VALUE filename = rb_iseq_path(CFP_ISEQ(ruby_cfp));
-    const rb_iseq_t *iseq = rb_iseq_new(Qnil, filename, filename, Qnil, 0, ISEQ_TYPE_TOP);
-    VALUE val;
+    /*
+     * Push a dummy block frame whose outer env is `ruby_cfp` so that the
+     * method resolves in the caller's box (via the ep chain) and the
+     * backtrace reads like a usual block invocation at the caller's site.
+     */
+    const rb_iseq_t *caller_iseq = CFP_ISEQ(ruby_cfp);
+    VALUE name = rb_sprintf("block in %"PRIsVALUE, rb_iseq_label(caller_iseq));
+    const rb_iseq_t *iseq = rb_iseq_new_with_opt(Qnil, name,
+                                                 rb_iseq_path(caller_iseq), rb_iseq_realpath(caller_iseq),
+                                                 rb_vm_get_sourceline(ruby_cfp), caller_iseq, 0,
+                                                 ISEQ_TYPE_BLOCK, NULL, Qnil);
+    volatile VALUE val = Qnil;
+    enum ruby_tag_type state;
 
-    vm_push_frame(ec, iseq, VM_FRAME_MAGIC_TOP | VM_ENV_FLAG_LOCAL | VM_FRAME_FLAG_FINISH,
-                  Qnil, GC_GUARDED_PTR(box),
-                  (VALUE)vm_cref_new_toplevel(ec), /* cref or me */
-                  0, reg_cfp->sp, 0, 0);
+    vm_push_frame(ec, iseq, VM_FRAME_MAGIC_BLOCK | VM_FRAME_FLAG_FINISH,
+                  ruby_cfp->self, VM_GUARDED_PREV_EP(ruby_cfp->ep),
+                  Qfalse, /* cref or me */
+                  ISEQ_BODY(iseq)->iseq_encoded, reg_cfp->sp,
+                  ISEQ_BODY(iseq)->local_table_size, ISEQ_BODY(iseq)->stack_max);
 
-    val = rb_sym_proc_call(SYM2ID(symbol), argc, argv, kw_splat, passed_proc);
+    /*
+     * The pushed frame is finished (owned by no vm_exec loop), so catch the
+     * non-local exit here, pop the frame, and let the caller's handlers see
+     * the exception.
+     */
+    EC_PUSH_TAG(ec);
+    if ((state = EC_EXEC_TAG()) == TAG_NONE) {
+        val = rb_sym_proc_call(SYM2ID(symbol), argc, argv, kw_splat, passed_proc);
+    }
+    EC_POP_TAG();
+
+    if (state != TAG_NONE) {
+        rb_vm_rewind_cfp(ec, (rb_control_frame_t *)reg_cfp);
+        EC_JUMP_TAG(ec, state);
+    }
 
     rb_vm_pop_frame(ec);
 

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -5291,18 +5291,18 @@ vm_yield_with_symbol(rb_execution_context_t *ec,  VALUE symbol, int argc, const 
     const rb_box_t *box = NULL;
 
     /*
-     * Traverse the frames until a user-defined Box (Optional Box) is found.
-     * Frames for built-in methods like <internal:xxx> run in the Root or Main Box,
+     * Traverse the frames until a user box (Main or Optional Box) is found.
+     * Frames for built-in methods like <internal:xxx> run in the Root or Master Box,
      */
     while (ruby_cfp) {
         box = current_box_on_cfp(ec, ruby_cfp);
-        if (BOX_OPTIONAL_P(box)) {
+        if (BOX_USER_P(box)) {
             break;
         }
         ruby_cfp = rb_vm_get_ruby_level_next_cfp(ec, RUBY_VM_PREVIOUS_CONTROL_FRAME(ruby_cfp));
     }
 
-    // Fallback to the normal call if no user-defined Box (Optional Box) is found
+    // Fallback to the normal call if no user box is found
     if (!ruby_cfp || !box) {
         return rb_sym_proc_call(SYM2ID(symbol), argc, argv, kw_splat, passed_proc);
     }

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -5293,7 +5293,6 @@ vm_yield_with_symbol(rb_execution_context_t *ec,  VALUE symbol, int argc, const 
     /*
      * Traverse the frames until a user-defined Box (Optional Box) is found.
      * Frames for built-in methods like <internal:xxx> run in the Root or Main Box,
-     * so we can safely skip them with this condition without doing string comparisons.
      */
     while (ruby_cfp) {
         box = current_box_on_cfp(ec, ruby_cfp);

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -5280,7 +5280,48 @@ rb_vm_yield_with_cfunc(rb_execution_context_t *ec, const struct rb_captured_bloc
 static VALUE
 vm_yield_with_symbol(rb_execution_context_t *ec,  VALUE symbol, int argc, const VALUE *argv, int kw_splat, VALUE block_handler)
 {
-    return rb_sym_proc_call(SYM2ID(symbol), argc, argv, kw_splat, rb_vm_bh_to_procval(ec, block_handler));
+    VALUE passed_proc = rb_vm_bh_to_procval(ec, block_handler);
+
+    if (!rb_box_available()) {
+        return rb_sym_proc_call(SYM2ID(symbol), argc, argv, kw_splat, passed_proc);
+    }
+
+    const rb_control_frame_t *reg_cfp = ec->cfp;
+    const rb_control_frame_t *ruby_cfp = rb_vm_get_ruby_level_next_cfp(ec, reg_cfp);
+    const rb_box_t *box = NULL;
+
+    /*
+     * Traverse the frames until a user-defined Box (Optional Box) is found.
+     * Frames for built-in methods like <internal:xxx> run in the Root or Main Box,
+     * so we can safely skip them with this condition without doing string comparisons.
+     */
+    while (ruby_cfp) {
+        box = current_box_on_cfp(ec, ruby_cfp);
+        if (BOX_OPTIONAL_P(box)) {
+            break;
+        }
+        ruby_cfp = rb_vm_get_ruby_level_next_cfp(ec, RUBY_VM_PREVIOUS_CONTROL_FRAME(ruby_cfp));
+    }
+
+    // Fallback to the normal call if no user-defined Box (Optional Box) is found
+    if (!ruby_cfp || !box) {
+        return rb_sym_proc_call(SYM2ID(symbol), argc, argv, kw_splat, passed_proc);
+    }
+
+    VALUE filename = rb_iseq_path(CFP_ISEQ(ruby_cfp));
+    const rb_iseq_t *iseq = rb_iseq_new(Qnil, filename, filename, Qnil, 0, ISEQ_TYPE_TOP);
+    VALUE val;
+
+    vm_push_frame(ec, iseq, VM_FRAME_MAGIC_TOP | VM_ENV_FLAG_LOCAL | VM_FRAME_FLAG_FINISH,
+                  Qnil, GC_GUARDED_PTR(box),
+                  (VALUE)vm_cref_new_toplevel(ec), /* cref or me */
+                  0, reg_cfp->sp, 0, 0);
+
+    val = rb_sym_proc_call(SYM2ID(symbol), argc, argv, kw_splat, passed_proc);
+
+    rb_vm_pop_frame(ec);
+
+    return val;
 }
 
 static inline int


### PR DESCRIPTION
This is #16865 by @niku rebased onto current master, plus three commits. Fixes [Bug #22015].

Since the main/root box separation ([Feature #21881]), a plain `RUBY_BOX=1` script runs in the main box, which `BOX_OPTIONAL_P` does not match, so the original patch no longer fixes the reported scenario (`["a b"].flat_map(&:shellsplit)` raising `NoMethodError`). The caller-frame traversal now stops at any user box (`BOX_USER_P`, main or optional).

Following @tagomoris's review on #16865, the pushed frame is `VM_FRAME_MAGIC_BLOCK` rather than `VM_FRAME_MAGIC_TOP`. Passing `VM_GUARDED_PREV_EP(ruby_cfp->ep)` as the specval lets the box resolve through the ep chain, and the backtrace becomes identical in shape to a literal block call, showing `block in <main>` at the caller's line. That frame is finished but owned by no `vm_exec` loop, which swallowed exceptions, so the call is wrapped in `EC_PUSH_TAG` to pop the frame and re-raise. `throw` and `ensure` are covered.

`make btest`, `test/ruby/test_box.rb`, `test_symbol.rb` and `test_proc.rb` are green, and rubygems' `bin/rspec` boots past this error under `RUBY_BOX=1`. Yields from Ruby-defined builtins (`Array#map`, via `vm_invoke_symbol_block`) remain uncovered, same as #16865, and the per-yield `rb_iseq_new` costs about 4x on a `flat_map(&:itself)` microbenchmark.
