### PR TITLE
Fix GC crash during `Hash#merge`

### DIFF
--- a/st.c
+++ b/st.c
@@ -596,6 +596,13 @@ st_init_existing_table_with_size(st_table *tab, const struct st_hash_type *type,
     tab->bin_power = features[n].bin_power;
     tab->size_ind = features[n].size_ind;
 
+    /* The table may be embedded in an object the GC can already reach (T_HASH,
+       imemo_cdhash), in which case the allocation below can mark it. Empty it
+       first, marking walks entries[entries_start..entries_bound). */
+    tab->entries = NULL;
+    tab->num_entries = 0;
+    tab->entries_start = tab->entries_bound = 0;
+
     size_t memsize = get_allocated_entries(tab) * sizeof(st_table_entry);
     if (tab->entry_power > MAX_POWER2_FOR_TABLES_WITHOUT_BINS) {
         memsize += bins_size(tab);

--- a/test/ruby/test_hash.rb
+++ b/test/ruby/test_hash.rb
@@ -1327,6 +1327,11 @@ class TestHash < Test::Unit::TestCase
     assert_equal({1=>8, 2=>4, 3=>4, 5=>7}, h1.merge(h2, h3) {|k, v1, v2| k + v1 + v2 })
   end
 
+  def test_merge_during_gc
+    hash = @cls[a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7, h: 8]
+    assert_equal(9, EnvUtil.under_gc_stress(0x04) { hash.merge(i: 9) }[:i])
+  end
+
   def test_merge_on_identhash
     h = @cls[1=>2,3=>4,5=>6]
     h.compare_by_identity


### PR DESCRIPTION
`Hash#merge` can allocate a destination large enough for an `st_table`.
`hash_copy` then marks the destination as ST-backed before `st_init_existing_table_with_size` allocates memory. If that allocation triggers GC, the uninitialized table is marked and Ruby crashes.

Clear the table before calling `hash_copy`, matching the existing `hash_dup_capa` protection, and add a GC-stress regression test.