### PR TITLE
[Bug #21697] Keep revision.h in a source tree without VCS

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -1517,9 +1517,10 @@ after-update:: extract-extlibs
 after-update:: extract-gems
 after-update:: update-default-gemspecs
 
+# Do not remove or empty revision.h itself, whose content file2lastrev.rb
+# keeps when the source tree has no VCS.
 update-src::
-	$(Q) $(RM) $(REVISION_H) revision.h "$(srcdir)/$(REVISION_H)" "$(srcdir)/revision.h"
-	$(Q) exit > "$(srcdir)/revision.h"
+	$(Q) $(RM) $(REVISION_H) "$(srcdir)/$(REVISION_H)"
 
 update-remote:: update-src update-download
 update-download:: $(ALWAYS_UPDATE_UNICODE:yes=update-unicode)


### PR DESCRIPTION
`make up` in a source tree without VCS, such as an extracted release tarball, dropped `RUBY_REVISION` and `RUBY_FULL_REVISION` from `revision.h` and left only the `RUBY_RELEASE_*` macros. This broke the 4.0.0-preview2 release and forced a workaround in `ruby/actions`.

`update-src` truncated `revision.h` to force the regeneration. `tool/file2lastrev.rb` already refuses to overwrite an existing `revision.h` when no VCS is available, but that guard treats a blank file as absent, so the truncation let `VCS::Null` rewrite the header with the release date alone. Dropping the `$(REVISION_H)` timestamp is enough to force the regeneration, and `defs/gmake.mk` forces it independently by comparing `RUBY_FULL_REVISION` against the VCS head.

Verified on mswin in-place and out-of-place, with and without `.git`.

Generated with [Claude Code](https://claude.com/claude-code)
