### PR TITLE
[4.0] struct.c: don't embed the largest possible embedded struct

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -3757,6 +3757,40 @@ assert_equal 'ok', %q{
   foo(s) rescue :ok
 }
 
+# max size struct with ivars
+assert_equal 'ok', <<~'RUBY'
+  n = 78
+  members = n.times.map { |i| :"m#{i}" }
+  klass = Struct.new(*members)
+  reader = ->(s) { s.m2 }
+  make = -> { klass.new(*n.times.to_a) }
+
+  before = make.call
+  300.times { reader.call(before); make.call }
+
+  before.instance_variable_set(:@iv, 1)
+  after = make.call
+  raise "wrong value" unless reader.call(after) == 2 && after.send(members.last) == (n - 1)
+  :ok
+RUBY
+
+# struct with ivars
+assert_equal 'ok', <<~'RUBY'
+  n = 3
+  members = n.times.map { |i| :"m#{i}" }
+  klass = Struct.new(*members)
+  reader = ->(s) { s.m2 }
+  make = -> { klass.new(*n.times.to_a) }
+
+  before = make.call
+  300.times { reader.call(before); make.call }
+
+  before.instance_variable_set(:@iv, 1)
+  after = make.call
+  raise "wrong value" unless reader.call(after) == 2 && after.send(members.last) == (n - 1)
+  :ok
+RUBY
+
 # File.join is a cfunc accepting variable arguments as a Ruby array (argc = -2)
 assert_equal 'foo/bar', %q{
   def foo

--- a/struct.c
+++ b/struct.c
@@ -821,50 +821,45 @@ static VALUE
 struct_alloc(VALUE klass)
 {
     long n = num_members(klass);
-    size_t embedded_size = offsetof(struct RStruct, as.ary) + (sizeof(VALUE) * n);
-    if (RCLASS_MAX_IV_COUNT(klass) > 0) {
-        embedded_size += sizeof(VALUE);
-    }
 
     VALUE flags = T_STRUCT | (RGENGC_WB_PROTECTED_STRUCT ? FL_WB_PROTECTED : 0);
 
-    if (n > 0 && rb_gc_size_allocatable_p(embedded_size)) {
-        flags |= n << RSTRUCT_EMBED_LEN_SHIFT;
-        if (RCLASS_MAX_IV_COUNT(klass) == 0) {
-            // We set the flag before calling `NEWOBJ_OF` in case a NEWOBJ tracepoint does
-            // attempt to write fields. We'll remove it later if no fields was written to.
-            flags |= RSTRUCT_GEN_FIELDS;
-        }
+    if (n > 0) {
+        size_t embedded_size = offsetof(struct RStruct, as.ary) + (sizeof(VALUE) * n);
+        size_t embedded_with_ivar_size = embedded_size + sizeof(VALUE);
 
-        NEWOBJ_OF(st, struct RStruct, klass, flags, embedded_size, 0);
-        if (RCLASS_MAX_IV_COUNT(klass) == 0) {
-            if (!rb_shape_obj_has_fields((VALUE)st)
-                    && embedded_size < rb_gc_obj_slot_size((VALUE)st)) {
+        // We always check if `n+1` is embeddable, because JITs expect all instances of a given
+        // struct to be either always or never embedded.
+        if (rb_gc_size_allocatable_p(embedded_with_ivar_size)) {
+            // We set the `RSTRUCT_GEN_FIELDS` flag before calling `NEWOBJ_OF` in case a NEWOBJ tracepoint
+            // does attempt to write fields. We'll remove it later if no fields was written to.
+            flags |= RSTRUCT_GEN_FIELDS | (n << RSTRUCT_EMBED_LEN_SHIFT);
+
+            bool has_ivar = RCLASS_MAX_IV_COUNT(klass) > 0;
+            NEWOBJ_OF(st, struct RStruct, klass, flags, has_ivar ? embedded_with_ivar_size : embedded_size, 0);
+
+            rb_mem_clear((VALUE *)st->as.ary, n);
+
+            if (!rb_shape_obj_has_fields((VALUE)st) && has_ivar) {
                 FL_UNSET_RAW((VALUE)st, RSTRUCT_GEN_FIELDS);
                 RSTRUCT_SET_FIELDS_OBJ((VALUE)st, 0);
             }
+
+            return (VALUE)st;
         }
-        else {
-            RSTRUCT_SET_FIELDS_OBJ((VALUE)st, 0);
-        }
-
-        rb_mem_clear((VALUE *)st->as.ary, n);
-
-        return (VALUE)st;
     }
-    else {
-        NEWOBJ_OF(st, struct RStruct, klass, flags, sizeof(struct RStruct), 0);
 
-        st->as.heap.ptr = NULL;
-        st->as.heap.fields_obj = 0;
-        st->as.heap.len = 0;
+    NEWOBJ_OF(st, struct RStruct, klass, flags, sizeof(struct RStruct), 0);
 
-        st->as.heap.ptr = struct_heap_alloc((VALUE)st, n);
-        rb_mem_clear((VALUE *)st->as.heap.ptr, n);
-        st->as.heap.len = n;
+    st->as.heap.ptr = NULL;
+    st->as.heap.fields_obj = 0;
+    st->as.heap.len = 0;
 
-        return (VALUE)st;
-    }
+    st->as.heap.ptr = struct_heap_alloc((VALUE)st, n);
+    rb_mem_clear((VALUE *)st->as.heap.ptr, n);
+    st->as.heap.len = n;
+
+    return (VALUE)st;
 }
 
 VALUE


### PR DESCRIPTION
[[Bug #22292]](https://bugs.ruby-lang.org/issues/22292)

JITs expect all instances of a given struct either always or never be embedded.
So when allocating a struct that would entirely fill the largest possible slot, we should not embed it as if it later gain ivars it would break that invariant.