### PR TITLE
Install MSYS2 perl on the MinGW runner

### DIFF
--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -71,6 +71,13 @@ jobs:
         with:
           ruby-version: ${{ matrix.baseruby }}
 
+      - name: Install MSYS2 perl
+        working-directory:
+        # MSYS2 dropped perl from its base install, and the runner image
+        # picked that up, so `autoreconf` no longer finds its interpreter.
+        # https://github.com/actions/runner-images/issues/14562
+        run: pacman --sync --refresh --needed --noconfirm perl
+
       - name: Misc system & package info
         working-directory:
         run: |


### PR DESCRIPTION
The MinGW job on this branch dies before compiling anything: `./autogen.sh` exits 126 with `/usr/bin/autoreconf-2.72: /usr/bin/perl: bad interpreter`. MSYS2 dropped perl from its base install and the windows-2022 runner image picked that up in 20260818.277.1, so the MSYS2 that `ruby/setup-ruby` reuses no longer has an interpreter for autoconf. See https://github.com/actions/runner-images/issues/14562.

master and `ruby_4_0` are unaffected because they set up their own MSYS2 through `msys2/setup-msys2` and list `autoconf`, which pulls perl in as a dependency. Backporting that whole change to a stable branch would also drag in the baseruby source, the console encoding workarounds and the Launchable wiring, so this installs the one missing package instead. It can be reverted once the image ships perl again.
