### PR TITLE
Avoid freezing nested array in Array#flatten!

### DIFF
--- a/array.c
+++ b/array.c
@@ -6916,7 +6916,7 @@ rb_ary_flatten_bang(int argc, VALUE *argv, VALUE ary)
         }
     }
 
-    if (!(mod = ARY_EMBED_P(result) && result != child)) rb_ary_freeze(result);
+    if (result != child && !(mod = ARY_EMBED_P(result))) rb_ary_freeze(result);
     rb_ary_replace(ary, result);
     if (mod) ARY_SET_EMBED_LEN(result, 0);
 

--- a/test/ruby/test_array.rb
+++ b/test/ruby/test_array.rb
@@ -1018,6 +1018,12 @@ class TestArray < Test::Unit::TestCase
     assert_equal(@cls[1, 2, 3, 4, 5, 6], a5)
   end
 
+  def test_flatten_bang_does_not_freeze_nested_array
+    child = []
+    [child].flatten!
+    assert_not_predicate(child, :frozen?)
+  end
+
   def test_flatten_empty!
     assert_nil(@cls[].flatten!)
     assert_equal(@cls[],


### PR DESCRIPTION
 `Array#flatten!` currently freezes a caller-owned nested Array when the single-array fast path introduced in #18438 is used:

```ruby
result = []
[result].flatten!

result.frozen?
# Ruby 4.0: false
# master: true
```

The fast path reuses the nested Array as result. rb_ary_flatten_bang then calls `rb_ary_freeze(result)`, which is intended for an internally-created temporary result, and consequently freezes the externally-owned Array.

Skip the internal freeze when result is the nested Array itself. rb_ary_replace can copy or share its storage without changing the nested Array's frozen state, while retaining the single-array fast path.

This regression was found in rmosolgo/graphql-ruby#5709. `GraphQL::Execution::Finalize` uses `[data].flatten!` while locating error targets, which freezes a response Array on Ruby master. Later null propagation then raises `FrozenError` when it updates that response.