### PR TITLE
Regenerate revision.h after removing it in update-src

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -1356,8 +1356,11 @@ clean-build-tool:
 
 $(srcdir)/revision.h$(no_baseruby:no=~disabled~): $(REVISION_H)
 
+REVISION_H_CMD = $(BASERUBY) $(tooldir)/file2lastrev.rb -q --revision.h \
+	--srcdir="$(srcdir)" --output=revision.h --timestamp=$(REVISION_H)
+
 $(REVISION_H)$(no_baseruby:no=~disabled~):
-	$(Q) $(BASERUBY) $(tooldir)/file2lastrev.rb -q --revision.h --srcdir="$(srcdir)" --output=revision.h --timestamp=$@
+	$(Q) $(REVISION_H_CMD)
 $(REVISION_H)$(yes_baseruby:yes=~disabled~):
 	$(Q) exit > $@
 
@@ -1520,6 +1523,11 @@ after-update:: update-default-gemspecs
 update-src::
 	$(Q) $(RM) $(REVISION_H) revision.h "$(srcdir)/$(REVISION_H)" "$(srcdir)/revision.h"
 	$(Q) exit > "$(srcdir)/revision.h"
+
+# $(REVISION_H) can have been made already in this run, as a prerequisite
+# of the included dependency file, and make does not make it twice.
+update-src$(no_baseruby:no=~disabled~)::
+	$(Q) $(REVISION_H_CMD)
 
 update-remote:: update-src update-download
 update-download:: $(ALWAYS_UPDATE_UNICODE:yes=update-unicode)


### PR DESCRIPTION
`make up` fails with `RUBY_RELEASE_MONTH` undefined because `revision.h` stays empty for the whole run.

`.deps/depend` gained `$(REVISION_H)` as a prerequisite in https://github.com/ruby/ruby/pull/18561, and `.deps/depend` is included by `GNUmakefile`, so make makes `$(REVISION_H)` while remaking the included makefiles. That happens before `update-src` removes it and writes an empty `revision.h`. Make does not make a target twice in one run, so the `$(REVISION_H)` prerequisite of `after-update` does nothing and the rest of the build compiles against the empty header.

Regenerate `revision.h` in `update-src` right after the removal. Reproduced with GNU make 4.4.1 on macOS and confirmed `make up` now finishes with a correct `revision.h`. GNU make 3.81 runs `after-update` in a sub-make and was not affected.

Generated with [Claude Code](https://claude.com/claude-code)
