### PR TITLE
Ractor: wake a receiver when its port is closed

### DIFF
--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -2863,3 +2863,31 @@ assert_equal '[[0, 1, 2], [:a, :b]]', %q{
   6.times { GC.start }
   [taken.map(&:receive), [closed.receive, closed.receive]]
 }
+
+# Closing a port wakes a receiver waiting on it, with or without a timeout.
+assert_equal '[:closed, :closed]', %q{
+  untimed = Ractor::Port.new
+  th = Thread.new do
+    begin
+      untimed.receive
+    rescue Ractor::ClosedError
+      :closed
+    end
+  end
+  Thread.pass until th.status == 'sleep'
+  untimed.close
+  untimed_result = th.value # before the next close, which would wake it too
+
+  timed = Ractor::Port.new
+  th2 = Thread.new do
+    begin
+      timed.receive(timeout: 10)
+    rescue Ractor::ClosedError
+      :closed
+    end
+  end
+  Thread.pass until th2.status == 'sleep'
+  timed.close
+
+  [untimed_result, th2.value]
+}

--- a/ractor.rb
+++ b/ractor.rb
@@ -297,6 +297,9 @@ class Ractor
   #    # r1 done
   #    # r0 done
   #
+  # Closing one of the given ports raises Ractor::ClosedError, whether it was
+  # closed before the call or while it waits.
+  #
   # The following example is almost equivalent to <code>ractors.map(&:value)</code> except the thread
   # is unblocked when any of the ractors has terminated as opposed to waiting for their termination in
   # the array element order.
@@ -759,11 +762,17 @@ class Ractor
     # is already there and returns +nil+ otherwise.
     #
     # If the port is closed and there are no more messages in the message queue,
-    # the method raises Ractor::ClosedError.
+    # the method raises Ractor::ClosedError. Closing a port while this method
+    # waits on it ends the wait the same way; messages queued before the close
+    # are received first.
     #
     #     port = Ractor::Port.new
     #     port.close
     #     port.receive #=> raise Ractor::ClosedError
+    #
+    #     port = Ractor::Port.new
+    #     Thread.new { sleep 0.1; port.close }
+    #     port.receive #=> raise Ractor::ClosedError, after 0.1 seconds
     #
     def receive(timeout: nil)
       __builtin_cexpr! %q{
@@ -822,6 +831,11 @@ class Ractor
     #
     # Closes the port. Sending to a closed port is prohibited.
     # Receiving is also prohibited if there are no messages in its message queue.
+    #
+    # Messages already in the queue are kept: a receiver takes them before the
+    # port reports itself closed. A Ractor::Port#receive waiting on the port when
+    # it closes stops there and raises Ractor::ClosedError, rather than waiting
+    # for a message that can no longer arrive.
     #
     # Only the Ractor which created the port is allowed to close it.
     #

--- a/ractor_core.h
+++ b/ractor_core.h
@@ -173,7 +173,7 @@ enum ractor_wakeup_status {
     wakeup_none,
     wakeup_by_send,
     wakeup_by_interrupt,
-    // wakeup_by_close,
+    wakeup_by_close,
 };
 
 struct ractor_waiter {

--- a/ractor_sync.c
+++ b/ractor_sync.c
@@ -1441,6 +1441,14 @@ ractor_check_received(rb_ractor_t *cr, struct ractor_queue *messages)
 
 // Returns false if the deadline `end` passed with nothing to deliver.  Incoming
 // messages are delivered even then, so the caller retries its queue once more.
+// A wait can end on a wakeup meant for another port, so the caller keeps the
+// deadline: a stream of them must not hold a timed receive past its time.
+static bool
+ractor_deadline_passed_p(const rb_hrtime_t *end)
+{
+    return end != NULL && rb_hrtime_now() >= *end;
+}
+
 static bool
 ractor_wait_receive(rb_execution_context_t *ec, rb_ractor_t *cr, const rb_hrtime_t *end)
 {
@@ -1524,6 +1532,11 @@ ractor_receive(rb_execution_context_t *ec, const struct ractor_port *rp, const r
         }
         else if (!ractor_wait_receive(ec, cr, end)) {
             return Qundef;
+        }
+        else if (ractor_deadline_passed_p(end)) {
+            // The wait ended on a wakeup meant for another port, which says
+            // nothing about the clock.  One more look, then the deadline stands.
+            return ractor_try_receive(ec, cr, rp);
         }
     }
 }
@@ -1831,6 +1844,10 @@ ractor_selector__wait(rb_execution_context_t *ec, VALUE selector, const rb_hrtim
         }
         else if (!ractor_wait_receive(ec, cr, end)) {
             return Qnil;
+        }
+        else if (ractor_deadline_passed_p(end)) {
+            st_foreach(s->ports, ractor_selector_wait_i, (st_data_t)&data);
+            return data.found ? rb_ary_new_from_args(2, data.rpv, data.v) : Qnil;
         }
     }
 }

--- a/ractor_sync.c
+++ b/ractor_sync.c
@@ -428,10 +428,13 @@ ractor_queue_size(const struct ractor_queue *rq)
     return size;
 }
 
-static void
+// Returns whether this call is the one that closed it.
+static bool
 ractor_queue_close(struct ractor_queue *rq)
 {
+    bool closed_now = !rq->closed;
     rq->closed = true;
+    return closed_now;
 }
 
 static void
@@ -612,18 +615,21 @@ ractor_closed_port_p(rb_execution_context_t *ec, rb_ractor_t *r, const struct ra
 static void ractor_deliver_incoming_messages(rb_execution_context_t *ec, rb_ractor_t *cr);
 static bool ractor_queue_empty_p(rb_ractor_t *r, const struct ractor_queue *rq);
 
+static bool ractor_wakeup_all(rb_ractor_t *r, enum ractor_wakeup_status wakeup_status);
+
 static bool
 ractor_close_port(rb_execution_context_t *ec, rb_ractor_t *cr, const struct ractor_port *rp)
 {
     VM_ASSERT(cr == rp->r);
     struct ractor_queue *rq = NULL;
+    bool closed_now = false;
 
     RACTOR_LOCK_SELF(cr);
     {
         ractor_deliver_incoming_messages(ec, cr); // check incoming messages
 
         if (st_lookup(rp->r->sync.ports, ractor_port_id(rp), (st_data_t *)&rq)) {
-            ractor_queue_close(rq);
+            closed_now = ractor_queue_close(rq);
 
             if (ractor_queue_empty_p(cr, rq)) {
                 // delete from the table
@@ -634,6 +640,12 @@ ractor_close_port(rb_execution_context_t *ec, rb_ractor_t *cr, const struct ract
         }
     }
     RACTOR_UNLOCK_SELF(cr);
+
+    if (closed_now) {
+        // Only when this call closed it: waking the Ractor is not free to the
+        // other waiters, and a re-close of a closed port is news to nobody.
+        ractor_wakeup_all(cr, wakeup_by_close);
+    }
 
     return rq != NULL;
 }
@@ -1281,7 +1293,7 @@ wakeup_status_str(enum ractor_wakeup_status wakeup_status)
       case wakeup_none: return "none";
       case wakeup_by_send: return "by_send";
       case wakeup_by_interrupt: return "by_interrupt";
-      // case wakeup_by_close: return "by_close";
+      case wakeup_by_close: return "by_close";
     }
     rb_bug("unreachable");
 }


### PR DESCRIPTION
`Ractor::Port#close` leaves a receiver already waiting on that port asleep. An
untimed `receive` never returns; a timed one waits out its whole timeout and
reports `nil`, where closing a port a thread is waiting on should tell it so.

```ruby
port = Ractor::Port.new
Thread.new { sleep 0.1; port.close }
port.receive                # never returns
port.receive(timeout: 10)   # nil, after the full 10 seconds
```

Closing a port means nothing more can arrive on it, which is the kind of news a
send delivers by waking every waiter. Do the same, with `wakeup_by_close` -- the
status already written out in `enum ractor_wakeup_status` and commented out.

Only a close that closed a port wakes anyone: `ractor_queue_close` reports
whether it was the call that closed the queue, so re-closing a closed port is
news to nobody.

Depends on the commit before it, which keeps a timed receive's deadline in the
caller: without that, any wakeup — this one included — can hold a timed receive
past its time.

`Ractor.select` over a port closed while it sleeps now raises
`Ractor::ClosedError`, as selecting an already-closed port does; it used to sleep
on.

The woken thread needs no new logic: `ractor_close_port` deletes an emptied port
from the table, and `ractor_try_receive` already raises `Ractor::ClosedError` for
a port that is no longer there. The wakeup runs outside the Ractor lock, which
`ractor_wakeup_all` asserts.

| | before | after |
|---|---|---|
| `receive` | never returns | `Ractor::ClosedError` when closed |
| `receive(timeout: 10)` | `nil` after 10s | `Ractor::ClosedError` when closed |

A port closed with messages still queued keeps them: it stays in the table until
a receiver drains it, and the last message takes it away, so `[:a, :b, :closed]`
for two sends then a close.

A bootstraptest covers both halves independently; it fails on master.
