### PR TITLE
ZJIT: Profile invalidated ISEQs and function stubs

### DIFF
--- a/zjit.c
+++ b/zjit.c
@@ -148,6 +148,13 @@ rb_zjit_compile_iseq(const rb_iseq_t *iseq, rb_execution_context_t *ec, bool jit
     }
 }
 
+// This is used by a function stub to install compiled code as the ISEQ's entry point.
+void
+rb_zjit_iseq_set_jit_entry(const rb_iseq_t *iseq, void *code_ptr)
+{
+    ISEQ_BODY(iseq)->jit_entry = (rb_jit_func_t)code_ptr;
+}
+
 extern VALUE *rb_vm_base_ptr(struct rb_control_frame_struct *cfp);
 
 // Convert a given ISEQ's instructions to zjit_* instructions
@@ -166,6 +173,26 @@ rb_zjit_profile_enable(const rb_iseq_t *iseq)
         }
         insn_idx += insn_len(insn);
     }
+}
+
+// Return false if a function stub has not collected enough profiles yet, enabling
+// profiling instructions as needed. Return true once enough profiles are collected.
+bool
+rb_zjit_profile_stub_hit(const rb_iseq_t *iseq)
+{
+    struct rb_iseq_constant_body *body = ISEQ_BODY(iseq);
+
+    if (body->jit_entry_calls < rb_zjit_profile_threshold) {
+        // Skip the unprofiled warmup. The compiled caller already establishes
+        // that the callee is hot, so go straight to the profiling window.
+        body->jit_entry_calls = rb_zjit_profile_threshold;
+        rb_zjit_profile_enable(iseq);
+    }
+    else {
+        body->jit_entry_calls++;
+    }
+
+    return body->jit_entry_calls >= rb_zjit_call_threshold;
 }
 
 // Convert a given ISEQ's ZJIT instructions to bare instructions

--- a/zjit.c
+++ b/zjit.c
@@ -178,7 +178,7 @@ rb_zjit_profile_enable(const rb_iseq_t *iseq)
 // Return false if a function stub has not collected enough profiles yet, enabling
 // profiling instructions as needed. Return true once enough profiles are collected.
 bool
-rb_zjit_profile_stub_hit(const rb_iseq_t *iseq)
+rb_zjit_iseq_has_profiled_enough(const rb_iseq_t *iseq)
 {
     struct rb_iseq_constant_body *body = ISEQ_BODY(iseq);
 

--- a/zjit/bindgen/src/main.rs
+++ b/zjit/bindgen/src/main.rs
@@ -111,6 +111,8 @@ fn main() {
         .allowlist_function("ruby_executable_node")
         .allowlist_function("rb_funcallv")
         .allowlist_function("rb_protect")
+        .allowlist_function("rb_zjit_profile_stub_hit")
+        .allowlist_function("rb_zjit_iseq_set_jit_entry")
         .allowlist_function("rb_zjit_profile_disable")
         .allowlist_function("rb_zjit_profile_enable")
         .allowlist_function("rb_zjit_insn_to_bare_insn")

--- a/zjit/bindgen/src/main.rs
+++ b/zjit/bindgen/src/main.rs
@@ -111,7 +111,7 @@ fn main() {
         .allowlist_function("ruby_executable_node")
         .allowlist_function("rb_funcallv")
         .allowlist_function("rb_protect")
-        .allowlist_function("rb_zjit_profile_stub_hit")
+        .allowlist_function("rb_zjit_iseq_has_profiled_enough")
         .allowlist_function("rb_zjit_iseq_set_jit_entry")
         .allowlist_function("rb_zjit_profile_disable")
         .allowlist_function("rb_zjit_profile_enable")

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -6,11 +6,11 @@ use std::mem::take;
 use std::rc::Rc;
 use crate::bitset::BitSet;
 use crate::codegen::{perf_symbol_range_start, perf_symbol_range_end, register_with_perf};
-use crate::cruby::{IseqPtr, RUBY_OFFSET_CFP_ISEQ, RUBY_OFFSET_CFP_JIT_RETURN, RUBY_OFFSET_CFP_PC, RUBY_OFFSET_CFP_SP, SIZEOF_VALUE_I32, VALUE, ZJIT_STACK_MAP_BASE_PTR_INDEX_MASK, ZJIT_STACK_MAP_BASE_PTR_SIZE_SHIFT, ZJIT_STACK_MAP_BASE_PTR_TAG, ZJIT_STACK_MAP_SHIFT, ZJIT_STACK_MAP_SKIP_TAG, ZJIT_STACK_MAP_VREG_TAG, vm_stack_canary, YarvInsnIdx, zjit_jit_frame, local_size_and_idx_to_ep_offset};
+use crate::cruby::{IseqPtr, RUBY_OFFSET_CFP_ISEQ, RUBY_OFFSET_CFP_JIT_RETURN, RUBY_OFFSET_CFP_PC, RUBY_OFFSET_CFP_SP, SIZEOF_VALUE_I32, VALUE, ZJIT_STACK_MAP_BASE_PTR_INDEX_MASK, ZJIT_STACK_MAP_BASE_PTR_SIZE_SHIFT, ZJIT_STACK_MAP_BASE_PTR_TAG, ZJIT_STACK_MAP_SHIFT, ZJIT_STACK_MAP_SKIP_TAG, ZJIT_STACK_MAP_VREG_TAG, vm_stack_canary, zjit_jit_frame, local_size_and_idx_to_ep_offset};
 use crate::hir::{Invariant, SideExitReason};
 use crate::hir;
 use crate::options::{TraceExits, PerfMap, get_option};
-use crate::payload::{IseqVersionRef, get_or_create_iseq_payload};
+use crate::payload::IseqVersionRef;
 use crate::stats::{exit_counter_ptr, exit_counter_ptr_for_opcode, side_exit_counter, CompileError};
 use crate::virtualmem::CodePtr;
 use crate::asm::{CodeBlock, Label};
@@ -628,8 +628,7 @@ pub struct SideExit {
     /// side exit. The current frame's stack and locals are still handled by
     /// `stack` and `locals` above.
     pub stack_map: Option<StackMap>,
-    /// If set, the side exit will profile the current instruction and invalidate
-    /// the compiled ISEQ for recompilation.
+    /// If set, the side exit will invalidate the compiled ISEQ for recompilation.
     pub recompile: Option<SideExitRecompile>,
 }
 
@@ -639,11 +638,6 @@ pub struct SideExitRecompile {
     /// The compiled unit whose version must be invalidated to force a recompile. For inlined
     /// methods, this will be the outer function it was inlined into.
     pub compiled_iseq: Opnd,
-    /// The exiting frame's ISEQ, which owns the profile entry for `insn_idx`. For
-    /// an exit out of inlined code this is the inlined callee, not the compiled unit.
-    pub frame_iseq: Opnd,
-    /// The exiting frame's instruction index within `frame_iseq`.
-    pub insn_idx: u32,
 }
 
 /// Payload of `Target::SideExit`, boxed to keep `Target` (and every `Insn`
@@ -3165,15 +3159,9 @@ impl Assembler
 
         fn compile_exit_recompile(asm: &mut Assembler, exit: &SideExit) {
             if let Some(recompile) = &exit.recompile {
-                let payload = get_or_create_iseq_payload(exit.iseq);
-                payload.reset_profiles_remaining(recompile.insn_idx as YarvInsnIdx);
                 use crate::codegen::exit_recompile;
-                asm_comment!(asm, "profile and maybe recompile");
-                asm_ccall!(asm, exit_recompile,
-                    recompile.compiled_iseq,
-                    recompile.frame_iseq,
-                    recompile.insn_idx.into()
-                );
+                asm_comment!(asm, "invalidate for recompilation");
+                asm_ccall!(asm, exit_recompile, recompile.compiled_iseq);
             }
         }
 

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -3676,8 +3676,6 @@ fn side_exit_with_recompile(jit: &JITState, function: &Function, state: &FrameSt
     let mut exit = build_side_exit(jit, function, state);
     exit.recompile = recompile.map(|_| SideExitRecompile {
         compiled_iseq: Opnd::Value(VALUE::from(jit.iseq())),
-        frame_iseq: Opnd::Value(VALUE::from(state.iseq)),
-        insn_idx: state.insn_idx() as u32,
     });
     Target::SideExit(Box::new(SideExitTarget { exit, reason }))
 }
@@ -3736,24 +3734,20 @@ macro_rules! c_callable {
 pub(crate) use c_callable;
 
 c_callable! {
-    /// Called from JIT side-exit code to profile operands and trigger recompilation.
-    /// Once enough profiles are gathered, invalidates the compiled unit for recompilation.
+    /// Called from JIT side-exit code to invalidate the compiled unit for recompilation.
     ///
     /// `compiled_iseq_raw` is the ISEQ that was actually compiled. For an exit out
     /// of inlined code, the inliner folds the callee's body into the outer ISEQ, so
     /// the outer ISEQ's version holds the failing guard and must be invalidated to
     /// force a recompile. For non-inlined code, it is the same as the frame ISEQ.
     ///
-    /// `frame_iseq_raw` and `insn_idx` identify the instruction this exit came from,
-    /// whose re-profiling gates the recompile. Both are baked in at compile time,
-    /// where the exit already knows them, rather than read back out of the control
-    /// frame: the control frame describes the exiting frame only because the exit
-    /// wrote its ISEQ and PC there moments earlier, and an exit path that does not
-    /// write them would silently gate the recompile on an unrelated instruction.
-    pub(crate) fn exit_recompile(compiled_iseq_raw: VALUE, frame_iseq_raw: VALUE, insn_idx: u32) {
+    /// The first exit invalidates the version right away. Invalidation resets the
+    /// ISEQ's call counter and re-stubs incoming JIT-to-JIT calls, so every entry
+    /// runs the profiling window in the interpreter before the next compile.
+    pub(crate) fn exit_recompile(compiled_iseq_raw: VALUE) {
         // Fast check before taking the VM lock: skip if the compiled unit is already
         // invalidated or at the version limit. This avoids expensive lock acquisition
-        // on every shape guard exit after the recompile has already been triggered.
+        // on every shape guard exit taken by frames still running the invalidated code.
         // The check is on the compiled unit because that is the version we invalidate.
         {
             let compiled_iseq: IseqPtr = compiled_iseq_raw.as_iseq();
@@ -3768,24 +3762,11 @@ c_callable! {
 
         with_vm_lock(src_loc!(), || {
             let compiled_iseq: IseqPtr = compiled_iseq_raw.as_iseq();
-
-            let should_recompile = with_time_stat(Counter::profile_time_ns, || {
-                get_or_create_iseq_payload(frame_iseq_raw.as_iseq())
-                    .profile.done_profiling_at(insn_idx as YarvInsnIdx)
-            });
-
-            // Once we have enough profiles, invalidate the compiled unit so it
-            // recompiles and reads the freshly recorded profile. We invalidate
-            // `compiled_iseq` rather than `frame_iseq` because an inlined callee has no
-            // compiled code of its own; the outer function it was folded into is what
-            // actually got compiled.
-            if should_recompile {
-                let payload = get_or_create_iseq_payload(compiled_iseq);
-                if let Some(version) = payload.versions.last_mut() {
-                    let cb = ZJITState::get_code_block();
-                    invalidate_iseq_version(cb, compiled_iseq, version);
-                    cb.mark_all_executable();
-                }
+            let payload = get_or_create_iseq_payload(compiled_iseq);
+            if let Some(version) = payload.versions.last_mut() {
+                let cb = ZJITState::get_code_block();
+                invalidate_iseq_version(cb, compiled_iseq, version);
+                cb.mark_all_executable();
             }
         });
     }
@@ -3828,7 +3809,7 @@ c_callable! {
 
             // JIT-to-JIT calls don't eagerly fill nils to non-parameter locals.
             // If we side-exit from function_stub_hit (before JIT code runs), we need to set them here.
-            fn prepare_for_exit(iseq: IseqPtr, cfp: CfpPtr, sp: *mut VALUE, argc: u16, num_opts_filled: u16, compile_error: &CompileError) {
+            fn prepare_for_exit(iseq: IseqPtr, cfp: CfpPtr, sp: *mut VALUE, argc: u16, num_opts_filled: u16, compile_error: Option<&CompileError>) {
                 unsafe {
                     // Caller frames are materialized by the materialize_exit trampoline before unwinding native frames.
                     // The current frame's pc and iseq are already set by function_stub_hit before this point.
@@ -3891,8 +3872,10 @@ c_callable! {
                 }
 
                 // Increment a compile error counter for --zjit-stats
-                if get_option!(stats) {
-                    incr_counter_by(exit_counter_for_compile_error(compile_error), 1);
+                if let Some(compile_error) = compile_error {
+                    if get_option!(stats) {
+                        incr_counter_by(exit_counter_for_compile_error(compile_error), 1);
+                    }
                 }
             }
 
@@ -3922,8 +3905,16 @@ c_callable! {
                 // We'll use this Rc again, so increment the ref count decremented by from_raw.
                 unsafe { Rc::increment_strong_count(iseq_call_ptr as *const IseqCall); }
 
-                prepare_for_exit(iseq, cfp, sp, argc, num_opts_filled, compile_error);
+                prepare_for_exit(iseq, cfp, sp, argc, num_opts_filled, Some(compile_error));
                 return ZJITState::get_materialize_exit_trampoline_with_counter().raw_ptr(cb);
+            }
+
+            // Exit to the interpreter until the callee ISEQ collects enough profiles.
+            if !unsafe { rb_zjit_profile_stub_hit(iseq) } {
+                // Preserve the reference owned by the stub when iseq_call is dropped.
+                unsafe { Rc::increment_strong_count(iseq_call_ptr as *const IseqCall); }
+                prepare_for_exit(iseq, cfp, sp, argc, num_opts_filled, None);
+                return ZJITState::get_materialize_exit_trampoline().raw_ptr(cb);
             }
 
             // Otherwise, attempt to compile the ISEQ. We have to mark_all_executable() beyond this point.
@@ -3937,7 +3928,7 @@ c_callable! {
                 // We'll use this Rc again, so increment the ref count decremented by from_raw.
                 unsafe { Rc::increment_strong_count(iseq_call_ptr as *const IseqCall); }
 
-                prepare_for_exit(iseq, cfp, sp, argc, num_opts_filled, &compile_error);
+                prepare_for_exit(iseq, cfp, sp, argc, num_opts_filled, Some(&compile_error));
                 ZJITState::get_materialize_exit_trampoline_with_counter()
             });
             cb.mark_all_executable();
@@ -3949,9 +3940,12 @@ c_callable! {
 /// Compile an ISEQ for a function stub
 fn function_stub_hit_body(cb: &mut CodeBlock, iseq_call: &IseqCallRef) -> Result<CodePtr, CompileError> {
     // Compile the stubbed ISEQ
-    let IseqCodePtrs { jit_entry_ptrs, .. } = gen_iseq(cb, iseq_call.iseq.get(), None).inspect_err(|err| {
+    let IseqCodePtrs { start_ptr, jit_entry_ptrs } = gen_iseq(cb, iseq_call.iseq.get(), None).inspect_err(|err| {
         debug!("{err:?}: gen_iseq failed: {}", iseq_get_location(iseq_call.iseq.get(), 0));
     })?;
+
+    // The compile above generated the interpreter entry along with the JIT-to-JIT entries, so install it now.
+    unsafe { rb_zjit_iseq_set_jit_entry(iseq_call.iseq.get(), start_ptr.raw_ptr(cb) as *mut c_void); }
 
     // Update the stub to call the code pointer
     let jit_entry_ptr = jit_entry_ptrs[iseq_call.jit_entry_idx.to_usize()];

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -3912,7 +3912,7 @@ c_callable! {
             }
 
             // Exit to the interpreter until the callee ISEQ collects enough profiles.
-            if !unsafe { rb_zjit_profile_stub_hit(iseq) } {
+            if !unsafe { rb_zjit_iseq_has_profiled_enough(iseq) } {
                 // Preserve the reference owned by the stub when iseq_call is dropped.
                 unsafe { Rc::increment_strong_count(iseq_call_ptr as *const IseqCall); }
                 prepare_for_exit(iseq, cfp, sp, argc, num_opts_filled, None);

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -3744,6 +3744,8 @@ c_callable! {
     /// The first exit invalidates the version right away. Invalidation resets the
     /// ISEQ's call counter and re-stubs incoming JIT-to-JIT calls, so every entry
     /// runs the profiling window in the interpreter before the next compile.
+    ///
+    /// TODO: Allow waiting for a configured number of exits before invalidating the ISEQ.
     pub(crate) fn exit_recompile(compiled_iseq_raw: VALUE) {
         // Fast check before taking the VM lock: skip if the compiled unit is already
         // invalidated or at the version limit. This avoids expensive lock acquisition

--- a/zjit/src/codegen_tests.rs
+++ b/zjit/src/codegen_tests.rs
@@ -6,7 +6,7 @@ use crate::backend::lir::Assembler;
 use crate::codegen::max_iseq_versions;
 use crate::cruby::*;
 use crate::hir::{Insn, iseq_to_hir};
-use crate::options::{get_option, rb_zjit_prepare_options, set_call_threshold, set_inline_threshold, set_max_versions, set_mem_bytes};
+use crate::options::{CallThreshold, get_option, rb_zjit_prepare_options, set_call_threshold, set_inline_threshold, set_max_versions, set_mem_bytes};
 use crate::payload::IseqVersion;
 use crate::hir::tests::hir_build_tests::assert_contains_opcode;
 use crate::payload::*;
@@ -114,6 +114,71 @@ fn test_nil() {
 }
 
 #[test]
+fn test_function_stub_profiles_before_compiling() {
+    rb_zjit_prepare_options();
+    set_inline_threshold(0);
+    let num_profiles = get_option!(num_profiles);
+    let call_threshold = CallThreshold::from(num_profiles) + 2;
+    set_call_threshold(call_threshold);
+
+    eval(&format!("
+        class Integer
+          def zjit_profile_stub_target = self + 1
+        end
+
+        def zjit_profile_stub_entry(run)
+          1.zjit_profile_stub_target if run
+        end
+
+        i = 0
+        while i < {call_threshold}
+          zjit_profile_stub_entry(false)
+          i += 1
+        end
+    "));
+
+    let entry_iseq = get_method_iseq("self", "zjit_profile_stub_entry");
+    let entry_payload = get_or_create_iseq_payload(entry_iseq);
+    let entry_version = unsafe { entry_payload.versions.last().unwrap().as_ref() };
+    assert_eq!(1, entry_version.outgoing.len(), "expected a JIT-to-JIT function stub");
+
+    let target_iseq = get_method_iseq("1", "zjit_profile_stub_target");
+    assert!(get_or_create_iseq_payload(target_iseq).versions.is_empty());
+
+    // Every stub hit in the profiling window should interpret the callee
+    // without compiling it.
+    for _ in 0..num_profiles {
+        assert_eq!(VALUE::fixnum_from_usize(2), eval("zjit_profile_stub_entry(true)"));
+        assert!(get_or_create_iseq_payload(target_iseq).versions.is_empty());
+    }
+
+    // Verify that the interpreted executions populated the profile for `+`.
+    let mut insn_idx = 0;
+    let iseq_size = unsafe { get_iseq_encoded_size(target_iseq) };
+    let plus_idx = loop {
+        assert!(insn_idx < iseq_size, "target ISEQ does not contain opt_plus");
+        let opcode = iseq_opcode_at_idx(target_iseq, insn_idx);
+        let bare_opcode = unsafe { rb_zjit_insn_to_bare_insn(opcode as i32) } as u32;
+        if bare_opcode == YARVINSN_opt_plus {
+            break insn_idx as usize;
+        }
+        insn_idx += insn_len(bare_opcode as usize);
+    };
+    assert_eq!(
+        2,
+        get_or_create_iseq_payload(target_iseq)
+            .profile
+            .get_operand_types(plus_idx)
+            .unwrap()
+            .len(),
+    );
+
+    // The following hit observes a completed profiling window and compiles.
+    assert_eq!(VALUE::fixnum_from_usize(2), eval("zjit_profile_stub_entry(true)"));
+    assert_eq!(1, get_or_create_iseq_payload(target_iseq).versions.len());
+}
+
+#[test]
 fn test_putobject() {
     assert_snapshot!(inspect("
         def test = 1
@@ -123,25 +188,69 @@ fn test_putobject() {
 }
 
 #[test]
-fn test_recompile_exit_waits_for_interpreter_profiles() {
+fn test_recompile_exit_invalidates_on_first_exit() {
     set_call_threshold(2);
     eval("
-        def recompile_profile_window(a, b) = a + b
-        recompile_profile_window(1, 2)
-        recompile_profile_window(1, 2)
+        def recompile_on_first_exit(a, b) = a + b
+        recompile_on_first_exit(1, 2)
+        recompile_on_first_exit(1, 2)
     ");
 
-    let iseq = get_method_iseq("self", "recompile_profile_window");
-    let num_profiles = get_option!(num_profiles);
-    for _ in 0..num_profiles {
-        eval("recompile_profile_window(1.5, 2.5)");
-    }
+    let iseq = get_method_iseq("self", "recompile_on_first_exit");
     let payload = get_or_create_iseq_payload(iseq);
+    assert_eq!(1, payload.versions.len());
     assert!(!unsafe { payload.versions.last().unwrap().as_ref() }.is_invalidated());
 
-    eval("recompile_profile_window(1.5, 2.5)");
+    // The first recompile exit invalidates the version right away, so subsequent
+    // calls re-profile every instruction in the interpreter before recompiling.
+    eval("recompile_on_first_exit(1.5, 2.5)");
     let payload = get_or_create_iseq_payload(iseq);
+    assert_eq!(1, payload.versions.len());
     assert!(unsafe { payload.versions.last().unwrap().as_ref() }.is_invalidated());
+}
+
+#[test]
+fn test_function_stub_reprofiles_after_invalidation() {
+    rb_zjit_prepare_options();
+    set_inline_threshold(0);
+    let num_profiles = get_option!(num_profiles);
+    let call_threshold = CallThreshold::from(num_profiles) + 2;
+    set_call_threshold(call_threshold);
+
+    eval(&format!("
+        def stub_reprofile_target(n) = n + 1
+        def stub_reprofile_entry(n) = stub_reprofile_target(n)
+
+        i = 0
+        while i < {call_threshold}
+          stub_reprofile_entry(1)
+          i += 1
+        end
+    "));
+
+    let target_iseq = get_method_iseq("self", "stub_reprofile_target");
+    let target_payload = get_or_create_iseq_payload(target_iseq);
+    assert_eq!(1, target_payload.versions.len());
+    assert!(!unsafe { target_payload.versions.last().unwrap().as_ref() }.is_invalidated());
+
+    // The first Float argument misses the Fixnum guard in the callee, and the
+    // recompile exit invalidates the callee right away, re-stubbing the
+    // JIT-to-JIT call into it.
+    assert_eq!(Qtrue, eval("stub_reprofile_entry(1.5) == 2.5"));
+    let target_payload = get_or_create_iseq_payload(target_iseq);
+    assert_eq!(1, target_payload.versions.len());
+    assert!(unsafe { target_payload.versions.last().unwrap().as_ref() }.is_invalidated());
+
+    // Every stub hit in the profiling window should interpret the invalidated
+    // callee without recompiling it.
+    for _ in 0..num_profiles {
+        assert_eq!(Qtrue, eval("stub_reprofile_entry(1.5) == 2.5"));
+        assert_eq!(1, get_or_create_iseq_payload(target_iseq).versions.len());
+    }
+
+    // The following hit observes a completed profiling window and recompiles.
+    assert_eq!(Qtrue, eval("stub_reprofile_entry(1.5) == 2.5"));
+    assert_eq!(2, get_or_create_iseq_payload(target_iseq).versions.len());
 }
 
 #[test]

--- a/zjit/src/codegen_tests.rs
+++ b/zjit/src/codegen_tests.rs
@@ -145,25 +145,30 @@ fn test_function_stub_profiles_before_compiling() {
     let target_iseq = get_method_iseq("1", "zjit_profile_stub_target");
     assert!(get_or_create_iseq_payload(target_iseq).versions.is_empty());
 
-    // Every stub hit in the profiling window should interpret the callee
+    // The first stub hit should interpret the callee without compiling it.
+    assert_eq!(VALUE::fixnum_from_usize(2), eval("zjit_profile_stub_entry(true)"));
+    assert!(get_or_create_iseq_payload(target_iseq).versions.is_empty());
+
+    // That hit also enabled profiling instructions, so find `+` by looking for the profiling variant.
+    let mut insn_idx = 0;
+    let iseq_size = unsafe { get_iseq_encoded_size(target_iseq) };
+    let plus_idx = loop {
+        assert!(insn_idx < iseq_size, "target ISEQ is not profiling opt_plus");
+        let opcode = iseq_opcode_at_idx(target_iseq, insn_idx);
+        if opcode == YARVINSN_zjit_opt_plus {
+            break insn_idx as usize;
+        }
+        insn_idx += insn_len(opcode as usize);
+    };
+
+    // Every remaining stub hit in the profiling window should interpret the callee
     // without compiling it.
-    for _ in 0..num_profiles {
+    for _ in 1..num_profiles {
         assert_eq!(VALUE::fixnum_from_usize(2), eval("zjit_profile_stub_entry(true)"));
         assert!(get_or_create_iseq_payload(target_iseq).versions.is_empty());
     }
 
     // Verify that the interpreted executions populated the profile for `+`.
-    let mut insn_idx = 0;
-    let iseq_size = unsafe { get_iseq_encoded_size(target_iseq) };
-    let plus_idx = loop {
-        assert!(insn_idx < iseq_size, "target ISEQ does not contain opt_plus");
-        let opcode = iseq_opcode_at_idx(target_iseq, insn_idx);
-        let bare_opcode = unsafe { rb_zjit_insn_to_bare_insn(opcode as i32) } as u32;
-        if bare_opcode == YARVINSN_opt_plus {
-            break insn_idx as usize;
-        }
-        insn_idx += insn_len(bare_opcode as usize);
-    };
     assert_eq!(
         2,
         get_or_create_iseq_payload(target_iseq)

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -2453,7 +2453,12 @@ unsafe extern "C" {
     pub fn rb_zjit_reserve_low_addr_space(size: usize) -> *mut ::std::os::raw::c_void;
     pub fn rb_zjit_profile_disable(iseq: *const rb_iseq_t);
     pub fn rb_zjit_insn_to_bare_insn(insn: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn rb_zjit_iseq_set_jit_entry(
+        iseq: *const rb_iseq_t,
+        code_ptr: *mut ::std::os::raw::c_void,
+    );
     pub fn rb_vm_base_ptr(cfp: *mut rb_control_frame_struct) -> *mut VALUE;
+    pub fn rb_zjit_profile_stub_hit(iseq: *const rb_iseq_t) -> bool;
     pub fn rb_zjit_iseq_insn_set(
         iseq: *const rb_iseq_t,
         insn_idx: ::std::os::raw::c_uint,

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -2458,7 +2458,7 @@ unsafe extern "C" {
         code_ptr: *mut ::std::os::raw::c_void,
     );
     pub fn rb_vm_base_ptr(cfp: *mut rb_control_frame_struct) -> *mut VALUE;
-    pub fn rb_zjit_profile_stub_hit(iseq: *const rb_iseq_t) -> bool;
+    pub fn rb_zjit_iseq_has_profiled_enough(iseq: *const rb_iseq_t) -> bool;
     pub fn rb_zjit_iseq_insn_set(
         iseq: *const rb_iseq_t,
         insn_idx: ::std::os::raw::c_uint,

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -10406,8 +10406,14 @@ mod hir_opt_tests {
           StoreField v6, :@foo@0x1002, v10
           Jump bb4()
         bb6():
-          v22:CShape[0x1003] = GuardBitEquals v15, CShape(0x1003) recompile
+          v22:CShape[0x1003] = Const CShape(0x1003)
+          v23:CBool = IsBitEqual v15, v22
+          CondBranch v23, bb7(), bb8()
+        bb7():
           StoreField v6, :@foo@0x1004, v10
+          Jump bb4()
+        bb8():
+          SetIvar v6, :@foo, v10
           Jump bb4()
         bb4():
           CheckInterrupts
@@ -20856,7 +20862,10 @@ mod hir_opt_tests {
 
     #[test]
     fn test_trigger_guard_type_recompilation() {
-        set_max_versions(2);
+        // The first call transitions C's shape by defining @a, so the setivar shape
+        // guard misses once and already spends a version during the Fixnum phase.
+        // Leave room for one more version so the Float phase can recompile.
+        set_max_versions(3);
         set_inline_threshold(0);
         eval("
             class C
@@ -20961,7 +20970,7 @@ mod hir_opt_tests {
           v8:BasicObject = LoadArg :x@1
           Jump bb3(v7, v8)
         bb3(v11:HeapBasicObject, v12:BasicObject):
-          v90:NilClass = Const Value(nil)
+          v94:NilClass = Const Value(nil)
           v17:Fixnum[1] = Const Value(1)
           PatchPoint SingleRactorMode
           v21:CShape = LoadField v11, :shape_id@0x1001
@@ -21002,9 +21011,11 @@ mod hir_opt_tests {
           v89:Float = FloatAdd v57, v44
           Jump bb9(v89)
         bb13():
-          v60:BasicObject = Send v12, :+, v44 # SendFallbackReason: Send: polymorphic call site
-          Jump bb9(v60)
-        bb9(v47:BasicObject):
+          PatchPoint MethodRedefined(Integer@0x1008, +@0x1010, cme:0x1018)
+          v92:Fixnum = GuardType v12, Fixnum recompile
+          v93:Fixnum = FixnumAdd v92, v44
+          Jump bb9(v93)
+        bb9(v47:Float|Fixnum):
           PatchPoint SingleRactorMode
           v69:CShape = LoadField v11, :shape_id@0x1001
           v70:CShape[0x1002] = Const CShape(0x1002)

--- a/zjit/src/payload.rs
+++ b/zjit/src/payload.rs
@@ -3,7 +3,6 @@ use std::ptr::NonNull;
 use crate::codegen::IseqCallRef;
 use crate::stats::CompileError;
 use crate::{cruby::*, profile::IseqProfile, virtualmem::CodePtr};
-use crate::options::get_option;
 
 pub use crate::jit_frame::JITFrame;
 
@@ -35,14 +34,6 @@ impl IseqPayload {
             was_invalidated_for_singleton_class_creation: false,
             self_is_heap_object: false,
         }
-    }
-
-    /// Profile counts are used for compilation policy.
-    /// When we deoptimize a method that can be recompiled, we need to update the count to collect more profiles.
-    /// Otherwise, we will generate the same code that was just deoptimized.
-    pub fn reset_profiles_remaining(&mut self, insn_idx: YarvInsnIdx) {
-        let num_profiles = get_option!(num_profiles);
-        self.profile.entry_mut(insn_idx).set_profiles_remaining(num_profiles);
     }
 }
 

--- a/zjit/src/profile.rs
+++ b/zjit/src/profile.rs
@@ -408,12 +408,6 @@ pub struct ProfileEntry {
     profiles_remaining: NumProfiles,
 }
 
-impl ProfileEntry {
-    pub fn set_profiles_remaining(&mut self, num_profiles: NumProfiles) {
-        self.profiles_remaining = num_profiles;
-    }
-}
-
 #[derive(Debug)]
 pub struct IseqProfile {
     /// Sparse storage of per-instruction profile data, sorted by instruction index.
@@ -457,11 +451,6 @@ impl IseqProfile {
         let idx = insn_idx as u32;
         self.entries.binary_search_by_key(&idx, |e| e.insn_idx)
             .ok().map(|i| &self.entries[i])
-    }
-
-    /// Check if enough profiles have been gathered for this instruction.
-    pub fn done_profiling_at(&self, insn_idx: YarvInsnIdx) -> bool {
-        self.entry(insn_idx).map_or(false, |e| e.profiles_remaining == 0)
     }
 
     /// Get profiled operand types for a given instruction index


### PR DESCRIPTION
This PR changes function stubs and invalidated ISEQs to profile `num-profiles` cycles and invalidated ISEQs before compiling a next version.

https://github.com/ruby/ruby/pull/17915 was our previous approach for re-profiling ISEQs that exited. While the subject says "re-profile whole ISEQ", it didn't actually profile the whole ISEQ; it only profiled the exited instruction and the rest of the ISEQ, which missed instructions that are executed until the exit. Now, instead of running the JIT code of an exited ISEQ until exiting `num-profiles` times, it just turns such ISEQs back to function stubs right after the first exit, and lets function stubs wait for `num-profiles` profiles instead.

This is part of the adaptive compilation effort https://github.com/Shopify/ruby/issues/1031. This change alone didn't have a significant impact on lobsters by itself, but having more profiles should be generally useful and I'm hoping that combining it with other tuning knobs will help us in the future.