### PR TITLE
Backport the regexp repeat-range double free fix to ruby_3_4

### DIFF
--- a/regparse.c
+++ b/regparse.c
@@ -6662,7 +6662,7 @@ parse_subexp(Node** top, OnigToken* tok, int term,
 	     UChar** src, UChar* end, ScanEnv* env)
 {
   int r;
-  Node *node, **headp;
+  Node *node, *topnode, **headp;
 
   *top = NULL;
   env->parse_depth++;
@@ -6678,26 +6678,29 @@ parse_subexp(Node** top, OnigToken* tok, int term,
     *top = node;
   }
   else if (r == TK_ALT) {
-    *top  = onig_node_new_alt(node, NULL);
-    headp = &(NCDR(*top));
+    topnode = onig_node_new_alt(node, NULL);
+    headp   = &(NCDR(topnode));
     while (r == TK_ALT) {
       r = fetch_token(tok, src, end, env);
       if (r < 0) {
-	onig_node_free(node);
+	onig_node_free(topnode);
 	return r;
       }
       r = parse_branch(&node, tok, term, src, end, env);
       if (r < 0) {
-	onig_node_free(node);
+	onig_node_free(topnode);
 	return r;
       }
 
       *headp = onig_node_new_alt(node, NULL);
-      headp = &(NCDR(*headp));
+      headp  = &(NCDR(*headp));
     }
 
-    if (tok->type != (enum TokenSyms )term)
+    if (tok->type != (enum TokenSyms )term) {
+      onig_node_free(topnode);
       goto err;
+    }
+    *top = topnode;
   }
   else {
     onig_node_free(node);

--- a/test/ruby/test_regexp.rb
+++ b/test/ruby/test_regexp.rb
@@ -1775,6 +1775,12 @@ class TestRegexp < Test::Unit::TestCase
     end;
   end
 
+  def test_too_big_number_for_repeat_range
+    assert_raise_with_message(SyntaxError, /too big number for repeat range/) do
+      eval(%[/|{1000000}/])
+    end
+  end
+
   # This assertion is for porting x2() tests in testpy.py of Onigmo.
   def assert_match_at(re, str, positions, msg = nil)
     re = Regexp.new(re) unless re.is_a?(Regexp)


### PR DESCRIPTION
On ruby_3_4, `Regexp.new("|{2,1}")` aborts the process with SIGABRT instead of raising `RegexpError`, so the error cannot be rescued. `parse_subexp` publishes the alternation chain through `*top` before parsing finishes, and its error paths then free a branch node that the chain already owns. The caller frees the chain afterwards and hits the same node twice.

This is a clean cherry-pick of 35000ac2ed3a1829f8d193ffb23da0e44cc6fe5f (#13332) by Hiroya Fujinami. It landed in master and ruby_4_0 but never reached ruby_3_4. No adaptation was needed.

I built ruby_3_4 with the patch and ran `make test-all TESTS=test/ruby/test_regexp.rb`: 149 tests, 62555 assertions, 0 failures, 0 errors, 0 skips. `Regexp.new("|{2,1}")` now raises `RegexpError`.

Generated with [Claude Code](https://claude.com/claude-code)
