### PR TITLE
Fix Hash#merge SEGV

### DIFF
--- a/st.c
+++ b/st.c
@@ -596,6 +596,13 @@ st_init_existing_table_with_size(st_table *tab, const struct st_hash_type *type,
     tab->bin_power = features[n].bin_power;
     tab->size_ind = features[n].size_ind;
 
+    /* The table may be embedded in an object the GC can already reach (T_HASH,
+       imemo_cdhash), in which case the allocation below can mark it. Empty it
+       first, marking walks entries[entries_start..entries_bound). */
+    tab->entries = NULL;
+    tab->num_entries = 0;
+    tab->entries_start = tab->entries_bound = 0;
+
     size_t memsize = get_allocated_entries(tab) * sizeof(st_table_entry);
     if (tab->entry_power > MAX_POWER2_FOR_TABLES_WITHOUT_BINS) {
         memsize += bins_size(tab);


### PR DESCRIPTION
We're seeing crashes like this in CI:

```
/usr/local/ruby/bin/ruby(sigsegv+0x54) [0x5d222041e074] /tmp/ruby-build/ruby-4.1.0-daf616ac718d0bfcaee7c3e4f092aa26e75f3e78/signal.c:948
/lib/x86_64-linux-gnu/libc.so.6(0x7c34def84330) [0x7c34def84330]
/usr/local/ruby/bin/ruby(st_general_foreach+0x77) [0x5d2220423657] /tmp/ruby-build/ruby-4.1.0-daf616ac718d0bfcaee7c3e4f092aa26e75f3e78/st.c:1641
/usr/local/ruby/bin/ruby(rb_hash_stlike_foreach+0x71) [0x5d22203076d1] /tmp/ruby-build/ruby-4.1.0-daf616ac718d0bfcaee7c3e4f092aa26e75f3e78/st.c:1795
/usr/local/ruby/bin/ruby(RSTRUCT_FIELDS_OBJ+0x0) [0x5d22203049ff] /tmp/ruby-build/ruby-4.1.0-daf616ac718d0bfcaee7c3e4f092aa26e75f3e78/gc.c:3006
/usr/local/ruby/bin/ruby(rb_gc_mark_children) /tmp/ruby-build/ruby-4.1.0-daf616ac718d0bfcaee7c3e4f092aa26e75f3e78/gc.c:3645
/usr/local/ruby/bin/ruby(gc_mark_children+0x1b) [0x5d222066fdf3] gc/default/default.c:5969
/usr/local/ruby/bin/ruby(gc_mark_stacked_objects) gc/default/default.c:5991
/usr/local/ruby/bin/ruby(gc_mark_stacked_objects_all+0x5) [0x5d22202f2bc5] gc/default/default.c:6032
/usr/local/ruby/bin/ruby(gc_marks_rest) gc/default/default.c:7313
/usr/local/ruby/bin/ruby(gc_marks+0x42c) [0x5d22202f300c] gc/default/default.c:7504
/usr/local/ruby/bin/ruby(gc_start_body+0x2d2) [0x5d22202f4952] gc/default/default.c:8347
/usr/local/ruby/bin/ruby(objspace_malloc_fixup+0x39) [0x5d22202f7599] gc/default/default.c:10846
/usr/local/ruby/bin/ruby(rb_gc_impl_malloc) gc/default/default.c:11051
/usr/local/ruby/bin/ruby(handle_malloc_failure+0x0) [0x5d222030a5c8] /tmp/ruby-build/ruby-4.1.0-daf616ac718d0bfcaee7c3e4f092aa26e75f3e78/gc.c:6094
/usr/local/ruby/bin/ruby(ruby_xmalloc) /tmp/ruby-build/ruby-4.1.0-daf616ac718d0bfcaee7c3e4f092aa26e75f3e78/gc.c:6076
/usr/local/ruby/bin/ruby(st_has_bins+0x0) [0x5d222068cae2] /tmp/ruby-build/ruby-4.1.0-daf616ac718d0bfcaee7c3e4f092aa26e75f3e78/st.c:603
/usr/local/ruby/bin/ruby(st_bins_ptr) /tmp/ruby-build/ruby-4.1.0-daf616ac718d0bfcaee7c3e4f092aa26e75f3e78/st.c:498
/usr/local/ruby/bin/ruby(make_tab_empty) /tmp/ruby-build/ruby-4.1.0-daf616ac718d0bfcaee7c3e4f092aa26e75f3e78/st.c:536
/usr/local/ruby/bin/ruby(rb_st_init_existing_table_with_size) /tmp/ruby-build/ruby-4.1.0-daf616ac718d0bfcaee7c3e4f092aa26e75f3e78/st.c:610
/usr/local/ruby/bin/ruby(hash_copy+0x112) [0x5d222030c9a2] /tmp/ruby-build/ruby-4.1.0-daf616ac718d0bfcaee7c3e4f092aa26e75f3e78/hash.c:1678
/usr/local/ruby/bin/ruby(rb_copy_generic_ivar+0x0) [0x5d222030d0e5] /tmp/ruby-build/ruby-4.1.0-daf616ac718d0bfcaee7c3e4f092aa26e75f3e78/hash.c:1720
/usr/local/ruby/bin/ruby(rb_hash_dup_capa) /tmp/ruby-build/ruby-4.1.0-daf616ac718d0bfcaee7c3e4f092aa26e75f3e78/hash.c:1744
/usr/local/ruby/bin/ruby(rb_hash_merge+0x1aa) [0x5d222030fc6a] /tmp/ruby-build/ruby-4.1.0-daf616ac718d0bfcaee7c3e4f092aa26e75f3e78/hash.c:4630
```

We can reproduce the crash with this script:

```ruby
OTHER = { i: 9, j: 10, k: 11, l: 12 }

200_000.times { { a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7, h: 8, i: 9, j: 10, k: 11, l: 12 } }
GC.start
GC.start

src = { a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7, h: 8 }

GC.stress = true
300.times { src.merge(OTHER) }
GC.stress = false
```

We need to set tab->entries_start and tab->entries_bound to 0 in case the xmalloc below it causes GC and marks a HASH in which the table is embedded.

I'm not adding the repro script as a regression test because it's very implementation specific and I don't have a better one.