### PR TITLE
ractor.h: export rb_obj_set_shareable()

### DIFF
--- a/include/ruby/ractor.h
+++ b/include/ruby/ractor.h
@@ -221,6 +221,26 @@ VALUE rb_ractor_make_shareable(VALUE obj);
  */
 VALUE rb_ractor_make_shareable_copy(VALUE obj);
 
+/**
+ * Marks the passed object as shareable, without any check.  This is for
+ * objects which the caller knows are safe to be shared among Ractors, for
+ * instance because they are frozen and only refer to shareable objects.
+ *
+ * @param[out]  obj  Arbitrary ruby object, except special constants.
+ * @return      Passed `obj`.
+ * @post        Multiple Ractors can share `obj`.
+ * @warning     No check is done.  Marking an unsafe object as shareable
+ *              breaks the Ractor isolation.
+ * @warning     Do not make objects shareable more than needed.  A shareable
+ *              object is out of the reach of a local GC, so it is not
+ *              collected until a global GC runs.  This is for the few objects
+ *              which live as long as the process, typically internal
+ *              constants, not for objects created per call.
+ * @note        Do not call this directly; use #RB_OBJ_SET_SHAREABLE, or
+ *              #RB_OBJ_SET_FROZEN_SHAREABLE to freeze at the same time.
+ */
+VALUE rb_obj_set_shareable(VALUE obj);
+
 RBIMPL_SYMBOL_EXPORT_END()
 
 /**
@@ -262,11 +282,21 @@ rb_ractor_shareable_p(VALUE obj)
 }
 
 // TODO: optimize on interpreter core
+
+/**
+ * Wrapper of rb_obj_set_shareable().  Use this macro, not the function.
+ */
 #ifndef RB_OBJ_SET_SHAREABLE
-VALUE rb_obj_set_shareable(VALUE obj); // ractor.c
 #define RB_OBJ_SET_SHAREABLE(obj) rb_obj_set_shareable(obj)
 #endif
 
+/**
+ * Freezes and marks the object as shareable.  The same warning and note as
+ * rb_obj_set_shareable() apply.
+ *
+ * @param[out]  obj  Arbitrary ruby object, except special constants.
+ * @return      Passed `obj`.
+ */
 static inline VALUE
 RB_OBJ_SET_FROZEN_SHAREABLE(VALUE obj)
 {


### PR DESCRIPTION
RB_OBJ_SET_SHAREABLE() was unusable from extensions: the declaration was outside RBIMPL_SYMBOL_EXPORT_BEGIN/END, so the symbol was compiled with hidden visibility and did not appear in libruby.so.

Also document it, including the cost that a shareable object is not collected by a local GC.