### PR TITLE
[Bug #7082] Check exit status of the target process in kill(sig 0)

### DIFF
--- a/test/ruby/test_process.rb
+++ b/test/ruby/test_process.rb
@@ -2461,6 +2461,24 @@ EOS
     assert_equal(th, x, bug11166)
   end if defined?(fork)
 
+  def test_kill_zero_exited_child
+    bug7082 = '[Bug #7082]'
+    assert_equal(1, Process.kill(0, Process.pid), bug7082)
+    IO.popen([RUBY, "-e", "exit"]) do |io|
+      pid = io.pid
+      io.read # wait for the child to exit
+      EnvUtil.timeout(10) do
+        loop do
+          Process.kill(0, pid)
+          sleep 0.01
+        rescue Errno::ESRCH
+          break
+        end
+      end
+      assert_raise(Errno::ESRCH, bug7082) {Process.kill(0, pid)}
+    end
+  end if windows?
+
   def test_exec_fd_3_redirect
     # ensure we can redirect anything to fd=3 in a child process.
     # fd=3 is a commonly reserved FD for the timer thread pipe in the

--- a/win32/win32.c
+++ b/win32/win32.c
@@ -5013,7 +5013,7 @@ kill(rb_pid_t pid, int sig)
       case 0:
         RUBY_CRITICAL {
             HANDLE hProc;
-            struct ChildRecord* child = FindChildSlot(pid);
+            struct ChildRecord *child = FindChildSlot(pid);
             if (child) {
                 hProc = child->hProcess;
             }
@@ -5073,7 +5073,7 @@ kill(rb_pid_t pid, int sig)
       case SIGKILL:
         RUBY_CRITICAL {
             HANDLE hProc;
-            struct ChildRecord* child = FindChildSlot(pid);
+            struct ChildRecord *child = FindChildSlot(pid);
             if (child) {
                 hProc = child->hProcess;
             }

--- a/win32/win32.c
+++ b/win32/win32.c
@@ -5012,8 +5012,14 @@ kill(rb_pid_t pid, int sig)
     switch (sig) {
       case 0:
         RUBY_CRITICAL {
-            HANDLE hProc =
-                OpenProcess(PROCESS_QUERY_INFORMATION, FALSE, (DWORD)pid);
+            HANDLE hProc;
+            struct ChildRecord* child = FindChildSlot(pid);
+            if (child) {
+                hProc = child->hProcess;
+            }
+            else {
+                hProc = OpenProcess(PROCESS_QUERY_INFORMATION, FALSE, (DWORD)pid);
+            }
             if (hProc == NULL || hProc == INVALID_HANDLE_VALUE) {
                 if (GetLastError() == ERROR_INVALID_PARAMETER) {
                     errno = ESRCH;
@@ -5024,7 +5030,24 @@ kill(rb_pid_t pid, int sig)
                 ret = -1;
             }
             else {
-                CloseHandle(hProc);
+                DWORD status;
+                if (!GetExitCodeProcess(hProc, &status)) {
+                    errno = map_errno(GetLastError());
+                    ret = -1;
+                }
+                else if (status != STILL_ACTIVE) {
+                    /* The process has exited, but its handle is still
+                     * open elsewhere (e.g., a child spawned by
+                     * IO.popen).  A process which exited with the
+                     * code STILL_ACTIVE (259) cannot be distinguished
+                     * from a running process, due to the Windows API
+                     * limitation. */
+                    errno = ESRCH;
+                    ret = -1;
+                }
+                if (!child) {
+                    CloseHandle(hProc);
+                }
             }
         }
         break;


### PR DESCRIPTION
On Windows, `Process.kill(0, pid)` returns success for a process which has already exited but whose handle is still open somewhere, such as a child spawned by `IO.popen`. `OpenProcess` succeeds as long as any handle keeps the process object alive, so callers using signal 0 as a liveness check see a dead process as running.

Check `GetExitCodeProcess` in the signal 0 path and set `ESRCH` when the target is no longer `STILL_ACTIVE`, mirroring what the `SIGKILL` path already does. The child process table is consulted first so that children spawned by this process and unrelated processes opened directly both take the same decision.

A process which exits with the code 259 cannot be told apart from a running one. That ambiguity is inherent to `GetExitCodeProcess` and is noted in a comment.

This diverges from POSIX, where signal 0 succeeds for a zombie that has not been reaped yet. On Windows the process itself is already gone at that point and only the handle remains, so reporting `ESRCH` describes the actual state.

https://bugs.ruby-lang.org/issues/7082
