### PR TITLE
Don't create CCs for hook methods called from C

### DIFF
--- a/class.c
+++ b/class.c
@@ -28,6 +28,7 @@
 #include "internal/object.h"
 #include "internal/string.h"
 #include "internal/variable.h"
+#include "internal/vm.h"
 #include "ruby/st.h"
 #include "vm_core.h"
 #include "ruby/ractor.h"
@@ -1404,7 +1405,7 @@ rb_class_inherited(VALUE super, VALUE klass)
     ID inherited;
     if (!super) super = rb_cObject;
     CONST_ID(inherited, "inherited");
-    return rb_funcall(super, inherited, 1, klass);
+    return rb_funcallv_uncached(super, inherited, 1, &klass);
 }
 
 #ifdef rb_define_class

--- a/eval.c
+++ b/eval.c
@@ -30,6 +30,7 @@
 #include "internal/object.h"
 #include "internal/thread.h"
 #include "internal/variable.h"
+#include "internal/vm.h"
 #include "ruby/fiber/scheduler.h"
 #include "iseq.h"
 #include "probes.h"
@@ -1328,8 +1329,8 @@ rb_mod_include(int argc, VALUE *argv, VALUE module)
         }
     }
     while (argc--) {
-        rb_funcall(argv[argc], id_append_features, 1, module);
-        rb_funcall(argv[argc], id_included, 1, module);
+        rb_funcallv_uncached(argv[argc], id_append_features, 1, &module);
+        rb_funcallv_uncached(argv[argc], id_included, 1, &module);
     }
     return module;
 }
@@ -1385,8 +1386,8 @@ rb_mod_prepend(int argc, VALUE *argv, VALUE module)
         }
     }
     while (argc--) {
-        rb_funcall(argv[argc], id_prepend_features, 1, module);
-        rb_funcall(argv[argc], id_prepended, 1, module);
+        rb_funcallv_uncached(argv[argc], id_prepend_features, 1, &module);
+        rb_funcallv_uncached(argv[argc], id_prepended, 1, &module);
     }
     return module;
 }
@@ -1981,8 +1982,8 @@ rb_obj_extend(int argc, VALUE *argv, VALUE obj)
         }
     }
     while (argc--) {
-        rb_funcall(argv[argc], id_extend_object, 1, obj);
-        rb_funcall(argv[argc], id_extended, 1, obj);
+        rb_funcallv_uncached(argv[argc], id_extend_object, 1, &obj);
+        rb_funcallv_uncached(argv[argc], id_extended, 1, &obj);
     }
     return obj;
 }

--- a/internal/vm.h
+++ b/internal/vm.h
@@ -81,6 +81,7 @@ void rb_check_stack_overflow(void);
 VALUE rb_block_call2(VALUE obj, ID mid, int argc, const VALUE *argv, rb_block_call_func_t bl_proc, VALUE data2, long flags);
 struct vm_ifunc *rb_current_ifunc(void);
 VALUE rb_gccct_clear_table(void);
+VALUE rb_funcallv_uncached(VALUE recv, ID mid, int argc, const VALUE *argv);
 VALUE rb_eval_cmd_call_kw(VALUE cmd, int argc, const VALUE *argv, int kw_splat);
 
 #if USE_YJIT || USE_ZJIT

--- a/variable.c
+++ b/variable.c
@@ -34,6 +34,7 @@
 #include "internal/symbol.h"
 #include "internal/thread.h"
 #include "internal/variable.h"
+#include "internal/vm.h"
 #include "ruby/encoding.h"
 #include "ruby/st.h"
 #include "ruby/util.h"
@@ -3831,8 +3832,8 @@ static void
 const_added(VALUE klass, ID const_name)
 {
     if (GET_VM()->running) {
-        VALUE name = ID2SYM(const_name);
-        rb_funcallv(klass, idConst_added, 1, &name);
+        VALUE arg = ID2SYM(const_name);
+        rb_funcallv_uncached(klass, idConst_added, 1, &arg);
     }
 }
 

--- a/vm_method.c
+++ b/vm_method.c
@@ -1704,6 +1704,8 @@ rb_check_overloaded_cme(const rb_callable_method_entry_t *cme, const struct rb_c
     return cme;
 }
 
+static inline void stack_check(rb_execution_context_t *ec);
+
 #define CALL_METHOD_HOOK(klass, hook, mid) do {		\
         const VALUE arg = ID2SYM(mid);			\
         VALUE recv_class = (klass);			\
@@ -1712,7 +1714,7 @@ rb_check_overloaded_cme(const rb_callable_method_entry_t *cme, const struct rb_c
             recv_class = RCLASS_ATTACHED_OBJECT((klass));	\
             hook_id = singleton_##hook;			\
         }						\
-        rb_funcallv(recv_class, hook_id, 1, &arg);	\
+        rb_funcallv_uncached(recv_class, hook_id, 1, &arg);	\
     } while (0)
 
 static void
@@ -1930,6 +1932,34 @@ prepare_callable_method_entry(VALUE defined_class, ID id, const rb_method_entry_
     else {
         return NULL;
     }
+}
+
+/* A hook like this fires from C with no call site to cache into except for the gccct table,
+ * which is often cleared anyway. It would leave a permanent CC behind (tied to the class) if it
+ * created one, so we try to avoid it. */
+VALUE
+rb_funcallv_uncached(VALUE recv, ID mid, int argc, const VALUE *argv)
+{
+    VALUE defined_class;
+    const rb_method_entry_t *me = search_method(CLASS_OF(recv), mid, &defined_class);
+
+    if (UNLIKELY(UNDEFINED_METHOD_ENTRY_P(me))) {
+        return rb_funcallv(recv, mid, argc, argv);
+    }
+
+    const rb_callable_method_entry_t *cme;
+
+    if (UNLIKELY(me->defined_class == 0)) {
+        // produce a transient CME that will get collected
+        cme = rb_method_entry_complement_defined_class(me, me->called_id, defined_class);
+    }
+    else {
+        cme = (const rb_callable_method_entry_t *)me;
+    }
+
+    rb_execution_context_t *ec = GET_EC();
+    stack_check(ec);
+    return rb_vm_call_kw(ec, recv, mid, argc, argv, cme, RB_NO_KEYWORDS);
 }
 
 static const rb_callable_method_entry_t *


### PR DESCRIPTION
Calling these hook methods shouldn't create CCs because these are not hot methods. These CCs were only looked up in the gccct table (global call cache lookup table) for rb_funcall and friends.

For one of our apps after bootup we reduced CCs significantly:


|                       | A control  | B (your commit) | B − A                 |
|-----------------------|------------|-----------------|-----------------------|
| callcaches (after GC) | 705,957    | 651,747         | −54,210 (−7.7%)       |
| cc tables             | 46,361     | 43,051          | −3,310                |
| total cc memory       | 86,441,345 | 79,823,142      | −6,618,203 (−6.3 MB)  |
