### PR TITLE
win32: Fix for NoDefaultCurrentDirectoryInExePath

### DIFF
--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -59,6 +59,7 @@ jobs:
       CPPFLAGS: '-D_FORTIFY_SOURCE=2 -D__USE_MINGW_ANSI_STDIO=1 -DFD_SETSIZE=2048'
       LDFLAGS: '-pipe'
       GITPULLOPTIONS: --no-tags origin ${{ github.ref }}
+      NoDefaultCurrentDirectoryInExePath: 1
 
     strategy:
       matrix:

--- a/.github/workflows/tarball-windows.yml
+++ b/.github/workflows/tarball-windows.yml
@@ -44,6 +44,7 @@ jobs:
       OS_VER: windows-${{ matrix.os }}
       VCPKG_DEFAULT_TRIPLET: x64-windows
       FEED_URL: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
+      NoDefaultCurrentDirectoryInExePath: 1
     steps:
       - run: md build
         working-directory:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -58,6 +58,7 @@ jobs:
       GITPULLOPTIONS: --no-tags origin ${{ github.ref }}
       VCPKG_DEFAULT_TRIPLET: ${{ matrix.target || 'x64' }}-windows
       FEED_URL: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
+      NoDefaultCurrentDirectoryInExePath: 1
 
     steps:
       - run: md build

--- a/win32/Makefile.sub
+++ b/win32/Makefile.sub
@@ -1140,7 +1140,7 @@ miniruby$(EXEEXT):
 		$(Q) $(PURIFY) $(CC) $(MAINOBJ) $(MINIOBJS) $(COMMONOBJS) $(LIBS) \
 			$(OUTFLAG)$@ -link $(LDFLAGS) $(XLDFLAGS)
 		@$(RM) miniruby.lib miniruby.exp
-		$(Q) miniruby.exe -v
+		$(Q) .\miniruby.exe -v
 		$(Q) $(LDSHARED_1)
 		$(Q) $(LDSHARED_2)
 

--- a/win32/setup.mak
+++ b/win32/setup.mak
@@ -182,7 +182,7 @@ revision_opt = -DRUBY_REVISION=0
 
 verconf.mk: nul
 	@findstr /R /C:"^#define RUBY_ABI_VERSION " $(srcdir:/=\)\include\ruby\internal\abi.h > $(@)
-	@$(CPP) -I$(srcdir) -I$(srcdir)/include $(revision_opt) <<"Creating $(@)" > $(*F).bat && cmd /c $(*F).bat > $(@)
+	@$(CPP) -I$(srcdir) -I$(srcdir)/include $(revision_opt) <<"Creating $(@)" > $(*F).bat && cmd /c .\$(*F).bat > $(@)
 @echo off
 #define STRINGIZE0(expr) #expr
 #define STRINGIZE(x) STRINGIZE0(x)


### PR DESCRIPTION
If the `NoDefaultCurrentDirectoryInExePath` environment variable is set, the current directory won't be part of the search path for the command without path separators.

https://learn.microsoft.com/en-us/windows/win32/api/processenv/nf-processenv-needcurrentdirectoryforexepathw#remarks
