### PR TITLE
[DOC] Fix error raised for lchmod

### DIFF
--- a/file.c
+++ b/file.c
@@ -3119,7 +3119,7 @@ lchmod_internal(const char *path, void *mode)
  *  call-seq:
  *    File.lchmod(mode, *paths) -> paths_count
  *
- *  Not supported on some platforms (raises Errno:: ENOTSUP).
+ *  Not supported on some platforms (raises NotImplementedError).
  *
  *  When supported: like File::chmod, but does not follow symbolic links,
  *  and therefore changes the mode of the entries given by `paths`;

--- a/pathname_builtin.rb
+++ b/pathname_builtin.rb
@@ -1543,7 +1543,7 @@ class Pathname    # * File *
   #  call-seq:
   #    lchmod(mode) -> 1
   #
-  #  Not supported on some platforms (raises Errno::ENOTSUP).
+  #  Not supported on some platforms (raises NotImplementedError).
   #
   #  When supported: like Pathname::chmod, but does not follow symbolic links,
   #  and therefore changes the mode of the entry specified by `self`:


### PR DESCRIPTION
When lchmod isn't available, it raises NotImplementedError.