### PR TITLE
YJIT: Generate ISEQ_TRANSLATED with bindgen for YJIT

### DIFF
--- a/internal/struct.h
+++ b/internal/struct.h
@@ -18,7 +18,7 @@
  *          header, rather than being on a separately allocated buffer) and
  *          these bits are the length of the Struct.
  */
-enum {
+enum ruby_rstruct_flags {
     RSTRUCT_EMBED_LEN_MASK = RUBY_FL_USER7 | RUBY_FL_USER6 | RUBY_FL_USER5 | RUBY_FL_USER4 |
                                  RUBY_FL_USER3 | RUBY_FL_USER2 | RUBY_FL_USER1,
     RSTRUCT_EMBED_LEN_SHIFT = (RUBY_FL_USHIFT+1),

--- a/jit.c
+++ b/jit.c
@@ -20,6 +20,7 @@
 #include "internal/string.h"
 #include "internal/class.h"
 #include "internal/imemo.h"
+#include "internal/struct.h"
 #include "ruby/internal/core/rtypeddata.h"
 #include "zjit.h"
 

--- a/yjit.c
+++ b/yjit.c
@@ -49,6 +49,12 @@ STATIC_ASSERT(size_t_no_padding_bits, sizeof(size_t) == sizeof(uint64_t));
 // support one scheme for simplicity.
 STATIC_ASSERT(pointer_tagging_scheme, USE_FLONUM);
 
+enum yjit_bindgen_constants {
+    // ISEQ_TRANSLATED expands to an enum value through a chain of macros,
+    // which bindgen cannot evaluate, so it needs to be re-exposed here.
+    YJIT_ISEQ_TRANSLATED = ISEQ_TRANSLATED,
+};
+
 // NOTE: We can trust that uint8_t has no "padding bits" since the C spec
 // guarantees it. Wording about padding bits is more explicit in C11 compared
 // to C99. See C11 7.20.1.1p2. All this is to say we have _some_ standards backing to

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -284,6 +284,7 @@ fn main() {
         .allowlist_function("rb_jit_vm_unlock")
         .allowlist_function("rb_jit_for_each_iseq")
         .allowlist_type("jit_bindgen_constants")
+        .allowlist_type("yjit_bindgen_constants")
         .allowlist_function("rb_vm_barrier")
         .allowlist_function("rb_yjit_cdhash_all_fixnum_p")
         .allowlist_function("rb_yjit_cdhash_lookup")

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -76,6 +76,7 @@ fn main() {
         .allowlist_type("RBasic")
 
         .allowlist_type("ruby_rstring_flags")
+        .allowlist_type("ruby_rstruct_flags")
 
         // This function prints info about a value and is useful for debugging
         .allowlist_function("rb_obj_info_dump")

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -409,12 +409,29 @@ fn main() {
         // Unwrap the Result and panic on failure.
         .expect("Unable to generate bindings");
 
+    // Write to a Vec for post-processing
+    let mut bindings_string = Vec::new();
+    bindings.write(Box::new(&mut bindings_string)).expect("Couldn't write bindings!");
+    let mut bindings_string = String::from_utf8(bindings_string).expect("bindings should be UTF-8");
+
+    // Give some generated type aliases an integer type that is nicer to use from
+    // Rust than the one bindgen derives from C.
+    const TYPE_REPLACEMENTS: &[(&str, &str)] = &[
+        // usize is what VALUE() takes, so flag masks need no cast at their use sites
+        ("pub type ruby_rstruct_flags = u32;", "pub type ruby_rstruct_flags = usize;"),
+    ];
+    // Each needle is a whole line of the output, so plain replacement is unambiguous.
+    // Yes, this search-and-replace could be faster, but it's a small file.
+    for (needle, replacement) in TYPE_REPLACEMENTS {
+        assert!(bindings_string.contains(needle), "no line to replace: {needle}");
+        bindings_string = bindings_string.replace(needle, replacement);
+    }
+
+    // Write out to file
     let mut out_path: PathBuf = src_root;
     out_path.push("yjit");
     out_path.push("src");
     out_path.push("cruby_bindings.inc.rs");
 
-    bindings
-        .write_to_file(out_path)
-        .expect("Couldn't write bindings!");
+    std::fs::write(out_path, bindings_string).expect("file output failed");
 }

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -8990,7 +8990,7 @@ fn gen_struct_aref(
     // length. So if our comptime_recv is embedded all runtime
     // structs of the same class and shape_id should be as well, and the same is
     // true of the converse.
-    let embedded = unsafe { FL_TEST_RAW(comptime_recv, VALUE(RSTRUCT_EMBED_LEN_MASK)) };
+    let embedded = unsafe { FL_TEST_RAW(comptime_recv, VALUE(RSTRUCT_EMBED_LEN_MASK as usize)) };
 
     asm_comment!(asm, "struct aref");
 

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -8990,7 +8990,7 @@ fn gen_struct_aref(
     // length. So if our comptime_recv is embedded all runtime
     // structs of the same class and shape_id should be as well, and the same is
     // true of the converse.
-    let embedded = unsafe { FL_TEST_RAW(comptime_recv, VALUE(RSTRUCT_EMBED_LEN_MASK as usize)) };
+    let embedded = unsafe { FL_TEST_RAW(comptime_recv, VALUE(RSTRUCT_EMBED_LEN_MASK)) };
 
     asm_comment!(asm, "struct aref");
 

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -750,9 +750,6 @@ mod manual_defs {
     pub const VM_CALL_ZSUPER : u32 = 1 << VM_CALL_ZSUPER_bit;
     pub const VM_CALL_OPT_SEND : u32 = 1 << VM_CALL_OPT_SEND_bit;
 
-    // From internal/struct.h - in anonymous enum, so we can't easily import it
-    pub const RSTRUCT_EMBED_LEN_MASK: usize = (RUBY_FL_USER7 | RUBY_FL_USER6 | RUBY_FL_USER5 | RUBY_FL_USER4 | RUBY_FL_USER3 |RUBY_FL_USER2 | RUBY_FL_USER1) as usize;
-
     // We'll need to encode a lot of Ruby struct/field offsets as constants unless we want to
     // redeclare all the Ruby C structs and write our own offsetof macro. For now, we use constants.
     pub const RUBY_OFFSET_RBASIC_FLAGS: i32 = 0; // struct RBasic, field "flags"

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -753,9 +753,6 @@ mod manual_defs {
     // From internal/struct.h - in anonymous enum, so we can't easily import it
     pub const RSTRUCT_EMBED_LEN_MASK: usize = (RUBY_FL_USER7 | RUBY_FL_USER6 | RUBY_FL_USER5 | RUBY_FL_USER4 | RUBY_FL_USER3 |RUBY_FL_USER2 | RUBY_FL_USER1) as usize;
 
-    // From iseq.h - via a different constant, which seems to confuse bindgen
-    pub const ISEQ_TRANSLATED: usize = RUBY_FL_USER8 as usize;
-
     // We'll need to encode a lot of Ruby struct/field offsets as constants unless we want to
     // redeclare all the Ruby C structs and write our own offsetof macro. For now, we use constants.
     pub const RUBY_OFFSET_RBASIC_FLAGS: i32 = 0; // struct RBasic, field "flags"

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -1060,6 +1060,8 @@ pub const DEFINED_REF: defined_type = 15;
 pub const DEFINED_FUNC: defined_type = 16;
 pub const DEFINED_CONST_FROM: defined_type = 17;
 pub type defined_type = u32;
+pub const YJIT_ISEQ_TRANSLATED: yjit_bindgen_constants = 1048576;
+pub type yjit_bindgen_constants = u32;
 pub type rb_seq_param_keyword_struct =
     rb_iseq_constant_body_rb_iseq_parameters_rb_iseq_param_keyword;
 pub const ROBJECT_OFFSET_AS_HEAP_FIELDS: jit_bindgen_constants = 16;

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -1064,6 +1064,9 @@ pub const YJIT_ISEQ_TRANSLATED: yjit_bindgen_constants = 1048576;
 pub type yjit_bindgen_constants = u32;
 pub type rb_seq_param_keyword_struct =
     rb_iseq_constant_body_rb_iseq_parameters_rb_iseq_param_keyword;
+pub const RSTRUCT_EMBED_LEN_MASK: ruby_rstruct_flags = 1040384;
+pub const RSTRUCT_EMBED_LEN_SHIFT: ruby_rstruct_flags = 13;
+pub type ruby_rstruct_flags = u32;
 pub const ROBJECT_OFFSET_AS_HEAP_FIELDS: jit_bindgen_constants = 16;
 pub const ROBJECT_OFFSET_AS_ARY: jit_bindgen_constants = 16;
 pub const RCLASS_OFFSET_PRIME_FIELDS_OBJ: jit_bindgen_constants = 40;

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -1066,7 +1066,7 @@ pub type rb_seq_param_keyword_struct =
     rb_iseq_constant_body_rb_iseq_parameters_rb_iseq_param_keyword;
 pub const RSTRUCT_EMBED_LEN_MASK: ruby_rstruct_flags = 1040384;
 pub const RSTRUCT_EMBED_LEN_SHIFT: ruby_rstruct_flags = 13;
-pub type ruby_rstruct_flags = u32;
+pub type ruby_rstruct_flags = usize;
 pub const ROBJECT_OFFSET_AS_HEAP_FIELDS: jit_bindgen_constants = 16;
 pub const ROBJECT_OFFSET_AS_ARY: jit_bindgen_constants = 16;
 pub const RCLASS_OFFSET_PRIME_FIELDS_OBJ: jit_bindgen_constants = 40;

--- a/yjit/src/invariants.rs
+++ b/yjit/src/invariants.rs
@@ -504,7 +504,7 @@ pub extern "C" fn rb_yjit_constant_ic_update(iseq: *const rb_iseq_t, ic: IC, ins
 
         // This should come from a running iseq, so direct threading translation
         // should have been done
-        assert!(unsafe { FL_TEST(iseq.into(), VALUE(ISEQ_TRANSLATED)) } != VALUE(0));
+        assert!(unsafe { FL_TEST(iseq.into(), VALUE(YJIT_ISEQ_TRANSLATED as usize)) } != VALUE(0));
         assert!(u32::from(insn_idx) < unsafe { get_iseq_encoded_size(iseq) });
 
         // Ensure that the instruction the insn_idx is pointing to is in

--- a/zjit/bindgen/src/main.rs
+++ b/zjit/bindgen/src/main.rs
@@ -100,6 +100,7 @@ fn main() {
         .allowlist_var("RB_GC_ZJIT_FASTPATH_.*")
 
         .allowlist_type("ruby_rstring_flags")
+        .allowlist_type("ruby_rstruct_flags")
 
         // This function prints info about a value and is useful for debugging
         .allowlist_function("rb_raw_obj_info")

--- a/zjit/bindgen/src/main.rs
+++ b/zjit/bindgen/src/main.rs
@@ -498,16 +498,21 @@ fn main() {
     // Write to a Vec for post-processing
     let mut bindings_string = Vec::new();
     bindings.write(Box::new(&mut bindings_string)).expect("Couldn't write bindings!");
+    let mut bindings_string = String::from_utf8(bindings_string).expect("bindings should be UTF-8");
 
-    // Use i32 for this type since that's what the assembler APIs expect
-    const JIT_CONSTANTS_NEEDLE: &[u8]      = b"pub type jit_bindgen_constants = u32;";
-    const JIT_CONSTANTS_REPLACEMENT: &[u8] = b"pub type jit_bindgen_constants = i32;";
+    // Give some generated type aliases an integer type that is nicer to use from
+    // Rust than the one bindgen derives from C.
+    const TYPE_REPLACEMENTS: &[(&str, &str)] = &[
+        // i32 is what the assembler APIs expect
+        ("pub type jit_bindgen_constants = u32;", "pub type jit_bindgen_constants = i32;"),
+        // usize is what VALUE() takes, so flag masks need no cast at their use sites
+        ("pub type ruby_rstruct_flags = u32;", "pub type ruby_rstruct_flags = usize;"),
+    ];
+    // Each needle is a whole line of the output, so plain replacement is unambiguous.
     // Yes, this search-and-replace could be faster, but it's a small file.
-    for line in bindings_string.as_mut_slice().split_mut(|&byte| byte == b'\n') {
-        if line == JIT_CONSTANTS_NEEDLE {
-            line.copy_from_slice(JIT_CONSTANTS_REPLACEMENT);
-            break;
-        }
+    for (needle, replacement) in TYPE_REPLACEMENTS {
+        assert!(bindings_string.contains(needle), "no line to replace: {needle}");
+        bindings_string = bindings_string.replace(needle, replacement);
     }
 
     // Write out to file

--- a/zjit/src/cruby.rs
+++ b/zjit/src/cruby.rs
@@ -1223,9 +1223,6 @@ mod manual_defs {
     // From internal/struct.h - in anonymous enum, so we can't easily import it
     pub const RSTRUCT_EMBED_LEN_MASK: usize = (RUBY_FL_USER7 | RUBY_FL_USER6 | RUBY_FL_USER5 | RUBY_FL_USER4 | RUBY_FL_USER3 |RUBY_FL_USER2 | RUBY_FL_USER1) as usize;
 
-    // From iseq.h - via a different constant, which seems to confuse bindgen
-    pub const ISEQ_TRANSLATED: usize = RUBY_FL_USER8 as usize;
-
     // We'll need to encode a lot of Ruby struct/field offsets as constants unless we want to
     // redeclare all the Ruby C structs and write our own offsetof macro. For now, we use constants.
     pub const RUBY_OFFSET_RBASIC_FLAGS: i32 = 0; // struct RBasic, field "flags"

--- a/zjit/src/cruby.rs
+++ b/zjit/src/cruby.rs
@@ -678,7 +678,7 @@ impl VALUE {
     pub fn struct_embedded_p(self) -> bool {
         unsafe {
             RB_TYPE_P(self, RUBY_T_STRUCT) &&
-            FL_TEST_RAW(self, VALUE(RSTRUCT_EMBED_LEN_MASK)) != VALUE(0)
+            FL_TEST_RAW(self, VALUE(RSTRUCT_EMBED_LEN_MASK as usize)) != VALUE(0)
         }
     }
 
@@ -1219,9 +1219,6 @@ mod manual_defs {
     pub const VM_CALL_SUPER : u32 = 1 << VM_CALL_SUPER_bit;
     pub const VM_CALL_ZSUPER : u32 = 1 << VM_CALL_ZSUPER_bit;
     pub const VM_CALL_OPT_SEND : u32 = 1 << VM_CALL_OPT_SEND_bit;
-
-    // From internal/struct.h - in anonymous enum, so we can't easily import it
-    pub const RSTRUCT_EMBED_LEN_MASK: usize = (RUBY_FL_USER7 | RUBY_FL_USER6 | RUBY_FL_USER5 | RUBY_FL_USER4 | RUBY_FL_USER3 |RUBY_FL_USER2 | RUBY_FL_USER1) as usize;
 
     // We'll need to encode a lot of Ruby struct/field offsets as constants unless we want to
     // redeclare all the Ruby C structs and write our own offsetof macro. For now, we use constants.

--- a/zjit/src/cruby.rs
+++ b/zjit/src/cruby.rs
@@ -678,7 +678,7 @@ impl VALUE {
     pub fn struct_embedded_p(self) -> bool {
         unsafe {
             RB_TYPE_P(self, RUBY_T_STRUCT) &&
-            FL_TEST_RAW(self, VALUE(RSTRUCT_EMBED_LEN_MASK as usize)) != VALUE(0)
+            FL_TEST_RAW(self, VALUE(RSTRUCT_EMBED_LEN_MASK)) != VALUE(0)
         }
     }
 

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -2113,6 +2113,9 @@ pub struct rb_zjit_runtime_offsets {
     pub ractor_newobj_cache: i32,
     pub ractor_objspace: i32,
 }
+pub const RSTRUCT_EMBED_LEN_MASK: ruby_rstruct_flags = 1040384;
+pub const RSTRUCT_EMBED_LEN_SHIFT: ruby_rstruct_flags = 13;
+pub type ruby_rstruct_flags = u32;
 pub const ROBJECT_OFFSET_AS_HEAP_FIELDS: jit_bindgen_constants = 16;
 pub const ROBJECT_OFFSET_AS_ARY: jit_bindgen_constants = 16;
 pub const RCLASS_OFFSET_PRIME_FIELDS_OBJ: jit_bindgen_constants = 40;

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -2115,7 +2115,7 @@ pub struct rb_zjit_runtime_offsets {
 }
 pub const RSTRUCT_EMBED_LEN_MASK: ruby_rstruct_flags = 1040384;
 pub const RSTRUCT_EMBED_LEN_SHIFT: ruby_rstruct_flags = 13;
-pub type ruby_rstruct_flags = u32;
+pub type ruby_rstruct_flags = usize;
 pub const ROBJECT_OFFSET_AS_HEAP_FIELDS: jit_bindgen_constants = 16;
 pub const ROBJECT_OFFSET_AS_ARY: jit_bindgen_constants = 16;
 pub const RCLASS_OFFSET_PRIME_FIELDS_OBJ: jit_bindgen_constants = 40;


### PR DESCRIPTION
Follow-up on https://github.com/ruby/ruby/pull/18597#discussion_r3914719597

This PR moves the `ISEQ_TRANSLATED` binding from manually-defined code in `cruby.rs` to bindgen.

`ISEQ_TRANSLATED` is defined through a chain of macros that ends in an enum value (`IMEMO_FL_USER3` -> `FL_USER8` -> `RUBY_FL_USER8`), which bindgen cannot evaluate, so it needs to be re-exposed. ZJIT doesn't even use the constant, so drop it there.