### PR TITLE
ZJIT: Override megamorphic profiles with static type information

### DIFF
--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -4112,13 +4112,13 @@ impl Function {
     /// - Result of [`Self::resolve_receiver_type_from_profile`] if we need to check profile data
     fn resolve_receiver_type(&self, recv: InsnId, recv_type: Type, state: InsnId) -> ReceiverTypeResolution {
         match self.resolve_receiver_type_from_profile(recv, state) {
-            ReceiverTypeResolution::NoProfile => {
+            resolution@(ReceiverTypeResolution::NoProfile|ReceiverTypeResolution::Megamorphic) => {
                 // Use known type information as a fallback because it doesn't have shape
                 // information (and we can generally eliminate duplicate guards).
                 if let Some(class) = recv_type.runtime_exact_ruby_class() {
                     ReceiverTypeResolution::StaticallyKnown { class }
                 } else {
-                    ReceiverTypeResolution::NoProfile
+                    resolution
                 }
             }
             resolution => resolution,

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -18120,6 +18120,44 @@ mod hir_opt_tests {
     }
 
     #[test]
+    fn test_specialize_inlined_megamorphic_receiver() {
+        set_call_threshold(6);
+        eval("
+        def klass_eq(klass) = klass == Integer
+
+        def test = klass_eq(String)
+
+        # 5 distinct receiver classes at the == site: one more than the profile's
+        # 4 buckets, so the distribution is megamorphic.
+        klass_eq(Integer); klass_eq(Array); klass_eq(Hash); klass_eq(Symbol); klass_eq(Float)
+        6.times { test }
+        ");
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:4:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          Jump bb3(v1)
+        bb2():
+          EntryPoint JIT(0)
+          v4:BasicObject = LoadArg :self@0
+          Jump bb3(v4)
+        bb3(v6:BasicObject):
+          PatchPoint StableConstantNames(0x1000, String)
+          v12:ClassSubclass[String@0x1008] = Const Value(VALUE(0x1008))
+          PatchPoint MethodRedefined(Object@0x1010, klass_eq@0x1018, cme:0x1020)
+          v21:ObjectSubclass[class_exact*:Object@VALUE(0x1010)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1010)] recompile
+          PushInlineFrame :klass_eq, v21 (0x1048), num_args=1
+          PatchPoint StableConstantNames(0x1068, Integer)
+          v31:ClassSubclass[Integer@0x1070] = Const Value(VALUE(0x1070))
+          v34:BasicObject = Send v12, :==, v31 # SendFallbackReason: Send: megamorphic call site
+          CheckInterrupts
+          PopInlineFrame
+          Return v34
+        ");
+    }
+
+    #[test]
     fn specialize_polymorphic_send_preserves_argument_profiles() {
         // Each arm of a polymorphic dispatch must still see the profiled types of
         // the non-receiver arguments: the Array arm below can only inline ArrayAref

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -18150,10 +18150,12 @@ mod hir_opt_tests {
           PushInlineFrame :klass_eq, v21 (0x1048), num_args=1
           PatchPoint StableConstantNames(0x1068, Integer)
           v31:ClassSubclass[Integer@0x1070] = Const Value(VALUE(0x1070))
-          v34:BasicObject = Send v12, :==, v31 # SendFallbackReason: Send: megamorphic call site
+          PatchPoint MethodRedefined(Class@0x1078, ==@0x1080, cme:0x1088)
+          v45:CBool = IsBitEqual v12, v31
+          v46:BoolExact = BoxBool v45
           CheckInterrupts
           PopInlineFrame
-          Return v34
+          Return v46
         ");
     }
 


### PR DESCRIPTION
Instead of giving up, check if we have static information available. We might due to inlining or something. If we do, use it.

Megamorphic sends fall on lobsters.

Before:

```
Top-20 calls to C functions from JIT code (71.5% of total 54,279,914):
  rb_vm_opt_send_without_block: 8,654,924 (15.9%)
                  rb_hash_aref: 5,773,080 (10.6%)
...
Top-20 send fallback reasons (100.0% of total 14,319,353):
                          send_megamorphic: 4,665,247 (32.6%)
                          send_polymorphic: 3,583,215 (25.0%)
               invokeblock_not_specialized: 2,708,792 (18.9%)
```

After:

```
Top-20 calls to C functions from JIT code (71.2% of total 53,912,606):
  rb_vm_opt_send_without_block: 8,246,170 (15.3%)
                  rb_hash_aref: 5,770,298 (10.7%)
...
Top-20 send fallback reasons (100.0% of total 13,906,776):
                          send_megamorphic: 4,257,919 (30.6%)
                          send_polymorphic: 3,582,188 (25.8%)
               invokeblock_not_specialized: 2,707,310 (19.5%)
```