### PR TITLE
ZJIT: Avoid double bitset lookup in eliminate_dead_code

### DIFF
--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -6756,8 +6756,7 @@ impl Function {
         let mut necessary = InsnSet::with_capacity(self.insns.len());
         // Now recursively traverse their data dependencies and mark those as necessary
         while let Some(insn_id) = worklist.pop_front() {
-            if necessary.get(insn_id) { continue; }
-            necessary.insert(insn_id);
+            if !necessary.insert(insn_id) { continue; }
             let insn_id = self.union_find.borrow().find_const(insn_id);
             self.insns[insn_id].for_each_operand(|operand| {
                 worklist.push_back(self.union_find.borrow().find_const(operand));


### PR DESCRIPTION
This is a small cleanup, but
since `BitSet::insert` returns whether the value was newly inserted,
we don't need a separate `necessary.get(insn_id)` lookup.