### PR TITLE
Mark stdio global variables as box-dynamic

### DIFF
--- a/io.c
+++ b/io.c
@@ -15930,6 +15930,11 @@ Init_IO(void)
     rb_gvar_ractor_local("$>");
     rb_gvar_ractor_local("$stderr");
 
+    rb_gvar_box_dynamic("$stdin");
+    rb_gvar_box_dynamic("$stdout");
+    rb_gvar_box_dynamic("$>");
+    rb_gvar_box_dynamic("$stderr");
+
     rb_global_variable(&rb_stdin);
     rb_stdin  = rb_io_prep_stdin();
     rb_global_variable(&rb_stdout);

--- a/test/ruby/test_box.rb
+++ b/test/ruby/test_box.rb
@@ -710,6 +710,39 @@ class TestBox < Test::Unit::TestCase
     end;
   end
 
+  def test_stdio_gvar_reassignment_seen_by_kernel_methods
+    assert_separately([ENV_ENABLE_BOX], __FILE__, __LINE__, "#{<<~"begin;"}\n#{<<~'end;'}", ignore_stderr: true)
+    begin;
+      require "stringio"
+      orig_stdout, orig_stderr = $stdout, $stderr
+      $stdout, $stderr = StringIO.new, StringIO.new
+      puts "standard out"
+      warn "standard err"
+      out, err = $stdout.string, $stderr.string
+      $stdout, $stderr = orig_stdout, orig_stderr
+      assert_equal "standard out\n", out
+      assert_equal "standard err\n", err
+    end;
+  end
+
+  def test_stdio_gvar_reassignment_in_box_seen_by_kernel_methods
+    assert_separately([ENV_ENABLE_BOX], __FILE__, __LINE__, "#{<<~"begin;"}\n#{<<~'end;'}", ignore_stderr: true)
+    begin;
+      out, err = Ruby::Box.new.eval(<<~'CODE')
+        require "stringio"
+        orig_stdout, orig_stderr = $stdout, $stderr
+        $stdout, $stderr = StringIO.new, StringIO.new
+        puts "standard out"
+        warn "standard err"
+        result = [$stdout.string, $stderr.string]
+        $stdout, $stderr = orig_stdout, orig_stderr
+        result
+      CODE
+      assert_equal "standard out\n", out
+      assert_equal "standard err\n", err
+    end;
+  end
+
   def test_errinfo_isolated_between_boxes
     assert_separately([ENV_ENABLE_BOX], __FILE__, __LINE__, "#{<<~"begin;"}\n#{<<~'end;'}", ignore_stderr: true)
     begin;


### PR DESCRIPTION
With `RUBY_BOX=1`, `Kernel#puts` and `Kernel#warn` keep writing to the original streams after `$stdout` / `$stderr` are reassigned, so `capture_io`-style helpers in test-unit and minitest capture nothing. This breaks large parts of the RubyGems test suite under Box: 26 failures in `ruby/rubygems` master, including all of `TestGemDeprecate` and the `Kernel#warn` tests in `TestGemRequire`.

`$stdin`, `$stdout`, `$>`, and `$stderr` live in ractor-local storage that the C implementations of these methods read directly, while assignments in a box only go into the Box `gvar_tbl` cache and never reach the real setter. Marking them box-dynamic bypasses the cache so the setter updates the ractor-local value, the same approach already used for `$_` (f89b07ef0046), `$~`, and `$!`/`$@`.

Fixes [Bug #21867]. Since this changes Box gvar semantics for stdio, I'd like @tagomoris to review.
