### PR TITLE
Stop incrementing the JIT call counter when not compiled

### DIFF
--- a/vm.c
+++ b/vm.c
@@ -527,9 +527,9 @@ yjit_compile(rb_execution_context_t *ec)
     struct rb_iseq_constant_body *body = ISEQ_BODY(iseq);
 
     // Increment the ISEQ's call counter and trigger JIT compilation if not compiled.
-    // Stop incrementing at the threshold so that ISEQs that failed to compile
-    // (e.g. out of executable memory) don't keep dirtying CoW pages after fork.
-    if (body->jit_entry == NULL && body->jit_entry_calls < rb_yjit_call_threshold) {
+    // Stop incrementing when not compiling (out of executable memory) so that
+    // ISEQs that failed to compile don't keep dirtying CoW pages after fork.
+    if (body->jit_entry == NULL && rb_yjit_compiling_p) {
         body->jit_entry_calls++;
         if (rb_yjit_threshold_hit(iseq, body->jit_entry_calls)) {
             rb_yjit_compile_iseq(iseq, ec, false);
@@ -548,7 +548,7 @@ zjit_compile(rb_execution_context_t *ec)
     const rb_iseq_t *iseq = CFP_ISEQ(ec->cfp);
     struct rb_iseq_constant_body *body = ISEQ_BODY(iseq);
 
-    if (body->jit_entry == NULL && body->jit_entry_calls < rb_zjit_call_threshold) {
+    if (body->jit_entry == NULL && rb_zjit_compiling_p) {
         body->jit_entry_calls++;
 
         // At profile-threshold, rewrite some of the YARV instructions
@@ -609,7 +609,9 @@ jit_compile_exception(rb_execution_context_t *ec)
     struct rb_iseq_constant_body *body = ISEQ_BODY(iseq);
 
 #if USE_ZJIT
-    if (body->jit_exception == NULL && rb_zjit_enabled_p && body->jit_exception_calls < rb_zjit_call_threshold) {
+    // rb_zjit_compiling_p is false until ZJIT is enabled, so no
+    // rb_zjit_enabled_p check is needed here.
+    if (body->jit_exception == NULL && rb_zjit_compiling_p) {
         body->jit_exception_calls++;
 
         // At profile-threshold, rewrite some of the YARV instructions
@@ -626,8 +628,9 @@ jit_compile_exception(rb_execution_context_t *ec)
 #endif
 
 #if USE_YJIT
-    // Increment the ISEQ's call counter and trigger JIT compilation if not compiled
-    if (body->jit_exception == NULL && rb_yjit_enabled_p && body->jit_exception_calls < rb_yjit_call_threshold) {
+    // Increment the ISEQ's call counter and trigger JIT compilation if not compiled.
+    // Like the ZJIT branch above, no rb_yjit_enabled_p check is needed here.
+    if (body->jit_exception == NULL && rb_yjit_compiling_p) {
         body->jit_exception_calls++;
         if (body->jit_exception_calls == rb_yjit_call_threshold) {
             rb_yjit_compile_iseq(iseq, ec, true);

--- a/vm.c
+++ b/vm.c
@@ -526,8 +526,10 @@ yjit_compile(rb_execution_context_t *ec)
     const rb_iseq_t *iseq = CFP_ISEQ(ec->cfp);
     struct rb_iseq_constant_body *body = ISEQ_BODY(iseq);
 
-    // Increment the ISEQ's call counter and trigger JIT compilation if not compiled
-    if (body->jit_entry == NULL) {
+    // Increment the ISEQ's call counter and trigger JIT compilation if not compiled.
+    // Stop incrementing at the threshold so that ISEQs that failed to compile
+    // (e.g. out of executable memory) don't keep dirtying CoW pages after fork.
+    if (body->jit_entry == NULL && body->jit_entry_calls < rb_yjit_call_threshold) {
         body->jit_entry_calls++;
         if (rb_yjit_threshold_hit(iseq, body->jit_entry_calls)) {
             rb_yjit_compile_iseq(iseq, ec, false);
@@ -546,7 +548,7 @@ zjit_compile(rb_execution_context_t *ec)
     const rb_iseq_t *iseq = CFP_ISEQ(ec->cfp);
     struct rb_iseq_constant_body *body = ISEQ_BODY(iseq);
 
-    if (body->jit_entry == NULL) {
+    if (body->jit_entry == NULL && body->jit_entry_calls < rb_zjit_call_threshold) {
         body->jit_entry_calls++;
 
         // At profile-threshold, rewrite some of the YARV instructions
@@ -607,7 +609,7 @@ jit_compile_exception(rb_execution_context_t *ec)
     struct rb_iseq_constant_body *body = ISEQ_BODY(iseq);
 
 #if USE_ZJIT
-    if (body->jit_exception == NULL && rb_zjit_enabled_p) {
+    if (body->jit_exception == NULL && rb_zjit_enabled_p && body->jit_exception_calls < rb_zjit_call_threshold) {
         body->jit_exception_calls++;
 
         // At profile-threshold, rewrite some of the YARV instructions
@@ -625,7 +627,7 @@ jit_compile_exception(rb_execution_context_t *ec)
 
 #if USE_YJIT
     // Increment the ISEQ's call counter and trigger JIT compilation if not compiled
-    if (body->jit_exception == NULL && rb_yjit_enabled_p) {
+    if (body->jit_exception == NULL && rb_yjit_enabled_p && body->jit_exception_calls < rb_yjit_call_threshold) {
         body->jit_exception_calls++;
         if (body->jit_exception_calls == rb_yjit_call_threshold) {
             rb_yjit_compile_iseq(iseq, ec, true);

--- a/yjit.h
+++ b/yjit.h
@@ -29,6 +29,7 @@ extern uint64_t rb_yjit_cold_threshold;
 extern uint64_t rb_yjit_live_iseq_count;
 extern uint64_t rb_yjit_iseq_alloc_count;
 extern bool rb_yjit_enabled_p;
+extern bool rb_yjit_compiling_p;
 void rb_yjit_incr_counter(const char *counter_name);
 void rb_yjit_invalidate_all_method_lookup_assumptions(void);
 void rb_yjit_cme_invalidate(rb_callable_method_entry_t *cme);
@@ -58,6 +59,7 @@ void rb_yjit_mark_all_executable(void);
 // In these builds, YJIT could never be turned on. Provide dummy implementations.
 
 #define rb_yjit_enabled_p false
+#define rb_yjit_compiling_p false
 static inline void rb_yjit_incr_counter(const char *counter_name) {}
 static inline void rb_yjit_invalidate_all_method_lookup_assumptions(void) {}
 static inline void rb_yjit_cme_invalidate(rb_callable_method_entry_t *cme) {}

--- a/yjit/src/yjit.rs
+++ b/yjit/src/yjit.rs
@@ -17,6 +17,15 @@ use crate::log::Log;
 #[no_mangle]
 pub static mut rb_yjit_enabled_p: bool = false;
 
+/// Whether YJIT is compiling. Starts as false until YJIT is enabled, so the
+/// interpreter doesn't need to check rb_yjit_enabled_p before it. Set back to
+/// false when we run out of executable memory, in which case the interpreter
+/// stops incrementing ISEQ call counters so that ISEQs that will never be
+/// compiled stop dirtying CoW pages after fork.
+#[allow(non_upper_case_globals)]
+#[no_mangle]
+pub static mut rb_yjit_compiling_p: bool = false;
+
 // Time when YJIT was yjit was initialized (see yjit_init)
 pub static mut YJIT_INIT_TIME: Option<Instant> = None;
 
@@ -35,6 +44,14 @@ pub extern "C" fn rb_yjit_option_disable() -> bool {
 /// Like rb_yjit_enabled_p, but for Rust code.
 pub fn yjit_enabled_p() -> bool {
     unsafe { rb_yjit_enabled_p }
+}
+
+/// Whether we have run out of executable memory. Used by the C code to
+/// decide whether to keep incrementing ISEQ call counters.
+pub fn out_of_memory_p() -> bool {
+    let cb = CodegenGlobals::get_inline_cb();
+    let ocb = CodegenGlobals::get_outlined_cb();
+    cb.has_dropped_bytes() || ocb.unwrap().has_dropped_bytes()
 }
 
 /// Register specialized codegen for builtin C method entries.
@@ -77,7 +94,10 @@ fn yjit_init() {
 
         // YJIT enabled and initialized successfully
         assert!(unsafe{ !rb_yjit_enabled_p });
-        unsafe { rb_yjit_enabled_p = true; }
+        unsafe {
+            rb_yjit_enabled_p = true;
+            rb_yjit_compiling_p = true;
+        }
     });
 
     if let Err(_) = result {
@@ -179,10 +199,11 @@ pub extern "C" fn rb_yjit_iseq_gen_entry_point(iseq: IseqPtr, ec: EcPtr, jit_exc
 
     let maybe_code_ptr = with_compile_time(|| { gen_entry_point(iseq, ec, jit_exception) });
 
-    match maybe_code_ptr {
-        Some(ptr) => ptr,
-        None => std::ptr::null(),
-    }
+    // Stop compiling if we ran out of executable memory so that the
+    // interpreter stops incrementing ISEQ call counters.
+    unsafe { rb_yjit_compiling_p = !out_of_memory_p(); }
+
+    maybe_code_ptr.unwrap_or(std::ptr::null())
 }
 
 /// Free and recompile all existing JIT code

--- a/zjit.h
+++ b/zjit.h
@@ -107,6 +107,7 @@ ZJIT_STACK_MAP_BASE_PTR_STACK_SIZE(VALUE entry)
 }
 
 extern void *rb_zjit_entry;
+extern bool rb_zjit_compiling_p;
 extern const zjit_jit_frame_t rb_zjit_c_frame;
 extern uint64_t rb_zjit_call_threshold;
 extern uint64_t rb_zjit_profile_threshold;
@@ -170,6 +171,7 @@ CFP_ZJIT_FRAME(const rb_control_frame_t *cfp)
 }
 #else
 #define rb_zjit_entry 0
+#define rb_zjit_compiling_p false
 static inline void rb_zjit_compile_iseq(const rb_iseq_t *iseq, rb_execution_context_t *ec, bool jit_exception) {}
 static inline void rb_zjit_profile_insn(uint32_t insn, rb_execution_context_t *ec) {}
 static inline void rb_zjit_profile_enable(const rb_iseq_t *iseq) {}

--- a/zjit/src/asm/mod.rs
+++ b/zjit/src/asm/mod.rs
@@ -6,6 +6,7 @@ use std::ops::Range;
 use std::rc::Rc;
 use std::cell::RefCell;
 use std::mem;
+use crate::state::rb_zjit_compiling_p;
 use crate::virtualmem::*;
 
 // Lots of manual vertical alignment in there that rustfmt doesn't handle well.
@@ -218,6 +219,10 @@ impl CodeBlock {
     pub fn update_dropped_bytes(&mut self) {
         if self.mem_block.borrow().can_allocate() {
             self.dropped_bytes = false;
+
+            // Memory is available again, so let the interpreter resume
+            // triggering compilation.
+            unsafe { rb_zjit_compiling_p = true; }
         }
     }
 

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -18,7 +18,7 @@ use crate::invariants::{
 use crate::gc::append_gc_offsets;
 use crate::payload::{IseqCodePtrs, IseqStatus, IseqVersion, IseqVersionRef, JITFrame, get_or_create_iseq_payload};
 use crate::profile::reset_profiles_remaining;
-use crate::state::ZJITState;
+use crate::state::{rb_zjit_compiling_p, ZJITState};
 use crate::stats::{CompileError, exit_counter_for_compile_error, exit_counter_for_unhandled_hir_insn, incr_counter, incr_counter_by, send_fallback_counter, send_fallback_counter_for_method_type, send_fallback_counter_for_super_method_type, send_fallback_counter_ptr_for_opcode, send_fallback_counter_for_optimized_method_type};
 use crate::stats::{counter_ptr, with_time_stat, trace_compile_phase, Counter, Counter::{compile_time_ns, exit_compile_error}};
 use crate::{asm::CodeBlock, cruby::*, options::debug, virtualmem::CodePtr};
@@ -199,6 +199,14 @@ pub extern "C" fn rb_zjit_iseq_gen_entry_point(iseq: IseqPtr, ec: EcPtr, jit_exc
 
         let cb = ZJITState::get_code_block();
         let mut code_ptr = with_time_stat(compile_time_ns, || gen_iseq_entry_point(cb, iseq, jit_exception));
+
+        // If this compile ran out of executable memory, stop compiling so
+        // that the interpreter stops incrementing ISEQ call counters. It is
+        // set back to true in update_dropped_bytes() if memory becomes
+        // available again.
+        if matches!(&code_ptr, Err(CompileError::OutOfMemory)) {
+            unsafe { rb_zjit_compiling_p = false; }
+        }
 
         if let Err(err) = &code_ptr {
             // Assert that the ISEQ compiles if RubyVM::ZJIT.assert_compiles is enabled.

--- a/zjit/src/cruby.rs
+++ b/zjit/src/cruby.rs
@@ -1264,7 +1264,7 @@ pub use manual_defs::*;
 pub mod test_utils {
     use std::{ptr::null, sync::Once};
 
-    use crate::{options::{rb_zjit_call_threshold, rb_zjit_prepare_options, set_call_threshold, DEFAULT_CALL_THRESHOLD}, state::{rb_zjit_entry, ZJITState}};
+    use crate::{options::{DEFAULT_CALL_THRESHOLD, rb_zjit_call_threshold, rb_zjit_prepare_options, set_call_threshold}, state::{ZJITState, rb_zjit_compiling_p, rb_zjit_entry}};
 
     use super::*;
 
@@ -1316,7 +1316,10 @@ pub mod test_utils {
         let zjit_entry = ZJITState::init();
 
         // Enable zjit_* instructions
-        unsafe { rb_zjit_entry = zjit_entry; }
+        unsafe {
+            rb_zjit_entry = zjit_entry;
+            rb_zjit_compiling_p = true;
+        }
     }
 
     /// Make sure the Ruby VM is set up and run a given callback with rb_protect()

--- a/zjit/src/state.rs
+++ b/zjit/src/state.rs
@@ -20,6 +20,15 @@ use std::ptr::null;
 #[unsafe(no_mangle)]
 pub static mut rb_zjit_entry: *const u8 = null();
 
+/// Whether ZJIT is compiling. Starts as false until ZJIT is enabled, so the
+/// interpreter doesn't need to check rb_zjit_enabled_p before it. Set back to
+/// false when we run out of executable memory, in which case the interpreter
+/// stops incrementing ISEQ call counters so that ISEQs that will never be
+/// compiled stop dirtying CoW pages after fork.
+#[allow(non_upper_case_globals)]
+#[unsafe(no_mangle)]
+pub static mut rb_zjit_compiling_p: bool = false;
+
 /// Like rb_zjit_enabled_p, but for Rust code.
 pub fn zjit_enabled_p() -> bool {
     unsafe { rb_zjit_entry != null() }
@@ -410,7 +419,10 @@ fn zjit_enable() {
 
         // ZJIT enabled and initialized successfully
         assert!(unsafe{ rb_zjit_entry == null() });
-        unsafe { rb_zjit_entry = zjit_entry; }
+        unsafe {
+            rb_zjit_entry = zjit_entry;
+            rb_zjit_compiling_p = true;
+        }
     });
 
     if result.is_err() {


### PR DESCRIPTION
When we run out of JIT memory, we don't compile the iseq, so jit_entry will be forever NULL. This means that the JIT call counters (jit_entry_calls and jit_exception_calls) will continue to increase on every call. This is bad for copy-on-write because it causes the whole rb_iseq_constant_body to be copied.

We can see an example using the following script (which can only be ran on Linux) that allocates 200k methods, executes all the methods, then forks a child process that also executes all the methods and outputs the change in RSS and PSS:

```ruby
SYMS = 200_000.times.map { |i| eval("def m#{i} = nil"); :"m#{i}" }

def stats = File.read("/proc/self/smaps_rollup").scan(/^(Rss|Pss):\s+(\d+)/).to_h

SYMS.each { |s| 3.times { send(s) } }

fork do
  before = stats
  SYMS.each { |s| send(s) }
  after = stats
  puts "RSS: #{before["Rss"]} -> #{after["Rss"]} kB"
  puts "PSS: #{before["Pss"]} -> #{after["Pss"]} kB"
end

Process.wait
```

When running with YJIT (with `--yjit-call-threshold=1 --yjit-exec-mem-size=1`), we can see that before this commit, the PSS increases significantly but stays flat after this commit:

    Before:
      RSS: 210236 -> 210496 kB
      PSS: 104676 -> 162300 kB

    After:

      RSS: 204308 -> 204692 kB
      PSS: 101700 -> 101960 kB

We can see a similar result with ZJIT (with `--zjit-call-threshold=1 --zjit-exec-mem-size=1`):

    Before:
      RSS: 493564 -> 493732 kB
      PSS: 246416 -> 390452 kB

    After:

      RSS: 493292 -> 493516 kB
      PSS: 246286 -> 246428 kB