### PR TITLE
Report a void value in an and/or chain only once

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -13917,8 +13917,10 @@ value_expr_check(struct parser_params *p, NODE *node)
 
           case NODE_AND:
           case NODE_OR:
-            node = RNODE_AND(node)->nd_1st;
-            break;
+            /* The left operand was already checked for a value when logop()
+             * built this node, so stop here instead of re-reporting the same
+             * void value once per operator in a chain. */
+            return NULL;
 
           case NODE_LASGN:
           case NODE_DASGN:


### PR DESCRIPTION
`value_expr_check()` descends into the left operand of an and/or node, so a chain such as `x = (return) && (return) && a` reports the same void value once per operator instead of once.
The left operand is already checked for a value when `logop()` builds the node, so stop at the node rather than descending.

This matches the existing `test_void_value_in_rhs` expectation that the same warning is emitted just once, and mirrors the same change in ruby/prism#4221.
