### PR TITLE
ZJIT: Add support for once instruction

### DIFF
--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -6718,6 +6718,20 @@ rb_vm_opt_getconstant_path(rb_execution_context_t *ec, rb_control_frame_t *const
     return val;
 }
 
+// Return true if the once value is already computed and set *result to the value.
+// Otherwise, return false.
+// Used for ZJIT. Keep in sync with `vm_once_dispatch` below.
+bool
+rb_vm_once_done_value(ISE is, VALUE *result)
+{
+    rb_thread_t *running_th = rbimpl_atomic_ptr_load((void**)&is->once.running_thread, RBIMPL_ATOMIC_ACQUIRE);
+    if (running_th == RUNNING_THREAD_ONCE_DONE) {
+        *result = is->once.value;
+        return true;
+    }
+    return false;
+}
+
 static VALUE
 vm_once_dispatch(rb_execution_context_t *ec, ISEQ iseq, ISE is)
 {

--- a/zjit.c
+++ b/zjit.c
@@ -269,6 +269,7 @@ rb_zjit_class_has_default_allocator(VALUE klass)
 
 VALUE rb_vm_untag_block_handler(VALUE block_handler);
 VALUE rb_vm_get_untagged_block_handler(rb_control_frame_t *reg_cfp);
+bool rb_vm_once_done_value(ISE is, VALUE *result);
 
 // Primitives used by zjit.rb. Don't put other functions below, which wouldn't use them.
 VALUE rb_zjit_enable(rb_execution_context_t *ec, VALUE self);

--- a/zjit/bindgen/src/main.rs
+++ b/zjit/bindgen/src/main.rs
@@ -276,6 +276,7 @@ fn main() {
         .allowlist_function("rb_callable_method_entry")
         .allowlist_function("rb_callable_method_entry_or_negative")
         .allowlist_function("rb_vm_frame_method_entry")
+        .allowlist_function("rb_vm_once_done_value")
         .allowlist_type("IVC") // pointer to iseq_inline_iv_cache_entry
         .allowlist_type("IC")  // pointer to iseq_inline_constant_cache
         .allowlist_type("iseq_inline_constant_cache_entry")

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -1649,6 +1649,7 @@ pub type vm_special_object_type = u32;
 pub type IC = *mut iseq_inline_constant_cache;
 pub type IVC = *mut iseq_inline_iv_cache_entry;
 pub type ICVARC = *mut iseq_inline_cvar_cache_entry;
+pub type ISE = *mut iseq_inline_storage_entry;
 pub const VM_FRAME_MAGIC_METHOD: vm_frame_env_flags = 286326785;
 pub const VM_FRAME_MAGIC_BLOCK: vm_frame_env_flags = 572653569;
 pub const VM_FRAME_MAGIC_CLASS: vm_frame_env_flags = 858980353;
@@ -2475,6 +2476,7 @@ unsafe extern "C" {
     pub fn rb_zjit_class_has_default_allocator(klass: VALUE) -> bool;
     pub fn rb_vm_untag_block_handler(block_handler: VALUE) -> VALUE;
     pub fn rb_vm_get_untagged_block_handler(reg_cfp: *mut rb_control_frame_t) -> VALUE;
+    pub fn rb_vm_once_done_value(is: ISE, result: *mut VALUE) -> bool;
     pub fn rb_iseq_encoded_size(iseq: *const rb_iseq_t) -> ::std::os::raw::c_uint;
     pub fn rb_iseq_pc_at_idx(iseq: *const rb_iseq_t, insn_idx: u32) -> *mut VALUE;
     pub fn rb_iseq_opcode_at_pc(iseq: *const rb_iseq_t, pc: *const VALUE) -> ::std::os::raw::c_int;

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -673,6 +673,7 @@ pub enum SideExitReason {
     NoProfileGetIvar,
     NoProfileSetIvar,
     InvokeBlockNotIfunc,
+    OnceNotDone,
 }
 
 /// Marks a side exit as triggering profiling and recompilation.
@@ -9386,6 +9387,21 @@ fn add_iseq_to_hir(
                                 }
                             }
                         }
+                    }
+                }
+                YARVINSN_once => {
+                    let iseq: *const rb_iseq_t = get_arg(pc, 0).as_ptr();
+                    let ise: *mut iseq_inline_storage_entry = get_arg(pc, 1).as_mut_ptr();
+                    debug_assert!(!iseq.is_null());
+                    debug_assert!(!ise.is_null());
+                    let mut value = Qnil;
+                    if unsafe { rb_vm_once_done_value(ise, &mut value) } {
+                        let val = fun.push_insn(block, Insn::Const { val: Const::Value(value) });
+                        state.stack_push(val);
+                    } else {
+                        // Exit
+                        fun.push_insn(block, Insn::SideExit { state: exit_id, reason: Box::new(SideExitReason::OnceNotDone), recompile: Some(Recompile) });
+                        break;  // End the block
                     }
                 }
                 YARVINSN_branchunless | YARVINSN_branchunless_without_ints => {

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -9399,7 +9399,6 @@ fn add_iseq_to_hir(
                         let val = fun.push_insn(block, Insn::Const { val: Const::Value(value) });
                         state.stack_push(val);
                     } else {
-                        // Exit
                         fun.push_insn(block, Insn::SideExit { state: exit_id, reason: Box::new(SideExitReason::OnceNotDone), recompile: Some(Recompile) });
                         break;  // End the block
                     }

--- a/zjit/src/hir/tests.rs
+++ b/zjit/src/hir/tests.rs
@@ -6273,6 +6273,49 @@ pub(crate) mod hir_build_tests {
         Return v22
       ");
     }
+
+    #[test]
+    fn test_once_not_done_side_exits() {
+        eval("
+            def test = /#{'a'.upcase}/o
+        ");
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:2:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          Jump bb3(v1)
+        bb2():
+          EntryPoint JIT(0)
+          v4:BasicObject = LoadArg :self@0
+          Jump bb3(v4)
+        bb3(v6:BasicObject):
+          SideExit OnceNotDone recompile
+        ");
+    }
+
+    #[test]
+    fn test_once_done_returns_value() {
+        eval("
+            def test = /#{'a'.upcase}/o
+            test
+        ");
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:2:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          Jump bb3(v1)
+        bb2():
+          EntryPoint JIT(0)
+          v4:BasicObject = LoadArg :self@0
+          Jump bb3(v4)
+        bb3(v6:BasicObject):
+          v10:RegexpExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          CheckInterrupts
+          Return v10
+        ");
+    }
 }
 
  /// Test successor and predecessor set computations.

--- a/zjit/src/hir/tests.rs
+++ b/zjit/src/hir/tests.rs
@@ -6292,6 +6292,24 @@ pub(crate) mod hir_build_tests {
         bb3(v6:BasicObject):
           SideExit OnceNotDone recompile
         ");
+        // Running the method fills in the once cache, so a recompile sees the
+        // cached value instead of side-exiting.
+        eval("test");
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:2:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          Jump bb3(v1)
+        bb2():
+          EntryPoint JIT(0)
+          v4:BasicObject = LoadArg :self@0
+          Jump bb3(v4)
+        bb3(v6:BasicObject):
+          v10:RegexpExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          CheckInterrupts
+          Return v10
+        ");
     }
 
     #[test]

--- a/zjit/src/stats.rs
+++ b/zjit/src/stats.rs
@@ -251,6 +251,7 @@ make_counters! {
         exit_directive_induced,
         exit_send_while_tracing,
         exit_invokeblock_not_ifunc,
+        exit_once_not_done,
     }
 
     // Send fallback counters that are summed as dynamic_send_count
@@ -673,6 +674,7 @@ pub fn side_exit_counter(reason: crate::hir::SideExitReason) -> Counter {
         NoProfileGetIvar              => exit_no_profile_getivar,
         NoProfileSetIvar              => exit_no_profile_setivar,
         InvokeBlockNotIfunc           => exit_invokeblock_not_ifunc,
+        OnceNotDone                   => exit_once_not_done,
     }
 }
 


### PR DESCRIPTION
Much like `opt_getconstant_path`, check the cache and see if the
interpreter has done the hard work for us already. If it has, just
re-use the result.

For example, support regexp modifier `o` , which runs the code to
create the regular expression... once:

```ruby
def test = /#{'a'.upcase}/o
```