### PR TITLE
ZJIT: Compile direct sends to forwardable callees

### DIFF
--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -694,10 +694,10 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
         &Insn::Send { cd, block: Some(BlockHandler::BlockArg), state, reason, .. } => gen_send(jit, asm, function, cd, std::ptr::null(), &function.frame_state(state), reason),
         &Insn::SendForward { cd, blockiseq, state, reason, .. } => gen_send_forward(jit, asm, function, cd, blockiseq, &function.frame_state(state), reason),
         Insn::SendDirect(insn) => {
-            let SendDirectData { cme, iseq, recv, args, kw_bits, jit_entry_idx, block, state, .. } = &**insn;
+            let SendDirectData { cd, cme, iseq, recv, args, kw_bits, jit_entry_idx, block, state, .. } = &**insn;
             gen_send_iseq_direct(
                 cb, jit, asm,
-                function, *cme, *iseq, opnd!(recv), opnds!(args),
+                function, *cd, *cme, *iseq, opnd!(recv), opnds!(args),
                 *kw_bits, *jit_entry_idx, &function.frame_state(*state), *block,
             )
         }
@@ -1106,6 +1106,7 @@ fn gen_ccall_with_frame(
         frame_type: VM_FRAME_MAGIC_CFUNC | VM_FRAME_FLAG_CFRAME | VM_ENV_FLAG_LOCAL,
         specval: block_handler_specval,
         write_block_code: false,
+        forwarded_argc: None, // cfunc doesn't support forwarded arguments
     });
 
     asm_comment!(asm, "switch to new SP register");
@@ -1196,6 +1197,7 @@ fn gen_ccall_variadic(
         frame_type: VM_FRAME_MAGIC_CFUNC | VM_FRAME_FLAG_CFRAME | VM_ENV_FLAG_LOCAL,
         specval: block_handler_specval,
         write_block_code: false,
+        forwarded_argc: None, // cfunc doesn't support forwarded arguments
     });
 
     asm_comment!(asm, "switch to new SP register");
@@ -1697,6 +1699,7 @@ fn gen_push_inline_frame(
         frame_type,
         specval,
         write_block_code: iseq_may_write_block_code(iseq),
+        forwarded_argc: None, // `can_inline` rejects forwardable callees
     });
 
     // Publish the inlined callee's entry JITFrame before the inlined body runs.
@@ -1782,6 +1785,7 @@ fn gen_send_iseq_direct(
     jit: &mut JITState,
     asm: &mut Assembler,
     function: &Function,
+    cd: *const rb_call_data,
     cme: *const rb_callable_method_entry_t,
     iseq: IseqPtr,
     recv: Opnd,
@@ -1793,7 +1797,12 @@ fn gen_send_iseq_direct(
 ) -> lir::Opnd {
     gen_incr_counter(asm, Counter::iseq_optimized_send_count);
 
-    let local_size = unsafe { get_iseq_body_local_table_size(iseq) }.to_usize();
+    // The ISEQ of `def foo(...)` takes only 1 parameter for the forwarded callinfo, but the callee
+    // frame's local_size is increased by the callinfo's argc (see vm_call_iseq_forwardable()) to
+    // keep the caller's arguments as part of the callee's extra locals.
+    let forwarding = unsafe { rb_get_iseq_flags_forwardable(iseq) };
+    let forwarded_argc = if forwarding { args.len() } else { 0 };
+    let local_size = unsafe { get_iseq_body_local_table_size(iseq) }.to_usize() + forwarded_argc;
     let stack_growth = state.stack_size() + local_size + unsafe { get_iseq_body_stack_max(iseq) }.to_usize();
     gen_stack_overflow_check(jit, asm, function, state, stack_growth);
 
@@ -1839,6 +1848,7 @@ fn gen_send_iseq_direct(
         frame_type,
         specval,
         write_block_code: iseq_may_write_block_code(iseq),
+        forwarded_argc: Some(forwarded_argc),
     });
 
     // Write "keyword_bits" to the callee's frame if the callee accepts keywords.
@@ -1854,6 +1864,22 @@ fn gen_send_iseq_direct(
         let bits_offset = (state.stack().len() - args.len() + bits_start) * SIZEOF_VALUE;
         asm_comment!(asm, "write keyword bits to callee frame");
         asm.store(Opnd::mem(64, SP, bits_offset as i32), unspecified_bits.into());
+    }
+
+    // A forwardable callee reads its arguments out of the VM stack using memcpy on rb_vm_sendforward
+    // (see vm_adjust_stack_forwarding()), so we write these stack slots before the call. The callinfo
+    // goes into the `...` local, which sits directly above them.
+    if forwarding {
+        asm_comment!(asm, "copy forwarded arguments and callinfo to callee frame");
+        let locals_base = state.stack().len() - args.len();
+        for (idx, &arg) in args.iter().enumerate() {
+            asm.store(Opnd::mem(64, SP, ((locals_base + idx) * SIZEOF_VALUE) as i32), arg);
+        }
+        let ci = unsafe { (*cd).ci };
+        asm.store(
+            Opnd::mem(64, SP, ((locals_base + forwarded_argc) * SIZEOF_VALUE) as i32),
+            Opnd::const_ptr(ci as *const u8),
+        );
     }
 
     asm_comment!(asm, "switch to new SP register");
@@ -1879,7 +1905,13 @@ fn gen_send_iseq_direct(
         1 /* recv */ + args.len() + if needs_block { 1 } else { 0 }
     });
     c_args.push(recv);
-    c_args.extend(&args);
+    if forwarding {
+        // The JIT entry of a forwardable ISEQ takes exactly one parameter, the `...` local.
+        // The forwarded arguments were written to the VM stack slots above.
+        c_args.push(Opnd::const_ptr(unsafe { (*cd).ci } as *const u8));
+    } else {
+        c_args.extend(&args);
+    }
     if needs_block {
         if callee_is_bmethod {
             // For bmethods, specval is the captured EP, not the block handler.
@@ -1892,7 +1924,8 @@ fn gen_send_iseq_direct(
     }
 
     // Make a method call. The target address will be rewritten once compiled.
-    let iseq_call = IseqCall::new(iseq, jit_entry_idx, args.len().try_into().expect("checked in HIR"));
+    let call_argc = if forwarding { 1 } else { args.len() };
+    let iseq_call = IseqCall::new(iseq, jit_entry_idx, call_argc.try_into().expect("checked in HIR"));
     let dummy_ptr = cb.get_write_ptr().raw_ptr(cb);
     jit.iseq_calls.push(iseq_call.clone());
     let ret = asm.ccall_with_iseq_call(dummy_ptr, c_args, &iseq_call);
@@ -2044,6 +2077,7 @@ fn gen_invoke_block_iseq_direct(
         frame_type: VM_FRAME_MAGIC_BLOCK,
         specval,
         write_block_code: iseq_may_write_block_code(block_iseq),
+        forwarded_argc: None, // `...` is not allowed in block arguments
     });
 
     asm_comment!(asm, "switch to new SP register");
@@ -3557,6 +3591,9 @@ struct ControlFrame {
     /// Whether to write block_code = 0 at frame push time.
     /// True when the callee ISEQ may write to block_code (has send/invokesuper/invokeblock).
     write_block_code: bool,
+    /// Number of caller arguments a forwardable callee (`def foo(...)`) keeps below
+    /// the `...` local. `None` for non-forwardable callees.
+    forwarded_argc: Option<usize>,
 }
 
 /// Compile an interpreter frame
@@ -3567,7 +3604,7 @@ fn gen_push_frame(asm: &mut Assembler, argc: usize, state: &FrameState, frame: C
     asm_comment!(asm, "push cme, specval, frame type");
     // ep[-2]: cref of cme
     let local_size = if let Some(iseq) = frame.iseq {
-        (unsafe { get_iseq_body_local_table_size(iseq) }) as i32
+        (unsafe { get_iseq_body_local_table_size(iseq) }) as i32 + frame.forwarded_argc.unwrap_or(0) as i32
     } else {
         0
     };

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -1872,15 +1872,13 @@ fn gen_send_iseq_direct(
     // (see vm_adjust_stack_forwarding()), so we write these stack slots before the call. The callinfo
     // goes into the `...` local, which sits directly above them.
     if forwarding {
-        asm_comment!(asm, "copy forwarded arguments and callinfo to callee frame");
+        asm_comment!(asm, "copy forwarded arguments to callee frame");
         let locals_base = state.stack().len() - args.len();
         for (idx, &arg) in args.iter().enumerate() {
             asm.store(Opnd::mem(64, SP, ((locals_base + idx) * SIZEOF_VALUE) as i32), arg);
         }
-        asm.store(
-            Opnd::mem(64, SP, ((locals_base + forwarded_argc) * SIZEOF_VALUE) as i32),
-            forwarded_ci,
-        );
+        // The `...` local on top of the above argument is a method parameter of the callee, so
+        // the callee will spill the callinfo passed as part of `c_args` into the `...` local.
     }
 
     asm_comment!(asm, "switch to new SP register");

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -1802,6 +1802,8 @@ fn gen_send_iseq_direct(
     // keep the caller's arguments as part of the callee's extra locals.
     let forwarding = unsafe { rb_get_iseq_flags_forwardable(iseq) };
     let forwarded_argc = if forwarding { args.len() } else { 0 };
+    // Bake the callinfo as a GC offset since a non-packed (`vm_ci_packed_p`) callinfo is a movable imemo_callinfo.
+    let forwarded_ci = Opnd::Value(unsafe { (*cd).ci }.into());
     let local_size = unsafe { get_iseq_body_local_table_size(iseq) }.to_usize() + forwarded_argc;
     let stack_growth = state.stack_size() + local_size + unsafe { get_iseq_body_stack_max(iseq) }.to_usize();
     gen_stack_overflow_check(jit, asm, function, state, stack_growth);
@@ -1875,10 +1877,9 @@ fn gen_send_iseq_direct(
         for (idx, &arg) in args.iter().enumerate() {
             asm.store(Opnd::mem(64, SP, ((locals_base + idx) * SIZEOF_VALUE) as i32), arg);
         }
-        let ci = unsafe { (*cd).ci };
         asm.store(
             Opnd::mem(64, SP, ((locals_base + forwarded_argc) * SIZEOF_VALUE) as i32),
-            Opnd::const_ptr(ci as *const u8),
+            forwarded_ci,
         );
     }
 
@@ -1908,7 +1909,7 @@ fn gen_send_iseq_direct(
     if forwarding {
         // The JIT entry of a forwardable ISEQ takes exactly one parameter, the `...` local.
         // The forwarded arguments were written to the VM stack slots above.
-        c_args.push(Opnd::const_ptr(unsafe { (*cd).ci } as *const u8));
+        c_args.push(forwarded_ci);
     } else {
         c_args.extend(&args);
     }

--- a/zjit/src/codegen_tests.rs
+++ b/zjit/src/codegen_tests.rs
@@ -447,6 +447,147 @@ fn test_kwargs_with_max_direct_send_arg_count() {
 }
 
 #[test]
+fn test_forwardable_callee_positional_args() {
+    assert_snapshot!(inspect("
+        def target(a, b) = a + b
+        def fwd(...) = target(...)
+        5.times.map { fwd(1, 2) }.uniq
+    "), @"[3]");
+}
+
+#[test]
+fn test_forwardable_callee_no_args() {
+    assert_snapshot!(inspect("
+        def target = :ok
+        def fwd(...) = target(...)
+        5.times.map { fwd }.uniq
+    "), @"[:ok]");
+}
+
+#[test]
+fn test_forwardable_callee_kwargs() {
+    assert_snapshot!(inspect("
+        def target(a, b:, c: 3) = [a, b, c]
+        def fwd(...) = target(...)
+        5.times.flat_map { [fwd(1, b: 2), fwd(1, c: 9, b: 2)] }.uniq
+    "), @"[[1, 2, 3], [1, 2, 9]]");
+}
+
+#[test]
+fn test_forwardable_callee_wrong_number_of_arguments() {
+    assert_snapshot!(inspect(r#"
+        def target(a, b) = a + b
+        def fwd(...) = target(...)
+        5.times.map { (fwd(1) rescue $!.message) }.uniq
+    "#), @r#"["wrong number of arguments (given 1, expected 2)"]"#);
+}
+
+#[test]
+fn test_forwardable_callee_unknown_keyword() {
+    assert_snapshot!(inspect(r#"
+        def target(a, b:) = [a, b]
+        def fwd(...) = target(...)
+        5.times.map { (fwd(1, z: 2) rescue $!.message) }.uniq
+    "#), @r#"["missing keyword: :b"]"#);
+}
+
+#[test]
+fn test_forwardable_callee_literal_block() {
+    assert_snapshot!(inspect("
+        def target(x) = yield(x)
+        def fwd(...) = target(...)
+        5.times.map { fwd(4) { |v| v * 2 } }.uniq
+    "), @"[8]");
+}
+
+#[test]
+fn test_forwardable_callee_splat_call_site_stays_dynamic() {
+    assert_snapshot!(inspect("
+        def target(*a, **k) = [a, k]
+        def fwd(...) = target(...)
+        args = [1, 2]
+        opts = { x: 1 }
+        5.times.flat_map { [fwd(*args), fwd(**opts), fwd(&nil)] }.uniq
+    "), @"[[[1, 2], {}], [[], {x: 1}], [[], {}]]");
+}
+
+#[test]
+fn test_forwardable_callee_ruby2_keywords_flag_survives() {
+    assert_snapshot!(inspect("
+        def target(*a, **k) = [a, k]
+        def fwd(...) = target(...)
+        ruby2_keywords def r2k(*a) = fwd(*a)
+        5.times.map { r2k(1, k: 2) }.uniq
+    "), @"[[[1], {k: 2}]]");
+}
+
+#[test]
+fn test_forwardable_callee_chained_forwarding() {
+    assert_snapshot!(inspect("
+        def target(a, b:) = [a, b]
+        def inner(...) = target(...)
+        def outer(...) = inner(...)
+        5.times.map { outer(1, b: 2) }.uniq
+    "), @"[[1, 2]]");
+}
+
+#[test]
+fn test_forwardable_callee_with_extra_locals() {
+    assert_snapshot!(inspect("
+        def target(a) = a * 2
+        def fwd(...)
+          extra = 10
+          extra + target(...)
+        end
+        5.times.map { fwd(3) }.uniq
+    "), @"[16]");
+}
+
+#[test]
+fn test_forwardable_callee_super() {
+    assert_snapshot!(inspect(r#"
+        class Base
+          def run(*a, **k) = ["base", a, k]
+        end
+        class Child < Base
+          def run(...) = super
+        end
+        c = Child.new
+        5.times.map { c.run(1, k: 2) }.uniq
+    "#), @r#"[["base", [1], {k: 2}]]"#);
+}
+
+#[test]
+fn test_explicit_super_to_forwardable_callee() {
+    assert_snapshot!(inspect(r#"
+        class Base
+          def run(...) = fin(...)
+          def fin(a, b) = ["base", a, b]
+        end
+        class Child < Base
+          def run(a, b) = super(a, b)
+        end
+        c = Child.new
+        5.times.map { c.run(1, 2) }.uniq
+    "#), @r#"[["base", 1, 2]]"#);
+}
+
+#[test]
+fn test_zsuper_to_forwardable_callee() {
+    assert_snapshot!(inspect(r#"
+        class Base
+          def run(...) = fin(...)
+          def fin(a, b) = ["base", a, b]
+        end
+        class Child < Base
+          def run(a, b) = super
+        end
+        c = Child.new
+        5.times.map { c.run(3, 4) }.uniq
+    "#), @r#"[["base", 3, 4]]"#);
+}
+
+#[test]
 fn test_setlocal_on_eval() {
     assert_snapshot!(inspect("
         @b = binding

--- a/zjit/src/codegen_tests.rs
+++ b/zjit/src/codegen_tests.rs
@@ -500,6 +500,20 @@ fn test_forwardable_callee_literal_block() {
     "), @"[8]");
 }
 
+// Enabling a TracePoint invalidates the callee's PatchPoint NoTracePoint, so the interpreter takes
+// over the frame that the direct send pushed and runs the forwarding call itself.
+#[test]
+fn test_forwardable_callee_side_exit() {
+    assert_snapshot!(inspect("
+        def target(a, b:) = [a, b]
+        def fwd(...) = target(...)
+        def call_fwd = fwd(1, b: 2)
+        5.times { call_fwd }
+        tp = TracePoint.new(:line) { |_| }
+        tp.enable { 5.times.map { call_fwd }.uniq }
+    "), @"[[1, 2]]");
+}
+
 #[test]
 fn test_forwardable_callee_block_arg_proc() {
     assert_snapshot!(inspect("

--- a/zjit/src/codegen_tests.rs
+++ b/zjit/src/codegen_tests.rs
@@ -501,6 +501,76 @@ fn test_forwardable_callee_literal_block() {
 }
 
 #[test]
+fn test_forwardable_callee_block_arg_proc() {
+    assert_snapshot!(inspect("
+        def target(x) = yield(x)
+        def fwd(...) = target(...)
+        block = proc { |v| v * 2 }
+        5.times.map { fwd(4, &block) }.uniq
+    "), @"[8]");
+}
+
+#[test]
+fn test_forwardable_callee_block_arg_lambda() {
+    assert_snapshot!(inspect("
+        def target(x) = yield(x)
+        def fwd(...) = target(...)
+        block = ->(v) { v * 3 }
+        5.times.map { fwd(4, &block) }.uniq
+    "), @"[12]");
+}
+
+#[test]
+fn test_forwardable_callee_block_arg_symbol() {
+    assert_snapshot!(inspect(r#"
+        def target(x) = yield(x)
+        def fwd(...) = target(...)
+        5.times.map { fwd("hello", &:upcase) }.uniq
+    "#), @r#"["HELLO"]"#);
+}
+
+#[test]
+fn test_forwardable_callee_block_arg_method() {
+    assert_snapshot!(inspect("
+        def target(x) = yield(x)
+        def fwd(...) = target(...)
+        def double(v) = v * 2
+        5.times.map { fwd(4, &method(:double)) }.uniq
+    "), @"[8]");
+}
+
+#[test]
+fn test_forwardable_callee_block_arg_to_proc() {
+    assert_snapshot!(inspect("
+        class Doubler
+          def to_proc = proc { |v| v * 2 }
+        end
+        def target(x) = yield(x)
+        def fwd(...) = target(...)
+        doubler = Doubler.new
+        5.times.map { fwd(4, &doubler) }.uniq
+    "), @"[8]");
+}
+
+#[test]
+fn test_forwardable_callee_block_arg_nil() {
+    assert_snapshot!(inspect("
+        def target(x) = block_given? ? yield(x) : [:no_block, x]
+        def fwd(...) = target(...)
+        5.times.map { fwd(4, &nil) }.uniq
+    "), @"[[:no_block, 4]]");
+}
+
+#[test]
+fn test_forwardable_callee_block_arg_not_callable() {
+    assert_snapshot!(inspect(r#"
+        def target(x) = yield(x)
+        def fwd(...) = target(...)
+        5.times.map { (fwd(4, &42) rescue $!.class) }.uniq
+    "#), @"[TypeError]");
+}
+
+#[test]
 fn test_forwardable_callee_splat_call_site_stays_dynamic() {
     assert_snapshot!(inspect("
         def target(*a, **k) = [a, k]

--- a/zjit/src/cruby.rs
+++ b/zjit/src/cruby.rs
@@ -887,6 +887,12 @@ impl From<*const rb_callable_method_entry_t> for VALUE {
     }
 }
 
+impl From<*const rb_callinfo> for VALUE {
+    fn from(ci: *const rb_callinfo) -> Self {
+        VALUE(ci as usize)
+    }
+}
+
 impl From<&str> for VALUE {
     fn from(value: &str) -> Self {
         rust_str_to_ruby(value)

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -2634,6 +2634,32 @@ pub enum ValidationError {
     MiscValidationError(InsnId, String),
 }
 
+/// Set of flags incompatible with direct sends to forwardable callees.
+const FORWARDABLE_CALLEE_BLOCKERS: u32 =
+    // `gen_send_iseq_direct` currently handles only the interpreter's `vm_call_iseq_forwardable`
+    // fastpath case, which the interpreter itself rejects on VM_CALL_FORWARDING. The callinfo
+    // to hand over lives in the caller's `...` local, so it should be handled differently.
+    VM_CALL_FORWARDING
+    // We only support `def foo(...)` cases for now.
+    | VM_CALL_ARGS_SPLAT | VM_CALL_KW_SPLAT | VM_CALL_ARGS_BLOCKARG;
+
+/// Check if we can emit SendDirect to a forwardable (`def foo(...)`) ISEQ.
+fn can_direct_send_forwardable(caller_args: &CallerArguments) -> Result<(), SendDirectFailure> {
+    use Counter::*;
+    if caller_args.flags & FORWARDABLE_CALLEE_BLOCKERS != 0 {
+        return Err(SendDirectFailure::with_counters(
+            ComplexArgPass,
+            vec![complex_arg_pass_param_forwardable],
+        ));
+    }
+    // The frame is grown by exactly the call site's argument count.
+    // `IseqCall` stores argc as u16, and the callee frame has to fit the copied arguments.
+    if u16::try_from(caller_args.original.len()).is_err() {
+        return Err(SendDirectFailure::new(OperandTooLarge));
+    }
+    Ok(())
+}
+
 /// Check if we can emit SendDirect to the given ISEQ with the given arguments.
 fn can_direct_send(iseq: *const rb_iseq_t, caller_args: &CallerArguments, has_block: bool, caller_splat: Option<CallerSplat>) -> Result<(), SendDirectFailure> {
     let mut complex_arg_counters = vec![];
@@ -2644,7 +2670,9 @@ fn can_direct_send(iseq: *const rb_iseq_t, caller_args: &CallerArguments, has_bl
     let caller_passes_block_arg = has_block && (caller_args.flags & VM_CALL_ARGS_BLOCKARG) != 0;
 
     use Counter::*;
-    if 0 != params.flags.forwardable() { count_failure(complex_arg_pass_param_forwardable) }
+    if 0 != params.flags.forwardable() {
+        return can_direct_send_forwardable(caller_args);
+    }
     if callee_has_block_param && caller_passes_block_arg
                                        { count_failure(complex_arg_pass_param_block) }
     if 0 != params.flags.has_kwrest()  { count_failure(complex_arg_pass_param_kwrest) }
@@ -3894,6 +3922,14 @@ impl Function {
     /// Validate and normalize SendDirect arguments without emitting HIR.
     fn build_send_direct_args(&self, caller_args: &CallerArguments, caller_splat: Option<CallerSplat>, iseq: IseqPtr, has_block: bool) -> Result<SendDirectCall, SendDirectFailure> {
         can_direct_send(iseq, caller_args, has_block, caller_splat)?;
+        // A forwardable callee takes the caller's arguments as is.
+        if 0 != unsafe { iseq.params() }.flags.forwardable() {
+            return Ok(SendDirectCall {
+                args: caller_args.original.iter().copied().map(SendDirectArg::Existing).collect(),
+                kw_bits: 0,
+                jit_entry_idx: 0,
+            });
+        }
         let args = Self::expand_caller_splat_args(caller_args, caller_splat);
         let (args, kw_bits) = Self::plan_send_direct_keyword_arguments(args, caller_args, iseq)
             .map_err(SendDirectFailure::new)?;

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -2637,8 +2637,12 @@ pub enum ValidationError {
 /// Set of flags incompatible with direct sends to forwardable callees.
 const FORWARDABLE_CALLEE_BLOCKERS: u32 =
     // `gen_send_iseq_direct` currently handles only the interpreter's `vm_call_iseq_forwardable`
-    // fastpath case, which the interpreter itself rejects on VM_CALL_FORWARDING. The callinfo
-    // to hand over lives in the caller's `...` local, so it should be handled differently.
+    // fastpath case on forwardable ISEQs: pass non-`...` arguments to a `...` callee, which sets
+    // the callinfo of non-`...` arguments into the callee's local variable `...`.
+    //
+    // On the other hand, that fastpath and `gen_send_iseq_direct` don't handle the VM_CALL_FORWARDING
+    // case: pass `...` to a `...` callee, which sets the caller's callinfo into the callee's `...`
+    // local variable. It needs to be specialized differently.
     VM_CALL_FORWARDING
     // We only support `def foo(...)` cases for now.
     | VM_CALL_ARGS_SPLAT | VM_CALL_KW_SPLAT | VM_CALL_ARGS_BLOCKARG;

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -2647,23 +2647,6 @@ const FORWARDABLE_CALLEE_BLOCKERS: u32 =
     // We only support `def foo(...)` cases for now.
     | VM_CALL_ARGS_SPLAT | VM_CALL_KW_SPLAT | VM_CALL_ARGS_BLOCKARG;
 
-/// Check if we can emit SendDirect to a forwardable (`def foo(...)`) ISEQ.
-fn can_direct_send_forwardable(caller_args: &CallerArguments) -> Result<(), SendDirectFailure> {
-    use Counter::*;
-    if caller_args.flags & FORWARDABLE_CALLEE_BLOCKERS != 0 {
-        return Err(SendDirectFailure::with_counters(
-            ComplexArgPass,
-            vec![complex_arg_pass_param_forwardable],
-        ));
-    }
-    // The frame is grown by exactly the call site's argument count.
-    // `IseqCall` stores argc as u16, and the callee frame has to fit the copied arguments.
-    if u16::try_from(caller_args.original.len()).is_err() {
-        return Err(SendDirectFailure::new(OperandTooLarge));
-    }
-    Ok(())
-}
-
 /// Check if we can emit SendDirect to the given ISEQ with the given arguments.
 fn can_direct_send(iseq: *const rb_iseq_t, caller_args: &CallerArguments, has_block: bool, caller_splat: Option<CallerSplat>) -> Result<(), SendDirectFailure> {
     let mut complex_arg_counters = vec![];
@@ -2674,9 +2657,9 @@ fn can_direct_send(iseq: *const rb_iseq_t, caller_args: &CallerArguments, has_bl
     let caller_passes_block_arg = has_block && (caller_args.flags & VM_CALL_ARGS_BLOCKARG) != 0;
 
     use Counter::*;
-    if 0 != params.flags.forwardable() {
-        return can_direct_send_forwardable(caller_args);
-    }
+    let forwardable = 0 != params.flags.forwardable();
+    if forwardable && caller_args.flags & FORWARDABLE_CALLEE_BLOCKERS != 0
+                                       { count_failure(complex_arg_pass_param_forwardable) }
     if callee_has_block_param && caller_passes_block_arg
                                        { count_failure(complex_arg_pass_param_block) }
     if 0 != params.flags.has_kwrest()  { count_failure(complex_arg_pass_param_kwrest) }
@@ -2696,6 +2679,16 @@ fn can_direct_send(iseq: *const rb_iseq_t, caller_args: &CallerArguments, has_bl
             ComplexArgPass,
             complex_arg_counters,
         ));
+    }
+
+    // A forwardable callee has a single `...` parameter that takes the caller's arguments, and its frame is
+    // grown by exactly the call site's argument count, so none of the parameter matching below applies to it.
+    if forwardable {
+        // `IseqCall` stores argc as u16, and the callee frame has to fit the copied arguments.
+        if u16::try_from(caller_args.original.len()).is_err() {
+            return Err(SendDirectFailure::new(OperandTooLarge));
+        }
+        return Ok(());
     }
 
     let lead_num = params.lead_num;

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -16888,9 +16888,109 @@ mod hir_opt_tests {
           v4:BasicObject = LoadArg :self@0
           Jump bb3(v4)
         bb3(v6:BasicObject):
-          v11:BasicObject = Send v6, :forwardable # SendFallbackReason: Complex argument passing
+          PatchPoint MethodRedefined(Object@0x1000, forwardable@0x1008, cme:0x1010)
+          v18:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
+          v19:BasicObject = SendDirect v18, 0x0, :forwardable (0x1038)
           CheckInterrupts
-          Return v11
+          Return v19
+        ");
+    }
+
+    #[test]
+    fn call_method_forwardable_param_with_args() {
+        eval("
+           def target(a, b, k:) = [a, b, k]
+           def forwardable(...) = target(...)
+           def call_forwardable = forwardable(1, 2, k: 3)
+           call_forwardable
+        ");
+        assert_snapshot!(hir_string("call_forwardable"), @"
+        fn call_forwardable@<compiled>:4:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          Jump bb3(v1)
+        bb2():
+          EntryPoint JIT(0)
+          v4:BasicObject = LoadArg :self@0
+          Jump bb3(v4)
+        bb3(v6:BasicObject):
+          v11:Fixnum[1] = Const Value(1)
+          v13:Fixnum[2] = Const Value(2)
+          v15:Fixnum[3] = Const Value(3)
+          PatchPoint MethodRedefined(Object@0x1000, forwardable@0x1008, cme:0x1010)
+          v24:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
+          v25:BasicObject = SendDirect v24, 0x0, :forwardable (0x1038), v11, v13, v15
+          CheckInterrupts
+          Return v25
+        ");
+    }
+
+    #[test]
+    fn call_method_forwardable_param_with_splat() {
+        eval("
+           def forwardable(...) = itself(...)
+           def call_forwardable(args) = forwardable(*args)
+           call_forwardable([])
+        ");
+        assert_snapshot!(hir_string("call_forwardable"), @"
+        fn call_forwardable@<compiled>:3:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          v2:CPtr = LoadSP
+          v3:BasicObject = LoadField v2, :args@0x1000
+          Jump bb3(v1, v3)
+        bb2():
+          EntryPoint JIT(0)
+          v6:BasicObject = LoadArg :self@0
+          v7:BasicObject = LoadArg :args@1
+          Jump bb3(v6, v7)
+        bb3(v9:BasicObject, v10:BasicObject):
+          v16:ArrayExact = ToArray v10
+          v18:BasicObject = Send v9, :forwardable, v16 # SendFallbackReason: Complex argument passing
+          CheckInterrupts
+          Return v18
+        ");
+    }
+
+    #[test]
+    fn call_super_to_forwardable_param() {
+        eval("
+           class SuperFwdBase
+             def run(...) = fin(...)
+             def fin(a, b) = [a, b]
+           end
+           class SuperFwdChild < SuperFwdBase
+             def run(a, b) = super(a, b)
+           end
+           SuperFwdChild.new.run(1, 2)
+        ");
+        assert_snapshot!(hir_string_proc("SuperFwdChild.instance_method(:run)"), @"
+        fn run@<compiled>:7:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          v2:CPtr = LoadSP
+          v3:BasicObject = LoadField v2, :a@0x1000
+          v4:BasicObject = LoadField v2, :b@0x1001
+          Jump bb3(v1, v3, v4)
+        bb2():
+          EntryPoint JIT(0)
+          v7:BasicObject = LoadArg :self@0
+          v8:BasicObject = LoadArg :a@1
+          v9:BasicObject = LoadArg :b@2
+          Jump bb3(v7, v8, v9)
+        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          PatchPoint MethodRedefined(SuperFwdBase@0x1008, run@0x1010, cme:0x1018)
+          v27:CPtr = GetEP 0
+          v28:RubyValue = LoadField v27, :VM_ENV_DATA_INDEX_ME_CREF@0x1040
+          v29:CallableMethodEntry[VALUE(0x1048)] = GuardBitEquals v28, Value(VALUE(0x1048))
+          v30:RubyValue = LoadField v27, :VM_ENV_DATA_INDEX_SPECVAL@0x1050
+          v31:FalseClass = GuardBitEquals v30, Value(false)
+          v32:BasicObject = SendDirect v11, 0x0, :run (0x1058), v12, v13
+          CheckInterrupts
+          Return v32
         ");
     }
 

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -16926,6 +16926,36 @@ mod hir_opt_tests {
         ");
     }
 
+    // A literal block goes through a different path than `&block`: it stays a direct send,
+    // with the blockiseq (the second SendDirect operand, 0x0 without a block) passed along.
+    #[test]
+    fn call_method_forwardable_param_with_block_literal() {
+        eval("
+           def target(a) = yield(a)
+           def forwardable(...) = target(...)
+           def call_forwardable = forwardable(1) { |v| v }
+           call_forwardable
+        ");
+        assert_snapshot!(hir_string("call_forwardable"), @"
+        fn call_forwardable@<compiled>:4:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          Jump bb3(v1)
+        bb2():
+          EntryPoint JIT(0)
+          v4:BasicObject = LoadArg :self@0
+          Jump bb3(v4)
+        bb3(v6:BasicObject):
+          v11:Fixnum[1] = Const Value(1)
+          PatchPoint MethodRedefined(Object@0x1000, forwardable@0x1008, cme:0x1010)
+          v20:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
+          v21:BasicObject = SendDirect v20, 0x1038, :forwardable (0x1058), v11
+          CheckInterrupts
+          Return v21
+        ");
+    }
+
     #[test]
     fn call_method_forwardable_param_with_splat() {
         eval("


### PR DESCRIPTION
This PR supports compiling direct sends to a forwardable ISEQ (`def foo(...)`).

It compiles such calls as the interpreter's `vm_call_iseq_forwardable` fastpath does. It passes arguments as the callee's extra locals below the `...` local, which holds the callinfo of that call (see https://github.com/ruby/ruby/pull/10510). Because those arguments are only read by `memcpy` from the VM stack on `sendforward` instruction, it writes them into the VM stack slots.

## Benchmark

This speeds up lobsters by about 1%.

```
before: ruby 4.1.0dev (2026-09-02T23:38:46Z master 1d8d84b3d6) +ZJIT +PRISM [x86_64-linux]
after: ruby 4.1.0dev (2026-09-03T00:43:37Z zjit-send-forward 41867f3044) +ZJIT +PRISM [x86_64-linux]

--------  ------------  ------------  -------------  ------------
bench      before (ms)    after (ms)  after 1st itr  before/after
lobsters  451.9 ± 6.0%  444.1 ± 5.6%          0.996         1.018
--------  ------------  ------------  -------------  ------------
```

## Stats

This reduces send fallbacks on lobsters.

```diff
-Top-20 calls to C functions from JIT code (71.7% of total 17,983,625):
+Top-20 calls to C functions from JIT code (71.3% of total 17,807,374):
                   rb_hash_aref: 1,963,406 (10.9%)
              rb_vm_invokeblock: 1,718,221 ( 9.6%)
-  rb_vm_opt_send_without_block: 1,392,518 ( 7.7%)
             rb_gc_writebarrier: 1,308,099 ( 7.3%)
+  rb_vm_opt_send_without_block: 1,171,709 ( 6.6%)
                   rb_hash_aset: 1,049,359 ( 5.8%)
                     Hash#fetch:   903,755 ( 5.0%)
              rb_obj_is_kind_of:   693,172 ( 3.9%)
                     rb_vm_send:   659,816 ( 3.7%)
                      Hash#key?:   554,158 ( 3.1%)
                    rb_ivar_get:   537,585 ( 3.0%)
                rb_jit_ary_push:   435,166 ( 2.4%)
             String#start_with?:   326,293 ( 1.8%)
             rb_vm_get_ev_const:   228,773 ( 1.3%)
              rb_vm_sendforward:   217,595 ( 1.2%)
                rb_vm_env_write:   215,729 ( 1.2%)
       rb_yarv_str_eql_internal:   164,500 ( 0.9%)
     ObjectSpace::WeakKeyMap#[]:   137,561 ( 0.8%)
                     Array#any?:   136,844 ( 0.8%)
             Symbol#start_with?:   131,022 ( 0.7%)
      rb_vm_getinstancevariable:   127,085 ( 0.7%)

-Top-20 send fallback reasons (100.0% of total 4,065,879):
+Top-20 send fallback reasons (100.0% of total 3,846,379):
               invokeblock_polymorphic_miss: 1,159,511 (28.5%)
                           send_polymorphic:   944,553 (23.2%)
                invokeblock_not_specialized:   558,710 (13.7%)
-              one_or_more_complex_arg_pass:   375,087 ( 9.2%)
                     send_block_arg_not_nil:   374,068 ( 9.2%)
                sendforward_not_specialized:   217,595 ( 5.4%)
+              one_or_more_complex_arg_pass:   152,127 ( 4.0%)
                              uncategorized:   124,350 ( 3.1%)
   send_not_optimized_method_type_optimized:    97,267 ( 2.4%)
         send_not_optimized_need_permission:    83,563 ( 2.1%)
                           send_megamorphic:    35,708 ( 0.9%)
                          super_polymorphic:    28,182 ( 0.7%)
         invokesuperforward_not_specialized:    22,240 ( 0.5%)
                    super_complex_args_pass:    14,401 ( 0.4%)
             send_not_optimized_method_type:    11,330 ( 0.3%)
                           super_from_block:    11,119 ( 0.3%)
                       singleton_class_seen:     6,389 ( 0.2%)
            super_not_optimized_method_type:     1,001 ( 0.0%)
                           send_no_profiles:       388 ( 0.0%)
                      super_call_with_block:       343 ( 0.0%)
                  send_polymorphic_fallback:        68 ( 0.0%)

-Top-6 popular complex argument-parameter features not optimized (100.0% of total 348,993):
+Top-5 popular complex argument-parameter features not optimized (100.0% of total 88,513):
-  param_forwardable: 260,480 (74.6%)
        param_kwrest:  67,981 (19.5%)
     caller_kw_splat:  13,754 ( 3.9%)
     caller_blockarg:   3,844 ( 1.1%)
        caller_splat:   1,478 ( 0.4%)
        caller_kwarg:   1,456 ( 0.4%)
```