### PR TITLE
mswin: Add statically linked extension exports to the import library

### DIFF
--- a/win32/Makefile.sub
+++ b/win32/Makefile.sub
@@ -1194,10 +1194,10 @@ $(LIBRUBY_SO):	$(LIBRUBY_A) $(DLDOBJS) $(RUBYDEF) $(RUBY_SO_NAME).res
 			$(LIBRUBY_DLDFLAGS)
 		@$(RM) dummy.lib dummy.exp
 
-$(RUBYDEF):	$(LIBRUBY_A) $(RBCONFIG)
+$(RUBYDEF):	$(LIBRUBY_A) $(DLDOBJS) $(RBCONFIG)
 		$(ECHO) generating $(@:\=/)
 		$(Q) $(BOOTSTRAPRUBY_COMMAND) $(srcdir)/win32/mkexports.rb \
-		  -output=$@ -arch=$(ARCH) $(LIBRUBY_A)
+		  -output=$@ -arch=$(ARCH) $(LIBRUBY_A) -- $(DLDOBJS)
 
 {$(win_srcdir)}.def.lib:
 		$(Q) $(AR) $(ARFLAGS)$@ -def:$<

--- a/win32/mkexports.rb
+++ b/win32/mkexports.rb
@@ -20,8 +20,14 @@ class Exports
     klass.new(*args, &block)
   end
 
+  # Files after "--" contribute only the symbols they ask the linker to
+  # export, not everything they define.
   def self.extract(objs, *rest)
-    create(objs).exports(*rest)
+    dllexports = []
+    if i = objs.index("--")
+      objs, dllexports = objs[0, i], objs[(i + 1)..-1]
+    end
+    create(objs, dllexports).exports(*rest)
   end
 
   def self.output(output = $output, &block)
@@ -32,13 +38,16 @@ class Exports
     end
   end
 
-  def initialize(objs)
+  def initialize(objs, dllexports = [])
     syms = {}
     winapis = {}
     syms["ruby_sysinit_real"] = "ruby_sysinit"
     each_export(objs) do |internal, export|
       syms[internal] = export
       winapis[$1] = internal if /^_?(rb_w32_\w+)(?:@\d+)?$/ =~ internal
+    end
+    each_dllexport(dllexports) do |internal, export|
+      syms[internal] = export
     end
     incdir = File.join(File.dirname(File.dirname(__FILE__)), "include/ruby")
     read_substitution(incdir+"/win32.h", syms, winapis)
@@ -79,6 +88,9 @@ class Exports
   end
 
   def each_export(objs)
+  end
+
+  def each_dllexport(objs)
   end
 
   def objdump(objs, &block)
@@ -133,6 +145,20 @@ class Exports::Mswin < Exports
     end
     yield "strcasecmp", "msvcrt.stricmp"
     yield "strncasecmp", "msvcrt.strnicmp"
+  end
+
+  def each_dllexport(objs)
+    return if objs.empty?
+    objs = objs.collect {|s| s.tr('/', '\\')}
+    IO.popen(%w"dumpbin -directives" + objs) do |f|
+      f.each do |l|
+        next unless /^\s*\/EXPORT:(\S+)/ =~ l
+        name, kind = $1.split(',', 2)
+        next if /^_?#{PrivateNames}/o =~ name
+        name.sub!(/^[@_]/, '') if /@\d+$/ !~ name
+        yield name, kind == "DATA"
+      end
+    end
   end
 end
 


### PR DESCRIPTION
On mswin an extension built against a `--with-static-linked-ext` ruby fails to link with `error LNK2019: unresolved external symbol rb_digest_wrap_metadata`, although the shipped DLL does export it. `config.h` defines `EXTSTATIC` for such a build, so `ruby/digest.h` makes every digest-based extension refer to that symbol directly.

The def file is generated from `$(LIBRUBY_A)` alone. Whatever a statically linked extension exports with `RUBY_FUNC_EXPORTED` therefore reaches the DLL through its own `/EXPORT:` linker directive, but never reaches the import library that ships next to it. `win32/mkexports.rb` now also reads those directives from the files listed after `--`, and `$(RUBYDEF)` passes `$(DLDOBJS)` there.

Only explicit exports are collected, so the DLL's export table does not change and the dynamic build still produces a byte-identical def file. Reproducing the failure needs https://github.com/ruby/digest/pull/152, without which `--with-static-linked-ext` does not compile on MSVC.

Generated with [Claude Code](https://claude.com/claude-code)
