### PR TITLE
JIT: Use tagged pointers for jit_entry_calls/jit_exception_calls

### DIFF
--- a/jit.c
+++ b/jit.c
@@ -636,12 +636,11 @@ void
 rb_iseq_reset_jit_func(const rb_iseq_t *iseq)
 {
     RUBY_ASSERT_ALWAYS(IMEMO_TYPE_P(iseq, imemo_iseq));
-    ISEQ_BODY(iseq)->jit_entry = NULL;
-    ISEQ_BODY(iseq)->jit_exception = NULL;
-    // Enable re-compiling this ISEQ. Event when it's invalidated for TracePoint,
+    // 0 packs a NULL code pointer with a zeroed call counter, enabling
+    // re-compiling this ISEQ. Even when it's invalidated for TracePoint,
     // we'd like to re-compile ISEQs that haven't been converted to trace_* insns.
-    ISEQ_BODY(iseq)->jit_entry_calls = 0;
-    ISEQ_BODY(iseq)->jit_exception_calls = 0;
+    ISEQ_BODY(iseq)->jit_entry = 0;
+    ISEQ_BODY(iseq)->jit_exception = 0;
 }
 
 // Callback data for rb_jit_for_each_iseq

--- a/vm.c
+++ b/vm.c
@@ -526,16 +526,19 @@ yjit_compile(rb_execution_context_t *ec)
     const rb_iseq_t *iseq = CFP_ISEQ(ec->cfp);
     struct rb_iseq_constant_body *body = ISEQ_BODY(iseq);
 
+    rb_jit_func_t jit_entry = rb_iseq_jit_func(body->jit_entry);
+
     // Increment the ISEQ's call counter and trigger JIT compilation if not compiled.
     // Stop incrementing when not compiling (out of executable memory) so that
     // ISEQs that failed to compile don't keep dirtying CoW pages after fork.
-    if (body->jit_entry == NULL && rb_yjit_compiling_p) {
-        body->jit_entry_calls++;
-        if (rb_yjit_threshold_hit(iseq, body->jit_entry_calls)) {
+    if (jit_entry == NULL && rb_yjit_compiling_p) {
+        body->jit_entry = rb_iseq_jit_increment_calls(body->jit_entry);
+        if (rb_yjit_threshold_hit(iseq, rb_iseq_jit_calls(body->jit_entry))) {
             rb_yjit_compile_iseq(iseq, ec, false);
+            jit_entry = rb_iseq_jit_func(body->jit_entry);
         }
     }
-    return body->jit_entry;
+    return jit_entry;
 }
 #else
 # define yjit_compile(ec) ((rb_jit_func_t)0)
@@ -548,21 +551,25 @@ zjit_compile(rb_execution_context_t *ec)
     const rb_iseq_t *iseq = CFP_ISEQ(ec->cfp);
     struct rb_iseq_constant_body *body = ISEQ_BODY(iseq);
 
-    if (body->jit_entry == NULL && rb_zjit_compiling_p) {
-        body->jit_entry_calls++;
+    rb_jit_func_t jit_entry = rb_iseq_jit_func(body->jit_entry);
+
+    if (jit_entry == NULL && rb_zjit_compiling_p) {
+        body->jit_entry = rb_iseq_jit_increment_calls(body->jit_entry);
+        unsigned long entry_calls = rb_iseq_jit_calls(body->jit_entry);
 
         // At profile-threshold, rewrite some of the YARV instructions
         // to zjit_* instructions to profile these instructions.
-        if (body->jit_entry_calls == rb_zjit_profile_threshold) {
+        if (entry_calls == rb_zjit_profile_threshold) {
             rb_zjit_profile_enable(iseq);
         }
 
         // At call-threshold, compile the ISEQ with ZJIT.
-        if (body->jit_entry_calls == rb_zjit_call_threshold) {
+        if (entry_calls == rb_zjit_call_threshold) {
             rb_zjit_compile_iseq(iseq, ec, false);
+            jit_entry = rb_iseq_jit_func(body->jit_entry);
         }
     }
-    return body->jit_entry;
+    return jit_entry;
 }
 #else
 # define zjit_compile(ec) ((rb_jit_func_t)0)
@@ -608,21 +615,25 @@ jit_compile_exception(rb_execution_context_t *ec)
     const rb_iseq_t *iseq = CFP_ISEQ(ec->cfp);
     struct rb_iseq_constant_body *body = ISEQ_BODY(iseq);
 
+    rb_jit_func_t jit_entry = rb_iseq_jit_func(body->jit_exception);
+
 #if USE_ZJIT
     // rb_zjit_compiling_p is false until ZJIT is enabled, so no
     // rb_zjit_enabled_p check is needed here.
-    if (body->jit_exception == NULL && rb_zjit_compiling_p) {
-        body->jit_exception_calls++;
+    if (jit_entry == NULL && rb_zjit_compiling_p) {
+        body->jit_exception = rb_iseq_jit_increment_calls(body->jit_exception);
+        unsigned long exception_calls = rb_iseq_jit_calls(body->jit_exception);
 
         // At profile-threshold, rewrite some of the YARV instructions
         // to zjit_* instructions to profile these instructions.
-        if (body->jit_exception_calls == rb_zjit_profile_threshold) {
+        if (exception_calls == rb_zjit_profile_threshold) {
             rb_zjit_profile_enable(iseq);
         }
 
         // At call-threshold, compile the ISEQ with ZJIT.
-        if (body->jit_exception_calls == rb_zjit_call_threshold) {
+        if (exception_calls == rb_zjit_call_threshold) {
             rb_zjit_compile_iseq(iseq, ec, true);
+            jit_entry = rb_iseq_jit_func(body->jit_exception);
         }
     }
 #endif
@@ -630,14 +641,15 @@ jit_compile_exception(rb_execution_context_t *ec)
 #if USE_YJIT
     // Increment the ISEQ's call counter and trigger JIT compilation if not compiled.
     // Like the ZJIT branch above, no rb_yjit_enabled_p check is needed here.
-    if (body->jit_exception == NULL && rb_yjit_compiling_p) {
-        body->jit_exception_calls++;
-        if (body->jit_exception_calls == rb_yjit_call_threshold) {
+    if (jit_entry == NULL && rb_yjit_compiling_p) {
+        body->jit_exception = rb_iseq_jit_increment_calls(body->jit_exception);
+        if (rb_iseq_jit_calls(body->jit_exception) == rb_yjit_call_threshold) {
             rb_yjit_compile_iseq(iseq, ec, true);
+            jit_entry = rb_iseq_jit_func(body->jit_exception);
         }
     }
 #endif
-    return body->jit_exception;
+    return jit_entry;
 }
 
 // Execute JIT code compiled by jit_compile_exception()

--- a/vm_core.h
+++ b/vm_core.h
@@ -563,14 +563,14 @@ struct rb_iseq_constant_body {
     const rb_iseq_t *mandatory_only_iseq;
 
 #if USE_YJIT || USE_ZJIT
-    // Function pointer for JIT code on jit_exec()
-    rb_jit_func_t jit_entry;
-    // Number of calls on jit_exec()
-    long unsigned jit_entry_calls;
-    // Function pointer for JIT code on jit_exec_exception()
-    rb_jit_func_t jit_exception;
-    // Number of calls on jit_exec_exception()
-    long unsigned jit_exception_calls;
+    // When ISEQ_JIT_CALLS_TAG bit is set, stores the number of calls on
+    // jit_exec(). Otherwise, stores the function pointer for JIT code on
+    // jit_exec().
+    uintptr_t jit_entry;
+    // When ISEQ_JIT_CALLS_TAG bit is set, stores the number of calls on
+    // jit_exec_exception(). Otherwise, stores the function pointer for JIT
+    // code on jit_exec_exception().
+    uintptr_t jit_exception;
     void *jit_payload;
 #endif
 
@@ -584,6 +584,36 @@ struct rb_iseq_constant_body {
     // 0 never denotes a real hash.
     uint64_t source_hash;
 };
+
+#if USE_YJIT || USE_ZJIT
+#define ISEQ_JIT_CALLS_TAG ((uintptr_t)0x1)
+
+static inline rb_jit_func_t
+rb_iseq_jit_func(uintptr_t tagged)
+{
+    return (tagged & ISEQ_JIT_CALLS_TAG) ? NULL : (rb_jit_func_t)tagged;
+}
+
+static inline unsigned long
+rb_iseq_jit_calls(uintptr_t tagged)
+{
+    return (unsigned long)(tagged >> 1);
+}
+
+static inline uintptr_t
+rb_iseq_jit_increment_calls(uintptr_t tagged)
+{
+    RUBY_ASSERT(!rb_iseq_jit_func(tagged));
+    return ((tagged >> 1) + 1) << 1 | ISEQ_JIT_CALLS_TAG;
+}
+
+static inline uintptr_t
+rb_iseq_jit_pack_func(rb_jit_func_t func)
+{
+    RUBY_ASSERT(((uintptr_t)func & ISEQ_JIT_CALLS_TAG) == 0);
+    return (uintptr_t)func;
+}
+#endif
 
 /* T_IMEMO/iseq */
 /* typedef rb_iseq_t is in method.h */

--- a/yjit.c
+++ b/yjit.c
@@ -368,11 +368,13 @@ rb_yjit_compile_iseq(const rb_iseq_t *iseq, rb_execution_context_t *ec, bool jit
         uint8_t *rb_yjit_iseq_gen_entry_point(const rb_iseq_t *iseq, rb_execution_context_t *ec, bool jit_exception); // defined in Rust
         uintptr_t code_ptr = (uintptr_t)rb_yjit_iseq_gen_entry_point(iseq, ec, jit_exception);
 
-        if (jit_exception) {
-            ISEQ_BODY(iseq)->jit_exception = (rb_jit_func_t)code_ptr;
-        }
-        else {
-            ISEQ_BODY(iseq)->jit_entry = (rb_jit_func_t)code_ptr;
+        if (code_ptr) {
+            if (jit_exception) {
+                ISEQ_BODY(iseq)->jit_exception = rb_iseq_jit_pack_func((rb_jit_func_t)code_ptr);
+            }
+            else {
+                ISEQ_BODY(iseq)->jit_entry = rb_iseq_jit_pack_func((rb_jit_func_t)code_ptr);
+            }
         }
     }
 }

--- a/yjit/src/asm/arm64/mod.rs
+++ b/yjit/src/asm/arm64/mod.rs
@@ -755,6 +755,8 @@ pub fn nop(cb: &mut CodeBlock) {
     cb.write_bytes(&bytes);
 }
 
+pub fn align(_cb: &mut CodeBlock, _alignment: u32) {}
+
 /// ORN - perform a bitwise OR of rn and NOT rm, put the result in rd, don't update flags
 pub fn orn(cb: &mut CodeBlock, rd: A64Opnd, rn: A64Opnd, rm: A64Opnd) {
     let bytes: [u8; 4] = match (rd, rn, rm) {

--- a/yjit/src/asm/mod.rs
+++ b/yjit/src/asm/mod.rs
@@ -18,6 +18,16 @@ pub mod x86_64;
 
 pub mod arm64;
 
+/// Pad the code block with NOPs so the write address is aligned to the given
+/// byte boundary (a no-op on A64, where code is always 4-byte aligned).
+/// ISEQ entry points must be at least 2-byte aligned because the C side packs
+/// a call counter into the least significant bit of the stored entry point
+/// (rb_iseq_jit_pack_func).
+#[cfg(target_arch = "x86_64")]
+pub use x86_64::align;
+#[cfg(target_arch = "aarch64")]
+pub use arm64::align;
+
 //
 // TODO: need a field_size_of macro, to compute the size of a struct field in bytes
 //

--- a/yjit/src/asm/x86_64/mod.rs
+++ b/yjit/src/asm/x86_64/mod.rs
@@ -1170,6 +1170,21 @@ pub fn nop(cb: &mut CodeBlock, length: u32) {
     };
 }
 
+pub fn align(cb: &mut CodeBlock, alignment: u32) {
+    fn padding_for(cb: &CodeBlock, alignment: u32) -> u32 {
+        let alignment = alignment as usize;
+        ((alignment - cb.get_write_ptr().raw_addr(cb) % alignment) % alignment) as u32
+    }
+
+    let mut padding = padding_for(cb, alignment);
+    if padding > 0 && !cb.has_capacity(padding as usize) {
+        let write_ptr = cb.get_write_ptr();
+        let _ = cb.next_page(write_ptr, jmp_ptr);
+        padding = padding_for(cb, alignment);
+    }
+    nop(cb, padding);
+}
+
 /// not - Bitwise NOT
 pub fn not(cb: &mut CodeBlock, opnd: X86Opnd) {
     write_rm_unary(

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -1107,6 +1107,14 @@ pub fn gen_entry_prologue(
     jit_exception: bool,
 ) -> Option<(CodePtr, RegMapping)> {
     let iseq = blockid.iseq;
+
+    // The C side packs a call counter into the least significant bit of the
+    // iseq's entry point (rb_iseq_jit_pack_func), so the entry point must be
+    // at least 2-byte aligned. Variable-length x86_64 instructions can leave
+    // the write position on an odd address, so pad with NOPs (no-op on A64,
+    // where code is always 4-byte aligned).
+    align(cb, 2);
+
     let code_ptr = cb.get_write_ptr();
 
     let mut asm = Assembler::new(unsafe { get_iseq_body_local_table_size(iseq) });

--- a/zjit.c
+++ b/zjit.c
@@ -75,11 +75,13 @@ rb_zjit_compile_iseq(const rb_iseq_t *iseq, rb_execution_context_t *ec, bool jit
         uint8_t *rb_zjit_iseq_gen_entry_point(const rb_iseq_t *iseq, rb_execution_context_t *ec, bool jit_exception); // defined in Rust
         uintptr_t code_ptr = (uintptr_t)rb_zjit_iseq_gen_entry_point(iseq, ec, jit_exception);
 
-        if (jit_exception) {
-            ISEQ_BODY(iseq)->jit_exception = (rb_jit_func_t)code_ptr;
-        }
-        else {
-            ISEQ_BODY(iseq)->jit_entry = (rb_jit_func_t)code_ptr;
+        if (code_ptr) {
+            if (jit_exception) {
+                ISEQ_BODY(iseq)->jit_exception = rb_iseq_jit_pack_func((rb_jit_func_t)code_ptr);
+            }
+            else {
+                ISEQ_BODY(iseq)->jit_entry = rb_iseq_jit_pack_func((rb_jit_func_t)code_ptr);
+            }
         }
     }
 }

--- a/zjit/src/asm/arm64/mod.rs
+++ b/zjit/src/asm/arm64/mod.rs
@@ -829,6 +829,8 @@ pub fn nop(cb: &mut CodeBlock) {
     cb.write_bytes(&bytes);
 }
 
+pub fn align(_cb: &mut CodeBlock, _alignment: u32) {}
+
 /// ORN - perform a bitwise OR of rn and NOT rm, put the result in rd, don't update flags
 pub fn orn(cb: &mut CodeBlock, rd: A64Opnd, rn: A64Opnd, rm: A64Opnd) {
     let bytes: [u8; 4] = match (rd, rn, rm) {

--- a/zjit/src/asm/mod.rs
+++ b/zjit/src/asm/mod.rs
@@ -16,6 +16,16 @@ pub mod x86_64;
 #[cfg(target_arch = "aarch64")]
 pub mod arm64;
 
+/// Pad the code block with NOPs so the write address is aligned to the given
+/// byte boundary (a no-op on A64, where code is always 4-byte aligned).
+/// ISEQ entry points must be at least 2-byte aligned because the C side packs
+/// a call counter into the least significant bit of the stored entry point
+/// (rb_iseq_jit_pack_func).
+#[cfg(target_arch = "x86_64")]
+pub use x86_64::align;
+#[cfg(target_arch = "aarch64")]
+pub use arm64::align;
+
 /// Index to a label created by cb.new_label()
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
 pub struct Label(pub usize);

--- a/zjit/src/asm/x86_64/mod.rs
+++ b/zjit/src/asm/x86_64/mod.rs
@@ -1079,6 +1079,11 @@ pub fn nop(cb: &mut CodeBlock, length: u32) {
     };
 }
 
+pub fn align(cb: &mut CodeBlock, alignment: u32) {
+    let padding = (alignment as usize - cb.get_write_ptr().raw_addr(cb) % alignment as usize) % alignment as usize;
+    nop(cb, padding as u32);
+}
+
 /// not - Bitwise NOT
 pub fn not(cb: &mut CodeBlock, opnd: X86Opnd) {
     write_rm_unary(

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -593,6 +593,13 @@ fn gen_function(cb: &mut CodeBlock, iseq: IseqPtr, version: IseqVersionRef, func
     });
 
     // Generate code if everything can be compiled
+    //
+    // The C side packs a call counter into the least significant bit of the
+    // iseq's entry point (rb_iseq_jit_pack_func), so the compiled code must
+    // start at least 2-byte aligned. Variable-length x86_64 instructions can
+    // leave the write position on an odd address, so pad with NOPs (no-op on
+    // A64, where code is always 4-byte aligned).
+    crate::asm::align(cb, 2);
     let result = asm.compile(cb);
     if let Ok((start_ptr, _)) = result {
         if get_option!(perf) == Some(PerfMap::ISEQ) {
@@ -4271,6 +4278,8 @@ fn gen_compile_error_counter(cb: &mut CodeBlock, compile_error: &CompileError) -
     gen_incr_counter(&mut asm, exit_counter_for_compile_error(compile_error));
     asm.cret(Qundef.into());
 
+    // Keep the entry point address aligned for rb_iseq_jit_pack_func; see gen_function.
+    crate::asm::align(cb, 2);
     asm.compile(cb).map(|(code_ptr, gc_offsets)| {
         assert_eq!(0, gc_offsets.len());
         code_ptr
@@ -4284,6 +4293,8 @@ fn gen_exception_handler_counter(cb: &mut CodeBlock) -> Result<CodePtr, CompileE
     gen_incr_counter(&mut asm, Counter::exit_exception_handler);
     asm.cret(Qundef.into());
 
+    // Keep the entry point address aligned for rb_iseq_jit_pack_func; see gen_function.
+    crate::asm::align(cb, 2);
     asm.compile(cb).map(|(code_ptr, gc_offsets)| {
         assert_eq!(0, gc_offsets.len());
         code_ptr

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -642,12 +642,6 @@ pub const BUILTIN_ATTR_INLINE_BLOCK: rb_builtin_attr = 4;
 pub const BUILTIN_ATTR_C_TRACE: rb_builtin_attr = 8;
 pub const BUILTIN_ATTR_WITHOUT_INTERRUPTS: rb_builtin_attr = 16;
 pub type rb_builtin_attr = u32;
-pub type rb_jit_func_t = ::std::option::Option<
-    unsafe extern "C" fn(
-        arg1: *mut rb_execution_context_struct,
-        arg2: *mut rb_control_frame_struct,
-    ) -> VALUE,
->;
 #[repr(C)]
 pub struct rb_iseq_variable {
     pub flip_count: rb_snum_t,


### PR DESCRIPTION
We either keep track of number of calls in jit_entry_calls/jit_exception_calls or it has already been JIT compiled into jit_entry/jit_exception. Since the usage of these fields are mutually exclusive, we can save 16 bytes in rb_iseq_constant_body by using a tagged pointer in jit_entry/jit_exception to keep track of the number of calls. This commit uses the lowest bit in jit_entry/jit_exception to signal that it stores calls instead of the JIT entry.