### PR TITLE
Fix and document `--with-static-linked-ext`

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -1065,7 +1065,7 @@ $(PLATFORM_D):
 exe/$(PROGRAM): $(TIMESTAMPDIR)/$(arch)/.time
 exe/$(PROGRAM): ruby-runner.c ruby-runner.h exe/.time $(PREP) {$(VPATH)}config.h
 	$(Q) $(CC) $(CFLAGS) $(INCFLAGS) $(CPPFLAGS) -DRUBY_INSTALL_NAME=$(@F) $(COUTFLAG)ruby-runner.$(OBJEXT) -c $(CSRCFLAG)$(srcdir)/ruby-runner.c
-	$(Q) $(PURIFY) $(CC) $(CFLAGS) $(LDFLAGS) $(OUTFLAG)$@ ruby-runner.$(OBJEXT) $(LIBS)
+	$(Q) $(PURIFY) $(CC) $(CFLAGS) $(LDFLAGS) $(XLDFLAGS) $(OUTFLAG)$@ ruby-runner.$(OBJEXT) $(LIBS)
 	$(Q) $(POSTLINK)
 	$(Q) $(BOOTSTRAPRUBY) \
 	    -e 'prog, dest, inst = ARGV; dest += "/ruby"' \

--- a/configure.ac
+++ b/configure.ac
@@ -698,7 +698,15 @@ RUBY_WERROR_FLAG([
 	[
 	cd .. && rm -fr tmp.$$.try_link
 	AC_MSG_RESULT(no)
-	AC_MSG_ERROR([something wrong with LDFLAGS="$LDFLAGS"])
+	rb_ldflags_nodir=
+	for rb_ldflags_arg in $LDFLAGS; do
+	    AS_CASE(["$rb_ldflags_arg"], [-L?*], [
+		AS_IF([test -d "${rb_ldflags_arg#-L}"], [],
+		      [rb_ldflags_nodir="$rb_ldflags_nodir ${rb_ldflags_arg#-L}"])
+	    ])
+	done
+	AC_MSG_ERROR([something wrong with LDFLAGS="$LDFLAGS"]dnl
+[${rb_ldflags_nodir:+; no such directory:$rb_ldflags_nodir}])
 	]
     )
     cd .. && rm -fr tmp.$$.try_link

--- a/configure.ac
+++ b/configure.ac
@@ -698,12 +698,15 @@ RUBY_WERROR_FLAG([
 	[
 	cd .. && rm -fr tmp.$$.try_link
 	AC_MSG_RESULT(no)
-	rb_ldflags_nodir=
+	rb_ldflags_nodir= rb_ldflags_Lopt=
 	for rb_ldflags_arg in $LDFLAGS; do
-	    AS_CASE(["$rb_ldflags_arg"], [-L?*], [
-		AS_IF([test -d "${rb_ldflags_arg#-L}"], [],
-		      [rb_ldflags_nodir="$rb_ldflags_nodir ${rb_ldflags_arg#-L}"])
-	    ])
+	    AS_IF([test "$rb_ldflags_Lopt"], [rb_ldflags_Lopt=],
+		  [AS_CASE(["$rb_ldflags_arg"],
+			   [-L?*], [rb_ldflags_arg="${rb_ldflags_arg@%:@-L}" rb_ldflags_Lopt=],
+			   [-L], [rb_ldflags_Lopt=yes; continue],
+			   [continue])])
+	    AS_IF([test -d "${rb_ldflags_arg}"], [],
+		  [rb_ldflags_nodir="$rb_ldflags_nodir ${rb_ldflags_arg}"])
 	done
 	AC_MSG_ERROR([something wrong with LDFLAGS="$LDFLAGS"]dnl
 [${rb_ldflags_nodir:+; no such directory:$rb_ldflags_nodir}])

--- a/doc/contributing/building_ruby.md
+++ b/doc/contributing/building_ruby.md
@@ -235,6 +235,32 @@ required to build Ruby. To build Miniruby:
 make miniruby
 ```
 
+### Statically linking extensions
+
+`configure --with-static-linked-ext` links the extension libraries under `ext/`
+into the `ruby` binary instead of building them as separate `.so`/`.bundle`
+files, and makes `RbConfig::CONFIG["EXTSTATIC"]` `"static"`. Bundled gems that
+have C extensions, such as `bigdecimal` and `fiddle`, are unaffected and are
+still built as loadable objects.
+
+The external libraries the extensions need are then linked into `ruby` itself,
+so pass `--with-EXTLIB-dir` to `configure` rather than putting the paths in
+`LDFLAGS` by hand. On macOS with Homebrew:
+
+```sh
+./configure --with-static-linked-ext --with-openssl-dir=$(brew --prefix openssl@3)
+```
+
+`brew --prefix LIB` prints a path even for a formula that is not installed, so
+generating `LDFLAGS` from it can yield `-L` options for directories that do not
+exist, which `configure` rejects. Use `brew --prefix --installed LIB`, which
+fails instead of printing a path for an uninstalled formula.
+
+Build this configuration with GNU make 4 or later. Under GNU
+make 3 a parallel build can link `ruby` without the extension objects, and that
+link succeeds silently, leaving an interpreter with no extensions and no
+encodings.
+
 ## Debugging
 
 You can use either lldb or gdb for debugging. Before debugging, you need to

--- a/doc/contributing/building_ruby.md
+++ b/doc/contributing/building_ruby.md
@@ -256,11 +256,6 @@ generating `LDFLAGS` from it can yield `-L` options for directories that do not
 exist, which `configure` rejects. Use `brew --prefix --installed LIB`, which
 fails instead of printing a path for an uninstalled formula.
 
-Build this configuration with GNU make 4 or later. Under GNU
-make 3 a parallel build can link `ruby` without the extension objects, and that
-link succeeds silently, leaving an interpreter with no extensions and no
-encodings.
-
 ## Debugging
 
 You can use either lldb or gdb for debugging. Before debugging, you need to

--- a/ext/extmk.rb
+++ b/ext/extmk.rb
@@ -123,6 +123,10 @@ def extract_makefile(makefile, keep = true)
     /^STATIC_LIB[ \t]*=[ \t]*\S+/ =~ m or $static = false
   end
   $preload = Shellwords.shellwords(m[/^preload[ \t]*=[ \t]*(.*)/, 1] || "")
+  if ldflags = m[/^ldflags[ \t]*=[ \t]*(.*)/, 1] and !$LDFLAGS.include?(ldflags)
+    # extconf.rb may have added library paths here, e.g. via pkg_config.
+    $LDFLAGS += " " + ldflags
+  end
   if dldflags = m[/^dldflags[ \t]*=[ \t]*(.*)/, 1] and !$DLDFLAGS.include?(dldflags)
     $DLDFLAGS += " " + dldflags
   end


### PR DESCRIPTION
On macOS with Homebrew, `./configure --with-static-linked-ext --with-openssl-dir=$(brew --prefix openssl@3)` fails at `linking exe/ruby` with `ld: library 'ssl' not found`. The `exe/$(PROGRAM)` rule links `$(LIBS)`, which pulls in `$(EXTLIBS)`, yet it is the only such rule that omits `$(XLDFLAGS)`, so the search paths collected into `$(EXTLDFLAGS)` never reach it. Rebuilding hits a related failure on `-lyaml`, because `ext/extmk.rb` restores `dldflags` and `libpath` from a reused extension Makefile but not `ldflags`, where `pkg_config` records what it found.

The other two commits improve the `LDFLAGS` check, which now names the directories that do not exist, and document the option in `doc/contributing/building_ruby.md`.

Verified on `master` and `ruby_4_0` on arm64-darwin27. A clean build with only `--with-openssl-dir` succeeds, every statically linked extension loads and works, and `make test-all` matches a dynamic build apart from the tests that need `ext/-test-`.

Generated with [Claude Code](https://claude.com/claude-code)
