### PR TITLE
ZJIT: Also count calls from the interpreter

### DIFF
--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -10559,6 +10559,10 @@ fn compile_entry_block(fun: &mut Function, jit_entry_insns: &[u32], insn_idx_to_
     let mut pc: Option<InsnId> = None;
     let &all_opts_passed_insn_idx = jit_entry_insns.last().unwrap();
 
+    if get_option!(stats) {
+        fun.count_iseq_calls(entry_block);
+    }
+
     // Check-and-jump for each missing optional PC
     let mut iter = jit_entry_insns.iter().peekable();
     while let Some(&jit_entry_insn) = iter.next() {

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -5486,23 +5486,24 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
+          IncrCounterPtr
           Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :self@0
           IncrCounterPtr
-          Jump bb3(v4)
-        bb3(v7:BasicObject):
+          Jump bb3(v5)
+        bb3(v8:BasicObject):
           IncrCounter zjit_insn_count
           IncrCounter zjit_insn_count
-          v14:HashExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-          v15:HashExact = HashDup v14
+          v15:HashExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          v16:HashExact = HashDup v15
           IncrCounter zjit_insn_count
           IncrCounter complex_arg_pass_caller_kw_splat
-          v18:BasicObject = Send v7, :foo, v15 # SendFallbackReason: Complex argument passing
+          v19:BasicObject = Send v8, :foo, v16 # SendFallbackReason: Complex argument passing
           IncrCounter zjit_insn_count
           CheckInterrupts
-          Return v18
+          Return v19
         ");
     }
 
@@ -5520,23 +5521,24 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
+          IncrCounterPtr
           Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :self@0
           IncrCounterPtr
-          Jump bb3(v4)
-        bb3(v7:BasicObject):
+          Jump bb3(v5)
+        bb3(v8:BasicObject):
           IncrCounter zjit_insn_count
           IncrCounter zjit_insn_count
-          v14:Fixnum[1] = Const Value(1)
+          v15:Fixnum[1] = Const Value(1)
           IncrCounter zjit_insn_count
           IncrCounter complex_arg_pass_keyword_to_positional_hash
           IncrCounter send_direct_fallback_context_send
-          v17:BasicObject = Send v7, :foo, v14 # SendFallbackReason: Complex argument passing
+          v18:BasicObject = Send v8, :foo, v15 # SendFallbackReason: Complex argument passing
           IncrCounter zjit_insn_count
           CheckInterrupts
-          Return v17
+          Return v18
         ");
     }
 
@@ -5554,23 +5556,24 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
+          IncrCounterPtr
           Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :self@0
           IncrCounterPtr
-          Jump bb3(v4)
-        bb3(v7:BasicObject):
+          Jump bb3(v5)
+        bb3(v8:BasicObject):
           IncrCounter zjit_insn_count
           IncrCounter zjit_insn_count
-          v14:Fixnum[1] = Const Value(1)
+          v15:Fixnum[1] = Const Value(1)
           IncrCounter zjit_insn_count
           IncrCounter complex_arg_pass_keyword_to_positional_hash
           IncrCounter send_direct_fallback_context_send
-          v17:BasicObject = Send v7, :foo, v14 # SendFallbackReason: Complex argument passing
+          v18:BasicObject = Send v8, :foo, v15 # SendFallbackReason: Complex argument passing
           IncrCounter zjit_insn_count
           CheckInterrupts
-          Return v17
+          Return v18
         ");
     }
 
@@ -5772,23 +5775,24 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
+          IncrCounterPtr
           Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :self@0
           IncrCounterPtr
-          Jump bb3(v4)
-        bb3(v7:BasicObject):
+          Jump bb3(v5)
+        bb3(v8:BasicObject):
           IncrCounter zjit_insn_count
           IncrCounter zjit_insn_count
-          v14:Fixnum[1] = Const Value(1)
+          v15:Fixnum[1] = Const Value(1)
           IncrCounter zjit_insn_count
           IncrCounter complex_arg_pass_param_kwrest
           IncrCounter send_direct_fallback_context_send
-          v17:BasicObject = Send v7, :foo, v14 # SendFallbackReason: Complex argument passing
+          v18:BasicObject = Send v8, :foo, v15 # SendFallbackReason: Complex argument passing
           IncrCounter zjit_insn_count
           CheckInterrupts
-          Return v17
+          Return v18
         ");
     }
 
@@ -5893,23 +5897,24 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
+          IncrCounterPtr
           Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :self@0
           IncrCounterPtr
-          Jump bb3(v4)
-        bb3(v7:BasicObject):
+          Jump bb3(v5)
+        bb3(v8:BasicObject):
           IncrCounter zjit_insn_count
           IncrCounter zjit_insn_count
-          v14:HashExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-          v15:HashExact = HashDup v14
+          v15:HashExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          v16:HashExact = HashDup v15
           IncrCounter zjit_insn_count
           IncrCounter complex_arg_pass_caller_kw_splat
-          v18:BasicObject = Send v7, :foo, v15 # SendFallbackReason: Complex argument passing
+          v19:BasicObject = Send v8, :foo, v16 # SendFallbackReason: Complex argument passing
           IncrCounter zjit_insn_count
           CheckInterrupts
-          Return v18
+          Return v19
         ");
     }
 
@@ -5927,21 +5932,22 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
+          IncrCounterPtr
           Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :self@0
           IncrCounterPtr
-          Jump bb3(v4)
-        bb3(v7:BasicObject):
+          Jump bb3(v5)
+        bb3(v8:BasicObject):
           IncrCounter zjit_insn_count
           IncrCounter zjit_insn_count
           IncrCounter complex_arg_pass_param_kwrest
           IncrCounter send_direct_fallback_context_send
-          v14:BasicObject = Send v7, :foo # SendFallbackReason: Complex argument passing
+          v15:BasicObject = Send v8, :foo # SendFallbackReason: Complex argument passing
           IncrCounter zjit_insn_count
           CheckInterrupts
-          Return v14
+          Return v15
         ");
     }
 
@@ -14706,25 +14712,26 @@ mod hir_opt_tests {
           v1:BasicObject = LoadSelf
           v2:CPtr = LoadSP
           v3:BasicObject = LoadField v2, :args@0x1000
+          IncrCounterPtr
           Jump bb3(v1, v3)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :args@1
+          v7:BasicObject = LoadArg :self@0
+          v8:BasicObject = LoadArg :args@1
           IncrCounterPtr
-          Jump bb3(v6, v7)
-        bb3(v10:BasicObject, v11:BasicObject):
+          Jump bb3(v7, v8)
+        bb3(v11:BasicObject, v12:BasicObject):
           IncrCounter zjit_insn_count
           IncrCounter zjit_insn_count
           IncrCounter zjit_insn_count
-          v20:ArrayExact = ToArray v11
+          v21:ArrayExact = ToArray v12
           IncrCounter zjit_insn_count
           IncrCounter complex_arg_pass_caller_splat
           IncrCounter caller_splat_profile_monomorphic
-          v23:BasicObject = Send v10, :foo, v20 # SendFallbackReason: Complex argument passing
+          v24:BasicObject = Send v11, :foo, v21 # SendFallbackReason: Complex argument passing
           IncrCounter zjit_insn_count
           CheckInterrupts
-          Return v23
+          Return v24
         ");
     }
 
@@ -14746,25 +14753,26 @@ mod hir_opt_tests {
           v1:BasicObject = LoadSelf
           v2:CPtr = LoadSP
           v3:BasicObject = LoadField v2, :args@0x1000
+          IncrCounterPtr
           Jump bb3(v1, v3)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :args@1
+          v7:BasicObject = LoadArg :self@0
+          v8:BasicObject = LoadArg :args@1
           IncrCounterPtr
-          Jump bb3(v6, v7)
-        bb3(v10:BasicObject, v11:BasicObject):
+          Jump bb3(v7, v8)
+        bb3(v11:BasicObject, v12:BasicObject):
           IncrCounter zjit_insn_count
           IncrCounter zjit_insn_count
           IncrCounter zjit_insn_count
-          v20:ArrayExact = ToArray v11
+          v21:ArrayExact = ToArray v12
           IncrCounter zjit_insn_count
           IncrCounter complex_arg_pass_caller_splat
           IncrCounter caller_splat_profile_polymorphic
-          v23:BasicObject = Send v10, :foo, v20 # SendFallbackReason: Complex argument passing
+          v24:BasicObject = Send v11, :foo, v21 # SendFallbackReason: Complex argument passing
           IncrCounter zjit_insn_count
           CheckInterrupts
-          Return v23
+          Return v24
         ");
     }
 
@@ -17945,20 +17953,21 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:HeapBasicObject = LoadSelf
+          IncrCounterPtr
           Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v4:HeapBasicObject = LoadArg :self@0
+          v5:HeapBasicObject = LoadArg :self@0
           IncrCounterPtr
-          Jump bb3(v4)
-        bb3(v7:HeapBasicObject):
+          Jump bb3(v5)
+        bb3(v8:HeapBasicObject):
           IncrCounter zjit_insn_count
           IncrCounter zjit_insn_count
           IncrCounter send_direct_fallback_context_super
-          v14:BasicObject = InvokeSuper v7, 0x1000 # SendFallbackReason: Argument count does not match parameter count
+          v15:BasicObject = InvokeSuper v8, 0x1000 # SendFallbackReason: Argument count does not match parameter count
           IncrCounter zjit_insn_count
           CheckInterrupts
-          Return v14
+          Return v15
         ");
     }
 


### PR DESCRIPTION
We were missing a lot of calls in our top-called list. For example, for lobsters:

Before:

```
Top-20 most called JIT functions (20.4% of total 12,040,141):
                          fetch@/Users/emacs/.gem/ruby/ruby-zjit-rel-stats/gems/concurrent-ruby-1.3.5/lib/concurrent-ruby/concurrent/map.rb:183: 268,895 ( 2.2%)
                 fetch_or_store@/Users/emacs/.gem/ruby/ruby-zjit-rel-stats/gems/concurrent-ruby-1.3.5/lib/concurrent-ruby/concurrent/map.rb:205: 267,411 ( 2.2%)
                                                                                                                      each@<internal:array>:222: 252,044 ( 2.1%)
                                   klass@/Users/emacs/.gem/ruby/ruby-zjit-rel-stats/gems/activerecord-8.1.1/lib/active_record/reflection.rb:423: 145,723 ( 1.2%)
  connection_specification_name@/Users/emacs/.gem/ruby/ruby-zjit-rel-stats/gems/activerecord-8.1.1/lib/active_record/connection_handling.rb:320: 126,207 ( 1.0%)
    []@/Users/emacs/.gem/ruby/ruby-zjit-rel-stats/gems/activerecord-8.1.1/lib/active_record/connection_adapters/abstract/connection_pool.rb:187: 124,689 ( 1.0%)
                                        fetch@/Users/emacs/.gem/ruby/ruby-zjit-rel-stats/gems/activerecord-8.1.1/lib/active_record/result.rb:76: 123,449 ( 1.0%)
                     html_escape@/Users/emacs/.gem/ruby/ruby-zjit-rel-stats/gems/activesupport-8.1.1/lib/active_support/core_ext/erb/util.rb:11: 115,758 ( 1.0%)
                             foreign_key@/Users/emacs/.gem/ruby/ruby-zjit-rel-stats/gems/activerecord-8.1.1/lib/active_record/reflection.rb:559: 113,200 ( 0.9%)
                            association@/Users/emacs/.gem/ruby/ruby-zjit-rel-stats/gems/activerecord-8.1.1/lib/active_record/associations.rb:54:  98,595 ( 0.8%)
                                                                                                                       map@<internal:array>:240:  97,415 ( 0.8%)
                     klass@/Users/emacs/.gem/ruby/ruby-zjit-rel-stats/gems/activerecord-8.1.1/lib/active_record/associations/association.rb:166:  93,497 ( 0.8%)
                    ===@/Users/emacs/.gem/ruby/ruby-zjit-rel-stats/gems/activesupport-8.1.1/lib/active_support/core_ext/time/calculations.rb:19:  86,726 ( 0.7%)
                                                   for@/Users/emacs/.gem/ruby/ruby-zjit-rel-stats/gems/tzinfo-2.0.6/lib/tzinfo/timestamp.rb:112:  86,521 ( 0.7%)
                            connected_to_stack@/Users/emacs/.gem/ruby/ruby-zjit-rel-stats/gems/activerecord-8.1.1/lib/active_record/core.rb:216:  80,057 ( 0.7%)
                       []@/Users/emacs/.gem/ruby/ruby-zjit-rel-stats/gems/activesupport-8.1.1/lib/active_support/isolated_execution_state.rb:32:  78,839 ( 0.7%)
                  context@/Users/emacs/.gem/ruby/ruby-zjit-rel-stats/gems/activesupport-8.1.1/lib/active_support/isolated_execution_state.rb:55:  77,134 ( 0.6%)
                                   initialize@/Users/emacs/.gem/ruby/ruby-zjit-rel-stats/gems/tzinfo-2.0.6/lib/tzinfo/timezone_transition.rb:35:  76,603 ( 0.6%)
                 block in redefine@/Users/emacs/.gem/ruby/ruby-zjit-rel-stats/gems/activesupport-8.1.1/lib/active_support/class_attribute.rb:15:  73,963 ( 0.6%)
               association_instance_get@/Users/emacs/.gem/ruby/ruby-zjit-rel-stats/gems/activerecord-8.1.1/lib/active_record/associations.rb:84:  72,814 ( 0.6%)
```

After:

```
Top-20 most called JIT functions (22.6% of total 22,686,232):
                                         block in _load_from_sql@/Users/emacs/.gem/ruby/ruby-zjit-rel-stats/gems/activerecord-8.1.1/lib/active_record/querying.rb:77: 564,328 ( 2.5%)
                                                                                                                                           each@<internal:array>:222: 467,559 ( 2.1%)
                                      block in redefine@/Users/emacs/.gem/ruby/ruby-zjit-rel-stats/gems/activesupport-8.1.1/lib/active_support/class_attribute.rb:15: 381,214 ( 1.7%)
                                          fetch_value@/Users/emacs/.gem/ruby/ruby-zjit-rel-stats/gems/activemodel-8.1.1/lib/active_model/attribute_set/builder.rb:42: 365,814 ( 1.6%)
                                           block in merge@/Users/emacs/.gem/ruby/ruby-zjit-rel-stats/gems/activerecord-8.1.1/lib/active_record/relation/merger.rb:60: 314,382 ( 1.4%)
                                block (2 levels) in clean_load_path@/Users/emacs/.gem/ruby/ruby-zjit-rel-stats/gems/bundler-4.0.12/lib/bundler/shared_helpers.rb:370: 311,248 ( 1.4%)
                                            block in column_types@/Users/emacs/.gem/ruby/ruby-zjit-rel-stats/gems/activerecord-8.1.1/lib/active_record/result.rb:172: 282,164 ( 1.2%)
                                               fetch@/Users/emacs/.gem/ruby/ruby-zjit-rel-stats/gems/concurrent-ruby-1.3.5/lib/concurrent-ruby/concurrent/map.rb:183: 268,899 ( 1.2%)
                                      fetch_or_store@/Users/emacs/.gem/ruby/ruby-zjit-rel-stats/gems/concurrent-ruby-1.3.5/lib/concurrent-ruby/concurrent/map.rb:205: 267,411 ( 1.2%)
  block in perform_query@/Users/emacs/.gem/ruby/ruby-zjit-rel-stats/gems/activerecord-8.1.1/lib/active_record/connection_adapters/sqlite3/database_statements.rb:123: 267,148 ( 1.2%)
                                   _read_attribute@/Users/emacs/.gem/ruby/ruby-zjit-rel-stats/gems/activerecord-8.1.1/lib/active_record/attribute_methods/read.rb:39: 248,941 ( 1.1%)
                                                        klass@/Users/emacs/.gem/ruby/ruby-zjit-rel-stats/gems/activerecord-8.1.1/lib/active_record/reflection.rb:423: 219,426 ( 1.0%)
                       block in period_for@/Users/emacs/.gem/ruby/ruby-zjit-rel-stats/gems/tzinfo-2.0.6/lib/tzinfo/data_sources/transitions_data_timezone_info.rb:45: 189,701 ( 0.8%)
                                                          safe_concat@/Users/emacs/.gem/ruby/ruby-zjit-rel-stats/gems/actionview-8.1.1/lib/action_view/buffers.rb:57: 153,995 ( 0.7%)
                                                                                                             block in print_counters_with_prefix@<internal:zjit>:253: 143,882 ( 0.6%)
                       connection_specification_name@/Users/emacs/.gem/ruby/ruby-zjit-rel-stats/gems/activerecord-8.1.1/lib/active_record/connection_handling.rb:320: 140,225 ( 0.6%)
                                    association_instance_get@/Users/emacs/.gem/ruby/ruby-zjit-rel-stats/gems/activerecord-8.1.1/lib/active_record/associations.rb:84: 138,333 ( 0.6%)
                                                 association@/Users/emacs/.gem/ruby/ruby-zjit-rel-stats/gems/activerecord-8.1.1/lib/active_record/associations.rb:54: 138,322 ( 0.6%)
                                          klass@/Users/emacs/.gem/ruby/ruby-zjit-rel-stats/gems/activerecord-8.1.1/lib/active_record/associations/association.rb:166: 137,059 ( 0.6%)
                         []@/Users/emacs/.gem/ruby/ruby-zjit-rel-stats/gems/activerecord-8.1.1/lib/active_record/connection_adapters/abstract/connection_pool.rb:187: 124,689 ( 0.5%)
```
