### PR TITLE
ZJIT: Don't include builtin bits in user-defined classes

### DIFF
--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -16790,6 +16790,38 @@ mod hir_opt_tests {
     }
 
     #[test]
+    fn test_fold_is_a_user_class_with_profiled_fixnum_to_false() {
+        eval(r#"
+            class C; end
+            def test(o) = o.is_a?(C)
+            test(5)
+            test(5)
+        "#);
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:3:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          v2:CPtr = LoadSP
+          v3:BasicObject = LoadField v2, :o@0x1000
+          Jump bb3(v1, v3)
+        bb2():
+          EntryPoint JIT(0)
+          v6:BasicObject = LoadArg :self@0
+          v7:BasicObject = LoadArg :o@1
+          Jump bb3(v6, v7)
+        bb3(v9:BasicObject, v10:BasicObject):
+          PatchPoint StableConstantNames(0x1008, C)
+          v16:ClassSubclass[C@0x1010] = Const Value(VALUE(0x1010))
+          PatchPoint MethodRedefined(Integer@0x1018, is_a?@0x1020, cme:0x1028)
+          v26:Fixnum = GuardType v10, Fixnum recompile
+          v28:FalseClass = Const Value(false)
+          CheckInterrupts
+          Return v28
+        ");
+    }
+
+    #[test]
     fn test_is_a_array_subclass_folds_to_true() {
         eval(r#"
             class C < Array; end

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -16535,9 +16535,56 @@ mod hir_opt_tests {
           PatchPoint NoSingletonClass(String@0x1010)
           PatchPoint MethodRedefined(String@0x1010, is_a?@0x1011, cme:0x1018)
           v27:StringExact = GuardType v10, StringExact recompile
-          v28:BoolExact = IsA v27, v16
+          v29:TrueClass = Const Value(true)
           CheckInterrupts
-          Return v28
+          Return v29
+        ");
+    }
+
+    #[test]
+    fn test_specialize_is_a_class_polymorphic() {
+        set_call_threshold(4);
+        eval(r#"
+            def test(o) = o.is_a?(String)
+            test("asdf")
+            test(4)
+        "#);
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:2:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          v2:CPtr = LoadSP
+          v3:BasicObject = LoadField v2, :o@0x1000
+          Jump bb3(v1, v3)
+        bb2():
+          EntryPoint JIT(0)
+          v6:BasicObject = LoadArg :self@0
+          v7:BasicObject = LoadArg :o@1
+          Jump bb3(v6, v7)
+        bb3(v9:BasicObject, v10:BasicObject):
+          PatchPoint StableConstantNames(0x1008, String)
+          v16:ClassSubclass[String@0x1010] = Const Value(VALUE(0x1010))
+          v19:CBool = HasType v10, Fixnum
+          CondBranch v19, bb5(), bb6()
+        bb5():
+          PatchPoint MethodRedefined(Integer@0x1018, is_a?@0x1020, cme:0x1028)
+          v45:FalseClass = Const Value(false)
+          Jump bb4(v45)
+        bb6():
+          v25:CBool = HasType v10, StringExact
+          CondBranch v25, bb7(), bb8()
+        bb7():
+          PatchPoint NoSingletonClass(String@0x1010)
+          PatchPoint MethodRedefined(String@0x1010, is_a?@0x1020, cme:0x1028)
+          v46:TrueClass = Const Value(true)
+          Jump bb4(v46)
+        bb8():
+          v31:BasicObject = Send v10, :is_a?, v16 # SendFallbackReason: Send: polymorphic call site
+          Jump bb4(v31)
+        bb4(v18:BasicObject):
+          CheckInterrupts
+          Return v18
         ");
     }
 
@@ -16664,9 +16711,9 @@ mod hir_opt_tests {
           PatchPoint NoSingletonClass(String@0x1010)
           PatchPoint MethodRedefined(String@0x1010, kind_of?@0x1011, cme:0x1018)
           v27:StringExact = GuardType v10, StringExact recompile
-          v28:BoolExact = IsA v27, v16
+          v29:TrueClass = Const Value(true)
           CheckInterrupts
-          Return v28
+          Return v29
         ");
     }
 

--- a/zjit/src/hir_type/mod.rs
+++ b/zjit/src/hir_type/mod.rs
@@ -259,6 +259,9 @@ impl Type {
         Type::new(bits::Fixnum, Specialization::Object(VALUE::fixnum_from_usize(val as usize)))
     }
 
+    /// Find the type bits corresponding to exactly the given Ruby class. If we already have
+    /// pre-defined bit patterns for it (say, `NilClass` or `String`), then return those bits
+    /// (`NilClass`, `StringExact`). Otherwise return None.
     fn bits_from_exact_class(class: VALUE) -> Option<u64> {
         types::ExactBitsAndClass
             .iter()
@@ -266,6 +269,19 @@ impl Type {
             .map(|&(bits, _)| bits)
     }
 
+    /// Find the type bits corresponding to the given Ruby class and all of its subclasses. If we
+    /// already have pre-defined bit patterns for it (say, `Array` or `Hash`), then return those
+    /// bits (`Array`, `Hash`). Otherwise return None.
+    fn bits_from_inexact_class(class: VALUE) -> Option<u64> {
+        types::InexactBitsAndClass
+            .iter()
+            .find(|&&(_, class_object)| unsafe { *class_object } == class)
+            .map(|&(bits, _)| bits)
+    }
+
+    /// Find the type bits corresponding to the given Ruby class's subclasses, excluding the class
+    /// itself. If we already have pre-defined bit patterns for it (say, `Array` or `Hash`), then
+    /// return those bits (`ArraySubclass`, `HashSubclass`). Otherwise return None.
     fn bits_from_subclass(class: VALUE) -> Option<u64> {
         types::SubclassBitsAndClass
             .iter()
@@ -352,6 +368,11 @@ impl Type {
         else { Self::from_class(val.class()).intersection(types::HeapBasicObject) }
     }
 
+    /// Try to represent the class using only bits, falling back to the nearest builtin subclass
+    /// and a TypeExact specialization.
+    ///
+    /// Useful for getting specific type information: if we know that we're allocating from a
+    /// specific class, we know the results will be exactly that class and not a subclass.
     pub fn from_class(class: VALUE) -> Type {
         if let Some(bits) = Self::bits_from_exact_class(class) {
             return Type::from_bits(bits);
@@ -363,11 +384,14 @@ impl Type {
                      get_class_name(class))
     }
 
+    /// Try to represent the class or its subclasses using only bits, falling back to the nearest
+    /// builtin subclass and a Type specialization.
+    ///
+    /// Useful for querying subclassing. For example, if we want to query if some `t: Type` is a
+    /// subclass of `class`, we can use `t.is_subtype(Type::from_class_inexact(class))`.
     pub fn from_class_inexact(class: VALUE) -> Type {
-        if let Some(&(bits, _)) = types::InexactBitsAndClass
-            .iter()
-            .find(|&&(_, class_object)| unsafe { *class_object } == class) {
-            return Type::new(bits, Specialization::Type(class));
+        if let Some(bits) = Self::bits_from_inexact_class(class) {
+            return Type::from_bits(bits);
         }
         if let Some(bits) = Self::bits_from_subclass(class) {
             return Type::new(bits, Specialization::Type(class));
@@ -925,9 +949,9 @@ mod tests {
     #[test]
     fn from_class_inexact() {
         crate::cruby::with_rubyvm(|| {
-            let string_class = unsafe { rb_cString };
-            assert_bit_equal(Type::from_class_inexact(string_class),
-                             Type::new(bits::String, Specialization::Type(string_class)));
+            assert_bit_equal(Type::from_class_inexact(unsafe { rb_cArray }), types::Array);
+            assert_bit_equal(Type::from_class_inexact(unsafe { rb_cNilClass }), types::NilClass);
+            assert_bit_equal(Type::from_class_inexact(unsafe { rb_cString }), types::String);
             let c_class = define_class("C", unsafe { rb_cObject });
             assert_bit_equal(Type::from_class_inexact(c_class),
                              Type::new(bits::ObjectSubclass, Specialization::Type(c_class)));

--- a/zjit/src/hir_type/mod.rs
+++ b/zjit/src/hir_type/mod.rs
@@ -364,11 +364,16 @@ impl Type {
     }
 
     pub fn from_class_inexact(class: VALUE) -> Type {
-        let bits = types::InexactBitsAndClass
+        if let Some(&(bits, _)) = types::InexactBitsAndClass
             .iter()
-            .find(|&(_, class_object)| class.is_subclass_of(unsafe { **class_object }) == ClassRelationship::Subclass)
-            .unwrap_or_else(|| panic!("Class {} is not a subclass of BasicObject! Don't know what to do.", get_class_name(class))).0;
-        Type::new(bits, Specialization::Type(class))
+            .find(|&&(_, class_object)| unsafe { *class_object } == class) {
+            return Type::new(bits, Specialization::Type(class));
+        }
+        if let Some(bits) = Self::bits_from_subclass(class) {
+            return Type::new(bits, Specialization::Type(class));
+        }
+        unreachable!("Class {} is not a subclass of BasicObject! Don't know what to do.",
+                     get_class_name(class))
     }
 
     /// Private. Only for creating type globals.
@@ -914,6 +919,32 @@ mod tests {
             assert_bit_equal(Type::from_class(unsafe { rb_cFalseClass }), types::FalseClass);
             let c_class = define_class("C", unsafe { rb_cObject });
             assert_bit_equal(Type::from_class(c_class), Type::new(bits::ObjectSubclass, Specialization::TypeExact(c_class)));
+        });
+    }
+
+    #[test]
+    fn from_class_inexact() {
+        crate::cruby::with_rubyvm(|| {
+            let string_class = unsafe { rb_cString };
+            assert_bit_equal(Type::from_class_inexact(string_class),
+                             Type::new(bits::String, Specialization::Type(string_class)));
+            let c_class = define_class("C", unsafe { rb_cObject });
+            assert_bit_equal(Type::from_class_inexact(c_class),
+                             Type::new(bits::ObjectSubclass, Specialization::Type(c_class)));
+        });
+    }
+
+    #[test]
+    fn intersection_of_builtin_and_user_class_inexact_is_empty() {
+        crate::cruby::with_rubyvm(|| {
+            let c_class = define_class("C", unsafe { rb_cObject });
+            let c_inexact = Type::from_class_inexact(c_class);
+            // A Fixnum can never be an instance of C or any subclass of C; the
+            // bits are disjoint, so no specialization comparison is needed.
+            assert_bit_equal(Type::fixnum(123).intersection(c_inexact), types::Empty);
+            assert_bit_equal(c_inexact.intersection(Type::fixnum(123)), types::Empty);
+            assert_bit_equal(types::Fixnum.intersection(c_inexact), types::Empty);
+            assert_bit_equal(c_inexact.intersection(types::Fixnum), types::Empty);
         });
     }
 


### PR DESCRIPTION
This makes Fixnum.intersect(some user class Foo) result in Empty instead
of previously some nonsense value like Fixnum[Foo].

This allows folding a lot of calls to `IsA` to `false` that were not possible before.

Drops total number of calls to `rb_obj_is_kind_of` from 3.5MM to 2.9MM
on lobsters.

```diff
--- /tmp/ccalls-before.txt
+++ /tmp/ccalls-after.txt
@@ -1,9 +1,9 @@
-Top-20 calls to C functions from JIT code (69.8% of total 87,587,232):
-  rb_vm_opt_send_without_block: 9,913,465 (11.3%)
-                  rb_hash_aref: 9,901,809 (11.3%)
-                   rb_ivar_get: 6,116,145 ( 7.0%)
-            rb_gc_writebarrier: 5,463,959 ( 6.2%)
+          Array#reverse_each:   236,567 ( 1.0%)
+Top-20 calls to C functions from JIT code (69.6% of total 86,987,847):
+  rb_vm_opt_send_without_block: 9,913,448 (11.4%)
+                  rb_hash_aref: 9,901,807 (11.4%)
+                   rb_ivar_get: 6,116,147 ( 7.0%)
+            rb_gc_writebarrier: 5,463,952 ( 6.3%)
              rb_vm_invokeblock: 4,348,396 ( 5.0%)
-                    rb_vm_send: 3,874,202 ( 4.4%)
-                    Hash#fetch: 3,705,675 ( 4.2%)
-             rb_obj_is_kind_of: 3,507,142 ( 4.0%)
-                  rb_hash_aset: 2,916,632 ( 3.3%)
-     rb_vm_getinstancevariable: 2,325,583 ( 2.7%)
-                     Hash#key?: 1,411,874 ( 1.6%)
+                    rb_vm_send: 3,874,201 ( 4.5%)
+                    Hash#fetch: 3,705,677 ( 4.3%)
+                  rb_hash_aset: 2,916,628 ( 3.4%)
+             rb_obj_is_kind_of: 2,897,725 ( 3.3%)
+     rb_vm_getinstancevariable: 2,325,637 ( 2.7%)
```

Co-authored-by: Aaron Patterson <tenderlove@ruby-lang.org>
