### PR TITLE
[Bug #14640] Fix File.realpath with a drive-relative path

### DIFF
--- a/file.c
+++ b/file.c
@@ -5078,6 +5078,16 @@ rb_check_realpath_emulate(VALUE basedir, VALUE path, rb_encoding *origenc, enum 
     char *ptr, *prefixptr = NULL, *pend;
     long len;
 
+#ifdef DOSISH_DRIVE_LETTER
+    RSTRING_GETMEM(path, ptr, len);
+    if (len >= 2 && has_drive_letter(ptr) && (len == 2 || !isdirsep(ptr[2]))) {
+        /* Expand a drive-relative path against the current directory
+         * of the drive, as File.expand_path does */
+        path = rb_file_expand_path(path, basedir);
+        basedir = Qnil;
+    }
+#endif
+
     unresolved_path = rb_str_dup_frozen(path);
 
     if (!NIL_P(basedir)) {

--- a/test/ruby/test_file_exhaustive.rb
+++ b/test/ruby/test_file_exhaustive.rb
@@ -835,6 +835,16 @@ class TestFileExhaustive < Test::Unit::TestCase
     end
   end
 
+  def test_realpath_drive_relative_path
+    bug14640 = '[Bug #14640]'
+    File.write(File.join(@dir, "t"), "")
+    drive = @dir[/\A\w:/]
+    Dir.chdir(@dir) do
+      assert_equal(File.realpath("t"), File.realpath("#{drive}t"), bug14640)
+    end
+    assert_equal(File.realpath("t", @dir), File.realpath("#{drive}t", @dir), bug14640)
+  end if DRIVE
+
   def test_unlink
     assert_equal(1, File.unlink(regular_file))
     make_file("foo", regular_file)

--- a/test/ruby/test_file_exhaustive.rb
+++ b/test/ruby/test_file_exhaustive.rb
@@ -837,8 +837,9 @@ class TestFileExhaustive < Test::Unit::TestCase
 
   def test_realpath_drive_relative_path
     bug14640 = '[Bug #14640]'
+    drive = @dir[/\A[a-z]:/i]
+    omit "#{@dir} is not on a drive letter" unless drive
     File.write(File.join(@dir, "t"), "")
-    drive = @dir[/\A\w:/]
     Dir.chdir(@dir) do
       assert_equal(File.realpath("t"), File.realpath("#{drive}t"), bug14640)
     end


### PR DESCRIPTION
On Windows, `File.realpath("c:t")` raised `Errno::ENOENT` for `c:/t` even when `t` exists in the current directory of drive `C:`. A drive letter that is not followed by a separator means a path relative to that drive's current directory, and `File.expand_path` already reads it that way, so the two methods disagreed.

`rb_check_realpath_emulate` now expands such a path with `File.expand_path` before resolving it, which also picks up the per-drive current directory for a drive other than the current one. Paths without a drive letter take the same code path as before, so `require` and the loaded feature check are unaffected.

Verified on mswin with the reproducer from the ticket, and `test/ruby/test_file.rb`, `test/ruby/test_file_exhaustive.rb` and `test/ruby/test_require.rb` all pass.
