### PR TITLE
win32: escape spawn arguments re-parsed by cmd.exe

### DIFF
--- a/test/ruby/test_process.rb
+++ b/test/ruby/test_process.rb
@@ -1150,6 +1150,76 @@ class TestProcess < Test::Unit::TestCase
     assert_raise(Errno::ENOENT) { IO.popen([str, str]) }
   end
 
+  PAYLOADS = [
+    'a&echo.>INJECTED',       # command separator
+    'a|echo.>INJECTED',       # pipe
+    'a>INJECTED',             # redirection
+    'a&(echo.>INJECTED)',     # grouping
+    'a"&echo.>INJECTED',      # double-quote break-out
+    'a^&echo.>INJECTED',      # caret escape
+  ]
+
+  # An argument passed via the array form must reach a batch file as a plain
+  # argument, not be re-interpreted as cmd.exe syntax.
+  def test_spawn_bat_argument_quoting
+    omit "Windows only" unless windows?
+    with_tmpchdir do
+      bat = File.expand_path("harmless.bat")
+      # %1 keeps the quotes the caller added.  A batch that strips them with
+      # %~1 and reuses the result in command position re-exposes the
+      # metacharacter, which no runtime can prevent.
+      File.binwrite(bat, "@echo off\r\necho [%1]\r\n")
+      PAYLOADS.each do |payload|
+        File.delete("INJECTED") if File.exist?("INJECTED")
+        system(bat, payload, out: "out", err: File::NULL)
+        assert_not_operator(File, :exist?, "INJECTED",
+                            "#{payload.inspect} was re-interpreted by cmd.exe")
+      end
+
+      # An argument that needs no quoting still reaches %1 unquoted.
+      system(bat, "plain", out: "out", err: File::NULL)
+      assert_equal("[plain]", File.binread("out").chomp)
+    end
+  end
+
+  # The same protection applies to a cmd.exe internal command, which is run as
+  # `cmd.exe /c`.  There the argument must survive without being quoted, since
+  # quoting would change what the command itself receives.
+  def test_spawn_internal_command_argument_quoting
+    omit "Windows only" unless windows?
+    with_tmpchdir do
+      PAYLOADS.each do |payload|
+        File.delete("INJECTED") if File.exist?("INJECTED")
+        system("echo", payload, out: "out", err: File::NULL)
+        assert_not_operator(File, :exist?, "INJECTED",
+                            "#{payload.inspect} was re-interpreted by cmd.exe")
+      end
+
+      system("echo", "plain", out: "out", err: File::NULL)
+      assert_equal("plain", File.binread("out").chomp,
+                   "an argument that needs no quoting must not gain quotes")
+    end
+  end
+
+  # A command name that merely starts with an internal command must not be
+  # taken for that command.  [Bug #22199] adjacent: internal_match compares the
+  # terminator so "setlocal&..." no longer matches "setlocal".
+  def test_spawn_internal_command_name_is_not_a_prefix_match
+    omit "Windows only" unless windows?
+    with_tmpchdir do
+      %w[setlocal endlocal truename].each do |builtin|
+        File.delete("INJECTED") if File.exist?("INJECTED")
+        begin
+          system("#{builtin}>INJECTED", "x", out: File::NULL, err: File::NULL)
+        rescue SystemCallError
+          # not found is the expected outcome
+        end
+        assert_not_operator(File, :exist?, "INJECTED",
+                            "#{builtin}>INJECTED ran as the #{builtin} builtin")
+      end
+    end
+  end
+
   def test_exec_noshell
     with_tmpchdir {|d|
       File.write("s", <<-"End")

--- a/win32/win32.c
+++ b/win32/win32.c
@@ -1050,7 +1050,9 @@ static const char szInternalCmds[][InternalCmdsMax+2] = {
 static int
 internal_match(const void *key, const void *elem)
 {
-    return strncmp(key, ((const char *)elem) + 1, InternalCmdsMax);
+    /* Compare the terminator too, so a longer key that merely starts with an
+     * entry (e.g. "setlocal&...") does not match that entry. */
+    return strncmp(key, ((const char *)elem) + 1, InternalCmdsMax + 1);
 }
 
 /* License: Ruby's */
@@ -1120,8 +1122,23 @@ rb_w32_get_osfhandle(int fh)
 }
 
 /* License: Ruby's */
+/* How an argument is kept from being re-parsed by the cmd.exe that runs a
+ * batch file or an internal command.  CMDQ_CARET escapes a metacharacter with
+ * a caret, which the single cmd.exe parse of an internal command honors and
+ * which leaves the argument itself unchanged.  A batch file needs CMDQ_QUOTE
+ * instead, because CreateProcess wraps the command line before cmd.exe sees it
+ * and the caret is lost; there an argument carrying a metacharacter is wrapped
+ * in double quotes.  Both modes double an embedded double quote instead of
+ * escaping it with a backslash, which cmd.exe does not honor.  `quote_bs`
+ * doubles a trailing run of backslashes so it does not escape the closing
+ * quote ([Bug #22199]). */
+#define CMDQ_NONE 0
+#define CMDQ_CARET 1
+#define CMDQ_QUOTE 2
+#define CMDQ_METACHARS "&|<>()^"
+
 static int
-join_argv(char *cmd, char *const *argv, BOOL escape, UINT cp, int backslash, BOOL quote_bs)
+join_argv(char *cmd, char *const *argv, int cmdmode, UINT cp, int backslash, BOOL quote_bs)
 {
     const char *p, *s;
     char *q, *const *t;
@@ -1130,7 +1147,8 @@ join_argv(char *cmd, char *const *argv, BOOL escape, UINT cp, int backslash, BOO
     for (t = argv, q = cmd, len = 0; (p = *t) != 0; t++) {
         quote = 0;
         s = p;
-        if (!*p || strpbrk(p, " \t\"'")) {
+        if (!*p || strpbrk(p, " \t\"'") ||
+            (cmdmode == CMDQ_QUOTE && strpbrk(p, CMDQ_METACHARS))) {
             quote = 1;
             len++;
             if (q) *q++ = '"';
@@ -1146,16 +1164,30 @@ join_argv(char *cmd, char *const *argv, BOOL escape, UINT cp, int backslash, BOO
                     memcpy(q, s, n);
                     q += n;
                 }
-                s = p;
-                len += ++bs;
-                if (q) {
-                    memset(q, '\\', bs);
-                    q += bs;
+                if (cmdmode != CMDQ_NONE) {
+                    /* double the run of backslashes, then emit "" */
+                    len += bs + 2;
+                    if (q) {
+                        memset(q, '\\', bs);
+                        q += bs;
+                        *q++ = '"';
+                        *q++ = '"';
+                    }
+                    s = p + 1;
+                }
+                else {
+                    s = p;
+                    len += ++bs;
+                    if (q) {
+                        memset(q, '\\', bs);
+                        q += bs;
+                    }
                 }
                 bs = 0;
                 break;
-              case '<': case '>': case '|': case '^':
-                if (escape && !quote) {
+              case '&': case '|': case '<': case '>':
+              case '(': case ')': case '^':
+                if (cmdmode == CMDQ_CARET && !quote) {
                     len += (n = p - s) + 1;
                     if (q) {
                         memcpy(q, s, n);
@@ -1163,8 +1195,10 @@ join_argv(char *cmd, char *const *argv, BOOL escape, UINT cp, int backslash, BOO
                         *q++ = '^';
                     }
                     s = p;
+                    bs = 0;
                     break;
                 }
+                /* fall through */
               default:
                 bs = 0;
                 p = CharNextExA(cp, p, 0) - 1;
@@ -1172,7 +1206,7 @@ join_argv(char *cmd, char *const *argv, BOOL escape, UINT cp, int backslash, BOO
             }
         }
         len += (n = p - s) + 1;
-        if (quote) len += (quote_bs ? bs : 0) + 1;
+        if (quote) len += ((cmdmode != CMDQ_NONE || quote_bs) ? bs : 0) + 1;
         if (q) {
             memcpy(q, s, n);
             if (backslash > 0) {
@@ -1182,8 +1216,9 @@ join_argv(char *cmd, char *const *argv, BOOL escape, UINT cp, int backslash, BOO
             }
             q += n;
             if (quote) {
-                // See [Bug #22199]
-                if (quote_bs && bs) {
+                /* Double a trailing run of backslashes so it does not escape
+                 * the closing quote for CommandLineToArgvW.  See [Bug #22199]. */
+                if ((cmdmode != CMDQ_NONE || quote_bs) && bs) {
                     memset(q, '\\', bs);
                     q += bs;
                 }
@@ -1483,9 +1518,9 @@ static rb_pid_t
 w32_spawn_process(int mode, const char *prog, char *const *argv,
                   int in_fd, int out_fd, int err_fd, DWORD flags, UINT cp)
 {
-    int c_switch = 0;
+    int c_switch = 0, cmdmode = CMDQ_NONE;
     size_t len;
-    BOOL ntcmd = FALSE, tmpnt;
+    BOOL tmpnt;
     const char *shell;
     char *cmd, fbuf[PATH_MAX];
     WCHAR *wcmd = NULL, *wprog = NULL;
@@ -1509,7 +1544,7 @@ w32_spawn_process(int mode, const char *prog, char *const *argv,
     if (!prog) prog = argv[0];
     if ((shell = w32_getenv("COMSPEC", cp)) &&
         internal_cmd_match(prog, tmpnt = !is_command_com(shell))) {
-        ntcmd = tmpnt;
+        if (tmpnt) cmdmode = CMDQ_CARET;
         prog = shell;
         c_switch = 1;
     }
@@ -1529,22 +1564,25 @@ w32_spawn_process(int mode, const char *prog, char *const *argv,
     }
     if (c_switch || is_batch(prog)) {
         char *progs[2];
+        /* CreateProcess wraps a batch file's command line before cmd.exe sees
+         * it and the caret is lost, so quote its arguments instead. */
+        int argmode = c_switch ? cmdmode : CMDQ_QUOTE;
         progs[0] = (char *)prog;
         progs[1] = NULL;
-        len = join_argv(NULL, progs, ntcmd, cp, 1, FALSE);
+        len = join_argv(NULL, progs, cmdmode, cp, 1, FALSE);
         if (c_switch) len += 3;
         else ++argv;
-        if (argv[0]) len += join_argv(NULL, argv, ntcmd, cp, 0, FALSE);
+        if (argv[0]) len += join_argv(NULL, argv, argmode, cp, 0, FALSE);
         cmd = ALLOCV(v, len);
-        join_argv(cmd, progs, ntcmd, cp, 1, FALSE);
+        join_argv(cmd, progs, cmdmode, cp, 1, FALSE);
         if (c_switch) strlcat(cmd, " /c", len);
-        if (argv[0]) join_argv(cmd + strlcat(cmd, " ", len), argv, ntcmd, cp, 0, FALSE);
+        if (argv[0]) join_argv(cmd + strlcat(cmd, " ", len), argv, argmode, cp, 0, FALSE);
         prog = c_switch ? shell : 0;
     }
     else {
-        len = join_argv(NULL, argv, FALSE, cp, 1, TRUE);
+        len = join_argv(NULL, argv, CMDQ_NONE, cp, 1, TRUE);
         cmd = ALLOCV(v, len);
-        join_argv(cmd, argv, FALSE, cp, 1, TRUE);
+        join_argv(cmd, argv, CMDQ_NONE, cp, 1, TRUE);
     }
 
     if (!e && cmd && !(wcmd = mbstr_to_wstr(cp, cmd, -1, NULL))) e = E2BIG;


### PR DESCRIPTION
On Windows a batch file or an internal command is launched through cmd.exe, which re-parses the command line before the target sees it. Arguments passed with the array form of `Kernel#spawn` and `Kernel#system` are meant to bypass the shell, but `join_argv` only quoted an argument that already contained whitespace and escaped an embedded quote with a backslash, which cmd.exe does not honor. An argument containing a metacharacter such as `&`, `|`, or `(` was therefore re-interpreted by cmd.exe instead of reaching the target as a plain argument.

```ruby
File.write("e.bat", "@echo off\r\necho GOT:%1\r\n")
system("e.bat", "a&b")   # cmd.exe split the argument at `&`
```

The protection differs per path. An internal command runs through a single cmd.exe parse, so a caret escape is enough there and leaves the argument itself untouched. A batch file is wrapped by CreateProcess, which drops the caret, so its arguments are quoted instead, and only when they carry a metacharacter. An argument that needs no quoting reaches the target exactly as it did before.

`internal_match` compared only the first eight bytes of a name, so `setlocal&...` matched the `setlocal` builtin and the rest of the name reached cmd.exe as syntax. It now compares the terminator too.

A batch file that strips the quotes with `%~1` and reuses the result in command position still re-exposes the metacharacter. No runtime can prevent that, and the added test documents it.

Verified with a full mswin build: `test/ruby/test_process.rb`, `spec/ruby/core/process/spawn_spec.rb`, `spec/ruby/core/kernel/system_spec.rb`, `test_system`, `test_env`, `io/console` and btest all pass.
