### PR TITLE
Do not treat a closed fd as ready on the M:N scheduler

### DIFF
--- a/test/-ext-/wait/test_wait.rb
+++ b/test/-ext-/wait/test_wait.rb
@@ -26,6 +26,27 @@ class TestWait < Test::Unit::TestCase
     RUBY
   end
 
+  def test_wait_for_invalid_fd_in_ractor
+    # Threads of a Ractor always run on the M:N scheduler, whose readiness
+    # probe must not report a closed fd as ready.
+    assert_ractor(<<~'RUBY')
+      error = Ractor.new do
+        r, w = IO.pipe
+        r.close
+        IO.for_fd(w.fileno).close
+
+        begin
+          w.wait_writable
+          nil
+        rescue SystemCallError => e
+          e.class
+        end
+      end.value
+
+      assert_equal Errno::EBADF, error
+    RUBY
+  end
+
   def test_wait_for_closed_pipe
     IO.pipe do |r,w|
       w.close

--- a/thread_sched_mn.c
+++ b/thread_sched_mn.c
@@ -1343,23 +1343,16 @@ fd_waiters_arm(int fd, struct rb_fd_waiters *e, uint32_t want, bool consumed)
 }
 
 static bool
-fd_readable_nonblock(int fd)
+fd_ready_nonblock(int fd, short events)
 {
     struct pollfd pfd = {
         .fd = fd,
-        .events = POLLIN,
+        .events = events,
     };
-    return poll(&pfd, 1, 0) != 0;
-}
 
-static bool
-fd_writable_nonblock(int fd)
-{
-    struct pollfd pfd = {
-        .fd = fd,
-        .events = POLLOUT,
-    };
-    return poll(&pfd, 1, 0) != 0;
+    // A "ready" answer makes the caller report the requested event, so a
+    // closed fd (POLLNVAL) must not count: it owes the caller EBADF.
+    return poll(&pfd, 1, 0) > 0 && !(pfd.revents & POLLNVAL);
 }
 
 static void
@@ -1479,16 +1472,16 @@ timer_thread_register_waiting(rb_thread_t *th, int fd, enum thread_sched_waiting
     }
 
     if (flags & thread_sched_waiting_io_read) {
-        if (!(flags & thread_sched_waiting_io_force) && fd_readable_nonblock(fd)) {
-            RUBY_DEBUG_LOG("fd_readable_nonblock");
+        if (!(flags & thread_sched_waiting_io_force) && fd_ready_nonblock(fd, POLLIN)) {
+            RUBY_DEBUG_LOG("fd readable");
             return timer_thread_already_ready;
         }
         VM_ASSERT(fd >= 0);
     }
 
     if (flags & thread_sched_waiting_io_write) {
-        if (!(flags & thread_sched_waiting_io_force) && fd_writable_nonblock(fd)) {
-            RUBY_DEBUG_LOG("fd_writable_nonblock");
+        if (!(flags & thread_sched_waiting_io_force) && fd_ready_nonblock(fd, POLLOUT)) {
+            RUBY_DEBUG_LOG("fd writable");
             return timer_thread_already_ready;
         }
         VM_ASSERT(fd >= 0);


### PR DESCRIPTION
Before parking a thread on an fd, the M:N scheduler polls it once to see whether it is ready already, and counts any answer poll gives as readiness.  poll answers POLLNVAL for a closed fd, so the wait reported the event its caller asked for: IO#wait_writable on a closed fd returned the IO instead of raising Errno::EBADF, where a thread on a dedicated native thread raises it from the POLLNVAL its own poll returns.

The probe has read POLLNVAL as readiness since the M:N scheduler was added, but it was harmless while rb_thread_wait_for_single_fd polled regardless and only asked the scheduler whether to retry.  Since 41dd15944f a scheduler that reports readiness skips the poll and fills in the requested events, so the POLLNVAL that becomes EBADF below is never seen.  Ruby 3.3 raises it; 3.4 and later do not.

Report readiness only for an actual event.  A closed fd then goes on to the registration, which the backend also refuses for it (EBADF), and from there to the blocking path, whose poll reports it as before.

The test covers it from a Ractor, whose threads use the M:N scheduler whatever RUBY_MN_THREADS says.