### PR TITLE
ZJIT: Inline write barrier check in LIR

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -658,6 +658,7 @@ typedef struct gc_function_map {
     // Object allocation
     VALUE (*new_obj)(void *objspace_ptr, void *cache_ptr, VALUE klass, VALUE flags, bool wb_protected, size_t alloc_size, size_t *actual_alloc_size);
     bool (*zjit_new_obj_fastpath)(void *objspace_ptr, size_t alloc_size, VALUE flags, VALUE klass, struct rb_gc_zjit_fastpath *fastpath);
+    const uintptr_t *(*zjit_incremental_marking_ptr)(void *objspace_ptr);
     size_t (*obj_slot_size)(VALUE obj);
     size_t (*size_slot_size)(void *objspace_ptr, size_t size);
     bool (*size_allocatable_p)(size_t size);
@@ -853,6 +854,7 @@ ruby_modular_gc_init(void)
     // Object allocation
     load_modular_gc_func(new_obj);
     load_modular_gc_func(zjit_new_obj_fastpath);
+    load_modular_gc_func(zjit_incremental_marking_ptr);
     load_modular_gc_func(obj_slot_size);
     load_modular_gc_func(size_slot_size);
     load_modular_gc_func(size_allocatable_p);
@@ -957,6 +959,7 @@ ruby_modular_gc_init(void)
 // Object allocation
 # define rb_gc_impl_new_obj rb_gc_functions.new_obj
 # define rb_gc_impl_zjit_new_obj_fastpath rb_gc_functions.zjit_new_obj_fastpath
+# define rb_gc_impl_zjit_incremental_marking_ptr rb_gc_functions.zjit_incremental_marking_ptr
 # define rb_gc_impl_obj_slot_size rb_gc_functions.obj_slot_size
 # define rb_gc_impl_size_slot_size rb_gc_functions.size_slot_size
 # define rb_gc_impl_size_allocatable_p rb_gc_functions.size_allocatable_p
@@ -3803,6 +3806,12 @@ rb_gc_zjit_new_obj_fastpath(size_t alloc_size, VALUE flags, VALUE klass, struct 
 #else
     return rb_gc_impl_zjit_new_obj_fastpath(rb_gc_get_objspace(), alloc_size, flags, klass, fastpath);
 #endif
+}
+
+const uintptr_t *
+rb_gc_zjit_incremental_marking_ptr(void)
+{
+    return rb_gc_impl_zjit_incremental_marking_ptr(rb_gc_get_objspace());
 }
 
 void

--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -1414,6 +1414,23 @@ total_final_slots_count(rb_objspace_t *objspace)
 #define is_full_marking(objspace)        ((objspace)->flags.during_minor_gc == FALSE)
 #define is_incremental_marking(objspace) ((objspace)->flags.during_incremental_marking != FALSE)
 #define will_be_incremental_marking(objspace) ((objspace)->rgengc.need_major_gc != GPR_FLAG_NONE)
+
+/* Mirrors flags.during_incremental_marking so that ZJIT-generated code can
+ * read it (a bitfield has no address); see rb_gc_impl_zjit_incremental_marking_ptr.
+ * Only transitions write to it: incremental marking requires a single objspace,
+ * so a redundant FALSE store from another objspace's GC entry must not clobber
+ * the marking objspace's TRUE. Written inside GC while mutators are stopped;
+ * read by JIT code. */
+static uintptr_t zjit_during_incremental_marking = FALSE;
+
+static void
+gc_set_incremental_marking(rb_objspace_t *objspace, unsigned int value)
+{
+    if (objspace->flags.during_incremental_marking != value) {
+        objspace->flags.during_incremental_marking = value;
+        zjit_during_incremental_marking = value;
+    }
+}
 /*
  * Byte budget for incremental sweep steps. Each step sweeps at most
  * this many bytes worth of slots before yielding. The effective slot
@@ -3248,6 +3265,12 @@ rb_gc_impl_zjit_new_obj_fastpath(void *objspace_ptr, size_t alloc_size, VALUE fl
 #endif
 }
 
+const uintptr_t *
+rb_gc_impl_zjit_incremental_marking_ptr(void *objspace_ptr)
+{
+    return &zjit_during_incremental_marking;
+}
+
 NOINLINE(static VALUE newobj_refill(rb_objspace_t *objspace, size_t heap_idx));
 
 static VALUE
@@ -3985,7 +4008,7 @@ gc_abort(void *objspace_ptr)
         VALUE obj;
         while (pop_mark_stack(&objspace->mark_stack, &obj));
 
-        objspace->flags.during_incremental_marking = FALSE;
+        gc_set_incremental_marking(objspace, FALSE);
     }
 
     if (is_lazy_sweeping(objspace)) {
@@ -7007,7 +7030,7 @@ gc_marks_finish(rb_objspace_t *objspace)
         }
 #endif
 
-        objspace->flags.during_incremental_marking = FALSE;
+        gc_set_incremental_marking(objspace, FALSE);
         /* check children of all marked wb-unprotected objects */
         for (int i = 0; i < HEAP_COUNT; i++) {
             gc_marks_wb_unprotected_objects(objspace, &heaps[i]);
@@ -8276,10 +8299,10 @@ gc_start_body(rb_objspace_t *objspace, unsigned int reason, bool allow_global)
              * Ractor can create and share objects behind this objspace's already-scanned
              * roots. */
             !rb_gc_single_objspace_p()) {
-        objspace->flags.during_incremental_marking = FALSE;
+        gc_set_incremental_marking(objspace, FALSE);
     }
     else {
-        objspace->flags.during_incremental_marking = do_full_mark;
+        gc_set_incremental_marking(objspace, do_full_mark);
     }
 
     /* Compaction on the local GC path (autocompact) runs only with a single objspace:
@@ -9010,7 +9033,7 @@ gc_start_global(rb_objspace_t *driver, unsigned int reason, bool compact, bool a
     for (size_t i = 0; i < global_objspace->global_gc.n_objspaces; i++) {
         rb_objspace_t *objspace = global_objspace->global_gc.objspaces[i];
         objspace->flags.during_minor_gc = FALSE;
-        objspace->flags.during_incremental_marking = FALSE;
+        gc_set_incremental_marking(objspace, FALSE);
         /* The unified mark is precise and does not pin, so the per-objspace sweep below must
          * not re-check against a stale local cycle. */
         objspace->last_cycle_pinned = 0;

--- a/gc/gc_impl.h
+++ b/gc/gc_impl.h
@@ -89,6 +89,14 @@ GC_IMPL_FN VALUE rb_gc_impl_new_obj(void *objspace_ptr, void *cache_ptr, VALUE k
  * generated instruction sequence; see zjit/src/gc_fastpath.rs.
  */
 GC_IMPL_FN bool rb_gc_impl_zjit_new_obj_fastpath(void *objspace_ptr, size_t alloc_size, VALUE flags, VALUE klass, struct rb_gc_zjit_fastpath *fastpath);
+/* Returns a pointer to a word that is nonzero while incremental marking is in
+ * progress, or NULL if the implementation does not support ZJIT's inline write
+ * barrier fast path. ZJIT-generated code skips the call to rb_gc_writebarrier()
+ * when the receiver has neither RUBY_FL_PROMOTED nor RUBY_FL_SHAREABLE set and
+ * this word is zero, so only implementations whose write barrier is a no-op
+ * under exactly those conditions may return non-NULL.
+ */
+GC_IMPL_FN const uintptr_t *rb_gc_impl_zjit_incremental_marking_ptr(void *objspace_ptr);
 GC_IMPL_FN size_t rb_gc_impl_obj_slot_size(VALUE obj);
 GC_IMPL_FN size_t rb_gc_impl_size_slot_size(void *objspace_ptr, size_t size);
 GC_IMPL_FN bool rb_gc_impl_size_allocatable_p(size_t size);

--- a/gc/mmtk/mmtk.c
+++ b/gc/mmtk/mmtk.c
@@ -749,6 +749,14 @@ rb_gc_impl_zjit_new_obj_fastpath(void *objspace_ptr, size_t alloc_size, VALUE fl
 #endif
 }
 
+const uintptr_t *
+rb_gc_impl_zjit_incremental_marking_ptr(void *objspace_ptr)
+{
+    /* MMTk's write barrier is not a no-op for young, unshareable receivers,
+     * so ZJIT must always call rb_gc_writebarrier(). */
+    return NULL;
+}
+
 void
 rb_gc_impl_init(void)
 {

--- a/internal/gc.h
+++ b/internal/gc.h
@@ -210,6 +210,7 @@ VALUE rb_newobj_of_unprotected(VALUE klass, VALUE flags, size_t size);
 void *rb_gc_ractor_cache_alloc(struct rb_ractor_struct *ractor);
 void rb_gc_ractor_cache_free(void *cache);
 bool rb_gc_zjit_new_obj_fastpath(size_t alloc_size, VALUE flags, VALUE klass, struct rb_gc_zjit_fastpath *fastpath);
+const uintptr_t *rb_gc_zjit_incremental_marking_ptr(void);
 
 bool rb_gc_size_allocatable_p(size_t size);
 size_t rb_gc_size_slot_size(size_t size);

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -1489,6 +1489,23 @@ fn gen_write_barrier(jit: &mut JITState, asm: &mut Assembler, recv: Opnd, val: O
         asm.cmp(val, Qfalse.into());
         asm.je(jit, result_edge.clone());
 
+        unsafe extern "C" {
+            fn rb_gc_zjit_incremental_marking_ptr() -> *const usize;
+        }
+        // The barrier is a no-op when the receiver is young (not RUBY_FL_PROMOTED),
+        // not RUBY_FL_SHAREABLE, and incremental marking is off; see
+        // rb_gc_impl_writebarrier. NULL means the GC has no such fast path.
+        let marking_ptr = unsafe { rb_gc_zjit_incremental_marking_ptr() };
+        if !marking_ptr.is_null() {
+            let flags = asm.load(Opnd::mem(64, recv, RUBY_OFFSET_RBASIC_FLAGS));
+            let old_or_shareable = asm.and(flags, Opnd::UImm((RUBY_FL_PROMOTED | RUBY_FL_SHAREABLE) as u64));
+            let marking_addr = asm.load(Opnd::const_ptr(marking_ptr));
+            let marking = asm.load(Opnd::mem(64, marking_addr, 0));
+            let needs_wb = asm.or(old_or_shareable, marking);
+            asm.test(needs_wb, needs_wb);
+            asm.jz(jit, result_edge.clone());
+        }
+
         // Heap object; fire the write barrier
         asm_ccall!(asm, rb_gc_writebarrier, recv, val);
         asm.jmp(result_edge);


### PR DESCRIPTION
For `WriteBarrier a, b`, inline the fast-path of the write barrier that covers the majority of cases and doesn't require any actual barrier:

* `a` isn't old
* `a` isn't shareable
* not incremental marking

Removes the vast majority of barrier C calls.

Lobsters before:

```
Top-20 calls to C functions from JIT code (69.2% of total 50,814,557):
                  rb_hash_aref: 5,770,278 (11.4%)
  rb_vm_opt_send_without_block: 5,428,040 (10.7%)
            rb_gc_writebarrier: 3,304,955 ( 6.5%)
...
```

After: completely gone from top-20. Total C calls drop from ~50.8MM to ~47.6MM.

On a microbenchmark such as `setivar_object` or `setivar_young`, it takes per-iteration time from ~41ms to ~36ms (roughly -12%).

```c
void
rb_gc_impl_writebarrier(void *objspace_ptr, VALUE a, VALUE b)
{
    rb_objspace_t *objspace = objspace_ptr;

#if RGENGC_CHECK_MODE
    if (SPECIAL_CONST_P(a)) rb_bug("rb_gc_writebarrier: a is special const: %"PRIxVALUE, a);
    if (SPECIAL_CONST_P(b)) rb_bug("rb_gc_writebarrier: b is special const: %"PRIxVALUE, b);
#else
    RBIMPL_ASSERT_OR_ASSUME(!SPECIAL_CONST_P(a));
    RBIMPL_ASSERT_OR_ASSUME(!SPECIAL_CONST_P(b));
#endif

    GC_ASSERT(!during_gc);
    GC_ASSERT(RB_BUILTIN_TYPE(a) != T_NONE);
    GC_ASSERT(RB_BUILTIN_TYPE(a) != T_MOVED);
    GC_ASSERT(RB_BUILTIN_TYPE(a) != T_ZOMBIE);

    /* A shareable object now references an unshareable one: record b as a shref so its
     * owner's local GC roots it (the parent may live in another objspace, untraversed
     * there).  Only b's owner stores this, on its own page: a plain store suffices. */
    if (RB_UNLIKELY(RB_FL_TEST_RAW(a, RUBY_FL_SHAREABLE)) &&
            !RB_FL_TEST_RAW(b, RUBY_FL_SHAREABLE)) {
        struct heap_page *bpage = GET_HEAP_PAGE(b);
        if (!_MARKED_IN_BITMAP(bpage->shref_bits, bpage, b)) {
            _MARK_IN_BITMAP(bpage->shref_bits, bpage, b);
            bpage->flags.has_shref_objects = TRUE;
        }
    }

  retry:
    if (!is_incremental_marking(objspace)) {
        /* The generational barrier covers old->young edges within one objspace only; a
         * foreign a or b has age bits another objspace mutates, unsafe to read, so check
         * locality first when multi-Ractor (a foreign a is shareable and the shref above
         * already keeps b alive).  With a single Ractor nothing is foreign. */
        if ((rb_gc_multi_ractor_p() &&
                (GET_HEAP_OBJSPACE(a) != objspace || GET_HEAP_OBJSPACE(b) != objspace)) ||
                !RVALUE_OLD_P(objspace, a) || RVALUE_OLD_P(objspace, b)) {
            // do nothing
        }
        else {
            gc_writebarrier_generational(a, b, objspace);
        }
    }
    else {
        /* Slow path, no lock: incremental marking only runs while the process has a single
         * objspace, so the owning Ractor's GVL already serializes this barrier against its
         * own GC. */
        if (is_incremental_marking(objspace)) {
            gc_writebarrier_incremental(a, b, objspace);
        }
        else {
            goto retry;
        }
    }
    return;
}
```