### PR TITLE
[DOC] Fixes for `Appendix G. Embedded TypedData` in `extension.rdoc`

### DIFF
--- a/doc/extension.rdoc
+++ b/doc/extension.rdoc
@@ -2425,7 +2425,7 @@ Here is an example of how to use +RUBY_TYPED_EMBEDDABLE+:
   {
       struct my_data *data;
       VALUE my_data_obj = my_data_alloc(klass);
-      TypedData_Get_Struct(obj, struct my_data, &my_type, data);
+      TypedData_Get_Struct(my_data_obj, struct my_data, &my_type, data);
 
       // `my_data_obj` was allocated from C, `RB_GC_GUARD` must be used to
       // ensure the compiler will keep its reference on the stack.
@@ -2436,7 +2436,7 @@ Here is an example of how to use +RUBY_TYPED_EMBEDDABLE+:
   my_data_read(VALUE self)
   {
       struct my_data *data;
-      TypedData_Get_Struct(obj, struct my_data, &my_type, data);
+      TypedData_Get_Struct(self, struct my_data, &my_type, data);
 
       // `self` is received from `rb_define_method` so `RB_GC_GUARD` isn't necessary.
       return rb_str_new(data->buffer, data->buffer_capa);

--- a/doc/extension.rdoc
+++ b/doc/extension.rdoc
@@ -2445,7 +2445,7 @@ Here is an example of how to use +RUBY_TYPED_EMBEDDABLE+:
   void
   Init_my_data(void)
   {
-      VALUE cMyData = rb_define_class("MyData");
+      VALUE cMyData = rb_define_class("MyData", rb_cObject);
       rb_define_method(cMyData, "read", my_data_read, 0);
       rb_define_singleton_method(cMyData, "parse", my_data_m_parse, 0);
   }

--- a/doc/extension.rdoc
+++ b/doc/extension.rdoc
@@ -2401,7 +2401,7 @@ Here is an example of how to use +RUBY_TYPED_EMBEDDABLE+:
       .function = {
         .dfree = my_data_free,
         .dsize = my_data_size,
-      }
+      },
       .flags = RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_EMBEDDABLE,
   };
 
@@ -2417,7 +2417,7 @@ Here is an example of how to use +RUBY_TYPED_EMBEDDABLE+:
       data->buffer_capa = 1024;
       data->buffer = ZALLOC_N(char, data->buffer_capa);
 
-      return obj
+      return obj;
   }
 
   static VALUE
@@ -2429,7 +2429,7 @@ Here is an example of how to use +RUBY_TYPED_EMBEDDABLE+:
 
       // `my_data_obj` was allocated from C, `RB_GC_GUARD` must be used to
       // ensure the compiler will keep its reference on the stack.
-      RB_GC_GUARD(my_data_obj)
+      RB_GC_GUARD(my_data_obj);
   }
 
   static VALUE
@@ -2439,7 +2439,7 @@ Here is an example of how to use +RUBY_TYPED_EMBEDDABLE+:
       TypedData_Get_Struct(obj, struct my_data, &my_type, data);
 
       // `self` is received from `rb_define_method` so `RB_GC_GUARD` isn't necessary.
-      return rb_str_new(data->buffer, data->buffer_capa)
+      return rb_str_new(data->buffer, data->buffer_capa);
   }
 
   void

--- a/doc/extension.rdoc
+++ b/doc/extension.rdoc
@@ -2391,7 +2391,7 @@ Here is an example of how to use +RUBY_TYPED_EMBEDDABLE+:
   my_data_size(const void *ptr)
   {
     const struct my_data *data = (const struct my_data *)ptr;
-    // We don't need to account for `sizeof(struct my_struct)` because it is embedded inside the Ruby object.
+    // We don't need to account for `sizeof(struct my_data)` because it is embedded inside the Ruby object.
     // Only auxiliary memory need to be reported.
     return data->buffer_capa;
   }

--- a/doc/extension.rdoc
+++ b/doc/extension.rdoc
@@ -2421,18 +2421,6 @@ Here is an example of how to use +RUBY_TYPED_EMBEDDABLE+:
   }
 
   static VALUE
-  my_data_m_parse(VALUE klass)
-  {
-      struct my_data *data;
-      VALUE my_data_obj = my_data_alloc(klass);
-      TypedData_Get_Struct(my_data_obj, struct my_data, &my_type, data);
-
-      // `my_data_obj` was allocated from C, `RB_GC_GUARD` must be used to
-      // ensure the compiler will keep its reference on the stack.
-      RB_GC_GUARD(my_data_obj);
-  }
-
-  static VALUE
   my_data_read(VALUE self)
   {
       struct my_data *data;
@@ -2440,6 +2428,18 @@ Here is an example of how to use +RUBY_TYPED_EMBEDDABLE+:
 
       // `self` is received from `rb_define_method` so `RB_GC_GUARD` isn't necessary.
       return rb_str_new(data->buffer, data->buffer_capa);
+  }
+
+  static VALUE
+  my_data_m_parse(VALUE klass)
+  {
+      VALUE my_data_obj = my_data_alloc(klass);
+      VALUE result = my_data_read(my_data_obj);
+
+      // `my_data_obj` was allocated from C, `RB_GC_GUARD` must be used to
+      // ensure the compiler will keep its reference on the stack.
+      RB_GC_GUARD(my_data_obj);
+      return result;
   }
 
   void

--- a/doc/extension.rdoc
+++ b/doc/extension.rdoc
@@ -2383,7 +2383,7 @@ Here is an example of how to use +RUBY_TYPED_EMBEDDABLE+:
       struct my_data *data = (struct my_data *)ptr;
 
       // Deliberately don't free `ptr` if it is embeddable.
-      // Only auxiliary memory need to be freed.
+      // Only auxiliary memory needs to be freed.
       ruby_xfree(data->buffer);
   }
 
@@ -2392,7 +2392,7 @@ Here is an example of how to use +RUBY_TYPED_EMBEDDABLE+:
   {
       const struct my_data *data = (const struct my_data *)ptr;
       // We don't need to account for `sizeof(struct my_data)` because it is embedded inside the Ruby object.
-      // Only auxiliary memory need to be reported.
+      // Only auxiliary memory needs to be reported.
       return data->buffer_capa;
   }
 
@@ -2411,8 +2411,8 @@ Here is an example of how to use +RUBY_TYPED_EMBEDDABLE+:
       struct my_data *data;
       VALUE obj = TypedData_Make_Struct(klass, struct my_data, &my_type, data);
 
-      // Is it fine to pass pointers into the embedded struct, for as long as
-      // the called function won't use it after the Ruby object have left the stack.
+      // It is fine to pass pointers into the embedded struct, for as long as
+      // the called function won't use it after the Ruby object has left the stack.
       clock_gettime(CLOCK_REALTIME, &data->created_at);
       data->buffer_capa = 1024;
       data->buffer = ZALLOC_N(char, data->buffer_capa);

--- a/doc/extension.rdoc
+++ b/doc/extension.rdoc
@@ -2390,10 +2390,10 @@ Here is an example of how to use +RUBY_TYPED_EMBEDDABLE+:
   static size_t
   my_data_size(const void *ptr)
   {
-    const struct my_data *data = (const struct my_data *)ptr;
-    // We don't need to account for `sizeof(struct my_data)` because it is embedded inside the Ruby object.
-    // Only auxiliary memory need to be reported.
-    return data->buffer_capa;
+      const struct my_data *data = (const struct my_data *)ptr;
+      // We don't need to account for `sizeof(struct my_data)` because it is embedded inside the Ruby object.
+      // Only auxiliary memory need to be reported.
+      return data->buffer_capa;
   }
 
   static const rb_data_type_t my_type = {

--- a/doc/extension.rdoc
+++ b/doc/extension.rdoc
@@ -2369,7 +2369,7 @@ To make a "Ractor-safe" C extension, we need to check the following points:
 
 == Appendix G. Embedded TypedData
 
-Here is an example of how to use +RUBY_TYPED_EMBEDDABLE+::
+Here is an example of how to use +RUBY_TYPED_EMBEDDABLE+:
 
   struct my_data {
       struct timespec created_at;


### PR DESCRIPTION
Currently the code snippets don't render correctly:
https://github.com/ruby/ruby/blob/1c452981b69dea8ee45455008d1ab24ab9e972b1/doc/extension.rdoc#appendix-g-embedded-typeddata

Fixed version: https://github.com/eregon/ruby/blob/extension-rdoc-fixes/doc/extension.rdoc#appendix-g-embedded-typeddata

Claude found some other issues in that section, which are now fixed too.

I'd recommend to review commit by commit (otherwise the diff gets confusing about a moved function).

I wish we'd get syntax highlighting and migrate to markdown here, but that's out of scope and these fixes are a good step anyway.