### PR TITLE
Make Ruby::Box extension loading survive fork

### DIFF
--- a/box.c
+++ b/box.c
@@ -54,6 +54,7 @@ static bool tmp_dir_has_dirsep;
 
 /* process-private 0700 directory for box-local copies of extensions */
 static char box_ext_tmp_dir[MAXPATHLEN];
+static rb_pid_t box_ext_tmp_dir_owner;
 static unsigned long box_ext_seq;
 
 #define BOX_TMP_PREFIX "_ruby_box_"
@@ -574,6 +575,13 @@ system_tmpdir(void)
 static void
 ensure_box_ext_tmp_dir(void)
 {
+    /* A forked child inherits the parent's directory path; discard it so
+     * that each process creates its own directory and removes only that
+     * one at teardown. */
+    if (box_ext_tmp_dir[0] && box_ext_tmp_dir_owner != getpid()) {
+        box_ext_tmp_dir[0] = '\0';
+        box_ext_seq = 0;
+    }
     if (box_ext_tmp_dir[0]) return;
 
     int last_errno = 0;
@@ -592,6 +600,7 @@ ensure_box_ext_tmp_dir(void)
         }
         if (mkdir(path, 0700) == 0) {
             strlcpy(box_ext_tmp_dir, path, sizeof(box_ext_tmp_dir));
+            box_ext_tmp_dir_owner = getpid();
             return;
         }
         last_errno = errno;
@@ -852,7 +861,7 @@ rb_box_unload_local_extensions(void)
         ext = next;
     }
 #endif
-    if (box_ext_tmp_dir[0]) {
+    if (box_ext_tmp_dir[0] && box_ext_tmp_dir_owner == getpid()) {
         rmdir(box_ext_tmp_dir);
         box_ext_tmp_dir[0] = '\0';
     }

--- a/test/ruby/test_box.rb
+++ b/test/ruby/test_box.rb
@@ -1301,6 +1301,18 @@ class TestBox < Test::Unit::TestCase
     end
   end
 
+  def test_extension_loading_survives_fork_in_user_box
+    omit "fork is not supported" unless Process.respond_to?(:fork)
+
+    assert_ruby_status([ENV_ENABLE_BOX], "#{<<~"begin;"}\n#{<<~'end;'}")
+    begin;
+      Ruby::Box.new.require "digest/md5"
+      pid = fork {Ruby::Box.new.require "digest/sha2"}
+      raise "extension loading failed in the child" unless Process.wait2(pid)[1].success?
+      Ruby::Box.new.require "digest/sha2"
+    end;
+  end
+
   def test_root_box_iclasses_should_be_boxable
     assert_separately([ENV_ENABLE_BOX], __FILE__, __LINE__, "#{<<~"begin;"}\n#{<<~'end;'}", ignore_stderr: true)
     begin;


### PR DESCRIPTION
Box-local extension loading does not work in processes that fork. The process-private directory holding the extension copies (104c0f06dd32) is cached in the static `box_ext_tmp_dir`, which a forked child inherits. When the child exits, its VM teardown removes the directory the parent still owns, so every later box-local extension require in the parent fails with `LoadError: can't prepare the extension file for Ruby Box (...): can't open the file to write`. A child that loads extensions itself is broken too: it reuses the parent's directory name and sequence counter.

```ruby
# RUBY_BOX=1 ruby repro.rb
box = Ruby::Box.new
box.require "digest/md5"

pid = fork {}
Process.wait(pid)

Ruby::Box.new.require "digest/sha2" # LoadError
```

Record the pid that created the directory, remove it at teardown only in that process, and discard the inherited path after fork so each process creates its own directory. This fixes `bundler/inline` under RUBY_BOX=1, which forks to run the install: 25 examples of bundler's spec/runtime/inline_spec.rb fail without this change.
