### PR TITLE
[4.0] Do not increase ::Object and ::BasicObject `max_iv_count`

### DIFF
--- a/internal/class.h
+++ b/internal/class.h
@@ -730,7 +730,9 @@ RCLASS_SET_ATTACHED_OBJECT(VALUE klass, VALUE attached_object)
 static inline void
 RCLASS_SET_MAX_IV_COUNT(VALUE klass, attr_index_t count)
 {
-    RCLASS_MAX_IV_COUNT(klass) = count;
+    if (klass != rb_cObject && klass != rb_cBasicObject) {
+        RCLASS_MAX_IV_COUNT(klass) = count;
+    }
 }
 
 static inline void

--- a/test/ruby/test_variable.rb
+++ b/test/ruby/test_variable.rb
@@ -62,6 +62,27 @@ class TestVariable < Test::Unit::TestCase
     assert_not_equal god.object_id, zeus.object_id
   end
 
+  def test_raw_object_smallest_slot
+    assert_separately([], <<-"end;")
+      require 'objspace'
+      base_size = ObjectSpace.memsize_of(Object.new)
+
+      assert_equal base_size, ObjectSpace.memsize_of(Object.new)
+
+      object = Object.new
+      10.times do |i|
+        object.instance_variable_set("@iv_\#{i}", i)
+      end
+
+      assert_equal base_size, ObjectSpace.memsize_of(Object.new)
+
+      class TestClass
+      end
+
+      assert_equal base_size, ObjectSpace.memsize_of(TestClass.new)
+    end;
+  end
+
   def test_singleton_class_included_class_variable
     c = Class.new
     c.extend(Olympians)


### PR DESCRIPTION
[[Bug #22290]](https://bugs.ruby-lang.org/issues/22290)

Otherwise any code defining instance variables on `::Object` (including `main`) will bloat all classes defined afterwards.