### PR TITLE
Build a child Ractor's wrappers in its objspace by naming it, not by …

### DIFF
--- a/cont.c
+++ b/cont.c
@@ -2124,10 +2124,18 @@ static const rb_data_type_t rb_fiber_data_type = {
     0, 0, RUBY_TYPED_FREE_IMMEDIATELY
 };
 
+static VALUE fiber_alloc_in(VALUE klass, void *objspace);
+
 static VALUE
 fiber_alloc(VALUE klass)
 {
-    VALUE obj = TypedData_Wrap_Struct(klass, &rb_fiber_data_type, 0);
+    return fiber_alloc_in(klass, GET_RACTOR()->objspace);
+}
+
+static VALUE
+fiber_alloc_in(VALUE klass, void *objspace)
+{
+    VALUE obj = rb_data_typed_object_wrap_in_objspace(objspace, klass, 0, &rb_fiber_data_type);
     rb_gc_declare_weak_references(obj);
     return obj;
 }
@@ -2701,10 +2709,10 @@ rb_threadptr_root_fiber_setup(rb_thread_t *th)
 }
 
 void
-rb_root_fiber_obj_setup(rb_thread_t *th)
+rb_root_fiber_obj_setup(rb_thread_t *th, void *objspace)
 {
     rb_fiber_t *fiber = th->ec->fiber_ptr;
-    VALUE fiber_value = fiber_alloc(rb_cFiber);
+    VALUE fiber_value = fiber_alloc_in(rb_cFiber, objspace);
     DATA_PTR(fiber_value) = fiber;
     fiber->cont.self = fiber_value;
 }

--- a/ext/-test-/gvl/call_without_gvl/call_without_gvl.c
+++ b/ext/-test-/gvl/call_without_gvl/call_without_gvl.c
@@ -68,6 +68,31 @@ thread_ubf_async_safe(VALUE thread, VALUE notify_fd)
     return Qnil;
 }
 
+/* Churn the malloc accounting from a thread that released the GVL but kept its EC.
+ * The block is over GC_MALLOC_INCREASE_LOCAL_THRESHOLD so every free reaches the
+ * objspace instead of the thread-local counter; freeing it sized keeps that true
+ * where malloc_usable_size is unavailable. */
+#define XFREE_LOOP_SIZE (16 * 1024)
+
+static void *
+xfree_loop(void *p)
+{
+    for (long i = *(long *)p; i > 0; i--) {
+        ruby_xfree_sized(ruby_xmalloc(XFREE_LOOP_SIZE), XFREE_LOOP_SIZE);
+    }
+    return NULL;
+}
+
+static VALUE
+thread_xfree_without_gvl(VALUE klass, VALUE count)
+{
+    long n = NUM2LONG(count);
+
+    rb_thread_call_without_gvl(xfree_loop, &n, RUBY_UBF_IO, NULL);
+
+    return Qnil;
+}
+
 void
 Init_call_without_gvl(void)
 {
@@ -75,4 +100,5 @@ Init_call_without_gvl(void)
     VALUE klass = rb_define_module_under(mBug, "Thread");
     rb_define_singleton_method(klass, "runnable_sleep", thread_runnable_sleep, 1);
     rb_define_singleton_method(klass, "ubf_async_safe", thread_ubf_async_safe, 1);
+    rb_define_singleton_method(klass, "xfree_without_gvl", thread_xfree_without_gvl, 1);
 }

--- a/gc.c
+++ b/gc.c
@@ -1129,20 +1129,17 @@ gc_newobj_hook(VALUE obj)
     RB_GC_VM_UNLOCK_NO_BARRIER(lev);
 }
 
-ALWAYS_INLINE(static VALUE newobj_body(rb_execution_context_t *ec, VALUE klass, VALUE flags, shape_id_t shape_id, bool wb_protected, size_t size));
+ALWAYS_INLINE(static VALUE newobj_body(rb_ractor_t *cr, void *objspace, VALUE klass, VALUE flags, shape_id_t shape_id, bool wb_protected, size_t size));
 
 /* The allocation body shared by rb_newobj and rb_ec_newobj_of, forced inline into
  * both: left to this big translation unit's inline budget, gcc drops it from one
  * entry point or the other and that allocation path grows a call. */
 static VALUE
-newobj_body(rb_execution_context_t *ec, VALUE klass, VALUE flags, shape_id_t shape_id, bool wb_protected, size_t size)
+newobj_body(rb_ractor_t *cr, void *objspace, VALUE klass, VALUE flags, shape_id_t shape_id, bool wb_protected, size_t size)
 {
     GC_ASSERT((flags & FL_WB_PROTECTED) == 0);
-    rb_ractor_t *cr = rb_ec_ractor_ptr(ec);
-    /* Use cr->objspace directly: rb_gc_get_objspace() would look cr up through TLS
-     * on every allocation. */
     size_t actual_alloc_size;
-    VALUE obj = rb_gc_impl_new_obj(cr->objspace, cr->newobj_cache, klass, flags, wb_protected, size, &actual_alloc_size);
+    VALUE obj = rb_gc_impl_new_obj(objspace, cr->newobj_cache, klass, flags, wb_protected, size, &actual_alloc_size);
 
     GC_ASSERT(actual_alloc_size >= size);
     shape_id = rb_shape_transition_slot_size(shape_id, actual_alloc_size);
@@ -1177,7 +1174,30 @@ newobj_body(rb_execution_context_t *ec, VALUE klass, VALUE flags, shape_id_t sha
 VALUE
 rb_newobj(rb_execution_context_t *ec, VALUE klass, VALUE flags, shape_id_t shape_id, bool wb_protected, size_t size)
 {
-    return newobj_body(ec, klass, flags, shape_id, wb_protected, size);
+    /* Read the Ractor's slot directly: rb_gc_get_objspace() would look cr up through
+     * TLS on every allocation. */
+    rb_ractor_t *cr = rb_ec_ractor_ptr(ec);
+    return newobj_body(cr, cr->objspace, klass, flags, shape_id, wb_protected, size);
+}
+
+/* Build the object in a named objspace rather than the current Ractor's.  The only
+ * foreign objspace allowed is the child this Ractor is building
+ * (create_ractor_alloc_thread), whose wrappers must be objects the child owns.
+ *
+ * That target has no thread of its own yet, which is what makes this cheap: nothing
+ * allocates, sweeps or collects there, so the half-built objects need no root and its
+ * GC can be suppressed outright.  Aiming at a live Ractor's objspace -- to build a
+ * copy where it will be used, say -- needs three things this does not have: a root the
+ * target's own GC marks the objects under construction from, a newobj_cache paired
+ * with that objspace (today the only multi-objspace collector has no per-Ractor cache,
+ * and the ones that do are single-objspace), and write barriers aimed at the target.
+ * The assertion stops the shortcut. */
+static VALUE
+rb_newobj_in_objspace(rb_execution_context_t *ec, void *objspace, VALUE klass, VALUE flags, shape_id_t shape_id, bool wb_protected, size_t size)
+{
+    rb_ractor_t *cr = rb_ec_ractor_ptr(ec);
+    RUBY_ASSERT(objspace == cr->objspace || objspace == cr->creating_child_objspace);
+    return newobj_body(cr, objspace, klass, flags, shape_id, wb_protected, size);
 }
 
 VALUE
@@ -1191,7 +1211,8 @@ rb_ec_newobj_of(rb_execution_context_t *ec, VALUE klass, VALUE flags, size_t siz
     RUBY_ASSERT(type != T_ICLASS);
     (void)type;
 
-    return newobj_body(ec, klass, flags, ROOT_SHAPE_ID | SHAPE_ID_LAYOUT_OTHER, true, size);
+    rb_ractor_t *cr = rb_ec_ractor_ptr(ec);
+    return newobj_body(cr, cr->objspace, klass, flags, ROOT_SHAPE_ID | SHAPE_ID_LAYOUT_OTHER, true, size);
 }
 
 static VALUE
@@ -1318,12 +1339,12 @@ rb_data_object_check(VALUE klass)
 #define RTYPEDDATA_EMBEDDABLE_P(obj) RB_DATA_TYPE_EMBEDDABLE_P(RTYPEDDATA_TYPE(obj))
 
 static VALUE
-typed_data_alloc(VALUE klass, VALUE typed_flag, void *datap, const rb_data_type_t *type, size_t size)
+typed_data_alloc_in(void *objspace, VALUE klass, VALUE typed_flag, void *datap, const rb_data_type_t *type, size_t size)
 {
     RBIMPL_NONNULL_ARG(type);
     if (klass) rb_data_object_check(klass);
     bool wb_protected = (type->flags & RUBY_FL_WB_PROTECTED) || !type->function.dmark;
-    VALUE obj = rb_newobj(GET_EC(), klass, T_DATA, ROOT_SHAPE_ID | SHAPE_ID_LAYOUT_RDATA, wb_protected, size);
+    VALUE obj = rb_newobj_in_objspace(GET_EC(), objspace, klass, T_DATA, ROOT_SHAPE_ID | SHAPE_ID_LAYOUT_RDATA, wb_protected, size);
 
     rb_gc_register_pinning_obj(obj);
 
@@ -1335,18 +1356,30 @@ typed_data_alloc(VALUE klass, VALUE typed_flag, void *datap, const rb_data_type_
     return obj;
 }
 
-VALUE
-rb_data_typed_object_wrap(VALUE klass, void *datap, const rb_data_type_t *type)
+static VALUE
+typed_data_wrap_in(void *objspace, VALUE klass, void *datap, const rb_data_type_t *type)
 {
     if (UNLIKELY(RB_DATA_TYPE_EMBEDDABLE_P(type))) {
         rb_raise(rb_eTypeError, "Cannot wrap an embeddable TypedData");
     }
 
-    return typed_data_alloc(klass, 0, datap, type, sizeof(struct RTypedData));
+    return typed_data_alloc_in(objspace, klass, 0, datap, type, sizeof(struct RTypedData));
 }
 
 VALUE
-rb_data_typed_object_zalloc(VALUE klass, size_t size, const rb_data_type_t *type)
+rb_data_typed_object_wrap(VALUE klass, void *datap, const rb_data_type_t *type)
+{
+    return typed_data_wrap_in(rb_ec_ractor_ptr(GET_EC())->objspace, klass, datap, type);
+}
+
+VALUE
+rb_data_typed_object_wrap_in_objspace(void *objspace, VALUE klass, void *datap, const rb_data_type_t *type)
+{
+    return typed_data_wrap_in(objspace, klass, datap, type);
+}
+
+static VALUE
+typed_data_zalloc_in(void *objspace, VALUE klass, size_t size, const rb_data_type_t *type)
 {
     if (RB_DATA_TYPE_EMBEDDABLE_P(type)) {
         if (!(type->flags & (RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_THREAD_SAFE_FREE))) {
@@ -1355,15 +1388,27 @@ rb_data_typed_object_zalloc(VALUE klass, size_t size, const rb_data_type_t *type
 
         size_t embed_size = offsetof(struct RTypedData, data) + size;
         if (rb_gc_size_allocatable_p(embed_size)) {
-            VALUE obj = typed_data_alloc(klass, TYPED_DATA_EMBEDDED, 0, type, embed_size);
+            VALUE obj = typed_data_alloc_in(objspace, klass, TYPED_DATA_EMBEDDED, 0, type, embed_size);
             memset((char *)obj + offsetof(struct RTypedData, data), 0, size);
             return obj;
         }
     }
 
-    VALUE obj = typed_data_alloc(klass, 0, NULL, type, sizeof(struct RTypedData));
+    VALUE obj = typed_data_alloc_in(objspace, klass, 0, NULL, type, sizeof(struct RTypedData));
     DATA_PTR(obj) = xcalloc(1, size);
     return obj;
+}
+
+VALUE
+rb_data_typed_object_zalloc(VALUE klass, size_t size, const rb_data_type_t *type)
+{
+    return typed_data_zalloc_in(rb_ec_ractor_ptr(GET_EC())->objspace, klass, size, type);
+}
+
+VALUE
+rb_data_typed_object_zalloc_in_objspace(void *objspace, VALUE klass, size_t size, const rb_data_type_t *type)
+{
+    return typed_data_zalloc_in(objspace, klass, size, type);
 }
 
 static size_t
@@ -5367,19 +5412,30 @@ rb_objspace_gc_disable(void *objspace)
 }
 
 VALUE
+rb_gc_objspace_enable(void *objspace)
+{
+    return rb_objspace_gc_enable(objspace);
+}
+
+VALUE
 rb_gc_local_enable(void)
 {
-    return rb_objspace_gc_enable(rb_gc_get_objspace());
+    return rb_gc_objspace_enable(rb_gc_get_objspace());
 }
 
 
 VALUE
-rb_gc_local_disable_no_rest(void)
+rb_gc_objspace_disable_no_rest(void *objspace)
 {
-    void *objspace = rb_gc_get_objspace();
     bool disabled = !rb_gc_impl_gc_enabled_p(objspace);
     rb_gc_impl_gc_disable(objspace, false);
     return RBOOL(disabled);
+}
+
+VALUE
+rb_gc_local_disable_no_rest(void)
+{
+    return rb_gc_objspace_disable_no_rest(rb_gc_get_objspace());
 }
 
 static VALUE

--- a/internal/gc.h
+++ b/internal/gc.h
@@ -308,6 +308,13 @@ bool rb_gc_multi_objspace_p(void);
 bool rb_gc_obj_foreign_p(VALUE obj);
 void *rb_gc_objspace_alloc(void);
 void rb_gc_objspace_retire_gc(void);
+/* Build an object, or suppress GC, in a named objspace rather than the current
+ * Ractor's.  Only create_ractor_alloc_thread() needs these. */
+VALUE rb_data_typed_object_wrap_in_objspace(void *objspace, VALUE klass, void *datap, const rb_data_type_t *type);
+VALUE rb_data_typed_object_zalloc_in_objspace(void *objspace, VALUE klass, size_t size, const rb_data_type_t *type);
+VALUE rb_gc_objspace_disable_no_rest(void *objspace);
+VALUE rb_gc_objspace_enable(void *objspace);
+
 void rb_gc_objspace_retire(void **objspace_slot);
 void rb_gc_objspace_postmortem_self(void);
 void rb_gc_objspace_absorb_into_current(void **objspace_slot);

--- a/test/ruby/test_ractor.rb
+++ b/test/ruby/test_ractor.rb
@@ -563,6 +563,34 @@ class TestRactor < Test::Unit::TestCase
     RUBY
   end
 
+  # A thread that released the GVL keeps its EC, so it still resolves an objspace to
+  # charge its frees to.  It must not be sent to the objspace of a child Ractor being
+  # built by another thread of the same Ractor: a stillborn child frees that objspace.
+  def test_stillborn_ractor_with_free_off_gvl
+    assert_ractor(<<~'RUBY', require: '-test-/gvl/call_without_gvl', timeout: 60)
+      x = 42 # capturing an outer local makes Ractor.new raise IsolationError
+      stop = false
+      ready = Queue.new
+      freers = 4.times.map do
+        Thread.new do
+          ready << :up
+          Bug::Thread.xfree_without_gvl(2_000) until stop
+        end
+      end
+      freers.size.times { ready.pop } # all of them are churning before we start
+      2_000.times do
+        begin
+          Ractor.new { x }
+        rescue Ractor::IsolationError
+        end
+      end
+      stop = true
+      freers.each(&:join)
+      GC.start
+      GC.verify_internal_consistency
+    RUBY
+  end
+
   # Moving a CoW shared-root String must not steal its buffer (regression guard for the
   # remaining sharers reading freed memory).
   def test_move_shared_root_string_keeps_buffer

--- a/thread.c
+++ b/thread.c
@@ -1134,49 +1134,48 @@ rb_thread_create(VALUE (*fn)(void *), void *arg)
 static VALUE
 create_ractor_alloc_thread(rb_ractor_t *r, rb_ractor_t *cr, rb_execution_context_t *ec)
 {
-    /* Allocate the child's main Thread and root Fiber wrappers directly in the child's
-     * objspace, so the thread is built of objects it owns.  Whole-VM walks read
-     * cr->objspace: swap it under the VM lock, unobservable to others. */
+    /* Build the child's main Thread and root Fiber wrappers in the child's objspace,
+     * so the thread is made of objects it owns.  Hand that objspace down rather than
+     * pointing cr->objspace at it: threads holding no GVL read that slot to charge
+     * their frees, and one of them must never be sent to a heap a stillborn child is
+     * about to free.
+     *
+     * The child's objspace is not in vm->ractor.set yet, so cover it through its
+     * creator before the first allocation and keep the cover until vm_insert_ractor
+     * clears it under the VM lock.  One slot suffices: one Ractor creates children
+     * serially. */
+    void *const child_objspace = r->objspace;
     volatile VALUE thval = Qundef;
     const bool multi_objspace = rb_gc_multi_objspace_p();
     enum ruby_tag_type alloc_state = TAG_NONE;
     RB_VM_LOCKING() {
-        void *const parent_objspace = cr->objspace;
-        if (multi_objspace) cr->objspace = r->objspace;
-        /* The wrapper allocations must not re-enter GC: while cr->objspace points at
-         * the child, the creator's own objspace is invisible to every walk, so a global
-         * GC would skip it and leave stale mark bits (a UAF).  Single allocations;
-         * suppressing GC costs only a little growth. */
-        VALUE gc_was_disabled = rb_gc_local_disable_no_rest();
-        /* The alloc can raise NoMemoryError; a longjmp here would skip both the unlock
-         * of RB_VM_LOCKING and the objspace restore, so catch and rethrow outside. */
+        if (multi_objspace) {
+            RUBY_ASSERT(cr->creating_child_objspace == NULL);
+            cr->creating_child_objspace = child_objspace;
+        }
+        /* Suppress the child's GC, not the creator's: a cycle here would collect a
+         * half-built child.  Single allocations; this costs only a little growth. */
+        VALUE gc_was_disabled = rb_gc_objspace_disable_no_rest(child_objspace);
+        /* The alloc can raise NoMemoryError; a longjmp here would skip the unlock of
+         * RB_VM_LOCKING, so catch and rethrow outside. */
         EC_PUSH_TAG(ec);
         if ((alloc_state = EC_EXEC_TAG()) == TAG_NONE) {
-            thval = rb_thread_alloc(rb_cThread);
+            thval = rb_thread_alloc_in_objspace(rb_cThread, child_objspace);
         }
         EC_POP_TAG();
-        if (gc_was_disabled == Qfalse) rb_gc_local_enable();
-        if (multi_objspace) cr->objspace = parent_objspace;
-        /* The child's objspace holds the wrappers but is not in vm->ractor.set yet:
-         * keep it enumerable until vm_insert_ractor clears this under the VM lock.  One
-         * slot suffices: the GVL is never released between set and clear and one
-         * Ractor creates children serially, so no overwrite (asserted: releasing the
-         * GVL here in the future would break it). */
-        if (alloc_state == TAG_NONE && multi_objspace) {
-            RUBY_ASSERT(cr->creating_child_objspace == NULL);
-            cr->creating_child_objspace = r->objspace;
-        }
-    }
-    if (alloc_state != TAG_NONE) {
-        /* No cover was set; park the child objspace for the orphan merge and re-raise. */
-        RB_VM_LOCKING() {
+        if (gc_was_disabled == Qfalse) rb_gc_objspace_enable(child_objspace);
+        if (alloc_state != TAG_NONE) {
+            /* Drop the cover and park the objspace in this same section: between two of
+             * them another Ractor's global GC would find a populated objspace that is
+             * neither covered nor a zombie. */
+            if (multi_objspace) cr->creating_child_objspace = NULL;
             if (r->objspace) {
                 rb_gc_objspace_disown(r->objspace);
                 r->objspace = NULL;
             }
         }
-        EC_JUMP_TAG(ec, alloc_state);
     }
+    if (alloc_state != TAG_NONE) EC_JUMP_TAG(ec, alloc_state);
     return thval;
 }
 

--- a/vm.c
+++ b/vm.c
@@ -3929,7 +3929,7 @@ rb_execution_context_mark(const rb_execution_context_t *ec)
 void rb_fiber_mark_self(rb_fiber_t *fib);
 void rb_fiber_update_self(rb_fiber_t *fib);
 void rb_threadptr_root_fiber_setup(rb_thread_t *th);
-void rb_root_fiber_obj_setup(rb_thread_t *th);
+void rb_root_fiber_obj_setup(rb_thread_t *th, void *objspace);
 void rb_threadptr_root_fiber_release(rb_thread_t *th);
 
 static void
@@ -4083,10 +4083,9 @@ rb_obj_is_thread(VALUE obj)
 }
 
 static VALUE
-thread_alloc(VALUE klass)
+thread_alloc(VALUE klass, void *objspace)
 {
-    rb_thread_t *th;
-    return TypedData_Make_Struct(klass, rb_thread_t, &thread_data_type, th);
+    return rb_data_typed_object_zalloc_in_objspace(objspace, klass, sizeof(rb_thread_t), &thread_data_type);
 }
 
 void
@@ -4198,14 +4197,20 @@ th_init(rb_thread_t *th, VALUE self, rb_vm_t *vm)
 }
 
 VALUE
-rb_thread_alloc(VALUE klass)
+rb_thread_alloc_in_objspace(VALUE klass, void *objspace)
 {
-    VALUE self = thread_alloc(klass);
+    VALUE self = thread_alloc(klass, objspace);
     rb_thread_t *target_th = rb_thread_ptr(self);
     target_th->ractor = GET_RACTOR();
     th_init(target_th, self, target_th->vm = GET_VM());
-    rb_root_fiber_obj_setup(target_th);
+    rb_root_fiber_obj_setup(target_th, objspace);
     return self;
+}
+
+VALUE
+rb_thread_alloc(VALUE klass)
+{
+    return rb_thread_alloc_in_objspace(klass, GET_RACTOR()->objspace);
 }
 
 #define REWIND_CFP(expr) do { \
@@ -4822,7 +4827,7 @@ Init_VM(void)
         th->top_wrapper = 0;
         th->top_self = rb_vm_top_self();
 
-        rb_root_fiber_obj_setup(th);
+        rb_root_fiber_obj_setup(th, th->ractor->objspace);
 
         rb_vm_register_global_object((VALUE)iseq);
         th->ec->cfp->_iseq = iseq;

--- a/vm_core.h
+++ b/vm_core.h
@@ -2022,6 +2022,9 @@ VM_BH_FROM_PROC(VALUE procval)
 
 /* VM related object allocate functions */
 VALUE rb_thread_alloc(VALUE klass);
+/* Build the Thread out of objects a named objspace owns; only a Ractor building its
+ * child needs this (create_ractor_alloc_thread). */
+VALUE rb_thread_alloc_in_objspace(VALUE klass, void *objspace);
 VALUE rb_binding_alloc(VALUE klass);
 VALUE rb_proc_alloc(VALUE klass, enum rb_block_type block_type);
 VALUE rb_proc_dup(VALUE self);


### PR DESCRIPTION
…moving it

create_ractor_alloc_thread() pointed cr->objspace at the child's objspace while it allocated the child's Thread and root Fiber wrappers, so that they would be made of objects the child owns.  That slot is read without the VM lock by threads that hold no GVL -- a Ractor's postmortem epilogue, which clears the TLS EC before freeing the dead thread, thread_sched_reclaim, and any thread that released the GVL inside rb_nogvl -- to decide which objspace to charge a free to.  One of them could therefore be sent to the child's objspace; a stillborn child (IsolationError) is then disowned and freed by the orphan merge job, and the free landed in released memory (ASAN heap-use-after-free at the malloc accounting in ruby_xfree_sized, seen once in 209 CI runs).

The window allocates exactly two objects, so hand the objspace down to them instead: rb_newobj_in_objspace() and the two TypedData entry points built on it carry it to thread_alloc() and fiber_alloc_in().  cr->objspace never moves, so no other thread can observe anything, and rb_gc_get_objspace() is unchanged.

GC suppression around the wrappers now names the child's objspace too, which is the one the allocations go to; resolving it through the current Ractor would suppress the creator's instead and let a cycle collect the half-built child. The creation cover goes up before the first allocation rather than after the last one, and the allocation-failure path parks the objspace in the same VM-lock section, so a global GC can never find it neither covered nor a zombie.