### PR TITLE
[DOC] Pathname#rmtree returns self, not 0

### DIFF
--- a/lib/pathname.rb
+++ b/lib/pathname.rb
@@ -88,9 +88,9 @@ class Pathname    # * FileUtils *
   # :markup: markdown
   #
   # call-seq:
-  #   rmtree -> 0
+  #   rmtree(noop: nil, verbose: nil, secure: nil) -> self
   #
-  # Deletes the entire filetree at the path in `self`; returns `0`:
+  # Deletes the entire filetree at the path in `self`; returns `self`:
   #
   # ```ruby
   # dir_pn = Pathname('foo/bar/baz') # => #<Pathname:foo/bar/baz>
@@ -102,6 +102,8 @@ class Pathname    # * FileUtils *
   # ```
   #
   # Use method #rmdir to delete a single (empty) directory.
+  #
+  # See FileUtils.rm_rf for keyword arguments.
   #
   def rmtree(noop: nil, verbose: nil, secure: nil)
     # The name "rmtree" is borrowed from File::Path of Perl.


### PR DESCRIPTION
Fixes [Bug #22288](https://bugs.ruby-lang.org/issues/22288).

The docs for `Pathname#rmtree` claim a `0` return value in both the call-seq and the prose:

```ruby
# call-seq:
#   rmtree -> 0
#
# Deletes the entire filetree at the path in `self`; returns `0`:
```

The method returns `self`. It has done so since [Feature #17294](https://bugs.ruby-lang.org/issues/17294) made `mkpath` and `rmtree` chainable, and `test_rmtree` asserts `assert_equal(path, path.rmtree)`.

The call-seq also omitted the keyword arguments, so this adds them along with a pointer to `FileUtils.rm_rf`, which they are forwarded to. `mkpath` already documents its keyword the same way (`mkpath(mode: nil) -> self`).
