### PR TITLE
ZJIT: Support dumping HIR to a file

### DIFF
--- a/doc/jit/zjit.md
+++ b/doc/jit/zjit.md
@@ -427,6 +427,15 @@ Note that this disables profiling. To inject interpreter profiles into ZJIT, con
 ./miniruby --zjit --zjit-dump-hir -e "30.times { 1 + 1 }"
 ```
 
+To write the dump to a file instead of stdout, pass a file path as the option value. Any value other than `all` or `debug` is treated as a path, and it composes with those format variants:
+
+```bash
+./miniruby --zjit --zjit-dump-hir=/tmp/out.hir --zjit-call-threshold=1 -e "1 + 1"
+./miniruby --zjit --zjit-dump-hir=all --zjit-dump-hir=/tmp/out.hir --zjit-call-threshold=1 -e "1 + 1"
+```
+
+The file is truncated at startup and appended to as each method compiles.
+
 ### Viewing HIR in Iongraph
 
 Using `--zjit-dump-hir-iongraph` will dump all compiled functions into a directory named `/tmp/zjit-iongraph-{PROCESS_PID}`. Each file will be named `func_{ZJIT_FUNC_NAME}.json`. In order to use them in the Iongraph viewer, you'll need to use `jq` to collate them to a single file. An example invocation of `jq` is shown below for reference.

--- a/doc/jit/zjit.md
+++ b/doc/jit/zjit.md
@@ -427,7 +427,7 @@ Note that this disables profiling. To inject interpreter profiles into ZJIT, con
 ./miniruby --zjit --zjit-dump-hir -e "30.times { 1 + 1 }"
 ```
 
-To write the dump to a file instead of stdout, pass a file path as the option value. Any value other than `all` or `debug` is treated as a directory name, and it composes with those format variants:
+To write the dump to a file instead of stdout, pass an existing directory as the option value. Any value other than `all` or `debug` is treated as a directory name, and it composes with those format variants:
 
 ```bash
 ./miniruby --zjit --zjit-dump-hir=/tmp --zjit-call-threshold=1 -e "1 + 1"

--- a/doc/jit/zjit.md
+++ b/doc/jit/zjit.md
@@ -427,14 +427,14 @@ Note that this disables profiling. To inject interpreter profiles into ZJIT, con
 ./miniruby --zjit --zjit-dump-hir -e "30.times { 1 + 1 }"
 ```
 
-To write the dump to a file instead of stdout, pass a file path as the option value. Any value other than `all` or `debug` is treated as a path, and it composes with those format variants:
+To write the dump to a file instead of stdout, pass a file path as the option value. Any value other than `all` or `debug` is treated as a directory name, and it composes with those format variants:
 
 ```bash
 ./miniruby --zjit --zjit-dump-hir=/tmp/out.hir --zjit-call-threshold=1 -e "1 + 1"
-./miniruby --zjit --zjit-dump-hir=all --zjit-dump-hir=/tmp/out.hir --zjit-call-threshold=1 -e "1 + 1"
+./miniruby --zjit --zjit-dump-hir=all --zjit-dump-hir=/tmp --zjit-call-threshold=1 -e "1 + 1"
 ```
 
-The file is truncated at startup and appended to as each method compiles.
+The file `/tmp/hir-$PID` is truncated at startup and appended to as each method compiles.
 
 ### Viewing HIR in Iongraph
 

--- a/doc/jit/zjit.md
+++ b/doc/jit/zjit.md
@@ -430,7 +430,7 @@ Note that this disables profiling. To inject interpreter profiles into ZJIT, con
 To write the dump to a file instead of stdout, pass a file path as the option value. Any value other than `all` or `debug` is treated as a directory name, and it composes with those format variants:
 
 ```bash
-./miniruby --zjit --zjit-dump-hir=/tmp/out.hir --zjit-call-threshold=1 -e "1 + 1"
+./miniruby --zjit --zjit-dump-hir=/tmp --zjit-call-threshold=1 -e "1 + 1"
 ./miniruby --zjit --zjit-dump-hir=all --zjit-dump-hir=/tmp --zjit-call-threshold=1 -e "1 + 1"
 ```
 

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -2521,6 +2521,21 @@ impl<'a> FunctionPrinter<'a> {
     }
 }
 
+/// Write a HIR dump to the file given by --zjit-dump-hir=<path>, or to stdout if no path was given.
+fn print_hir_dump(label: &str, body: &dyn std::fmt::Display) {
+    match crate::options::get_option_ref!(dump_hir_file) {
+        Some(path) => {
+            use std::io::Write;
+            let result = std::fs::OpenOptions::new().create(true).append(true).open(path)
+                .and_then(|mut file| writeln!(file, "{label}:\n{body}"));
+            if let Err(e) = result {
+                eprintln!("ZJIT: Failed to write HIR dump to '{}': {}", path.display(), e);
+            }
+        }
+        None => println!("{label}:\n{body}"),
+    }
+}
+
 /// Union-Find (Disjoint-Set) is a data structure for managing disjoint sets that has an interface
 /// of two operations:
 ///
@@ -7302,9 +7317,9 @@ impl Function {
     pub fn dump_hir(&self) {
         // Dump HIR after optimization
         match get_option!(dump_hir_opt) {
-            Some(DumpHIR::WithoutSnapshot) => println!("Optimized HIR:\n{}", FunctionPrinter::without_snapshot(self)),
-            Some(DumpHIR::All) => println!("Optimized HIR:\n{}", FunctionPrinter::with_snapshot(self)),
-            Some(DumpHIR::Debug) => println!("Optimized HIR:\n{:#?}", &self),
+            Some(DumpHIR::WithoutSnapshot) => print_hir_dump("Optimized HIR", &FunctionPrinter::without_snapshot(self)),
+            Some(DumpHIR::All) => print_hir_dump("Optimized HIR", &FunctionPrinter::with_snapshot(self)),
+            Some(DumpHIR::Debug) => print_hir_dump("Optimized HIR", &format_args!("{:#?}", self)),
             None => {},
         }
     }
@@ -10556,9 +10571,9 @@ fn add_iseq_to_hir(
         fun.infer_types();
 
         match get_option!(dump_hir_init) {
-            Some(DumpHIR::WithoutSnapshot) => println!("Initial HIR:\n{}", FunctionPrinter::without_snapshot(fun)),
-            Some(DumpHIR::All) => println!("Initial HIR:\n{}", FunctionPrinter::with_snapshot(fun)),
-            Some(DumpHIR::Debug) => println!("Initial HIR:\n{:#?}", fun),
+            Some(DumpHIR::WithoutSnapshot) => print_hir_dump("Initial HIR", &FunctionPrinter::without_snapshot(fun)),
+            Some(DumpHIR::All) => print_hir_dump("Initial HIR", &FunctionPrinter::with_snapshot(fun)),
+            Some(DumpHIR::Debug) => print_hir_dump("Initial HIR", &format_args!("{:#?}", fun)),
             None => {},
         }
     }

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -2521,7 +2521,8 @@ impl<'a> FunctionPrinter<'a> {
     }
 }
 
-/// Write a HIR dump to the file given by --zjit-dump-hir=<path>, or to stdout if no path was given.
+/// Write a HIR dump to the file given by --zjit-dump-hir=some_directory, or to stdout if no path
+/// was given.
 fn print_hir_dump(label: &str, body: &dyn std::fmt::Display) {
     match crate::options::get_option_ref!(dump_hir_file) {
         Some(path) => {

--- a/zjit/src/options.rs
+++ b/zjit/src/options.rs
@@ -789,7 +789,7 @@ mod tests {
         let options = unsafe { OPTIONS.as_ref() }.unwrap();
         // parse_option canonicalizes the path, so canonicalize the expectation too
         let expected = std::fs::canonicalize(&path).unwrap().join(format!("hir-{}", std::process::id()));
-        assert_eq!(options.dump_hir_file, Some(expected));
+        assert_eq!(options.dump_hir_file, Some(expected.clone()));
         assert!(matches!(options.dump_hir_opt, Some(DumpHIR::WithoutSnapshot)));
         assert!(expected.exists());
 
@@ -810,7 +810,7 @@ mod tests {
         let options = unsafe { OPTIONS.as_ref() }.unwrap();
         // parse_option canonicalizes the path, so canonicalize the expectation too
         let expected = std::fs::canonicalize(&path).unwrap().join(format!("hir-{}", std::process::id()));
-        assert_eq!(options.dump_hir_file, Some(expected));
+        assert_eq!(options.dump_hir_file, Some(expected.clone()));
         assert!(matches!(options.dump_hir_opt, Some(DumpHIR::All)));
         assert!(expected.exists());
 

--- a/zjit/src/options.rs
+++ b/zjit/src/options.rs
@@ -545,6 +545,10 @@ fn parse_option(str_ptr: *const std::os::raw::c_char) -> Option<()> {
         ("dump-hir" | "dump-hir-opt", _) => {
             let directory = std::fs::canonicalize(&opt_val)
                 .map_err(|e| eprintln!("Failed to canonicalize path '{opt_val}': {e}")).ok()?;
+            if !directory.is_dir() {
+                eprintln!("Path '{opt_val}' is not a directory");
+                return None;
+            }
             let file_name = directory.join(format!("hir-{}", std::process::id()));
             // Truncate the file if it exists
             std::fs::OpenOptions::new()
@@ -787,9 +791,9 @@ mod tests {
         let expected = std::fs::canonicalize(&path).unwrap().join(format!("hir-{}", std::process::id()));
         assert_eq!(options.dump_hir_file, Some(expected));
         assert!(matches!(options.dump_hir_opt, Some(DumpHIR::WithoutSnapshot)));
-        assert!(path.exists());
+        assert!(expected.exists());
 
-        let _ = std::fs::remove_file(path);
+        let _ = std::fs::remove_file(expected);
     }
 
     #[test]
@@ -808,8 +812,9 @@ mod tests {
         let expected = std::fs::canonicalize(&path).unwrap().join(format!("hir-{}", std::process::id()));
         assert_eq!(options.dump_hir_file, Some(expected));
         assert!(matches!(options.dump_hir_opt, Some(DumpHIR::All)));
+        assert!(expected.exists());
 
-        let _ = std::fs::remove_file(path);
+        let _ = std::fs::remove_file(expected);
     }
 
     #[test]

--- a/zjit/src/options.rs
+++ b/zjit/src/options.rs
@@ -105,6 +105,9 @@ pub struct Options {
     /// Dump High-level IR after optimization, right before codegen.
     pub dump_hir_opt: Option<DumpHIR>,
 
+    /// Dump High-level IR to the given file instead of stdout
+    pub dump_hir_file: Option<std::path::PathBuf>,
+
     /// Dump High-level IR to the given file in Graphviz format after optimization
     pub dump_hir_graphviz: Option<std::path::PathBuf>,
 
@@ -203,6 +206,7 @@ impl Default for Options {
             disable_hir_opt: false,
             dump_hir_init: None,
             dump_hir_opt: None,
+            dump_hir_file: None,
             dump_hir_graphviz: None,
             dump_hir_iongraph: false,
             dump_lir: None,
@@ -536,6 +540,21 @@ fn parse_option(str_ptr: *const std::os::raw::c_char) -> Option<()> {
         ("dump-hir" | "dump-hir-opt", "") => options.dump_hir_opt = Some(DumpHIR::WithoutSnapshot),
         ("dump-hir" | "dump-hir-opt", "all") => options.dump_hir_opt = Some(DumpHIR::All),
         ("dump-hir" | "dump-hir-opt", "debug") => options.dump_hir_opt = Some(DumpHIR::Debug),
+        // Any other value is a file path to dump HIR to instead of stdout. It composes with the
+        // format variants, e.g. --zjit-dump-hir=all --zjit-dump-hir=/tmp/out.hir.
+        ("dump-hir" | "dump-hir-opt", _) => {
+            // Truncate the file if it exists
+            std::fs::OpenOptions::new()
+                .create(true)
+                .write(true)
+                .truncate(true)
+                .open(opt_val)
+                .map_err(|e| eprintln!("Failed to open file '{opt_val}': {e}"))
+                .ok();
+            let opt_val = std::fs::canonicalize(opt_val).unwrap_or_else(|_| opt_val.into());
+            options.dump_hir_file = Some(opt_val);
+            options.dump_hir_opt.get_or_insert(DumpHIR::WithoutSnapshot);
+        }
 
         ("dump-hir-init", "") => options.dump_hir_init = Some(DumpHIR::WithoutSnapshot),
         ("dump-hir-init", "all") => options.dump_hir_init = Some(DumpHIR::All),
@@ -751,6 +770,42 @@ pub extern "C" fn rb_zjit_get_stats_file_path_p(_ec: EcPtr, _self: VALUE) -> VAL
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parse_dump_hir_path() {
+        unsafe { OPTIONS = Some(Options::default()); }
+
+        let path = std::env::temp_dir().join(format!("zjit_dump_hir_{}.txt", std::process::id()));
+        let option = CString::new(format!("dump-hir={}", path.display())).unwrap();
+
+        assert!(parse_option(option.as_ptr()).is_some());
+
+        let options = unsafe { OPTIONS.as_ref() }.unwrap();
+        // parse_option canonicalizes the path, so canonicalize the expectation too
+        assert_eq!(options.dump_hir_file, Some(std::fs::canonicalize(&path).unwrap()));
+        assert!(matches!(options.dump_hir_opt, Some(DumpHIR::WithoutSnapshot)));
+        assert!(path.exists());
+
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn parse_dump_hir_path_keeps_format() {
+        unsafe { OPTIONS = Some(Options::default()); }
+
+        let path = std::env::temp_dir().join(format!("zjit_dump_hir_all_{}.txt", std::process::id()));
+        let all = CString::new("dump-hir=all").unwrap();
+        let file = CString::new(format!("dump-hir={}", path.display())).unwrap();
+
+        assert!(parse_option(all.as_ptr()).is_some());
+        assert!(parse_option(file.as_ptr()).is_some());
+
+        let options = unsafe { OPTIONS.as_ref() }.unwrap();
+        assert_eq!(options.dump_hir_file, Some(std::fs::canonicalize(&path).unwrap()));
+        assert!(matches!(options.dump_hir_opt, Some(DumpHIR::All)));
+
+        let _ = std::fs::remove_file(path);
+    }
 
     #[test]
     fn parse_dump_disasm_path() {

--- a/zjit/src/options.rs
+++ b/zjit/src/options.rs
@@ -543,8 +543,9 @@ fn parse_option(str_ptr: *const std::os::raw::c_char) -> Option<()> {
         // Any other value is a directory to dump HIR to instead of stdout. It composes with the
         // format variants, e.g. `--zjit-dump-hir=all --zjit-dump-hir=/tmp/` dumps to /tmp/hir-PID.
         ("dump-hir" | "dump-hir-opt", _) => {
-            let file_name = format!("{opt_val}/hir-{}", std::process::id());
-            let file_name = std::fs::canonicalize(&file_name).unwrap_or_else(|_| file_name.into());
+            let directory = std::fs::canonicalize(&opt_val)
+                .map_err(|e| eprintln!("Failed to canonicalize path '{opt_val}': {e}")).ok()?;
+            let file_name = directory.join(format!("hir-{}", std::process::id()));
             // Truncate the file if it exists
             std::fs::OpenOptions::new()
                 .create(true)
@@ -776,14 +777,15 @@ mod tests {
     fn parse_dump_hir_path() {
         unsafe { OPTIONS = Some(Options::default()); }
 
-        let path = std::env::temp_dir().join(format!("zjit_dump_hir_{}.txt", std::process::id()));
+        let path = std::path::PathBuf::from("/tmp");
         let option = CString::new(format!("dump-hir={}", path.display())).unwrap();
 
         assert!(parse_option(option.as_ptr()).is_some());
 
         let options = unsafe { OPTIONS.as_ref() }.unwrap();
         // parse_option canonicalizes the path, so canonicalize the expectation too
-        assert_eq!(options.dump_hir_file, Some(std::fs::canonicalize(&path).unwrap()));
+        let expected = std::fs::canonicalize(&path).unwrap().join(format!("hir-{}", std::process::id()));
+        assert_eq!(options.dump_hir_file, Some(expected));
         assert!(matches!(options.dump_hir_opt, Some(DumpHIR::WithoutSnapshot)));
         assert!(path.exists());
 
@@ -794,7 +796,7 @@ mod tests {
     fn parse_dump_hir_path_keeps_format() {
         unsafe { OPTIONS = Some(Options::default()); }
 
-        let path = std::env::temp_dir().join(format!("zjit_dump_hir_all_{}.txt", std::process::id()));
+        let path = std::path::PathBuf::from(".");
         let all = CString::new("dump-hir=all").unwrap();
         let file = CString::new(format!("dump-hir={}", path.display())).unwrap();
 
@@ -802,7 +804,9 @@ mod tests {
         assert!(parse_option(file.as_ptr()).is_some());
 
         let options = unsafe { OPTIONS.as_ref() }.unwrap();
-        assert_eq!(options.dump_hir_file, Some(std::fs::canonicalize(&path).unwrap()));
+        // parse_option canonicalizes the path, so canonicalize the expectation too
+        let expected = std::fs::canonicalize(&path).unwrap().join(format!("hir-{}", std::process::id()));
+        assert_eq!(options.dump_hir_file, Some(expected));
         assert!(matches!(options.dump_hir_opt, Some(DumpHIR::All)));
 
         let _ = std::fs::remove_file(path);

--- a/zjit/src/options.rs
+++ b/zjit/src/options.rs
@@ -540,19 +540,20 @@ fn parse_option(str_ptr: *const std::os::raw::c_char) -> Option<()> {
         ("dump-hir" | "dump-hir-opt", "") => options.dump_hir_opt = Some(DumpHIR::WithoutSnapshot),
         ("dump-hir" | "dump-hir-opt", "all") => options.dump_hir_opt = Some(DumpHIR::All),
         ("dump-hir" | "dump-hir-opt", "debug") => options.dump_hir_opt = Some(DumpHIR::Debug),
-        // Any other value is a file path to dump HIR to instead of stdout. It composes with the
-        // format variants, e.g. --zjit-dump-hir=all --zjit-dump-hir=/tmp/out.hir.
+        // Any other value is a directory to dump HIR to instead of stdout. It composes with the
+        // format variants, e.g. `--zjit-dump-hir=all --zjit-dump-hir=/tmp/` dumps to /tmp/hir-PID.
         ("dump-hir" | "dump-hir-opt", _) => {
+            let file_name = format!("{opt_val}/hir-{}", std::process::id());
+            let file_name = std::fs::canonicalize(&file_name).unwrap_or_else(|_| file_name.into());
             // Truncate the file if it exists
             std::fs::OpenOptions::new()
                 .create(true)
                 .write(true)
                 .truncate(true)
-                .open(opt_val)
-                .map_err(|e| eprintln!("Failed to open file '{opt_val}': {e}"))
+                .open(&file_name)
+                .map_err(|e| eprintln!("Failed to open file '{}': {e}", file_name.display()))
                 .ok();
-            let opt_val = std::fs::canonicalize(opt_val).unwrap_or_else(|_| opt_val.into());
-            options.dump_hir_file = Some(opt_val);
+            options.dump_hir_file = Some(file_name);
             options.dump_hir_opt.get_or_insert(DumpHIR::WithoutSnapshot);
         }
 


### PR DESCRIPTION
This lets us analyze HIR without redirecting all stdout somewhere.
