### PR TITLE
[Bug #20269] Clamp too-large offsets in String byte APIs

### DIFF
--- a/string.c
+++ b/string.c
@@ -37,6 +37,7 @@
 #include "internal/numeric.h"
 #include "internal/object.h"
 #include "internal/proc.h"
+#include "internal/range.h"
 #include "internal/re.h"
 #include "internal/sanitizers.h"
 #include "internal/simd.h"
@@ -4726,6 +4727,75 @@ str_ensure_byte_pos(VALUE str, long pos)
     }
 }
 
+#if SIZEOF_LONG < SIZEOF_LONG_LONG
+/* Index and length arguments saturate here.  It has to stay clear of
+ * LONG_MAX so that rb_range_component_beg_len can increment an inclusive
+ * end, and it must not depend on the size of the string: another
+ * argument's #to_int can grow the string afterwards, and a saturated
+ * value that the string grew past would become a valid offset. */
+#define STR_CLAMPED_MAX (LONG_MAX - 1)
+#endif
+
+/* Convert an index or length argument to `long`, saturating a value too
+ * large for `long` instead of raising, so that it behaves as it does
+ * where `long` is 64-bit: an index is out of range, a length is
+ * truncated to the end of the string.  A value that already fits passes
+ * through untouched, and one that does not fit in `long long` still
+ * raises RangeError.
+ * [Bug #20269] */
+static long
+str_num2long_clamped(VALUE str, VALUE num)
+{
+#if SIZEOF_LONG < SIZEOF_LONG_LONG
+    /* NUM2LL rejects String and boolean before trying #to_int, unlike
+     * NUM2LONG, so normalize them first.  #to_int can resize str, so
+     * str is only looked at afterwards. */
+    if (!RB_INTEGER_TYPE_P(num) && !RB_FLOAT_TYPE_P(num)) {
+        num = rb_to_int(num);
+    }
+    /* a string that long can be indexed up to the saturated value, so it
+     * keeps raising RangeError as it did before */
+    if (RSTRING_LEN(str) < STR_CLAMPED_MAX) {
+        LONG_LONG n = NUM2LL(num);
+        if (n > LONG_MAX) return STR_CLAMPED_MAX;
+        if (n < LONG_MIN) return LONG_MIN;
+        return (long)n;
+    }
+#endif
+    return NUM2LONG(num);
+}
+
+/* Saturate a Range bound so that rb_range_component_beg_len can convert
+ * it with NUM2LONG.  See str_num2long_clamped(). */
+static VALUE
+str_num_clamped(VALUE str, VALUE num)
+{
+#if SIZEOF_LONG < SIZEOF_LONG_LONG
+    if (!NIL_P(num)) num = LONG2NUM(str_num2long_clamped(str, num));
+#endif
+    return num;
+}
+
+/* rb_range_beg_len with the bounds saturated. */
+static VALUE
+str_byte_range_beg_len(VALUE str, VALUE range, long *begp, long *lenp, long len, int err)
+{
+    VALUE b, e;
+    int excl;
+
+    if (!rb_range_values(range, &b, &e, &excl)) return Qfalse;
+
+    /* sequenced, so that #to_int on the bounds runs in written order */
+    b = str_num_clamped(str, b);
+    e = str_num_clamped(str, e);
+
+    VALUE res = rb_range_component_beg_len(b, e, excl, begp, lenp, len, err);
+    if (NIL_P(res) && err) {
+        rb_raise(rb_eRangeError, "%+"PRIsVALUE" out of range", range);
+    }
+    return res;
+}
+
 /*
  *  call-seq:
  *    byteindex(object, offset = 0) -> integer or nil
@@ -4801,8 +4871,9 @@ rb_str_byteindex_m(int argc, VALUE *argv, VALUE str)
     long pos;
 
     if (rb_scan_args(argc, argv, "11", &sub, &initpos) == 2) {
+        pos = str_num2long_clamped(str, initpos);
+        /* the conversion can run #to_int, which can resize str */
         long slen = RSTRING_LEN(str);
-        pos = NUM2LONG(initpos);
         if (pos < 0 ? (pos += slen) < 0 : pos > slen) {
             if (RB_TYPE_P(sub, T_REGEXP)) {
                 rb_backref_set(Qnil);
@@ -5079,7 +5150,9 @@ rb_str_byterindex_m(int argc, VALUE *argv, VALUE str)
     long pos, len = RSTRING_LEN(str);
 
     if (rb_scan_args(argc, argv, "11", &sub, &initpos) == 2) {
-        pos = NUM2LONG(initpos);
+        pos = str_num2long_clamped(str, initpos);
+        /* the conversion can run #to_int, which can resize str */
+        len = RSTRING_LEN(str);
         if (pos < 0 && (pos += len) < 0) {
             if (RB_TYPE_P(sub, T_REGEXP)) {
                 rb_backref_set(Qnil);
@@ -6710,7 +6783,7 @@ rb_str_chr(VALUE str)
 VALUE
 rb_str_getbyte(VALUE str, VALUE index)
 {
-    long pos = NUM2LONG(index);
+    long pos = str_num2long_clamped(str, index);
 
     if (pos < 0)
         pos += RSTRING_LEN(str);
@@ -6736,7 +6809,7 @@ rb_str_getbyte(VALUE str, VALUE index)
 VALUE
 rb_str_setbyte(VALUE str, VALUE index, VALUE value)
 {
-    long pos = NUM2LONG(index);
+    long pos = str_num2long_clamped(str, index);
     long len = RSTRING_LEN(str);
     char *ptr, *head, *left = 0;
     rb_encoding *enc;
@@ -7315,7 +7388,9 @@ str_byte_substr(VALUE str, long beg, long len, int empty)
 VALUE
 rb_str_byte_substr(VALUE str, VALUE beg, VALUE len)
 {
-    return str_byte_substr(str, NUM2LONG(beg), NUM2LONG(len), TRUE);
+    long b = str_num2long_clamped(str, beg);
+    long n = str_num2long_clamped(str, len);
+    return str_byte_substr(str, b, n, TRUE);
 }
 
 static VALUE
@@ -7329,7 +7404,7 @@ str_byte_aref(VALUE str, VALUE indx)
         /* check if indx is Range */
         long beg, len = RSTRING_LEN(str);
 
-        switch (rb_range_beg_len(indx, &beg, &len, len, 0)) {
+        switch (str_byte_range_beg_len(str, indx, &beg, &len, len, 0)) {
           case Qfalse:
             break;
           case Qnil:
@@ -7338,7 +7413,7 @@ str_byte_aref(VALUE str, VALUE indx)
             return str_byte_substr(str, beg, len, TRUE);
         }
 
-        idx = NUM2LONG(indx);
+        idx = str_num2long_clamped(str, indx);
     }
     return str_byte_substr(str, idx, 1, FALSE);
 }
@@ -7355,8 +7430,8 @@ static VALUE
 rb_str_byteslice(int argc, VALUE *argv, VALUE str)
 {
     if (argc == 2) {
-        long beg = NUM2LONG(argv[0]);
-        long len = NUM2LONG(argv[1]);
+        long beg = str_num2long_clamped(str, argv[0]);
+        long len = str_num2long_clamped(str, argv[1]);
         return str_byte_substr(str, beg, len, TRUE);
     }
     rb_check_arity(argc, 1, 2);
@@ -7408,7 +7483,7 @@ rb_str_bytesplice(int argc, VALUE *argv, VALUE str)
         rb_raise(rb_eArgError, "wrong number of arguments (given %d, expected 2, 3, or 5)", argc);
     }
     if (argc == 2 || (argc == 3 && !RB_INTEGER_TYPE_P(argv[0]))) {
-        if (!rb_range_beg_len(argv[0], &beg, &len, RSTRING_LEN(str), 2)) {
+        if (!str_byte_range_beg_len(str, argv[0], &beg, &len, RSTRING_LEN(str), 2)) {
             rb_raise(rb_eTypeError, "wrong argument type %s (expected Range)",
                      rb_builtin_class_name(argv[0]));
         }
@@ -7421,15 +7496,15 @@ rb_str_bytesplice(int argc, VALUE *argv, VALUE str)
         }
         else {
             /* bytesplice(range, str, str_range) */
-            if (!rb_range_beg_len(argv[2], &vbeg, &vlen, RSTRING_LEN(val), 2)) {
+            if (!str_byte_range_beg_len(val, argv[2], &vbeg, &vlen, RSTRING_LEN(val), 2)) {
                 rb_raise(rb_eTypeError, "wrong argument type %s (expected Range)",
                          rb_builtin_class_name(argv[2]));
             }
         }
     }
     else {
-        beg = NUM2LONG(argv[0]);
-        len = NUM2LONG(argv[1]);
+        beg = str_num2long_clamped(str, argv[0]);
+        len = str_num2long_clamped(str, argv[1]);
         val = argv[2];
         StringValue(val);
         if (argc == 3) {
@@ -7439,8 +7514,8 @@ rb_str_bytesplice(int argc, VALUE *argv, VALUE str)
         }
         else {
             /* bytesplice(index, length, str, str_index, str_length) */
-            vbeg = NUM2LONG(argv[3]);
-            vlen = NUM2LONG(argv[4]);
+            vbeg = str_num2long_clamped(val, argv[3]);
+            vlen = str_num2long_clamped(val, argv[4]);
         }
     }
     str_check_beg_len(str, &beg, &len);

--- a/test/ruby/test_string.rb
+++ b/test/ruby/test_string.rb
@@ -1152,6 +1152,19 @@ CODE
     assert_raise(FrozenError) { S("\x00").freeze.bitwise_xor!(S("\x00")) }
   end
 
+  def test_getbyte_setbyte_out_of_long_range
+    bug20269 = '[Bug #20269]'
+    s = S('foo')
+    [2**31, 2**32, 2**62].each do |big|
+      assert_nil(s.getbyte(big), bug20269)
+      assert_nil(s.getbyte(-big), bug20269)
+      assert_raise(IndexError, bug20269) { s.setbyte(big, 0) }
+      assert_raise(IndexError, bug20269) { s.setbyte(-big, 0) }
+    end
+    assert_raise(RangeError) { s.getbyte(2**63) }
+    assert_raise(RangeError) { s.setbyte(2**63, 0) }
+  end
+
   def test_each_codepoint
     # Single byte optimization
     assert_equal 65, S("ABC").each_codepoint.next
@@ -3657,6 +3670,99 @@ CODE
     assert_equal(false, ("\u3042"*10).byteslice(0, 20).valid_encoding?, bug7954)
   end
 
+  def test_byteslice_out_of_long_range
+    bug20269 = '[Bug #20269]'
+    s = S("hello")
+    [2**31 - 1, 2**31, 2**32 - 1, 2**32, 2**62].each do |big|
+      assert_equal("hello", s.byteslice(0, big), bug20269)
+      assert_equal("llo", s.byteslice(2, big), bug20269)
+      assert_nil(s.byteslice(big), bug20269)
+      assert_nil(s.byteslice(big, 1), bug20269)
+      assert_nil(s.byteslice(-big), bug20269)
+      assert_nil(s.byteslice(-big, 1), bug20269)
+      assert_nil(s.byteslice(0, -big), bug20269)
+    end
+    assert_equal("", S("").byteslice(0, 2547483647), bug20269)
+    assert_nil(s.byteslice(0, -2**63), bug20269)
+    assert_raise(RangeError) { s.byteslice(2**63) }
+    assert_raise(RangeError) { s.byteslice(2**63, 1) }
+    assert_raise(RangeError) { s.byteslice(0, 2**63) }
+    assert_raise(RangeError) { s.byteslice(0, -2**63 - 1) }
+  end
+
+  def test_byteslice_range_out_of_long_range
+    bug20269 = '[Bug #20269]'
+    s = S("hello")
+    # LONG_MAX itself is left out: rb_range_component_beg_len overflows
+    # incrementing an inclusive end there, on every platform.
+    [2**31, 2**32, 2**62].each do |big|
+      assert_equal("hello", s.byteslice(0..big), bug20269)
+      assert_equal("hello", s.byteslice(0...big), bug20269)
+      assert_equal("llo", s.byteslice(2..big), bug20269)
+      assert_nil(s.byteslice(big..), bug20269)
+      assert_nil(s.byteslice(-big..0), bug20269)
+    end
+    assert_raise(RangeError) { s.byteslice(0..2**63) }
+    assert_raise(RangeError) { s.byteslice(2**63..) }
+  end
+
+  def test_byte_apis_reread_length_after_to_int
+    bug20269 = '[Bug #20269]'
+    # #to_int runs during conversion and may resize the receiver, so the
+    # size the saturation and the bounds check use has to be read after it
+    grown = S("hello")
+    o = Object.new
+    o.define_singleton_method(:to_int) { grown << "world"; 2**40 }
+    assert_nil(grown.byteslice(o), bug20269)
+
+    one = S("あ")
+    shrunk = S("あ" * 2000)
+    p = Object.new
+    p.define_singleton_method(:to_int) { shrunk.replace(one); 2**40 }
+    assert_equal(0, shrunk.byterindex(one, p), bug20269)
+
+    shrunk2 = S("あ" * 2000)
+    q = Object.new
+    q.define_singleton_method(:to_int) { shrunk2.replace(one); 5000 }
+    assert_equal(0, shrunk2.byterindex(one, q), bug20269)
+
+    # a later argument can grow the string too, so a saturated value must
+    # not be one the string can grow past
+    grown2 = S("hello")
+    g = Object.new
+    g.define_singleton_method(:to_int) { grown2 << "world"; 1 }
+    assert_nil(grown2.byteslice(2**40, g), bug20269)
+
+    grown3 = S("hello")
+    g2 = Object.new
+    g2.define_singleton_method(:to_int) { grown3 << "world"; 1 }
+    assert_raise(IndexError, bug20269) { grown3.bytesplice(2**40, g2, S("bye")) }
+  end
+
+  def test_byteslice_float_out_of_long_range
+    bug20269 = '[Bug #20269]'
+    s = S("hello")
+    assert_equal("hello", s.byteslice(0, 1e18), bug20269)
+    assert_nil(s.byteslice(1e18), bug20269)
+    assert_raise(RangeError) { s.byteslice(0, 1e30) }
+  end
+
+  def test_byte_apis_accept_to_int
+    bug20269 = '[Bug #20269]'
+    s = S("hello")
+    obj = Object.new
+    def obj.to_int; 2; end
+    assert_equal("l", s.byteslice(obj, 1), bug20269)
+
+    str = Class.new(String) { def to_int; 2; end }.new
+    assert_equal("l", s.byteslice(str, 1), bug20269)
+    assert_equal(108, s.getbyte(str), bug20269)
+    assert_equal(2, s.byteindex(S("l"), str), bug20269)
+    assert_equal(2, s.byterindex(S("l"), str), bug20269)
+    assert_equal(120, S("hello").setbyte(str, 120), bug20269)
+    assert_bytesplice_result("ello", S("hello"), 0, 2, "bye", str, 1)
+  end
+
   def test_shared_middle_string_terminator
     ten = "0123456789"
     hundred = ten * 10
@@ -3959,6 +4065,19 @@ CODE
     assert_byterindex(nil, S(""), S("こんにちは"))
   end
 
+  def test_byteindex_byterindex_out_of_long_range
+    bug20269 = '[Bug #20269]'
+    s = S("hello")
+    [2**31 - 1, 2**31, 2**32, 2**62].each do |big|
+      assert_nil(s.byteindex("l", big), bug20269)
+      assert_nil(s.byteindex("l", -big), bug20269)
+      assert_equal(3, s.byterindex("l", big), bug20269)
+      assert_nil(s.byterindex("l", -big), bug20269)
+    end
+    assert_raise(RangeError) { s.byteindex("l", 2**63) }
+    assert_raise(RangeError) { s.byterindex("l", 2**63) }
+  end
+
   def test_bytesplice
     assert_bytesplice_raise(IndexError, S("hello"), -6, 0, "bye")
     assert_bytesplice_result("byehello", S("hello"), -5, 0, "bye")
@@ -4034,6 +4153,30 @@ CODE
     assert_bytesplice_raise(ArgumentError, S("hello"), 0, 5, "bye", 0)
     assert_bytesplice_raise(ArgumentError, S("hello"), 0, 5, "bye", 0..-1)
     assert_bytesplice_raise(ArgumentError, S("hello"), 0..-1, "bye", 0, 3)
+  end
+
+  def test_bytesplice_out_of_long_range
+    [2**31, 2**32, 2**62].each do |big|
+      assert_bytesplice_raise(IndexError, S("hello"), big, 1, "bye")
+      assert_bytesplice_raise(IndexError, S("hello"), -big, 1, "bye")
+      assert_bytesplice_raise(IndexError, S("hello"), 0, -big, "bye")
+      assert_bytesplice_result("bye", S("hello"), 0, big, "bye")
+      assert_bytesplice_result("byehello", S("hello"), 0, 0, "bye", 0, big)
+      assert_bytesplice_raise(IndexError, S("hello"), 0, 0, "bye", -big, 1)
+    end
+    assert_bytesplice_raise(RangeError, S("hello"), 2**63, 1, "bye")
+  end
+
+  def test_bytesplice_range_out_of_long_range
+    # see test_byteslice_range_out_of_long_range for the omitted LONG_MAX
+    [2**31, 2**32, 2**62].each do |big|
+      assert_bytesplice_result("bye", S("hello"), 0..big, "bye")
+      assert_bytesplice_result("bye", S("hello"), 0...big, "bye")
+      assert_bytesplice_result("hebye", S("hello"), 2..big, "bye")
+      assert_bytesplice_result("HELLOllo", S("hello"), 0..1, "HELLO", 0..big)
+      assert_bytesplice_raise(RangeError, S("hello"), -big..0, "bye")
+    end
+    assert_bytesplice_raise(RangeError, S("hello"), 0..2**63, "bye")
   end
 
   def test_append_bytes_into_binary


### PR DESCRIPTION
On Windows and other LLP64 platforms where `long` is 32-bit, passing an offset or length larger than 32 bits to `String#byteslice` raises `RangeError` with `bignum too big to convert into 'long'`, while LP64 platforms clamp the value to the string size and return a result. `"".byteslice(0, 2547483647)` returns `""` on Linux and macOS but fails on Windows.

The integer arguments of `byteslice`, `byteindex`, `byterindex`, `bytesplice`, `getbyte` and `setbyte` are now clamped to the `long` range before conversion, so a value beyond the string size is treated as out of range exactly as it is on LP64. Values that do not fit in `long long` still raise `RangeError` on every platform.

Verified on a `x64-mswin64_140` build.
