### PR TITLE
align IO#open default textmode with/without opthash

### DIFF
--- a/io.c
+++ b/io.c
@@ -7025,11 +7025,6 @@ rb_io_extract_modeenc(VALUE *vmode_p, VALUE *vperm_p, VALUE opthash,
             if (!has_enc)
                 rb_io_ext_int_to_encs(rb_ascii8bit_encoding(), NULL, &enc, &enc2, fmode);
         }
-#if DEFAULT_TEXTMODE
-        else if (NIL_P(vmode)) {
-            fmode |= DEFAULT_TEXTMODE;
-        }
-#endif
         v = rb_hash_aref(opthash, sym_perm);
         if (!NIL_P(v)) {
             if (vperm_p) {
@@ -7049,6 +7044,11 @@ rb_io_extract_modeenc(VALUE *vmode_p, VALUE *vperm_p, VALUE opthash,
         ecflags |= (fmode & FMODE_WRITABLE) ?
             MODE_BTMODE(TEXTMODE_NEWLINE_DECORATOR_ON_WRITE,
                         0, TEXTMODE_NEWLINE_DECORATOR_ON_WRITE) : 0;
+#endif
+#if DEFAULT_TEXTMODE
+        if (!(fmode & FMODE_BINMODE) && NIL_P(vmode)) {
+            fmode |= DEFAULT_TEXTMODE;
+        }
 #endif
 
         if (rb_io_extract_encoding_option(opthash, &enc, &enc2, &fmode)) {

--- a/test/ruby/test_io_m17n.rb
+++ b/test/ruby/test_io_m17n.rb
@@ -153,6 +153,28 @@ EOT
     }
   end
 
+  def test_open_enc_in_opt_without_encoding_conversion
+    bug20526 = '[ruby-core:118182][Bug #20526]'
+    with_tmpdir {
+      generate_file('tmp', "a\r\r\n")
+      expected = open("tmp") {|f| f.read }
+      actual = open("tmp", encoding: "bom|utf-8") {|f| f.read }
+      assert_equal(expected, actual, bug20526)
+
+      # open(name, encoding: ...) must apply the same default text-mode
+      # on Windows.
+      if /mswin|mingw/ =~ RUBY_PLATFORM
+        assert_equal("a\r\n", actual, bug20526)
+      end
+
+      omit "affected by Bug #21691 on Windows" if /mswin|mingw/ =~ RUBY_PLATFORM
+      expected = open("tmp", universal_newline: true) {|f| f.read }
+      actual = open("tmp", encoding: "bom|utf-8", universal_newline: true) {|f| f.read }
+      assert_equal(expected, actual, bug20526)
+      assert_equal("a\n\n", actual, bug20526)
+    }
+  end
+
   def test_open_r_encname_in_opt
     with_tmpdir {
       generate_file('tmp', "")


### PR DESCRIPTION
partially fixes [Bug#20526](https://bugs.ruby-lang.org/issues/20526)
This fix addresses the first problem of https://bugs.ruby-lang.org/issues/20526#note-10, but does not address the second, that related to Bug #21691.

`rb_io_extract_modeenc` contains a branch based on the presence or absence of `opthash`.
The branch with `opthash` failed to determine the default text mode and incorrectly set `universal newline`.
This is fixed by aligning the processing order with that of the branch without `opthash`.