### PR TITLE
Fix the Etc.getlogin spec on Windows

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -284,6 +284,10 @@ Ruby 4.0 bundled RubyGems and Bundler version 4. see the following links for det
 
 ## Stdlib compatibility issues
 
+* `Etc.getlogin` on Windows now returns the login name determined when the
+  process starts, from the `USER` or `USERNAME` environment variable or
+  `GetUserName()`.  It used to follow later changes to `ENV['USER']`.
+
 ## C API updates
 
 ### Embedded TypedData

--- a/spec/ruby/library/etc/getlogin_spec.rb
+++ b/spec/ruby/library/etc/getlogin_spec.rb
@@ -5,8 +5,8 @@ platform_is :windows do
   describe "Etc.getlogin" do
     it "returns the name associated with the current login activity" do
       # The login name is determined when the process starts, from ENV['USER'],
-      # ENV['USERNAME'] or GetUserName(), so ENV['USER'] has no effect here.
-      Etc.getlogin.should == ENV['USERNAME']
+      # ENV['USERNAME'] or GetUserName(), and ENV['USER'] is set from it.
+      Etc.getlogin.should == ENV['USER']
     end
   end
 end

--- a/spec/ruby/library/etc/getlogin_spec.rb
+++ b/spec/ruby/library/etc/getlogin_spec.rb
@@ -1,43 +1,55 @@
 require_relative '../../spec_helper'
 require 'etc'
 
-describe "Etc.getlogin" do
-  it "returns the name associated with the current login activity" do
-    getlogin_null = false
-
-    # POSIX logname(1) shows getlogin(2)'s result
-    # NOTE: Etc.getlogin returns ENV['USER'] if getlogin(2) returns NULL
-    begin
-      # make Etc.getlogin to return nil if getlogin(3) returns NULL
-      envuser, ENV['USER'] = ENV['USER'], nil
-      if Etc.getlogin
-        if ENV['TRAVIS'] and platform_is(:darwin)
-          # See https://travis-ci.org/ruby/spec/jobs/285967744
-          # and https://travis-ci.org/ruby/spec/jobs/285999602
-          Etc.getlogin.should.instance_of?(String)
-        else
-          # Etc.getlogin returns the same result of logname(2)
-          # if it returns non NULL
-          if system("which logname", out: File::NULL, err: File::NULL)
-            Etc.getlogin.should == `logname`.chomp
-          else
-            # fallback to `id` command since `logname` is not available
-            Etc.getlogin.should == `id -un`.chomp
-          end
-        end
-      else
-        # Etc.getlogin may return nil if the login name is not set
-        # because of chroot or sudo or something.
-        Etc.getlogin.should == nil
-        getlogin_null = true
-      end
-    ensure
-      ENV['USER'] = envuser
+platform_is :windows do
+  describe "Etc.getlogin" do
+    it "returns the name associated with the current login activity" do
+      # The login name is determined when the process starts, from ENV['USER'],
+      # ENV['USERNAME'] or GetUserName(), so ENV['USER'] has no effect here.
+      Etc.getlogin.should == ENV['USERNAME']
     end
+  end
+end
 
-    # if getlogin(2) returns NULL, Etc.getlogin returns ENV['USER']
-    if getlogin_null
-      Etc.getlogin.should == ENV['USER']
+platform_is_not :windows do
+  describe "Etc.getlogin" do
+    it "returns the name associated with the current login activity" do
+      getlogin_null = false
+
+      # POSIX logname(1) shows getlogin(2)'s result
+      # NOTE: Etc.getlogin returns ENV['USER'] if getlogin(2) returns NULL
+      begin
+        # make Etc.getlogin to return nil if getlogin(3) returns NULL
+        envuser, ENV['USER'] = ENV['USER'], nil
+        if Etc.getlogin
+          if ENV['TRAVIS'] and platform_is(:darwin)
+            # See https://travis-ci.org/ruby/spec/jobs/285967744
+            # and https://travis-ci.org/ruby/spec/jobs/285999602
+            Etc.getlogin.should.instance_of?(String)
+          else
+            # Etc.getlogin returns the same result of logname(2)
+            # if it returns non NULL
+            if system("which logname", out: File::NULL, err: File::NULL)
+              Etc.getlogin.should == `logname`.chomp
+            else
+              # fallback to `id` command since `logname` is not available
+              Etc.getlogin.should == `id -un`.chomp
+            end
+          end
+        else
+          # Etc.getlogin may return nil if the login name is not set
+          # because of chroot or sudo or something.
+          Etc.getlogin.should == nil
+          getlogin_null = true
+        end
+      ensure
+        ENV['USER'] = envuser
+      end
+
+      # if getlogin(2) returns NULL, Etc.getlogin returns ENV['USER']
+      if getlogin_null
+        Etc.getlogin.should == ENV['USER']
+      end
     end
   end
 end


### PR DESCRIPTION
`spec/ruby/library/etc/getlogin_spec.rb` errored on mswin with `Errno::ENOENT: No such file or directory - id -un`. The example clears `ENV['USER']` expecting `Etc.getlogin` to return `nil`, and otherwise compares the result with `logname` or `id -un`, neither of which exists on Windows.

Since c63df6edd5 the bundled extension checks link the configured libruby instead of the static one, so `have_func("getlogin")` now succeeds on mswin and `Etc.getlogin` returns the login name that `win32/win32.c` captures at startup.

This splits the example per platform as the other specs in that directory do. The Windows expectation is `ENV['USER']`, which `win32/win32.c` sets from the same login name, so it holds whether or not the extension detected `getlogin(3)` and when `USER` differs from `USERNAME`. NEWS records the behaviour change.

Generated with [Claude Code](https://claude.com/claude-code)
