### PR TITLE
[DOC] Fix block precedence description and add ::, [] to the table

### DIFF
--- a/doc/syntax/precedence.rdoc
+++ b/doc/syntax/precedence.rdoc
@@ -3,6 +3,10 @@
 From highest to lowest, this is the precedence table for ruby.  High precedence
 operations happen before low precedence operations.
 
+  ::
+
+  []
+
   !, ~, unary +
 
   **
@@ -43,8 +47,6 @@ operations happen before low precedence operations.
 
   modifier-if, modifier-unless, modifier-while, modifier-until
 
-  { } blocks
-
 Unary <code>+</code> and unary <code>-</code> are for <code>+1</code>,
 <code>-1</code> or <code>-(a + b)</code>.
 
@@ -57,8 +59,14 @@ Note that <code>(a if b rescue c)</code> is parsed as <code>((a if b) rescue
 c)</code> due to reasons not related to precedence. See {modifier
 statements}[control_expressions.rdoc#label-Modifier+Statements].
 
-<code>{ ... }</code> blocks have priority below all listed operations, but
-<code>do ... end</code> blocks have lower priority.
+Blocks are not part of the precedence table above; the difference between the
+two block forms is how far they reach.  A <code>{ ... }</code> block binds to
+the nearest method call, while a <code>do ... end</code> block binds to the
+outermost one, so <code>{ ... }</code> binds more tightly than
+<code>do ... end</code>:
+
+  p [1, 2].map { |x| x * 2 }      # prints [2, 4]
+  p [1, 2].map do |x| x * 2 end   # prints an Enumerator
 
 All other words in the precedence table above are keywords.
 


### PR DESCRIPTION
## Problem

`doc/syntax/precedence.rdoc` has two inaccuracies:

1. The last row of the table (`{ } blocks`) and the sentence "`{ ... }` blocks have priority below all listed operations" do not match the actual behavior. A `{ ... }` block binds to the *nearest* method call, not below all listed operations:

   ```ruby
   def f(x) = (block_given? ? [:f_block, x] : [:f, x])
   def a = (block_given? ? :a_block : :a)
   p f a { :blk }   # => [:f, :a_block]  ({ } binds to a, the nearest call)

   p [1, 2].map { |x| x * 2 }      # => [2, 4]              ({ } binds to map)
   p [1, 2].map do |x| x * 2 end   # => #<Enumerator: ...>  (do...end binds to p)
   ```

   The only precedence-like statement that holds is the *relative* one: `{ ... }` binds more tightly than `do ... end`.

2. The table is missing `::` (scope resolution) and `[]` (element reference), which bind more tightly than the unary operators listed at the top:

   ```ruby
   module M; X = false; end
   p !M::X    # => true   (parsed as !(M::X))
   a = [10]
   p -a[0]    # => -10    (parsed as -(a[0]))
   ```

## Fix

- Add `::` and `[]` at the top of the table.
- Remove the `{ } blocks` row and rewrite the paragraph about blocks to state only the relative binding between `{ ... }` and `do ... end`, with an example.

Verified the behavior on Ruby 3.3 / 3.4 / 4.0 (identical results).

Found while syncing the Japanese reference manual's operator precedence table with this document (rurema/doctree#3513).

(この文書と日本語リファレンスの優先順位表を突き合わせた際に見つかった不一致の修正です。)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
