### PR TITLE
Do not cache $VERBOSE and $DEBUG in the box gvar table

### DIFF
--- a/ruby.c
+++ b/ruby.c
@@ -3202,6 +3202,15 @@ ruby_prog_init(void)
     rb_gvar_ractor_local("$DEBUG");
     rb_gvar_ractor_local("$-d");
 
+    // Stored in the ractor, not per box, so a box-local copy would only drift
+    // away from the flag the interpreter actually reads.
+    rb_gvar_box_dynamic("$VERBOSE");
+    rb_gvar_box_dynamic("$-v");
+    rb_gvar_box_dynamic("$-w");
+    rb_gvar_box_ready("$-W");
+    rb_gvar_box_dynamic("$DEBUG");
+    rb_gvar_box_dynamic("$-d");
+
     rb_define_hooked_variable("$0", &rb_progname, 0, set_arg0);
     rb_define_hooked_variable("$PROGRAM_NAME", &rb_progname, 0, set_arg0);
 

--- a/test/ruby/test_box.rb
+++ b/test/ruby/test_box.rb
@@ -866,7 +866,7 @@ class TestBox < Test::Unit::TestCase
   end
 
   def test_verbose_nil_silences_warnings_in_box
-    assert_in_out_err([ENV_ENABLE_BOX, "--disable=gems"], "#{<<-"begin;"}\n#{<<-'end;'}") do |output, error|
+    assert_in_out_err([ENV_ENABLE_BOX, "--disable=gems", "-W:experimental"], "#{<<-"begin;"}\n#{<<-'end;'}") do |output, error|
       begin;
         old, $VERBOSE = $VERBOSE, nil
         warn "silenced"

--- a/test/ruby/test_box.rb
+++ b/test/ruby/test_box.rb
@@ -839,6 +839,58 @@ class TestBox < Test::Unit::TestCase
     end;
   end
 
+  # [Bug #22282]
+  def test_verbose_not_cached_in_box
+    assert_separately([ENV_ENABLE_BOX], __FILE__, __LINE__, "#{<<~"begin;"}\n#{<<~'end;'}", ignore_stderr: true)
+    begin;
+      $VERBOSE = nil
+      assert_equal [nil, nil, nil, 0], [$VERBOSE, $-v, $-w, $-W]
+
+      $VERBOSE = false
+      assert_equal [false, false, false, 1], [$VERBOSE, $-v, $-w, $-W]
+
+      $VERBOSE = true
+      assert_equal [true, true, true, 2], [$VERBOSE, $-v, $-w, $-W]
+    end;
+  end
+
+  def test_debug_not_cached_in_box
+    assert_separately([ENV_ENABLE_BOX], __FILE__, __LINE__, "#{<<~"begin;"}\n#{<<~'end;'}", ignore_stderr: true)
+    begin;
+      $DEBUG = true
+      assert_equal [true, true], [$DEBUG, $-d]
+
+      $DEBUG = false
+      assert_equal [false, false], [$DEBUG, $-d]
+    end;
+  end
+
+  def test_verbose_nil_silences_warnings_in_box
+    assert_in_out_err([ENV_ENABLE_BOX, "--disable=gems"], "#{<<-"begin;"}\n#{<<-'end;'}") do |output, error|
+      begin;
+        old, $VERBOSE = $VERBOSE, nil
+        warn "silenced"
+        $VERBOSE = old
+        warn "printed"
+      end;
+      assert_equal [], output
+      assert_match EXPERIMENTAL_WARNING_LINE_PATTERNS[0], error[0]
+      assert_match EXPERIMENTAL_WARNING_LINE_PATTERNS[1], error[1]
+      assert_equal ["printed"], error[2..]
+    end
+  end
+
+  def test_verbose_from_command_line_option_in_box
+    assert_in_out_err([ENV_ENABLE_BOX, "--disable=gems", "-W0"], "#{<<-"begin;"}\n#{<<-'end;'}") do |output, error|
+      begin;
+        p [$VERBOSE, $-v, $-W]
+        warn "silenced"
+      end;
+      assert_equal ["[nil, nil, 0]"], output
+      assert_equal [], error
+    end
+  end
+
   def test_load_path_and_loaded_features
     setup_box
 


### PR DESCRIPTION
Under `RUBY_BOX=1`, assigning to `$VERBOSE` or `$DEBUG` has no effect. `gvar_use_box_tbl()` routes the write into the box-local gvar table because neither is marked `box_ready` nor `box_dynamic`, so `verbose_setter`/`debug_setter` never run. Reading `$VERBOSE` then returns the box-local copy while `$-v`, `$-w`, `$-W` and `$-d` return the unchanged flag, and warnings are neither silenced nor enabled. This silently breaks the `old, $VERBOSE = $VERBOSE, nil; ...; $VERBOSE = old` idiom used across RubyGems, Bundler, Rails and many test suites.

Both flags live in the ractor (`rb_ruby_verbose_ptr()` / `rb_ruby_debug_ptr()`), not in the box, so a box-local copy can only drift away from the flag the interpreter actually reads. I marked the five writable ones `box_dynamic`, and `$-W` `box_ready` following 8ad6baa0174, since its setter is `rb_gvar_readonly_setter` and that is the case `gvar_use_box_tbl()` already short-circuits.

One design point for @tagomoris: this makes `$VERBOSE` shared across boxes rather than per box. Per-box verbosity is defensible in itself, but it cannot be built on the current storage. Tell me if you would rather go that way.

Reproduced on master and on released 4.0.6, so 4.0 is a backport candidate. Found while running the RubyGems and Bundler suites under `RUBY_BOX=1`, tracked at https://bugs.ruby-lang.org/issues/22275.

Fixes https://bugs.ruby-lang.org/issues/22282
