### PR TITLE
ZJIT: Seed polymorphic type branches with shape data too

### DIFF
--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -4718,8 +4718,8 @@ impl Function {
         caller_splat_length: Option<SplatLength>,
         profiled_types: &[ProfiledType],
     ) -> BlockId {
-        let args = match self.find(insn_id) {
-            Insn::Send { args, .. } => args,
+        let args = match self.resolve(insn_id).insn(self) {
+            Insn::Send { args, .. } => args.clone(),
             insn => panic!("Expected Send instruction, got {insn:?}"),
         };
         let insn_idx = self.frame_state_insn_idx(state) as u32;
@@ -4815,10 +4815,11 @@ impl Function {
         join_block
     }
 
-    /// Specialize a copy of the Send at `insn_id` against a dispatch arm whose receiver class
-    /// (and shape, when the profiled type has one) is guaranteed by the enclosing branch tests,
-    /// so the specialized code emits no receiver guards. On failure the copy stays in the arm as
-    /// a dynamic send. Returns the arm's result value.
+    /// Specialize the Send at `insn_id` into a dispatch arm whose receiver class (and shape,
+    /// when the profiled type has one) is guaranteed by the enclosing branch tests, so the
+    /// specialized code emits no receiver guards. The original send is only read for its
+    /// arguments; on failure a dynamic send on the refined receiver is pushed into the arm.
+    /// Returns the arm's result value.
     fn specialize_send_arm(
         &mut self,
         arm_block: BlockId,
@@ -4829,17 +4830,15 @@ impl Function {
         caller_splat_length: Option<SplatLength>,
         profiled_type: ProfiledType,
     ) -> InsnId {
-        let (args, reason) = match self.find(insn_id) {
-            Insn::Send { args, reason, .. } => (args, reason),
-            insn => panic!("Expected Send instruction, got {insn:?}"),
-        };
-        let arm_send = self.new_insn(Insn::Send { recv, cd, block: None, args, caller_splat_length, state, reason });
-        self.insn_types[arm_send] = self.infer_type(arm_send);
-        match self.type_specialize_send(arm_block, arm_send, recv, cd, state, None, caller_splat_length, SpecializedReceiver::Guaranteed { profiled_type }) {
+        match self.type_specialize_send(arm_block, insn_id, recv, cd, state, None, caller_splat_length, SpecializedReceiver::Guaranteed { profiled_type }) {
             Ok(replacement) => replacement,
             Err(reason) => {
-                self.set_dynamic_send_reason(arm_send, reason);
-                self.push_insn_id(arm_block, arm_send);
+                let args = match self.resolve(insn_id).insn(self) {
+                    Insn::Send { args, .. } => args.clone(),
+                    insn => panic!("Expected Send instruction, got {insn:?}"),
+                };
+                let arm_send = self.push_insn(arm_block, Insn::Send { recv, cd, block: None, args, caller_splat_length, state, reason });
+                self.insn_types[arm_send] = self.infer_type(arm_send);
                 arm_send
             }
         }
@@ -4901,8 +4900,8 @@ impl Function {
         // block arg stripped from the stack.
         let mut send_block = send_block;
         let mut send_frame_state = state;
-        let mut args = match self.find(insn_id) {
-            Insn::Send { args, .. } => args,
+        let mut args = match self.resolve(insn_id).insn(self) {
+            Insn::Send { args, .. } => args.clone(),
             insn => panic!("Expected Send instruction, got {insn:?}"),
         };
         let mut stripped_nil_block = false;

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -777,6 +777,46 @@ pub enum ReceiverTypeResolution {
     StaticallyKnown { class: VALUE },
 }
 
+/// How the receiver class (and shape) that a Send is specialized against is established at
+/// runtime. Specialization emits receiver guards only for a `Speculated` receiver.
+#[derive(Debug, Clone, Copy)]
+enum SpecializedReceiver {
+    /// Known statically from the receiver's HIR type; nothing to guard.
+    Static { class: VALUE },
+    /// Speculated from profiling; specialization must guard the receiver (GuardType, plus a
+    /// shape guard for shape-dependent rewrites) before committing.
+    Speculated { profiled_type: ProfiledType },
+    /// Established by enclosing dispatch branches (HasType and shape tests); emit no guards.
+    Guaranteed { profiled_type: ProfiledType },
+}
+
+impl SpecializedReceiver {
+    fn class(&self) -> VALUE {
+        match *self {
+            SpecializedReceiver::Static { class } => class,
+            SpecializedReceiver::Speculated { profiled_type }
+            | SpecializedReceiver::Guaranteed { profiled_type } => profiled_type.class(),
+        }
+    }
+
+    /// The profiled receiver type, if any (None for a statically known receiver).
+    fn profiled_type(&self) -> Option<ProfiledType> {
+        match *self {
+            SpecializedReceiver::Static { .. } => None,
+            SpecializedReceiver::Speculated { profiled_type }
+            | SpecializedReceiver::Guaranteed { profiled_type } => Some(profiled_type),
+        }
+    }
+
+    /// The profiled type to guard against, if guards are needed (only for `Speculated`).
+    fn speculated_type(&self) -> Option<ProfiledType> {
+        match *self {
+            SpecializedReceiver::Speculated { profiled_type } => Some(profiled_type),
+            _ => None,
+        }
+    }
+}
+
 /// Reason why a send-ish instruction cannot be optimized from a fallback instruction
 #[derive(Debug, Clone, Copy)]
 pub enum SendFallbackReason {
@@ -4623,11 +4663,29 @@ impl Function {
         self.polymorphic_summary(profiles, recv, state)
     }
 
-    /// Split `block` into a chain of type tests for a Send with a polymorphic receiver: each
-    /// profiled receiver type gets a branch in which the receiver's type is refined and the send
-    /// specialized against exactly that type; receivers matching no profiled type fall through to
-    /// a generic dynamic send. All branches join on a block whose Param replaces the original
-    /// send. Returns the join block, which the caller should continue filling.
+    /// Split `block` into a dispatch chain for a Send with a polymorphic receiver:
+    ///
+    /// ```text
+    /// for class in profiles:
+    ///     if HasType class:
+    ///         RefineType class
+    ///         s = load shape
+    ///         for shape in class:
+    ///             if s == shape:
+    ///                 specialize send for (class, shape)
+    ///             else:
+    ///                 goto next shape
+    ///         goto next class
+    ///     else:
+    ///         goto next class
+    /// ```
+    ///
+    /// The outer chain tests the receiver's class (HasType/RefineType) and the inner chain its
+    /// shape (IsBitEqual on the loaded shape id), so each arm's send specializes against a fully
+    /// guaranteed (class, shape) pair and emits no receiver guards of its own. Receivers matching
+    /// no profiled class or shape fall through to a generic dynamic send. All branches join on a
+    /// block whose Param replaces the original send. Returns the join block, which the caller
+    /// should continue filling.
     fn specialize_polymorphic_send(
         &mut self,
         mut block: BlockId,
@@ -4636,10 +4694,10 @@ impl Function {
         cd: *const rb_call_data,
         state: InsnId,
         caller_splat_length: Option<SplatLength>,
-        summary: &TypeDistributionSummary,
+        profiled_types: &[ProfiledType],
     ) -> BlockId {
-        let (args, reason) = match self.find(insn_id) {
-            Insn::Send { args, reason, .. } => (args, reason),
+        let args = match self.find(insn_id) {
+            Insn::Send { args, .. } => args,
             insn => panic!("Expected Send instruction, got {insn:?}"),
         };
         let insn_idx = self.frame_state_insn_idx(state) as u32;
@@ -4648,42 +4706,72 @@ impl Function {
         // Types were already inferred, so new instructions compute their own types; the join
         // Param's type is the union of the incoming edge arguments.
         let mut join_type = types::Empty;
-        // Dedup by expected type so immediate/heap variants
-        // under the same Ruby class can still get separate branches.
-        let mut seen_types = Vec::with_capacity(summary.buckets().len());
-        for &profiled_type in summary.buckets() {
+        // Group buckets by expected HIR type so immediate/heap variants under the same Ruby
+        // class still get separate class branches, and each class branch dispatches only on the
+        // shapes profiled for that class.
+        let mut classes: Vec<(Type, Vec<ProfiledType>)> = vec![];
+        for &profiled_type in profiled_types {
             if profiled_type.is_empty() { break; }
             let expected = Type::from_profiled_type(profiled_type);
-            if seen_types.iter().any(|ty: &Type| ty.bit_equal(expected)) {
-                continue;
+            match classes.iter_mut().find(|(ty, _)| ty.bit_equal(expected)) {
+                Some((_, buckets)) => buckets.push(profiled_type),
+                None => classes.push((expected, vec![profiled_type])),
             }
-            seen_types.push(expected);
+        }
+        for (expected, buckets) in classes {
+            // if HasType class: ... else: goto next class
             let has_type = self.push_insn(block, Insn::HasType { val: recv, expected });
             self.insn_types[has_type] = self.infer_type(has_type);
-            let iftrue_block = self.new_block(insn_idx);
-            let fall_through = self.new_block(insn_idx);
+            let class_block = self.new_block(insn_idx);
+            let next_class = self.new_block(insn_idx);
             self.push_insn(block, Insn::CondBranch {
                 val: has_type,
-                if_true: BranchEdge { target: iftrue_block, args: vec![] },
-                if_false: BranchEdge { target: fall_through, args: vec![] }
+                if_true: BranchEdge { target: class_block, args: vec![] },
+                if_false: BranchEdge { target: next_class, args: vec![] }
             });
-            block = fall_through;
-            let refined_recv = self.push_insn(iftrue_block, Insn::RefineType { val: recv, new_type: expected });
+            block = next_class;
+            let refined_recv = self.push_insn(class_block, Insn::RefineType { val: recv, new_type: expected });
             self.insn_types[refined_recv] = self.infer_type(refined_recv);
-            // Specialize a copy of the send against this arm's exact receiver type. On failure
-            // the copy stays in the arm as a dynamic send.
-            let arm_send = self.new_insn(Insn::Send { recv: refined_recv, cd, block: None, args: args.clone(), caller_splat_length, state, reason });
-            self.insn_types[arm_send] = self.infer_type(arm_send);
-            let result = match self.type_specialize_send(iftrue_block, arm_send, refined_recv, cd, state, None, caller_splat_length, profiled_type.class(), Some(profiled_type)) {
-                Ok(replacement) => replacement,
-                Err(reason) => {
-                    self.set_dynamic_send_reason(arm_send, reason);
-                    self.push_insn_id(iftrue_block, arm_send);
-                    arm_send
+            // Dedup this class's buckets by shape so each shape gets one arm.
+            let mut shapes: Vec<ProfiledType> = Vec::with_capacity(buckets.len());
+            for &profiled_type in &buckets {
+                if profiled_type.shape().is_valid()
+                    && !shapes.iter().any(|seen| seen.shape() == profiled_type.shape()) {
+                    shapes.push(profiled_type);
                 }
-            };
-            join_type = join_type.union(self.type_of(result));
-            self.push_insn(iftrue_block, Insn::Jump(BranchEdge { target: join_block, args: vec![result] }));
+            }
+            if shapes.is_empty() {
+                // Immediates carry no shape (their profile entries have an invalid shape id);
+                // specialize directly against the class.
+                let result = self.specialize_send_arm(class_block, insn_id, refined_recv, cd, state, caller_splat_length, buckets[0]);
+                join_type = join_type.union(self.type_of(result));
+                self.push_insn(class_block, Insn::Jump(BranchEdge { target: join_block, args: vec![result] }));
+                continue;
+            }
+            // s = load shape
+            let shape = self.load_shape(class_block, refined_recv);
+            self.insn_types[shape] = self.infer_type(shape);
+            let mut shape_block = class_block;
+            for profiled_type in shapes {
+                // if s == shape: specialize send for (class, shape); else: goto next shape
+                let expected_shape = self.push_insn(shape_block, Insn::Const { val: Const::CShape(profiled_type.shape()) });
+                self.insn_types[expected_shape] = self.infer_type(expected_shape);
+                let has_shape = self.push_insn(shape_block, Insn::IsBitEqual { left: shape, right: expected_shape });
+                self.insn_types[has_shape] = self.infer_type(has_shape);
+                let arm_block = self.new_block(insn_idx);
+                let next_shape = self.new_block(insn_idx);
+                self.push_insn(shape_block, Insn::CondBranch {
+                    val: has_shape,
+                    if_true: BranchEdge { target: arm_block, args: vec![] },
+                    if_false: BranchEdge { target: next_shape, args: vec![] }
+                });
+                shape_block = next_shape;
+                let result = self.specialize_send_arm(arm_block, insn_id, refined_recv, cd, state, caller_splat_length, profiled_type);
+                join_type = join_type.union(self.type_of(result));
+                self.push_insn(arm_block, Insn::Jump(BranchEdge { target: join_block, args: vec![result] }));
+            }
+            // Shapes exhausted: goto next class, which eventually reaches the dynamic fallback.
+            self.push_insn(shape_block, Insn::Jump(BranchEdge { target: block, args: vec![] }));
         }
         // In the fallthrough case, do a generic dynamic send and then join.
         let fallback_send = self.push_insn(block, Insn::Send { recv, cd, block: None, args, caller_splat_length, state, reason: SendPolymorphicFallback });
@@ -4695,12 +4783,43 @@ impl Function {
         join_block
     }
 
-    /// Try to specialize the `Send` at `insn_id` against the given receiver class and optional
-    /// profiled type, emitting guards, patch points, and a specialized call into `block`. On
-    /// success, return the replacement value; the caller is responsible for `make_equal_to`. On
-    /// failure, return the fallback reason; the caller is responsible for setting the reason and
-    /// re-pushing the dynamic send (guards already emitted before the failure stay in the block,
-    /// which is safe because they re-enter the interpreter at the pre-send state).
+    /// Specialize a copy of the Send at `insn_id` against a dispatch arm whose receiver class
+    /// (and shape, when the profiled type has one) is guaranteed by the enclosing branch tests,
+    /// so the specialized code emits no receiver guards. On failure the copy stays in the arm as
+    /// a dynamic send. Returns the arm's result value.
+    fn specialize_send_arm(
+        &mut self,
+        arm_block: BlockId,
+        insn_id: InsnId,
+        recv: InsnId,
+        cd: *const rb_call_data,
+        state: InsnId,
+        caller_splat_length: Option<SplatLength>,
+        profiled_type: ProfiledType,
+    ) -> InsnId {
+        let (args, reason) = match self.find(insn_id) {
+            Insn::Send { args, reason, .. } => (args, reason),
+            insn => panic!("Expected Send instruction, got {insn:?}"),
+        };
+        let arm_send = self.new_insn(Insn::Send { recv, cd, block: None, args, caller_splat_length, state, reason });
+        self.insn_types[arm_send] = self.infer_type(arm_send);
+        match self.type_specialize_send(arm_block, arm_send, recv, cd, state, None, caller_splat_length, SpecializedReceiver::Guaranteed { profiled_type }) {
+            Ok(replacement) => replacement,
+            Err(reason) => {
+                self.set_dynamic_send_reason(arm_send, reason);
+                self.push_insn_id(arm_block, arm_send);
+                arm_send
+            }
+        }
+    }
+
+    /// Try to specialize the `Send` at `insn_id` against the receiver described by `recv_spec`,
+    /// emitting guards (for a speculated receiver only), patch points, and a specialized call
+    /// into `block`. On success, return the replacement value; the caller is responsible for
+    /// `make_equal_to`. On failure, return the fallback reason; the caller is responsible for
+    /// setting the reason and re-pushing the dynamic send (guards already emitted before the
+    /// failure stay in the block, which is safe because they re-enter the interpreter at the
+    /// pre-send state).
     fn type_specialize_send(
         &mut self,
         block: BlockId,
@@ -4710,9 +4829,9 @@ impl Function {
         state: InsnId,
         send_block: Option<BlockHandler>,
         caller_splat_length: Option<SplatLength>,
-        klass: VALUE,
-        profiled_type: Option<ProfiledType>,
+        recv_spec: SpecializedReceiver,
     ) -> Result<InsnId, SendFallbackReason> {
+        let klass = recv_spec.class();
         let mut has_block = send_block.is_some();
         let ci = unsafe { (*cd).ci }; // info about the call site
 
@@ -4856,9 +4975,8 @@ impl Function {
             self.push_insn(block, Insn::PatchPoint { invariant: Invariant::MethodRedefined { klass, method: mid, cme }, state });
 
             // Add GuardType for profiled receiver
-            if let Some(profiled_type) = profiled_type {
-                recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: Some(Recompile) });
-                self.insn_types[recv] = self.infer_type(recv);
+            if let Some(profiled_type) = recv_spec.speculated_type() {
+                recv = self.guard_type_recompile(block, recv, Type::from_profiled_type(profiled_type), state, Recompile);
             }
 
             let SendDirectArgs { state: send_state, args: send_args, kw_bits, jit_entry_idx } =
@@ -4895,7 +5013,7 @@ impl Function {
             }
             self.push_insn(block, Insn::PatchPoint { invariant: Invariant::MethodRedefined { klass, method: mid, cme }, state });
 
-            if let Some(profiled_type) = profiled_type {
+            if let Some(profiled_type) = recv_spec.speculated_type() {
                 recv = self.guard_type_recompile(block, recv, Type::from_profiled_type(profiled_type), state, Recompile);
             }
 
@@ -4916,19 +5034,30 @@ impl Function {
             self.push_insn(block, Insn::PatchPoint { invariant: Invariant::MethodRedefined { klass, method: mid, cme }, state });
 
             let id = unsafe { get_cme_def_body_attr_id(cme) };
-            if let Some(profiled_type) = profiled_type {
-                recv = self.guard_type_recompile(block, recv, Type::from_profiled_type(profiled_type), state, Recompile);
+            match recv_spec {
+                SpecializedReceiver::Speculated { profiled_type } => {
+                    recv = self.guard_type_recompile(block, recv, Type::from_profiled_type(profiled_type), state, Recompile);
 
-                Ok(self.try_emit_optimized_getivar(block, recv, id, profiled_type, state).unwrap_or_else(|counter| {
+                    Ok(self.try_emit_optimized_getivar(block, recv, id, profiled_type, state).unwrap_or_else(|counter| {
+                        self.count(block, counter);
+                        self.push_insn(block, Insn::GetIvar { self_val: recv, id, ic: std::ptr::null(), state })
+                    }))
+                }
+                SpecializedReceiver::Guaranteed { profiled_type } => {
+                    // Class and shape are established by the enclosing dispatch branches; load
+                    // the ivar without guards.
+                    Ok(self.emit_guaranteed_getivar(block, recv, id, profiled_type).unwrap_or_else(|counter| {
+                        self.count(block, counter);
+                        self.push_insn(block, Insn::GetIvar { self_val: recv, id, ic: std::ptr::null(), state })
+                    }))
+                }
+                SpecializedReceiver::Static { .. } => {
+                    // No shape information, just static class information
+                    let resolution = self.resolve_receiver_type_from_profile(recv, state);
+                    let counter = Self::getivar_fallback_reason(resolution, std::ptr::null());
                     self.count(block, counter);
-                    self.push_insn(block, Insn::GetIvar { self_val: recv, id, ic: std::ptr::null(), state })
-                }))
-            } else {
-                // No shape information, just static class information
-                let resolution = self.resolve_receiver_type_from_profile(recv, state);
-                let counter = Self::getivar_fallback_reason(resolution, std::ptr::null());
-                self.count(block, counter);
-                Ok(self.push_insn(block, Insn::GetIvar { self_val: recv, id, ic: std::ptr::null(), state }))
+                    Ok(self.push_insn(block, Insn::GetIvar { self_val: recv, id, ic: std::ptr::null(), state }))
+                }
             }
         } else if let (false, VM_METHOD_TYPE_ATTRSET, &[val]) = (has_block, def_type, args.as_slice()) {
             // Check if we're accessing ivars of a Class or Module object as they require single-ractor mode.
@@ -4939,19 +5068,33 @@ impl Function {
 
             self.push_insn(block, Insn::PatchPoint { invariant: Invariant::MethodRedefined { klass, method: mid, cme }, state });
             let id = unsafe { get_cme_def_body_attr_id(cme) };
-            if let Some(profiled_type) = profiled_type {
-                // TODO: attr_writer SetIvar has a null inline cache and may target a receiver
-                // operand other than CFP self. Support it with a reprofile strategy that
-                // profiles the receiver operand even after the send insn has finished profiling.
-                recv = self.guard_type_recompile(block, recv, Type::from_profiled_type(profiled_type), state, Recompile);
-                let recompile = None;
-                self.try_emit_optimized_setivar(block, recv, id, val, profiled_type, state, recompile).unwrap_or_else(|counter| {
-                    self.count(block, counter);
+            match recv_spec {
+                SpecializedReceiver::Speculated { profiled_type } => {
+                    // TODO: attr_writer SetIvar has a null inline cache and may target a receiver
+                    // operand other than CFP self. Support it with a reprofile strategy that
+                    // profiles the receiver operand even after the send insn has finished profiling.
+                    recv = self.guard_type_recompile(block, recv, Type::from_profiled_type(profiled_type), state, Recompile);
+                    let recompile = None;
+                    self.try_emit_optimized_setivar(block, recv, id, val, profiled_type, state, recompile).unwrap_or_else(|counter| {
+                        self.count(block, counter);
+                        self.push_insn(block, Insn::SetIvar { self_val: recv, id, ic: std::ptr::null(), val, state });
+                    });
+                }
+                SpecializedReceiver::Guaranteed { profiled_type } => {
+                    // Class and shape are established by the enclosing dispatch branches; write
+                    // the ivar without guards.
+                    match self.prepare_optimized_setivar(id, profiled_type) {
+                        Ok(spec) => self.emit_optimized_setivar(block, recv, id, val, spec),
+                        Err(counter) => {
+                            self.count(block, counter);
+                            self.push_insn(block, Insn::SetIvar { self_val: recv, id, ic: std::ptr::null(), val, state });
+                        }
+                    }
+                }
+                SpecializedReceiver::Static { .. } => {
+                    // No shape information, just static class information
                     self.push_insn(block, Insn::SetIvar { self_val: recv, id, ic: std::ptr::null(), val, state });
-                });
-            } else {
-                // No shape information, just static class information
-                self.push_insn(block, Insn::SetIvar { self_val: recv, id, ic: std::ptr::null(), val, state });
+                }
             }
             Ok(val)
         } else if !has_block && def_type == VM_METHOD_TYPE_OPTIMIZED {
@@ -4967,7 +5110,7 @@ impl Function {
                         return Err(SingletonClassSeen);
                     }
                     self.push_insn(block, Insn::PatchPoint { invariant: Invariant::MethodRedefined { klass, method: mid, cme }, state });
-                    if let Some(profiled_type) = profiled_type {
+                    if let Some(profiled_type) = recv_spec.speculated_type() {
                         recv = self.guard_type_recompile(block, recv, Type::from_profiled_type(profiled_type), state, Recompile);
                     }
                     let kw_splat = flags & VM_CALL_KW_SPLAT != 0;
@@ -4990,7 +5133,7 @@ impl Function {
                         }
                     }
                     // Use the profiled type to check if the fields are embedded or heap allocated.
-                    let Some(is_embedded) = profiled_type.map(|t| t.flags().is_struct_embedded()) else {
+                    let Some(is_embedded) = recv_spec.profiled_type().map(|t| t.flags().is_struct_embedded()) else {
                         // No (monomorphic/skewed polymorphic) profile info
                         return Err(SendNoProfiles);
                     };
@@ -4999,7 +5142,7 @@ impl Function {
                         return Err(SingletonClassSeen);
                     }
                     self.push_insn(block, Insn::PatchPoint { invariant: Invariant::MethodRedefined { klass, method: mid, cme }, state });
-                    if let Some(profiled_type) = profiled_type {
+                    if let Some(profiled_type) = recv_spec.speculated_type() {
                         recv = self.guard_type_recompile(block, recv, Type::from_profiled_type(profiled_type), state, Recompile);
                     }
                     // All structs from the same Struct class should have the same
@@ -5042,7 +5185,9 @@ impl Function {
                 args: Vec<InsnId>,
                 state: InsnId,
                 recv_class: VALUE,
-                profiled_type: Option<ProfiledType>,
+                // The profiled type to guard against, if the receiver is speculated rather than
+                // statically known or guaranteed by dispatch branches.
+                speculated_type: Option<ProfiledType>,
                 cme: *const rb_callable_method_entry_struct,
             ) -> Result<InsnId, SendFallbackReason> {
                 let call_info = unsafe { (*cd).ci };
@@ -5101,7 +5246,7 @@ impl Function {
                         // Commit to the replacement. Put PatchPoint.
                         fun.gen_patch_points_for_optimized_ccall(block, recv_class, method_id, cme, state);
 
-                        if let Some(profiled_type) = profiled_type {
+                        if let Some(profiled_type) = speculated_type {
                             // Guard receiver class
                             recv = fun.guard_type_recompile(block, recv, Type::from_profiled_type(profiled_type), state, Recompile);
                         }
@@ -5164,7 +5309,7 @@ impl Function {
 
                         fun.gen_patch_points_for_optimized_ccall(block, recv_class, method_id, cme, state);
 
-                        if let Some(profiled_type) = profiled_type {
+                        if let Some(profiled_type) = speculated_type {
                             // Guard receiver class
                             recv = fun.guard_type_recompile(block, recv, Type::from_profiled_type(profiled_type), state, Recompile);
                         }
@@ -5223,7 +5368,7 @@ impl Function {
                 }
             }
 
-            reduce_send_to_ccall(self, block, recv, cd, send_block, args, state, klass, profiled_type, cme)
+            reduce_send_to_ccall(self, block, recv, cd, send_block, args, state, klass, recv_spec.speculated_type(), cme)
         } else {
             Err(SendNotOptimizedMethodType(MethodType::from(def_type)))
         }
@@ -5248,24 +5393,35 @@ impl Function {
                     &Insn::Send { recv, block: None, ref args, state, cd, .. } if ruby_call_method_id(cd) == ID!(minusat) && args.is_empty() =>
                         self.try_rewrite_uminus(block, insn_id, recv, state),
                     &Insn::Send { recv, cd, state, block: send_block, caller_splat_length, reason, .. } => {
-                        // A polymorphic receiver gets a chain of type tests, with the send
-                        // specialized separately against each profiled type. Only dispatch sends
-                        // that haven't been through specialization yet (Uncategorized) so the
-                        // per-arm and fallback sends aren't re-expanded on later fixpoint
-                        // iterations, and skip YARVINSN_send (block/complex argument passing that
-                        // would fail per-arm specialization anyway).
-                        if send_block.is_none()
-                            && matches!(reason, Uncategorized(op) if op != VmInsnType::from(YARVINSN_send))
-                        {
+                        // A polymorphic receiver gets a chain of class tests with nested shape
+                        // tests, and the send specialized separately against each profiled
+                        // (class, shape) arm. Only dispatch sends that haven't been through
+                        // specialization yet (Uncategorized) so the per-arm and fallback sends
+                        // aren't re-expanded on later fixpoint iterations, and skip YARVINSN_send
+                        // (block/complex argument passing that would fail per-arm specialization
+                        // anyway).
+                        let can_dispatch = send_block.is_none()
+                            && matches!(reason, Uncategorized(op) if op != VmInsnType::from(YARVINSN_send));
+                        if can_dispatch {
                             if let Some(summary) = self.send_polymorphic_summary(recv, state) {
-                                block = self.specialize_polymorphic_send(block, insn_id, recv, cd, state, caller_splat_length, &summary);
+                                block = self.specialize_polymorphic_send(block, insn_id, recv, cd, state, caller_splat_length, summary.buckets());
                                 continue;
                             }
                         }
-                        let (klass, profiled_type) = match self.resolve_receiver_type(recv, self.type_of(recv), state) {
-                            ReceiverTypeResolution::StaticallyKnown { class } => (class, None),
+                        let recv_spec = match self.resolve_receiver_type(recv, self.type_of(recv), state) {
+                            ReceiverTypeResolution::StaticallyKnown { class } => SpecializedReceiver::Static { class },
                             ReceiverTypeResolution::Monomorphic { profiled_type }
-                            | ReceiverTypeResolution::SkewedPolymorphic { profiled_type } => (profiled_type.class(), Some(profiled_type)),
+                            | ReceiverTypeResolution::SkewedPolymorphic { profiled_type } => {
+                                // Speculating on the profile needs receiver guards. On the final
+                                // version, where guard side exits are not allowed, use branch
+                                // dispatch instead: a single guaranteed (class, shape) arm plus
+                                // a dynamic fallback.
+                                if self.policy.no_side_exits && can_dispatch {
+                                    block = self.specialize_polymorphic_send(block, insn_id, recv, cd, state, caller_splat_length, &[profiled_type]);
+                                    continue;
+                                }
+                                SpecializedReceiver::Speculated { profiled_type }
+                            }
                             ReceiverTypeResolution::SkewedMegamorphic { .. }
                             | ReceiverTypeResolution::Megamorphic => {
                                 self.set_dynamic_send_reason(insn_id, SendMegamorphic);
@@ -5283,7 +5439,7 @@ impl Function {
                                 continue;
                             }
                         };
-                        match self.type_specialize_send(block, insn_id, recv, cd, state, send_block, caller_splat_length, klass, profiled_type) {
+                        match self.type_specialize_send(block, insn_id, recv, cd, state, send_block, caller_splat_length, recv_spec) {
                             Ok(replacement) => self.make_equal_to(insn_id, replacement),
                             Err(reason) => {
                                 self.set_dynamic_send_reason(insn_id, reason);
@@ -6081,7 +6237,9 @@ impl Function {
         }
     }
 
-    fn try_emit_optimized_getivar(&mut self, block: BlockId, self_val: InsnId, id: ID, profiled_type: ProfiledType, state: InsnId) -> Result<InsnId, Counter> {
+    /// Shape-based ivar load preconditions shared by the guarded ([`Self::try_emit_optimized_getivar`])
+    /// and dispatch-guaranteed ([`Self::emit_guaranteed_getivar`]) paths.
+    fn can_optimize_getivar(profiled_type: ProfiledType) -> Result<(), Counter> {
         if profiled_type.flags().is_immediate() {
             // Instance variable lookups on immediate values are always nil
             return Err(Counter::getivar_fallback_immediate);
@@ -6091,16 +6249,21 @@ impl Function {
             // too-complex shapes can't use index access
             return Err(Counter::getivar_fallback_complex);
         }
-        if self.policy.no_side_exits {
-            // On the final version, skip GetIvar shape specialization.
-            // iseq_to_hir already generates polymorphic branches with a
-            // GetIvar C call fallback for getinstancevariable, so we don't
-            // need to wrap it again here.
-            return Err(Counter::getivar_fallback_no_side_exits);
-        }
+        Ok(())
+    }
+
+    fn try_emit_optimized_getivar(&mut self, block: BlockId, self_val: InsnId, id: ID, profiled_type: ProfiledType, state: InsnId) -> Result<InsnId, Counter> {
+        Self::can_optimize_getivar(profiled_type)?;
         let self_val = self.guard_heap(block, self_val, state);
         let shape = self.load_shape(block, self_val);
         self.guard_shape(block, shape, profiled_type.shape(), state, Some(Recompile));
+        Ok(self.load_ivar(block, self_val, profiled_type, id))
+    }
+
+    /// Like [`Self::try_emit_optimized_getivar`], but for a receiver whose class and shape are
+    /// already established by enclosing dispatch branches: no guards are emitted.
+    fn emit_guaranteed_getivar(&mut self, block: BlockId, self_val: InsnId, id: ID, profiled_type: ProfiledType) -> Result<InsnId, Counter> {
+        Self::can_optimize_getivar(profiled_type)?;
         Ok(self.load_ivar(block, self_val, profiled_type, id))
     }
 
@@ -6199,10 +6362,6 @@ impl Function {
     }
 
     fn try_emit_optimized_setivar(&mut self, block: BlockId, self_val: InsnId, id: ID, val: InsnId, profiled_type: ProfiledType, state: InsnId, recompile: Option<Recompile>) -> Result<(), Counter> {
-        if self.policy.no_side_exits {
-            // On the final version, don't add a shape guard without a fallback.
-            return Err(Counter::setivar_fallback_no_side_exits);
-        }
         let spec = self.prepare_optimized_setivar(id, profiled_type)?;
         let self_val = self.guard_heap(block, self_val, state);
         let shape = self.load_shape(block, self_val);

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -3569,7 +3569,8 @@ impl Function {
     fn infer_type(&self, insn: InsnId) -> Type {
         assert!(self.insns[insn].has_output());
         match &self.insns[insn] {
-            Insn::Param => unimplemented!("params should not be present in block.insns"),
+            // We can't infer the type of Param without computing in-edges.
+            Insn::Param => types::Any,
             Insn::LoadArg { val_type, .. } => *val_type,
             Insn::SetGlobal { .. } | Insn::Jump(_) | Insn::Entries { .. } | Insn::EntryPoint { .. }
             | Insn::Comment { .. }
@@ -3974,8 +3975,9 @@ impl Function {
     }
 
     /// Select the monomorphic caller-splat length while translating the Send.
-    /// The selected length is attached to every receiver dispatch arm so later
-    /// specialization does not need to read the profile again.
+    /// The selected length is attached to the Send (and copied onto every
+    /// polymorphic dispatch arm) so later specialization does not need to read
+    /// the profile again.
     fn monomorphic_caller_splat_length(&self, ci: *const rb_callinfo, state: InsnId) -> Option<SplatLength> {
         if self.policy.no_side_exits {
             return None;
@@ -4615,14 +4617,629 @@ impl Function {
         }
     }
 
+    /// Like [`Function::polymorphic_summary`], but reads this Function's own profile oracle.
+    fn send_polymorphic_summary(&self, recv: InsnId, state: InsnId) -> Option<TypeDistributionSummary> {
+        let profiles = self.profiles.as_ref()?;
+        self.polymorphic_summary(profiles, recv, state)
+    }
+
+    /// Split `block` into a chain of type tests for a Send with a polymorphic receiver: each
+    /// profiled receiver type gets a branch in which the receiver's type is refined and the send
+    /// specialized against exactly that type; receivers matching no profiled type fall through to
+    /// a generic dynamic send. All branches join on a block whose Param replaces the original
+    /// send. Returns the join block, which the caller should continue filling.
+    fn specialize_polymorphic_send(
+        &mut self,
+        mut block: BlockId,
+        insn_id: InsnId,
+        recv: InsnId,
+        cd: *const rb_call_data,
+        state: InsnId,
+        caller_splat_length: Option<SplatLength>,
+        summary: &TypeDistributionSummary,
+    ) -> BlockId {
+        let (args, reason) = match self.find(insn_id) {
+            Insn::Send { args, reason, .. } => (args, reason),
+            insn => panic!("Expected Send instruction, got {insn:?}"),
+        };
+        let insn_idx = self.frame_state_insn_idx(state) as u32;
+        let join_block = self.new_block(insn_idx);
+        let join_param = self.push_insn(join_block, Insn::Param);
+        // Types were already inferred, so new instructions compute their own types; the join
+        // Param's type is the union of the incoming edge arguments.
+        let mut join_type = types::Empty;
+        // Dedup by expected type so immediate/heap variants
+        // under the same Ruby class can still get separate branches.
+        let mut seen_types = Vec::with_capacity(summary.buckets().len());
+        for &profiled_type in summary.buckets() {
+            if profiled_type.is_empty() { break; }
+            let expected = Type::from_profiled_type(profiled_type);
+            if seen_types.iter().any(|ty: &Type| ty.bit_equal(expected)) {
+                continue;
+            }
+            seen_types.push(expected);
+            let has_type = self.push_insn(block, Insn::HasType { val: recv, expected });
+            self.insn_types[has_type] = self.infer_type(has_type);
+            let iftrue_block = self.new_block(insn_idx);
+            let fall_through = self.new_block(insn_idx);
+            self.push_insn(block, Insn::CondBranch {
+                val: has_type,
+                if_true: BranchEdge { target: iftrue_block, args: vec![] },
+                if_false: BranchEdge { target: fall_through, args: vec![] }
+            });
+            block = fall_through;
+            let refined_recv = self.push_insn(iftrue_block, Insn::RefineType { val: recv, new_type: expected });
+            self.insn_types[refined_recv] = self.infer_type(refined_recv);
+            // Specialize a copy of the send against this arm's exact receiver type. On failure
+            // the copy stays in the arm as a dynamic send.
+            let arm_send = self.new_insn(Insn::Send { recv: refined_recv, cd, block: None, args: args.clone(), caller_splat_length, state, reason });
+            self.insn_types[arm_send] = self.infer_type(arm_send);
+            let result = match self.type_specialize_send(iftrue_block, arm_send, refined_recv, cd, state, None, caller_splat_length, profiled_type.class(), Some(profiled_type)) {
+                Ok(replacement) => replacement,
+                Err(reason) => {
+                    self.set_dynamic_send_reason(arm_send, reason);
+                    self.push_insn_id(iftrue_block, arm_send);
+                    arm_send
+                }
+            };
+            join_type = join_type.union(self.type_of(result));
+            self.push_insn(iftrue_block, Insn::Jump(BranchEdge { target: join_block, args: vec![result] }));
+        }
+        // In the fallthrough case, do a generic dynamic send and then join.
+        let fallback_send = self.push_insn(block, Insn::Send { recv, cd, block: None, args, caller_splat_length, state, reason: SendPolymorphicFallback });
+        self.insn_types[fallback_send] = self.infer_type(fallback_send);
+        join_type = join_type.union(self.type_of(fallback_send));
+        self.push_insn(block, Insn::Jump(BranchEdge { target: join_block, args: vec![fallback_send] }));
+        self.insn_types[join_param] = join_type;
+        self.make_equal_to(insn_id, join_param);
+        join_block
+    }
+
+    /// Try to specialize the `Send` at `insn_id` against the given receiver class and optional
+    /// profiled type, emitting guards, patch points, and a specialized call into `block`. On
+    /// success, return the replacement value; the caller is responsible for `make_equal_to`. On
+    /// failure, return the fallback reason; the caller is responsible for setting the reason and
+    /// re-pushing the dynamic send (guards already emitted before the failure stay in the block,
+    /// which is safe because they re-enter the interpreter at the pre-send state).
+    fn type_specialize_send(
+        &mut self,
+        block: BlockId,
+        insn_id: InsnId,
+        mut recv: InsnId,
+        cd: *const rb_call_data,
+        state: InsnId,
+        send_block: Option<BlockHandler>,
+        caller_splat_length: Option<SplatLength>,
+        klass: VALUE,
+        profiled_type: Option<ProfiledType>,
+    ) -> Result<InsnId, SendFallbackReason> {
+        let mut has_block = send_block.is_some();
+        let ci = unsafe { (*cd).ci }; // info about the call site
+
+        let flags = unsafe { rb_vm_ci_flag(ci) };
+
+        let mid = unsafe { vm_ci_mid(ci) };
+        // Do method lookup
+        let mut cme = unsafe { rb_callable_method_entry(klass, mid) };
+        if cme.is_null() {
+            return Err(SendNotOptimizedMethodType(MethodType::Null));
+        }
+        // Load an overloaded cme if applicable. See vm_search_cc().
+        // It allows you to use a faster ISEQ if possible.
+        cme = unsafe { rb_check_overloaded_cme(cme, ci) };
+        let visibility = unsafe { METHOD_ENTRY_VISI(cme) };
+        match (visibility, flags & VM_CALL_FCALL != 0) {
+            (METHOD_VISI_PUBLIC, _) => {}
+            (METHOD_VISI_PRIVATE, true) => {}
+            (METHOD_VISI_PROTECTED, true) => {}
+            _ => {
+                return Err(SendNotOptimizedNeedPermission);
+            }
+        }
+        let mut def_type = unsafe { get_cme_def_type(cme) };
+        while def_type == VM_METHOD_TYPE_ALIAS {
+            cme = unsafe { rb_aliased_callable_method_entry(cme) };
+            def_type = unsafe { get_cme_def_type(cme) };
+        }
+
+        // Check if we can optimize `foo(&block)` where block is nil to a send without block.
+        // `state` keeps referring to the pre-send frame state (block arg still on the
+        // stack). Any guard that side-exits before the call re-executes the `send` in
+        // the interpreter, so it must reconstruct the stack with the block arg present.
+        // Only the direct-send frame setup uses `send_frame_state`, which has the nil
+        // block arg stripped from the stack.
+        let mut send_block = send_block;
+        let mut send_frame_state = state;
+        let mut args = match self.find(insn_id) {
+            Insn::Send { args, .. } => args,
+            insn => panic!("Expected Send instruction, got {insn:?}"),
+        };
+        let mut stripped_nil_block = false;
+        if send_block == Some(BlockHandler::BlockArg) && def_type == VM_METHOD_TYPE_ISEQ {
+            // The block arg is the last element in args
+            if let Some(&block_arg) = args.last() {
+                let statically_nil = self.is_a(block_arg, types::NilClass);
+                let profiled_nil = self.profiled_type_of_at(block_arg, state)
+                    .map_or(false, |pt| pt.is_nil());
+                if statically_nil || profiled_nil {
+                    if !statically_nil {
+                        // Guard needed when relying on profiled type. Uses the original
+                        // `state` so a side exit re-executes the send with the block
+                        // arg still on the VM stack.
+                        //
+                        // Recompile on exit so a site that starts seeing non-nil
+                        // blocks re-profiles the block arg and drops this speculation
+                        // (falling back to a dynamic send) instead of paying the guard
+                        // side exit repeatedly. This matches the receiver GuardType
+                        // below and the getblockparamproxy BlockParamProxyNotNil guard.
+                        self.push_insn(block, Insn::GuardBitEquals {
+                            val: block_arg,
+                            expected: Const::Value(Qnil),
+                            reason: Box::new(SideExitReason::BlockArgNotNil),
+                            state,
+                            recompile: Some(Recompile),
+                        });
+                    }
+                    // Strip nil block arg and treat as no block
+                    args = args[..args.len() - 1].to_vec();
+                    send_block = None;
+                    has_block = false;
+                    stripped_nil_block = true;
+                    // Frame state for the direct send only: the block arg is removed
+                    // from the stack so the callee frame is laid out correctly.
+                    let new_state = self.frame_state(state).with_replaced_args(&args, args.len() + 1);
+                    send_frame_state = self.push_insn(block, Insn::Snapshot { state: Box::new(new_state) });
+                } else {
+                    // Can't prove block arg is nil
+                    return Err(SendBlockArgNotNil);
+                }
+            }
+        }
+
+        // If the call site info indicates that the `Function` has overly complex arguments, then do not optimize into a `SendDirect`.
+        // Optimized methods(`VM_METHOD_TYPE_OPTIMIZED`) and C methods handle their own argument constraints (e.g., kw_splat for Proc call).
+        // Mask out ARGS_BLOCKARG only if we've already handled the nil block arg case above.
+        let mut flags_for_check = if stripped_nil_block { flags & !VM_CALL_ARGS_BLOCKARG } else { flags };
+        if def_type == VM_METHOD_TYPE_ISEQ {
+            // Caller splat specialization currently only supports ISEQ callees, so
+            // skip the generic splat rejection here and validate its profile below.
+            flags_for_check &= !VM_CALL_ARGS_SPLAT;
+        }
+        if def_type != VM_METHOD_TYPE_OPTIMIZED && def_type != VM_METHOD_TYPE_CFUNC && unspecializable_call_type(flags_for_check) {
+            self.count_complex_call_features(block, flags, state);
+            return Err(ComplexArgPass);
+        }
+
+        if def_type == VM_METHOD_TYPE_ISEQ {
+            // TODO(max): Allow non-iseq; cache cme
+            // Only specialize positional-positional calls
+            // TODO(max): Handle other kinds of parameter passing
+            let iseq = unsafe { get_def_iseq_ptr((*cme).def) };
+            let caller_args = CallerArguments::new(&args, ci);
+            let caller_splat = if let Some(arg_idx) = caller_args.splat_arg_idx {
+                // Count the profile shape for every caller-splat execution;
+                // complex_arg_pass_caller_splat separately tracks fallbacks.
+                self.count_caller_splat_profile(block, state);
+                // `add_iseq_to_hir` selects caller-splat lengths while translating
+                // the Send. A Send without a selected length stays dynamic.
+                let Some(length) = caller_splat_length else {
+                    self.count(block, Counter::complex_arg_pass_caller_splat);
+                    return Err(ComplexArgPass);
+                };
+                Some(CallerSplat {
+                    arg_idx,
+                    array: caller_args.original[arg_idx],
+                    length,
+                })
+            } else {
+                None
+            };
+            let call = self.build_send_direct_args(&caller_args, caller_splat, iseq, has_block)
+                .map_err(|failure| {
+                    failure.record(self, block, insn_id, SendDirectFallbackContext::Send);
+                    failure.reason
+                })?;
+
+            // Check singleton class assumption first, before emitting other patchpoints
+            if !self.assume_no_singleton_classes(block, klass, state) {
+                return Err(SingletonClassSeen);
+            }
+
+            if let Some(caller_splat) = caller_splat {
+                self.emit_caller_splat(block, caller_splat, state);
+                // Count caller-splat executions that take this optimized path.
+                // This is a feature-specific counter, not part of optimized_send_count.
+                self.count(block, Counter::caller_splat_optimized);
+            }
+
+            // Add PatchPoint for method redefinition
+            self.push_insn(block, Insn::PatchPoint { invariant: Invariant::MethodRedefined { klass, method: mid, cme }, state });
+
+            // Add GuardType for profiled receiver
+            if let Some(profiled_type) = profiled_type {
+                recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: Some(Recompile) });
+                self.insn_types[recv] = self.infer_type(recv);
+            }
+
+            let SendDirectArgs { state: send_state, args: send_args, kw_bits, jit_entry_idx } =
+                self.emit_send_direct_args(block, call, &args, send_frame_state);
+            Ok(self.try_inline_send_direct(block, Insn::SendDirect(Box::new(SendDirectData { recv, cd, cme, iseq, args: send_args, kw_bits, jit_entry_idx, state: send_state, block: send_block }))))
+        } else if !has_block && def_type == VM_METHOD_TYPE_BMETHOD {
+            let procv = unsafe { rb_get_def_bmethod_proc((*cme).def) };
+            let proc = unsafe { rb_jit_get_proc_ptr(procv) };
+            let proc_block = unsafe { (*proc).block.as_ref() };
+            // Target ISEQ bmethods. Can't handle for example, `define_method(:foo, &:foo)`
+            // which makes a `block_type_symbol` bmethod.
+            if proc_block.type_() != block_type_iseq {
+                return Err(BmethodNonIseqProc);
+            }
+            let capture = unsafe { proc_block.as_.captured.as_ref() };
+            let iseq = unsafe { *capture.code.iseq.as_ref() };
+
+            let caller_args = CallerArguments::new(&args, ci);
+            let call = self.build_send_direct_args(&caller_args, None, iseq, has_block)
+                .map_err(|failure| {
+                    failure.record(self, block, insn_id, SendDirectFallbackContext::Send);
+                    failure.reason
+                })?;
+
+            // Patch points:
+            // Check for "defined with an un-shareable Proc in a different Ractor"
+            if !procv.shareable_p() && !self.assume_single_ractor_mode(block, state) {
+                // TODO(alan): Turn this into a ractor belonging guard to work better in multi ractor mode.
+                return Err(SingleRactorModeRequired);
+            }
+            // Check singleton class assumption first, before emitting other patchpoints
+            if !self.assume_no_singleton_classes(block, klass, state) {
+                return Err(SingletonClassSeen);
+            }
+            self.push_insn(block, Insn::PatchPoint { invariant: Invariant::MethodRedefined { klass, method: mid, cme }, state });
+
+            if let Some(profiled_type) = profiled_type {
+                recv = self.guard_type_recompile(block, recv, Type::from_profiled_type(profiled_type), state, Recompile);
+            }
+
+            let SendDirectArgs { state: send_state, args: send_args, kw_bits, jit_entry_idx } =
+                self.emit_send_direct_args(block, call, &args, send_frame_state);
+            Ok(self.try_inline_send_direct(block, Insn::SendDirect(Box::new(SendDirectData { recv, cd, cme, iseq, args: send_args, kw_bits, jit_entry_idx, state: send_state, block: None }))))
+        } else if !has_block && def_type == VM_METHOD_TYPE_IVAR && args.is_empty() {
+            // Check if we're accessing ivars of a Class or Module object as they require single-ractor mode.
+            // We omit gen_prepare_non_leaf_call on gen_getivar, so it's unsafe to raise for multi-ractor mode.
+            if klass.is_metaclass() && !self.assume_single_ractor_mode(block, state) {
+                return Err(SingleRactorModeRequired);
+            }
+            // Check singleton class assumption first, before emitting other patchpoints
+            if !self.assume_no_singleton_classes(block, klass, state) {
+                return Err(SingletonClassSeen);
+            }
+
+            self.push_insn(block, Insn::PatchPoint { invariant: Invariant::MethodRedefined { klass, method: mid, cme }, state });
+
+            let id = unsafe { get_cme_def_body_attr_id(cme) };
+            if let Some(profiled_type) = profiled_type {
+                recv = self.guard_type_recompile(block, recv, Type::from_profiled_type(profiled_type), state, Recompile);
+
+                Ok(self.try_emit_optimized_getivar(block, recv, id, profiled_type, state).unwrap_or_else(|counter| {
+                    self.count(block, counter);
+                    self.push_insn(block, Insn::GetIvar { self_val: recv, id, ic: std::ptr::null(), state })
+                }))
+            } else {
+                // No shape information, just static class information
+                let resolution = self.resolve_receiver_type_from_profile(recv, state);
+                let counter = Self::getivar_fallback_reason(resolution, std::ptr::null());
+                self.count(block, counter);
+                Ok(self.push_insn(block, Insn::GetIvar { self_val: recv, id, ic: std::ptr::null(), state }))
+            }
+        } else if let (false, VM_METHOD_TYPE_ATTRSET, &[val]) = (has_block, def_type, args.as_slice()) {
+            // Check if we're accessing ivars of a Class or Module object as they require single-ractor mode.
+            // We omit gen_prepare_non_leaf_call on gen_getivar, so it's unsafe to raise for multi-ractor mode.
+            if klass.is_metaclass() && !self.assume_single_ractor_mode(block, state) {
+                return Err(SingleRactorModeRequired);
+            }
+
+            self.push_insn(block, Insn::PatchPoint { invariant: Invariant::MethodRedefined { klass, method: mid, cme }, state });
+            let id = unsafe { get_cme_def_body_attr_id(cme) };
+            if let Some(profiled_type) = profiled_type {
+                // TODO: attr_writer SetIvar has a null inline cache and may target a receiver
+                // operand other than CFP self. Support it with a reprofile strategy that
+                // profiles the receiver operand even after the send insn has finished profiling.
+                recv = self.guard_type_recompile(block, recv, Type::from_profiled_type(profiled_type), state, Recompile);
+                let recompile = None;
+                self.try_emit_optimized_setivar(block, recv, id, val, profiled_type, state, recompile).unwrap_or_else(|counter| {
+                    self.count(block, counter);
+                    self.push_insn(block, Insn::SetIvar { self_val: recv, id, ic: std::ptr::null(), val, state });
+                });
+            } else {
+                // No shape information, just static class information
+                self.push_insn(block, Insn::SetIvar { self_val: recv, id, ic: std::ptr::null(), val, state });
+            }
+            Ok(val)
+        } else if !has_block && def_type == VM_METHOD_TYPE_OPTIMIZED {
+            let opt_type: OptimizedMethodType = unsafe { get_cme_def_body_optimized_type(cme) }.into();
+            match (opt_type, args.as_slice()) {
+                (OptimizedMethodType::Call, _) => {
+                    if flags & (VM_CALL_ARGS_SPLAT | VM_CALL_KWARG) != 0 {
+                        self.count_complex_call_features(block, flags, state);
+                        return Err(ComplexArgPass);
+                    }
+                    // Check singleton class assumption first, before emitting other patchpoints
+                    if !self.assume_no_singleton_classes(block, klass, state) {
+                        return Err(SingletonClassSeen);
+                    }
+                    self.push_insn(block, Insn::PatchPoint { invariant: Invariant::MethodRedefined { klass, method: mid, cme }, state });
+                    if let Some(profiled_type) = profiled_type {
+                        recv = self.guard_type_recompile(block, recv, Type::from_profiled_type(profiled_type), state, Recompile);
+                    }
+                    let kw_splat = flags & VM_CALL_KW_SPLAT != 0;
+                    Ok(self.push_insn(block, Insn::InvokeProc { recv, args: args.clone(), state, kw_splat }))
+                }
+                (OptimizedMethodType::StructAref, &[]) | (OptimizedMethodType::StructAset, &[_]) => {
+                    if unspecializable_call_type(flags) {
+                        self.count_complex_call_features(block, flags, state);
+                        return Err(ComplexArgPass);
+                    }
+                    let index: i32 = unsafe { get_cme_def_body_optimized_index(cme) }
+                                    .try_into()
+                                    .unwrap();
+                    // We are going to use an encoding that takes a 4-byte immediate which
+                    // limits the offset to INT32_MAX.
+                    {
+                        let native_index = (index as i64) * (SIZEOF_VALUE as i64);
+                        if native_index > (i32::MAX as i64) {
+                            return Err(OperandTooLarge);
+                        }
+                    }
+                    // Use the profiled type to check if the fields are embedded or heap allocated.
+                    let Some(is_embedded) = profiled_type.map(|t| t.flags().is_struct_embedded()) else {
+                        // No (monomorphic/skewed polymorphic) profile info
+                        return Err(SendNoProfiles);
+                    };
+                    // Check singleton class assumption first, before emitting other patchpoints
+                    if !self.assume_no_singleton_classes(block, klass, state) {
+                        return Err(SingletonClassSeen);
+                    }
+                    self.push_insn(block, Insn::PatchPoint { invariant: Invariant::MethodRedefined { klass, method: mid, cme }, state });
+                    if let Some(profiled_type) = profiled_type {
+                        recv = self.guard_type_recompile(block, recv, Type::from_profiled_type(profiled_type), state, Recompile);
+                    }
+                    // All structs from the same Struct class should have the same
+                    // length. So if our recv is embedded all runtime
+                    // structs of the same class should be as well, and the same is
+                    // true of the converse.
+                    //
+                    // No need for a GuardShape.
+                    if let OptimizedMethodType::StructAset = opt_type {
+                        self.guard_not_frozen(block, recv, state);
+                    }
+
+                    let (target, offset) = if is_embedded {
+                        let offset = RUBY_OFFSET_RSTRUCT_AS_ARY + (SIZEOF_VALUE_I32 * index);
+                        (recv, offset)
+                    } else {
+                        let as_heap = self.load_field(block, recv, FieldName::as_heap, RUBY_OFFSET_RSTRUCT_AS_HEAP_PTR, types::CPtr);
+                        let offset = SIZEOF_VALUE_I32 * index;
+                        (as_heap, offset)
+                    };
+
+                    if let (OptimizedMethodType::StructAset, &[val]) = (opt_type, args.as_slice()) {
+                        self.push_insn(block, Insn::StoreField { recv: target, id: mid.into(), offset, val, num_bits: types::BasicObject.num_bits() });
+                        self.push_insn(block, Insn::WriteBarrier { recv, val });
+                        Ok(val)
+                    } else { // StructAref
+                        Ok(self.load_field(block, target, mid.into(), offset, types::BasicObject))
+                    }
+                },
+                _ => Err(SendNotOptimizedMethodTypeOptimized(OptimizedMethodType::from(opt_type))),
+            }
+        } else if def_type == VM_METHOD_TYPE_CFUNC && !unsafe { rb_zjit_method_tracing_currently_enabled() } {
+            // Try to reduce a Send insn to a CCallWithFrame
+            fn reduce_send_to_ccall(
+                fun: &mut Function,
+                block: BlockId,
+                mut recv: InsnId,
+                cd: *const rb_call_data,
+                send_block: Option<BlockHandler>,
+                args: Vec<InsnId>,
+                state: InsnId,
+                recv_class: VALUE,
+                profiled_type: Option<ProfiledType>,
+                cme: *const rb_callable_method_entry_struct,
+            ) -> Result<InsnId, SendFallbackReason> {
+                let call_info = unsafe { (*cd).ci };
+                let argc = unsafe { vm_ci_argc(call_info) };
+                let method_id = unsafe { rb_vm_ci_mid(call_info) };
+
+                let ci_flags = unsafe { vm_ci_flag(call_info) };
+                // When seeing &block argument, fall back to dynamic dispatch for now
+                // TODO: Support block forwarding
+                if unspecializable_c_call_type(ci_flags) {
+                    // Only count features NOT already counted in type_specialize.
+                    if !unspecializable_call_type(ci_flags) {
+                        fun.count_complex_call_features(block, ci_flags, state);
+                    }
+                    return Err(ComplexArgPass);
+                }
+
+                let blockiseq = match send_block {
+                    Some(BlockHandler::BlockArg) => unreachable!("unsupported &block should have been filtered out"),
+                    Some(BlockHandler::BlockIseq(blockiseq)) => Some(blockiseq),
+                    None => None,
+                };
+
+                let cfunc = unsafe { get_cme_def_body_cfunc(cme) };
+                // Find the `argc` (arity) of the C method, which describes the parameters it expects
+                let cfunc_argc = unsafe { get_mct_argc(cfunc) };
+                let cfunc_ptr = unsafe { get_mct_func(cfunc) }.cast();
+                let name = unsafe { (*cme).called_id };
+
+                // Look up annotations
+                let props = ZJITState::get_method_annotations().get_cfunc_properties(cme);
+                if props.is_none() && get_option!(stats) {
+                    fun.count_not_annotated_cfunc(block, cme);
+                }
+                let props = props.unwrap_or_default();
+                let return_type = props.return_type;
+                let elidable = match blockiseq {
+                    Some(_) => false, // Don't consider cfuncs with block arguments as elidable for now
+                    None => props.elidable,
+                };
+
+                match cfunc_argc {
+                    0.. => {
+                        // (self, arg0, arg1, ..., argc) form
+                        //
+                        // Bail on argc mismatch
+                        if argc != cfunc_argc as u32 {
+                            return Err(ArgcParamMismatch);
+                        }
+
+                        // Check singleton class assumption first, before emitting other patchpoints
+                        if !fun.assume_no_singleton_classes(block, recv_class, state) {
+                            return Err(SingletonClassSeen);
+                        }
+
+                        // Commit to the replacement. Put PatchPoint.
+                        fun.gen_patch_points_for_optimized_ccall(block, recv_class, method_id, cme, state);
+
+                        if let Some(profiled_type) = profiled_type {
+                            // Guard receiver class
+                            recv = fun.guard_type_recompile(block, recv, Type::from_profiled_type(profiled_type), state, Recompile);
+                        }
+
+                        // Try inlining the cfunc into HIR. Only inline if we don't have a block argument
+                        if blockiseq.is_none() {
+                            let tmp_block = fun.new_block(u32::MAX);
+                            if let Some(replacement) = (props.inline)(fun, tmp_block, recv, &args, state) {
+                                // Copy contents of tmp_block to block
+                                assert_ne!(block, tmp_block);
+                                let insns = std::mem::take(&mut fun.blocks[tmp_block].insns);
+                                fun.blocks[block].insns.extend(insns);
+                                fun.count(block, Counter::inline_cfunc_optimized_send_count);
+                                if fun.type_of(replacement).bit_equal(types::Any) {
+                                    // Not set yet; infer type
+                                    fun.insn_types[replacement] = fun.infer_type(replacement);
+                                }
+                                fun.remove_block(tmp_block);
+                                return Ok(replacement);
+                            }
+
+                            // Only allow leaf calls if we don't have a block argument
+                            if props.leaf && props.no_gc {
+                                fun.count(block, Counter::inline_cfunc_optimized_send_count);
+                                let owner = unsafe { (*cme).owner };
+                                let ccall = fun.push_insn(block, Insn::CCall { cfunc: cfunc_ptr, recv, args, name, owner, return_type, elidable });
+                                fun.insn_types[ccall] = fun.infer_type(ccall);
+                                return Ok(ccall);
+                            }
+                        }
+
+                        // Emit a call
+                        if get_option!(stats) {
+                            fun.count_not_inlined_cfunc(block, cme);
+                        }
+                        let ccall = fun.push_insn(block, Insn::CCallWithFrame(Box::new(CCallWithFrameData {
+                            cd,
+                            cfunc: cfunc_ptr,
+                            recv,
+                            args,
+                            cme,
+                            name,
+                            state,
+                            return_type,
+                            elidable,
+                            block: blockiseq.map(BlockHandler::BlockIseq),
+                        })));
+                        fun.insn_types[ccall] = fun.infer_type(ccall);
+                        Ok(ccall)
+                    }
+                    // Variadic method
+                    -1 => {
+                        // The method gets a pointer to the first argument
+                        // func(int argc, VALUE *argv, VALUE recv)
+
+                        // Check singleton class assumption first, before emitting other patchpoints
+                        if !fun.assume_no_singleton_classes(block, recv_class, state) {
+                            return Err(SingletonClassSeen);
+                        }
+
+                        fun.gen_patch_points_for_optimized_ccall(block, recv_class, method_id, cme, state);
+
+                        if let Some(profiled_type) = profiled_type {
+                            // Guard receiver class
+                            recv = fun.guard_type_recompile(block, recv, Type::from_profiled_type(profiled_type), state, Recompile);
+                        }
+
+                        // Try inlining the cfunc into HIR. Only inline if we don't have a block argument
+                        if blockiseq.is_none() {
+                            let tmp_block = fun.new_block(u32::MAX);
+                            if let Some(replacement) = (props.inline)(fun, tmp_block, recv, &args, state) {
+                                // Copy contents of tmp_block to block
+                                assert_ne!(block, tmp_block);
+                                let insns = std::mem::take(&mut fun.blocks[tmp_block].insns);
+                                fun.blocks[block].insns.extend(insns);
+                                fun.count(block, Counter::inline_cfunc_optimized_send_count);
+                                if fun.type_of(replacement).bit_equal(types::Any) {
+                                    // Not set yet; infer type
+                                    fun.insn_types[replacement] = fun.infer_type(replacement);
+                                }
+                                fun.remove_block(tmp_block);
+                                return Ok(replacement);
+                            }
+
+                            // Only allow inline calls if they are leaf, don't allocate, and don't have a block argument
+                            if props.leaf && props.no_gc {
+                                fun.count(block, Counter::inline_cfunc_optimized_send_count);
+                                let owner = unsafe { (*cme).owner };
+                                let ccall = fun.push_insn(block, Insn::CCall { cfunc: cfunc_ptr, recv, args, name, owner, return_type, elidable });
+                                fun.insn_types[ccall] = fun.infer_type(ccall);
+                                return Ok(ccall);
+                            }
+                        }
+
+                        // No inlining; emit a call
+                        if get_option!(stats) {
+                            fun.count_not_inlined_cfunc(block, cme);
+                        }
+
+                        let ccall = fun.push_insn(block, Insn::CCallVariadic(Box::new(CCallVariadicData {
+                            cfunc: cfunc_ptr,
+                            recv,
+                            args,
+                            cme,
+                            name: method_id,
+                            state,
+                            return_type,
+                            elidable,
+                            block: blockiseq.map(BlockHandler::BlockIseq),
+                        })));
+                        fun.insn_types[ccall] = fun.infer_type(ccall);
+                        Ok(ccall)
+                    }
+                    -2 => {
+                        // (self, args_ruby_array)
+                        Err(SendCfuncArrayVariadic)
+                    }
+                    _ => unreachable!("unknown cfunc kind: argc={argc}")
+                }
+            }
+
+            reduce_send_to_ccall(self, block, recv, cd, send_block, args, state, klass, profiled_type, cme)
+        } else {
+            Err(SendNotOptimizedMethodType(MethodType::from(def_type)))
+        }
+    }
+
     /// Rewrite eligible Send opcodes into SendDirect
     /// opcodes if we know the target ISEQ statically. This removes run-time method lookups and
     /// opens the door for inlining.
     /// Also try and inline constant caches, specialize object allocations, and more.
     fn type_specialize(&mut self) {
-        for block in self.reverse_post_order() {
-            let old_insns = std::mem::take(&mut self.blocks[block].insns);
-            assert!(self.blocks[block].insns.is_empty());
+        for entry_block in self.reverse_post_order() {
+            let old_insns = std::mem::take(&mut self.blocks[entry_block].insns);
+            assert!(self.blocks[entry_block].insns.is_empty());
+            // Polymorphic send dispatch splits the block; `block` tracks the current
+            // tail block that the remaining instructions flow into.
+            let mut block = entry_block;
             for insn_id in old_insns {
                 let resolved = self.resolve(insn_id);
                 match resolved.insn(self) {
@@ -4630,8 +5247,21 @@ impl Function {
                         self.try_rewrite_freeze(block, insn_id, recv, state),
                     &Insn::Send { recv, block: None, ref args, state, cd, .. } if ruby_call_method_id(cd) == ID!(minusat) && args.is_empty() =>
                         self.try_rewrite_uminus(block, insn_id, recv, state),
-                    &Insn::Send { mut recv, cd, state, block: send_block, caller_splat_length, .. } => {
-                        let mut has_block = send_block.is_some();
+                    &Insn::Send { recv, cd, state, block: send_block, caller_splat_length, reason, .. } => {
+                        // A polymorphic receiver gets a chain of type tests, with the send
+                        // specialized separately against each profiled type. Only dispatch sends
+                        // that haven't been through specialization yet (Uncategorized) so the
+                        // per-arm and fallback sends aren't re-expanded on later fixpoint
+                        // iterations, and skip YARVINSN_send (block/complex argument passing that
+                        // would fail per-arm specialization anyway).
+                        if send_block.is_none()
+                            && matches!(reason, Uncategorized(op) if op != VmInsnType::from(YARVINSN_send))
+                        {
+                            if let Some(summary) = self.send_polymorphic_summary(recv, state) {
+                                block = self.specialize_polymorphic_send(block, insn_id, recv, cd, state, caller_splat_length, &summary);
+                                continue;
+                            }
+                        }
                         let (klass, profiled_type) = match self.resolve_receiver_type(recv, self.type_of(recv), state) {
                             ReceiverTypeResolution::StaticallyKnown { class } => (class, None),
                             ReceiverTypeResolution::Monomorphic { profiled_type }
@@ -4653,560 +5283,12 @@ impl Function {
                                 continue;
                             }
                         };
-                        let ci = unsafe { (*cd).ci }; // info about the call site
-
-                        let flags = unsafe { rb_vm_ci_flag(ci) };
-
-                        let mid = unsafe { vm_ci_mid(ci) };
-                        // Do method lookup
-                        let mut cme = unsafe { rb_callable_method_entry(klass, mid) };
-                        if cme.is_null() {
-                            self.set_dynamic_send_reason(insn_id, SendNotOptimizedMethodType(MethodType::Null));
-                            self.push_insn_id(block, insn_id); continue;
-                        }
-                        // Load an overloaded cme if applicable. See vm_search_cc().
-                        // It allows you to use a faster ISEQ if possible.
-                        cme = unsafe { rb_check_overloaded_cme(cme, ci) };
-                        let visibility = unsafe { METHOD_ENTRY_VISI(cme) };
-                        match (visibility, flags & VM_CALL_FCALL != 0) {
-                            (METHOD_VISI_PUBLIC, _) => {}
-                            (METHOD_VISI_PRIVATE, true) => {}
-                            (METHOD_VISI_PROTECTED, true) => {}
-                            _ => {
-                                self.set_dynamic_send_reason(insn_id, SendNotOptimizedNeedPermission);
-                                self.push_insn_id(block, insn_id); continue;
+                        match self.type_specialize_send(block, insn_id, recv, cd, state, send_block, caller_splat_length, klass, profiled_type) {
+                            Ok(replacement) => self.make_equal_to(insn_id, replacement),
+                            Err(reason) => {
+                                self.set_dynamic_send_reason(insn_id, reason);
+                                self.push_insn_id(block, insn_id);
                             }
-                        }
-                        let mut def_type = unsafe { get_cme_def_type(cme) };
-                        while def_type == VM_METHOD_TYPE_ALIAS {
-                            cme = unsafe { rb_aliased_callable_method_entry(cme) };
-                            def_type = unsafe { get_cme_def_type(cme) };
-                        }
-
-                        // Check if we can optimize `foo(&block)` where block is nil to a send without block.
-                        // `state` keeps referring to the pre-send frame state (block arg still on the
-                        // stack). Any guard that side-exits before the call re-executes the `send` in
-                        // the interpreter, so it must reconstruct the stack with the block arg present.
-                        // Only the direct-send frame setup uses `send_frame_state`, which has the nil
-                        // block arg stripped from the stack.
-                        let mut send_block = send_block;
-                        let mut send_frame_state = state;
-                        let mut args = match resolved.insn(self) {
-                            Insn::Send { args, .. } => args.to_vec(),
-                            _ => panic!("Expected Send instruction"),
-                        };
-                        let mut stripped_nil_block = false;
-                        if send_block == Some(BlockHandler::BlockArg) && def_type == VM_METHOD_TYPE_ISEQ {
-                            // The block arg is the last element in args
-                            if let Some(&block_arg) = args.last() {
-                                let statically_nil = self.is_a(block_arg, types::NilClass);
-                                let profiled_nil = self.profiled_type_of_at(block_arg, state)
-                                    .map_or(false, |pt| pt.is_nil());
-                                if statically_nil || profiled_nil {
-                                    if !statically_nil {
-                                        // Guard needed when relying on profiled type. Uses the original
-                                        // `state` so a side exit re-executes the send with the block
-                                        // arg still on the VM stack.
-                                        //
-                                        // Recompile on exit so a site that starts seeing non-nil
-                                        // blocks re-profiles the block arg and drops this speculation
-                                        // (falling back to a dynamic send) instead of paying the guard
-                                        // side exit repeatedly. This matches the receiver GuardType
-                                        // below and the getblockparamproxy BlockParamProxyNotNil guard.
-                                        self.push_insn(block, Insn::GuardBitEquals {
-                                            val: block_arg,
-                                            expected: Const::Value(Qnil),
-                                            reason: Box::new(SideExitReason::BlockArgNotNil),
-                                            state,
-                                            recompile: Some(Recompile),
-                                        });
-                                    }
-                                    // Strip nil block arg and treat as no block
-                                    args = args[..args.len() - 1].to_vec();
-                                    send_block = None;
-                                    has_block = false;
-                                    stripped_nil_block = true;
-                                    // Frame state for the direct send only: the block arg is removed
-                                    // from the stack so the callee frame is laid out correctly.
-                                    let new_state = self.frame_state(state).with_replaced_args(&args, args.len() + 1);
-                                    send_frame_state = self.push_insn(block, Insn::Snapshot { state: Box::new(new_state) });
-                                } else {
-                                    // Can't prove block arg is nil
-                                    self.set_dynamic_send_reason(insn_id, SendBlockArgNotNil);
-                                    self.push_insn_id(block, insn_id); continue;
-                                }
-                            }
-                        }
-
-                        // If the call site info indicates that the `Function` has overly complex arguments, then do not optimize into a `SendDirect`.
-                        // Optimized methods(`VM_METHOD_TYPE_OPTIMIZED`) and C methods handle their own argument constraints (e.g., kw_splat for Proc call).
-                        // Mask out ARGS_BLOCKARG only if we've already handled the nil block arg case above.
-                        let mut flags_for_check = if stripped_nil_block { flags & !VM_CALL_ARGS_BLOCKARG } else { flags };
-                        if def_type == VM_METHOD_TYPE_ISEQ {
-                            // Caller splat specialization currently only supports ISEQ callees, so
-                            // skip the generic splat rejection here and validate its profile below.
-                            flags_for_check &= !VM_CALL_ARGS_SPLAT;
-                        }
-                        if def_type != VM_METHOD_TYPE_OPTIMIZED && def_type != VM_METHOD_TYPE_CFUNC && unspecializable_call_type(flags_for_check) {
-                            self.count_complex_call_features(block, flags, state);
-                            self.set_dynamic_send_reason(insn_id, ComplexArgPass);
-                            self.push_insn_id(block, insn_id); continue;
-                        }
-
-                        if def_type == VM_METHOD_TYPE_ISEQ {
-                            // TODO(max): Allow non-iseq; cache cme
-                            // Only specialize positional-positional calls
-                            // TODO(max): Handle other kinds of parameter passing
-                            let iseq = unsafe { get_def_iseq_ptr((*cme).def) };
-                            let caller_args = CallerArguments::new(&args, ci);
-                            let caller_splat = if let Some(arg_idx) = caller_args.splat_arg_idx {
-                                // Count the profile shape for every caller-splat execution;
-                                // complex_arg_pass_caller_splat separately tracks fallbacks.
-                                self.count_caller_splat_profile(block, state);
-                                // `add_iseq_to_hir` selects caller-splat lengths before building
-                                // receiver dispatch. A Send without a selected length stays dynamic.
-                                let Some(length) = caller_splat_length else {
-                                    self.count(block, Counter::complex_arg_pass_caller_splat);
-                                    self.set_dynamic_send_reason(insn_id, ComplexArgPass);
-                                    self.push_insn_id(block, insn_id); continue;
-                                };
-                                Some(CallerSplat {
-                                    arg_idx,
-                                    array: caller_args.original[arg_idx],
-                                    length,
-                                })
-                            } else {
-                                None
-                            };
-                            let Ok(call) = self.build_send_direct_args(&caller_args, caller_splat, iseq, has_block)
-                                .inspect_err(|failure| failure.record(self, block, insn_id, SendDirectFallbackContext::Send)) else {
-                                self.push_insn_id(block, insn_id); continue;
-                            };
-
-                            // Check singleton class assumption first, before emitting other patchpoints
-                            if !self.assume_no_singleton_classes(block, klass, state) {
-                                self.set_dynamic_send_reason(insn_id, SingletonClassSeen);
-                                self.push_insn_id(block, insn_id); continue;
-                            }
-
-                            if let Some(caller_splat) = caller_splat {
-                                self.emit_caller_splat(block, caller_splat, state);
-                                // Count caller-splat executions that take this optimized path.
-                                // This is a feature-specific counter, not part of optimized_send_count.
-                                self.count(block, Counter::caller_splat_optimized);
-                            }
-
-                            // Add PatchPoint for method redefinition
-                            self.push_insn(block, Insn::PatchPoint { invariant: Invariant::MethodRedefined { klass, method: mid, cme }, state });
-
-                            // Add GuardType for profiled receiver
-                            if let Some(profiled_type) = profiled_type {
-                                recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state, recompile: Some(Recompile) });
-                                self.insn_types[recv] = self.infer_type(recv);
-                            }
-
-                            let SendDirectArgs { state: send_state, args: send_args, kw_bits, jit_entry_idx } =
-                                self.emit_send_direct_args(block, call, &args, send_frame_state);
-                            let replacement = self.try_inline_send_direct(block, Insn::SendDirect(Box::new(SendDirectData { recv, cd, cme, iseq, args: send_args, kw_bits, jit_entry_idx, state: send_state, block: send_block })));
-                            self.make_equal_to(insn_id, replacement);
-                        } else if !has_block && def_type == VM_METHOD_TYPE_BMETHOD {
-                            let procv = unsafe { rb_get_def_bmethod_proc((*cme).def) };
-                            let proc = unsafe { rb_jit_get_proc_ptr(procv) };
-                            let proc_block = unsafe { (*proc).block.as_ref() };
-                            // Target ISEQ bmethods. Can't handle for example, `define_method(:foo, &:foo)`
-                            // which makes a `block_type_symbol` bmethod.
-                            if proc_block.type_() != block_type_iseq {
-                                self.set_dynamic_send_reason(insn_id, BmethodNonIseqProc);
-                                self.push_insn_id(block, insn_id); continue;
-                            }
-                            let capture = unsafe { proc_block.as_.captured.as_ref() };
-                            let iseq = unsafe { *capture.code.iseq.as_ref() };
-
-                            let caller_args = CallerArguments::new(&args, ci);
-                            let Ok(call) = self.build_send_direct_args(&caller_args, None, iseq, has_block)
-                                .inspect_err(|failure| failure.record(self, block, insn_id, SendDirectFallbackContext::Send)) else {
-                                self.push_insn_id(block, insn_id); continue;
-                            };
-
-                            // Patch points:
-                            // Check for "defined with an un-shareable Proc in a different Ractor"
-                            if !procv.shareable_p() && !self.assume_single_ractor_mode(block, state) {
-                                // TODO(alan): Turn this into a ractor belonging guard to work better in multi ractor mode.
-                                self.set_dynamic_send_reason(insn_id, SingleRactorModeRequired);
-                                self.push_insn_id(block, insn_id); continue;
-                            }
-                            // Check singleton class assumption first, before emitting other patchpoints
-                            if !self.assume_no_singleton_classes(block, klass, state) {
-                                self.set_dynamic_send_reason(insn_id, SingletonClassSeen);
-                                self.push_insn_id(block, insn_id); continue;
-                            }
-                            self.push_insn(block, Insn::PatchPoint { invariant: Invariant::MethodRedefined { klass, method: mid, cme }, state });
-
-                            if let Some(profiled_type) = profiled_type {
-                                recv = self.guard_type_recompile(block, recv, Type::from_profiled_type(profiled_type), state, Recompile);
-                            }
-
-                            let SendDirectArgs { state: send_state, args: send_args, kw_bits, jit_entry_idx } =
-                                self.emit_send_direct_args(block, call, &args, send_frame_state);
-                            let replacement = self.try_inline_send_direct(block, Insn::SendDirect(Box::new(SendDirectData { recv, cd, cme, iseq, args: send_args, kw_bits, jit_entry_idx, state: send_state, block: None })));
-                            self.make_equal_to(insn_id, replacement);
-                        } else if !has_block && def_type == VM_METHOD_TYPE_IVAR && args.is_empty() {
-                            // Check if we're accessing ivars of a Class or Module object as they require single-ractor mode.
-                            // We omit gen_prepare_non_leaf_call on gen_getivar, so it's unsafe to raise for multi-ractor mode.
-                            if klass.is_metaclass() && !self.assume_single_ractor_mode(block, state) {
-                                self.set_dynamic_send_reason(insn_id, SingleRactorModeRequired);
-                                self.push_insn_id(block, insn_id); continue;
-                            }
-                            // Check singleton class assumption first, before emitting other patchpoints
-                            if !self.assume_no_singleton_classes(block, klass, state) {
-                                self.set_dynamic_send_reason(insn_id, SingletonClassSeen);
-                                self.push_insn_id(block, insn_id); continue;
-                            }
-
-                            self.push_insn(block, Insn::PatchPoint { invariant: Invariant::MethodRedefined { klass, method: mid, cme }, state });
-
-                            let id = unsafe { get_cme_def_body_attr_id(cme) };
-                            if let Some(profiled_type) = profiled_type {
-                                recv = self.guard_type_recompile(block, recv, Type::from_profiled_type(profiled_type), state, Recompile);
-
-                                let replacement = self.try_emit_optimized_getivar(block, recv, id, profiled_type, state).unwrap_or_else(|counter| {
-                                    self.count(block, counter);
-                                    self.push_insn(block, Insn::GetIvar { self_val: recv, id, ic: std::ptr::null(), state })
-                                });
-                                self.make_equal_to(insn_id, replacement);
-                            } else {
-                                // No shape information, just static class information
-                                let resolution = self.resolve_receiver_type_from_profile(recv, state);
-                                let counter = Self::getivar_fallback_reason(resolution, std::ptr::null());
-                                self.count(block, counter);
-                                let getivar = self.push_insn(block, Insn::GetIvar { self_val: recv, id, ic: std::ptr::null(), state });
-                                self.make_equal_to(insn_id, getivar);
-                            }
-                        } else if let (false, VM_METHOD_TYPE_ATTRSET, &[val]) = (has_block, def_type, args.as_slice()) {
-                            // Check if we're accessing ivars of a Class or Module object as they require single-ractor mode.
-                            // We omit gen_prepare_non_leaf_call on gen_getivar, so it's unsafe to raise for multi-ractor mode.
-                            if klass.is_metaclass() && !self.assume_single_ractor_mode(block, state) {
-                                self.set_dynamic_send_reason(insn_id, SingleRactorModeRequired);
-                                self.push_insn_id(block, insn_id); continue;
-                            }
-
-                            self.push_insn(block, Insn::PatchPoint { invariant: Invariant::MethodRedefined { klass, method: mid, cme }, state });
-                            let id = unsafe { get_cme_def_body_attr_id(cme) };
-                            if let Some(profiled_type) = profiled_type {
-                                // TODO: attr_writer SetIvar has a null inline cache and may target a receiver
-                                // operand other than CFP self. Support it with a reprofile strategy that
-                                // profiles the receiver operand even after the send insn has finished profiling.
-                                recv = self.guard_type_recompile(block, recv, Type::from_profiled_type(profiled_type), state, Recompile);
-                                let recompile = None;
-                                self.try_emit_optimized_setivar(block, recv, id, val, profiled_type, state, recompile).unwrap_or_else(|counter| {
-                                    self.count(block, counter);
-                                    self.push_insn(block, Insn::SetIvar { self_val: recv, id, ic: std::ptr::null(), val, state });
-                                });
-                            } else {
-                                // No shape information, just static class information
-                                self.push_insn(block, Insn::SetIvar { self_val: recv, id, ic: std::ptr::null(), val, state });
-                            }
-                            self.make_equal_to(insn_id, val);
-                        } else if !has_block && def_type == VM_METHOD_TYPE_OPTIMIZED {
-                            let opt_type: OptimizedMethodType = unsafe { get_cme_def_body_optimized_type(cme) }.into();
-                            match (opt_type, args.as_slice()) {
-                                (OptimizedMethodType::Call, _) => {
-                                    if flags & (VM_CALL_ARGS_SPLAT | VM_CALL_KWARG) != 0 {
-                                        self.count_complex_call_features(block, flags, state);
-                                        self.set_dynamic_send_reason(insn_id, ComplexArgPass);
-                                        self.push_insn_id(block, insn_id); continue;
-                                    }
-                                    // Check singleton class assumption first, before emitting other patchpoints
-                                    if !self.assume_no_singleton_classes(block, klass, state) {
-                                        self.set_dynamic_send_reason(insn_id, SingletonClassSeen);
-                                        self.push_insn_id(block, insn_id); continue;
-                                    }
-                                    self.push_insn(block, Insn::PatchPoint { invariant: Invariant::MethodRedefined { klass, method: mid, cme }, state });
-                                    if let Some(profiled_type) = profiled_type {
-                                        recv = self.guard_type_recompile(block, recv, Type::from_profiled_type(profiled_type), state, Recompile);
-                                    }
-                                    let kw_splat = flags & VM_CALL_KW_SPLAT != 0;
-                                    let invoke_proc = self.push_insn(block, Insn::InvokeProc { recv, args: args.clone(), state, kw_splat });
-                                    self.make_equal_to(insn_id, invoke_proc);
-                                }
-                                (OptimizedMethodType::StructAref, &[]) | (OptimizedMethodType::StructAset, &[_]) => {
-                                    if unspecializable_call_type(flags) {
-                                        self.count_complex_call_features(block, flags, state);
-                                        self.set_dynamic_send_reason(insn_id, ComplexArgPass);
-                                        self.push_insn_id(block, insn_id); continue;
-                                    }
-                                    let index: i32 = unsafe { get_cme_def_body_optimized_index(cme) }
-                                                    .try_into()
-                                                    .unwrap();
-                                    // We are going to use an encoding that takes a 4-byte immediate which
-                                    // limits the offset to INT32_MAX.
-                                    {
-                                        let native_index = (index as i64) * (SIZEOF_VALUE as i64);
-                                        if native_index > (i32::MAX as i64) {
-                                            self.set_dynamic_send_reason(insn_id, OperandTooLarge);
-                                            self.push_insn_id(block, insn_id); continue;
-                                        }
-                                    }
-                                    // Get the profiled type to check if the fields is embedded or heap allocated.
-                                    let Some(is_embedded) = self.profiled_type_of_at(recv, state).map(|t| t.flags().is_struct_embedded()) else {
-                                        // No (monomorphic/skewed polymorphic) profile info
-                                        self.set_dynamic_send_reason(insn_id, SendNoProfiles);
-                                        self.push_insn_id(block, insn_id); continue;
-                                    };
-                                    // Check singleton class assumption first, before emitting other patchpoints
-                                    if !self.assume_no_singleton_classes(block, klass, state) {
-                                        self.set_dynamic_send_reason(insn_id, SingletonClassSeen);
-                                        self.push_insn_id(block, insn_id); continue;
-                                    }
-                                    self.push_insn(block, Insn::PatchPoint { invariant: Invariant::MethodRedefined { klass, method: mid, cme }, state });
-                                    if let Some(profiled_type) = profiled_type {
-                                        recv = self.guard_type_recompile(block, recv, Type::from_profiled_type(profiled_type), state, Recompile);
-                                    }
-                                    // All structs from the same Struct class should have the same
-                                    // length. So if our recv is embedded all runtime
-                                    // structs of the same class should be as well, and the same is
-                                    // true of the converse.
-                                    //
-                                    // No need for a GuardShape.
-                                    if let OptimizedMethodType::StructAset = opt_type {
-                                        self.guard_not_frozen(block, recv, state);
-                                    }
-
-                                    let (target, offset) = if is_embedded {
-                                        let offset = RUBY_OFFSET_RSTRUCT_AS_ARY + (SIZEOF_VALUE_I32 * index);
-                                        (recv, offset)
-                                    } else {
-                                        let as_heap = self.load_field(block, recv, FieldName::as_heap, RUBY_OFFSET_RSTRUCT_AS_HEAP_PTR, types::CPtr);
-                                        let offset = SIZEOF_VALUE_I32 * index;
-                                        (as_heap, offset)
-                                    };
-
-                                    let replacement = if let (OptimizedMethodType::StructAset, &[val]) = (opt_type, args.as_slice()) {
-                                        self.push_insn(block, Insn::StoreField { recv: target, id: mid.into(), offset, val, num_bits: types::BasicObject.num_bits() });
-                                        self.push_insn(block, Insn::WriteBarrier { recv, val });
-                                        val
-                                    } else { // StructAref
-                                        self.load_field(block, target, mid.into(), offset, types::BasicObject)
-                                    };
-                                    self.make_equal_to(insn_id, replacement);
-                                },
-                                _ => {
-                                    self.set_dynamic_send_reason(insn_id, SendNotOptimizedMethodTypeOptimized(OptimizedMethodType::from(opt_type)));
-                                    self.push_insn_id(block, insn_id); continue;
-                                },
-                            };
-                        } else if def_type == VM_METHOD_TYPE_CFUNC && !unsafe { rb_zjit_method_tracing_currently_enabled() } {
-                            // Try to reduce a Send insn to a CCallWithFrame
-                            fn reduce_send_to_ccall(
-                                fun: &mut Function,
-                                block: BlockId,
-                                send_insn_id: InsnId,
-                                mut recv: InsnId,
-                                cd: *const rb_call_data,
-                                send_block: Option<BlockHandler>,
-                                args: Vec<InsnId>,
-                                state: InsnId,
-                                recv_class: VALUE,
-                                profiled_type: Option<ProfiledType>,
-                                cme: *const rb_callable_method_entry_struct,
-                            ) -> Result<(), ()> {
-                                let call_info = unsafe { (*cd).ci };
-                                let argc = unsafe { vm_ci_argc(call_info) };
-                                let method_id = unsafe { rb_vm_ci_mid(call_info) };
-
-                                let ci_flags = unsafe { vm_ci_flag(call_info) };
-                                // When seeing &block argument, fall back to dynamic dispatch for now
-                                // TODO: Support block forwarding
-                                if unspecializable_c_call_type(ci_flags) {
-                                    // Only count features NOT already counted in type_specialize.
-                                    if !unspecializable_call_type(ci_flags) {
-                                        fun.count_complex_call_features(block, ci_flags, state);
-                                    }
-                                    fun.set_dynamic_send_reason(send_insn_id, ComplexArgPass);
-                                    return Err(());
-                                }
-
-                                let blockiseq = match send_block {
-                                    Some(BlockHandler::BlockArg) => unreachable!("unsupported &block should have been filtered out"),
-                                    Some(BlockHandler::BlockIseq(blockiseq)) => Some(blockiseq),
-                                    None => None,
-                                };
-
-                                let cfunc = unsafe { get_cme_def_body_cfunc(cme) };
-                                // Find the `argc` (arity) of the C method, which describes the parameters it expects
-                                let cfunc_argc = unsafe { get_mct_argc(cfunc) };
-                                let cfunc_ptr = unsafe { get_mct_func(cfunc) }.cast();
-                                let name = unsafe { (*cme).called_id };
-
-                                // Look up annotations
-                                let props = ZJITState::get_method_annotations().get_cfunc_properties(cme);
-                                if props.is_none() && get_option!(stats) {
-                                    fun.count_not_annotated_cfunc(block, cme);
-                                }
-                                let props = props.unwrap_or_default();
-                                let return_type = props.return_type;
-                                let elidable = match blockiseq {
-                                    Some(_) => false, // Don't consider cfuncs with block arguments as elidable for now
-                                    None => props.elidable,
-                                };
-
-                                match cfunc_argc {
-                                    0.. => {
-                                        // (self, arg0, arg1, ..., argc) form
-                                        //
-                                        // Bail on argc mismatch
-                                        if argc != cfunc_argc as u32 {
-                                            fun.set_dynamic_send_reason(send_insn_id, ArgcParamMismatch);
-                                            return Err(());
-                                        }
-
-                                        // Check singleton class assumption first, before emitting other patchpoints
-                                        if !fun.assume_no_singleton_classes(block, recv_class, state) {
-                                            fun.set_dynamic_send_reason(send_insn_id, SingletonClassSeen);
-                                            return Err(());
-                                        }
-
-                                        // Commit to the replacement. Put PatchPoint.
-                                        fun.gen_patch_points_for_optimized_ccall(block, recv_class, method_id, cme, state);
-
-                                        if let Some(profiled_type) = profiled_type {
-                                            // Guard receiver class
-                                            recv = fun.guard_type_recompile(block, recv, Type::from_profiled_type(profiled_type), state, Recompile);
-                                        }
-
-                                        // Try inlining the cfunc into HIR. Only inline if we don't have a block argument
-                                        if blockiseq.is_none() {
-                                            let tmp_block = fun.new_block(u32::MAX);
-                                            if let Some(replacement) = (props.inline)(fun, tmp_block, recv, &args, state) {
-                                                // Copy contents of tmp_block to block
-                                                assert_ne!(block, tmp_block);
-                                                let insns = std::mem::take(&mut fun.blocks[tmp_block].insns);
-                                                fun.blocks[block].insns.extend(insns);
-                                                fun.count(block, Counter::inline_cfunc_optimized_send_count);
-                                                fun.make_equal_to(send_insn_id, replacement);
-                                                if fun.type_of(replacement).bit_equal(types::Any) {
-                                                    // Not set yet; infer type
-                                                    fun.insn_types[replacement] = fun.infer_type(replacement);
-                                                }
-                                                fun.remove_block(tmp_block);
-                                                return Ok(());
-                                            }
-
-                                            // Only allow leaf calls if we don't have a block argument
-                                            if props.leaf && props.no_gc {
-                                                fun.count(block, Counter::inline_cfunc_optimized_send_count);
-                                                let owner = unsafe { (*cme).owner };
-                                                let ccall = fun.push_insn(block, Insn::CCall { cfunc: cfunc_ptr, recv, args, name, owner, return_type, elidable });
-                                                fun.insn_types[ccall] = fun.infer_type(ccall);
-                                                fun.make_equal_to(send_insn_id, ccall);
-                                                return Ok(());
-                                            }
-                                        }
-
-                                        // Emit a call
-                                        if get_option!(stats) {
-                                            fun.count_not_inlined_cfunc(block, cme);
-                                        }
-                                        let ccall = fun.push_insn(block, Insn::CCallWithFrame(Box::new(CCallWithFrameData {
-                                            cd,
-                                            cfunc: cfunc_ptr,
-                                            recv,
-                                            args,
-                                            cme,
-                                            name,
-                                            state,
-                                            return_type,
-                                            elidable,
-                                            block: blockiseq.map(BlockHandler::BlockIseq),
-                                        })));
-                                        fun.insn_types[ccall] = fun.infer_type(ccall);
-                                        fun.make_equal_to(send_insn_id, ccall);
-                                        Ok(())
-                                    }
-                                    // Variadic method
-                                    -1 => {
-                                        // The method gets a pointer to the first argument
-                                        // func(int argc, VALUE *argv, VALUE recv)
-
-                                        // Check singleton class assumption first, before emitting other patchpoints
-                                        if !fun.assume_no_singleton_classes(block, recv_class, state) {
-                                            fun.set_dynamic_send_reason(send_insn_id, SingletonClassSeen);
-                                            return Err(());
-                                        }
-
-                                        fun.gen_patch_points_for_optimized_ccall(block, recv_class, method_id, cme, state);
-
-                                        if let Some(profiled_type) = profiled_type {
-                                            // Guard receiver class
-                                            recv = fun.guard_type_recompile(block, recv, Type::from_profiled_type(profiled_type), state, Recompile);
-                                        }
-
-                                        // Try inlining the cfunc into HIR. Only inline if we don't have a block argument
-                                        if blockiseq.is_none() {
-                                            let tmp_block = fun.new_block(u32::MAX);
-                                            if let Some(replacement) = (props.inline)(fun, tmp_block, recv, &args, state) {
-                                                // Copy contents of tmp_block to block
-                                                assert_ne!(block, tmp_block);
-                                                let insns = std::mem::take(&mut fun.blocks[tmp_block].insns);
-                                                fun.blocks[block].insns.extend(insns);
-                                                fun.count(block, Counter::inline_cfunc_optimized_send_count);
-                                                fun.make_equal_to(send_insn_id, replacement);
-                                                if fun.type_of(replacement).bit_equal(types::Any) {
-                                                    // Not set yet; infer type
-                                                    fun.insn_types[replacement] = fun.infer_type(replacement);
-                                                }
-                                                fun.remove_block(tmp_block);
-                                                return Ok(());
-                                            }
-
-                                            // Only allow inline calls if they are leaf, don't allocate, and don't have a block argument
-                                            if props.leaf && props.no_gc {
-                                                fun.count(block, Counter::inline_cfunc_optimized_send_count);
-                                                let owner = unsafe { (*cme).owner };
-                                                let ccall = fun.push_insn(block, Insn::CCall { cfunc: cfunc_ptr, recv, args, name, owner, return_type, elidable });
-                                                fun.insn_types[ccall] = fun.infer_type(ccall);
-                                                fun.make_equal_to(send_insn_id, ccall);
-                                                return Ok(());
-                                            }
-                                        }
-
-                                        // No inlining; emit a call
-                                        if get_option!(stats) {
-                                            fun.count_not_inlined_cfunc(block, cme);
-                                        }
-
-                                        let ccall = fun.push_insn(block, Insn::CCallVariadic(Box::new(CCallVariadicData {
-                                            cfunc: cfunc_ptr,
-                                            recv,
-                                            args,
-                                            cme,
-                                            name: method_id,
-                                            state,
-                                            return_type,
-                                            elidable,
-                                            block: blockiseq.map(BlockHandler::BlockIseq),
-                                        })));
-                                        fun.insn_types[ccall] = fun.infer_type(ccall);
-                                        fun.make_equal_to(send_insn_id, ccall);
-                                        Ok(())
-                                    }
-                                    -2 => {
-                                        // (self, args_ruby_array)
-                                        fun.set_dynamic_send_reason(send_insn_id, SendCfuncArrayVariadic);
-                                        Err(())
-                                    }
-                                    _ => unreachable!("unknown cfunc kind: argc={argc}")
-                                }
-                            }
-
-                            if reduce_send_to_ccall(self, block, insn_id, recv, cd, send_block, args, state, klass, profiled_type, cme).is_ok() {
-                                continue;
-                            }
-
-                            self.push_insn_id(block, insn_id);
-                        } else {
-                            self.set_dynamic_send_reason(insn_id, SendNotOptimizedMethodType(MethodType::from(def_type)));
-                            self.push_insn_id(block, insn_id); continue;
                         }
                     }
                     &Insn::IsMethodCfunc { val, cd, cfunc, state } if self.type_of(val).ruby_object_known() => {
@@ -8635,26 +8717,6 @@ impl ProfileOracle {
         }
     }
 
-    /// Copy the profile entries recorded for the `src` Snapshot to the `dst` Snapshot, excluding
-    /// entries for `exclude` (chased through guards). Used by polymorphic dispatch, where each
-    /// refined arm gets a fresh Snapshot: the receiver must resolve from its refined type rather
-    /// than the polymorphic profile, but the other operands' profiles should remain visible so
-    /// argument-profile-dependent specializations (e.g. Array#[]) still apply.
-    fn copy_entries_except(&mut self, src: InsnId, dst: InsnId, exclude: InsnId, excluded_profiled_type: ProfiledType, fun: &Function) {
-        use crate::profile::TypeDistribution;
-        let Some(entries) = self.types.get(&src) else { return };
-        let exclude = fun.chase_insn(exclude);
-        // Remove the polymorphic entries for `excluded`
-        let mut filtered: Vec<_> = entries.iter()
-            .filter(|(insn, _)| fun.chase_insn(*insn) != exclude)
-            .cloned()
-            .collect();
-        // Re-add a monomorphic entry for this arm of the dispatch
-        let mut dist = TypeDistribution::new();
-        dist.observe(excluded_profiled_type);
-        filtered.push((exclude, TypeDistributionSummary::new(&dist)));
-        self.types.insert(dst, filtered);
-    }
 }
 
 fn invalidates_locals(opcode: u32, operands: *const VALUE) -> bool {
@@ -10102,55 +10164,9 @@ fn add_iseq_to_hir(
                     let recv = state.stack_pop()?;
                     let caller_splat_length = fun.monomorphic_caller_splat_length(call_info, exit_id);
 
-                    if let Some(summary) = fun.polymorphic_summary(&profiles, recv, exit_id) {
-                        let join_block = fun.new_block(insn_idx);
-                        let join_param = fun.push_insn(join_block, Insn::Param);
-                        // Dedup by expected type so immediate/heap variants
-                        // under the same Ruby class can still get separate branches.
-                        let mut seen_types = Vec::with_capacity(summary.buckets().len());
-                        for &profiled_type in summary.buckets() {
-                            if profiled_type.is_empty() { break; }
-                            let expected = Type::from_profiled_type(profiled_type);
-                            if seen_types.iter().any(|ty: &Type| ty.bit_equal(expected)) {
-                                continue;
-                            }
-                            seen_types.push(expected);
-                            let has_type = fun.push_insn(block, Insn::HasType { val: recv, expected });
-                            let iftrue_block = fun.new_block(insn_idx);
-                            let fall_through = fun.new_block(insn_idx);
-                            fun.push_insn(block, Insn::CondBranch {
-                                val: has_type,
-                                if_true: BranchEdge { target: iftrue_block, args: vec![] },
-                                if_false: BranchEdge { target: fall_through, args: vec![] }
-                            });
-                            block = fall_through;
-                            // Take a fresh Snapshot rather than
-                            // reusing exit_id so type specialization resolves the receiver from
-                            // its refined, exact type instead of the polymorphic profile that is
-                            // keyed at exit_id.
-                            let snapshot = fun.push_insn(iftrue_block, Insn::Snapshot { state: Box::new(exit_state.clone()) });
-                            // Keep the other operands' profile entries visible at the fresh
-                            // Snapshot so the specialized send can still see argument profiles
-                            // (e.g. Array#[] needs a Fixnum-profiled index to be inlined). Only
-                            // the receiver's entry is dropped: it must resolve from its refined,
-                            // exact type, and resolve_receiver_type prefers profiles over types.
-                            profiles.copy_entries_except(exit_id, snapshot, recv, profiled_type, fun);
-                            let refined_recv = fun.push_insn(iftrue_block, Insn::RefineType { val: recv, new_type: expected });
-                            let send = fun.push_insn(iftrue_block, Insn::Send { recv: refined_recv, cd, block: None, args: args.clone(), caller_splat_length, state: snapshot, reason: Uncategorized(opcode.into()) });
-                            fun.push_insn(iftrue_block, Insn::Jump(BranchEdge { target: join_block, args: vec![send] }));
-                        }
-                        // In the fallthrough case, do a generic interpreter send and then join.
-                        let reason = SendPolymorphicFallback;
-                        let send = fun.push_insn(block, Insn::Send { recv, cd, block: None, args, caller_splat_length, state: exit_id, reason });
-                        fun.push_insn(block, Insn::Jump(BranchEdge { target: join_block, args: vec![send] }));
-                        state.stack_push(join_param);
-                        // Continue compilation from the join block at the next instruction.
-                        block = join_block;
-                    } else {
-                        // Maybe monomorphic; handled in type_specialize
-                        let send = fun.push_insn(block, Insn::Send { recv, cd, block: None, args, caller_splat_length, state: exit_id, reason: Uncategorized(opcode.into()) });
-                        state.stack_push(send);
-                    }
+                    // Receiver dispatch (mono- and polymorphic) is handled in type_specialize.
+                    let send = fun.push_insn(block, Insn::Send { recv, cd, block: None, args, caller_splat_length, state: exit_id, reason: Uncategorized(opcode.into()) });
+                    state.stack_push(send);
                 }
                 YARVINSN_send => {
                     let cd: *const rb_call_data = get_arg(pc, 0).as_ptr();

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -8640,16 +8640,20 @@ impl ProfileOracle {
     /// refined arm gets a fresh Snapshot: the receiver must resolve from its refined type rather
     /// than the polymorphic profile, but the other operands' profiles should remain visible so
     /// argument-profile-dependent specializations (e.g. Array#[]) still apply.
-    fn copy_entries_except(&mut self, src: InsnId, dst: InsnId, exclude: InsnId, fun: &Function) {
+    fn copy_entries_except(&mut self, src: InsnId, dst: InsnId, exclude: InsnId, excluded_profiled_type: ProfiledType, fun: &Function) {
+        use crate::profile::TypeDistribution;
         let Some(entries) = self.types.get(&src) else { return };
         let exclude = fun.chase_insn(exclude);
-        let filtered: Vec<_> = entries.iter()
+        // Remove the polymorphic entries for `excluded`
+        let mut filtered: Vec<_> = entries.iter()
             .filter(|(insn, _)| fun.chase_insn(*insn) != exclude)
             .cloned()
             .collect();
-        if !filtered.is_empty() {
-            self.types.insert(dst, filtered);
-        }
+        // Re-add a monomorphic entry for this arm of the dispatch
+        let mut dist = TypeDistribution::new();
+        dist.observe(excluded_profiled_type);
+        filtered.push((exclude, TypeDistributionSummary::new(&dist)));
+        self.types.insert(dst, filtered);
     }
 }
 
@@ -10130,7 +10134,7 @@ fn add_iseq_to_hir(
                             // (e.g. Array#[] needs a Fixnum-profiled index to be inlined). Only
                             // the receiver's entry is dropped: it must resolve from its refined,
                             // exact type, and resolve_receiver_type prefers profiles over types.
-                            profiles.copy_entries_except(exit_id, snapshot, recv, fun);
+                            profiles.copy_entries_except(exit_id, snapshot, recv, profiled_type, fun);
                             let refined_recv = fun.push_insn(iftrue_block, Insn::RefineType { val: recv, new_type: expected });
                             let send = fun.push_insn(iftrue_block, Insn::Send { recv: refined_recv, cd, block: None, args: args.clone(), caller_splat_length, state: snapshot, reason: Uncategorized(opcode.into()) });
                             fun.push_insn(iftrue_block, Insn::Jump(BranchEdge { target: join_block, args: vec![send] }));

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -4663,29 +4663,51 @@ impl Function {
         self.polymorphic_summary(profiles, recv, state)
     }
 
+    /// Return the definition type of the method `cd` names on `klass`, chasing aliases, or None
+    /// if lookup fails. This is advisory (no patch point): [`Function::type_specialize_send`]
+    /// repeats the lookup and emits the MethodRedefined patch point itself.
+    fn resolved_method_def_type(klass: VALUE, cd: *const rb_call_data) -> Option<rb_method_type_t> {
+        let mid = unsafe { vm_ci_mid((*cd).ci) };
+        let mut cme = unsafe { rb_callable_method_entry(klass, mid) };
+        if cme.is_null() {
+            return None;
+        }
+        let mut def_type = unsafe { get_cme_def_type(cme) };
+        while def_type == VM_METHOD_TYPE_ALIAS {
+            cme = unsafe { rb_aliased_callable_method_entry(cme) };
+            def_type = unsafe { get_cme_def_type(cme) };
+        }
+        Some(def_type)
+    }
+
     /// Split `block` into a dispatch chain for a Send with a polymorphic receiver:
     ///
     /// ```text
     /// for class in profiles:
     ///     if HasType class:
     ///         RefineType class
-    ///         s = load shape
-    ///         for shape in class:
-    ///             if s == shape:
-    ///                 specialize send for (class, shape)
-    ///             else:
-    ///                 goto next shape
-    ///         goto next class
+    ///         if method(class) is an ivar accessor:
+    ///             s = load shape
+    ///             for shape in class:
+    ///                 if s == shape:
+    ///                     specialize send for (class, shape)
+    ///                 else:
+    ///                     goto next shape
+    ///             goto next class
+    ///         else:
+    ///             specialize send for class
     ///     else:
     ///         goto next class
     /// ```
     ///
     /// The outer chain tests the receiver's class (HasType/RefineType) and the inner chain its
     /// shape (IsBitEqual on the loaded shape id), so each arm's send specializes against a fully
-    /// guaranteed (class, shape) pair and emits no receiver guards of its own. Receivers matching
-    /// no profiled class or shape fall through to a generic dynamic send. All branches join on a
-    /// block whose Param replaces the original send. Returns the join block, which the caller
-    /// should continue filling.
+    /// guaranteed (class, shape) pair and emits no receiver guards of its own. Only ivar
+    /// accessors (attr_reader/attr_writer) consume the receiver's shape, so the shape dispatch
+    /// is emitted only for them; every other method type specializes against the class alone.
+    /// Receivers matching no profiled class or shape fall through to a generic dynamic send.
+    /// All branches join on a block whose Param replaces the original send. Returns the join
+    /// block, which the caller should continue filling.
     fn specialize_polymorphic_send(
         &mut self,
         mut block: BlockId,
@@ -4732,17 +4754,27 @@ impl Function {
             block = next_class;
             let refined_recv = self.push_insn(class_block, Insn::RefineType { val: recv, new_type: expected });
             self.insn_types[refined_recv] = self.infer_type(refined_recv);
+            // Only ivar accessors consume the receiver's shape, so only they need per-shape
+            // dispatch arms. The arm re-resolves the same method, so a shape-guaranteed arm is
+            // emitted exactly when the specialization would read the profiled shape.
+            let needs_shape = matches!(
+                Self::resolved_method_def_type(buckets[0].class(), cd),
+                Some(def_type) if def_type == VM_METHOD_TYPE_IVAR || def_type == VM_METHOD_TYPE_ATTRSET
+            );
             // Dedup this class's buckets by shape so each shape gets one arm.
             let mut shapes: Vec<ProfiledType> = Vec::with_capacity(buckets.len());
-            for &profiled_type in &buckets {
-                if profiled_type.shape().is_valid()
-                    && !shapes.iter().any(|seen| seen.shape() == profiled_type.shape()) {
-                    shapes.push(profiled_type);
+            if needs_shape {
+                for &profiled_type in &buckets {
+                    if profiled_type.shape().is_valid()
+                        && !shapes.iter().any(|seen| seen.shape() == profiled_type.shape()) {
+                        shapes.push(profiled_type);
+                    }
                 }
             }
             if shapes.is_empty() {
-                // Immediates carry no shape (their profile entries have an invalid shape id);
-                // specialize directly against the class.
+                // No shape dispatch needed: either the method doesn't consume the receiver's
+                // shape, or the receivers are immediates, which carry no shape (their profile
+                // entries have an invalid shape id). Specialize directly against the class.
                 let result = self.specialize_send_arm(class_block, insn_id, refined_recv, cd, state, caller_splat_length, buckets[0]);
                 join_type = join_type.union(self.type_of(result));
                 self.push_insn(class_block, Insn::Jump(BranchEdge { target: join_block, args: vec![result] }));

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -1767,11 +1767,11 @@ mod hir_opt_tests {
           v20:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)] recompile
           PushInlineFrame :m, v20 (0x1038), num_args=1
           PatchPoint MethodRedefined(NilClass@0x1058, nil?@0x1060, cme:0x1068)
-          v52:Fixnum[0] = Const Value(0)
+          v38:Fixnum[0] = Const Value(0)
           CheckInterrupts
-          v85:Fixnum[0] = Const Value(0)
+          v87:Fixnum[0] = Const Value(0)
           PopInlineFrame
-          Return v85
+          Return v87
         ");
     }
 
@@ -9711,25 +9711,25 @@ mod hir_opt_tests {
           v27:NilClass = Const Value(nil)
           Jump bb5(v16, v27)
         bb5(v30:BasicObject, v31:Falsy):
-          v36:CBool = HasType v31, FalseClass
-          CondBranch v36, bb8(), bb9()
+          v42:CBool = HasType v31, FalseClass
+          CondBranch v42, bb8(), bb9()
         bb8():
           PatchPoint MethodRedefined(FalseClass@0x1008, !@0x1010, cme:0x1018)
-          v58:TrueClass = Const Value(true)
-          Jump bb7(v58)
+          v49:TrueClass = Const Value(true)
+          Jump bb7(v49)
         bb9():
-          v42:CBool = HasType v31, NilClass
-          CondBranch v42, bb10(), bb11()
+          v51:CBool = HasType v31, NilClass
+          CondBranch v51, bb10(), bb11()
         bb10():
           PatchPoint MethodRedefined(NilClass@0x1040, !@0x1010, cme:0x1018)
-          v62:TrueClass = Const Value(true)
-          Jump bb7(v62)
+          v58:TrueClass = Const Value(true)
+          Jump bb7(v58)
         bb11():
-          v48:BasicObject = Send v31, :! # SendFallbackReason: Send: polymorphic call site
-          Jump bb7(v48)
-        bb7(v35:BasicObject):
+          v60:BasicObject = Send v31, :! # SendFallbackReason: Send: polymorphic fallback
+          Jump bb7(v60)
+        bb7(v41:BasicObject):
           CheckInterrupts
-          Return v35
+          Return v41
         ");
     }
 
@@ -10456,19 +10456,19 @@ mod hir_opt_tests {
           Jump bb3(v6, v7)
         bb3(v9:HeapBasicObject, v10:BasicObject):
           v17:Fixnum[5] = Const Value(5)
-          v21:CBool = HasType v10, ObjectSubclass[class_exact:C]
-          CondBranch v21, bb5(), bb6()
+          v28:CBool = HasType v10, ObjectSubclass[class_exact:C]
+          CondBranch v28, bb5(), bb6()
         bb5():
-          v24:ObjectSubclass[class_exact:C] = RefineType v10, ObjectSubclass[class_exact:C]
+          v30:ObjectSubclass[class_exact:C] = RefineType v10, ObjectSubclass[class_exact:C]
           PatchPoint MethodRedefined(C@0x1008, foo=@0x1010, cme:0x1018)
-          v38:CShape = LoadField v24, :shape_id@0x1040
-          v39:CShape[0x1041] = GuardBitEquals v38, CShape(0x1041)
-          StoreField v24, :@foo@0x1042, v17
+          v35:CShape = LoadField v30, :shape_id@0x1040
+          v36:CShape[0x1041] = GuardBitEquals v35, CShape(0x1041)
+          StoreField v30, :@foo@0x1042, v17
           Jump bb4(v17)
         bb6():
-          v27:BasicObject = Send v10, :foo=, v17 # SendFallbackReason: Send: polymorphic call site
-          Jump bb4(v27)
-        bb4(v20:BasicObject):
+          v40:BasicObject = Send v10, :foo=, v17 # SendFallbackReason: Send: polymorphic fallback
+          Jump bb4(v40)
+        bb4(v27:BasicObject):
           CheckInterrupts
           Return v17
         ");
@@ -11040,22 +11040,22 @@ mod hir_opt_tests {
           v7:BasicObject = LoadArg :o@1
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
-          v16:CBool = HasType v10, ObjectSubclass[class_exact:C]
-          CondBranch v16, bb5(), bb6()
+          v22:CBool = HasType v10, ObjectSubclass[class_exact:C]
+          CondBranch v22, bb5(), bb6()
         bb5():
-          v19:ObjectSubclass[class_exact:C] = RefineType v10, ObjectSubclass[class_exact:C]
+          v24:ObjectSubclass[class_exact:C] = RefineType v10, ObjectSubclass[class_exact:C]
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
-          v33:CShape = LoadField v19, :shape_id@0x1040
-          v34:CShape[0x1041] = GuardBitEquals v33, CShape(0x1041) recompile
-          v35:BasicObject = LoadField v19, :@foo@0x1042
-          Jump bb4(v35)
+          v30:CShape = LoadField v24, :shape_id@0x1040
+          v31:CShape[0x1041] = GuardBitEquals v30, CShape(0x1041) recompile
+          v32:BasicObject = LoadField v24, :@foo@0x1042
+          Jump bb4(v32)
         bb6():
-          v22:BasicObject = Send v10, :foo # SendFallbackReason: Send: polymorphic call site
-          Jump bb4(v22)
-        bb4(v15:BasicObject):
+          v34:BasicObject = Send v10, :foo # SendFallbackReason: Send: polymorphic fallback
+          Jump bb4(v34)
+        bb4(v21:BasicObject):
           CheckInterrupts
-          Return v15
+          Return v21
         ");
     }
 
@@ -14863,47 +14863,47 @@ mod hir_opt_tests {
           Jump bb3(v7, v8, v9)
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           v19:ArrayExact = ToArray v13
-          v22:CBool = HasType v12, ObjectSubclass[class_exact:CallerSplatA]
-          CondBranch v22, bb5(), bb6()
+          v28:CBool = HasType v12, ObjectSubclass[class_exact:CallerSplatA]
+          CondBranch v28, bb5(), bb6()
         bb5():
-          v25:ObjectSubclass[class_exact:CallerSplatA] = RefineType v12, ObjectSubclass[class_exact:CallerSplatA]
+          v30:ObjectSubclass[class_exact:CallerSplatA] = RefineType v12, ObjectSubclass[class_exact:CallerSplatA]
           PatchPoint NoSingletonClass(CallerSplatA@0x1008)
-          v42:CInt64 = ArrayLength v19
-          v43:CInt64[1] = GuardBitEquals v42, CInt64(1) recompile
-          v44:CInt64 = CCall v19, :rb_jit_ruby2_keywords_splat_p@0x1010
-          v45:CInt64[0] = GuardBitEquals v44, CInt64(0)
+          v33:CInt64 = ArrayLength v19
+          v34:CInt64[1] = GuardBitEquals v33, CInt64(1) recompile
+          v35:CInt64 = CCall v19, :rb_jit_ruby2_keywords_splat_p@0x1010
+          v36:CInt64[0] = GuardBitEquals v35, CInt64(0)
           PatchPoint MethodRedefined(CallerSplatA@0x1008, target@0x1011, cme:0x1018)
-          v48:CInt64[0] = Const CInt64(0)
-          v49:BasicObject = ArrayAref v19, v48
-          v50:ArrayExact = NewArray v49
-          PushInlineFrame :target, v25 (0x1040), num_args=1
+          v39:CInt64[0] = Const CInt64(0)
+          v40:BasicObject = ArrayAref v19, v39
+          v41:ArrayExact = NewArray v40
+          PushInlineFrame :target, v30 (0x1040), num_args=1
           CheckInterrupts
           PopInlineFrame
-          Jump bb4(v50)
+          Jump bb4(v41)
         bb6():
-          v28:CBool = HasType v12, ObjectSubclass[class_exact:CallerSplatB]
-          CondBranch v28, bb7(), bb8()
+          v45:CBool = HasType v12, ObjectSubclass[class_exact:CallerSplatB]
+          CondBranch v45, bb7(), bb8()
         bb7():
-          v31:ObjectSubclass[class_exact:CallerSplatB] = RefineType v12, ObjectSubclass[class_exact:CallerSplatB]
+          v47:ObjectSubclass[class_exact:CallerSplatB] = RefineType v12, ObjectSubclass[class_exact:CallerSplatB]
           PatchPoint NoSingletonClass(CallerSplatB@0x1060)
-          v54:CInt64 = ArrayLength v19
-          v55:CInt64[1] = GuardBitEquals v54, CInt64(1) recompile
-          v56:CInt64 = CCall v19, :rb_jit_ruby2_keywords_splat_p@0x1010
-          v57:CInt64[0] = GuardBitEquals v56, CInt64(0)
+          v50:CInt64 = ArrayLength v19
+          v51:CInt64[1] = GuardBitEquals v50, CInt64(1) recompile
+          v52:CInt64 = CCall v19, :rb_jit_ruby2_keywords_splat_p@0x1010
+          v53:CInt64[0] = GuardBitEquals v52, CInt64(0)
           PatchPoint MethodRedefined(CallerSplatB@0x1060, target@0x1011, cme:0x1068)
-          v60:CInt64[0] = Const CInt64(0)
-          v61:BasicObject = ArrayAref v19, v60
-          v62:ArrayExact = NewArray v61
-          PushInlineFrame :target, v31 (0x1090), num_args=1
+          v56:CInt64[0] = Const CInt64(0)
+          v57:BasicObject = ArrayAref v19, v56
+          v58:ArrayExact = NewArray v57
+          PushInlineFrame :target, v47 (0x1090), num_args=1
           CheckInterrupts
           PopInlineFrame
-          Jump bb4(v62)
+          Jump bb4(v58)
         bb8():
-          v34:BasicObject = Send v12, :target, v19 # SendFallbackReason: Send: polymorphic call site
-          Jump bb4(v34)
-        bb4(v21:BasicObject):
+          v62:BasicObject = Send v12, :target, v19 # SendFallbackReason: Send: polymorphic call site
+          Jump bb4(v62)
+        bb4(v27:BasicObject):
           CheckInterrupts
-          Return v21
+          Return v27
         ");
     }
 
@@ -18688,31 +18688,31 @@ mod hir_opt_tests {
           v7:BasicObject = LoadArg :o@1
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
-          v16:CBool = HasType v10, ObjectSubclass[class_exact:C]
-          CondBranch v16, bb5(), bb6()
+          v27:CBool = HasType v10, ObjectSubclass[class_exact:C]
+          CondBranch v27, bb5(), bb6()
         bb5():
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
-          v43:Fixnum[3] = Const Value(3)
-          Jump bb4(v43)
+          v34:Fixnum[3] = Const Value(3)
+          Jump bb4(v34)
         bb6():
-          v22:CBool = HasType v10, ObjectSubclass[class_exact:D]
-          CondBranch v22, bb7(), bb8()
+          v36:CBool = HasType v10, ObjectSubclass[class_exact:D]
+          CondBranch v36, bb7(), bb8()
         bb7():
           PatchPoint NoSingletonClass(D@0x1040)
           PatchPoint MethodRedefined(D@0x1040, foo@0x1010, cme:0x1048)
-          v47:Fixnum[4] = Const Value(4)
-          Jump bb4(v47)
+          v43:Fixnum[4] = Const Value(4)
+          Jump bb4(v43)
         bb8():
-          v28:BasicObject = Send v10, :foo # SendFallbackReason: Send: polymorphic call site
-          Jump bb4(v28)
-        bb4(v15:BasicObject):
-          v31:Fixnum[2] = Const Value(2)
+          v45:BasicObject = Send v10, :foo # SendFallbackReason: Send: polymorphic fallback
+          Jump bb4(v45)
+        bb4(v26:BasicObject):
+          v17:Fixnum[2] = Const Value(2)
           PatchPoint MethodRedefined(Integer@0x1070, +@0x1078, cme:0x1080)
-          v50:Fixnum = GuardType v15, Fixnum recompile
-          v51:Fixnum = FixnumAdd v50, v31
+          v49:Fixnum = GuardType v26, Fixnum recompile
+          v50:Fixnum = FixnumAdd v49, v17
           CheckInterrupts
-          Return v51
+          Return v50
         ");
     }
 
@@ -18742,26 +18742,26 @@ mod hir_opt_tests {
           v7:BasicObject = LoadArg :o@1
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
-          v16:CBool = HasType v10, ObjectSubclass[class_exact:C]
-          CondBranch v16, bb5(), bb6()
+          v22:CBool = HasType v10, ObjectSubclass[class_exact:C]
+          CondBranch v22, bb5(), bb6()
         bb5():
-          v19:ObjectSubclass[class_exact:C] = RefineType v10, ObjectSubclass[class_exact:C]
+          v24:ObjectSubclass[class_exact:C] = RefineType v10, ObjectSubclass[class_exact:C]
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, itself@0x1010, cme:0x1018)
-          Jump bb4(v19)
+          Jump bb4(v24)
         bb6():
-          v22:CBool = HasType v10, Fixnum
-          CondBranch v22, bb7(), bb8()
+          v31:CBool = HasType v10, Fixnum
+          CondBranch v31, bb7(), bb8()
         bb7():
-          v25:Fixnum = RefineType v10, Fixnum
+          v33:Fixnum = RefineType v10, Fixnum
           PatchPoint MethodRedefined(Integer@0x1040, itself@0x1010, cme:0x1018)
-          Jump bb4(v25)
+          Jump bb4(v33)
         bb8():
-          v28:BasicObject = Send v10, :itself # SendFallbackReason: Send: polymorphic call site
-          Jump bb4(v28)
-        bb4(v15:BasicObject):
+          v39:BasicObject = Send v10, :itself # SendFallbackReason: Send: polymorphic fallback
+          Jump bb4(v39)
+        bb4(v21:BasicObject):
           CheckInterrupts
-          Return v15
+          Return v21
         ");
     }
 
@@ -18798,11 +18798,11 @@ mod hir_opt_tests {
           PatchPoint StableConstantNames(0x1068, Integer)
           v31:ClassSubclass[Integer@0x1070] = Const Value(VALUE(0x1070))
           PatchPoint MethodRedefined(Class@0x1078, ==@0x1080, cme:0x1088)
-          v83:CBool = IsBitEqual v12, v31
-          v84:BoolExact = BoxBool v83
+          v51:CBool = IsBitEqual v12, v31
+          v52:BoolExact = BoxBool v51
           CheckInterrupts
           PopInlineFrame
-          Return v84
+          Return v52
         ");
     }
 
@@ -18838,36 +18838,36 @@ mod hir_opt_tests {
           v9:BasicObject = LoadArg :i@2
           Jump bb3(v7, v8, v9)
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
-          v21:CBool = HasType v12, ArrayExact
-          CondBranch v21, bb5(), bb6()
+          v27:CBool = HasType v12, ArrayExact
+          CondBranch v27, bb5(), bb6()
         bb5():
-          v24:ArrayExact = RefineType v12, ArrayExact
+          v29:ArrayExact = RefineType v12, ArrayExact
           PatchPoint NoSingletonClass(Array@0x1008)
           PatchPoint MethodRedefined(Array@0x1008, []@0x1010, cme:0x1018)
-          v44:Fixnum = GuardType v13, Fixnum
-          v45:CInt64 = UnboxFixnum v44
-          v46:CInt64 = ArrayLength v24
-          v47:CInt64 = GuardLess v45, v46
-          v48:CInt64 = AdjustBounds v47, v46
-          v49:CInt64[0] = Const CInt64(0)
-          v50:CInt64 = GuardGreaterEq v48, v49
-          v51:BasicObject = ArrayAref v24, v50
-          Jump bb4(v51)
+          v35:Fixnum = GuardType v13, Fixnum
+          v36:CInt64 = UnboxFixnum v35
+          v37:CInt64 = ArrayLength v29
+          v38:CInt64 = GuardLess v36, v37
+          v39:CInt64 = AdjustBounds v38, v37
+          v40:CInt64[0] = Const CInt64(0)
+          v41:CInt64 = GuardGreaterEq v39, v40
+          v42:BasicObject = ArrayAref v29, v41
+          Jump bb4(v42)
         bb6():
-          v27:CBool = HasType v12, HashExact
-          CondBranch v27, bb7(), bb8()
+          v44:CBool = HasType v12, HashExact
+          CondBranch v44, bb7(), bb8()
         bb7():
-          v30:HashExact = RefineType v12, HashExact
+          v46:HashExact = RefineType v12, HashExact
           PatchPoint NoSingletonClass(Hash@0x1040)
           PatchPoint MethodRedefined(Hash@0x1040, []@0x1010, cme:0x1048)
-          v56:BasicObject = HashAref v30, v13
-          Jump bb4(v56)
+          v52:BasicObject = HashAref v46, v13
+          Jump bb4(v52)
         bb8():
-          v33:BasicObject = Send v12, :[], v13 # SendFallbackReason: Send: polymorphic call site
-          Jump bb4(v33)
-        bb4(v20:BasicObject):
+          v54:BasicObject = Send v12, :[], v13 # SendFallbackReason: Send: polymorphic fallback
+          Jump bb4(v54)
+        bb4(v26:BasicObject):
           CheckInterrupts
-          Return v20
+          Return v26
         ");
     }
 
@@ -18903,27 +18903,27 @@ mod hir_opt_tests {
           v7:BasicObject = LoadArg :x@1
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
-          v16:CBool = HasType v10, Fixnum
-          CondBranch v16, bb5(), bb6()
+          v22:CBool = HasType v10, Fixnum
+          CondBranch v22, bb5(), bb6()
         bb5():
-          v19:Fixnum = RefineType v10, Fixnum
+          v24:Fixnum = RefineType v10, Fixnum
           PatchPoint MethodRedefined(Integer@0x1008, to_s@0x1010, cme:0x1018)
-          v38:StringExact = CCallVariadic v19, :Integer#to_s@0x1040
-          Jump bb4(v38)
+          v29:StringExact = CCallVariadic v24, :Integer#to_s@0x1040
+          Jump bb4(v29)
         bb6():
-          v22:CBool = HasType v10, Bignum
-          CondBranch v22, bb7(), bb8()
-        bb7():
-          v25:Bignum = RefineType v10, Bignum
-          PatchPoint MethodRedefined(Integer@0x1008, to_s@0x1010, cme:0x1018)
-          v42:StringExact = CCallVariadic v25, :Integer#to_s@0x1040
-          Jump bb4(v42)
+          v31:CBool = HasType v10, Bignum
+          CondBranch v31, bb8(), bb9()
         bb8():
-          v28:BasicObject = Send v10, :to_s # SendFallbackReason: Send: polymorphic call site
-          Jump bb4(v28)
-        bb4(v15:BasicObject):
+          v33:Bignum = RefineType v10, Bignum
+          PatchPoint MethodRedefined(Integer@0x1008, to_s@0x1010, cme:0x1018)
+          v38:StringExact = CCallVariadic v33, :Integer#to_s@0x1040
+          Jump bb4(v38)
+        bb9():
+          v40:BasicObject = Send v10, :to_s # SendFallbackReason: Send: polymorphic fallback
+          Jump bb4(v40)
+        bb4(v21:BasicObject):
           CheckInterrupts
-          Return v15
+          Return v21
         ");
     }
 
@@ -18956,27 +18956,27 @@ mod hir_opt_tests {
           v7:BasicObject = LoadArg :x@1
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
-          v16:CBool = HasType v10, Flonum
-          CondBranch v16, bb5(), bb6()
+          v22:CBool = HasType v10, Flonum
+          CondBranch v22, bb5(), bb6()
         bb5():
-          v19:Flonum = RefineType v10, Flonum
+          v24:Flonum = RefineType v10, Flonum
           PatchPoint MethodRedefined(Float@0x1008, to_s@0x1010, cme:0x1018)
-          v38:BasicObject = CCallWithFrame v19, :Float#to_s@0x1040
-          Jump bb4(v38)
+          v29:BasicObject = CCallWithFrame v24, :Float#to_s@0x1040
+          Jump bb4(v29)
         bb6():
-          v22:CBool = HasType v10, HeapFloat
-          CondBranch v22, bb7(), bb8()
-        bb7():
-          v25:HeapFloat = RefineType v10, HeapFloat
-          PatchPoint MethodRedefined(Float@0x1008, to_s@0x1010, cme:0x1018)
-          v42:BasicObject = CCallWithFrame v25, :Float#to_s@0x1040
-          Jump bb4(v42)
+          v31:CBool = HasType v10, HeapFloat
+          CondBranch v31, bb8(), bb9()
         bb8():
-          v28:BasicObject = Send v10, :to_s # SendFallbackReason: Send: polymorphic call site
-          Jump bb4(v28)
-        bb4(v15:BasicObject):
+          v33:HeapFloat = RefineType v10, HeapFloat
+          PatchPoint MethodRedefined(Float@0x1008, to_s@0x1010, cme:0x1018)
+          v38:BasicObject = CCallWithFrame v33, :Float#to_s@0x1040
+          Jump bb4(v38)
+        bb9():
+          v40:BasicObject = Send v10, :to_s # SendFallbackReason: Send: polymorphic fallback
+          Jump bb4(v40)
+        bb4(v21:BasicObject):
           CheckInterrupts
-          Return v15
+          Return v21
         ");
     }
 
@@ -19009,27 +19009,27 @@ mod hir_opt_tests {
           v7:BasicObject = LoadArg :x@1
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
-          v16:CBool = HasType v10, StaticSymbol
-          CondBranch v16, bb5(), bb6()
+          v22:CBool = HasType v10, StaticSymbol
+          CondBranch v22, bb5(), bb6()
         bb5():
-          v19:StaticSymbol = RefineType v10, StaticSymbol
+          v24:StaticSymbol = RefineType v10, StaticSymbol
           PatchPoint MethodRedefined(Symbol@0x1008, to_s@0x1010, cme:0x1018)
-          v37:StringExact = InvokeBuiltin leaf <inline_expr>, v19
-          Jump bb4(v37)
-        bb6():
-          v22:CBool = HasType v10, DynamicSymbol
-          CondBranch v22, bb7(), bb8()
-        bb7():
-          v25:DynamicSymbol = RefineType v10, DynamicSymbol
-          PatchPoint MethodRedefined(Symbol@0x1008, to_s@0x1010, cme:0x1018)
-          v40:StringExact = InvokeBuiltin leaf <inline_expr>, v25
-          Jump bb4(v40)
-        bb8():
-          v28:BasicObject = Send v10, :to_s # SendFallbackReason: Send: polymorphic call site
+          v28:StringExact = InvokeBuiltin leaf <inline_expr>, v24
           Jump bb4(v28)
-        bb4(v15:BasicObject):
+        bb6():
+          v30:CBool = HasType v10, DynamicSymbol
+          CondBranch v30, bb8(), bb9()
+        bb8():
+          v32:DynamicSymbol = RefineType v10, DynamicSymbol
+          PatchPoint MethodRedefined(Symbol@0x1008, to_s@0x1010, cme:0x1018)
+          v36:StringExact = InvokeBuiltin leaf <inline_expr>, v32
+          Jump bb4(v36)
+        bb9():
+          v38:BasicObject = Send v10, :to_s # SendFallbackReason: Send: polymorphic fallback
+          Jump bb4(v38)
+        bb4(v21:BasicObject):
           CheckInterrupts
-          Return v15
+          Return v21
         ");
     }
 
@@ -19066,19 +19066,19 @@ mod hir_opt_tests {
           v7:BasicObject = LoadArg :o@1
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
-          v16:CBool = HasType v10, ObjectSubclass[class_exact:C]
-          CondBranch v16, bb5(), bb6()
+          v22:CBool = HasType v10, ObjectSubclass[class_exact:C]
+          CondBranch v22, bb5(), bb6()
         bb5():
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
-          v32:Fixnum[3] = Const Value(3)
-          Jump bb4(v32)
+          v29:Fixnum[3] = Const Value(3)
+          Jump bb4(v29)
         bb6():
-          v22:BasicObject = Send v10, :foo # SendFallbackReason: Send: polymorphic call site
-          Jump bb4(v22)
-        bb4(v15:BasicObject):
+          v31:BasicObject = Send v10, :foo # SendFallbackReason: Send: polymorphic fallback
+          Jump bb4(v31)
+        bb4(v21:BasicObject):
           CheckInterrupts
-          Return v15
+          Return v21
         ");
     }
 
@@ -20595,28 +20595,28 @@ mod hir_opt_tests {
           v9:BasicObject = LoadArg :b@2
           Jump bb3(v7, v8, v9)
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
-          v21:CBool = HasType v12, HeapFloat
-          CondBranch v21, bb5(), bb6()
+          v27:CBool = HasType v12, HeapFloat
+          CondBranch v27, bb5(), bb6()
         bb5():
-          v24:HeapFloat = RefineType v12, HeapFloat
+          v29:HeapFloat = RefineType v12, HeapFloat
           PatchPoint MethodRedefined(Float@0x1008, *@0x1010, cme:0x1018)
-          v43:BasicObject = CCallWithFrame v24, :Float#*@0x1040, v13
-          Jump bb4(v43)
+          v34:BasicObject = CCallWithFrame v29, :Float#*@0x1040, v13
+          Jump bb4(v34)
         bb6():
-          v27:CBool = HasType v12, Flonum
-          CondBranch v27, bb7(), bb8()
-        bb7():
-          v30:Flonum = RefineType v12, Flonum
-          PatchPoint MethodRedefined(Float@0x1008, *@0x1010, cme:0x1018)
-          v47:Flonum = GuardType v13, Flonum recompile
-          v48:Float = FloatMul v30, v47
-          Jump bb4(v48)
+          v36:CBool = HasType v12, Flonum
+          CondBranch v36, bb8(), bb9()
         bb8():
-          v33:BasicObject = Send v12, :*, v13 # SendFallbackReason: Send: polymorphic call site
-          Jump bb4(v33)
-        bb4(v20:BasicObject):
+          v38:Flonum = RefineType v12, Flonum
+          PatchPoint MethodRedefined(Float@0x1008, *@0x1010, cme:0x1018)
+          v43:Flonum = GuardType v13, Flonum recompile
+          v44:Float = FloatMul v38, v43
+          Jump bb4(v44)
+        bb9():
+          v46:BasicObject = Send v12, :*, v13 # SendFallbackReason: Send: polymorphic fallback
+          Jump bb4(v46)
+        bb4(v26:BasicObject):
           CheckInterrupts
-          Return v20
+          Return v26
         ");
     }
 
@@ -20886,7 +20886,7 @@ mod hir_opt_tests {
           v8:BasicObject = LoadArg :x@1
           Jump bb3(v7, v8)
         bb3(v11:HeapBasicObject, v12:BasicObject):
-          v92:NilClass = Const Value(nil)
+          v91:NilClass = Const Value(nil)
           v17:Fixnum[1] = Const Value(1)
           PatchPoint SingleRactorMode
           v21:CShape = LoadField v11, :shape_id@0x1001
@@ -20911,40 +20911,40 @@ mod hir_opt_tests {
         bb4():
           PatchPoint NoEPEscape(f)
           v44:Fixnum[1] = Const Value(1)
-          v48:CBool = HasType v12, Fixnum
-          CondBranch v48, bb10(), bb11()
-        bb10():
-          v51:Fixnum = RefineType v12, Fixnum
-          PatchPoint MethodRedefined(Integer@0x1008, +@0x1010, cme:0x1018)
-          v87:Fixnum = FixnumAdd v51, v44
-          Jump bb9(v87)
-        bb11():
-          v54:CBool = HasType v12, Flonum
-          CondBranch v54, bb12(), bb13()
-        bb12():
-          v57:Flonum = RefineType v12, Flonum
-          PatchPoint MethodRedefined(Float@0x1040, +@0x1010, cme:0x1048)
-          v91:Float = FloatAdd v57, v44
-          Jump bb9(v91)
+          v71:CBool = HasType v12, Fixnum
+          CondBranch v71, bb13(), bb14()
         bb13():
-          v60:BasicObject = Send v12, :+, v44 # SendFallbackReason: Send: polymorphic call site
-          Jump bb9(v60)
-        bb9(v47:BasicObject):
-          PatchPoint SingleRactorMode
-          v69:CShape = LoadField v11, :shape_id@0x1001
-          v70:CShape[0x1002] = Const CShape(0x1002)
-          v71:CBool = IsBitEqual v69, v70
-          CondBranch v71, bb15(), bb16()
-        bb15():
-          StoreField v11, :@a@0x1003, v47
-          WriteBarrier v11, v47
-          Jump bb14()
-        bb16():
-          SetIvar v11, :@a, v47
-          Jump bb14()
+          v73:Fixnum = RefineType v12, Fixnum
+          PatchPoint MethodRedefined(Integer@0x1008, +@0x1010, cme:0x1018)
+          v78:Fixnum = FixnumAdd v73, v44
+          Jump bb12(v78)
         bb14():
+          v80:CBool = HasType v12, Flonum
+          CondBranch v80, bb15(), bb16()
+        bb15():
+          v82:Flonum = RefineType v12, Flonum
+          PatchPoint MethodRedefined(Float@0x1040, +@0x1010, cme:0x1048)
+          v87:Float = FloatAdd v82, v44
+          Jump bb12(v87)
+        bb16():
+          v89:BasicObject = Send v12, :+, v44 # SendFallbackReason: Send: polymorphic fallback
+          Jump bb12(v89)
+        bb12(v70:BasicObject):
+          PatchPoint SingleRactorMode
+          v55:CShape = LoadField v11, :shape_id@0x1001
+          v56:CShape[0x1002] = Const CShape(0x1002)
+          v57:CBool = IsBitEqual v55, v56
+          CondBranch v57, bb10(), bb11()
+        bb10():
+          StoreField v11, :@a@0x1003, v70
+          WriteBarrier v11, v70
+          Jump bb9()
+        bb11():
+          SetIvar v11, :@a, v70
+          Jump bb9()
+        bb9():
           CheckInterrupts
-          Return v47
+          Return v70
         ");
     }
 

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -1769,9 +1769,9 @@ mod hir_opt_tests {
           PatchPoint MethodRedefined(NilClass@0x1058, nil?@0x1060, cme:0x1068)
           v38:Fixnum[0] = Const Value(0)
           CheckInterrupts
-          v87:Fixnum[0] = Const Value(0)
+          v85:Fixnum[0] = Const Value(0)
           PopInlineFrame
-          Return v87
+          Return v85
         ");
     }
 
@@ -9715,18 +9715,18 @@ mod hir_opt_tests {
           CondBranch v42, bb8(), bb9()
         bb8():
           PatchPoint MethodRedefined(FalseClass@0x1008, !@0x1010, cme:0x1018)
-          v49:TrueClass = Const Value(true)
-          Jump bb7(v49)
+          v48:TrueClass = Const Value(true)
+          Jump bb7(v48)
         bb9():
-          v51:CBool = HasType v31, NilClass
-          CondBranch v51, bb10(), bb11()
+          v50:CBool = HasType v31, NilClass
+          CondBranch v50, bb10(), bb11()
         bb10():
           PatchPoint MethodRedefined(NilClass@0x1040, !@0x1010, cme:0x1018)
-          v58:TrueClass = Const Value(true)
-          Jump bb7(v58)
+          v56:TrueClass = Const Value(true)
+          Jump bb7(v56)
         bb11():
-          v60:BasicObject = Send v31, :! # SendFallbackReason: Send: polymorphic fallback
-          Jump bb7(v60)
+          v58:BasicObject = Send v31, :! # SendFallbackReason: Send: polymorphic fallback
+          Jump bb7(v58)
         bb7(v41:BasicObject):
           CheckInterrupts
           Return v41
@@ -10460,14 +10460,27 @@ mod hir_opt_tests {
           CondBranch v28, bb5(), bb6()
         bb5():
           v30:ObjectSubclass[class_exact:C] = RefineType v10, ObjectSubclass[class_exact:C]
+          v31:CShape = LoadField v30, :shape_id@0x1001
+          v32:CShape[0x1002] = Const CShape(0x1002)
+          v33:CBool = IsBitEqual v31, v32
+          CondBranch v33, bb7(), bb8()
+        bb7():
           PatchPoint MethodRedefined(C@0x1008, foo=@0x1010, cme:0x1018)
-          v35:CShape = LoadField v30, :shape_id@0x1040
-          v36:CShape[0x1041] = GuardBitEquals v35, CShape(0x1041)
+          StoreField v30, :@foo@0x1040, v17
+          Jump bb4(v17)
+        bb8():
+          v40:CShape[0x1041] = Const CShape(0x1041)
+          v41:CBool = IsBitEqual v31, v40
+          CondBranch v41, bb9(), bb10()
+        bb9():
+          PatchPoint MethodRedefined(C@0x1008, foo=@0x1010, cme:0x1018)
           StoreField v30, :@foo@0x1042, v17
           Jump bb4(v17)
+        bb10():
+          Jump bb6()
         bb6():
-          v40:BasicObject = Send v10, :foo=, v17 # SendFallbackReason: Send: polymorphic fallback
-          Jump bb4(v40)
+          v49:BasicObject = Send v10, :foo=, v17 # SendFallbackReason: Send: polymorphic fallback
+          Jump bb4(v49)
         bb4(v27:BasicObject):
           CheckInterrupts
           Return v17
@@ -11044,15 +11057,29 @@ mod hir_opt_tests {
           CondBranch v22, bb5(), bb6()
         bb5():
           v24:ObjectSubclass[class_exact:C] = RefineType v10, ObjectSubclass[class_exact:C]
+          v25:CShape = LoadField v24, :shape_id@0x1001
+          v26:CShape[0x1002] = Const CShape(0x1002)
+          v27:CBool = IsBitEqual v25, v26
+          CondBranch v27, bb7(), bb8()
+        bb7():
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
-          v30:CShape = LoadField v24, :shape_id@0x1040
-          v31:CShape[0x1041] = GuardBitEquals v30, CShape(0x1041) recompile
-          v32:BasicObject = LoadField v24, :@foo@0x1042
+          v32:BasicObject = LoadField v24, :@foo@0x1040
           Jump bb4(v32)
+        bb8():
+          v34:CShape[0x1041] = Const CShape(0x1041)
+          v35:CBool = IsBitEqual v25, v34
+          CondBranch v35, bb9(), bb10()
+        bb9():
+          PatchPoint NoSingletonClass(C@0x1008)
+          PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
+          v40:BasicObject = LoadField v24, :@foo@0x1042
+          Jump bb4(v40)
+        bb10():
+          Jump bb6()
         bb6():
-          v34:BasicObject = Send v10, :foo # SendFallbackReason: Send: polymorphic fallback
-          Jump bb4(v34)
+          v43:BasicObject = Send v10, :foo # SendFallbackReason: Send: polymorphic fallback
+          Jump bb4(v43)
         bb4(v21:BasicObject):
           CheckInterrupts
           Return v21
@@ -14867,40 +14894,54 @@ mod hir_opt_tests {
           CondBranch v28, bb5(), bb6()
         bb5():
           v30:ObjectSubclass[class_exact:CallerSplatA] = RefineType v12, ObjectSubclass[class_exact:CallerSplatA]
+          v31:CShape = LoadField v30, :shape_id@0x1002
+          v32:CShape[0x1003] = Const CShape(0x1003)
+          v33:CBool = IsBitEqual v31, v32
+          CondBranch v33, bb7(), bb8()
+        bb7():
           PatchPoint NoSingletonClass(CallerSplatA@0x1008)
-          v33:CInt64 = ArrayLength v19
-          v34:CInt64[1] = GuardBitEquals v33, CInt64(1) recompile
-          v35:CInt64 = CCall v19, :rb_jit_ruby2_keywords_splat_p@0x1010
-          v36:CInt64[0] = GuardBitEquals v35, CInt64(0)
+          v37:CInt64 = ArrayLength v19
+          v38:CInt64[1] = GuardBitEquals v37, CInt64(1) recompile
+          v39:CInt64 = CCall v19, :rb_jit_ruby2_keywords_splat_p@0x1010
+          v40:CInt64[0] = GuardBitEquals v39, CInt64(0)
           PatchPoint MethodRedefined(CallerSplatA@0x1008, target@0x1011, cme:0x1018)
-          v39:CInt64[0] = Const CInt64(0)
-          v40:BasicObject = ArrayAref v19, v39
-          v41:ArrayExact = NewArray v40
+          v42:CInt64[0] = Const CInt64(0)
+          v43:BasicObject = ArrayAref v19, v42
+          v44:ArrayExact = NewArray v43
           PushInlineFrame :target, v30 (0x1040), num_args=1
           CheckInterrupts
           PopInlineFrame
-          Jump bb4(v41)
+          Jump bb4(v44)
+        bb8():
+          Jump bb6()
         bb6():
-          v45:CBool = HasType v12, ObjectSubclass[class_exact:CallerSplatB]
-          CondBranch v45, bb7(), bb8()
-        bb7():
-          v47:ObjectSubclass[class_exact:CallerSplatB] = RefineType v12, ObjectSubclass[class_exact:CallerSplatB]
+          v49:CBool = HasType v12, ObjectSubclass[class_exact:CallerSplatB]
+          CondBranch v49, bb9(), bb10()
+        bb9():
+          v51:ObjectSubclass[class_exact:CallerSplatB] = RefineType v12, ObjectSubclass[class_exact:CallerSplatB]
+          v52:CShape = LoadField v51, :shape_id@0x1002
+          v53:CShape[0x1003] = Const CShape(0x1003)
+          v54:CBool = IsBitEqual v52, v53
+          CondBranch v54, bb11(), bb12()
+        bb11():
           PatchPoint NoSingletonClass(CallerSplatB@0x1060)
-          v50:CInt64 = ArrayLength v19
-          v51:CInt64[1] = GuardBitEquals v50, CInt64(1) recompile
-          v52:CInt64 = CCall v19, :rb_jit_ruby2_keywords_splat_p@0x1010
-          v53:CInt64[0] = GuardBitEquals v52, CInt64(0)
+          v58:CInt64 = ArrayLength v19
+          v59:CInt64[1] = GuardBitEquals v58, CInt64(1) recompile
+          v60:CInt64 = CCall v19, :rb_jit_ruby2_keywords_splat_p@0x1010
+          v61:CInt64[0] = GuardBitEquals v60, CInt64(0)
           PatchPoint MethodRedefined(CallerSplatB@0x1060, target@0x1011, cme:0x1068)
-          v56:CInt64[0] = Const CInt64(0)
-          v57:BasicObject = ArrayAref v19, v56
-          v58:ArrayExact = NewArray v57
-          PushInlineFrame :target, v47 (0x1090), num_args=1
+          v63:CInt64[0] = Const CInt64(0)
+          v64:BasicObject = ArrayAref v19, v63
+          v65:ArrayExact = NewArray v64
+          PushInlineFrame :target, v51 (0x1090), num_args=1
           CheckInterrupts
           PopInlineFrame
-          Jump bb4(v58)
-        bb8():
-          v62:BasicObject = Send v12, :target, v19 # SendFallbackReason: Send: polymorphic call site
-          Jump bb4(v62)
+          Jump bb4(v65)
+        bb12():
+          Jump bb10()
+        bb10():
+          v70:BasicObject = Send v12, :target, v19 # SendFallbackReason: Send: polymorphic call site
+          Jump bb4(v70)
         bb4(v27:BasicObject):
           CheckInterrupts
           Return v27
@@ -18691,28 +18732,44 @@ mod hir_opt_tests {
           v27:CBool = HasType v10, ObjectSubclass[class_exact:C]
           CondBranch v27, bb5(), bb6()
         bb5():
+          v29:ObjectSubclass[class_exact:C] = RefineType v10, ObjectSubclass[class_exact:C]
+          v30:CShape = LoadField v29, :shape_id@0x1001
+          v31:CShape[0x1002] = Const CShape(0x1002)
+          v32:CBool = IsBitEqual v30, v31
+          CondBranch v32, bb7(), bb8()
+        bb7():
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
-          v34:Fixnum[3] = Const Value(3)
-          Jump bb4(v34)
+          v37:Fixnum[3] = Const Value(3)
+          Jump bb4(v37)
+        bb8():
+          Jump bb6()
         bb6():
-          v36:CBool = HasType v10, ObjectSubclass[class_exact:D]
-          CondBranch v36, bb7(), bb8()
-        bb7():
+          v40:CBool = HasType v10, ObjectSubclass[class_exact:D]
+          CondBranch v40, bb9(), bb10()
+        bb9():
+          v42:ObjectSubclass[class_exact:D] = RefineType v10, ObjectSubclass[class_exact:D]
+          v43:CShape = LoadField v42, :shape_id@0x1001
+          v44:CShape[0x1002] = Const CShape(0x1002)
+          v45:CBool = IsBitEqual v43, v44
+          CondBranch v45, bb11(), bb12()
+        bb11():
           PatchPoint NoSingletonClass(D@0x1040)
           PatchPoint MethodRedefined(D@0x1040, foo@0x1010, cme:0x1048)
-          v43:Fixnum[4] = Const Value(4)
-          Jump bb4(v43)
-        bb8():
-          v45:BasicObject = Send v10, :foo # SendFallbackReason: Send: polymorphic fallback
-          Jump bb4(v45)
+          v50:Fixnum[4] = Const Value(4)
+          Jump bb4(v50)
+        bb12():
+          Jump bb10()
+        bb10():
+          v53:BasicObject = Send v10, :foo # SendFallbackReason: Send: polymorphic fallback
+          Jump bb4(v53)
         bb4(v26:BasicObject):
           v17:Fixnum[2] = Const Value(2)
           PatchPoint MethodRedefined(Integer@0x1070, +@0x1078, cme:0x1080)
-          v49:Fixnum = GuardType v26, Fixnum recompile
-          v50:Fixnum = FixnumAdd v49, v17
+          v57:Fixnum = GuardType v26, Fixnum recompile
+          v58:Fixnum = FixnumAdd v57, v17
           CheckInterrupts
-          Return v50
+          Return v58
         ");
     }
 
@@ -18746,19 +18803,26 @@ mod hir_opt_tests {
           CondBranch v22, bb5(), bb6()
         bb5():
           v24:ObjectSubclass[class_exact:C] = RefineType v10, ObjectSubclass[class_exact:C]
+          v25:CShape = LoadField v24, :shape_id@0x1001
+          v26:CShape[0x1002] = Const CShape(0x1002)
+          v27:CBool = IsBitEqual v25, v26
+          CondBranch v27, bb7(), bb8()
+        bb7():
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, itself@0x1010, cme:0x1018)
           Jump bb4(v24)
-        bb6():
-          v31:CBool = HasType v10, Fixnum
-          CondBranch v31, bb7(), bb8()
-        bb7():
-          v33:Fixnum = RefineType v10, Fixnum
-          PatchPoint MethodRedefined(Integer@0x1040, itself@0x1010, cme:0x1018)
-          Jump bb4(v33)
         bb8():
-          v39:BasicObject = Send v10, :itself # SendFallbackReason: Send: polymorphic fallback
-          Jump bb4(v39)
+          Jump bb6()
+        bb6():
+          v35:CBool = HasType v10, Fixnum
+          CondBranch v35, bb9(), bb10()
+        bb9():
+          v37:Fixnum = RefineType v10, Fixnum
+          PatchPoint MethodRedefined(Integer@0x1040, itself@0x1010, cme:0x1018)
+          Jump bb4(v37)
+        bb10():
+          v42:BasicObject = Send v10, :itself # SendFallbackReason: Send: polymorphic fallback
+          Jump bb4(v42)
         bb4(v21:BasicObject):
           CheckInterrupts
           Return v21
@@ -18797,12 +18861,22 @@ mod hir_opt_tests {
           PushInlineFrame :klass_eq, v21 (0x1048), num_args=1
           PatchPoint StableConstantNames(0x1068, Integer)
           v31:ClassSubclass[Integer@0x1070] = Const Value(VALUE(0x1070))
+          v47:CShape = LoadField v12, :shape_id@0x1071
+          v48:CShape[0x1072] = Const CShape(0x1072)
+          v49:CBool = IsBitEqual v47, v48
+          CondBranch v49, bb9(), bb10()
+        bb9():
           PatchPoint MethodRedefined(Class@0x1078, ==@0x1080, cme:0x1088)
-          v51:CBool = IsBitEqual v12, v31
-          v52:BoolExact = BoxBool v51
+          v54:CBool = IsBitEqual v12, v31
+          v55:BoolExact = BoxBool v54
+          Jump bb6(v55)
+        bb10():
+          v114:BasicObject = Send v12, :==, v31 # SendFallbackReason: Send: polymorphic fallback
+          Jump bb6(v114)
+        bb6(v43:BasicObject):
           CheckInterrupts
           PopInlineFrame
-          Return v52
+          Return v43
         ");
     }
 
@@ -18842,29 +18916,43 @@ mod hir_opt_tests {
           CondBranch v27, bb5(), bb6()
         bb5():
           v29:ArrayExact = RefineType v12, ArrayExact
+          v30:CShape = LoadField v29, :shape_id@0x1002
+          v31:CShape[0x1003] = Const CShape(0x1003)
+          v32:CBool = IsBitEqual v30, v31
+          CondBranch v32, bb7(), bb8()
+        bb7():
           PatchPoint NoSingletonClass(Array@0x1008)
           PatchPoint MethodRedefined(Array@0x1008, []@0x1010, cme:0x1018)
-          v35:Fixnum = GuardType v13, Fixnum
-          v36:CInt64 = UnboxFixnum v35
-          v37:CInt64 = ArrayLength v29
-          v38:CInt64 = GuardLess v36, v37
-          v39:CInt64 = AdjustBounds v38, v37
-          v40:CInt64[0] = Const CInt64(0)
-          v41:CInt64 = GuardGreaterEq v39, v40
-          v42:BasicObject = ArrayAref v29, v41
-          Jump bb4(v42)
-        bb6():
-          v44:CBool = HasType v12, HashExact
-          CondBranch v44, bb7(), bb8()
-        bb7():
-          v46:HashExact = RefineType v12, HashExact
-          PatchPoint NoSingletonClass(Hash@0x1040)
-          PatchPoint MethodRedefined(Hash@0x1040, []@0x1010, cme:0x1048)
-          v52:BasicObject = HashAref v46, v13
-          Jump bb4(v52)
+          v38:Fixnum = GuardType v13, Fixnum
+          v39:CInt64 = UnboxFixnum v38
+          v40:CInt64 = ArrayLength v29
+          v41:CInt64 = GuardLess v39, v40
+          v42:CInt64 = AdjustBounds v41, v40
+          v43:CInt64[0] = Const CInt64(0)
+          v44:CInt64 = GuardGreaterEq v42, v43
+          v45:BasicObject = ArrayAref v29, v44
+          Jump bb4(v45)
         bb8():
-          v54:BasicObject = Send v12, :[], v13 # SendFallbackReason: Send: polymorphic fallback
-          Jump bb4(v54)
+          Jump bb6()
+        bb6():
+          v48:CBool = HasType v12, HashExact
+          CondBranch v48, bb9(), bb10()
+        bb9():
+          v50:HashExact = RefineType v12, HashExact
+          v51:CShape = LoadField v50, :shape_id@0x1002
+          v52:CShape[0x1040] = Const CShape(0x1040)
+          v53:CBool = IsBitEqual v51, v52
+          CondBranch v53, bb11(), bb12()
+        bb11():
+          PatchPoint NoSingletonClass(Hash@0x1048)
+          PatchPoint MethodRedefined(Hash@0x1048, []@0x1010, cme:0x1050)
+          v59:BasicObject = HashAref v50, v13
+          Jump bb4(v59)
+        bb12():
+          Jump bb10()
+        bb10():
+          v62:BasicObject = Send v12, :[], v13 # SendFallbackReason: Send: polymorphic fallback
+          Jump bb4(v62)
         bb4(v26:BasicObject):
           CheckInterrupts
           Return v26
@@ -18908,19 +18996,26 @@ mod hir_opt_tests {
         bb5():
           v24:Fixnum = RefineType v10, Fixnum
           PatchPoint MethodRedefined(Integer@0x1008, to_s@0x1010, cme:0x1018)
-          v29:StringExact = CCallVariadic v24, :Integer#to_s@0x1040
-          Jump bb4(v29)
+          v28:StringExact = CCallVariadic v24, :Integer#to_s@0x1040
+          Jump bb4(v28)
         bb6():
-          v31:CBool = HasType v10, Bignum
-          CondBranch v31, bb8(), bb9()
+          v30:CBool = HasType v10, Bignum
+          CondBranch v30, bb8(), bb9()
         bb8():
-          v33:Bignum = RefineType v10, Bignum
+          v32:Bignum = RefineType v10, Bignum
+          v33:CShape = LoadField v32, :shape_id@0x1041
+          v34:CShape[0x1042] = Const CShape(0x1042)
+          v35:CBool = IsBitEqual v33, v34
+          CondBranch v35, bb10(), bb11()
+        bb10():
           PatchPoint MethodRedefined(Integer@0x1008, to_s@0x1010, cme:0x1018)
-          v38:StringExact = CCallVariadic v33, :Integer#to_s@0x1040
-          Jump bb4(v38)
-        bb9():
-          v40:BasicObject = Send v10, :to_s # SendFallbackReason: Send: polymorphic fallback
+          v40:StringExact = CCallVariadic v32, :Integer#to_s@0x1040
           Jump bb4(v40)
+        bb11():
+          Jump bb9()
+        bb9():
+          v43:BasicObject = Send v10, :to_s # SendFallbackReason: Send: polymorphic fallback
+          Jump bb4(v43)
         bb4(v21:BasicObject):
           CheckInterrupts
           Return v21
@@ -18961,19 +19056,26 @@ mod hir_opt_tests {
         bb5():
           v24:Flonum = RefineType v10, Flonum
           PatchPoint MethodRedefined(Float@0x1008, to_s@0x1010, cme:0x1018)
-          v29:BasicObject = CCallWithFrame v24, :Float#to_s@0x1040
-          Jump bb4(v29)
+          v28:BasicObject = CCallWithFrame v24, :Float#to_s@0x1040
+          Jump bb4(v28)
         bb6():
-          v31:CBool = HasType v10, HeapFloat
-          CondBranch v31, bb8(), bb9()
+          v30:CBool = HasType v10, HeapFloat
+          CondBranch v30, bb8(), bb9()
         bb8():
-          v33:HeapFloat = RefineType v10, HeapFloat
+          v32:HeapFloat = RefineType v10, HeapFloat
+          v33:CShape = LoadField v32, :shape_id@0x1041
+          v34:CShape[0x1042] = Const CShape(0x1042)
+          v35:CBool = IsBitEqual v33, v34
+          CondBranch v35, bb10(), bb11()
+        bb10():
           PatchPoint MethodRedefined(Float@0x1008, to_s@0x1010, cme:0x1018)
-          v38:BasicObject = CCallWithFrame v33, :Float#to_s@0x1040
-          Jump bb4(v38)
-        bb9():
-          v40:BasicObject = Send v10, :to_s # SendFallbackReason: Send: polymorphic fallback
+          v40:BasicObject = CCallWithFrame v32, :Float#to_s@0x1040
           Jump bb4(v40)
+        bb11():
+          Jump bb9()
+        bb9():
+          v43:BasicObject = Send v10, :to_s # SendFallbackReason: Send: polymorphic fallback
+          Jump bb4(v43)
         bb4(v21:BasicObject):
           CheckInterrupts
           Return v21
@@ -19014,19 +19116,26 @@ mod hir_opt_tests {
         bb5():
           v24:StaticSymbol = RefineType v10, StaticSymbol
           PatchPoint MethodRedefined(Symbol@0x1008, to_s@0x1010, cme:0x1018)
-          v28:StringExact = InvokeBuiltin leaf <inline_expr>, v24
-          Jump bb4(v28)
+          v27:StringExact = InvokeBuiltin leaf <inline_expr>, v24
+          Jump bb4(v27)
         bb6():
-          v30:CBool = HasType v10, DynamicSymbol
-          CondBranch v30, bb8(), bb9()
+          v29:CBool = HasType v10, DynamicSymbol
+          CondBranch v29, bb8(), bb9()
         bb8():
-          v32:DynamicSymbol = RefineType v10, DynamicSymbol
+          v31:DynamicSymbol = RefineType v10, DynamicSymbol
+          v32:CShape = LoadField v31, :shape_id@0x1040
+          v33:CShape[0x1041] = Const CShape(0x1041)
+          v34:CBool = IsBitEqual v32, v33
+          CondBranch v34, bb10(), bb11()
+        bb10():
           PatchPoint MethodRedefined(Symbol@0x1008, to_s@0x1010, cme:0x1018)
-          v36:StringExact = InvokeBuiltin leaf <inline_expr>, v32
-          Jump bb4(v36)
-        bb9():
-          v38:BasicObject = Send v10, :to_s # SendFallbackReason: Send: polymorphic fallback
+          v38:StringExact = InvokeBuiltin leaf <inline_expr>, v31
           Jump bb4(v38)
+        bb11():
+          Jump bb9()
+        bb9():
+          v41:BasicObject = Send v10, :to_s # SendFallbackReason: Send: polymorphic fallback
+          Jump bb4(v41)
         bb4(v21:BasicObject):
           CheckInterrupts
           Return v21
@@ -19069,13 +19178,30 @@ mod hir_opt_tests {
           v22:CBool = HasType v10, ObjectSubclass[class_exact:C]
           CondBranch v22, bb5(), bb6()
         bb5():
+          v24:ObjectSubclass[class_exact:C] = RefineType v10, ObjectSubclass[class_exact:C]
+          v25:CShape = LoadField v24, :shape_id@0x1001
+          v26:CShape[0x1002] = Const CShape(0x1002)
+          v27:CBool = IsBitEqual v25, v26
+          CondBranch v27, bb7(), bb8()
+        bb7():
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
-          v29:Fixnum[3] = Const Value(3)
-          Jump bb4(v29)
+          v32:Fixnum[3] = Const Value(3)
+          Jump bb4(v32)
+        bb8():
+          v34:CShape[0x1040] = Const CShape(0x1040)
+          v35:CBool = IsBitEqual v25, v34
+          CondBranch v35, bb9(), bb10()
+        bb9():
+          PatchPoint NoSingletonClass(C@0x1008)
+          PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
+          v40:Fixnum[3] = Const Value(3)
+          Jump bb4(v40)
+        bb10():
+          Jump bb6()
         bb6():
-          v31:BasicObject = Send v10, :foo # SendFallbackReason: Send: polymorphic fallback
-          Jump bb4(v31)
+          v43:BasicObject = Send v10, :foo # SendFallbackReason: Send: polymorphic fallback
+          Jump bb4(v43)
         bb4(v21:BasicObject):
           CheckInterrupts
           Return v21
@@ -20599,21 +20725,28 @@ mod hir_opt_tests {
           CondBranch v27, bb5(), bb6()
         bb5():
           v29:HeapFloat = RefineType v12, HeapFloat
+          v30:CShape = LoadField v29, :shape_id@0x1002
+          v31:CShape[0x1003] = Const CShape(0x1003)
+          v32:CBool = IsBitEqual v30, v31
+          CondBranch v32, bb7(), bb8()
+        bb7():
           PatchPoint MethodRedefined(Float@0x1008, *@0x1010, cme:0x1018)
-          v34:BasicObject = CCallWithFrame v29, :Float#*@0x1040, v13
-          Jump bb4(v34)
-        bb6():
-          v36:CBool = HasType v12, Flonum
-          CondBranch v36, bb8(), bb9()
+          v37:BasicObject = CCallWithFrame v29, :Float#*@0x1040, v13
+          Jump bb4(v37)
         bb8():
-          v38:Flonum = RefineType v12, Flonum
+          Jump bb6()
+        bb6():
+          v40:CBool = HasType v12, Flonum
+          CondBranch v40, bb10(), bb11()
+        bb10():
+          v42:Flonum = RefineType v12, Flonum
           PatchPoint MethodRedefined(Float@0x1008, *@0x1010, cme:0x1018)
-          v43:Flonum = GuardType v13, Flonum recompile
-          v44:Float = FloatMul v38, v43
-          Jump bb4(v44)
-        bb9():
-          v46:BasicObject = Send v12, :*, v13 # SendFallbackReason: Send: polymorphic fallback
-          Jump bb4(v46)
+          v46:Flonum = GuardType v13, Flonum recompile
+          v47:Float = FloatMul v42, v46
+          Jump bb4(v47)
+        bb11():
+          v49:BasicObject = Send v12, :*, v13 # SendFallbackReason: Send: polymorphic fallback
+          Jump bb4(v49)
         bb4(v26:BasicObject):
           CheckInterrupts
           Return v26
@@ -20830,63 +20963,7 @@ mod hir_opt_tests {
           v8:BasicObject = LoadArg :x@1
           Jump bb3(v7, v8)
         bb3(v11:HeapBasicObject, v12:BasicObject):
-          v74:NilClass = Const Value(nil)
-          v17:Fixnum[1] = Const Value(1)
-          PatchPoint SingleRactorMode
-          v21:CShape = LoadField v11, :shape_id@0x1001
-          v22:CShape[0x1002] = Const CShape(0x1002)
-          v23:CBool = IsBitEqual v21, v22
-          CondBranch v23, bb5(), bb6()
-        bb5():
-          StoreField v11, :@a@0x1003, v17
-          Jump bb4()
-        bb6():
-          v28:CShape[0x1004] = Const CShape(0x1004)
-          v29:CBool = IsBitEqual v21, v28
-          CondBranch v29, bb7(), bb8()
-        bb7():
-          StoreField v11, :@a@0x1003, v17
-          v35:CShape[0x1002] = Const CShape(0x1002)
-          StoreField v11, :shape_id@0x1001, v35
-          Jump bb4()
-        bb8():
-          SetIvar v11, :@a, v17
-          Jump bb4()
-        bb4():
-          PatchPoint NoEPEscape(f)
-          v44:Fixnum[1] = Const Value(1)
-          PatchPoint MethodRedefined(Integer@0x1008, +@0x1010, cme:0x1018)
-          v72:Fixnum = GuardType v12, Fixnum recompile
-          v73:Fixnum = FixnumAdd v72, v44
-          PatchPoint SingleRactorMode
-          v55:CShape = LoadField v11, :shape_id@0x1001
-          v56:CShape[0x1002] = Const CShape(0x1002)
-          v57:CBool = IsBitEqual v55, v56
-          CondBranch v57, bb10(), bb11()
-        bb10():
-          StoreField v11, :@a@0x1003, v73
-          Jump bb9()
-        bb11():
-          SetIvar v11, :@a, v73
-          Jump bb9()
-        bb9():
-          CheckInterrupts
-          Return v73
-
-        fn f@<compiled>:4:
-        bb1():
-          EntryPoint interpreter
-          v1:HeapBasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          Jump bb3(v1, v3)
-        bb2():
-          EntryPoint JIT(0)
-          v7:HeapBasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :x@1
-          Jump bb3(v7, v8)
-        bb3(v11:HeapBasicObject, v12:BasicObject):
-          v91:NilClass = Const Value(nil)
+          v81:NilClass = Const Value(nil)
           v17:Fixnum[1] = Const Value(1)
           PatchPoint SingleRactorMode
           v21:CShape = LoadField v11, :shape_id@0x1001
@@ -20916,19 +20993,84 @@ mod hir_opt_tests {
         bb13():
           v73:Fixnum = RefineType v12, Fixnum
           PatchPoint MethodRedefined(Integer@0x1008, +@0x1010, cme:0x1018)
-          v78:Fixnum = FixnumAdd v73, v44
-          Jump bb12(v78)
+          v77:Fixnum = FixnumAdd v73, v44
+          Jump bb12(v77)
         bb14():
-          v80:CBool = HasType v12, Flonum
-          CondBranch v80, bb15(), bb16()
+          v79:BasicObject = Send v12, :+, v44 # SendFallbackReason: Send: polymorphic fallback
+          Jump bb12(v79)
+        bb12(v70:BasicObject):
+          PatchPoint SingleRactorMode
+          v55:CShape = LoadField v11, :shape_id@0x1001
+          v56:CShape[0x1002] = Const CShape(0x1002)
+          v57:CBool = IsBitEqual v55, v56
+          CondBranch v57, bb10(), bb11()
+        bb10():
+          StoreField v11, :@a@0x1003, v70
+          WriteBarrier v11, v70
+          Jump bb9()
+        bb11():
+          SetIvar v11, :@a, v70
+          Jump bb9()
+        bb9():
+          CheckInterrupts
+          Return v70
+
+        fn f@<compiled>:4:
+        bb1():
+          EntryPoint interpreter
+          v1:HeapBasicObject = LoadSelf
+          v2:CPtr = LoadSP
+          v3:BasicObject = LoadField v2, :x@0x1000
+          Jump bb3(v1, v3)
+        bb2():
+          EntryPoint JIT(0)
+          v7:HeapBasicObject = LoadArg :self@0
+          v8:BasicObject = LoadArg :x@1
+          Jump bb3(v7, v8)
+        bb3(v11:HeapBasicObject, v12:BasicObject):
+          v89:NilClass = Const Value(nil)
+          v17:Fixnum[1] = Const Value(1)
+          PatchPoint SingleRactorMode
+          v21:CShape = LoadField v11, :shape_id@0x1001
+          v22:CShape[0x1002] = Const CShape(0x1002)
+          v23:CBool = IsBitEqual v21, v22
+          CondBranch v23, bb5(), bb6()
+        bb5():
+          StoreField v11, :@a@0x1003, v17
+          Jump bb4()
+        bb6():
+          v28:CShape[0x1004] = Const CShape(0x1004)
+          v29:CBool = IsBitEqual v21, v28
+          CondBranch v29, bb7(), bb8()
+        bb7():
+          StoreField v11, :@a@0x1003, v17
+          v35:CShape[0x1002] = Const CShape(0x1002)
+          StoreField v11, :shape_id@0x1001, v35
+          Jump bb4()
+        bb8():
+          SetIvar v11, :@a, v17
+          Jump bb4()
+        bb4():
+          PatchPoint NoEPEscape(f)
+          v44:Fixnum[1] = Const Value(1)
+          v71:CBool = HasType v12, Fixnum
+          CondBranch v71, bb13(), bb14()
+        bb13():
+          v73:Fixnum = RefineType v12, Fixnum
+          PatchPoint MethodRedefined(Integer@0x1008, +@0x1010, cme:0x1018)
+          v77:Fixnum = FixnumAdd v73, v44
+          Jump bb12(v77)
+        bb14():
+          v79:CBool = HasType v12, Flonum
+          CondBranch v79, bb15(), bb16()
         bb15():
-          v82:Flonum = RefineType v12, Flonum
+          v81:Flonum = RefineType v12, Flonum
           PatchPoint MethodRedefined(Float@0x1040, +@0x1010, cme:0x1048)
-          v87:Float = FloatAdd v82, v44
-          Jump bb12(v87)
+          v85:Float = FloatAdd v81, v44
+          Jump bb12(v85)
         bb16():
-          v89:BasicObject = Send v12, :+, v44 # SendFallbackReason: Send: polymorphic fallback
-          Jump bb12(v89)
+          v87:BasicObject = Send v12, :+, v44 # SendFallbackReason: Send: polymorphic fallback
+          Jump bb12(v87)
         bb12(v70:BasicObject):
           PatchPoint SingleRactorMode
           v55:CShape = LoadField v11, :shape_id@0x1001

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -14894,54 +14894,40 @@ mod hir_opt_tests {
           CondBranch v28, bb5(), bb6()
         bb5():
           v30:ObjectSubclass[class_exact:CallerSplatA] = RefineType v12, ObjectSubclass[class_exact:CallerSplatA]
-          v31:CShape = LoadField v30, :shape_id@0x1002
-          v32:CShape[0x1003] = Const CShape(0x1003)
-          v33:CBool = IsBitEqual v31, v32
-          CondBranch v33, bb7(), bb8()
-        bb7():
           PatchPoint NoSingletonClass(CallerSplatA@0x1008)
-          v37:CInt64 = ArrayLength v19
-          v38:CInt64[1] = GuardBitEquals v37, CInt64(1) recompile
-          v39:CInt64 = CCall v19, :rb_jit_ruby2_keywords_splat_p@0x1010
-          v40:CInt64[0] = GuardBitEquals v39, CInt64(0)
+          v33:CInt64 = ArrayLength v19
+          v34:CInt64[1] = GuardBitEquals v33, CInt64(1) recompile
+          v35:CInt64 = CCall v19, :rb_jit_ruby2_keywords_splat_p@0x1010
+          v36:CInt64[0] = GuardBitEquals v35, CInt64(0)
           PatchPoint MethodRedefined(CallerSplatA@0x1008, target@0x1011, cme:0x1018)
-          v42:CInt64[0] = Const CInt64(0)
-          v43:BasicObject = ArrayAref v19, v42
-          v44:ArrayExact = NewArray v43
+          v38:CInt64[0] = Const CInt64(0)
+          v39:BasicObject = ArrayAref v19, v38
+          v40:ArrayExact = NewArray v39
           PushInlineFrame :target, v30 (0x1040), num_args=1
           CheckInterrupts
           PopInlineFrame
-          Jump bb4(v44)
-        bb8():
-          Jump bb6()
+          Jump bb4(v40)
         bb6():
-          v49:CBool = HasType v12, ObjectSubclass[class_exact:CallerSplatB]
-          CondBranch v49, bb9(), bb10()
-        bb9():
-          v51:ObjectSubclass[class_exact:CallerSplatB] = RefineType v12, ObjectSubclass[class_exact:CallerSplatB]
-          v52:CShape = LoadField v51, :shape_id@0x1002
-          v53:CShape[0x1003] = Const CShape(0x1003)
-          v54:CBool = IsBitEqual v52, v53
-          CondBranch v54, bb11(), bb12()
-        bb11():
+          v44:CBool = HasType v12, ObjectSubclass[class_exact:CallerSplatB]
+          CondBranch v44, bb7(), bb8()
+        bb7():
+          v46:ObjectSubclass[class_exact:CallerSplatB] = RefineType v12, ObjectSubclass[class_exact:CallerSplatB]
           PatchPoint NoSingletonClass(CallerSplatB@0x1060)
-          v58:CInt64 = ArrayLength v19
-          v59:CInt64[1] = GuardBitEquals v58, CInt64(1) recompile
-          v60:CInt64 = CCall v19, :rb_jit_ruby2_keywords_splat_p@0x1010
-          v61:CInt64[0] = GuardBitEquals v60, CInt64(0)
+          v49:CInt64 = ArrayLength v19
+          v50:CInt64[1] = GuardBitEquals v49, CInt64(1) recompile
+          v51:CInt64 = CCall v19, :rb_jit_ruby2_keywords_splat_p@0x1010
+          v52:CInt64[0] = GuardBitEquals v51, CInt64(0)
           PatchPoint MethodRedefined(CallerSplatB@0x1060, target@0x1011, cme:0x1068)
-          v63:CInt64[0] = Const CInt64(0)
-          v64:BasicObject = ArrayAref v19, v63
-          v65:ArrayExact = NewArray v64
-          PushInlineFrame :target, v51 (0x1090), num_args=1
+          v54:CInt64[0] = Const CInt64(0)
+          v55:BasicObject = ArrayAref v19, v54
+          v56:ArrayExact = NewArray v55
+          PushInlineFrame :target, v46 (0x1090), num_args=1
           CheckInterrupts
           PopInlineFrame
-          Jump bb4(v65)
-        bb12():
-          Jump bb10()
-        bb10():
-          v70:BasicObject = Send v12, :target, v19 # SendFallbackReason: Send: polymorphic call site
-          Jump bb4(v70)
+          Jump bb4(v56)
+        bb8():
+          v60:BasicObject = Send v12, :target, v19 # SendFallbackReason: Send: polymorphic call site
+          Jump bb4(v60)
         bb4(v27:BasicObject):
           CheckInterrupts
           Return v27
@@ -18732,44 +18718,28 @@ mod hir_opt_tests {
           v27:CBool = HasType v10, ObjectSubclass[class_exact:C]
           CondBranch v27, bb5(), bb6()
         bb5():
-          v29:ObjectSubclass[class_exact:C] = RefineType v10, ObjectSubclass[class_exact:C]
-          v30:CShape = LoadField v29, :shape_id@0x1001
-          v31:CShape[0x1002] = Const CShape(0x1002)
-          v32:CBool = IsBitEqual v30, v31
-          CondBranch v32, bb7(), bb8()
-        bb7():
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
-          v37:Fixnum[3] = Const Value(3)
-          Jump bb4(v37)
-        bb8():
-          Jump bb6()
+          v33:Fixnum[3] = Const Value(3)
+          Jump bb4(v33)
         bb6():
-          v40:CBool = HasType v10, ObjectSubclass[class_exact:D]
-          CondBranch v40, bb9(), bb10()
-        bb9():
-          v42:ObjectSubclass[class_exact:D] = RefineType v10, ObjectSubclass[class_exact:D]
-          v43:CShape = LoadField v42, :shape_id@0x1001
-          v44:CShape[0x1002] = Const CShape(0x1002)
-          v45:CBool = IsBitEqual v43, v44
-          CondBranch v45, bb11(), bb12()
-        bb11():
+          v35:CBool = HasType v10, ObjectSubclass[class_exact:D]
+          CondBranch v35, bb7(), bb8()
+        bb7():
           PatchPoint NoSingletonClass(D@0x1040)
           PatchPoint MethodRedefined(D@0x1040, foo@0x1010, cme:0x1048)
-          v50:Fixnum[4] = Const Value(4)
-          Jump bb4(v50)
-        bb12():
-          Jump bb10()
-        bb10():
-          v53:BasicObject = Send v10, :foo # SendFallbackReason: Send: polymorphic fallback
-          Jump bb4(v53)
+          v41:Fixnum[4] = Const Value(4)
+          Jump bb4(v41)
+        bb8():
+          v43:BasicObject = Send v10, :foo # SendFallbackReason: Send: polymorphic fallback
+          Jump bb4(v43)
         bb4(v26:BasicObject):
           v17:Fixnum[2] = Const Value(2)
           PatchPoint MethodRedefined(Integer@0x1070, +@0x1078, cme:0x1080)
-          v57:Fixnum = GuardType v26, Fixnum recompile
-          v58:Fixnum = FixnumAdd v57, v17
+          v47:Fixnum = GuardType v26, Fixnum recompile
+          v48:Fixnum = FixnumAdd v47, v17
           CheckInterrupts
-          Return v58
+          Return v48
         ");
     }
 
@@ -18803,26 +18773,19 @@ mod hir_opt_tests {
           CondBranch v22, bb5(), bb6()
         bb5():
           v24:ObjectSubclass[class_exact:C] = RefineType v10, ObjectSubclass[class_exact:C]
-          v25:CShape = LoadField v24, :shape_id@0x1001
-          v26:CShape[0x1002] = Const CShape(0x1002)
-          v27:CBool = IsBitEqual v25, v26
-          CondBranch v27, bb7(), bb8()
-        bb7():
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, itself@0x1010, cme:0x1018)
           Jump bb4(v24)
-        bb8():
-          Jump bb6()
         bb6():
-          v35:CBool = HasType v10, Fixnum
-          CondBranch v35, bb9(), bb10()
-        bb9():
-          v37:Fixnum = RefineType v10, Fixnum
+          v30:CBool = HasType v10, Fixnum
+          CondBranch v30, bb7(), bb8()
+        bb7():
+          v32:Fixnum = RefineType v10, Fixnum
           PatchPoint MethodRedefined(Integer@0x1040, itself@0x1010, cme:0x1018)
+          Jump bb4(v32)
+        bb8():
+          v37:BasicObject = Send v10, :itself # SendFallbackReason: Send: polymorphic fallback
           Jump bb4(v37)
-        bb10():
-          v42:BasicObject = Send v10, :itself # SendFallbackReason: Send: polymorphic fallback
-          Jump bb4(v42)
         bb4(v21:BasicObject):
           CheckInterrupts
           Return v21
@@ -18861,22 +18824,12 @@ mod hir_opt_tests {
           PushInlineFrame :klass_eq, v21 (0x1048), num_args=1
           PatchPoint StableConstantNames(0x1068, Integer)
           v31:ClassSubclass[Integer@0x1070] = Const Value(VALUE(0x1070))
-          v47:CShape = LoadField v12, :shape_id@0x1071
-          v48:CShape[0x1072] = Const CShape(0x1072)
-          v49:CBool = IsBitEqual v47, v48
-          CondBranch v49, bb9(), bb10()
-        bb9():
           PatchPoint MethodRedefined(Class@0x1078, ==@0x1080, cme:0x1088)
-          v54:CBool = IsBitEqual v12, v31
-          v55:BoolExact = BoxBool v54
-          Jump bb6(v55)
-        bb10():
-          v114:BasicObject = Send v12, :==, v31 # SendFallbackReason: Send: polymorphic fallback
-          Jump bb6(v114)
-        bb6(v43:BasicObject):
+          v50:CBool = IsBitEqual v12, v31
+          v51:BoolExact = BoxBool v50
           CheckInterrupts
           PopInlineFrame
-          Return v43
+          Return v51
         ");
     }
 
@@ -18916,43 +18869,29 @@ mod hir_opt_tests {
           CondBranch v27, bb5(), bb6()
         bb5():
           v29:ArrayExact = RefineType v12, ArrayExact
-          v30:CShape = LoadField v29, :shape_id@0x1002
-          v31:CShape[0x1003] = Const CShape(0x1003)
-          v32:CBool = IsBitEqual v30, v31
-          CondBranch v32, bb7(), bb8()
-        bb7():
           PatchPoint NoSingletonClass(Array@0x1008)
           PatchPoint MethodRedefined(Array@0x1008, []@0x1010, cme:0x1018)
-          v38:Fixnum = GuardType v13, Fixnum
-          v39:CInt64 = UnboxFixnum v38
-          v40:CInt64 = ArrayLength v29
-          v41:CInt64 = GuardLess v39, v40
-          v42:CInt64 = AdjustBounds v41, v40
-          v43:CInt64[0] = Const CInt64(0)
-          v44:CInt64 = GuardGreaterEq v42, v43
-          v45:BasicObject = ArrayAref v29, v44
-          Jump bb4(v45)
-        bb8():
-          Jump bb6()
+          v34:Fixnum = GuardType v13, Fixnum
+          v35:CInt64 = UnboxFixnum v34
+          v36:CInt64 = ArrayLength v29
+          v37:CInt64 = GuardLess v35, v36
+          v38:CInt64 = AdjustBounds v37, v36
+          v39:CInt64[0] = Const CInt64(0)
+          v40:CInt64 = GuardGreaterEq v38, v39
+          v41:BasicObject = ArrayAref v29, v40
+          Jump bb4(v41)
         bb6():
-          v48:CBool = HasType v12, HashExact
-          CondBranch v48, bb9(), bb10()
-        bb9():
-          v50:HashExact = RefineType v12, HashExact
-          v51:CShape = LoadField v50, :shape_id@0x1002
-          v52:CShape[0x1040] = Const CShape(0x1040)
-          v53:CBool = IsBitEqual v51, v52
-          CondBranch v53, bb11(), bb12()
-        bb11():
-          PatchPoint NoSingletonClass(Hash@0x1048)
-          PatchPoint MethodRedefined(Hash@0x1048, []@0x1010, cme:0x1050)
-          v59:BasicObject = HashAref v50, v13
-          Jump bb4(v59)
-        bb12():
-          Jump bb10()
-        bb10():
-          v62:BasicObject = Send v12, :[], v13 # SendFallbackReason: Send: polymorphic fallback
-          Jump bb4(v62)
+          v43:CBool = HasType v12, HashExact
+          CondBranch v43, bb7(), bb8()
+        bb7():
+          v45:HashExact = RefineType v12, HashExact
+          PatchPoint NoSingletonClass(Hash@0x1040)
+          PatchPoint MethodRedefined(Hash@0x1040, []@0x1010, cme:0x1048)
+          v50:BasicObject = HashAref v45, v13
+          Jump bb4(v50)
+        bb8():
+          v52:BasicObject = Send v12, :[], v13 # SendFallbackReason: Send: polymorphic fallback
+          Jump bb4(v52)
         bb4(v26:BasicObject):
           CheckInterrupts
           Return v26
@@ -19003,19 +18942,12 @@ mod hir_opt_tests {
           CondBranch v30, bb8(), bb9()
         bb8():
           v32:Bignum = RefineType v10, Bignum
-          v33:CShape = LoadField v32, :shape_id@0x1041
-          v34:CShape[0x1042] = Const CShape(0x1042)
-          v35:CBool = IsBitEqual v33, v34
-          CondBranch v35, bb10(), bb11()
-        bb10():
           PatchPoint MethodRedefined(Integer@0x1008, to_s@0x1010, cme:0x1018)
-          v40:StringExact = CCallVariadic v32, :Integer#to_s@0x1040
-          Jump bb4(v40)
-        bb11():
-          Jump bb9()
+          v36:StringExact = CCallVariadic v32, :Integer#to_s@0x1040
+          Jump bb4(v36)
         bb9():
-          v43:BasicObject = Send v10, :to_s # SendFallbackReason: Send: polymorphic fallback
-          Jump bb4(v43)
+          v38:BasicObject = Send v10, :to_s # SendFallbackReason: Send: polymorphic fallback
+          Jump bb4(v38)
         bb4(v21:BasicObject):
           CheckInterrupts
           Return v21
@@ -19063,19 +18995,12 @@ mod hir_opt_tests {
           CondBranch v30, bb8(), bb9()
         bb8():
           v32:HeapFloat = RefineType v10, HeapFloat
-          v33:CShape = LoadField v32, :shape_id@0x1041
-          v34:CShape[0x1042] = Const CShape(0x1042)
-          v35:CBool = IsBitEqual v33, v34
-          CondBranch v35, bb10(), bb11()
-        bb10():
           PatchPoint MethodRedefined(Float@0x1008, to_s@0x1010, cme:0x1018)
-          v40:BasicObject = CCallWithFrame v32, :Float#to_s@0x1040
-          Jump bb4(v40)
-        bb11():
-          Jump bb9()
+          v36:BasicObject = CCallWithFrame v32, :Float#to_s@0x1040
+          Jump bb4(v36)
         bb9():
-          v43:BasicObject = Send v10, :to_s # SendFallbackReason: Send: polymorphic fallback
-          Jump bb4(v43)
+          v38:BasicObject = Send v10, :to_s # SendFallbackReason: Send: polymorphic fallback
+          Jump bb4(v38)
         bb4(v21:BasicObject):
           CheckInterrupts
           Return v21
@@ -19123,19 +19048,12 @@ mod hir_opt_tests {
           CondBranch v29, bb8(), bb9()
         bb8():
           v31:DynamicSymbol = RefineType v10, DynamicSymbol
-          v32:CShape = LoadField v31, :shape_id@0x1040
-          v33:CShape[0x1041] = Const CShape(0x1041)
-          v34:CBool = IsBitEqual v32, v33
-          CondBranch v34, bb10(), bb11()
-        bb10():
           PatchPoint MethodRedefined(Symbol@0x1008, to_s@0x1010, cme:0x1018)
-          v38:StringExact = InvokeBuiltin leaf <inline_expr>, v31
-          Jump bb4(v38)
-        bb11():
-          Jump bb9()
+          v34:StringExact = InvokeBuiltin leaf <inline_expr>, v31
+          Jump bb4(v34)
         bb9():
-          v41:BasicObject = Send v10, :to_s # SendFallbackReason: Send: polymorphic fallback
-          Jump bb4(v41)
+          v36:BasicObject = Send v10, :to_s # SendFallbackReason: Send: polymorphic fallback
+          Jump bb4(v36)
         bb4(v21:BasicObject):
           CheckInterrupts
           Return v21
@@ -19178,30 +19096,13 @@ mod hir_opt_tests {
           v22:CBool = HasType v10, ObjectSubclass[class_exact:C]
           CondBranch v22, bb5(), bb6()
         bb5():
-          v24:ObjectSubclass[class_exact:C] = RefineType v10, ObjectSubclass[class_exact:C]
-          v25:CShape = LoadField v24, :shape_id@0x1001
-          v26:CShape[0x1002] = Const CShape(0x1002)
-          v27:CBool = IsBitEqual v25, v26
-          CondBranch v27, bb7(), bb8()
-        bb7():
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
-          v32:Fixnum[3] = Const Value(3)
-          Jump bb4(v32)
-        bb8():
-          v34:CShape[0x1040] = Const CShape(0x1040)
-          v35:CBool = IsBitEqual v25, v34
-          CondBranch v35, bb9(), bb10()
-        bb9():
-          PatchPoint NoSingletonClass(C@0x1008)
-          PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
-          v40:Fixnum[3] = Const Value(3)
-          Jump bb4(v40)
-        bb10():
-          Jump bb6()
+          v28:Fixnum[3] = Const Value(3)
+          Jump bb4(v28)
         bb6():
-          v43:BasicObject = Send v10, :foo # SendFallbackReason: Send: polymorphic fallback
-          Jump bb4(v43)
+          v30:BasicObject = Send v10, :foo # SendFallbackReason: Send: polymorphic fallback
+          Jump bb4(v30)
         bb4(v21:BasicObject):
           CheckInterrupts
           Return v21
@@ -20725,28 +20626,21 @@ mod hir_opt_tests {
           CondBranch v27, bb5(), bb6()
         bb5():
           v29:HeapFloat = RefineType v12, HeapFloat
-          v30:CShape = LoadField v29, :shape_id@0x1002
-          v31:CShape[0x1003] = Const CShape(0x1003)
-          v32:CBool = IsBitEqual v30, v31
-          CondBranch v32, bb7(), bb8()
-        bb7():
           PatchPoint MethodRedefined(Float@0x1008, *@0x1010, cme:0x1018)
-          v37:BasicObject = CCallWithFrame v29, :Float#*@0x1040, v13
-          Jump bb4(v37)
-        bb8():
-          Jump bb6()
+          v33:BasicObject = CCallWithFrame v29, :Float#*@0x1040, v13
+          Jump bb4(v33)
         bb6():
-          v40:CBool = HasType v12, Flonum
-          CondBranch v40, bb10(), bb11()
-        bb10():
-          v42:Flonum = RefineType v12, Flonum
+          v35:CBool = HasType v12, Flonum
+          CondBranch v35, bb8(), bb9()
+        bb8():
+          v37:Flonum = RefineType v12, Flonum
           PatchPoint MethodRedefined(Float@0x1008, *@0x1010, cme:0x1018)
-          v46:Flonum = GuardType v13, Flonum recompile
-          v47:Float = FloatMul v42, v46
-          Jump bb4(v47)
-        bb11():
-          v49:BasicObject = Send v12, :*, v13 # SendFallbackReason: Send: polymorphic fallback
-          Jump bb4(v49)
+          v41:Flonum = GuardType v13, Flonum recompile
+          v42:Float = FloatMul v37, v41
+          Jump bb4(v42)
+        bb9():
+          v44:BasicObject = Send v12, :*, v13 # SendFallbackReason: Send: polymorphic fallback
+          Jump bb4(v44)
         bb4(v26:BasicObject):
           CheckInterrupts
           Return v26

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -1769,9 +1769,9 @@ mod hir_opt_tests {
           PatchPoint MethodRedefined(NilClass@0x1058, nil?@0x1060, cme:0x1068)
           v52:Fixnum[0] = Const Value(0)
           CheckInterrupts
-          v84:Fixnum[0] = Const Value(0)
+          v85:Fixnum[0] = Const Value(0)
           PopInlineFrame
-          Return v84
+          Return v85
         ");
     }
 
@@ -9715,15 +9715,15 @@ mod hir_opt_tests {
           CondBranch v36, bb8(), bb9()
         bb8():
           PatchPoint MethodRedefined(FalseClass@0x1008, !@0x1010, cme:0x1018)
-          v57:TrueClass = Const Value(true)
-          Jump bb7(v57)
+          v58:TrueClass = Const Value(true)
+          Jump bb7(v58)
         bb9():
           v42:CBool = HasType v31, NilClass
           CondBranch v42, bb10(), bb11()
         bb10():
           PatchPoint MethodRedefined(NilClass@0x1040, !@0x1010, cme:0x1018)
-          v60:TrueClass = Const Value(true)
-          Jump bb7(v60)
+          v62:TrueClass = Const Value(true)
+          Jump bb7(v62)
         bb11():
           v48:BasicObject = Send v31, :! # SendFallbackReason: Send: polymorphic call site
           Jump bb7(v48)
@@ -10461,7 +10461,9 @@ mod hir_opt_tests {
         bb5():
           v24:ObjectSubclass[class_exact:C] = RefineType v10, ObjectSubclass[class_exact:C]
           PatchPoint MethodRedefined(C@0x1008, foo=@0x1010, cme:0x1018)
-          SetIvar v24, :@foo, v17
+          v38:CShape = LoadField v24, :shape_id@0x1040
+          v39:CShape[0x1041] = GuardBitEquals v38, CShape(0x1041)
+          StoreField v24, :@foo@0x1042, v17
           Jump bb4(v17)
         bb6():
           v27:BasicObject = Send v10, :foo=, v17 # SendFallbackReason: Send: polymorphic call site
@@ -11044,8 +11046,10 @@ mod hir_opt_tests {
           v19:ObjectSubclass[class_exact:C] = RefineType v10, ObjectSubclass[class_exact:C]
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
-          v31:BasicObject = GetIvar v19, :@foo
-          Jump bb4(v31)
+          v33:CShape = LoadField v19, :shape_id@0x1040
+          v34:CShape[0x1041] = GuardBitEquals v33, CShape(0x1041) recompile
+          v35:BasicObject = LoadField v19, :@foo@0x1042
+          Jump bb4(v35)
         bb6():
           v22:BasicObject = Send v10, :foo # SendFallbackReason: Send: polymorphic call site
           Jump bb4(v22)
@@ -14869,31 +14873,31 @@ mod hir_opt_tests {
           v44:CInt64 = CCall v19, :rb_jit_ruby2_keywords_splat_p@0x1010
           v45:CInt64[0] = GuardBitEquals v44, CInt64(0)
           PatchPoint MethodRedefined(CallerSplatA@0x1008, target@0x1011, cme:0x1018)
-          v47:CInt64[0] = Const CInt64(0)
-          v48:BasicObject = ArrayAref v19, v47
-          v49:ArrayExact = NewArray v48
+          v48:CInt64[0] = Const CInt64(0)
+          v49:BasicObject = ArrayAref v19, v48
+          v50:ArrayExact = NewArray v49
           PushInlineFrame :target, v25 (0x1040), num_args=1
           CheckInterrupts
           PopInlineFrame
-          Jump bb4(v49)
+          Jump bb4(v50)
         bb6():
           v28:CBool = HasType v12, ObjectSubclass[class_exact:CallerSplatB]
           CondBranch v28, bb7(), bb8()
         bb7():
           v31:ObjectSubclass[class_exact:CallerSplatB] = RefineType v12, ObjectSubclass[class_exact:CallerSplatB]
           PatchPoint NoSingletonClass(CallerSplatB@0x1060)
-          v53:CInt64 = ArrayLength v19
-          v54:CInt64[1] = GuardBitEquals v53, CInt64(1) recompile
-          v55:CInt64 = CCall v19, :rb_jit_ruby2_keywords_splat_p@0x1010
-          v56:CInt64[0] = GuardBitEquals v55, CInt64(0)
+          v54:CInt64 = ArrayLength v19
+          v55:CInt64[1] = GuardBitEquals v54, CInt64(1) recompile
+          v56:CInt64 = CCall v19, :rb_jit_ruby2_keywords_splat_p@0x1010
+          v57:CInt64[0] = GuardBitEquals v56, CInt64(0)
           PatchPoint MethodRedefined(CallerSplatB@0x1060, target@0x1011, cme:0x1068)
-          v58:CInt64[0] = Const CInt64(0)
-          v59:BasicObject = ArrayAref v19, v58
-          v60:ArrayExact = NewArray v59
+          v60:CInt64[0] = Const CInt64(0)
+          v61:BasicObject = ArrayAref v19, v60
+          v62:ArrayExact = NewArray v61
           PushInlineFrame :target, v31 (0x1090), num_args=1
           CheckInterrupts
           PopInlineFrame
-          Jump bb4(v60)
+          Jump bb4(v62)
         bb8():
           v34:BasicObject = Send v12, :target, v19 # SendFallbackReason: Send: polymorphic call site
           Jump bb4(v34)
@@ -18689,26 +18693,26 @@ mod hir_opt_tests {
         bb5():
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
-          v42:Fixnum[3] = Const Value(3)
-          Jump bb4(v42)
+          v43:Fixnum[3] = Const Value(3)
+          Jump bb4(v43)
         bb6():
           v22:CBool = HasType v10, ObjectSubclass[class_exact:D]
           CondBranch v22, bb7(), bb8()
         bb7():
           PatchPoint NoSingletonClass(D@0x1040)
           PatchPoint MethodRedefined(D@0x1040, foo@0x1010, cme:0x1048)
-          v45:Fixnum[4] = Const Value(4)
-          Jump bb4(v45)
+          v47:Fixnum[4] = Const Value(4)
+          Jump bb4(v47)
         bb8():
           v28:BasicObject = Send v10, :foo # SendFallbackReason: Send: polymorphic call site
           Jump bb4(v28)
         bb4(v15:BasicObject):
           v31:Fixnum[2] = Const Value(2)
           PatchPoint MethodRedefined(Integer@0x1070, +@0x1078, cme:0x1080)
-          v48:Fixnum = GuardType v15, Fixnum recompile
-          v49:Fixnum = FixnumAdd v48, v31
+          v50:Fixnum = GuardType v15, Fixnum recompile
+          v51:Fixnum = FixnumAdd v50, v31
           CheckInterrupts
-          Return v49
+          Return v51
         ");
     }
 
@@ -18794,11 +18798,11 @@ mod hir_opt_tests {
           PatchPoint StableConstantNames(0x1068, Integer)
           v31:ClassSubclass[Integer@0x1070] = Const Value(VALUE(0x1070))
           PatchPoint MethodRedefined(Class@0x1078, ==@0x1080, cme:0x1088)
-          v82:CBool = IsBitEqual v12, v31
-          v83:BoolExact = BoxBool v82
+          v83:CBool = IsBitEqual v12, v31
+          v84:BoolExact = BoxBool v83
           CheckInterrupts
           PopInlineFrame
-          Return v83
+          Return v84
         ");
     }
 
@@ -18840,15 +18844,15 @@ mod hir_opt_tests {
           v24:ArrayExact = RefineType v12, ArrayExact
           PatchPoint NoSingletonClass(Array@0x1008)
           PatchPoint MethodRedefined(Array@0x1008, []@0x1010, cme:0x1018)
-          v43:Fixnum = GuardType v13, Fixnum
-          v44:CInt64 = UnboxFixnum v43
-          v45:CInt64 = ArrayLength v24
-          v46:CInt64 = GuardLess v44, v45
-          v47:CInt64 = AdjustBounds v46, v45
-          v48:CInt64[0] = Const CInt64(0)
-          v49:CInt64 = GuardGreaterEq v47, v48
-          v50:BasicObject = ArrayAref v24, v49
-          Jump bb4(v50)
+          v44:Fixnum = GuardType v13, Fixnum
+          v45:CInt64 = UnboxFixnum v44
+          v46:CInt64 = ArrayLength v24
+          v47:CInt64 = GuardLess v45, v46
+          v48:CInt64 = AdjustBounds v47, v46
+          v49:CInt64[0] = Const CInt64(0)
+          v50:CInt64 = GuardGreaterEq v48, v49
+          v51:BasicObject = ArrayAref v24, v50
+          Jump bb4(v51)
         bb6():
           v27:CBool = HasType v12, HashExact
           CondBranch v27, bb7(), bb8()
@@ -18856,8 +18860,8 @@ mod hir_opt_tests {
           v30:HashExact = RefineType v12, HashExact
           PatchPoint NoSingletonClass(Hash@0x1040)
           PatchPoint MethodRedefined(Hash@0x1040, []@0x1010, cme:0x1048)
-          v54:BasicObject = HashAref v30, v13
-          Jump bb4(v54)
+          v56:BasicObject = HashAref v30, v13
+          Jump bb4(v56)
         bb8():
           v33:BasicObject = Send v12, :[], v13 # SendFallbackReason: Send: polymorphic call site
           Jump bb4(v33)
@@ -18904,16 +18908,16 @@ mod hir_opt_tests {
         bb5():
           v19:Fixnum = RefineType v10, Fixnum
           PatchPoint MethodRedefined(Integer@0x1008, to_s@0x1010, cme:0x1018)
-          v37:StringExact = CCallVariadic v19, :Integer#to_s@0x1040
-          Jump bb4(v37)
+          v38:StringExact = CCallVariadic v19, :Integer#to_s@0x1040
+          Jump bb4(v38)
         bb6():
           v22:CBool = HasType v10, Bignum
           CondBranch v22, bb7(), bb8()
         bb7():
           v25:Bignum = RefineType v10, Bignum
           PatchPoint MethodRedefined(Integer@0x1008, to_s@0x1010, cme:0x1018)
-          v40:StringExact = CCallVariadic v25, :Integer#to_s@0x1040
-          Jump bb4(v40)
+          v42:StringExact = CCallVariadic v25, :Integer#to_s@0x1040
+          Jump bb4(v42)
         bb8():
           v28:BasicObject = Send v10, :to_s # SendFallbackReason: Send: polymorphic call site
           Jump bb4(v28)
@@ -18957,16 +18961,16 @@ mod hir_opt_tests {
         bb5():
           v19:Flonum = RefineType v10, Flonum
           PatchPoint MethodRedefined(Float@0x1008, to_s@0x1010, cme:0x1018)
-          v37:BasicObject = CCallWithFrame v19, :Float#to_s@0x1040
-          Jump bb4(v37)
+          v38:BasicObject = CCallWithFrame v19, :Float#to_s@0x1040
+          Jump bb4(v38)
         bb6():
           v22:CBool = HasType v10, HeapFloat
           CondBranch v22, bb7(), bb8()
         bb7():
           v25:HeapFloat = RefineType v10, HeapFloat
           PatchPoint MethodRedefined(Float@0x1008, to_s@0x1010, cme:0x1018)
-          v40:BasicObject = CCallWithFrame v25, :Float#to_s@0x1040
-          Jump bb4(v40)
+          v42:BasicObject = CCallWithFrame v25, :Float#to_s@0x1040
+          Jump bb4(v42)
         bb8():
           v28:BasicObject = Send v10, :to_s # SendFallbackReason: Send: polymorphic call site
           Jump bb4(v28)
@@ -19010,16 +19014,16 @@ mod hir_opt_tests {
         bb5():
           v19:StaticSymbol = RefineType v10, StaticSymbol
           PatchPoint MethodRedefined(Symbol@0x1008, to_s@0x1010, cme:0x1018)
-          v36:StringExact = InvokeBuiltin leaf <inline_expr>, v19
-          Jump bb4(v36)
+          v37:StringExact = InvokeBuiltin leaf <inline_expr>, v19
+          Jump bb4(v37)
         bb6():
           v22:CBool = HasType v10, DynamicSymbol
           CondBranch v22, bb7(), bb8()
         bb7():
           v25:DynamicSymbol = RefineType v10, DynamicSymbol
           PatchPoint MethodRedefined(Symbol@0x1008, to_s@0x1010, cme:0x1018)
-          v38:StringExact = InvokeBuiltin leaf <inline_expr>, v25
-          Jump bb4(v38)
+          v40:StringExact = InvokeBuiltin leaf <inline_expr>, v25
+          Jump bb4(v40)
         bb8():
           v28:BasicObject = Send v10, :to_s # SendFallbackReason: Send: polymorphic call site
           Jump bb4(v28)
@@ -19067,8 +19071,8 @@ mod hir_opt_tests {
         bb5():
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
-          v31:Fixnum[3] = Const Value(3)
-          Jump bb4(v31)
+          v32:Fixnum[3] = Const Value(3)
+          Jump bb4(v32)
         bb6():
           v22:BasicObject = Send v10, :foo # SendFallbackReason: Send: polymorphic call site
           Jump bb4(v22)
@@ -20596,17 +20600,17 @@ mod hir_opt_tests {
         bb5():
           v24:HeapFloat = RefineType v12, HeapFloat
           PatchPoint MethodRedefined(Float@0x1008, *@0x1010, cme:0x1018)
-          v42:BasicObject = CCallWithFrame v24, :Float#*@0x1040, v13
-          Jump bb4(v42)
+          v43:BasicObject = CCallWithFrame v24, :Float#*@0x1040, v13
+          Jump bb4(v43)
         bb6():
           v27:CBool = HasType v12, Flonum
           CondBranch v27, bb7(), bb8()
         bb7():
           v30:Flonum = RefineType v12, Flonum
           PatchPoint MethodRedefined(Float@0x1008, *@0x1010, cme:0x1018)
-          v45:Flonum = GuardType v13, Flonum recompile
-          v46:Float = FloatMul v30, v45
-          Jump bb4(v46)
+          v47:Flonum = GuardType v13, Flonum recompile
+          v48:Float = FloatMul v30, v47
+          Jump bb4(v48)
         bb8():
           v33:BasicObject = Send v12, :*, v13 # SendFallbackReason: Send: polymorphic call site
           Jump bb4(v33)
@@ -20882,7 +20886,7 @@ mod hir_opt_tests {
           v8:BasicObject = LoadArg :x@1
           Jump bb3(v7, v8)
         bb3(v11:HeapBasicObject, v12:BasicObject):
-          v90:NilClass = Const Value(nil)
+          v92:NilClass = Const Value(nil)
           v17:Fixnum[1] = Const Value(1)
           PatchPoint SingleRactorMode
           v21:CShape = LoadField v11, :shape_id@0x1001
@@ -20912,16 +20916,16 @@ mod hir_opt_tests {
         bb10():
           v51:Fixnum = RefineType v12, Fixnum
           PatchPoint MethodRedefined(Integer@0x1008, +@0x1010, cme:0x1018)
-          v86:Fixnum = FixnumAdd v51, v44
-          Jump bb9(v86)
+          v87:Fixnum = FixnumAdd v51, v44
+          Jump bb9(v87)
         bb11():
           v54:CBool = HasType v12, Flonum
           CondBranch v54, bb12(), bb13()
         bb12():
           v57:Flonum = RefineType v12, Flonum
           PatchPoint MethodRedefined(Float@0x1040, +@0x1010, cme:0x1048)
-          v89:Float = FloatAdd v57, v44
-          Jump bb9(v89)
+          v91:Float = FloatAdd v57, v44
+          Jump bb9(v91)
         bb13():
           v60:BasicObject = Send v12, :+, v44 # SendFallbackReason: Send: polymorphic call site
           Jump bb9(v60)

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -1769,9 +1769,9 @@ mod hir_opt_tests {
           PatchPoint MethodRedefined(NilClass@0x1058, nil?@0x1060, cme:0x1068)
           v38:Fixnum[0] = Const Value(0)
           CheckInterrupts
-          v85:Fixnum[0] = Const Value(0)
+          v83:Fixnum[0] = Const Value(0)
           PopInlineFrame
-          Return v85
+          Return v83
         ");
     }
 
@@ -9715,18 +9715,18 @@ mod hir_opt_tests {
           CondBranch v42, bb8(), bb9()
         bb8():
           PatchPoint MethodRedefined(FalseClass@0x1008, !@0x1010, cme:0x1018)
-          v48:TrueClass = Const Value(true)
-          Jump bb7(v48)
+          v47:TrueClass = Const Value(true)
+          Jump bb7(v47)
         bb9():
-          v50:CBool = HasType v31, NilClass
-          CondBranch v50, bb10(), bb11()
+          v49:CBool = HasType v31, NilClass
+          CondBranch v49, bb10(), bb11()
         bb10():
           PatchPoint MethodRedefined(NilClass@0x1040, !@0x1010, cme:0x1018)
-          v56:TrueClass = Const Value(true)
-          Jump bb7(v56)
+          v54:TrueClass = Const Value(true)
+          Jump bb7(v54)
         bb11():
-          v58:BasicObject = Send v31, :! # SendFallbackReason: Send: polymorphic fallback
-          Jump bb7(v58)
+          v56:BasicObject = Send v31, :! # SendFallbackReason: Send: polymorphic fallback
+          Jump bb7(v56)
         bb7(v41:BasicObject):
           CheckInterrupts
           Return v41
@@ -10469,9 +10469,9 @@ mod hir_opt_tests {
           StoreField v30, :@foo@0x1040, v17
           Jump bb4(v17)
         bb8():
-          v40:CShape[0x1041] = Const CShape(0x1041)
-          v41:CBool = IsBitEqual v31, v40
-          CondBranch v41, bb9(), bb10()
+          v39:CShape[0x1041] = Const CShape(0x1041)
+          v40:CBool = IsBitEqual v31, v39
+          CondBranch v40, bb9(), bb10()
         bb9():
           PatchPoint MethodRedefined(C@0x1008, foo=@0x1010, cme:0x1018)
           StoreField v30, :@foo@0x1042, v17
@@ -10479,8 +10479,8 @@ mod hir_opt_tests {
         bb10():
           Jump bb6()
         bb6():
-          v49:BasicObject = Send v10, :foo=, v17 # SendFallbackReason: Send: polymorphic fallback
-          Jump bb4(v49)
+          v47:BasicObject = Send v10, :foo=, v17 # SendFallbackReason: Send: polymorphic fallback
+          Jump bb4(v47)
         bb4(v27:BasicObject):
           CheckInterrupts
           Return v17
@@ -11064,22 +11064,22 @@ mod hir_opt_tests {
         bb7():
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
-          v32:BasicObject = LoadField v24, :@foo@0x1040
-          Jump bb4(v32)
+          v31:BasicObject = LoadField v24, :@foo@0x1040
+          Jump bb4(v31)
         bb8():
-          v34:CShape[0x1041] = Const CShape(0x1041)
-          v35:CBool = IsBitEqual v25, v34
-          CondBranch v35, bb9(), bb10()
+          v33:CShape[0x1041] = Const CShape(0x1041)
+          v34:CBool = IsBitEqual v25, v33
+          CondBranch v34, bb9(), bb10()
         bb9():
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
-          v40:BasicObject = LoadField v24, :@foo@0x1042
-          Jump bb4(v40)
+          v38:BasicObject = LoadField v24, :@foo@0x1042
+          Jump bb4(v38)
         bb10():
           Jump bb6()
         bb6():
-          v43:BasicObject = Send v10, :foo # SendFallbackReason: Send: polymorphic fallback
-          Jump bb4(v43)
+          v41:BasicObject = Send v10, :foo # SendFallbackReason: Send: polymorphic fallback
+          Jump bb4(v41)
         bb4(v21:BasicObject):
           CheckInterrupts
           Return v21
@@ -14895,39 +14895,39 @@ mod hir_opt_tests {
         bb5():
           v30:ObjectSubclass[class_exact:CallerSplatA] = RefineType v12, ObjectSubclass[class_exact:CallerSplatA]
           PatchPoint NoSingletonClass(CallerSplatA@0x1008)
-          v33:CInt64 = ArrayLength v19
-          v34:CInt64[1] = GuardBitEquals v33, CInt64(1) recompile
-          v35:CInt64 = CCall v19, :rb_jit_ruby2_keywords_splat_p@0x1010
-          v36:CInt64[0] = GuardBitEquals v35, CInt64(0)
+          v32:CInt64 = ArrayLength v19
+          v33:CInt64[1] = GuardBitEquals v32, CInt64(1) recompile
+          v34:CInt64 = CCall v19, :rb_jit_ruby2_keywords_splat_p@0x1010
+          v35:CInt64[0] = GuardBitEquals v34, CInt64(0)
           PatchPoint MethodRedefined(CallerSplatA@0x1008, target@0x1011, cme:0x1018)
-          v38:CInt64[0] = Const CInt64(0)
-          v39:BasicObject = ArrayAref v19, v38
-          v40:ArrayExact = NewArray v39
+          v37:CInt64[0] = Const CInt64(0)
+          v38:BasicObject = ArrayAref v19, v37
+          v39:ArrayExact = NewArray v38
           PushInlineFrame :target, v30 (0x1040), num_args=1
           CheckInterrupts
           PopInlineFrame
-          Jump bb4(v40)
+          Jump bb4(v39)
         bb6():
-          v44:CBool = HasType v12, ObjectSubclass[class_exact:CallerSplatB]
-          CondBranch v44, bb7(), bb8()
+          v43:CBool = HasType v12, ObjectSubclass[class_exact:CallerSplatB]
+          CondBranch v43, bb7(), bb8()
         bb7():
-          v46:ObjectSubclass[class_exact:CallerSplatB] = RefineType v12, ObjectSubclass[class_exact:CallerSplatB]
+          v45:ObjectSubclass[class_exact:CallerSplatB] = RefineType v12, ObjectSubclass[class_exact:CallerSplatB]
           PatchPoint NoSingletonClass(CallerSplatB@0x1060)
-          v49:CInt64 = ArrayLength v19
-          v50:CInt64[1] = GuardBitEquals v49, CInt64(1) recompile
-          v51:CInt64 = CCall v19, :rb_jit_ruby2_keywords_splat_p@0x1010
-          v52:CInt64[0] = GuardBitEquals v51, CInt64(0)
+          v47:CInt64 = ArrayLength v19
+          v48:CInt64[1] = GuardBitEquals v47, CInt64(1) recompile
+          v49:CInt64 = CCall v19, :rb_jit_ruby2_keywords_splat_p@0x1010
+          v50:CInt64[0] = GuardBitEquals v49, CInt64(0)
           PatchPoint MethodRedefined(CallerSplatB@0x1060, target@0x1011, cme:0x1068)
-          v54:CInt64[0] = Const CInt64(0)
-          v55:BasicObject = ArrayAref v19, v54
-          v56:ArrayExact = NewArray v55
-          PushInlineFrame :target, v46 (0x1090), num_args=1
+          v52:CInt64[0] = Const CInt64(0)
+          v53:BasicObject = ArrayAref v19, v52
+          v54:ArrayExact = NewArray v53
+          PushInlineFrame :target, v45 (0x1090), num_args=1
           CheckInterrupts
           PopInlineFrame
-          Jump bb4(v56)
+          Jump bb4(v54)
         bb8():
-          v60:BasicObject = Send v12, :target, v19 # SendFallbackReason: Send: polymorphic call site
-          Jump bb4(v60)
+          v58:BasicObject = Send v12, :target, v19 # SendFallbackReason: Send: polymorphic call site
+          Jump bb4(v58)
         bb4(v27:BasicObject):
           CheckInterrupts
           Return v27
@@ -18720,26 +18720,26 @@ mod hir_opt_tests {
         bb5():
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
-          v33:Fixnum[3] = Const Value(3)
-          Jump bb4(v33)
+          v32:Fixnum[3] = Const Value(3)
+          Jump bb4(v32)
         bb6():
-          v35:CBool = HasType v10, ObjectSubclass[class_exact:D]
-          CondBranch v35, bb7(), bb8()
+          v34:CBool = HasType v10, ObjectSubclass[class_exact:D]
+          CondBranch v34, bb7(), bb8()
         bb7():
           PatchPoint NoSingletonClass(D@0x1040)
           PatchPoint MethodRedefined(D@0x1040, foo@0x1010, cme:0x1048)
-          v41:Fixnum[4] = Const Value(4)
-          Jump bb4(v41)
+          v39:Fixnum[4] = Const Value(4)
+          Jump bb4(v39)
         bb8():
-          v43:BasicObject = Send v10, :foo # SendFallbackReason: Send: polymorphic fallback
-          Jump bb4(v43)
+          v41:BasicObject = Send v10, :foo # SendFallbackReason: Send: polymorphic fallback
+          Jump bb4(v41)
         bb4(v26:BasicObject):
           v17:Fixnum[2] = Const Value(2)
           PatchPoint MethodRedefined(Integer@0x1070, +@0x1078, cme:0x1080)
-          v47:Fixnum = GuardType v26, Fixnum recompile
-          v48:Fixnum = FixnumAdd v47, v17
+          v45:Fixnum = GuardType v26, Fixnum recompile
+          v46:Fixnum = FixnumAdd v45, v17
           CheckInterrupts
-          Return v48
+          Return v46
         ");
     }
 
@@ -18777,15 +18777,15 @@ mod hir_opt_tests {
           PatchPoint MethodRedefined(C@0x1008, itself@0x1010, cme:0x1018)
           Jump bb4(v24)
         bb6():
-          v30:CBool = HasType v10, Fixnum
-          CondBranch v30, bb7(), bb8()
+          v29:CBool = HasType v10, Fixnum
+          CondBranch v29, bb7(), bb8()
         bb7():
-          v32:Fixnum = RefineType v10, Fixnum
+          v31:Fixnum = RefineType v10, Fixnum
           PatchPoint MethodRedefined(Integer@0x1040, itself@0x1010, cme:0x1018)
-          Jump bb4(v32)
+          Jump bb4(v31)
         bb8():
-          v37:BasicObject = Send v10, :itself # SendFallbackReason: Send: polymorphic fallback
-          Jump bb4(v37)
+          v35:BasicObject = Send v10, :itself # SendFallbackReason: Send: polymorphic fallback
+          Jump bb4(v35)
         bb4(v21:BasicObject):
           CheckInterrupts
           Return v21
@@ -18825,11 +18825,11 @@ mod hir_opt_tests {
           PatchPoint StableConstantNames(0x1068, Integer)
           v31:ClassSubclass[Integer@0x1070] = Const Value(VALUE(0x1070))
           PatchPoint MethodRedefined(Class@0x1078, ==@0x1080, cme:0x1088)
-          v50:CBool = IsBitEqual v12, v31
-          v51:BoolExact = BoxBool v50
+          v49:CBool = IsBitEqual v12, v31
+          v50:BoolExact = BoxBool v49
           CheckInterrupts
           PopInlineFrame
-          Return v51
+          Return v50
         ");
     }
 
@@ -18871,27 +18871,27 @@ mod hir_opt_tests {
           v29:ArrayExact = RefineType v12, ArrayExact
           PatchPoint NoSingletonClass(Array@0x1008)
           PatchPoint MethodRedefined(Array@0x1008, []@0x1010, cme:0x1018)
-          v34:Fixnum = GuardType v13, Fixnum
-          v35:CInt64 = UnboxFixnum v34
-          v36:CInt64 = ArrayLength v29
-          v37:CInt64 = GuardLess v35, v36
-          v38:CInt64 = AdjustBounds v37, v36
-          v39:CInt64[0] = Const CInt64(0)
-          v40:CInt64 = GuardGreaterEq v38, v39
-          v41:BasicObject = ArrayAref v29, v40
-          Jump bb4(v41)
+          v33:Fixnum = GuardType v13, Fixnum
+          v34:CInt64 = UnboxFixnum v33
+          v35:CInt64 = ArrayLength v29
+          v36:CInt64 = GuardLess v34, v35
+          v37:CInt64 = AdjustBounds v36, v35
+          v38:CInt64[0] = Const CInt64(0)
+          v39:CInt64 = GuardGreaterEq v37, v38
+          v40:BasicObject = ArrayAref v29, v39
+          Jump bb4(v40)
         bb6():
-          v43:CBool = HasType v12, HashExact
-          CondBranch v43, bb7(), bb8()
+          v42:CBool = HasType v12, HashExact
+          CondBranch v42, bb7(), bb8()
         bb7():
-          v45:HashExact = RefineType v12, HashExact
+          v44:HashExact = RefineType v12, HashExact
           PatchPoint NoSingletonClass(Hash@0x1040)
           PatchPoint MethodRedefined(Hash@0x1040, []@0x1010, cme:0x1048)
-          v50:BasicObject = HashAref v45, v13
-          Jump bb4(v50)
+          v48:BasicObject = HashAref v44, v13
+          Jump bb4(v48)
         bb8():
-          v52:BasicObject = Send v12, :[], v13 # SendFallbackReason: Send: polymorphic fallback
-          Jump bb4(v52)
+          v50:BasicObject = Send v12, :[], v13 # SendFallbackReason: Send: polymorphic fallback
+          Jump bb4(v50)
         bb4(v26:BasicObject):
           CheckInterrupts
           Return v26
@@ -18935,19 +18935,19 @@ mod hir_opt_tests {
         bb5():
           v24:Fixnum = RefineType v10, Fixnum
           PatchPoint MethodRedefined(Integer@0x1008, to_s@0x1010, cme:0x1018)
-          v28:StringExact = CCallVariadic v24, :Integer#to_s@0x1040
-          Jump bb4(v28)
+          v27:StringExact = CCallVariadic v24, :Integer#to_s@0x1040
+          Jump bb4(v27)
         bb6():
-          v30:CBool = HasType v10, Bignum
-          CondBranch v30, bb8(), bb9()
+          v29:CBool = HasType v10, Bignum
+          CondBranch v29, bb8(), bb9()
         bb8():
-          v32:Bignum = RefineType v10, Bignum
+          v31:Bignum = RefineType v10, Bignum
           PatchPoint MethodRedefined(Integer@0x1008, to_s@0x1010, cme:0x1018)
-          v36:StringExact = CCallVariadic v32, :Integer#to_s@0x1040
-          Jump bb4(v36)
+          v34:StringExact = CCallVariadic v31, :Integer#to_s@0x1040
+          Jump bb4(v34)
         bb9():
-          v38:BasicObject = Send v10, :to_s # SendFallbackReason: Send: polymorphic fallback
-          Jump bb4(v38)
+          v36:BasicObject = Send v10, :to_s # SendFallbackReason: Send: polymorphic fallback
+          Jump bb4(v36)
         bb4(v21:BasicObject):
           CheckInterrupts
           Return v21
@@ -18988,19 +18988,19 @@ mod hir_opt_tests {
         bb5():
           v24:Flonum = RefineType v10, Flonum
           PatchPoint MethodRedefined(Float@0x1008, to_s@0x1010, cme:0x1018)
-          v28:BasicObject = CCallWithFrame v24, :Float#to_s@0x1040
-          Jump bb4(v28)
+          v27:BasicObject = CCallWithFrame v24, :Float#to_s@0x1040
+          Jump bb4(v27)
         bb6():
-          v30:CBool = HasType v10, HeapFloat
-          CondBranch v30, bb8(), bb9()
+          v29:CBool = HasType v10, HeapFloat
+          CondBranch v29, bb8(), bb9()
         bb8():
-          v32:HeapFloat = RefineType v10, HeapFloat
+          v31:HeapFloat = RefineType v10, HeapFloat
           PatchPoint MethodRedefined(Float@0x1008, to_s@0x1010, cme:0x1018)
-          v36:BasicObject = CCallWithFrame v32, :Float#to_s@0x1040
-          Jump bb4(v36)
+          v34:BasicObject = CCallWithFrame v31, :Float#to_s@0x1040
+          Jump bb4(v34)
         bb9():
-          v38:BasicObject = Send v10, :to_s # SendFallbackReason: Send: polymorphic fallback
-          Jump bb4(v38)
+          v36:BasicObject = Send v10, :to_s # SendFallbackReason: Send: polymorphic fallback
+          Jump bb4(v36)
         bb4(v21:BasicObject):
           CheckInterrupts
           Return v21
@@ -19041,19 +19041,19 @@ mod hir_opt_tests {
         bb5():
           v24:StaticSymbol = RefineType v10, StaticSymbol
           PatchPoint MethodRedefined(Symbol@0x1008, to_s@0x1010, cme:0x1018)
-          v27:StringExact = InvokeBuiltin leaf <inline_expr>, v24
-          Jump bb4(v27)
+          v26:StringExact = InvokeBuiltin leaf <inline_expr>, v24
+          Jump bb4(v26)
         bb6():
-          v29:CBool = HasType v10, DynamicSymbol
-          CondBranch v29, bb8(), bb9()
+          v28:CBool = HasType v10, DynamicSymbol
+          CondBranch v28, bb8(), bb9()
         bb8():
-          v31:DynamicSymbol = RefineType v10, DynamicSymbol
+          v30:DynamicSymbol = RefineType v10, DynamicSymbol
           PatchPoint MethodRedefined(Symbol@0x1008, to_s@0x1010, cme:0x1018)
-          v34:StringExact = InvokeBuiltin leaf <inline_expr>, v31
-          Jump bb4(v34)
+          v32:StringExact = InvokeBuiltin leaf <inline_expr>, v30
+          Jump bb4(v32)
         bb9():
-          v36:BasicObject = Send v10, :to_s # SendFallbackReason: Send: polymorphic fallback
-          Jump bb4(v36)
+          v34:BasicObject = Send v10, :to_s # SendFallbackReason: Send: polymorphic fallback
+          Jump bb4(v34)
         bb4(v21:BasicObject):
           CheckInterrupts
           Return v21
@@ -19098,11 +19098,11 @@ mod hir_opt_tests {
         bb5():
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
-          v28:Fixnum[3] = Const Value(3)
-          Jump bb4(v28)
+          v27:Fixnum[3] = Const Value(3)
+          Jump bb4(v27)
         bb6():
-          v30:BasicObject = Send v10, :foo # SendFallbackReason: Send: polymorphic fallback
-          Jump bb4(v30)
+          v29:BasicObject = Send v10, :foo # SendFallbackReason: Send: polymorphic fallback
+          Jump bb4(v29)
         bb4(v21:BasicObject):
           CheckInterrupts
           Return v21
@@ -20627,20 +20627,20 @@ mod hir_opt_tests {
         bb5():
           v29:HeapFloat = RefineType v12, HeapFloat
           PatchPoint MethodRedefined(Float@0x1008, *@0x1010, cme:0x1018)
-          v33:BasicObject = CCallWithFrame v29, :Float#*@0x1040, v13
-          Jump bb4(v33)
+          v32:BasicObject = CCallWithFrame v29, :Float#*@0x1040, v13
+          Jump bb4(v32)
         bb6():
-          v35:CBool = HasType v12, Flonum
-          CondBranch v35, bb8(), bb9()
+          v34:CBool = HasType v12, Flonum
+          CondBranch v34, bb8(), bb9()
         bb8():
-          v37:Flonum = RefineType v12, Flonum
+          v36:Flonum = RefineType v12, Flonum
           PatchPoint MethodRedefined(Float@0x1008, *@0x1010, cme:0x1018)
-          v41:Flonum = GuardType v13, Flonum recompile
-          v42:Float = FloatMul v37, v41
-          Jump bb4(v42)
+          v39:Flonum = GuardType v13, Flonum recompile
+          v40:Float = FloatMul v36, v39
+          Jump bb4(v40)
         bb9():
-          v44:BasicObject = Send v12, :*, v13 # SendFallbackReason: Send: polymorphic fallback
-          Jump bb4(v44)
+          v42:BasicObject = Send v12, :*, v13 # SendFallbackReason: Send: polymorphic fallback
+          Jump bb4(v42)
         bb4(v26:BasicObject):
           CheckInterrupts
           Return v26
@@ -20857,7 +20857,7 @@ mod hir_opt_tests {
           v8:BasicObject = LoadArg :x@1
           Jump bb3(v7, v8)
         bb3(v11:HeapBasicObject, v12:BasicObject):
-          v81:NilClass = Const Value(nil)
+          v80:NilClass = Const Value(nil)
           v17:Fixnum[1] = Const Value(1)
           PatchPoint SingleRactorMode
           v21:CShape = LoadField v11, :shape_id@0x1001
@@ -20887,11 +20887,11 @@ mod hir_opt_tests {
         bb13():
           v73:Fixnum = RefineType v12, Fixnum
           PatchPoint MethodRedefined(Integer@0x1008, +@0x1010, cme:0x1018)
-          v77:Fixnum = FixnumAdd v73, v44
-          Jump bb12(v77)
+          v76:Fixnum = FixnumAdd v73, v44
+          Jump bb12(v76)
         bb14():
-          v79:BasicObject = Send v12, :+, v44 # SendFallbackReason: Send: polymorphic fallback
-          Jump bb12(v79)
+          v78:BasicObject = Send v12, :+, v44 # SendFallbackReason: Send: polymorphic fallback
+          Jump bb12(v78)
         bb12(v70:BasicObject):
           PatchPoint SingleRactorMode
           v55:CShape = LoadField v11, :shape_id@0x1001
@@ -20922,7 +20922,7 @@ mod hir_opt_tests {
           v8:BasicObject = LoadArg :x@1
           Jump bb3(v7, v8)
         bb3(v11:HeapBasicObject, v12:BasicObject):
-          v89:NilClass = Const Value(nil)
+          v87:NilClass = Const Value(nil)
           v17:Fixnum[1] = Const Value(1)
           PatchPoint SingleRactorMode
           v21:CShape = LoadField v11, :shape_id@0x1001
@@ -20952,19 +20952,19 @@ mod hir_opt_tests {
         bb13():
           v73:Fixnum = RefineType v12, Fixnum
           PatchPoint MethodRedefined(Integer@0x1008, +@0x1010, cme:0x1018)
-          v77:Fixnum = FixnumAdd v73, v44
-          Jump bb12(v77)
+          v76:Fixnum = FixnumAdd v73, v44
+          Jump bb12(v76)
         bb14():
-          v79:CBool = HasType v12, Flonum
-          CondBranch v79, bb15(), bb16()
+          v78:CBool = HasType v12, Flonum
+          CondBranch v78, bb15(), bb16()
         bb15():
-          v81:Flonum = RefineType v12, Flonum
+          v80:Flonum = RefineType v12, Flonum
           PatchPoint MethodRedefined(Float@0x1040, +@0x1010, cme:0x1048)
-          v85:Float = FloatAdd v81, v44
-          Jump bb12(v85)
+          v83:Float = FloatAdd v80, v44
+          Jump bb12(v83)
         bb16():
-          v87:BasicObject = Send v12, :+, v44 # SendFallbackReason: Send: polymorphic fallback
-          Jump bb12(v87)
+          v85:BasicObject = Send v12, :+, v44 # SendFallbackReason: Send: polymorphic fallback
+          Jump bb12(v85)
         bb12(v70:BasicObject):
           PatchPoint SingleRactorMode
           v55:CShape = LoadField v11, :shape_id@0x1001


### PR DESCRIPTION
This lets us optimize polymorphic attr_reader to field loads instead of
generic getivar.
