### PR TITLE
Drop the simplecov 0.x leftovers from the coverage tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,12 +88,10 @@ lcov*.info
 /config.status
 /config.status.lineno
 /configure
-/coverage/simplecov
-/coverage/simplecov-html
-/coverage/doclie
 /coverage/.last_run.json
+/coverage/.report_stamp
 /coverage/.resultset.json*
-/coverage/assets
+/coverage/coverage.json
 /coverage/index.html
 /doc/capi
 /enc.mk

--- a/common.mk
+++ b/common.mk
@@ -1537,7 +1537,7 @@ update-config_files: PHONY
 
 update-coverage: main PHONY
 	$(XRUBY) -C "$(srcdir)" bin/gem install --no-document \
-		--install-dir .bundle --conservative "simplecov"
+		--install-dir .bundle --conservative "simplecov" -v "~> 1.1"
 
 refresh-gems: update-bundled_gems prepare-gems
 # can't recall exactly, but `make` somewhere (not GNU or nmake)

--- a/coverage/README
+++ b/coverage/README
@@ -13,5 +13,4 @@ Limitation
 
 TODO
 
- * more reduce bundled simplecov(additional configuration, formatter, etc.)
  * measure rubyspec coverage

--- a/tool/test-coverage.rb
+++ b/tool/test-coverage.rb
@@ -72,11 +72,8 @@ def save_coverage_data(res1)
 end
 
 def invoke_simplecov_formatter
-  # XXX docile-x.y.z and simplecov-x.y.z, simplecov-html-x.y.z, simplecov_json_formatter-x.y.z
-  %w[simplecov simplecov-html simplecov_json_formatter docile].each do |f|
-    Dir.glob("#{__dir__}/../.bundle/gems/#{f}-*/lib").each do |d|
-      $LOAD_PATH.unshift d
-    end
+  Dir.glob("#{__dir__}/../.bundle/gems/simplecov-*/lib").each do |d|
+    $LOAD_PATH.unshift d
   end
 
   require "simplecov"


### PR DESCRIPTION
`tool/test-coverage.rb` puts `simplecov-html`, `simplecov_json_formatter` and `docile` from `.bundle/gems` on the load path. simplecov 1.1 ships both formatters inside the gem and declares no runtime dependencies, so those globs match nothing. `make update-coverage` now pins `~> 1.1` to match `tool/bundler/dev_gems.rb`, since `--conservative` would otherwise keep a `.bundle` holding 0.x, which still needs `docile` on the load path and would stop loading once the glob is gone.

The ignored artifacts move with the same release. A 1.x HTML report is a self-contained `index.html` plus `coverage.json` and `.report_stamp`, with no `assets` directory. The `simplecov`, `simplecov-html` and `doclie` entries go back to when `update-coverage` cloned the gem into `coverage/`.

I checked that the report still generates with `GEM_HOME` pointed at an empty directory, so simplecov resolved through the `.bundle` glob alone.
