### PR TITLE
ZJIT: Fold Fixnum identity subtraction and bitwise ops

### DIFF
--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -6547,6 +6547,10 @@ impl Function {
                             _ => None,
                         })
                     }
+                    &Insn::FixnumSub { left, right, .. } if left == right => {
+                        // x - x == 0 for every fixnum x
+                        self.new_insn(Insn::Const { val: Const::Value(VALUE::fixnum_from_isize(0)) })
+                    }
                     &Insn::FixnumSub { left, right, .. } => {
                         match (self.type_of(left).fixnum_value(), self.type_of(right).fixnum_value()) {
                             (_, Some(0)) => { self.make_equal_to(insn_id, left); continue; }
@@ -6624,19 +6628,44 @@ impl Function {
                             _ => None,
                         })
                     }
+                    &Insn::FixnumXor { left, right, .. } if left == right => {
+                        // x ^ x == 0 for every fixnum x
+                        self.new_insn(Insn::Const { val: Const::Value(VALUE::fixnum_from_isize(0)) })
+                    }
                     &Insn::FixnumXor { left, right, .. } => {
+                        match (self.type_of(left).fixnum_value(), self.type_of(right).fixnum_value()) {
+                            (Some(0), _) => { self.make_equal_to(insn_id, right); continue; }
+                            (_, Some(0)) => { self.make_equal_to(insn_id, left); continue; }
+                            _ => {}
+                        }
                         self.fold_fixnum_bop(insn_id, left, right, |l, r| match (l, r) {
                             (Some(l), Some(r)) => Some(l ^ r),
                             _ => None,
                         })
                     }
+                    &Insn::FixnumAnd { left, right, .. } if left == right => {
+                        // x & x == x for every fixnum x
+                        self.make_equal_to(insn_id, left);
+                        continue;
+                    }
                     &Insn::FixnumAnd { left, right, .. } => {
                         self.fold_fixnum_bop(insn_id, left, right, |l, r| match (l, r) {
                             (Some(l), Some(r)) => Some(l & r),
+                            (Some(0), _) | (_, Some(0)) => Some(0),
                             _ => None,
                         })
                     }
+                    &Insn::FixnumOr { left, right, .. } if left == right => {
+                        // x | x == x for every fixnum x
+                        self.make_equal_to(insn_id, left);
+                        continue;
+                    }
                     &Insn::FixnumOr { left, right, .. } => {
+                        match (self.type_of(left).fixnum_value(), self.type_of(right).fixnum_value()) {
+                            (Some(0), _) => { self.make_equal_to(insn_id, right); continue; }
+                            (_, Some(0)) => { self.make_equal_to(insn_id, left); continue; }
+                            _ => {}
+                        }
                         self.fold_fixnum_bop(insn_id, left, right, |l, r| match (l, r) {
                             (Some(l), Some(r)) => Some(l | r),
                             _ => None,

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -1061,6 +1061,229 @@ mod hir_opt_tests {
     }
 
     #[test]
+    fn test_fold_fixnum_sub_same_operand() {
+        eval("
+            def test(n)
+              n - n
+            end
+            test 1; test 2
+        ");
+
+        assert_snapshot!(inspect("test 3"), @"0");
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:3:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          v2:CPtr = LoadSP
+          v3:BasicObject = LoadField v2, :n@0x1000
+          Jump bb3(v1, v3)
+        bb2():
+          EntryPoint JIT(0)
+          v6:BasicObject = LoadArg :self@0
+          v7:BasicObject = LoadArg :n@1
+          Jump bb3(v6, v7)
+        bb3(v9:BasicObject, v10:BasicObject):
+          PatchPoint MethodRedefined(Integer@0x1008, -@0x1010, cme:0x1018)
+          v25:Fixnum = GuardType v10, Fixnum recompile
+          v28:Fixnum[0] = Const Value(0)
+          CheckInterrupts
+          Return v28
+        ");
+    }
+
+    #[test]
+    fn test_fold_fixnum_xor_same_operand() {
+        eval("
+            def test(n)
+              n ^ n
+            end
+            test 1; test 2
+        ");
+
+        assert_snapshot!(inspect("test 3"), @"0");
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:3:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          v2:CPtr = LoadSP
+          v3:BasicObject = LoadField v2, :n@0x1000
+          Jump bb3(v1, v3)
+        bb2():
+          EntryPoint JIT(0)
+          v6:BasicObject = LoadArg :self@0
+          v7:BasicObject = LoadArg :n@1
+          Jump bb3(v6, v7)
+        bb3(v9:BasicObject, v10:BasicObject):
+          PatchPoint MethodRedefined(Integer@0x1008, ^@0x1010, cme:0x1018)
+          v24:Fixnum = GuardType v10, Fixnum recompile
+          v27:Fixnum[0] = Const Value(0)
+          CheckInterrupts
+          Return v27
+        ");
+    }
+
+    #[test]
+    fn test_fold_fixnum_xor_zero() {
+        eval("
+            def test(n)
+              0 ^ n ^ 0
+            end
+            test 1; test 2
+        ");
+
+        assert_snapshot!(inspect("test 3"), @"3");
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:3:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          v2:CPtr = LoadSP
+          v3:BasicObject = LoadField v2, :n@0x1000
+          Jump bb3(v1, v3)
+        bb2():
+          EntryPoint JIT(0)
+          v6:BasicObject = LoadArg :self@0
+          v7:BasicObject = LoadArg :n@1
+          Jump bb3(v6, v7)
+        bb3(v9:BasicObject, v10:BasicObject):
+          v14:Fixnum[0] = Const Value(0)
+          PatchPoint MethodRedefined(Integer@0x1008, ^@0x1010, cme:0x1018)
+          v30:Fixnum = GuardType v10, Fixnum
+          CheckInterrupts
+          Return v30
+        ");
+    }
+
+    #[test]
+    fn test_fold_fixnum_and_same_operand() {
+        eval("
+            def test(n)
+              n & n
+            end
+            test 1; test 2
+        ");
+
+        assert_snapshot!(inspect("test 3"), @"3");
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:3:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          v2:CPtr = LoadSP
+          v3:BasicObject = LoadField v2, :n@0x1000
+          Jump bb3(v1, v3)
+        bb2():
+          EntryPoint JIT(0)
+          v6:BasicObject = LoadArg :self@0
+          v7:BasicObject = LoadArg :n@1
+          Jump bb3(v6, v7)
+        bb3(v9:BasicObject, v10:BasicObject):
+          PatchPoint MethodRedefined(Integer@0x1008, &@0x1010, cme:0x1018)
+          v25:Fixnum = GuardType v10, Fixnum recompile
+          CheckInterrupts
+          Return v25
+        ");
+    }
+
+    #[test]
+    fn test_fold_fixnum_and_zero() {
+        eval("
+            def test(n)
+              n & 0
+            end
+            test 1; test 2
+        ");
+
+        assert_snapshot!(inspect("test 3"), @"0");
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:3:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          v2:CPtr = LoadSP
+          v3:BasicObject = LoadField v2, :n@0x1000
+          Jump bb3(v1, v3)
+        bb2():
+          EntryPoint JIT(0)
+          v6:BasicObject = LoadArg :self@0
+          v7:BasicObject = LoadArg :n@1
+          Jump bb3(v6, v7)
+        bb3(v9:BasicObject, v10:BasicObject):
+          v15:Fixnum[0] = Const Value(0)
+          PatchPoint MethodRedefined(Integer@0x1008, &@0x1010, cme:0x1018)
+          v26:Fixnum = GuardType v10, Fixnum recompile
+          v28:Fixnum[0] = Const Value(0)
+          CheckInterrupts
+          Return v28
+        ");
+    }
+
+    #[test]
+    fn test_fold_fixnum_or_same_operand() {
+        eval("
+            def test(n)
+              n | n
+            end
+            test 1; test 2
+        ");
+
+        assert_snapshot!(inspect("test 3"), @"3");
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:3:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          v2:CPtr = LoadSP
+          v3:BasicObject = LoadField v2, :n@0x1000
+          Jump bb3(v1, v3)
+        bb2():
+          EntryPoint JIT(0)
+          v6:BasicObject = LoadArg :self@0
+          v7:BasicObject = LoadArg :n@1
+          Jump bb3(v6, v7)
+        bb3(v9:BasicObject, v10:BasicObject):
+          PatchPoint MethodRedefined(Integer@0x1008, |@0x1010, cme:0x1018)
+          v25:Fixnum = GuardType v10, Fixnum recompile
+          CheckInterrupts
+          Return v25
+        ");
+    }
+
+    #[test]
+    fn test_fold_fixnum_or_zero() {
+        eval("
+            def test(n)
+              0 | n | 0
+            end
+            test 1; test 2
+        ");
+
+        assert_snapshot!(inspect("test 3"), @"3");
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:3:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          v2:CPtr = LoadSP
+          v3:BasicObject = LoadField v2, :n@0x1000
+          Jump bb3(v1, v3)
+        bb2():
+          EntryPoint JIT(0)
+          v6:BasicObject = LoadArg :self@0
+          v7:BasicObject = LoadArg :n@1
+          Jump bb3(v6, v7)
+        bb3(v9:BasicObject, v10:BasicObject):
+          v14:Fixnum[0] = Const Value(0)
+          PatchPoint MethodRedefined(Integer@0x1008, |@0x1010, cme:0x1018)
+          v32:Fixnum = GuardType v10, Fixnum
+          CheckInterrupts
+          Return v32
+        ");
+    }
+
+    #[test]
     fn test_fold_fixnum_or_with_negative_self() {
         eval("
             def test


### PR DESCRIPTION
This PR folds algebraic identities on Fixnum subtraction and bitwise ops.

It's something what Max mentioned when we were discussing GVN:

> imagine turning `FixnumSub a, b` into `FixnumSub a, a` which could then be turned into `0`

Apparently there's no benchmark in ruby-bench that benefits from this optimization for now, but this seems like a fairly simple change that we might want to have in `fold_constants` later anyway. I'd be totally fine with not merging it until we find a benchmark optimized by that, but I'd like to hear your opinions on merging things like that in general.