### PR TITLE
[Feature #22279] Add region arguments to String bit operations

### DIFF
--- a/doc/string/bit_clear.rdoc
+++ b/doc/string/bit_clear.rdoc
@@ -4,13 +4,31 @@ Sets the bit at zero-based bit +offset+ to 0; returns +self+:
   s.bit_clear(1) # => "\xFD"
   s              # => "\xFD"
 
+With +length+, clears the +length+ consecutive bits beginning at +offset+;
+with a Range, clears the bits covered by +range+:
+
+  s = "\xFF\xFF"
+  s.bit_clear(4, 8)  # => "\x0F\xF0"
+  s = "\xFF\xFF"
+  s.bit_clear(4..11) # => "\x0F\xF0"
+
+The entire region must lie within +self+; a region that extends beyond the
+end raises +IndexError+ rather than being clamped. Writing zero bits is a
+no-op, but even an empty region raises +IndexError+ when it begins beyond
+the end of +self+.
+
 By default, bits within each byte are numbered from least-significant to
 most-significant. If +lsb_first+ is +false+, byte order is unchanged but bits
 within each byte are numbered from most-significant to least-significant:
 
   s = "\xFF"
-  s.bit_clear(1, lsb_first: false) # => "\xBF"
+  s.bit_clear(1, lsb_first: false)     # => "\xBF"
+  s = "\xFF\xFF"
+  s.bit_clear(4, 8, lsb_first: false)  # => "\xF0\x0F"
 
-Raises +IndexError+ if +offset+ is out of range.
-Raises +ArgumentError+ if +offset+ is too large to be represented.
+Raises +IndexError+ if +offset+ is out of range, or if any part of the
+region lies outside +self+.
+Raises +ArgumentError+ if +length+ is negative.
+Raises +ArgumentError+ if a bit position is too large to be represented.
 Raises +ArgumentError+ if +lsb_first+ is neither +true+ nor +false+.
+Raises +FrozenError+ if +self+ is frozen, even when writing zero bits.

--- a/doc/string/bit_count.rdoc
+++ b/doc/string/bit_count.rdoc
@@ -1,8 +1,38 @@
-Returns the number of set bits in +self+:
+Returns the number of set bits in +self+.
+
+With no arguments, counts over all bytes of +self+:
 
   "\x00".bit_count # => 0
   "\xFF".bit_count # => 8
   "\xAA".bit_count # => 4
 
+With +offset+ and +length+, counts only the +length+ bits beginning at
+zero-based bit +offset+; with a Range, counts the bits covered by +range+:
+
+  data = "\xFF\x00\xF0"
+  data.bit_count(0, 8)   # => 8
+  data.bit_count(8, 8)   # => 0
+  data.bit_count(0..7)   # => 8
+  data.bit_count(8...16) # => 0
+  data.bit_count(16..)   # => 4
+
+A region that extends beyond the end of +self+ is clamped to the bits that
+exist; a region that begins at or beyond the end counts zero:
+
+  data.bit_count(16, 100) # => 4
+  data.bit_count(100, 8)  # => 0
+
+By default, bits within each byte are numbered from least-significant to
+most-significant. If +lsb_first+ is +false+, byte order is unchanged but bits
+within each byte are numbered from most-significant to least-significant.
+The numbering matters only when the region is not byte-aligned; the
+no-argument form is independent of it:
+
+  "\xF0".bit_count(0, 4)                   # => 0
+  "\xF0".bit_count(0, 4, lsb_first: false) # => 4
+
 The count is over the bytes of +self+ and is independent of string encoding.
-Raises +ArgumentError+ if any argument is given.
+Raises +IndexError+ if +offset+ or a Range endpoint is negative.
+Raises +ArgumentError+ if +length+ is negative.
+Raises +ArgumentError+ if a bit position is too large to be represented.
+Raises +ArgumentError+ if +lsb_first+ is neither +true+ nor +false+.

--- a/doc/string/bit_flip.rdoc
+++ b/doc/string/bit_flip.rdoc
@@ -4,13 +4,31 @@ Flips the bit at zero-based bit +offset+; returns +self+:
   s.bit_flip(1) # => "\x02"
   s.bit_flip(1) # => "\x00"
 
+With +length+, flips the +length+ consecutive bits beginning at +offset+;
+with a Range, flips the bits covered by +range+:
+
+  s = "\x00\xFF"
+  s.bit_flip(4, 8)  # => "\xF0\xF0"
+  s = "\x00\xFF"
+  s.bit_flip(4..11) # => "\xF0\xF0"
+
+The entire region must lie within +self+; a region that extends beyond the
+end raises +IndexError+ rather than being clamped. Writing zero bits is a
+no-op, but even an empty region raises +IndexError+ when it begins beyond
+the end of +self+.
+
 By default, bits within each byte are numbered from least-significant to
 most-significant. If +lsb_first+ is +false+, byte order is unchanged but bits
 within each byte are numbered from most-significant to least-significant:
 
   s = "\x00"
-  s.bit_flip(1, lsb_first: false) # => "\x40"
+  s.bit_flip(1, lsb_first: false)     # => "\x40"
+  s = "\x00\xFF"
+  s.bit_flip(4, 8, lsb_first: false)  # => "\x0F\x0F"
 
-Raises +IndexError+ if +offset+ is out of range.
-Raises +ArgumentError+ if +offset+ is too large to be represented.
+Raises +IndexError+ if +offset+ is out of range, or if any part of the
+region lies outside +self+.
+Raises +ArgumentError+ if +length+ is negative.
+Raises +ArgumentError+ if a bit position is too large to be represented.
 Raises +ArgumentError+ if +lsb_first+ is neither +true+ nor +false+.
+Raises +FrozenError+ if +self+ is frozen, even when writing zero bits.

--- a/doc/string/bit_set.rdoc
+++ b/doc/string/bit_set.rdoc
@@ -4,13 +4,31 @@ Sets the bit at zero-based bit +offset+ to 1; returns +self+:
   s.bit_set(1) # => "\x02"
   s            # => "\x02"
 
+With +length+, sets the +length+ consecutive bits beginning at +offset+;
+with a Range, sets the bits covered by +range+:
+
+  s = "\x00\x00"
+  s.bit_set(4, 8)  # => "\xF0\x0F"
+  s = "\x00\x00"
+  s.bit_set(4..11) # => "\xF0\x0F"
+
+The entire region must lie within +self+; a region that extends beyond the
+end raises +IndexError+ rather than being clamped. Writing zero bits is a
+no-op, but even an empty region raises +IndexError+ when it begins beyond
+the end of +self+.
+
 By default, bits within each byte are numbered from least-significant to
 most-significant. If +lsb_first+ is +false+, byte order is unchanged but bits
 within each byte are numbered from most-significant to least-significant:
 
   s = "\x00"
   s.bit_set(1, lsb_first: false) # => "\x40"
+  s = "\x00\x00"
+  s.bit_set(4, 8, lsb_first: false) # => "\x0F\xF0"
 
-Raises +IndexError+ if +offset+ is out of range.
-Raises +ArgumentError+ if +offset+ is too large to be represented.
+Raises +IndexError+ if +offset+ is out of range, or if any part of the
+region lies outside +self+.
+Raises +ArgumentError+ if +length+ is negative.
+Raises +ArgumentError+ if a bit position is too large to be represented.
 Raises +ArgumentError+ if +lsb_first+ is neither +true+ nor +false+.
+Raises +FrozenError+ if +self+ is frozen, even when writing zero bits.

--- a/spec/ruby/core/string/bit_clear_spec.rb
+++ b/spec/ruby/core/string/bit_clear_spec.rb
@@ -21,9 +21,30 @@ ruby_version_is "4.1" do
       str.should == "\xFF\x7F"
     end
 
+    it "clears a region given as offset and length and returns self" do
+      str = +"\xFF\xFF"
+      str.bit_clear(4, 8).should.equal?(str)
+      str.should == "\x0F\xF0"
+    end
+
+    it "clears a region given as a Range" do
+      str = +"\xFF\xFF"
+      str.bit_clear(4..11)
+      str.should == "\x0F\xF0"
+    end
+
     it "raises an IndexError for an out of range bit offset" do
       -> { "\x00".bit_clear(8) }.should.raise(IndexError)
       -> { "\x00".bit_clear(-1) }.should.raise(IndexError)
+    end
+
+    it "raises an IndexError when a region extends past the end" do
+      -> { "\x00".bit_clear(0, 9) }.should.raise(IndexError)
+      -> { "\x00".bit_clear(0..8) }.should.raise(IndexError)
+    end
+
+    it "raises an ArgumentError for a negative length" do
+      -> { "\x00".bit_clear(0, -1) }.should.raise(ArgumentError)
     end
 
     it "raises a FrozenError if self is frozen" do

--- a/spec/ruby/core/string/bit_count_spec.rb
+++ b/spec/ruby/core/string/bit_count_spec.rb
@@ -10,9 +10,43 @@ ruby_version_is "4.1" do
       "\xAA\xF0".bit_count.should == 8
     end
 
-    it "raises an ArgumentError when given an argument" do
+    it "counts the set bits in a region given as offset and length" do
+      data = "\xFF\x00\xF0"
+      data.bit_count(0, 8).should == 8
+      data.bit_count(8, 8).should == 0
+      data.bit_count(4, 8).should == 4
+    end
+
+    it "counts the set bits in a region given as a Range" do
+      data = "\xFF\x00\xF0"
+      data.bit_count(0..7).should == 8
+      data.bit_count(8...16).should == 0
+      data.bit_count(16..).should == 4
+    end
+
+    it "clamps a region that extends past the end of the string" do
+      data = "\xFF\x00\xF0"
+      data.bit_count(16, 100).should == 4
+      data.bit_count(100, 8).should == 0
+    end
+
+    it "interprets a non-byte-aligned region according to lsb_first" do
+      "\xF0".bit_count(0, 4).should == 0
+      "\xF0".bit_count(0, 4, lsb_first: false).should == 4
+    end
+
+    it "accepts lsb_first for a whole-string count but does not use it" do
+      "\xFF".bit_count(lsb_first: false).should == 8
+    end
+
+    it "raises an ArgumentError for a lone offset without a length" do
       -> { "\x00".bit_count(0) }.should.raise(ArgumentError)
-      -> { "\x00".bit_count(lsb_first: false) }.should.raise(ArgumentError)
+    end
+
+    it "raises for an invalid region" do
+      -> { "\x00".bit_count(-1, 4) }.should.raise(IndexError)
+      -> { "\x00".bit_count(0, -1) }.should.raise(ArgumentError)
+      -> { "\x00".bit_count(0, 4, lsb_first: nil) }.should.raise(ArgumentError)
     end
   end
 end

--- a/spec/ruby/core/string/bit_flip_spec.rb
+++ b/spec/ruby/core/string/bit_flip_spec.rb
@@ -23,9 +23,30 @@ ruby_version_is "4.1" do
       str.should == "\x00\x80"
     end
 
+    it "flips a region given as offset and length and returns self" do
+      str = +"\x00\xFF"
+      str.bit_flip(4, 8).should.equal?(str)
+      str.should == "\xF0\xF0"
+    end
+
+    it "flips a region given as a Range" do
+      str = +"\x00\xFF"
+      str.bit_flip(4..11)
+      str.should == "\xF0\xF0"
+    end
+
     it "raises an IndexError for an out of range bit offset" do
       -> { "\x00".bit_flip(8) }.should.raise(IndexError)
       -> { "\x00".bit_flip(-1) }.should.raise(IndexError)
+    end
+
+    it "raises an IndexError when a region extends past the end" do
+      -> { "\x00".bit_flip(0, 9) }.should.raise(IndexError)
+      -> { "\x00".bit_flip(0..8) }.should.raise(IndexError)
+    end
+
+    it "raises an ArgumentError for a negative length" do
+      -> { "\x00".bit_flip(0, -1) }.should.raise(ArgumentError)
     end
 
     it "raises a FrozenError if self is frozen" do

--- a/spec/ruby/core/string/bit_set_spec.rb
+++ b/spec/ruby/core/string/bit_set_spec.rb
@@ -21,9 +21,30 @@ ruby_version_is "4.1" do
       str.should == "\x00\x80"
     end
 
+    it "sets a region given as offset and length and returns self" do
+      str = +"\x00\x00"
+      str.bit_set(4, 8).should.equal?(str)
+      str.should == "\xF0\x0F"
+    end
+
+    it "sets a region given as a Range" do
+      str = +"\x00\x00"
+      str.bit_set(4..11)
+      str.should == "\xF0\x0F"
+    end
+
     it "raises an IndexError for an out of range bit offset" do
       -> { "\x00".bit_set(8) }.should.raise(IndexError)
       -> { "\x00".bit_set(-1) }.should.raise(IndexError)
+    end
+
+    it "raises an IndexError when a region extends past the end" do
+      -> { "\x00".bit_set(0, 9) }.should.raise(IndexError)
+      -> { "\x00".bit_set(0..8) }.should.raise(IndexError)
+    end
+
+    it "raises an ArgumentError for a negative length" do
+      -> { "\x00".bit_set(0, -1) }.should.raise(ArgumentError)
     end
 
     it "raises a FrozenError if self is frozen" do

--- a/string.c
+++ b/string.c
@@ -6845,17 +6845,114 @@ str_bit_offset_from_index(VALUE index)
     return offset;
 }
 
+/*
+ * Bit lengths share the offset's representable range.
+ * A negative length is an ArgumentError rather than an IndexError.
+ */
+static uint64_t
+str_bit_length_from_index(VALUE index)
+{
+    VALUE integer = rb_to_int(index);
+
+    if (FIXNUM_P(integer)) {
+        long value = FIX2LONG(integer);
+        if (value < 0) {
+            rb_raise(rb_eArgError, "negative bit length");
+        }
+        return (uint64_t)value;
+    }
+
+    RUBY_ASSERT(RB_TYPE_P(integer, T_BIGNUM));
+    if (rb_int_negative_p(integer)) {
+        rb_raise(rb_eArgError, "negative bit length");
+    }
+    if (rb_cmpint(rb_int_cmp(integer, ULL2NUM(UINT64_MAX)), integer, ULL2NUM(UINT64_MAX)) > 0) {
+        rb_raise(rb_eArgError, "bit length out of representable range");
+    }
+    return (uint64_t)NUM2ULL(integer);
+}
+
+static inline uint64_t
+str_bit_size(long byte_len)
+{
+    /*
+     * byte_len * CHAR_BIT overflows uint64_t only for byte_len >= 2**61 which cannot
+     * be allocated. Saturate so that unreachable cases cannot wrap.
+     */
+    if ((uint64_t)byte_len > UINT64_MAX / CHAR_BIT) return UINT64_MAX;
+    return (uint64_t)byte_len * CHAR_BIT;
+}
+
+struct str_bit_range {
+    uint64_t beg;
+    uint64_t end_exclusive;  /* meaningful only when end_open is false */
+    bool end_open;           /* a nil end: the region runs to the end of self */
+};
+
+/*
+ * Coerce a bit Range's endpoints to bit offsets. This may run arbitrary Ruby
+ * (Integer#to_int on the endpoints), so it does NOT read the string's length:
+ * The caller must resolve the length only after this returns, otherwise
+ * to_int that reallocates self would leave a stale size.
+ */
+static void
+str_bit_range_to_offsets(VALUE range, struct str_bit_range *out)
+{
+    VALUE beg_v, end_v;
+    int excl;
+
+    /*
+     * We don't use rb_range_beg_len: it counts negative endpoints from the end,
+     * which is an IndexError for bit positions, and it is limited to long instead
+     * of uint64_t.
+     */
+    rb_range_values(range, &beg_v, &end_v, &excl);
+
+    out->beg = NIL_P(beg_v) ? 0 : str_bit_offset_from_index(beg_v).value;
+    if (NIL_P(end_v)) {
+        out->end_open = true;
+        out->end_exclusive = 0;
+    }
+    else {
+        uint64_t end = str_bit_offset_from_index(end_v).value;
+        out->end_open = false;
+        /*
+         * The saturation loses one position only for an inclusive end of
+         * 2**64-1, which lies beyond any real string either way.
+         */
+        out->end_exclusive = (excl || end == UINT64_MAX) ? end : end + 1;
+    }
+}
+
+/*
+ * Turn a coerced Range into (beg, len) against the now-current total bit size.
+ * The length is deliberately not clamped to the bits available, so a reading
+ * caller can clamp while a writing caller detects the overrun and raises.
+ */
 static bool
-str_lsb_first(int argc, VALUE *argv, VALUE *index)
+str_bit_range_resolve(const struct str_bit_range *range, uint64_t total_bits, uint64_t *begp, uint64_t *lenp)
+{
+    uint64_t beg = range->beg;
+    if (beg > total_bits) return false;
+
+    uint64_t end_exclusive = range->end_open ? total_bits : range->end_exclusive;
+    if (end_exclusive < beg) end_exclusive = beg;
+
+    *begp = beg;
+    *lenp = end_exclusive - beg;
+    return true;
+}
+
+static bool
+str_lsb_first_from_opts(VALUE opts)
 {
     static ID keywords[1];
-    VALUE opts, vlsb_first;
+    VALUE vlsb_first;
 
     if (!keywords[0]) {
         keywords[0] = rb_intern_const("lsb_first");
     }
 
-    rb_scan_args(argc, argv, "1:", index, &opts);
     rb_get_kwargs(opts, keywords, 0, 1, &vlsb_first);
     if (vlsb_first == Qundef || vlsb_first == Qtrue) {
         return true;
@@ -6865,6 +6962,15 @@ str_lsb_first(int argc, VALUE *argv, VALUE *index)
     }
     rb_raise(rb_eArgError, "lsb_first must be true or false");
     UNREACHABLE_RETURN(false);
+}
+
+static bool
+str_lsb_first(int argc, VALUE *argv, VALUE *index)
+{
+    VALUE opts;
+
+    rb_scan_args(argc, argv, "1:", index, &opts);
+    return str_lsb_first_from_opts(opts);
 }
 
 static inline uint64_t
@@ -6963,11 +7069,83 @@ enum str_bit_mutation {
     STR_BIT_FLIP
 };
 
-static VALUE
-str_mutate_bit(int argc, VALUE *argv, VALUE str, enum str_bit_mutation mutation)
+/*
+ * Mask for the logical in-byte positions lo..hi (0 <= lo <= hi <= 7) of one
+ * byte.  A contiguous logical run stays contiguous within a byte under both
+ * numbering conventions; MSB-first only mirrors it.
+ */
+static inline unsigned char
+str_bit_region_byte_mask(unsigned int lo, unsigned int hi, bool lsb_first)
 {
-    VALUE index;
-    bool lsb_first = str_lsb_first(argc, argv, &index);
+    if (lsb_first) {
+        return (unsigned char)((0xFFu >> (7 - hi)) & (0xFFu << lo));
+    }
+    else {
+        return (unsigned char)((0xFFu >> lo) & (0xFFu << (7 - hi)));
+    }
+}
+
+static inline void
+str_apply_bit_mask(unsigned char *byte, unsigned char mask, enum str_bit_mutation mutation)
+{
+    switch (mutation) {
+      case STR_BIT_SET:
+        *byte |= mask;
+        break;
+      case STR_BIT_CLEAR:
+        *byte &= (unsigned char)~mask;
+        break;
+      case STR_BIT_FLIP:
+        *byte ^= mask;
+        break;
+    }
+}
+
+/* The caller has bounds-checked [beg, beg+len) and called rb_str_modify. */
+static void
+str_mutate_bit_region(unsigned char *ptr, uint64_t beg, uint64_t len, bool lsb_first, enum str_bit_mutation mutation)
+{
+    uint64_t first_bit = beg;
+    uint64_t last_bit = beg + len - 1;
+    long first_byte = (long)(first_bit / CHAR_BIT);
+    long last_byte = (long)(last_bit / CHAR_BIT);
+    unsigned int first_off = (unsigned int)(first_bit % CHAR_BIT);
+    unsigned int last_off = (unsigned int)(last_bit % CHAR_BIT);
+
+    if (first_byte == last_byte) {
+        str_apply_bit_mask(ptr + first_byte, str_bit_region_byte_mask(first_off, last_off, lsb_first), mutation);
+        return;
+    }
+
+    str_apply_bit_mask(ptr + first_byte, str_bit_region_byte_mask(first_off, 7, lsb_first), mutation);
+    long middle_len = last_byte - first_byte - 1;
+    if (middle_len > 0) {
+        unsigned char *middle = ptr + first_byte + 1;
+        switch (mutation) {
+          case STR_BIT_SET:
+            memset(middle, 0xFF, middle_len);
+            break;
+          case STR_BIT_CLEAR:
+            memset(middle, 0, middle_len);
+            break;
+          case STR_BIT_FLIP:
+            /*
+             * Byte loop on purpose: the compiler auto-vectorizes it (verified on gcc 13.3
+             * and clang 18.1 with x86_64), and being read-modify-write, the flip is memory-bound,
+             * so a manual word-at-a-time XOR loop was measured to be no faster.
+             */
+            for (long i = 0; i < middle_len; i++) {
+                middle[i] ^= 0xFF;
+            }
+            break;
+        }
+    }
+    str_apply_bit_mask(ptr + last_byte, str_bit_region_byte_mask(0, last_off, lsb_first), mutation);
+}
+
+static VALUE
+str_mutate_single_bit(VALUE str, VALUE index, bool lsb_first, enum str_bit_mutation mutation)
+{
     struct str_bit_offset offset = str_bit_offset_from_index(index);
     struct str_bit_location location;
     long bit_index;
@@ -6990,24 +7168,70 @@ str_mutate_bit(int argc, VALUE *argv, VALUE str, enum str_bit_mutation mutation)
         mask = (unsigned char)(1u << location.bit_offset);
     }
 
-    switch (mutation) {
-      case STR_BIT_SET:
-        ptr[location.byte_index] |= mask;
-        break;
-      case STR_BIT_CLEAR:
-        ptr[location.byte_index] &= (unsigned char)~mask;
-        break;
-      case STR_BIT_FLIP:
-        ptr[location.byte_index] ^= mask;
-        break;
+    str_apply_bit_mask(ptr + location.byte_index, mask, mutation);
+    return str;
+}
+
+static VALUE
+str_mutate_bit(int argc, VALUE *argv, VALUE str, enum str_bit_mutation mutation)
+{
+    VALUE target, length_v, opts;
+    uint64_t beg = 0, len = 0;
+
+    /* Count positional arguments so that an explicit nil is not mistaken for an omitted one. */
+    int nargs = rb_scan_args(argc, argv, "11:", &target, &length_v, &opts);
+    bool lsb_first = str_lsb_first_from_opts(opts);
+
+    bool is_range = rb_obj_is_kind_of(target, rb_cRange);
+    if (nargs == 1 && !is_range) {
+        return str_mutate_single_bit(str, target, lsb_first, mutation);
     }
 
+    struct str_bit_range range = {0};
+    struct str_bit_offset offset;
+    if (is_range) {
+        if (nargs == 2) {
+            rb_raise(rb_eArgError, "bit length not allowed with a Range");
+        }
+        str_bit_range_to_offsets(target, &range);
+    }
+    else {
+        offset = str_bit_offset_from_index(target);
+        len = str_bit_length_from_index(length_v);
+    }
+
+    /*
+     * A region that begins past the end is out of range even when it is
+     * empty, and one that runs past the end is not allowed to silently
+     * shrink: both are errors for a mutation, unlike the clamping reads.
+     * An empty region whose start is within 0..bitsize writes nothing.
+     */
+    uint64_t total_bits = str_bit_size(RSTRING_LEN(str));
+    if (is_range) {
+        if (!str_bit_range_resolve(&range, total_bits, &beg, &len) || len > total_bits - beg) {
+            rb_raise(rb_eIndexError, "bit range out of range");
+        }
+    }
+    else {
+        beg = offset.value;
+        if (beg > total_bits || len > total_bits - beg) {
+            rb_raise(rb_eIndexError, "bit range out of range");
+        }
+    }
+    /* Even a zero-length write requires a mutable receiver. */
+    rb_check_frozen(str);
+    if (len == 0) return str;
+
+    rb_str_modify(str);
+    str_mutate_bit_region((unsigned char *)RSTRING_PTR(str), beg, len, lsb_first, mutation);
     return str;
 }
 
 /*
  *  call-seq:
  *    bit_set(offset, lsb_first: true) -> self
+ *    bit_set(offset, length, lsb_first: true) -> self
+ *    bit_set(range, lsb_first: true) -> self
  *
  *  :include: doc/string/bit_set.rdoc
  *
@@ -7021,6 +7245,8 @@ rb_str_bit_set(int argc, VALUE *argv, VALUE str)
 /*
  *  call-seq:
  *    bit_clear(offset, lsb_first: true) -> self
+ *    bit_clear(offset, length, lsb_first: true) -> self
+ *    bit_clear(range, lsb_first: true) -> self
  *
  *  :include: doc/string/bit_clear.rdoc
  *
@@ -7034,6 +7260,8 @@ rb_str_bit_clear(int argc, VALUE *argv, VALUE str)
 /*
  *  call-seq:
  *    bit_flip(offset, lsb_first: true) -> self
+ *    bit_flip(offset, length, lsb_first: true) -> self
+ *    bit_flip(range, lsb_first: true) -> self
  *
  *  :include: doc/string/bit_flip.rdoc
  *
@@ -7085,17 +7313,84 @@ str_count_bits(const unsigned char *ptr, long len)
     return count;
 }
 
+static uint64_t
+str_count_bits_region(const unsigned char *ptr, uint64_t beg, uint64_t len, bool lsb_first)
+{
+    uint64_t first_bit = beg;
+    uint64_t last_bit = beg + len - 1;
+    long first_byte = (long)(first_bit / CHAR_BIT);
+    long last_byte = (long)(last_bit / CHAR_BIT);
+    unsigned int first_off = (unsigned int)(first_bit % CHAR_BIT);
+    unsigned int last_off = (unsigned int)(last_bit % CHAR_BIT);
+
+    if (first_byte == last_byte) {
+        return rb_popcount32((uint32_t)(ptr[first_byte] & str_bit_region_byte_mask(first_off, last_off, lsb_first)));
+    }
+
+    uint64_t count = rb_popcount32((uint32_t)(ptr[first_byte] & str_bit_region_byte_mask(first_off, 7, lsb_first)));
+    count += str_count_bits(ptr + first_byte + 1, last_byte - first_byte - 1);
+    count += rb_popcount32((uint32_t)(ptr[last_byte] & str_bit_region_byte_mask(0, last_off, lsb_first)));
+    return count;
+}
+
 /*
  *  call-seq:
  *    bit_count -> integer
+ *    bit_count(offset, length, lsb_first: true) -> integer
+ *    bit_count(range, lsb_first: true) -> integer
  *
  *  :include: doc/string/bit_count.rdoc
  *
  */
 static VALUE
-rb_str_bit_count(VALUE str)
+rb_str_bit_count(int argc, VALUE *argv, VALUE str)
 {
-    return ULL2NUM(str_count_bits((const unsigned char *)RSTRING_PTR(str), RSTRING_LEN(str)));
+    VALUE v0, v1, opts;
+    uint64_t beg = 0, len = 0;
+
+    /* Count positional arguments so that an explicit nil is not mistaken for an omitted one. */
+    int nargs = rb_scan_args(argc, argv, "02:", &v0, &v1, &opts);
+    /*
+     * A whole-string popcount is independent of bit numbering.
+     * no-(offset|range)-argument form only validates lsb_first.
+     */
+    bool lsb_first = str_lsb_first_from_opts(opts);
+
+    if (nargs == 0) {
+        return ULL2NUM(str_count_bits((const unsigned char *)RSTRING_PTR(str), RSTRING_LEN(str)));
+    }
+
+    bool is_range = rb_obj_is_kind_of(v0, rb_cRange);
+    struct str_bit_range range = {0};
+    if (is_range) {
+        if (nargs == 2) {
+            rb_raise(rb_eArgError, "bit length not allowed with a Range");
+        }
+        str_bit_range_to_offsets(v0, &range);
+    }
+    else if (nargs == 1) {
+        rb_raise(rb_eArgError, "no bit length given");
+    }
+    else {
+        beg = str_bit_offset_from_index(v0).value;
+        len = str_bit_length_from_index(v1);
+    }
+
+    const unsigned char *ptr = (const unsigned char *)RSTRING_PTR(str);
+    uint64_t total_bits = str_bit_size(RSTRING_LEN(str));
+    if (is_range) {
+        if (!str_bit_range_resolve(&range, total_bits, &beg, &len)) {
+            return INT2FIX(0);
+        }
+    }
+    else if (beg >= total_bits) {
+        return INT2FIX(0);
+    }
+
+    /* Reads clamp: only the part of the region that exists is counted. */
+    if (len > total_bits - beg) len = total_bits - beg;
+    if (len == 0) return INT2FIX(0);
+    return ULL2NUM(str_count_bits_region(ptr, beg, len, lsb_first));
 }
 
 static void
@@ -13897,7 +14192,7 @@ Init_String(void)
     rb_define_method(rb_cString, "bit_set", rb_str_bit_set, -1);
     rb_define_method(rb_cString, "bit_clear", rb_str_bit_clear, -1);
     rb_define_method(rb_cString, "bit_flip", rb_str_bit_flip, -1);
-    rb_define_method(rb_cString, "bit_count", rb_str_bit_count, 0);
+    rb_define_method(rb_cString, "bit_count", rb_str_bit_count, -1);
     rb_define_method(rb_cString, "bitwise_not", rb_str_bitwise_not, 0);
     rb_define_method(rb_cString, "bitwise_not!", rb_str_bitwise_not_bang, 0);
     rb_define_method(rb_cString, "bitwise_and", rb_str_bitwise_and, 1);

--- a/test/ruby/test_string.rb
+++ b/test/ruby/test_string.rb
@@ -1092,13 +1092,196 @@ CODE
     assert_equal(S("car"), shared)
   end
 
+  def test_bit_set_clear_flip_region
+    s = S("\x00\x00")
+    assert_same(s, s.bit_set(4, 8))
+    assert_equal(S("\xF0\x0F"), s)
+    s = S("\x00\x00")
+    s.bit_set(4..11)
+    assert_equal(S("\xF0\x0F"), s)
+    s = S("\xFF\xFF")
+    assert_same(s, s.bit_clear(4, 8))
+    assert_equal(S("\x0F\xF0"), s)
+    s = S("\xFF\xFF")
+    s.bit_clear(4..11)
+    assert_equal(S("\x0F\xF0"), s)
+    s = S("\x00\xFF")
+    assert_same(s, s.bit_flip(4, 8))
+    assert_equal(S("\xF0\xF0"), s)
+    s = S("\x00\xFF")
+    s.bit_flip(4..11)
+    assert_equal(S("\xF0\xF0"), s)
+
+    # Range variants
+    s = S("\x00")
+    s.bit_set(0...8)
+    assert_equal(S("\xFF"), s)
+    s = S("\x00\x00")
+    s.bit_set(8..)
+    assert_equal(S("\x00\xFF"), s)
+    s = S("\x00")
+    s.bit_set(..3)
+    assert_equal(S("\x0F"), s)
+    s = S("\x00")
+    s.bit_set(nil..nil)
+    assert_equal(S("\xFF"), s)
+
+    # A region spanning several bytes exercises the byte-fill path.
+    s = S("\x00" * 5)
+    s.bit_set(4, 32)
+    assert_equal(S("\xF0\xFF\xFF\xFF\x0F"), s)
+    s.bit_flip(0..)
+    assert_equal(S("\x0F\x00\x00\x00\xF0"), s)
+
+    # One-bit and zero-bit forms
+    s = S("\x00")
+    s.bit_set(3, 1)
+    assert_equal(S("\x08"), s)
+    s = S("\xAA")
+    assert_same(s, s.bit_set(0, 0))
+    s.bit_clear(0, 0)
+    s.bit_flip(0, 0)
+    assert_equal(S("\xAA"), s)
+    s = S("\x00")
+    assert_same(s, s.bit_set(8..))  # empty region at the very end
+    s.bit_set(8, 0)
+    s.bit_set(0...0)
+    assert_equal(S("\x00"), s)
+
+    # lsb_first: false interprets the same logical positions MSB-first.
+    s = S("\x00\x00")
+    s.bit_set(6..9, lsb_first: false)
+    assert_equal(S("\x03\xC0"), s)
+    s = S("\x00\x00")
+    s.bit_set(6, 4, lsb_first: false)
+    assert_equal(S("\x03\xC0"), s)
+
+    # Writes do not clamp: any part of the region outside self raises.
+    assert_raise(IndexError) { S("\x00").bit_set(0, 9) }
+    assert_raise(IndexError) { S("\x00").bit_set(8, 1) }
+    assert_raise(IndexError) { S("\x00").bit_set(0..8) }
+    assert_raise(IndexError) { S("\x00").bit_set(0...9) }
+    assert_raise(IndexError) { S("\x00").bit_set(8..8) }
+    assert_raise(IndexError) { S("\x00").bit_set(9..) }
+    # An empty region is no exception when it begins past the end.
+    assert_raise(IndexError) { S("\x00").bit_set(9, 0) }
+    assert_raise(IndexError) { S("\x00").bit_set(9...9) }
+    assert_raise(IndexError) { S("\x00").bit_clear(9, 0) }
+    assert_raise(IndexError) { S("\x00").bit_flip(9, 0) }
+    assert_raise(IndexError) { S("\x00").bit_clear(0..100) }
+    assert_raise(IndexError) { S("\x00").bit_flip(0..100) }
+    assert_raise(IndexError) { S("").bit_set(0..7) }
+    assert_raise(IndexError) { S("\x00").bit_set(..-1) }
+    assert_raise(IndexError) { S("\x00").bit_set(-1..2) }
+    assert_raise(IndexError) { S("\x00").bit_set(2**62, 1) }
+    assert_raise(IndexError) { S("\x00").bit_set(2**62..2**62 + 4) }
+    assert_raise(ArgumentError) { S("\x00").bit_set(0, -1) }
+    assert_raise(ArgumentError) { S("\x00").bit_set(0, 2**100) }
+    assert_raise(ArgumentError) { S("\x00").bit_set(0..2**100) }
+    assert_raise(ArgumentError) { S("\x00").bit_set(0..3, 4) }
+    # An explicit nil is an argument, not an omitted one.
+    assert_raise(TypeError) { S("\x00").bit_set(0, nil) }
+    assert_raise(ArgumentError) { S("\x00").bit_set(0..3, nil) }
+    assert_raise(ArgumentError) { S("\x00").bit_set(0..3, lsb_first: nil) }
+    assert_raise(FrozenError) { S("\x00").freeze.bit_set(0..3) }
+    # A zero-length write still requires a mutable receiver, but an
+    # out-of-range region is detected before the frozen check.
+    assert_raise(FrozenError) { S("\x00").freeze.bit_set(0, 0) }
+    assert_raise(FrozenError) { S("\x00").freeze.bit_clear(0...0) }
+    assert_raise(FrozenError) { S("\x00").freeze.bit_flip(8..) }
+    assert_raise(IndexError) { S("\x00").freeze.bit_set(9, 0) }
+
+    # Copy-on-write: mutating must not affect a shared sibling.
+    shared = S("fooXbar").split(S("X")).last
+    shared.bit_set(0..7)
+    assert_equal(S("\xFFar").b, shared.b)
+  end
+
   def test_bit_count
     assert_equal(0, S("").bit_count)
     assert_equal(0, S("\x00").bit_count)
     assert_equal(8, S("\xFF").bit_count)
     assert_equal(8, S("\xAA\xF0").bit_count)
+    # A full-string popcount is bit-order independent; the keyword is
+    # validated but has no effect.
+    assert_equal(8, S("\xFF").bit_count(lsb_first: false))
     assert_raise(ArgumentError) { S("\x00").bit_count(0) }
-    assert_raise(ArgumentError) { S("\x00").bit_count(lsb_first: false) }
+    assert_raise(ArgumentError) { S("\x00").bit_count(lsb_first: nil) }
+  end
+
+  def test_bit_count_region
+    data = S("\xFF\x00\xF0")
+    assert_equal(8, data.bit_count(0, 8))
+    assert_equal(0, data.bit_count(8, 8))
+    assert_equal(0, data.bit_count(16, 4))
+    assert_equal(4, data.bit_count(20, 4))
+    assert_equal(4, data.bit_count(4, 8))
+    assert_equal(8, data.bit_count(0..7))
+    assert_equal(0, data.bit_count(8..15))
+    assert_equal(8, data.bit_count(0...8))
+    assert_equal(4, data.bit_count(16..))
+    assert_equal(8, data.bit_count(..7))
+    assert_equal(12, data.bit_count(nil..nil))
+    assert_equal(0, data.bit_count(0, 0))
+    assert_equal(0, data.bit_count(0...0))
+
+    # Reads clamp: only the part of the region that exists is counted.
+    assert_equal(4, data.bit_count(16, 100))
+    assert_equal(0, data.bit_count(24, 8))
+    assert_equal(0, data.bit_count(100, 8))
+    assert_equal(4, data.bit_count(16..100))
+    assert_equal(0, data.bit_count(100..200))
+    assert_equal(0, data.bit_count(2**62, 8))
+
+    # lsb_first: selects which physical bits a non-byte-aligned region means.
+    assert_equal(0, S("\xF0").bit_count(0, 4))
+    assert_equal(4, S("\xF0").bit_count(0, 4, lsb_first: false))
+    assert_equal(4, S("\xF0").bit_count(0..3, lsb_first: false))
+    assert_equal(4, S("\xF0").bit_count(4, 4))
+
+    assert_raise(IndexError) { S("\x00").bit_count(-1, 4) }
+    assert_raise(IndexError) { S("\x00").bit_count(-1..3) }
+    assert_raise(IndexError) { S("\x00").bit_count(..-1) }
+    assert_raise(ArgumentError) { S("\x00").bit_count(0, -1) }
+    assert_raise(ArgumentError) { S("\x00").bit_count(2**100, 1) }
+    assert_raise(ArgumentError) { S("\x00").bit_count(0, 2**100) }
+    assert_raise(ArgumentError) { S("\x00").bit_count(0..2**100) }
+    assert_raise(ArgumentError) { S("\x00").bit_count(0..3, 4) }
+    assert_raise_with_message(ArgumentError, "no bit length given") { S("\x00").bit_count(0) }
+    # An explicit nil is an argument, not an omitted one.
+    assert_raise(ArgumentError) { S("\x00").bit_count(nil) }
+    assert_raise(TypeError) { S("\x00").bit_count(nil, 3) }
+    assert_raise(TypeError) { S("\x00").bit_count(0, nil) }
+    assert_raise(ArgumentError) { S("\x00").bit_count(0..3, nil) }
+    assert_raise(ArgumentError) { S("\x00").bit_count(0, 4, lsb_first: nil) }
+  end
+
+  def test_bit_region_argument_side_effect
+    # Coercing an argument (Integer#to_int, or a Range endpoint) may run user
+    # code that resizes the receiver.  The bounds check and the memory access
+    # must both see the post-coercion length, or a stale size lets the region
+    # method read or write out of bounds.
+    shrink = Class.new do
+      def initialize(str, value); @str, @value = str, value; end
+      def to_int; @str.replace("\xFF".b); @value; end
+    end
+
+    # Writes: the region no longer fits the shrunken string, so this must raise
+    # rather than write past the reallocated buffer.
+    s = S("\x00") * 8
+    assert_raise(IndexError) { s.bit_set(0, shrink.new(s, 64)) }
+    assert_equal("\xFF".b, s.b)
+
+    # A Range endpoint is coerced the same way; a beginless range keeps the
+    # custom object out of Range's begin <=> end construction check.
+    s = S("\x00") * 8
+    assert_raise(IndexError) { s.bit_set(..shrink.new(s, 63)) }
+    assert_equal("\xFF".b, s.b)
+
+    # Reads clamp to the post-coercion length instead of reading freed memory.
+    s = S("\xFF") * 8
+    assert_equal(8, s.bit_count(0, shrink.new(s, 64)))
+    assert_equal("\xFF".b, s.b)
   end
 
   def test_bitwise


### PR DESCRIPTION
This patch extends the following String methods:

* String#bit_set(offset, length, lsb_first: true) -> self
* String#bit_set(range, lsb_first: true) -> self
* String#bit_clear(offset, length, lsb_first: true) -> self
* String#bit_clear(range, lsb_first: true) -> self
* String#bit_flip(offset, length, lsb_first: true) -> self
* String#bit_flip(range, lsb_first: true) -> self
* String#bit_count(offset, length, lsb_first: true) -> Integer
* String#bit_count(range, lsb_first: true) -> Integer

Link: [Feature #22279]