### PR TITLE
Fix understated max_output in three transcoders

### DIFF
--- a/enc/trans/iso2022.trans
+++ b/enc/trans/iso2022.trans
@@ -544,7 +544,7 @@ rb_cp50220_encoder = {
     TRANSCODE_TABLE_INFO,
     1, /* input_unit_length */
     3, /* max_input */
-    5, /* max_output */
+    9, /* max_output */
     asciicompat_encoder, /* asciicompat_type */
     3, iso2022jp_init, iso2022jp_init, /* state_size, state_init, state_fini */
     NULL, NULL, NULL, fun_so_cp50220_encoder,

--- a/enc/trans/utf_16_32.trans
+++ b/enc/trans/utf_16_32.trans
@@ -521,7 +521,7 @@ rb_to_UTF_16 = {
     TRANSCODE_TABLE_INFO,
     1, /* input_unit_length */
     4, /* max_input */
-    4, /* max_output */
+    6, /* max_output */
     asciicompat_encoder, /* asciicompat_type */
     1, state_init, NULL, /* state_size, state_init, state_fini */
     NULL, NULL, NULL, fun_so_to_utf_16
@@ -533,7 +533,7 @@ rb_to_UTF_32 = {
     TRANSCODE_TABLE_INFO,
     1, /* input_unit_length */
     4, /* max_input */
-    4, /* max_output */
+    8, /* max_output */
     asciicompat_encoder, /* asciicompat_type */
     1, state_init, NULL, /* state_size, state_init, state_fini */
     NULL, NULL, NULL, fun_so_to_utf_32

--- a/test/ruby/test_transcode.rb
+++ b/test/ruby/test_transcode.rb
@@ -1195,11 +1195,31 @@ class TestTranscode < Test::Unit::TestCase
     assert_invalid_in(%w/fffeb7df/.pack("H*"), "UTF-16")
   end
 
+  def test_utf_16_bom_partial_output
+    ec = Encoding::Converter.new("UTF-8", "UTF-16")
+    src = "\u{1F600}"
+    dst = "\0" * 64
+    assert_equal(:destination_buffer_full, ec.primitive_convert(src, dst, 0, 4))
+    assert_equal(4, dst.bytesize)
+    assert_equal(:finished, ec.primitive_convert(src, dst, 4, 4))
+    assert_equal("\xFE\xFF\xD8\x3D\xDE\x00", dst.b)
+  end
+
   def test_utf_32_bom
     expected = "\u{3042}\u{3044}\u{20bb7}"
     assert_equal(expected, %w/fffe00004230000044300000b70b0200/.pack("H*").encode("UTF-8","UTF-32"))
     check_both_ways(expected, %w/0000feff000030420000304400020bb7/.pack("H*"), "UTF-32")
     assert_invalid_in(%w/0000feff00110000/.pack("H*"), "UTF-32")
+  end
+
+  def test_utf_32_bom_partial_output
+    ec = Encoding::Converter.new("UTF-8", "UTF-32")
+    src = "A"
+    dst = "\0" * 64
+    assert_equal(:destination_buffer_full, ec.primitive_convert(src, dst, 0, 4))
+    assert_equal(4, dst.bytesize)
+    assert_equal(:finished, ec.primitive_convert(src, dst, 4, 4))
+    assert_equal("\x00\x00\xFE\xFF\x00\x00\x00A", dst.b)
   end
 
   def check_utf_32_both_ways(utf8, raw)

--- a/test/ruby/test_transcode.rb
+++ b/test/ruby/test_transcode.rb
@@ -1662,6 +1662,27 @@ class TestTranscode < Test::Unit::TestCase
                  "\x8E\xA1\x8E\xFE".encode("cp50220", "cp51932"))
   end
 
+  def test_to_cp50220_partial_output
+    # A katakana held back for a possible sound mark is flushed with its own
+    # designation (5 bytes) before the designation and data of the character
+    # that ended the hold (4 bytes).
+    ec = Encoding::Converter.new("CP51932", "CP50220")
+    src = "\x8E\xB6\x8E\xE0"
+    dst = "\0" * 64
+    assert_equal(:destination_buffer_full, ec.primitive_convert(src, dst, 0, 8))
+    assert_equal(8, dst.bytesize)
+    assert_equal(:finished, ec.primitive_convert(src, dst, 8, 8))
+    assert_equal("\e$B\x25\x2B\e(I\x60\e(B", dst.b)
+
+    ec = Encoding::Converter.new("CP51932", "CP50220")
+    src = "\x8E\xB6"
+    dst = "\0" * 64
+    assert_equal(:destination_buffer_full, ec.primitive_convert(src, dst, 0, 5))
+    assert_equal(5, dst.bytesize)
+    assert_equal(:finished, ec.primitive_convert(src, dst, 5, 5))
+    assert_equal("\e$B\x25\x2B\e(B", dst.b)
+  end
+
   def test_iso_2022_jp_1
     # check_both_ways("\u9299", "\x1b$(Dd!\x1b(B", "iso-2022-jp-1") # JIS X 0212 区68 点01 銙
   end


### PR DESCRIPTION
Converting into a fixed-size output window aborts the process with `[BUG] probable buffer overflow` when the window is exactly as large as the transcoder says it needs. `Encoding::Converter#primitive_convert` with a `destination_bytesize` of 4 reaches it.

```ruby
ec = Encoding::Converter.new("UTF-8", "UTF-16")
ec.primitive_convert("\u{1F600}", "X" * 4092, 4092, 4)
# -e:1: [BUG] probable buffer overflow: 4098 for 4096
```

Three `rb_transcoder` definitions declare a `max_output` below their real worst case. `rb_to_UTF_16` and `rb_to_UTF_32` leave out the BOM they write ahead of the first character, and `rb_cp50220_encoder` leaves out the katakana it holds back for a possible sound mark and flushes on the next character. `transcode.c` trusts the declared value and lets a transcoder write straight into the caller's window whenever that many bytes are free.

CP50220 needs 9, past the 8 byte inline write buffer, so that one transcoder now allocates its write buffer. The other nine `max_output` values of 4 in `utf_16_32.trans` belong to the endianness-explicit transcoders, which write no BOM and stay at 4.

Generated with [Claude Code](https://claude.com/claude-code)
