### PR TITLE
Resolve aliases of Object's methods in a module at call time

### DIFF
--- a/proc.c
+++ b/proc.c
@@ -2509,6 +2509,7 @@ mnew_internal(const rb_method_entry_t *me, VALUE klass, VALUE iclass,
     struct METHOD *data;
     VALUE method;
     const rb_method_entry_t *original_me = me;
+    const ID called_id = id;
     rb_method_visibility_t visi = METHOD_VISI_UNDEF;
 
   again:
@@ -2535,11 +2536,22 @@ mnew_internal(const rb_method_entry_t *me, VALUE klass, VALUE iclass,
             me = (rb_method_entry_t *)rb_callable_method_entry_with_refinements(klass, id, &iclass);
         }
         else {
-            VALUE klass = RCLASS_SUPER(RCLASS_ORIGIN(me->owner));
+            VALUE klass = RCLASS_SUPER(RCLASS_ORIGIN(RB_TYPE_P(iclass, T_ICLASS) ? iclass : me->owner));
             id = me->def->original_id;
             me = rb_method_entry_without_refinements(klass, id, &iclass);
         }
         goto again;
+    }
+
+    if (me->called_id != called_id) {
+        /* resolved from a ZSUPER alias; keep the name it was looked up by */
+        if (me->defined_class) {
+            me = (const rb_method_entry_t *)
+                rb_method_entry_complement_defined_class(me, called_id, me->defined_class);
+        }
+        else {
+            me = rb_method_entry_create(called_id, me->owner, METHOD_ENTRY_VISI(me), me->def);
+        }
     }
 
     method = TypedData_Make_Struct(mclass, struct METHOD, &method_data_type, data);

--- a/test/ruby/test_alias.rb
+++ b/test/ruby/test_alias.rb
@@ -330,15 +330,46 @@ class TestAlias < Test::Unit::TestCase
   end
 
   def test_undef_method_error_message_with_zsuper_method
-    modules = [
-      Module.new { private :class },
-      Module.new { prepend Module.new { private :class } },
+    a = Class.new { private def foo; end }
+    classes = [
+      Class.new(a) { public :foo },
+      Class.new(a) { prepend Module.new; public :foo },
     ]
-    message = "undefined method 'class' for module '%s'"
-    modules.each do |mod|
-      assert_raise_with_message(NameError, message % mod) do
-        mod.alias_method :xyz, :class
+    a.send(:remove_method, :foo)
+    message = "undefined method 'foo' for class '%s'"
+    classes.each do |klass|
+      assert_raise_with_message(NameError, message % klass) do
+        klass.alias_method :xyz, :foo
       end
     end
+  end
+
+  def test_alias_in_module_resolved_at_call_time
+    bug22276 = '[ruby-core:126537] [Bug #22276]'
+
+    m = Module.new do
+      alias orig_to_s to_s
+      alias orig_to_s2 orig_to_s
+      private def to_s = "M"
+    end
+
+    c = Class.new { include m }
+    obj = c.new
+    assert_equal(Kernel.instance_method(:to_s).bind_call(obj), obj.orig_to_s, bug22276)
+    assert_equal(obj.orig_to_s, obj.orig_to_s2, bug22276)
+    assert_equal(:orig_to_s, obj.method(:orig_to_s).name, bug22276)
+    assert_equal(m, obj.method(:orig_to_s).owner, bug22276)
+    assert_equal(obj.orig_to_s, obj.method(:orig_to_s).call, bug22276)
+    assert_equal(obj.orig_to_s, c.instance_method(:orig_to_s).bind_call(obj), bug22276)
+
+    m2 = Module.new { private :class; alias_method :xyz, :class }
+    obj = Class.new { include m2 }.new
+    assert_raise(NoMethodError, bug22276) { obj.xyz }
+    assert_equal(obj.instance_eval { self.class }, obj.instance_eval { xyz }, bug22276)
+
+    assert_raise(NameError, bug22276) { Module.new { alias foo bar } }
+
+    c = Class.new(BasicObject) { include m; public :orig_to_s }
+    assert_raise(NoMethodError, bug22276) { c.new.orig_to_s }
   end
 end

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -109,9 +109,8 @@ vm_call0_cme(rb_execution_context_t *ec, struct rb_calling_info *calling, const 
 }
 
 static VALUE
-vm_call0_super(rb_execution_context_t *ec, struct rb_calling_info *calling, const VALUE *argv, VALUE klass, enum method_missing_reason ex)
+vm_call0_super(rb_execution_context_t *ec, struct rb_calling_info *calling, const VALUE *argv, VALUE klass, ID mid, enum method_missing_reason ex)
 {
-    ID mid = vm_ci_mid(calling->cd->ci);
     klass = RCLASS_SUPER(klass);
 
     if (klass) {
@@ -124,7 +123,7 @@ vm_call0_super(rb_execution_context_t *ec, struct rb_calling_info *calling, cons
     }
 
     vm_passed_block_handler_set(ec, calling->block_handler);
-    return method_missing(ec, calling->recv, mid, calling->argc, argv, ex, calling->kw_splat);
+    return method_missing(ec, calling->recv, vm_ci_mid(calling->cd->ci), calling->argc, argv, ex, calling->kw_splat);
 }
 
 static VALUE
@@ -246,7 +245,7 @@ vm_call0_body(rb_execution_context_t *ec, struct rb_calling_info *calling, const
       case VM_METHOD_TYPE_ZSUPER:
         {
             VALUE klass = RCLASS_ORIGIN(vm_cc_cme(cc)->defined_class);
-            return vm_call0_super(ec, calling, argv, klass, MISSING_SUPER);
+            return vm_call0_super(ec, calling, argv, klass, vm_cc_cme(cc)->def->original_id, MISSING_SUPER);
         }
       case VM_METHOD_TYPE_REFINED:
         {
@@ -258,7 +257,7 @@ vm_call0_body(rb_execution_context_t *ec, struct rb_calling_info *calling, const
             }
 
             VALUE klass = cme->defined_class;
-            return vm_call0_super(ec, calling, argv, klass, 0);
+            return vm_call0_super(ec, calling, argv, klass, vm_ci_mid(calling->cd->ci), 0);
         }
       case VM_METHOD_TYPE_ALIAS:
         {

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -4548,7 +4548,8 @@ vm_call_zsuper(rb_execution_context_t *ec, rb_control_frame_t *cfp, struct rb_ca
 {
     klass = RCLASS_SUPER(klass);
 
-    const rb_callable_method_entry_t *cme = klass ? rb_callable_method_entry(klass, vm_ci_mid(calling->cd->ci)) : NULL;
+    ID mid = vm_cc_cme(calling->cc)->def->original_id;
+    const rb_callable_method_entry_t *cme = klass ? rb_callable_method_entry(klass, mid) : NULL;
     if (cme == NULL) {
         return vm_call_method_nome(ec, cfp, calling);
     }

--- a/vm_method.c
+++ b/vm_method.c
@@ -2860,6 +2860,7 @@ rb_alias(VALUE klass, ID alias_name, ID original_name)
     VALUE defined_class;
     const rb_method_entry_t *orig_me;
     rb_method_visibility_t visi = METHOD_VISI_UNDEF;
+    bool deferred = false;
 
     if (NIL_P(klass)) {
         rb_raise(rb_eTypeError, "no class to make alias");
@@ -2876,11 +2877,14 @@ rb_alias(VALUE klass, ID alias_name, ID original_name)
 
     if (UNDEFINED_METHOD_ENTRY_P(orig_me) ||
         UNDEFINED_REFINED_METHOD_P(orig_me->def)) {
-        if ((!RB_TYPE_P(klass, T_MODULE)) ||
-            (orig_me = search_method(rb_cObject, original_name, &defined_class),
-             UNDEFINED_METHOD_ENTRY_P(orig_me))) {
+        if (!RB_TYPE_P(target_klass, T_MODULE) || deferred) {
             rb_print_undef(target_klass, original_name, METHOD_VISI_UNDEF);
         }
+        /* Object is not an ancestor of the module; use it only to check the
+         * method and its visibility, and resolve the alias at call time. */
+        deferred = true;
+        klass = rb_cObject;
+        goto again;
     }
 
     switch (orig_me->def->type) {
@@ -2899,7 +2903,13 @@ rb_alias(VALUE klass, ID alias_name, ID original_name)
 
     if (visi == METHOD_VISI_UNDEF) visi = METHOD_ENTRY_VISI(orig_me);
 
-    if (orig_me->defined_class == 0) {
+    if (deferred) {
+        const rb_method_entry_t *alias_me =
+            rb_method_entry_make(target_klass, alias_name, target_klass, visi,
+                                 VM_METHOD_TYPE_ZSUPER, NULL, original_name, NULL);
+        method_added(target_klass, alias_name, alias_me);
+    }
+    else if (orig_me->defined_class == 0) {
         const rb_method_entry_t *alias_me =
             rb_method_entry_make(target_klass, alias_name, target_klass, visi,
                                  VM_METHOD_TYPE_ALIAS, NULL, orig_me->called_id,
@@ -3407,10 +3417,11 @@ rb_mod_modfunc(int argc, VALUE *argv, VALUE module)
         VALUE m = module;
 
         id = rb_to_id(argv[i]);
+        ID orig_id = id;
         for (;;) {
-            me = search_method(m, id, 0);
+            me = search_method(m, orig_id, 0);
             if (me == 0) {
-                me = search_method(rb_cObject, id, 0);
+                me = search_method(rb_cObject, orig_id, 0);
             }
             if (UNDEFINED_METHOD_ENTRY_P(me)) {
                 rb_print_undef(module, id, METHOD_VISI_UNDEF);
@@ -3418,6 +3429,7 @@ rb_mod_modfunc(int argc, VALUE *argv, VALUE module)
             if (me->def->type != VM_METHOD_TYPE_ZSUPER) {
                 break; /* normal case: need not to follow 'super' link */
             }
+            orig_id = me->def->original_id;
             m = RCLASS_SUPER(m);
             if (!m)
                 break;


### PR DESCRIPTION
When `alias` in a module did not find the method in the module, it searched Object and copied the method into the module.  This dates from 1.8, where Object was the root class, so every class including the module had Object and Kernel as ancestors.  Since BasicObject was introduced, a module can be included in a class without them, and the alias still called Kernel's method there.

Now such an alias is a ZSUPER method entry whose original_id is the aliased name; Object is searched only to check that the method exists and to take its visibility.  The method is resolved at call time from the ancestors after the module in the receiver's class, like `public` on an inherited method, so the alias works as before in subclasses of Object and raises NoMethodError in classes that do not inherit from Object.

ZSUPER dispatch now looks up def->original_id instead of the called name; they were always equal before.  Method objects for such entries keep the name they were looked up by, and instance_method on a class including a module with a ZSUPER entry starts from the iclass instead of the module.

[Bug #22276]