### PR TITLE
scheduler.c: Free temporary IO::Buffer objects when I/O hooks raise

### DIFF
--- a/scheduler.c
+++ b/scheduler.c
@@ -936,16 +936,45 @@ rb_fiber_scheduler_io_pwrite(VALUE scheduler, VALUE io, rb_off_t from, VALUE buf
     return rb_thread_io_blocking_operation(io, fiber_scheduler_io_pwrite, (VALUE)&arguments);
 }
 
+struct fiber_scheduler_io_memory_arguments {
+    VALUE scheduler;
+    VALUE io;
+    VALUE buffer;
+    rb_off_t from;
+    size_t offset;
+    size_t length;
+};
+
+static VALUE
+fiber_scheduler_io_read_memory(VALUE _arguments)
+{
+    struct fiber_scheduler_io_memory_arguments *arguments = (void *)_arguments;
+
+    return rb_fiber_scheduler_io_read(arguments->scheduler, arguments->io, arguments->buffer, arguments->offset, arguments->length);
+}
+
 VALUE
 rb_fiber_scheduler_io_read_memory(VALUE scheduler, VALUE io, void *base, size_t size)
 {
     VALUE buffer = rb_io_buffer_new_locked(base, size, 0);
 
-    VALUE result = rb_fiber_scheduler_io_read(scheduler, io, buffer, 0, size);
+    struct fiber_scheduler_io_memory_arguments arguments = {
+        .scheduler = scheduler,
+        .io = io,
+        .buffer = buffer,
+        .offset = 0,
+        .length = size,
+    };
 
-    rb_io_buffer_free_locked(buffer);
+    return rb_ensure(fiber_scheduler_io_read_memory, (VALUE)&arguments, rb_io_buffer_free_locked, buffer);
+}
 
-    return result;
+static VALUE
+fiber_scheduler_io_write_memory(VALUE _arguments)
+{
+    struct fiber_scheduler_io_memory_arguments *arguments = (void *)_arguments;
+
+    return rb_fiber_scheduler_io_write(arguments->scheduler, arguments->io, arguments->buffer, arguments->offset, arguments->length);
 }
 
 VALUE
@@ -953,11 +982,23 @@ rb_fiber_scheduler_io_write_memory(VALUE scheduler, VALUE io, const void *base, 
 {
     VALUE buffer = rb_io_buffer_new_locked((void*)base, size, RB_IO_BUFFER_READONLY);
 
-    VALUE result = rb_fiber_scheduler_io_write(scheduler, io, buffer, 0, size);
+    struct fiber_scheduler_io_memory_arguments arguments = {
+        .scheduler = scheduler,
+        .io = io,
+        .buffer = buffer,
+        .offset = 0,
+        .length = size,
+    };
 
-    rb_io_buffer_free_locked(buffer);
+    return rb_ensure(fiber_scheduler_io_write_memory, (VALUE)&arguments, rb_io_buffer_free_locked, buffer);
+}
 
-    return result;
+static VALUE
+fiber_scheduler_io_pread_memory(VALUE _arguments)
+{
+    struct fiber_scheduler_io_memory_arguments *arguments = (void *)_arguments;
+
+    return rb_fiber_scheduler_io_pread(arguments->scheduler, arguments->io, arguments->from, arguments->buffer, arguments->offset, arguments->length);
 }
 
 VALUE
@@ -965,11 +1006,24 @@ rb_fiber_scheduler_io_pread_memory(VALUE scheduler, VALUE io, rb_off_t from, voi
 {
     VALUE buffer = rb_io_buffer_new_locked(base, size, 0);
 
-    VALUE result = rb_fiber_scheduler_io_pread(scheduler, io, from, buffer, 0, size);
+    struct fiber_scheduler_io_memory_arguments arguments = {
+        .scheduler = scheduler,
+        .io = io,
+        .buffer = buffer,
+        .from = from,
+        .offset = 0,
+        .length = size,
+    };
 
-    rb_io_buffer_free_locked(buffer);
+    return rb_ensure(fiber_scheduler_io_pread_memory, (VALUE)&arguments, rb_io_buffer_free_locked, buffer);
+}
 
-    return result;
+static VALUE
+fiber_scheduler_io_pwrite_memory(VALUE _arguments)
+{
+    struct fiber_scheduler_io_memory_arguments *arguments = (void *)_arguments;
+
+    return rb_fiber_scheduler_io_pwrite(arguments->scheduler, arguments->io, arguments->from, arguments->buffer, arguments->offset, arguments->length);
 }
 
 VALUE
@@ -977,11 +1031,16 @@ rb_fiber_scheduler_io_pwrite_memory(VALUE scheduler, VALUE io, rb_off_t from, co
 {
     VALUE buffer = rb_io_buffer_new_locked((void*)base, size, RB_IO_BUFFER_READONLY);
 
-    VALUE result = rb_fiber_scheduler_io_pwrite(scheduler, io, from, buffer, 0, size);
+    struct fiber_scheduler_io_memory_arguments arguments = {
+        .scheduler = scheduler,
+        .io = io,
+        .buffer = buffer,
+        .from = from,
+        .offset = 0,
+        .length = size,
+    };
 
-    rb_io_buffer_free_locked(buffer);
-
-    return result;
+    return rb_ensure(fiber_scheduler_io_pwrite_memory, (VALUE)&arguments, rb_io_buffer_free_locked, buffer);
 }
 
 /*

--- a/test/fiber/scheduler.rb
+++ b/test/fiber/scheduler.rb
@@ -427,6 +427,31 @@ class IOErrorScheduler < Scheduler
   end
 end
 
+class FailingIOScheduler < Scheduler
+  # Expose the last temporary IO::Buffer to test escaping scenarios.
+  attr_reader :buffer
+
+  def io_read(io, buffer, offset, length)
+    @buffer = buffer
+    raise "scheduler read error"
+  end
+
+  def io_write(io, buffer, offset, length)
+    @buffer = buffer
+    raise "scheduler write error"
+  end
+
+  def io_pread(io, buffer, from, offset, length)
+    @buffer = buffer
+    raise "scheduler pread error"
+  end
+
+  def io_pwrite(io, buffer, from, offset, length)
+    @buffer = buffer
+    raise "scheduler pwrite error"
+  end
+end
+
 # This scheduler has a broken implementation of `unblock`` in the sense that it
 # raises an exception. This is used to test the behavior of the scheduler when
 # unblock raises an exception.

--- a/test/fiber/test_scheduler.rb
+++ b/test/fiber/test_scheduler.rb
@@ -397,4 +397,129 @@ class TestFiberScheduler < Test::Unit::TestCase
     thread.kill rescue nil
     FileUtils.rm_f(path)
   end
+
+  def test_io_read_exception_frees_temporary_buffer
+    r, w = IO.pipe
+    scheduler = FailingIOScheduler.new
+    error = nil
+
+    thread = Thread.new do
+      Fiber.set_scheduler(scheduler)
+
+      Fiber.schedule do
+        begin
+          r.read(1)
+        rescue RuntimeError => exception
+          error = exception
+        end
+      end
+
+      Fiber.set_scheduler(nil)
+    end
+
+    thread.join
+
+    assert_kind_of RuntimeError, error
+    assert_equal "scheduler read error", error.message
+    assert_predicate scheduler.buffer, :null?
+    assert_not_predicate scheduler.buffer, :locked?
+  ensure
+    thread&.kill
+    r&.close
+    w&.close
+  end
+
+  def test_io_write_exception_frees_temporary_buffer
+    r, w = IO.pipe
+    w.sync = true
+    scheduler = FailingIOScheduler.new
+    error = nil
+
+    thread = Thread.new do
+      Fiber.set_scheduler(scheduler)
+
+      Fiber.schedule do
+        begin
+          w.write("Hello World")
+        rescue RuntimeError => exception
+          error = exception
+        end
+      end
+
+      Fiber.set_scheduler(nil)
+    end
+
+    thread.join
+
+    assert_kind_of RuntimeError, error
+    assert_equal "scheduler write error", error.message
+    assert_predicate scheduler.buffer, :null?
+    assert_not_predicate scheduler.buffer, :locked?
+  ensure
+    thread&.kill
+    r&.close
+    w&.close
+  end
+
+  def test_io_pread_exception_frees_temporary_buffer
+    r, w = IO.pipe
+    scheduler = FailingIOScheduler.new
+    error = nil
+
+    thread = Thread.new do
+      Fiber.set_scheduler(scheduler)
+
+      Fiber.schedule do
+        begin
+          r.pread(1, 0)
+        rescue RuntimeError => exception
+          error = exception
+        end
+      end
+
+      Fiber.set_scheduler(nil)
+    end
+
+    thread.join
+
+    assert_kind_of RuntimeError, error
+    assert_equal "scheduler pread error", error.message
+    assert_predicate scheduler.buffer, :null?
+    assert_not_predicate scheduler.buffer, :locked?
+  ensure
+    thread&.kill
+    r&.close
+    w&.close
+  end
+
+  def test_io_pwrite_exception_frees_temporary_buffer
+    r, w = IO.pipe
+    scheduler = FailingIOScheduler.new
+    error = nil
+
+    thread = Thread.new do
+      Fiber.set_scheduler(scheduler)
+
+      Fiber.schedule do
+        begin
+          w.pwrite("Hello World", 0)
+        rescue RuntimeError => exception
+          error = exception
+        end
+      end
+
+      Fiber.set_scheduler(nil)
+    end
+
+    thread.join
+
+    assert_kind_of RuntimeError, error
+    assert_equal "scheduler pwrite error", error.message
+    assert_predicate scheduler.buffer, :null?
+    assert_not_predicate scheduler.buffer, :locked?
+  ensure
+    thread&.kill
+    r&.close
+    w&.close
+  end
 end


### PR DESCRIPTION
When an installed Fiber scheduler raises from its I/O hook, the temporary IO::Buffer passed to the hook is left unfreed. The buffer may then outlive the memory it wraps, so accessing it afterward can cause undefined behavior.

Use rb_ensure in rb_fiber_scheduler_io_*_memory to free the buffer when the hook raises. As before, scheduler hooks must not retain locks on the buffer beyond the hook invocation, or otherwise rb_bug is triggered.

Fixes: [[Bug #22298]](https://bugs.ruby-lang.org/issues/22298)
Assisted-by: Codex:gpt-5.6-sol