### PR TITLE
ZJIT: Fix Array#find override

### DIFF
--- a/array.rb
+++ b/array.rb
@@ -292,7 +292,11 @@ class Array
         Primitive.attr! :inline_block, :c_trace, :without_interrupts
 
         unless defined?(yield)
-          return Primitive.cexpr! 'SIZED_ENUMERATOR(self, 0, 0, ary_enum_length)'
+          if Primitive.mandatory_only?
+            return Primitive.cexpr! 'SIZED_ENUMERATOR(self, 0, 0, 0)'
+          else
+            return Primitive.cexpr! 'SIZED_ENUMERATOR(self, 1, &if_none_proc, 0)'
+          end
         end
         i = 0
         until Primitive.rb_builtin_ary_at_end(i)
@@ -301,6 +305,11 @@ class Array
           i = Primitive.rb_builtin_fixnum_inc(i)
         end
         if_none_proc&.call
+      end
+
+      if Primitive.rb_builtin_basic_definition_p(:detect)
+        undef :detect
+        alias detect find
       end
     end
   end

--- a/array.rb
+++ b/array.rb
@@ -285,24 +285,23 @@ class Array
       end
     end
 
-    # TODO: Temporarily disabled because it is not compatible and fails multiple spec/ruby/core/array specs
-    # if Primitive.rb_builtin_basic_definition_p(:find)
-    #   undef :find
+    if Primitive.rb_builtin_basic_definition_p(:find)
+      undef :find
 
-    #   def find(if_none_proc = nil) # :nodoc:
-    #     Primitive.attr! :inline_block, :c_trace, :without_interrupts
+      def find(if_none_proc = nil) # :nodoc:
+        Primitive.attr! :inline_block, :c_trace, :without_interrupts
 
-    #     unless defined?(yield)
-    #       return Primitive.cexpr! 'SIZED_ENUMERATOR(self, 0, 0, ary_enum_length)'
-    #     end
-    #     i = 0
-    #     until Primitive.rb_builtin_ary_at_end(i)
-    #       value = Primitive.rb_builtin_ary_at(i)
-    #       return value if yield(value)
-    #       i = Primitive.rb_builtin_fixnum_inc(i)
-    #     end
-    #     if_none_proc&.call
-    #   end
-    # end
+        unless defined?(yield)
+          return Primitive.cexpr! 'SIZED_ENUMERATOR(self, 0, 0, ary_enum_length)'
+        end
+        i = 0
+        until Primitive.rb_builtin_ary_at_end(i)
+          value = Primitive.rb_builtin_ary_at(i)
+          return value if yield(value)
+          i = Primitive.rb_builtin_fixnum_inc(i)
+        end
+        if_none_proc&.call
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes [Bug Shopify/ruby#1011]

The override was disabled in 09a9bdeb324 due to bugs from when I first implemented it. This commit fixes three issues:

1. The if_none_proc is now passed to the enumerator.
2. The `#size` of the enumerator must be `nil` (fixed by passing 0 as the size function to `SIZED_ENUMERATOR`).
3. The `find` method was not aliased to detect.