### PR TITLE
Fetch the execution context once in Array#each

### DIFF
--- a/array.c
+++ b/array.c
@@ -2752,8 +2752,9 @@ rb_ary_each(VALUE ary)
     long i;
     ary_verify(ary);
     RETURN_SIZED_ENUMERATOR(ary, 0, 0, ary_enum_length);
+    rb_execution_context_t *ec = GET_EC();
     for (i=0; i<RARRAY_LEN(ary); i++) {
-        rb_yield(RARRAY_AREF(ary, i));
+        rb_ec_yield(ec, RARRAY_AREF(ary, i));
     }
     return ary;
 }


### PR DESCRIPTION
`rb_yield()` calls `GET_EC()` on every element, which on arm64 is an out-of-line call to `rb_current_ec()` (`RB_THREAD_CURRENT_EC_NOINLINE`). Hoist it out of the loop and use `rb_ec_yield()`, as [ff831eb057](https://github.com/ruby/ruby/commit/ff831eb0572b2d8f794acca478ea77c7bfefbc61) does for Mutex#synchronize.

`benchmark/loop_each.yml`: 1.16x on arm64-darwin, 1.05x on aarch64-linux. Linux x86 stays the same, while Windows x86 is 1.04x. 