### PR TITLE
[Bug #12040] Fix File.stat on volume mount points named with "..."

### DIFF
--- a/test/ruby/test_file_exhaustive.rb
+++ b/test/ruby/test_file_exhaustive.rb
@@ -301,6 +301,40 @@ class TestFileExhaustive < Test::Unit::TestCase
     end
   end if NTFS
 
+  def test_stat_dotted_infix # [Bug #12040]
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, "x...y")
+      Dir.mkdir(path)
+      assert_nothing_raised { File.stat(path) }
+      assert_raise(Errno::ENOENT) { File.stat(File.join(path, "...")) }
+      assert_raise(Errno::ENOENT) { File.stat(File.join(path, "....")) }
+      assert_raise(Errno::ENOENT) { File.stat(File.join(path, "... ")) }
+    end
+  end if NTFS
+
+  def test_stat_dotted_infix_unlistable # [Bug #12040]
+    user = ENV["USERNAME"]
+    omit "USERNAME is not set or empty" if user.nil? or user.empty?
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, "x...y")
+      Dir.mkdir(path)
+      # Imitate a mount point root, which exists but cannot be enumerated.
+      case system("icacls", path, "/deny", "#{user}:(RD)", out: File::NULL, err: File::NULL)
+      when nil then omit "icacls is not available"
+      when false then omit "icacls failed to deny the listing"
+      end
+      begin
+        Dir.children(path)
+      rescue Errno::EACCES
+        assert_nothing_raised { File.stat(path) }
+      else
+        omit "denying the listing did not take effect"
+      ensure
+        system("icacls", path, "/remove:d", user, out: File::NULL, err: File::NULL)
+      end
+    end
+  end if NTFS
+
   def test_lstat
     return unless symlinkfile
     assert_equal(false, File.stat(symlinkfile).symlink?)

--- a/win32/win32.c
+++ b/win32/win32.c
@@ -6008,7 +6008,10 @@ winnt_stat(const WCHAR *path, struct stati128 *st, BOOL lstat)
             break;
           default:
             if (attr & FILE_ATTRIBUTE_DIRECTORY) {
-                if (check_valid_dir(path)) return -1;
+                if (check_valid_dir(path)) {
+                    CloseHandle(f);
+                    return -1;
+                }
             }
             if (attr & FILE_ATTRIBUTE_REPARSE_POINT) {
                 FILE_ATTRIBUTE_TAG_INFO attr_info;

--- a/win32/win32.c
+++ b/win32/win32.c
@@ -5783,43 +5783,22 @@ fileattr_to_unixmode(DWORD attr, const WCHAR *path, unsigned mode)
 static int
 check_valid_dir(const WCHAR *path)
 {
-    WIN32_FIND_DATAW fd;
-    HANDLE fh;
-    WCHAR full[PATH_MAX];
-    WCHAR *p, *q;
+    const WCHAR *p = path, *q;
 
-    /* GetFileAttributes() determines "..." as directory. */
-    /* We recheck it by FindFirstFile(). */
-    if (!(p = wcsstr(path, L"...")))
-        return 0;
-    q = p + wcsspn(p, L".");
-    if ((p == path || wcschr(L":/\\", *(p - 1))) &&
-        (!*q || wcschr(L":/\\", *q))) {
-        errno = ENOENT;
-        return -1;
+    /* CreateFile() and GetFileAttributes() strip trailing dots and
+     * spaces of the last path component, so a component of dots
+     * followed by spaces only, which cannot actually exist, falsely
+     * resolves to its parent directory.  A match inside a name, as in
+     * "a...b", does not end the search. */
+    while ((p = wcsstr(p, L"...")) != NULL) {
+        q = p + wcsspn(p, L". ");
+        if ((p == path || wcschr(L":/\\", *(p - 1))) &&
+            (!*q || wcschr(L":/\\", *q))) {
+            errno = ENOENT;
+            return -1;
+        }
+        p = q;
     }
-
-    /* if the specified path is the root of a drive and the drive is empty, */
-    /* FindFirstFile() returns INVALID_HANDLE_VALUE. */
-    DWORD len = GetFullPathNameW(path, numberof(full), full, NULL);
-    if (len >= numberof(full)) {
-        WCHAR *fullpath = malloc(len * sizeof(WCHAR));
-        if (!fullpath) return -1;
-        len = GetFullPathNameW(path, len, fullpath, NULL);
-        if (len == 3) MEMCPY(full, fullpath, WCHAR, len+1);
-        free(fullpath);
-    }
-    if (!len) {
-        errno = map_errno(GetLastError());
-        return -1;
-    }
-    if (len == 3 && full[1] == L':' && GetDriveTypeW(full) != DRIVE_NO_ROOT_DIR)
-        return 0;               /* x:\ only */
-
-    fh = open_dir_handle(path, &fd);
-    if (fh == INVALID_HANDLE_VALUE)
-        return -1;
-    FindClose(fh);
     return 0;
 }
 


### PR DESCRIPTION
`File.stat` raises `Errno::ENOENT` on a directory that is a volume mount point whose name contains `...`, while `Dir.chdir` into it and `File.stat(".")` there both succeed.

`check_valid_dir()` rechecked such paths by enumerating the directory with `FindFirstFile()`, since `GetFileAttributes()` reports a name of only dots as a directory. A volume root has no `.` or `..` entries, so the enumeration fails on an empty mounted volume and a real directory is reported as missing. The drive root already had a special case for this, but a directory mount point did not.

The recheck also stopped catching anything once `open_dir_handle()` began resolving the final path name in r51689, and `File.stat("dir...")` succeeds on released Ruby today. This drops it and keeps only the name check, which now scans every component rather than stopping at the first `...`, so `a...b/...` is rejected too.

Verified on a mounted VHD.
