### PR TITLE
win32: Fix reconfiguring a reused out-of-source build directory

### DIFF
--- a/win32/configure.bat
+++ b/win32/configure.bat
@@ -161,11 +161,13 @@ goto :loopend ;
   )
 goto :loopend ;
 :withoutarg
+  ::- These take an argument and are recorded in :witharg.  Recording
+  ::- them here too would duplicate them at each reconfiguration.
+  if "%opt%" == "--without-ext" goto :witharg
+  if "%opt%" == "--without-extensions" goto :witharg
   echo>>%confargs%  "%opt%" \
   if "%opt%" == "--without-baseruby" goto :nobaseruby
   if "%opt%" == "--without-git" goto :nogit
-  if "%opt%" == "--without-ext" goto :witharg
-  if "%opt%" == "--without-extensions" goto :witharg
 goto :loop ;
 :witharg
   if "%opt%" == "--with-static-linked-ext" goto :extstatic

--- a/win32/setup.mak
+++ b/win32/setup.mak
@@ -55,10 +55,14 @@ prefix = $(prefix:\=/)
 	@cd $(srcdir:/=\)\tool && $(BASERUBY:/=\) missing-baseruby.bat --verbose || exit $(HAVE_BASERUBY:yes=non-)0
 !endif
 
+# Unlike -baseruby-, this runs in the build directory, where a just
+# built `ruby.exe` would be found prior to $PATH but cannot load the
+# standard library yet.
 -dependencies-: -baseruby-
 !if "$(HAVE_BASERUBY)" != "no"
-	@$(BASERUBY:/=\) $(srcdir)/tool/mkdepend.rb --root=$(srcdir) \
-	    --scope=core --nmake --output=.deps
+	@$(COMSPEC) /C "set NoDefaultCurrentDirectoryInExePath=1& \
+	$(BASERUBY:/=\) $(srcdir)/tool/mkdepend.rb --root=$(srcdir) \
+	    --scope=core --nmake --output=.deps"
 !endif
 
 -gmp-:


### PR DESCRIPTION
Reconfiguring an out-of-source build directory that already produced `ruby.exe` fails. `win32/setup.mak` runs `tool/mkdepend.rb` with a bare `ruby`, and `cmd.exe` searches the current directory before `$PATH`, so it picks the just built executable, which cannot load the standard library yet. `configure.bat` then aborts before renaming `Makefile`, and the following `fc Makefile Makefile.old` keeps asking for another `nmake`. The neighbouring `-baseruby-` rule avoids this by changing into `$(srcdir)/tool` first. NMAKE applies a bare `SET` to its own environment, hence the subshell, which keeps `verconf.bat` findable in the later rules.

The second commit stops `--without-ext` from being recorded in `configure_args` both as a bare flag and with its argument. Each reconfiguration re-reads them and doubles the bare copies, which eventually overflows the command line.

Generated with [Claude Code](https://claude.com/claude-code)
