### PR TITLE
thread_sched: keep io fds registered in epoll with EPOLLONESHOT

### DIFF
--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -92,7 +92,12 @@ static const void *const condattr_monotonic = NULL;
     #define USE_MN_THREADS 0
   #elif HAVE_SYS_EPOLL_H
     #include <sys/epoll.h>
-    #define USE_MN_THREADS 1
+    #ifdef EPOLLONESHOT
+      #define USE_MN_THREADS 1
+    #else
+      // the scheduler arms io fds with EPOLLONESHOT (Linux 2.6.2)
+      #define USE_MN_THREADS 0
+    #endif
   #elif HAVE_SYS_EVENT_H
     #include <sys/event.h>
     #define USE_MN_THREADS 1

--- a/thread_sched.h
+++ b/thread_sched.h
@@ -77,6 +77,9 @@ struct rb_fd_waiters {
     // what its waiters asked for.
     uint32_t armed_flags;
 
+    // epoll only: the fd is in the interest set (kept across oneshot disarms).
+    bool registered;
+
     // Bumped on full disarm.  Events carry the generation they were armed with,
     // so one queued before the fd was disarmed (and reused) is recognised.
     uint32_t generation;

--- a/thread_sched_mn.c
+++ b/thread_sched_mn.c
@@ -1228,11 +1228,14 @@ fd_event_tag(int fd, uint32_t generation)
 
 // Make the backend match `want`.  Returns false if the fd cannot be registered
 // at all (closed, or unsupported by the backend), leaving the entry untouched.
-// The fd's shard lock must be held.
+// The fd's shard lock must be held.  `consumed` says an epoll event for the
+// current arming was just delivered, so EPOLLONESHOT has already disarmed it.
 static bool
-fd_waiters_arm(int fd, struct rb_fd_waiters *e, uint32_t want)
+fd_waiters_arm(int fd, struct rb_fd_waiters *e, uint32_t want, bool consumed)
 {
-    if (want == e->armed_flags) return true;
+    // After a delivery the kernel side is disarmed even when the flags agree,
+    // so a consumed call must fall through to re-arm.
+    if (want == e->armed_flags && !consumed) return true;
 
 #if HAVE_SYS_EVENT_H
     struct kevent ke[2];
@@ -1268,15 +1271,22 @@ fd_waiters_arm(int fd, struct rb_fd_waiters *e, uint32_t want)
     }
 #elif HAVE_SYS_EPOLL_H
     if (want == 0) {
-        if (epoll_ctl(timer_th.event_fd, EPOLL_CTL_DEL, fd, NULL) == -1) {
-            switch (errno) {
-              case EBADF:
-              case ENOENT:
-                // the fd is already closed or gone from the set
-                break;
-              default:
-                perror("epoll_ctl");
-                rb_bug("fd_waiters_arm/epoll_ctl del failed (fd:%d errno:%d)", fd, errno);
+        // A delivered oneshot event has already disarmed the fd; otherwise
+        // disarm by MOD to no events.  Either way the registration stays, so
+        // the next wait is one MOD instead of DEL + ADD.
+        if (!consumed && e->registered) {
+            struct epoll_event off = { .events = 0, .data = { .u64 = 0 } };
+            if (epoll_ctl(timer_th.event_fd, EPOLL_CTL_MOD, fd, &off) == -1) {
+                switch (errno) {
+                  case EBADF:
+                  case ENOENT:
+                    // the fd is already closed or gone from the set
+                    e->registered = false;
+                    break;
+                  default:
+                    perror("epoll_ctl");
+                    rb_bug("fd_waiters_arm/epoll_ctl disarm failed (fd:%d errno:%d)", fd, errno);
+                }
             }
         }
         // Anything epoll_wait already queued for the old arming is stale now.
@@ -1285,7 +1295,7 @@ fd_waiters_arm(int fd, struct rb_fd_waiters *e, uint32_t want)
         return true;
     }
 
-    uint32_t epoll_events = 0;
+    uint32_t epoll_events = EPOLLONESHOT;
     if (want & thread_sched_waiting_io_read)  epoll_events |= EPOLLIN;
     if (want & thread_sched_waiting_io_write) epoll_events |= EPOLLOUT;
 
@@ -1294,7 +1304,7 @@ fd_waiters_arm(int fd, struct rb_fd_waiters *e, uint32_t want)
         .data = { .u64 = fd_event_tag(fd, e->generation) },
     };
 
-    int op = e->armed_flags ? EPOLL_CTL_MOD : EPOLL_CTL_ADD;
+    int op = e->registered ? EPOLL_CTL_MOD : EPOLL_CTL_ADD;
 
     if (epoll_ctl(timer_th.event_fd, op, fd, &event) == -1) {
         switch (errno) {
@@ -1304,6 +1314,7 @@ fd_waiters_arm(int fd, struct rb_fd_waiters *e, uint32_t want)
                 epoll_ctl(timer_th.event_fd, EPOLL_CTL_ADD, fd, &event) == 0) {
                 break;
             }
+            e->registered = false;
             return false;
           case EEXIST:
             // Likewise in the other direction.
@@ -1315,12 +1326,14 @@ fd_waiters_arm(int fd, struct rb_fd_waiters *e, uint32_t want)
           case EBADF:
           case EPERM:
             // closed, or the fd does not support epoll
+            e->registered = false;
             return false;
           default:
             perror("epoll_ctl");
             rb_bug("fd_waiters_arm/epoll_ctl failed (fd:%d op:%d errno:%d)", fd, op, errno);
         }
     }
+    e->registered = true;
 #else
 # error "neither kqueue nor epoll"
 #endif
@@ -1493,7 +1506,7 @@ timer_thread_register_waiting(rb_thread_t *th, int fd, enum thread_sched_waiting
 
             // Arm the union of what this fd's waiters want, so a second waiter
             // on the same fd extends the arming instead of colliding with it.
-            if (!fd_waiters_arm(fd, e, fd_waiters_union(e) | (uint32_t)(flags & FD_WAIT_IO_MASK))) {
+            if (!fd_waiters_arm(fd, e, fd_waiters_union(e) | (uint32_t)(flags & FD_WAIT_IO_MASK), false)) {
                 fd_shard_unlock(fd);
                 return timer_thread_unavailable;
             }
@@ -1573,7 +1586,7 @@ timer_thread_unregister_waiting(rb_thread_t *th, int fd, enum thread_sched_waiti
 
     struct rb_fd_waiters *e = fd_waiters_lookup(fd, false);
     if (e) {
-        fd_waiters_arm(fd, e, fd_waiters_union(e));
+        fd_waiters_arm(fd, e, fd_waiters_union(e), false);
     }
 }
 
@@ -1689,7 +1702,7 @@ timer_thread_wake_fd_waiters(int fd, uint32_t generation, uint32_t wake_flags, i
 
                 // Re-arm for whoever is still waiting on this fd (nothing, if
                 // they all just woke up).
-                fd_waiters_arm(fd, e, fd_waiters_union(e));
+                fd_waiters_arm(fd, e, fd_waiters_union(e), true);
             }
         }
         fd_shard_unlock(fd);


### PR DESCRIPTION
A blocking read used to cost four epoll_ctl per wait cycle: ADD before the wait and DEL after the wake, on both ends of an exchange.  The DEL ran on the timer thread, the one serial resource every io readiness event already passes through.

With EPOLLONESHOT the delivery itself disarms the fd inside the kernel: the post-wake DEL becomes no syscall at all, and the next wait re-arms with one MOD on a registration that persists for the fd's lifetime. A disarm with no delivery (timeout, interrupt) MODs the event mask to zero instead of deleting.  Registration stays level-triggered, so a woken reader is under no obligation to drain the fd; the generation tag already guards against events queued under an old arming, and a stale registration left by close is repaired by the existing ENOENT fallback on the next arm.

Two round trips of a 64-byte socketpair exchange drop from 12 to 10 syscalls (epoll_ctl 4.00 -> 2.00) and the timer thread falls from 97% to 82% of a core.  On master 22e4a75d67, sp4 (16 cores), medians:

  io_intensive (socketpair round trips, 2 Ractors/pair)
     8 pairs   218,839 -> 432,810 rt/s  (+98%)
    64 pairs   276,556 -> 591,171 rt/s  (+114%)
  punicorn (one Ractor per connection, wrk from a second box)
    keepalive c=64      280,678 -> 309,530 rps  (+10%)
    4x memcached/req    59,683 ->  67,082 rps  (+12%)
  SSE probe beside 512 held streams   193,769 -> 205,602 rps (+6%)

Workloads that wait on the timer wheel (sleep), the GVL (cpu), or connection churn are unchanged; so are Ractor creation, GC and plain threads (~50 configurations within +-2%).

make btest and full test-all pass with the feature on, as does btest on a RUBY_DEBUG=1 build, and an adversarial fd close/reuse + cross-thread close + fork-with-live-io stress.  Platforms: epoll only; kqueue keeps its current path (EV_DISPATCH would be the analogue).  EPOLLONESHOT predates every kernel that can build ruby (Linux 2.6.2), and an epoll without it now falls back to USE_MN_THREADS=0 at compile time.