### PR TITLE
Fix memory leak reported in TestRequire#test_loading_fifo_threading_raise

### DIFF
--- a/load.c
+++ b/load.c
@@ -731,6 +731,46 @@ realpath_internal_cached(VALUE hash, VALUE path)
     return realpath;
 }
 
+struct load_prism_args {
+    pm_parse_result_t result;
+    VALUE fname;
+    VALUE realpath_map;
+    const rb_iseq_t *iseq;
+    VALUE error;
+};
+
+static VALUE
+load_prism_parse(VALUE args_ptr)
+{
+    struct load_prism_args *args = (struct load_prism_args *)args_ptr;
+    pm_parse_result_t *result = &args->result;
+    VALUE fname = args->fname;
+
+    VALUE error = pm_load_parse_file(result, fname, NULL);
+    if (error != Qnil) {
+        args->error = error;
+        return Qnil;
+    }
+
+    int error_state;
+    args->iseq = pm_iseq_new_top(&result->node, rb_fstring_lit("<top (required)>"), fname,
+                                 realpath_internal_cached(args->realpath_map, fname), NULL, &error_state);
+    if (error_state) {
+        RUBY_ASSERT(args->iseq == NULL);
+        rb_jump_tag(error_state);
+    }
+
+    return Qnil;
+}
+
+static VALUE
+load_prism_free_result(VALUE args_ptr)
+{
+    struct load_prism_args *args = (struct load_prism_args *)args_ptr;
+    pm_parse_result_free(&args->result);
+    return Qnil;
+}
+
 static inline void
 load_iseq_eval(rb_execution_context_t *ec, VALUE fname)
 {
@@ -744,29 +784,27 @@ load_iseq_eval(rb_execution_context_t *ec, VALUE fname)
         VALUE realpath_map = box->loaded_features_realpath_map;
 
         if (rb_ruby_prism_p()) {
-            pm_parse_result_t result;
-            pm_parse_result_init(&result);
-            result.node.coverage_enabled = 1;
+            struct load_prism_args args = {
+                .fname = fname,
+                .realpath_map = realpath_map,
+                .iseq = NULL,
+                .error = Qnil,
+            };
+            pm_parse_result_init(&args.result);
+            args.result.node.coverage_enabled = 1;
 
-            VALUE error = pm_load_parse_file(&result, fname, NULL);
+            /* The parse result must be freed even if parsing or compiling
+             * raises (e.g. an asynchronously raised IOError while reading a
+             * pipe), so wrap it in rb_ensure. */
+            rb_ensure(load_prism_parse, (VALUE)&args, load_prism_free_result, (VALUE)&args);
 
-            if (error == Qnil) {
-                int error_state;
-                iseq = pm_iseq_new_top(&result.node, rb_fstring_lit("<top (required)>"), fname, realpath_internal_cached(realpath_map, fname), NULL, &error_state);
-
-                pm_parse_result_free(&result);
-
-                if (error_state) {
-                    RUBY_ASSERT(iseq == NULL);
-                    rb_jump_tag(error_state);
-                }
-            }
-            else {
+            if (args.error != Qnil) {
                 rb_vm_pop_frame(ec);
                 RB_GC_GUARD(v);
-                pm_parse_result_free(&result);
-                rb_exc_raise(error);
+                rb_exc_raise(args.error);
             }
+
+            iseq = args.iseq;
         }
         else {
             rb_ast_t *ast;


### PR DESCRIPTION
The test TestRequire#test_loading_fifo_threading_raise fails with the following error in LSAN because pm_load_parse_file could raise which will cause the pm_parse_result_t to leak.

    Direct leak of 104 byte(s) in 1 object(s) allocated from:
        #0 0x64ee1a50385d in calloc build-llvm/tools/clang/stage2-bins/runtimes/runtimes-bins/compiler-rt/lib/asan/asan_malloc_linux.cpp:74:3
        #1 0x64ee1a578206 in calloc1 gc/default/default.c:2000:12
        #2 0x64ee1a578206 in rb_gc_impl_calloc gc/default/default.c:11069:5
        #3 0x64ee1a578206 in ruby_xcalloc_body gc.c:6146:12
        #4 0x64ee1a578206 in ruby_xcalloc gc.c:6140:34
        #5 0x64ee1acfaed1 in pm_parse_result_init prism_compile.c:10639:23
        #6 0x64ee1a67bbd1 in load_iseq_eval load.c:748:13
        #7 0x64ee1a674cd4 in rb_load_internal load.c:866:9
        #8 0x64ee1a6754d6 in rb_load_entrypoint load.c:908:5
        #9 0x64ee1a6790a5 in rb_f_load load.c:950:12
        #10 0x64ee1a97043b in vm_call_cfunc_with_frame_ vm_insnhelper.c:3899:11
        #11 0x64ee1a957d0b in vm_call_method_each_type vm_insnhelper.c:4891:16
        #12 0x64ee1a95779b in vm_call_method vm_insnhelper.c
        #13 0x64ee1a91a9ad in vm_sendish vm_insnhelper.c:6213:15
        #14 0x64ee1a91a9ad in vm_exec_core insns.def:909:11
        #15 0x64ee1a9083bd in rb_vm_exec vm.c:2875:22
        #16 0x64ee1a54bccc in rb_ec_exec_node eval.c:299:9
        #17 0x64ee1a54b993 in ruby_run_node eval.c:337:30
        #18 0x64ee1a547f50 in rb_main main.c:42:12
        #19 0x64ee1a547f50 in main main.c:62:12
        #20 0x7f8507a2a1c9 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
        #21 0x7f8507a2a28a in __libc_start_main csu/../csu/libc-start.c:360:3
        #22 0x64ee1a45fb74 in _start (ruby+0x197b74) (BuildId: 5b18a734908cec0a5f93267f1f350850b0f3fb6d)

    Direct leak of 16 byte(s) in 1 object(s) allocated from:
        #0 0x64ee1a50385d in calloc build-llvm/tools/clang/stage2-bins/runtimes/runtimes-bins/compiler-rt/lib/asan/asan_malloc_linux.cpp:74:3
        #1 0x64ee1a578206 in calloc1 gc/default/default.c:2000:12
        #2 0x64ee1a578206 in rb_gc_impl_calloc gc/default/default.c:11069:5
        #3 0x64ee1a578206 in ruby_xcalloc_body gc.c:6146:12
        #4 0x64ee1a578206 in ruby_xcalloc gc.c:6140:34
        #5 0x64ee1acfaeb9 in pm_parse_result_init prism_compile.c:10638:21
        #6 0x64ee1a67bbd1 in load_iseq_eval load.c:748:13
        #7 0x64ee1a674cd4 in rb_load_internal load.c:866:9
        #8 0x64ee1a6754d6 in rb_load_entrypoint load.c:908:5
        #9 0x64ee1a6790a5 in rb_f_load load.c:950:12
        #10 0x64ee1a97043b in vm_call_cfunc_with_frame_ vm_insnhelper.c:3899:11
        #11 0x64ee1a957d0b in vm_call_method_each_type vm_insnhelper.c:4891:16
        #12 0x64ee1a95779b in vm_call_method vm_insnhelper.c
        #13 0x64ee1a91a9ad in vm_sendish vm_insnhelper.c:6213:15
        #14 0x64ee1a91a9ad in vm_exec_core insns.def:909:11
        #15 0x64ee1a9083bd in rb_vm_exec vm.c:2875:22
        #16 0x64ee1a54bccc in rb_ec_exec_node eval.c:299:9
        #17 0x64ee1a54b993 in ruby_run_node eval.c:337:30
        #18 0x64ee1a547f50 in rb_main main.c:42:12
        #19 0x64ee1a547f50 in main main.c:62:12
        #20 0x7f8507a2a1c9 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
        #21 0x7f8507a2a28a in __libc_start_main csu/../csu/libc-start.c:360:3
        #22 0x64ee1a45fb74 in _start (ruby+0x197b74) (BuildId: 5b18a734908cec0a5f93267f1f350850b0f3fb6d)