### PR TITLE
ZJIT: Spill the block handler in function stubs

### DIFF
--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -3987,10 +3987,11 @@ fn gen_function_stub(cb: &mut CodeBlock, iseq_call: IseqCallRef) -> Result<CodeP
     let block_spill = (params.flags.has_block() != 0).then(|| {
         let block_local_idx: usize = params.block_start.try_into()
             .expect("ISEQ block_start should be non-negative");
-        (argc + 1, block_local_idx)
+        (argc + 1, block_local_idx) // +1 for self
     });
 
-    let spills = (0..argc).map(|arg_idx| (arg_idx + 1, arg_idx)).chain(block_spill);
+    let spills = (0..argc).map(|arg_idx| (arg_idx + 1, arg_idx)) // +1 for self
+        .chain(block_spill);
     for (c_arg_idx, local_idx) in spills {
         let src = match lir::c_arg_location(c_arg_idx) {
             CArgLocation::Reg(reg) => reg,

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -3976,7 +3976,7 @@ fn gen_function_stub(cb: &mut CodeBlock, iseq_call: IseqCallRef) -> Result<CodeP
     // If the stubbed ISEQ fails to compile, function_stub_hit exits to the
     // interpreter with this callee frame. Direct JIT-to-JIT calls pass arguments
     // in C argument registers and the rest on the native stack, so spill the
-    // packed argument locals first. The fallback path will reshape these around
+    // packed argument locals first. prepare_for_exit() will reshape these around
     // any optional positional gaps.
     let argc = iseq_call.argc.to_usize();
     let local_size = unsafe { get_iseq_body_local_table_size(iseq_call.iseq.get()) }.to_usize();

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -3980,8 +3980,19 @@ fn gen_function_stub(cb: &mut CodeBlock, iseq_call: IseqCallRef) -> Result<CodeP
     // any optional positional gaps.
     let argc = iseq_call.argc.to_usize();
     let local_size = unsafe { get_iseq_body_local_table_size(iseq_call.iseq.get()) }.to_usize();
-    for arg_idx in 0..argc {
-        let src = match lir::c_arg_location(arg_idx + 1) { // +1 for self
+
+    // Mirror the argument layout of gen_send_direct: self, then the packed
+    // positional arguments, and the block handler if it exists.
+    let params = unsafe { iseq_call.iseq.get().params() };
+    let mut spills: Vec<(usize, usize)> = (0..argc).map(|arg_idx| (arg_idx + 1, arg_idx)).collect();
+    if params.flags.has_block() != 0 {
+        let block_local_idx: usize = params.block_start.try_into()
+            .expect("ISEQ block_start should be non-negative");
+        spills.push((argc + 1, block_local_idx));
+    }
+
+    for (c_arg_idx, local_idx) in spills {
+        let src = match lir::c_arg_location(c_arg_idx) {
             CArgLocation::Reg(reg) => reg,
             CArgLocation::StackSlot(slot) => {
                 // The stub runs before any frame setup, so stack-passed arguments
@@ -3993,7 +4004,7 @@ fn gen_function_stub(cb: &mut CodeBlock, iseq_call: IseqCallRef) -> Result<CodeP
             }
         };
         asm.store(
-            Opnd::mem(64, SP, -local_size_and_idx_to_bp_offset(local_size, arg_idx) * SIZEOF_VALUE_I32),
+            Opnd::mem(64, SP, -local_size_and_idx_to_bp_offset(local_size, local_idx) * SIZEOF_VALUE_I32),
             src,
         );
     }

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -3983,6 +3983,7 @@ fn gen_function_stub(cb: &mut CodeBlock, iseq_call: IseqCallRef) -> Result<CodeP
 
     // Mirror the argument layout of gen_send_direct: self, then the packed
     // positional arguments, and the block handler if it exists.
+    // TODO: Unify the argument order to avoid having to manually keep in sync
     let params = unsafe { iseq_call.iseq.get().params() };
     let block_spill = (params.flags.has_block() != 0).then(|| {
         let block_local_idx: usize = params.block_start.try_into()

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -3984,13 +3984,13 @@ fn gen_function_stub(cb: &mut CodeBlock, iseq_call: IseqCallRef) -> Result<CodeP
     // Mirror the argument layout of gen_send_direct: self, then the packed
     // positional arguments, and the block handler if it exists.
     let params = unsafe { iseq_call.iseq.get().params() };
-    let mut spills: Vec<(usize, usize)> = (0..argc).map(|arg_idx| (arg_idx + 1, arg_idx)).collect();
-    if params.flags.has_block() != 0 {
+    let block_spill = (params.flags.has_block() != 0).then(|| {
         let block_local_idx: usize = params.block_start.try_into()
             .expect("ISEQ block_start should be non-negative");
-        spills.push((argc + 1, block_local_idx));
-    }
+        (argc + 1, block_local_idx)
+    });
 
+    let spills = (0..argc).map(|arg_idx| (arg_idx + 1, arg_idx)).chain(block_spill);
     for (c_arg_idx, local_idx) in spills {
         let src = match lir::c_arg_location(c_arg_idx) {
             CArgLocation::Reg(reg) => reg,

--- a/zjit/src/codegen_tests.rs
+++ b/zjit/src/codegen_tests.rs
@@ -1315,7 +1315,7 @@ fn test_function_stub_exit_initializes_block_param() {
         # stub hit fails with OutOfMemory and falls back to the interpreter.
         body = (0...400).map { |k| "u#{k} = #{k} + n" }.join("
 ")
-        # Using a bmethod makes &blk observable on the captured EP rather than a block handler.
+        # Using a bmethod forces a Proc allocation for &blk in the EP at call time
         Integer.class_eval <<~BMETHOD
           define_method(:zjit_blk_callee) do |n, &blk|
             #{body}

--- a/zjit/src/codegen_tests.rs
+++ b/zjit/src/codegen_tests.rs
@@ -1306,6 +1306,34 @@ fn test_no_ep_escape_patch_point_after_send_does_not_repeat_send() {
 }
 
 #[test]
+fn test_function_stub_exit_initializes_block_param() {
+    set_mem_bytes(1024 * 1024);
+    set_inline_threshold(0);
+    set_call_threshold(2);
+    assert_snapshot!(inspect(r#"
+        # Make the callee big enough that compiling it exhausts the code region, so the
+        # stub hit fails with OutOfMemory and falls back to the interpreter.
+        body = (0...400).map { |k| "u#{k} = #{k} + n" }.join("
+")
+        # Using a bmethod makes &blk observable on the captured EP rather than a block handler.
+        Integer.class_eval <<~BMETHOD
+          define_method(:zjit_blk_callee) do |n, &blk|
+            #{body}
+            blk.nil?
+          end
+        BMETHOD
+
+        # Compile the call site, which generates the function stub, without running it,
+        # so the callee is still uncompiled when the stub is first hit.
+        def kaller(run) = run ? 1.zjit_blk_callee(2) : nil
+        300.times { kaller(false) }
+
+        # No block is passed, so the callee must see a nil block parameter.
+        kaller(true)
+    "#), @"true");
+}
+
+#[test]
 fn test_no_ep_escape_side_exit_restores_locals_while_oom() {
     // A regression test for stub compilation failures on OOM. Functions patched by NoEPEscape
     // is unsafe to enter (FrameState uses without_locals() and doesn't spill the entry state),


### PR DESCRIPTION
This PR fixes a latent bug in function stub exits.

Previously, a function stub did not spill a `&block` parameter, so when a function stub fails to compile the callee and exits to the interpreter, `&block` would refer to anything that happens to be on the stack. Since a JIT-to-JIT call passes a block param at the end of the C ABI argument list, it should be spilled into the local `iseq->body->param.block_start` points to.