### PR TITLE
parse.y: clear errno before parsing float literals

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -9885,6 +9885,7 @@ parse_numeric(struct parser_params *p, int c)
             type = tRATIONAL;
         }
         else {
+            errno = 0;
             strtod(tok(p), 0);
             if (errno == ERANGE) {
                 rb_warning1("Float %s out of range", WARN_S(tok(p)));


### PR DESCRIPTION
`parse_numeric` checked `errno` after calling `strtod` without clearing it first. A successful `strtod` call is not required to clear `errno`, so a stale `ERANGE` value could cause a valid Float literal to emit an out-of-range warning.

Clear `errno` before calling `strtod` so the warning reflects only the current conversion. This preserves warnings for Float literals that are actually out of range.