### PR TITLE
Fix memsize of imemo_ment

### DIFF
--- a/imemo.c
+++ b/imemo.c
@@ -298,7 +298,7 @@ rb_imemo_memsize(VALUE obj)
       case imemo_memo:
         break;
       case imemo_ment:
-        size += sizeof(((rb_method_entry_t *)obj)->def);
+        size += sizeof(struct rb_method_definition_struct);
 
         break;
       case imemo_svar:


### PR DESCRIPTION
sizeof(((rb_method_entry_t *)obj)->def) returned the size of the pointer (8 bytes) and not the size of the rb_method_entry_t.