### PR TITLE
[Backport #22269] Do not let `Coverage.line_stub` clobber existing coverage data

### DIFF
--- a/ext/coverage/lib/coverage.rb
+++ b/ext/coverage/lib/coverage.rb
@@ -3,7 +3,7 @@ require "coverage.so"
 module Coverage
   def self.line_stub(file)
     lines = File.foreach(file).map { nil }
-    iseqs = [RubyVM::InstructionSequence.compile_file(file)]
+    iseqs = [RubyVM::InstructionSequence.compile_file(file, coverage_enabled: false)]
     until iseqs.empty?
       iseq = iseqs.pop
       iseq.trace_points.each {|n, type| lines[n - 1] = 0 if type == :line }

--- a/iseq.c
+++ b/iseq.c
@@ -1298,7 +1298,7 @@ rb_iseq_compile_with_option(VALUE src, VALUE file, VALUE realpath, VALUE line, V
         rb_exc_raise(GET_EC()->errinfo);
     }
     else {
-        iseq_new_setup_coverage(file, ast_line_count(ast_value));
+        if (option.coverage_enabled) iseq_new_setup_coverage(file, ast_line_count(ast_value));
         iseq = rb_iseq_new_with_opt(ast_value, name, file, realpath, ln,
                                     NULL, 0, ISEQ_TYPE_TOP, &option,
                                     Qnil);
@@ -1333,7 +1333,7 @@ pm_iseq_compile_with_option(VALUE src, VALUE file, VALUE realpath, VALUE line, V
     pm_parse_result_t result = { 0 };
     pm_options_line_set(&result.options, NUM2INT(line));
     pm_options_scopes_init(&result.options, 1);
-    result.node.coverage_enabled = 1;
+    result.node.coverage_enabled = option.coverage_enabled;
 
     switch (option.frozen_string_literal) {
       case ISEQ_FROZEN_STRING_LITERAL_UNSET:
@@ -1363,7 +1363,7 @@ pm_iseq_compile_with_option(VALUE src, VALUE file, VALUE realpath, VALUE line, V
 
     if (error == Qnil) {
         int error_state;
-        iseq_new_setup_coverage(file, (int) (result.node.parser->newline_list.size - 1));
+        if (option.coverage_enabled) iseq_new_setup_coverage(file, (int) (result.node.parser->newline_list.size - 1));
         iseq = pm_iseq_new_with_opt(&result.node, name, file, realpath, ln, NULL, 0, ISEQ_TYPE_TOP, &option, &error_state);
 
         pm_parse_result_free(&result);
@@ -1754,6 +1754,8 @@ iseqw_s_compile_file(int argc, VALUE *argv, VALUE self)
     FilePathValue(file);
     file = rb_fstring(file); /* rb_io_t->pathv gets frozen anyways */
 
+    make_compile_option(&option, opt);
+
     f = rb_file_open_str(file, "r");
 
     rb_execution_context_t *ec = GET_EC();
@@ -1762,7 +1764,7 @@ iseqw_s_compile_file(int argc, VALUE *argv, VALUE self)
     parser = rb_parser_new();
     rb_parser_set_context(parser, NULL, FALSE);
     ast_value = rb_parser_load_file(parser, file);
-    iseq_new_setup_coverage(file, ast_line_count(ast_value));
+    if (option.coverage_enabled) iseq_new_setup_coverage(file, ast_line_count(ast_value));
     ast = rb_ruby_ast_data_get(ast_value);
     if (!ast->body.root) exc = GET_EC()->errinfo;
 
@@ -1771,8 +1773,6 @@ iseqw_s_compile_file(int argc, VALUE *argv, VALUE self)
         rb_ast_dispose(ast);
         rb_exc_raise(exc);
     }
-
-    make_compile_option(&option, opt);
 
     ret = iseqw_new(rb_iseq_new_with_opt(ast_value, rb_fstring_lit("<main>"),
                                          file,
@@ -1830,7 +1830,7 @@ iseqw_s_compile_file_prism(int argc, VALUE *argv, VALUE self)
 
     pm_parse_result_t result = { 0 };
     result.options.line = 1;
-    result.node.coverage_enabled = 1;
+    result.node.coverage_enabled = option.coverage_enabled;
 
     switch (option.frozen_string_literal) {
       case ISEQ_FROZEN_STRING_LITERAL_UNSET:
@@ -1851,7 +1851,7 @@ iseqw_s_compile_file_prism(int argc, VALUE *argv, VALUE self)
 
     if (error == Qnil) {
         int error_state;
-        iseq_new_setup_coverage(file, (int) (result.node.parser->newline_list.size - 1));
+        if (option.coverage_enabled) iseq_new_setup_coverage(file, (int) (result.node.parser->newline_list.size - 1));
         rb_iseq_t *iseq = pm_iseq_new_with_opt(&result.node, rb_fstring_lit("<main>"),
                                                file,
                                                rb_realpath_internal(Qnil, file, 1),

--- a/test/coverage/test_coverage.rb
+++ b/test/coverage/test_coverage.rb
@@ -879,6 +879,35 @@ class TestCoverage < Test::Unit::TestCase
     }
   end
 
+  def test_line_stub_does_not_clobber_existing_coverage
+    Dir.mktmpdir {|tmp|
+      Dir.chdir(tmp) {
+        File.open("test.rb", "w") do |f|
+          f.puts <<-EOS
+            def coverage_test_snapshot
+              :ok
+            end
+          EOS
+        end
+
+        assert_in_out_err(ARGV, <<-"end;", ["[1, 1, nil]", "[1, 1, nil]", "[1, 2, nil]"], [])
+          Coverage.start
+          tmp = Dir.pwd
+          f = tmp + "/test.rb"
+          require f
+          coverage_test_snapshot
+          cov = Coverage.peek_result[f]
+          Coverage.line_stub(f)
+          cov2 = Coverage.peek_result[f]
+          coverage_test_snapshot
+          p cov
+          p cov2
+          p Coverage.result[f]
+        end;
+      }
+    }
+  end
+
   def test_stop_wrong_peephole_optimization
     result = {
       :lines => [1, 1, 1, nil]


### PR DESCRIPTION
Backport of https://bugs.ruby-lang.org/issues/22269 to ruby_3_4.

Original PR: https://github.com/ruby/ruby/pull/18533

---

`Coverage.line_stub` compiles the file with `compile_file` only to read the ISeq's `trace_points`. The `coverage_enabled: false` option has never worked for `compile`/`compile_file`: the coverage-table setup is not gated by the compile option, and the parser-side `coverage_enabled` overrides the user-specified option.

As a result, calling `line_stub` while `Coverage` is running resets the file's already-collected counters.

```ruby
require "coverage"

f = File.expand_path("m.rb")
File.write(f, "def m\n  :ok\nend\n")

Coverage.start
require f
m
p Coverage.peek_result[f]

Coverage.line_stub(f)
p Coverage.peek_result[f]

m
p Coverage.result[f]
```

Before:

```
[1, 1, nil]
[0, 0, nil]
[0, 0, nil]
```

After:

```
[1, 1, nil]
[1, 1, nil]
[1, 2, nil]
```

Fixed by guarding the coverage-table setup with the compile option at the callers and making the Prism paths honor `option.coverage_enabled`, so `line_stub` (which compiles with `coverage_enabled: false`) no longer modifies the running coverage data.
