### PR TITLE
runruby.rb: Ask baseruby for its effective CA bundle on Windows

### DIFF
--- a/tool/runruby.rb
+++ b/tool/runruby.rb
@@ -142,14 +142,14 @@ env['LD_BIND_NOW'] = 'yes' if /freebsd/ =~ RUBY_PLATFORM
 
 # On Windows the freshly built ruby often has no usable default CA bundle (its
 # OpenSSL's OPENSSLDIR does not exist), which breaks HTTPS in tests such as
-# test-bundler. Fall back to the CA bundle of baseruby (the installed ruby the
-# build was bootstrapped with, recorded in the fake script), unless the caller
-# already configured one.
+# test-bundler. Fall back to whatever bundle baseruby (the installed ruby the
+# build was bootstrapped with, recorded in the fake script) resolves to: it may
+# point SSL_CERT_FILE at one on startup rather than rely on OPENSSLDIR.
 if /mswin|mingw/ =~ RUBY_PLATFORM and !ENV["SSL_CERT_FILE"] and !ENV["SSL_CERT_DIR"]
   fake = File.join(abs_archdir, "#{config['arch']}-fake.rb")
   if File.exist?(fake) and /^baseruby\s*=\s*"([^"\n]+)"/ =~ File.read(fake)
     baseruby = $1
-    script = "f = OpenSSL::X509::DEFAULT_CERT_FILE; print f if File.exist?(f)"
+    script = "f = ENV['SSL_CERT_FILE'] || OpenSSL::X509::DEFAULT_CERT_FILE; print f if File.exist?(f)"
     begin
       cert = IO.popen([baseruby, "-ropenssl", "-e", script], err: File::NULL, &:read)
       env["SSL_CERT_FILE"] = cert if $?.success? and !cert.empty?


### PR DESCRIPTION
On Windows `make test-bundler` and `make test-bundler-parallel` die during spec setup with `certificate verify failed (unable to get local issuer certificate)` while `install_vendored_compact_index` fetches from `raw.githubusercontent.com`. The freshly built ruby has no trust anchors at all, because the mswin OpenSSL bakes an `OPENSSLDIR` that exists on no end-user machine.

The fallback added in f00181bb23 was meant to cover this by borrowing the CA bundle of baseruby, but it asked for `OpenSSL::X509::DEFAULT_CERT_FILE`, which on such an installation names the very same missing path. An installed ruby can still have a working bundle exported into `SSL_CERT_FILE` during startup, so ask for that first and keep `DEFAULT_CERT_FILE` as the fallback for installations whose `OPENSSLDIR` is real.

Verified on mswin by running the bundler spec setup and then one spec through `spec/bin/parallel_rspec`, both of which previously failed at setup.
