### PR TITLE
Ractor: do not republish port queues a reap freed during a table rebuild

### DIFF
--- a/ractor_sync.c
+++ b/ractor_sync.c
@@ -536,8 +536,27 @@ ractor_add_port(rb_ractor_t *r, st_data_t id)
         // The table is full. Rebuild it outside of the ractor lock (mutators
         // are serialized by the per-ractor GVL) and swap it under the lock
         // to exclude the readers (other ractors).
-        st_table *const new_tab = st_copy(old_tab);
-        st_insert(new_tab, id, (st_data_t)rq);
+        st_table *new_tab;
+
+        // Those allocations can run a global GC, whose reap frees dead ports and
+        // drops them from old_tab; a copy taken across one would republish the
+        // freed queues.  Only the owner inserts into its own table, so a changed
+        // count means a reap ran.  Check after each allocation: st_copy fills the
+        // header before it allocates the entries, so a reap in between leaves the
+        // copy counting rows it does not have, which st_insert must not be given.
+        while (1) {
+            const st_index_t entries = st_table_size(old_tab);
+
+            new_tab = st_copy(old_tab);
+
+            if (st_table_size(old_tab) == entries) {
+                st_insert(new_tab, id, (st_data_t)rq);
+
+                if (st_table_size(old_tab) == entries) break;
+            }
+
+            st_free_table(new_tab);
+        }
 
         RACTOR_LOCK(r);
         {


### PR DESCRIPTION
ractor_add_port grows a full port table by copying it: st_copy(old_tab), then st_insert of the new entry, then swapping the copy in under the Ractor lock and freeing the old table.  Both calls allocate, and an allocation is a safepoint, so a global GC can run there.  The end of a global GC is where rb_ractor_reap_dead_ports frees the queues of ports whose Ractor::Port went unmarked and ST_DELETEs them -- from r->sync.ports, which is still old_tab.  The copy already taken then carries entries the reap deleted, and swapping it in republishes queues that have been freed.  The next global GC walks them:

  ERROR: AddressSanitizer: heap-use-after-free
      #0 ractor_queue_mark             ractor_sync.c
      #1 ractor_mark_ports_i           ractor_sync.c
      #3 ractor_sync_mark              ractor_sync.c
      #5 rb_ractor_mark_local_roots    ractor.c
      #6 gc_start_global               gc/default/default.c

Only the owning Ractor inserts into its own table, so a changed entry count means a reap ran; take the copy again when it did.  The count is checked after each allocation rather than once at the end: st_copy fills the header before it allocates the entry storage, so a reap in between leaves the copy counting rows it does not have, and st_insert must not be handed a table in that state.

The retry is bounded: each failure means the source table lost at least one entry.

Reproduced with Ractor.select over many Ractors that finish and are absorbed, with allocation running a global GC underneath (a supervisor loop).  A plain build crashes only under load; under ASAN, 2 of 3 runs on master and 0 of 5 with this change.