### PR TITLE
JIT: Reduce jit_entry_calls/jit_exception_calls to 32 bits

### DIFF
--- a/vm.c
+++ b/vm.c
@@ -470,14 +470,14 @@ static VALUE vm_invoke_proc(rb_execution_context_t *ec, rb_proc_t *proc, VALUE s
 
 #if USE_YJIT
 // Counter to serve as a proxy for execution time, total number of calls
-static uint64_t yjit_total_entry_hits = 0;
+static unsigned int yjit_total_entry_hits = 0;
 
 // Number of calls used to estimate how hot an ISEQ is
 #define YJIT_CALL_COUNT_INTERV 20u
 
 /// Test whether we are ready to compile an ISEQ or not
 static inline bool
-rb_yjit_threshold_hit(const rb_iseq_t *iseq, uint64_t entry_calls)
+rb_yjit_threshold_hit(const rb_iseq_t *iseq, unsigned int entry_calls)
 {
     yjit_total_entry_hits += 1;
 
@@ -494,7 +494,7 @@ rb_yjit_threshold_hit(const rb_iseq_t *iseq, uint64_t entry_calls)
             return true;
         }
 
-        uint64_t num_calls = yjit_total_entry_hits - ISEQ_BODY(iseq)->yjit_calls_at_interv;
+        unsigned int num_calls = yjit_total_entry_hits - ISEQ_BODY(iseq)->yjit_calls_at_interv;
 
         // Reject ISEQs that don't get called often enough
         if (num_calls > rb_yjit_cold_threshold) {

--- a/vm_core.h
+++ b/vm_core.h
@@ -566,20 +566,20 @@ struct rb_iseq_constant_body {
     const rb_iseq_t *mandatory_only_iseq;
 
 #if USE_YJIT || USE_ZJIT
+    // Number of calls on jit_exec()
+    unsigned int jit_entry_calls;
+    // Number of calls on jit_exec_exception()
+    unsigned int jit_exception_calls;
     // Function pointer for JIT code on jit_exec()
     rb_jit_func_t jit_entry;
-    // Number of calls on jit_exec()
-    long unsigned jit_entry_calls;
     // Function pointer for JIT code on jit_exec_exception()
     rb_jit_func_t jit_exception;
-    // Number of calls on jit_exec_exception()
-    long unsigned jit_exception_calls;
     void *jit_payload;
 #endif
 
 #if USE_YJIT
     // Used to estimate how frequently this ISEQ gets called
-    uint64_t yjit_calls_at_interv;
+    unsigned int yjit_calls_at_interv;
 #endif
 
     // Hash of the source this iseq was compiled from, or 0 if it is

--- a/yjit.h
+++ b/yjit.h
@@ -24,8 +24,8 @@
 #endif
 
 // Expose these as declarations since we are building YJIT.
-extern uint64_t rb_yjit_call_threshold;
-extern uint64_t rb_yjit_cold_threshold;
+extern unsigned int rb_yjit_call_threshold;
+extern unsigned int rb_yjit_cold_threshold;
 extern uint64_t rb_yjit_live_iseq_count;
 extern uint64_t rb_yjit_iseq_alloc_count;
 extern bool rb_yjit_enabled_p;

--- a/yjit/src/options.rs
+++ b/yjit/src/options.rs
@@ -3,10 +3,10 @@ use crate::{backend::current::TEMP_REGS, cruby::*, stats::Counter};
 use std::os::raw::{c_char, c_int, c_uint};
 
 // Call threshold for small deployments and command-line apps
-pub static SMALL_CALL_THRESHOLD: u64 = 30;
+pub static SMALL_CALL_THRESHOLD: u32 = 30;
 
 // Call threshold for larger deployments and production-sized applications
-pub static LARGE_CALL_THRESHOLD: u64 = 120;
+pub static LARGE_CALL_THRESHOLD: u32 = 120;
 
 // Number of live ISEQs after which we consider an app to be large
 pub static LARGE_ISEQ_COUNT: u64 = 40_000;
@@ -15,13 +15,13 @@ pub static LARGE_ISEQ_COUNT: u64 = 40_000;
 // Number of method calls after which to start generating code
 // Threshold==1 means compile on first execution
 #[no_mangle]
-pub static mut rb_yjit_call_threshold: u64 = SMALL_CALL_THRESHOLD;
+pub static mut rb_yjit_call_threshold: u32 = SMALL_CALL_THRESHOLD;
 
 // This option is exposed to the C side in a global variable for performance, see vm.c
 // Number of execution requests after which a method is no longer
 // considered hot. Raising this results in more generated code.
 #[no_mangle]
-pub static mut rb_yjit_cold_threshold: u64 = 200_000;
+pub static mut rb_yjit_cold_threshold: u32 = 200_000;
 
 // Command-line options
 #[derive(Debug)]

--- a/yjit/src/yjit.rs
+++ b/yjit/src/yjit.rs
@@ -238,7 +238,7 @@ pub extern "C" fn rb_yjit_enable(_ec: EcPtr, _ruby_self: VALUE, gen_stats: VALUE
         if !call_threshold.nil_p() {
             let threshold = call_threshold.as_isize() >> 1;
             unsafe {
-                rb_yjit_call_threshold = threshold as u64;
+                rb_yjit_call_threshold = threshold as u32;
             }
         }
 

--- a/zjit.h
+++ b/zjit.h
@@ -109,8 +109,8 @@ ZJIT_STACK_MAP_BASE_PTR_STACK_SIZE(VALUE entry)
 extern void *rb_zjit_entry;
 extern bool rb_zjit_compiling_p;
 extern const zjit_jit_frame_t rb_zjit_c_frame;
-extern uint64_t rb_zjit_call_threshold;
-extern uint64_t rb_zjit_profile_threshold;
+extern unsigned int rb_zjit_call_threshold;
+extern unsigned int rb_zjit_profile_threshold;
 void rb_zjit_compile_iseq(const rb_iseq_t *iseq, rb_execution_context_t *ec, bool jit_exception);
 void rb_zjit_profile_insn(uint32_t insn, rb_execution_context_t *ec);
 void rb_zjit_profile_enable(const rb_iseq_t *iseq);

--- a/zjit/src/options.rs
+++ b/zjit/src/options.rs
@@ -25,7 +25,7 @@ pub type NumProfiles = u16;
 /// Default --zjit-call-threshold. This should be large enough to avoid compiling
 /// warmup code, but small enough to perform well on micro-benchmarks.
 pub const DEFAULT_CALL_THRESHOLD: CallThreshold = 30;
-pub type CallThreshold = u64;
+pub type CallThreshold = u32;
 
 /// Default --zjit-inline-threshold
 /// TODO (nirvdrum 2026-06-25): 30 has proven to work well with ruby-bench, but we should finely


### PR DESCRIPTION
We don't need 64 bits for jit_entry_calls/jit_exception_calls so dropping them down to 32 bits will allow us to save 8 bytes per iseq.