### PR TITLE
ZJIT: Specialize `String#byteslice` with two args

### DIFF
--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -680,6 +680,7 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
         Insn::StringCopy { val, chilled, state } => gen_string_copy(jit, asm, function, *val, opnd!(val), *chilled, &function.frame_state(*state)),
         Insn::StringConcat { strings, state } => gen_string_concat(jit, asm, function, opnds!(strings), &function.frame_state(*state)),
         &Insn::StringGetbyte { string, index } => gen_string_getbyte(asm, opnd!(string), opnd!(index)),
+        Insn::StringByteslice { string, beg, len, state } => gen_string_byteslice(asm, opnd!(string), opnd!(beg), opnd!(len), &function.frame_state(*state)),
         Insn::StringSetbyteFixnum { string, index, value } => gen_string_setbyte_fixnum(asm, opnd!(string), opnd!(index), opnd!(value)),
         Insn::StringAppend { recv, other, state } => gen_string_append(jit, asm, function, opnd!(recv), opnd!(other), &function.frame_state(*state)),
         Insn::StringAppendCodepoint { recv, other, state } => gen_string_append_codepoint(jit, asm, function, opnd!(recv), opnd!(other), &function.frame_state(*state)),
@@ -4217,6 +4218,11 @@ fn gen_string_getbyte(asm: &mut Assembler, string: Opnd, index: Opnd) -> Opnd {
     // Tag the byte
     let byte = asm.lshift(byte, Opnd::UImm(1));
     asm.or(byte, Opnd::UImm(1))
+}
+
+fn gen_string_byteslice(asm: &mut Assembler, string: Opnd, beg: Opnd, len: Opnd, state: &FrameState) -> Opnd {
+    gen_prepare_leaf_call_with_gc(asm, state);
+    asm_ccall!(asm, rb_str_byte_substr, string, beg, len)
 }
 
 fn gen_string_setbyte_fixnum(asm: &mut Assembler, string: Opnd, index: Opnd, value: Opnd) -> Opnd {

--- a/zjit/src/codegen_tests.rs
+++ b/zjit/src/codegen_tests.rs
@@ -4859,6 +4859,25 @@ fn test_array_pop_arg() {
 }
 
 #[test]
+fn test_string_byteslice_basic() {
+    assert_snapshot!(inspect(r#"
+        def test(s, beg, len) = s.byteslice(beg, len)
+        test("hello", 1, 3)
+        test("hello", 1, 3)
+    "#), @r#""ell""#);
+}
+
+#[test]
+fn test_string_byteslice_bignum_arg_falls_back() {
+    assert_snapshot!(inspect(r#"
+        def test(s, beg, len) = s.byteslice(beg, len)
+        fixnum_result = test("hello", 0, 3)
+        bignum_result = test("hello", 0, 2**62)
+        [fixnum_result, bignum_result]
+    "#), @r#"["hel", "hello"]"#);
+}
+
+#[test]
 fn test_new_range_inclusive() {
     assert_snapshot!(inspect("
         def test(a, b) = a..b

--- a/zjit/src/codegen_tests.rs
+++ b/zjit/src/codegen_tests.rs
@@ -4868,6 +4868,16 @@ fn test_string_byteslice_basic() {
 }
 
 #[test]
+fn test_string_byteslice_out_of_range_returns_nil() {
+    assert_snapshot!(inspect(r#"
+        def test(s, beg, len) = s.byteslice(beg, len)
+        test("hello", 1, 3)
+        test("hello", 1, 3)
+        test("hello", 6, 1)
+    "#), @"nil");
+}
+
+#[test]
 fn test_string_byteslice_bignum_arg_falls_back() {
     assert_snapshot!(inspect(r#"
         def test(s, beg, len) = s.byteslice(beg, len)

--- a/zjit/src/codegen_tests.rs
+++ b/zjit/src/codegen_tests.rs
@@ -4878,6 +4878,28 @@ fn test_string_byteslice_out_of_range_returns_nil() {
 }
 
 #[test]
+fn test_string_byteslice_one_arg() {
+    assert_snapshot!(inspect(r#"
+        def test(s, beg) = s.byteslice(beg)
+        test("hello", 1)
+        test("hello", 1)
+    "#), @r#""e""#);
+}
+
+#[test]
+fn test_string_byteslice_three_args_raises() {
+    assert_snapshot!(inspect(r#"
+        def test(s, beg, len, extra)
+          s.byteslice(beg, len, extra)
+        rescue ArgumentError
+          "ArgumentError"
+        end
+        test("hello", 1, 3, 5)
+        test("hello", 1, 3, 5)
+    "#), @r#""ArgumentError""#);
+}
+
+#[test]
 fn test_string_byteslice_bignum_arg_falls_back() {
     assert_snapshot!(inspect(r#"
         def test(s, beg, len) = s.byteslice(beg, len)

--- a/zjit/src/cruby_methods.rs
+++ b/zjit/src/cruby_methods.rs
@@ -221,6 +221,7 @@ pub fn init() -> Annotations {
     annotate!(rb_cString, "size", types::Fixnum, no_gc, leaf, elidable);
     annotate!(rb_cString, "length", types::Fixnum, no_gc, leaf, elidable);
     annotate!(rb_cString, "getbyte", inline_string_getbyte);
+    annotate!(rb_cString, "byteslice", inline_string_byteslice);
     annotate!(rb_cString, "setbyte", inline_string_setbyte);
     annotate!(rb_cString, "empty?", inline_string_empty_p, types::BoolExact, no_gc, leaf, elidable);
     annotate!(rb_cString, "<<", inline_string_append);
@@ -507,6 +508,17 @@ fn inline_string_getbyte(fun: &mut hir::Function, block: hir::BlockId, recv: hir
         return Some(result);
     }
     None
+}
+
+fn inline_string_byteslice(fun: &mut hir::Function, block: hir::BlockId, recv: hir::InsnId, args: &[hir::InsnId], state: hir::InsnId) -> Option<hir::InsnId> {
+    let &[beg, len] = args else { return None; };
+    if fun.likely_a(beg, types::Fixnum, state) && fun.likely_a(len, types::Fixnum, state) {
+        let beg = fun.coerce_to(block, beg, types::Fixnum, state);
+        let len = fun.coerce_to(block, len, types::Fixnum, state);
+        Some(fun.push_insn(block, hir::Insn::StringByteslice { string: recv, beg, len, state }))
+    } else {
+        None
+    }
 }
 
 fn inline_string_setbyte(fun: &mut hir::Function, block: hir::BlockId, recv: hir::InsnId, args: &[hir::InsnId], state: hir::InsnId) -> Option<hir::InsnId> {

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -1010,6 +1010,8 @@ pub enum Insn {
     StringConcat { strings: Vec<InsnId>, state: InsnId },
     /// Call rb_str_getbyte with known-Fixnum index
     StringGetbyte { string: InsnId, index: InsnId },
+    /// Call rb_str_byte_substr with known-Fixnum beg/len
+    StringByteslice { string: InsnId, beg: InsnId, len: InsnId, state: InsnId },
     StringSetbyteFixnum { string: InsnId, index: InsnId, value: InsnId },
     StringAppend { recv: InsnId, other: InsnId, state: InsnId },
     StringAppendCodepoint { recv: InsnId, other: InsnId, state: InsnId },
@@ -1430,6 +1432,12 @@ macro_rules! for_each_operand_impl {
                 $visit_one!(*string);
                 $visit_one!(*index);
             }
+            Insn::StringByteslice { string, beg, len, state } => {
+                $visit_one!(*string);
+                $visit_one!(*beg);
+                $visit_one!(*len);
+                $visit_one!(*state);
+            }
             Insn::StringSetbyteFixnum { string, index, value } => {
                 $visit_one!(*string);
                 $visit_one!(*index);
@@ -1756,6 +1764,7 @@ impl Insn {
             Insn::StringIntern { .. } => effects::Any,
             Insn::StringConcat { .. } => effects::Any,
             Insn::StringGetbyte { .. } => Effect::read_write(abstract_heaps::Other, abstract_heaps::Empty),
+            Insn::StringByteslice { .. } => allocates.union(Effect::read(abstract_heaps::Other)),
             Insn::StringSetbyteFixnum { .. } => effects::Any,
             Insn::StringAppend { .. } => effects::Any,
             Insn::StringAppendCodepoint { .. } => effects::Any,
@@ -2150,6 +2159,9 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
             }
             Insn::StringGetbyte { string, index, .. } => {
                 write!(f, "StringGetbyte {string}, {index}")
+            }
+            Insn::StringByteslice { string, beg, len, .. } => {
+                write!(f, "StringByteslice {string}, {beg}, {len}")
             }
             Insn::StringSetbyteFixnum { string, index, value, .. } => {
                 write!(f, "StringSetbyteFixnum {string}, {index}, {value}")
@@ -3629,6 +3641,7 @@ impl Function {
             Insn::StringIntern { .. } => types::Symbol,
             Insn::StringConcat { .. } => types::StringExact,
             Insn::StringGetbyte { .. } => types::Fixnum,
+            Insn::StringByteslice { .. } => types::StringExact.union(types::NilClass),
             Insn::StringSetbyteFixnum { .. } => types::Fixnum,
             Insn::StringAppend { .. } => types::StringExact,
             Insn::StringAppendCodepoint { .. } => types::StringExact,
@@ -8011,6 +8024,11 @@ impl Function {
             Insn::StringGetbyte { string, index } => {
                 self.assert_subtype(insn_id, string, types::String)?;
                 self.assert_subtype(insn_id, index, types::CInt64)
+            },
+            Insn::StringByteslice { string, beg, len, .. } => {
+                self.assert_subtype(insn_id, string, types::String)?;
+                self.assert_subtype(insn_id, beg, types::Fixnum)?;
+                self.assert_subtype(insn_id, len, types::Fixnum)
             },
             Insn::StringSetbyteFixnum { string, index, value } => {
                 self.assert_subtype(insn_id, string, types::String)?;

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -13088,7 +13088,7 @@ mod hir_opt_tests {
     }
 
     #[test]
-    fn test_no_optimize_string_byteslice_non_fixnum() {
+    fn test_do_not_optimize_string_byteslice_non_fixnum() {
         eval(r#"
             def test(s, beg, len) = s.byteslice(beg, len)
             test("foo", 0.0, 1.0)
@@ -13117,6 +13117,76 @@ mod hir_opt_tests {
           v33:BasicObject = CCallVariadic v32, :String#byteslice@0x1040, v15, v16
           CheckInterrupts
           Return v33
+        ");
+    }
+
+    #[test]
+    fn test_do_not_optimize_string_byteslice_one_arg() {
+        eval(r#"
+            def test(s, beg) = s.byteslice(beg)
+            test("foo", 0)
+        "#);
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:2:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          v2:CPtr = LoadSP
+          v3:BasicObject = LoadField v2, :s@0x1000
+          v4:BasicObject = LoadField v2, :beg@0x1001
+          Jump bb3(v1, v3, v4)
+        bb2():
+          EntryPoint JIT(0)
+          v7:BasicObject = LoadArg :self@0
+          v8:BasicObject = LoadArg :s@1
+          v9:BasicObject = LoadArg :beg@2
+          Jump bb3(v7, v8, v9)
+        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          PatchPoint NoSingletonClass(String@0x1008)
+          PatchPoint MethodRedefined(String@0x1008, byteslice@0x1010, cme:0x1018)
+          v28:StringExact = GuardType v12, StringExact recompile
+          v29:BasicObject = CCallVariadic v28, :String#byteslice@0x1040, v13
+          CheckInterrupts
+          Return v29
+        ");
+    }
+
+    #[test]
+    fn test_do_not_optimize_string_byteslice_three_args() {
+        eval(r#"
+            def test(s, beg, len, extra)
+              s.byteslice(beg, len, extra)
+            rescue ArgumentError
+              nil
+            end
+            test("foo", 0, 1, 2)
+        "#);
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:3:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          v2:CPtr = LoadSP
+          v3:BasicObject = LoadField v2, :s@0x1000
+          v4:BasicObject = LoadField v2, :beg@0x1001
+          v5:BasicObject = LoadField v2, :len@0x1002
+          v6:BasicObject = LoadField v2, :extra@0x1003
+          Jump bb3(v1, v3, v4, v5, v6)
+        bb2():
+          EntryPoint JIT(0)
+          v9:BasicObject = LoadArg :self@0
+          v10:BasicObject = LoadArg :s@1
+          v11:BasicObject = LoadArg :beg@2
+          v12:BasicObject = LoadArg :len@3
+          v13:BasicObject = LoadArg :extra@4
+          Jump bb3(v9, v10, v11, v12, v13)
+        bb3(v15:BasicObject, v16:BasicObject, v17:BasicObject, v18:BasicObject, v19:BasicObject):
+          PatchPoint NoSingletonClass(String@0x1008)
+          PatchPoint MethodRedefined(String@0x1008, byteslice@0x1010, cme:0x1018)
+          v37:StringExact = GuardType v16, StringExact recompile
+          v38:BasicObject = CCallVariadic v37, :String#byteslice@0x1040, v17, v18, v19
+          CheckInterrupts
+          Return v38
         ");
     }
 

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -13053,6 +13053,74 @@ mod hir_opt_tests {
     }
 
     #[test]
+    fn test_optimize_string_byteslice_fixnum() {
+        eval(r#"
+            def test(s, beg, len) = s.byteslice(beg, len)
+            test("foo", 0, 1)
+        "#);
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:2:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          v2:CPtr = LoadSP
+          v3:BasicObject = LoadField v2, :s@0x1000
+          v4:BasicObject = LoadField v2, :beg@0x1001
+          v5:BasicObject = LoadField v2, :len@0x1002
+          Jump bb3(v1, v3, v4, v5)
+        bb2():
+          EntryPoint JIT(0)
+          v8:BasicObject = LoadArg :self@0
+          v9:BasicObject = LoadArg :s@1
+          v10:BasicObject = LoadArg :beg@2
+          v11:BasicObject = LoadArg :len@3
+          Jump bb3(v8, v9, v10, v11)
+        bb3(v13:BasicObject, v14:BasicObject, v15:BasicObject, v16:BasicObject):
+          PatchPoint NoSingletonClass(String@0x1008)
+          PatchPoint MethodRedefined(String@0x1008, byteslice@0x1010, cme:0x1018)
+          v32:StringExact = GuardType v14, StringExact recompile
+          v33:Fixnum = GuardType v15, Fixnum
+          v34:Fixnum = GuardType v16, Fixnum
+          v35:StringExact|NilClass = StringByteslice v32, v33, v34
+          CheckInterrupts
+          Return v35
+        ");
+    }
+
+    #[test]
+    fn test_no_optimize_string_byteslice_non_fixnum() {
+        eval(r#"
+            def test(s, beg, len) = s.byteslice(beg, len)
+            test("foo", 0.0, 1.0)
+        "#);
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:2:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          v2:CPtr = LoadSP
+          v3:BasicObject = LoadField v2, :s@0x1000
+          v4:BasicObject = LoadField v2, :beg@0x1001
+          v5:BasicObject = LoadField v2, :len@0x1002
+          Jump bb3(v1, v3, v4, v5)
+        bb2():
+          EntryPoint JIT(0)
+          v8:BasicObject = LoadArg :self@0
+          v9:BasicObject = LoadArg :s@1
+          v10:BasicObject = LoadArg :beg@2
+          v11:BasicObject = LoadArg :len@3
+          Jump bb3(v8, v9, v10, v11)
+        bb3(v13:BasicObject, v14:BasicObject, v15:BasicObject, v16:BasicObject):
+          PatchPoint NoSingletonClass(String@0x1008)
+          PatchPoint MethodRedefined(String@0x1008, byteslice@0x1010, cme:0x1018)
+          v32:StringExact = GuardType v14, StringExact recompile
+          v33:BasicObject = CCallVariadic v32, :String#byteslice@0x1040, v15, v16
+          CheckInterrupts
+          Return v33
+        ");
+    }
+
+    #[test]
     fn test_elide_string_getbyte_fixnum() {
         eval(r#"
             def test(s, i)

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -13121,6 +13121,45 @@ mod hir_opt_tests {
     }
 
     #[test]
+    fn test_string_byteslice_result_may_be_nil() {
+        eval(r#"
+            def test(s, beg, len) = s.byteslice(beg, len).length
+            test("foo", 0, 1)
+        "#);
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:2:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          v2:CPtr = LoadSP
+          v3:BasicObject = LoadField v2, :s@0x1000
+          v4:BasicObject = LoadField v2, :beg@0x1001
+          v5:BasicObject = LoadField v2, :len@0x1002
+          Jump bb3(v1, v3, v4, v5)
+        bb2():
+          EntryPoint JIT(0)
+          v8:BasicObject = LoadArg :self@0
+          v9:BasicObject = LoadArg :s@1
+          v10:BasicObject = LoadArg :beg@2
+          v11:BasicObject = LoadArg :len@3
+          Jump bb3(v8, v9, v10, v11)
+        bb3(v13:BasicObject, v14:BasicObject, v15:BasicObject, v16:BasicObject):
+          PatchPoint NoSingletonClass(String@0x1008)
+          PatchPoint MethodRedefined(String@0x1008, byteslice@0x1010, cme:0x1018)
+          v35:StringExact = GuardType v14, StringExact recompile
+          v36:Fixnum = GuardType v15, Fixnum
+          v37:Fixnum = GuardType v16, Fixnum
+          v38:StringExact|NilClass = StringByteslice v35, v36, v37
+          PatchPoint NoSingletonClass(String@0x1008)
+          PatchPoint MethodRedefined(String@0x1008, length@0x1040, cme:0x1048)
+          v42:StringExact = GuardType v38, StringExact recompile
+          v43:Fixnum = CCall v42, :String#length@0x1070
+          CheckInterrupts
+          Return v43
+        ");
+    }
+
+    #[test]
     fn test_elide_string_getbyte_fixnum() {
         eval(r#"
             def test(s, i)


### PR DESCRIPTION
## What
When the receiver is a `String` and both arguments are likely `Fixnum`, the annotation now emits a new `StringByteslice` HIR instruction that calls `rb_str_byte_substr` directly, instead of going through `CCallVariadic`.

Any other shape, one argument, a Range, or non-Fixnum arguments, keeps using CCallVariadic.

https://github.com/Shopify/ruby/issues/1036

## Bench
Measured with ruby-bench in a Docker container (aarch64-linux, --zjit), comparing master vs. this branch.
The median of 10 runs shows a consistent ~2% speedup on protoboeuf and no change on protoboeuf-encode.

```
$ ruby run_benchmarks.rb protoboeuf protoboeuf-encode \
    --chruby 'before --zjit;after --zjit'

before: ruby 4.1.0dev (2026-08-30T06:52:45Z master a889da909c) +ZJIT +PRISM [aarch64-linux]
after: ruby 4.1.0dev (2026-08-30T15:09:42Z zjit-specialize-string-byteslice-two-args 06a0bcd6fd) +ZJIT +PRISM [aarch64-linux]

-----------------  -----------  -----------  -------------  ------------
bench              before (ms)   after (ms)  after 1st itr  before/after
protoboeuf         11.5 ± 2.2%  11.1 ± 2.0%          1.022         1.035
protoboeuf-encode  13.2 ± 9.4%  13.3 ± 9.3%          0.993         0.986
-----------------  -----------  -----------  -------------  ------------
```