### PR TITLE
Regenerate build dependencies after revision changes

### DIFF
--- a/depend
+++ b/depend
@@ -36,7 +36,7 @@
 # mkdepend: depends vmtc.inc => {$(VPATH)}vmtc.inc
 # mkdepend: undef parse.y => RIPPER
 
-.deps/depend update-dependencies: $(srcdir)/depend \
+.deps/depend update-dependencies: $(REVISION_H) $(srcdir)/depend \
                                   $(srcdir)/tool/mkdepend.rb \
                                   $(srcdir)/lib/mkmf/depend.rb
 	$(BASERUBY) "$(srcdir)/tool/mkdepend.rb" --root="$(srcdir)" \


### PR DESCRIPTION
 When switching across 90e729c9bc, an existing `.deps/depend` can still reference `thread_pthread_mn.c`, which was renamed to `thread_sched_mn.c`. Since none of its current prerequisites necessarily change on checkout, Make does not regenerate it and fails with:

```
make: *** No rule to make target 'thread_pthread_mn.c', needed by 'thread.o'. Stop.
```

Make `.deps/depend` depend on `$(REVISION_H)` so dependency files are regenerated when the checked-out revision changes. When the revision is unchanged, the dependency cache introduced by #18351 is still reused.

Verified by making `.deps/depend` and `revision.h` stale and running `make -n thread.o`. The dependency file was regenerated with `thread_sched_mn.c`, and a subsequent invocation did not run the dependency scanner again.