### PR TITLE
Check struct size when a user class relabels a loaded struct

### DIFF
--- a/marshal.c
+++ b/marshal.c
@@ -1971,6 +1971,11 @@ r_object_for(struct load_arg *arg, bool partial, int *ivp, VALUE klass, VALUE ex
 
                 if (TYPE(v) != TYPE(tmp)) goto format_error;
             }
+            if (RB_TYPE_P(v, T_STRUCT) &&
+                RSTRUCT_LEN_RAW(v) != RARRAY_LEN(rb_struct_s_members(c))) {
+                rb_raise(rb_eTypeError, "struct %"PRIsVALUE" not compatible (struct size differs)",
+                         rb_class_name(c));
+            }
             RBASIC_SET_CLASS(v, c);
         }
         break;

--- a/test/ruby/test_marshal.rb
+++ b/test/ruby/test_marshal.rb
@@ -212,6 +212,19 @@ class TestMarshal < Test::Unit::TestCase
     self.class.__send__(:remove_const, :C3) if self.class.const_defined?(:C3)
   end
 
+  UserClassWideStruct = Struct.new(:a, :b, :c, :d, :e)
+  UserClassNarrowStruct = Struct.new(:a)
+
+  def test_user_class_struct_size
+    wide = Marshal.dump(UserClassWideStruct.new(1, 2, 3, 4, 5)).byteslice(2..)
+    narrow = Marshal.dump(UserClassNarrowStruct.new(6)).byteslice(2..)
+    # An array of both structs, then a user class marker relabelling the
+    # narrow struct (object link "@\a") as the wide class (symbol link ";\0").
+    data = "\x04\b[\b".b + wide + narrow + "C;\0@\a".b
+    message = /\Astruct #{UserClassWideStruct.name} not compatible \(struct size differs\)/
+    assert_raise_with_message(TypeError, message) {Marshal.load(data)}
+  end
+
   class C4
     def initialize(gc)
       @gc = gc


### PR DESCRIPTION
`Marshal.load` can hand back a `Struct` whose class claims more members than the object actually has. The `TYPE_UCLASS` marker only compares the built-in type before it swaps the class, so a struct read earlier in the stream can be relabelled as a struct class of a different size. Its accessors then read and write past the allocated slots, which can land on another object the same `Marshal.load` call returns.

`TYPE_STRUCT` already rejects a size mismatch with `struct ... not compatible (struct size differs)`. I apply the same check on the `TYPE_UCLASS` path and reuse that message. Only `T_STRUCT` is checked, so the ordinary `String`, `Array` and `Hash` subclass round trips are untouched.

Before this change:

```ruby
S1 = Struct.new(:a)
S5 = Struct.new(:a, :b, :c, :d, :e)
payload = "\x04\x08[\x08S:\x07S1\x06:\x06ai\x06S:\x07S1\x06:\x06ai\x07C:\x07S5@\x06"
malformed, victim = Marshal.load(payload)
malformed.class  #=> S5
malformed.size   #=> 1
malformed.e = :written_by_accessor
victim.a         #=> :written_by_accessor
```

Generated with [Claude Code](https://claude.com/claude-code)
