### PR TITLE
Fix use-after-free of the fallback string in String#encode

### DIFF
--- a/test/ruby/test_transcode.rb
+++ b/test/ruby/test_transcode.rb
@@ -2232,6 +2232,16 @@ class TestTranscode < Test::Unit::TestCase
     assert_equal("U+3042", "\u{3042}".encode("US-ASCII", fallback: fallback))
   end
 
+  def test_fallback_grow_insert_buffer
+    # A later fallback insertion larger than the first one's buffer grows it
+    # in rb_econv_insert_output; the sized realloc there passed a wrong old
+    # size (caught by RUBY_DEBUG builds).
+    n = 0
+    r = "\u{3042}\u{3044}\u{3046}".encode("US-ASCII",
+          fallback: proc {|x| n += 1; "Y" * (5000 * n)})
+    assert_equal(30000, r.bytesize)
+  end
+
   def test_fallback_method
     def (fallback = "U+%.4X").escape(x)
       self % x.unpack("U")

--- a/transcode.c
+++ b/transcode.c
@@ -1712,7 +1712,7 @@ rb_econv_insert_output(rb_econv_t *ec,
             size_t s = (*data_end_p - *buf_start_p) + need;
             if (s < need)
                 goto fail;
-            buf = ruby_xrealloc_sized(*buf_start_p, s, buf_end_p - buf_start_p);
+            buf = ruby_xrealloc_sized(*buf_start_p, s, *buf_end_p - *buf_start_p);
             *data_start_p = buf;
             *data_end_p = buf + (*data_end_p - *buf_start_p);
             *buf_start_p = buf;

--- a/transcode.c
+++ b/transcode.c
@@ -2439,6 +2439,7 @@ transcode_loop(const unsigned char **in_pos, unsigned char **out_pos,
         if (!UNDEF_P(rep) && !NIL_P(rep)) {
             ret = rb_econv_insert_output(ec, (const unsigned char *)RSTRING_PTR(rep),
                     RSTRING_LEN(rep), rb_enc_name(rb_enc_get(rep)));
+            RB_GC_GUARD(rep); // insert_output may GC while reading rep's bytes
             if ((int)ret == -1) {
                 rb_econv_close(ec);
                 rb_raise(rb_eArgError, "too big fallback string");


### PR DESCRIPTION
`transcode_loop()` passes the fallback result to `rb_econv_insert_output()` as a bare pointer and length. Nothing roots the string during that call: `args.rep` still holds the pre-fallback error-bytes string, and with clang -O3 the VALUE itself lives in no stack slot the conservative scan can see -- only the raw data pointer survives in a register, and for an embedded string that is an interior pointer the scanner rejects.

`rb_econv_insert_output()` can run a GC: when the fallback string's encoding differs from the converter's insert encoding it calls `allocate_converted_string()`, which opens a fresh econv and allocates the destination buffer. For the common "encode to US-ASCII with a fallback" case the insert encoding is the destination encoding, so this sub-conversion runs on every fallback insertion. The fallback string is then swept mid-call and the sub-conversion reads its freed bytes.

On an ASAN build this reports use-after-poison at the 1-byte input read in `transcode_restartable0()`:

    ==ERROR: AddressSanitizer: use-after-poison ... READ of size 1
    #0 transcode_restartable0 transcode.c:592:36
    ...
    #7 allocate_converted_string
    #8 rb_econv_insert_output transcode.c:1655
    #9 transcode_loop transcode.c:2440

CI hit it about once in two hundred runs of `test_fallback_proc` (http://ci.rvm.jp/results/trunk_asan@ruby-sp2/6453938); `GC.stress` reproduces it within a few hundred iterations on a clang -O3 ASAN build:

```ruby
GC.stress = true
fallback = proc {|x| "U+%.4X" % x.unpack("U")}
300.times { "\u{3042}".encode("US-ASCII", fallback: fallback) }
```

The pattern predates the recent fallback refactoring (it goes back to when fallback: was introduced); gcc happens to keep the VALUE in a scanned stack slot, which is why only the clang ASAN CI sees it. With RB_GC_GUARD(rep) the same loop is clean, as are the reproducer under stress, a 3-thread variant, and the full test_transcode suite.

The second commit fixes an unrelated bug found in the same function: the buffer-growing path passed buf_end_p - buf_start_p -- the distance between two local pointer variables, a constant 3 -- to ruby_xrealloc_sized() as the old size, instead of *buf_end_p - *buf_start_p. A RUBY_DEBUG build catches this immediately (VERIFY_FREE_SIZE):

[BUG] buffer realloced with old_size=3, but was allocated with size=4096
but no existing test reached the path: it needs a second fallback insertion into the same econv that outgrows the buffer the first one allocated exactly. On glibc the wrong value is masked by malloc_usable_size; elsewhere it only skews malloc accounting. The commit adds a test that exercises the growth path (which crashes a RUBY_DEBUG build without the fix).