### PR TITLE
Add and use rb_gc_update_moved(VALUE *obj) which conditionally assigns

### DIFF
--- a/box.c
+++ b/box.c
@@ -203,21 +203,21 @@ rb_box_gc_update_references(void *ptr)
     if (!box) return;
 
     if (box->box_object)
-        box->box_object = rb_gc_location(box->box_object);
+        rb_gc_update_moved(&box->box_object);
     if (box->top_self)
-        box->top_self = rb_gc_location(box->top_self);
-    box->load_path = rb_gc_location(box->load_path);
-    box->expanded_load_path = rb_gc_location(box->expanded_load_path);
-    box->load_path_snapshot = rb_gc_location(box->load_path_snapshot);
+        rb_gc_update_moved(&box->top_self);
+    rb_gc_update_moved(&box->load_path);
+    rb_gc_update_moved(&box->expanded_load_path);
+    rb_gc_update_moved(&box->load_path_snapshot);
     if (box->load_path_check_cache) {
-        box->load_path_check_cache = rb_gc_location(box->load_path_check_cache);
+        rb_gc_update_moved(&box->load_path_check_cache);
     }
-    box->loaded_features = rb_gc_location(box->loaded_features);
-    box->loaded_features_snapshot = rb_gc_location(box->loaded_features_snapshot);
-    box->loaded_features_realpaths = rb_gc_location(box->loaded_features_realpaths);
-    box->loaded_features_realpath_map = rb_gc_location(box->loaded_features_realpath_map);
-    box->ruby_dln_libmap = rb_gc_location(box->ruby_dln_libmap);
-    box->gvar_tbl = rb_gc_location(box->gvar_tbl);
+    rb_gc_update_moved(&box->loaded_features);
+    rb_gc_update_moved(&box->loaded_features_snapshot);
+    rb_gc_update_moved(&box->loaded_features_realpaths);
+    rb_gc_update_moved(&box->loaded_features_realpath_map);
+    rb_gc_update_moved(&box->ruby_dln_libmap);
+    rb_gc_update_moved(&box->gvar_tbl);
 }
 
 void

--- a/cont.c
+++ b/cont.c
@@ -1107,9 +1107,9 @@ cont_compact(void *ptr)
     rb_context_t *cont = ptr;
 
     if (cont->self) {
-        cont->self = rb_gc_location(cont->self);
+        rb_gc_update_moved(&cont->self);
     }
-    cont->value = rb_gc_location(cont->value);
+    rb_gc_update_moved(&cont->value);
     rb_execution_context_update(&cont->saved_ec);
 }
 
@@ -1220,7 +1220,7 @@ void
 rb_fiber_update_self(rb_fiber_t *fiber)
 {
     if (fiber->cont.self) {
-        fiber->cont.self = rb_gc_location(fiber->cont.self);
+        rb_gc_update_moved(&fiber->cont.self);
     }
     else {
         rb_execution_context_update(&fiber->cont.saved_ec);
@@ -1237,7 +1237,7 @@ static void
 fiber_compact(void *ptr)
 {
     rb_fiber_t *fiber = ptr;
-    fiber->first_proc = rb_gc_location(fiber->first_proc);
+    rb_gc_update_moved(&fiber->first_proc);
 
     if (fiber->prev) rb_fiber_update_self(fiber->prev);
 

--- a/gc.c
+++ b/gc.c
@@ -3107,6 +3107,15 @@ rb_gc_location(VALUE value)
     return gc_location_internal(rb_gc_get_objspace(), value);
 }
 
+void
+rb_gc_update_moved(VALUE *ptr)
+{
+    VALUE destination = rb_gc_location(*ptr);
+    if (destination != *ptr) {
+        *ptr = destination;
+    }
+}
+
 #if defined(__wasm__)
 
 
@@ -4421,9 +4430,7 @@ rb_gc_update_set_refs_i(st_data_t key, st_data_t value, st_data_t argp, int erro
 static int
 rb_gc_update_set_refs_replace_i(st_data_t *key, st_data_t *value, st_data_t argp, int existing)
 {
-    if (rb_gc_location((VALUE)*key) != (VALUE)*key) {
-        *key = rb_gc_location((VALUE)*key);
-    }
+    rb_gc_update_moved((VALUE *)key);
 
     return ST_CONTINUE;
 }

--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -9852,7 +9852,7 @@ gc_update_references_weak_table_i(VALUE obj, void *data)
 static int
 gc_update_references_weak_table_replace_i(VALUE *obj, void *data)
 {
-    *obj = rb_gc_location(*obj);
+    rb_gc_update_moved(obj);
 
     return ST_CONTINUE;
 }

--- a/gc/gc.h
+++ b/gc/gc.h
@@ -171,7 +171,7 @@ hash_foreach_replace_value(st_data_t key, st_data_t value, st_data_t argp, int e
 static int
 hash_replace_ref_value(st_data_t *key, st_data_t *value, st_data_t argp, int existing)
 {
-    *value = rb_gc_location((VALUE)*value);
+    rb_gc_update_moved((VALUE *)value);
 
     return ST_CONTINUE;
 }
@@ -219,15 +219,8 @@ hash_foreach_replace(st_data_t key, st_data_t value, st_data_t argp, int error)
 static int
 hash_replace_ref(st_data_t *key, st_data_t *value, st_data_t argp, int existing)
 {
-    VALUE new_key = rb_gc_location((VALUE)*key);
-    if (new_key != (VALUE)*key) {
-        *key = new_key;
-    }
-
-    VALUE new_value = rb_gc_location((VALUE)*value);
-    if (new_value != (VALUE)*value) {
-        *value = new_value;
-    }
+    rb_gc_update_moved((VALUE *)key);
+    rb_gc_update_moved((VALUE *)value);
 
     return ST_CONTINUE;
 }

--- a/id_table.c
+++ b/id_table.c
@@ -515,7 +515,7 @@ marked_id_table_compact_check_i(VALUE value, void *data)
 static enum rb_id_table_iterator_result
 marked_id_table_compact_replace_i(VALUE *value, void *data, int existing)
 {
-    *value = rb_gc_location(*value);
+    rb_gc_update_moved(value);
     return ID_TABLE_CONTINUE;
 }
 

--- a/imemo.c
+++ b/imemo.c
@@ -422,9 +422,8 @@ rb_imemo_mark_and_move(VALUE obj, bool reference_updating)
              */
         }
         else if (reference_updating) {
-            *((VALUE *)&cc->klass) = rb_gc_location(cc->klass);
-            *((struct rb_callable_method_entry_struct **)&cc->cme_) =
-                (struct rb_callable_method_entry_struct *)rb_gc_location((VALUE)cc->cme_);
+            rb_gc_update_moved((VALUE *)&cc->klass);
+            rb_gc_update_moved_ptr((struct rb_callable_method_entry_struct **)&cc->cme_);
 
             RUBY_ASSERT(RB_TYPE_P(cc->klass, T_CLASS) || RB_TYPE_P(cc->klass, T_ICLASS));
             RUBY_ASSERT(IMEMO_TYPE_P((VALUE)cc->cme_, imemo_ment));
@@ -488,7 +487,7 @@ rb_imemo_mark_and_move(VALUE obj, bool reference_updating)
             }
 
             if (reference_updating) {
-                ((VALUE *)env->ep)[VM_ENV_DATA_INDEX_ENV] = rb_gc_location(env->ep[VM_ENV_DATA_INDEX_ENV]);
+                rb_gc_update_moved(&((VALUE *)env->ep)[VM_ENV_DATA_INDEX_ENV]);
             }
             else {
                 if (!VM_ENV_FLAGS(env->ep, VM_ENV_FLAG_WB_REQUIRED)) {
@@ -564,7 +563,7 @@ rb_imemo_mark_and_move(VALUE obj, bool reference_updating)
             VALUE *entries = rb_imemo_subclasses_entries(obj);
             for (uint32_t i = 0; i < subs->count; i++) {
                 if (entries[i]) {
-                    entries[i] = rb_gc_location(entries[i]);
+                    rb_gc_update_moved(&entries[i]);
                 }
             }
         }

--- a/include/ruby/internal/core/rtypeddata.h
+++ b/include/ruby/internal/core/rtypeddata.h
@@ -282,7 +282,7 @@ struct rb_data_type_struct {
          * ::rb_data_type_struct::dmark, you need to  update references to Ruby
          * objects inside of your structs.
          *
-         * @see      rb_gc_location()
+         * @see      rb_gc_update_moved(), rb_gc_location()
          * @warning  This  is called  during GC  runs.  Object  allocations are
          *           impossible at that moment (that is why GC runs).
          */

--- a/include/ruby/internal/gc.h
+++ b/include/ruby/internal/gc.h
@@ -187,7 +187,8 @@ void rb_gc_mark(VALUE obj);
  * your struct  in the  first place.   But if  that is  not possible,  use this
  * function  from your  ::rb_data_type_struct::dmark  then.   This way  objects
  * marked using it are  considered movable.  If you chose this  way you have to
- * manually fix up locations of such moved pointers using rb_gc_location().
+ * manually fix up locations of such  moved pointers using rb_gc_update_moved()
+ * or rb_gc_location().
  *
  * @see  Bartlett,  Joel  F.,  "Compacting Garbage  Collection  with  Ambiguous
  *       Roots",  ACM  SIGPLAN  Lisp  Pointers  Volume  1  Issue  6  pp.  3-12,
@@ -208,6 +209,18 @@ void rb_gc_mark_movable(VALUE obj);
  * @return     An object, which holds the current contents of former `obj`.
  */
 VALUE rb_gc_location(VALUE obj);
+
+/**
+ * Updates  a reference  to a possibly moved object.  This is the same as doing
+ * `struct->field = rb_gc_location(struct->field)`, except it does not write to
+ * `struct->field`   when the   object did   not move.    Prefer this  over the
+ * assignment,  which dirties the page it writes to, and so un-shares it from a
+ * forked parent process.
+ *
+ * @param[in,out]  ptr  A place holding an object, possibly already moved.
+ * @post           `*ptr` holds the current location of the object.
+ */
+void rb_gc_update_moved(VALUE *ptr);
 
 /**
  * Triggers a GC process.  This was the only  GC entry point that we had at the

--- a/internal/gc.h
+++ b/internal/gc.h
@@ -230,8 +230,9 @@ void rb_gc_after_fork(rb_pid_t pid);
     if (_obj != (VALUE)*(ptr)) *(ptr) = (void *)_obj; \
 } while (0)
 
-#define rb_gc_move_ptr(ptr) do { \
-    VALUE _obj = rb_gc_location((VALUE)*(ptr)); \
+#define rb_gc_update_moved_ptr(ptr) do { \
+    VALUE _obj = (VALUE)*(ptr); \
+    rb_gc_update_moved(&_obj); \
     if (_obj != (VALUE)*(ptr)) *(ptr) = (void *)_obj; \
 } while (0)
 

--- a/io_buffer.c
+++ b/io_buffer.c
@@ -304,7 +304,7 @@ rb_io_buffer_type_compact(void *_buffer)
             // The `source` String has to be pinned, because the `base` may point to the embedded String content,
             // which can be otherwise moved by GC compaction.
         } else {
-            buffer->source = rb_gc_location(buffer->source);
+            rb_gc_update_moved(&buffer->source);
         }
     }
 }

--- a/iseq.c
+++ b/iseq.c
@@ -436,7 +436,7 @@ rb_iseq_mark_and_move(rb_iseq_t *iseq, bool reference_updating)
                 }
 
                 if (reference_updating) {
-                    rb_gc_move_ptr(&cds[i].cc);
+                    rb_gc_update_moved_ptr(&cds[i].cc);
                 }
                 else {
                     if (cc_is_active(cc)) {

--- a/symbol.c
+++ b/symbol.c
@@ -197,7 +197,7 @@ sym_id_entry_list_compact(void *ptr)
 
     struct sym_id_entry *entry;
     rb_darray_foreach(ary, i, entry) {
-        entry->str = rb_gc_location(entry->str);
+        rb_gc_update_moved(&entry->str);
     }
 }
 
@@ -251,7 +251,7 @@ id_entry_dir_compact(void *ptr)
     struct id_entry_dir *dir = ptr;
     for (long i = 0; i < dir->capa; i++) {
         if (dir->entries[i]) {
-            dir->entries[i] = rb_gc_location(dir->entries[i]);
+            rb_gc_update_moved(&dir->entries[i]);
         }
     }
 }

--- a/thread_sync.c
+++ b/thread_sync.c
@@ -1274,7 +1274,7 @@ static void
 monitor_compact(void *ptr)
 {
     struct rb_monitor *mc = ptr;
-    mc->mutex = rb_gc_location(mc->mutex);
+    rb_gc_update_moved(&mc->mutex);
 }
 
 static const rb_data_type_t monitor_data_type = {

--- a/variable.c
+++ b/variable.c
@@ -689,13 +689,8 @@ rb_gvar_val_compactor(void *_var)
 {
     struct rb_global_variable *var = (struct rb_global_variable *)_var;
 
-    VALUE obj = (VALUE)var->data;
-
-    if (obj) {
-        VALUE new = rb_gc_location(obj);
-        if (new != obj) {
-            var->data = (void*)new;
-        }
+    if (var->data) {
+        rb_gc_update_moved_ptr(&var->data);
     }
 }
 

--- a/vm.c
+++ b/vm.c
@@ -3388,9 +3388,9 @@ rb_vm_update_references(void *ptr)
     if (ptr) {
         rb_vm_t *vm = ptr;
 
-        vm->self = rb_gc_location(vm->self);
-        vm->orig_progname = rb_gc_location(vm->orig_progname);
-        vm->cc_refinement_set = rb_gc_location(vm->cc_refinement_set);
+        rb_gc_update_moved(&vm->self);
+        rb_gc_update_moved(&vm->orig_progname);
+        rb_gc_update_moved(&vm->cc_refinement_set);
 
         if (vm->root_box)
             rb_box_gc_update_references(vm->root_box);
@@ -3400,9 +3400,9 @@ rb_vm_update_references(void *ptr)
         rb_gc_update_values(RUBY_NSIG, vm->trap_list.cmd);
 
         if (vm->coverages) {
-            vm->coverages = rb_gc_location(vm->coverages);
-            vm->cme2counter = rb_gc_location(vm->cme2counter);
-            vm->me_set = rb_gc_location(vm->me_set);
+            rb_gc_update_moved(&vm->coverages);
+            rb_gc_update_moved(&vm->cme2counter);
+            rb_gc_update_moved(&vm->me_set);
         }
     }
 }
@@ -3774,17 +3774,13 @@ rb_execution_context_update(rb_execution_context_t *ec)
         // safely use rb_gc_location on such slots.
         if (!rb_zjit_enabled_p) {
             for (i = 0; i < (long)(sp - p); i++) {
-                VALUE ref = p[i];
-                VALUE update = rb_gc_location(ref);
-                if (ref != update) {
-                    p[i] = update;
-                }
+                rb_gc_update_moved(&p[i]);
             }
         }
 
         while (cfp != limit_cfp) {
             const VALUE *ep = cfp->ep;
-            cfp->self = rb_gc_location(cfp->self);
+            rb_gc_update_moved(&cfp->self);
             if (CFP_ZJIT_FRAME_P(cfp)) {
                 const zjit_jit_frame_t *jit_frame = CFP_ZJIT_FRAME(cfp);
                 rb_zjit_jit_frame_update_references((zjit_jit_frame_t *)jit_frame);
@@ -3793,23 +3789,23 @@ rb_execution_context_update(rb_execution_context_t *ec)
                 // was initialized by ZJIT and may have been written later by
                 // vm_caller_setup_arg_block (ISEQ frames) or rb_iterate0 (C frames).
                 if (!jit_frame->materialize_block_code) {
-                    cfp->block_code = (void *)rb_gc_location((VALUE)cfp->block_code);
+                    rb_gc_update_moved_ptr(&cfp->block_code);
                 }
             }
             else {
-                cfp->_iseq = (rb_iseq_t *)rb_gc_location((VALUE)cfp->_iseq);
-                cfp->block_code = (void *)rb_gc_location((VALUE)cfp->block_code);
+                rb_gc_update_moved_ptr(&cfp->_iseq);
+                rb_gc_update_moved_ptr(&cfp->block_code);
             }
 
             if (!VM_ENV_LOCAL_P(ep)) {
                 const VALUE *prev_ep = VM_ENV_PREV_EP(ep);
                 if (VM_ENV_FLAGS(prev_ep, VM_ENV_FLAG_ESCAPED)) {
-                    VM_FORCE_WRITE(&prev_ep[VM_ENV_DATA_INDEX_ENV], rb_gc_location(prev_ep[VM_ENV_DATA_INDEX_ENV]));
+                    rb_gc_update_moved((VALUE *)&prev_ep[VM_ENV_DATA_INDEX_ENV]);
                 }
 
                 if (VM_ENV_FLAGS(ep, VM_ENV_FLAG_ESCAPED)) {
-                    VM_FORCE_WRITE(&ep[VM_ENV_DATA_INDEX_ENV], rb_gc_location(ep[VM_ENV_DATA_INDEX_ENV]));
-                    VM_FORCE_WRITE(&ep[VM_ENV_DATA_INDEX_ME_CREF], rb_gc_location(ep[VM_ENV_DATA_INDEX_ME_CREF]));
+                    rb_gc_update_moved((VALUE *)&ep[VM_ENV_DATA_INDEX_ENV]);
+                    rb_gc_update_moved((VALUE *)&ep[VM_ENV_DATA_INDEX_ME_CREF]);
                 }
             }
 
@@ -3817,10 +3813,10 @@ rb_execution_context_update(rb_execution_context_t *ec)
         }
     }
 
-    ec->storage = rb_gc_location(ec->storage);
+    rb_gc_update_moved(&ec->storage);
 
-    ec->gen_fields_cache.obj = rb_gc_location(ec->gen_fields_cache.obj);
-    ec->gen_fields_cache.fields_obj = rb_gc_location(ec->gen_fields_cache.fields_obj);
+    rb_gc_update_moved(&ec->gen_fields_cache.obj);
+    rb_gc_update_moved(&ec->gen_fields_cache.fields_obj);
 }
 
 static enum rb_id_table_iterator_result
@@ -3926,7 +3922,7 @@ thread_compact(void *ptr)
 {
     rb_thread_t *th = ptr;
 
-    th->self = rb_gc_location(th->self);
+    rb_gc_update_moved(&th->self);
 }
 
 /* Mark the heap objects a thread owns (the caller handles ec and fiber).  Split

--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -143,7 +143,7 @@ static void
 location_ref_update(void *ptr)
 {
     struct valued_frame_info *vfi = ptr;
-    vfi->btobj = rb_gc_location(vfi->btobj);
+    rb_gc_update_moved(&vfi->btobj);
 }
 
 static void
@@ -798,9 +798,9 @@ backtrace_mark(void *ptr)
 static void
 location_update_entry(rb_backtrace_location_t *fi)
 {
-    fi->cme = (rb_callable_method_entry_t *)rb_gc_location((VALUE)fi->cme);
+    rb_gc_update_moved_ptr(&fi->cme);
     if (fi->iseq) {
-        fi->iseq = (rb_iseq_t *)rb_gc_location((VALUE)fi->iseq);
+        rb_gc_update_moved_ptr(&fi->iseq);
     }
 }
 
@@ -813,8 +813,8 @@ backtrace_update(void *ptr)
     for (i=0; i<s; i++) {
         location_update_entry(&bt->backtrace[i]);
     }
-    bt->strary = rb_gc_location(bt->strary);
-    bt->locary = rb_gc_location(bt->locary);
+    rb_gc_update_moved(&bt->strary);
+    rb_gc_update_moved(&bt->locary);
 }
 
 static const rb_data_type_t backtrace_data_type = {

--- a/vm_method.c
+++ b/vm_method.c
@@ -105,11 +105,11 @@ compact_cc_entry_i(VALUE ccs_ptr, void *data)
 {
     struct rb_class_cc_entries *ccs = (struct rb_class_cc_entries *)ccs_ptr;
 
-    ccs->cme = (const struct rb_callable_method_entry_struct *)rb_gc_location((VALUE)ccs->cme);
+    rb_gc_update_moved_ptr(&ccs->cme);
     VM_ASSERT(vm_ccs_p(ccs));
 
     for (int i=0; i<ccs->len; i++) {
-        ccs->entries[i].cc = (const struct rb_callcache *)rb_gc_location((VALUE)ccs->entries[i].cc);
+        rb_gc_update_moved_ptr(&ccs->entries[i].cc);
     }
 
     return ID_TABLE_CONTINUE;
@@ -776,7 +776,7 @@ cc_refinement_set_compact(void *ptr)
 {
     struct cc_refinement_entries *e = ptr;
     for (size_t i = 0; i < e->len; i++) {
-        e->entries[i] = rb_gc_location(e->entries[i]);
+        rb_gc_update_moved(&e->entries[i]);
     }
 }
 

--- a/weakmap.c
+++ b/weakmap.c
@@ -91,7 +91,7 @@ wmap_compact_table_replace_i(st_data_t *k, st_data_t *v, st_data_t d, int existi
 {
     RUBY_ASSERT((VALUE)*k == rb_gc_location((VALUE)*k));
 
-    *v = (st_data_t)rb_gc_location((VALUE)*v);
+    rb_gc_update_moved((VALUE *)v);
 
     return ST_CONTINUE;
 }
@@ -579,8 +579,8 @@ wkmap_compact_table_replace(st_data_t *key_ptr, st_data_t *val_ptr, st_data_t _d
 {
     RUBY_ASSERT(existing);
 
-    *key_ptr = (st_data_t)rb_gc_location((VALUE)*key_ptr);
-    *val_ptr = (st_data_t)rb_gc_location((VALUE)*val_ptr);
+    rb_gc_update_moved((VALUE *)key_ptr);
+    rb_gc_update_moved((VALUE *)val_ptr);
 
     return ST_CONTINUE;
 }


### PR DESCRIPTION
Using the `container->obj = rb_gc_location(container->obj)` pattern dirties pages unconditionally. If we're in a forked process, this is bad for CoW. If the object hasn't moved, don't reassign.