### PR TITLE
[3.4] Do not increase ::Object and ::BasicObject `max_iv_count`

### DIFF
--- a/shape.c
+++ b/shape.c
@@ -726,7 +726,7 @@ shape_get_next(rb_shape_t *shape, VALUE obj, ID id, bool emit_warnings)
     // Check if we should update max_iv_count on the object's class
     if (BUILTIN_TYPE(obj) == T_OBJECT) {
         VALUE klass = rb_obj_class(obj);
-        if (new_shape->next_iv_index > RCLASS_EXT(klass)->max_iv_count) {
+        if (new_shape->next_iv_index > RCLASS_EXT(klass)->max_iv_count && klass != rb_cObject && klass != rb_cBasicObject) {
             RCLASS_EXT(klass)->max_iv_count = new_shape->next_iv_index;
         }
 

--- a/test/ruby/test_variable.rb
+++ b/test/ruby/test_variable.rb
@@ -62,6 +62,27 @@ class TestVariable < Test::Unit::TestCase
     assert_not_equal god.object_id, zeus.object_id
   end
 
+  def test_raw_object_smallest_slot
+    assert_separately([], <<-"end;")
+      require 'objspace'
+      base_size = ObjectSpace.memsize_of(Object.new)
+
+      assert_equal base_size, ObjectSpace.memsize_of(Object.new)
+
+      object = Object.new
+      10.times do |i|
+        object.instance_variable_set("@iv_\#{i}", i)
+      end
+
+      assert_equal base_size, ObjectSpace.memsize_of(Object.new)
+
+      class TestClass
+      end
+
+      assert_equal base_size, ObjectSpace.memsize_of(TestClass.new)
+    end;
+  end
+
   def test_singleton_class_included_class_variable
     c = Class.new
     c.extend(Olympians)


### PR DESCRIPTION
[[Bug #22290]](https://bugs.ruby-lang.org/issues/22290)

Otherwise any code defining instance variables on `::Object` (including `main`) will bloat all classes defined afterwards.