### PR TITLE
.github/labeler.yml: Skip labeling "jit" for backport or auto-merged PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -9,6 +9,9 @@ Backport:
 jit:
 - all:
   - base-branch: '^master$'
+  # Skip dependabot's PRs, which bump actions in the CI files.
+  # They're noisy in notifications, and they're auto-merged anyway.
+  - head-branch: '^(?!dependabot/)'
   - changed-files:
     - any-glob-to-any-file:
       # JIT sources (Rust + C + Ruby)

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -7,40 +7,42 @@ Backport:
 - base-branch: 'ruby_4_\d'
 
 jit:
-- changed-files:
-  - any-glob-to-any-file:
-    # JIT sources (Rust + C + Ruby)
-    - 'jit/**'
-    # All of {y,z}jit/ except the generated cruby_bindings.inc.rs files.
-    # `!(...)` can't span a `/`, so each pair splits the tree into
-    # non-Rust files and Rust files not named cruby_bindings.inc.rs;
-    # their union is everything but the bindings file.
-    - 'yjit/**/!(*.rs)'
-    - 'yjit/**/!(cruby_bindings.inc).rs'
-    - 'zjit/**/!(*.rs)'
-    - 'zjit/**/!(cruby_bindings.inc).rs'
-    - 'jit.c'
-    - 'jit_hook.rb'
-    - 'jit_undef.rb'
-    - '{y,z}jit.{c,h,rb}'
+- all:
+  - base-branch: '^master$'
+  - changed-files:
+    - any-glob-to-any-file:
+      # JIT sources (Rust + C + Ruby)
+      - 'jit/**'
+      # All of {y,z}jit/ except the generated cruby_bindings.inc.rs files.
+      # `!(...)` can't span a `/`, so each pair splits the tree into
+      # non-Rust files and Rust files not named cruby_bindings.inc.rs;
+      # their union is everything but the bindings file.
+      - 'yjit/**/!(*.rs)'
+      - 'yjit/**/!(cruby_bindings.inc).rs'
+      - 'zjit/**/!(*.rs)'
+      - 'zjit/**/!(cruby_bindings.inc).rs'
+      - 'jit.c'
+      - 'jit_hook.rb'
+      - 'jit_undef.rb'
+      - '{y,z}jit.{c,h,rb}'
 
-    # Build + GC fast paths
-    - 'defs/jit.mk'
-    - 'gc/**/zjit_fastpath.h'
+      # Build + GC fast paths
+      - 'defs/jit.mk'
+      - 'gc/**/zjit_fastpath.h'
 
-    # Docs
-    - 'doc/jit/**'
+      # Docs
+      - 'doc/jit/**'
 
-    # Specs + tests
-    - 'spec/zjit.mspec'
-    - 'test/.excludes-zjit/**'
-    - 'test/lib/jit_support.rb'
-    - 'test/ruby/test_*jit*.rb'
-    - 'bootstraptest/test_*jit*.rb'
+      # Specs + tests
+      - 'spec/zjit.mspec'
+      - 'test/.excludes-zjit/**'
+      - 'test/lib/jit_support.rb'
+      - 'test/ruby/test_*jit*.rb'
+      - 'bootstraptest/test_*jit*.rb'
 
-    # Tooling
-    - 'tool/zjit_*'
-    - 'tool/ruby_vm/**/*zjit*'
+      # Tooling
+      - 'tool/zjit_*'
+      - 'tool/ruby_vm/**/*zjit*'
 
-    # CI
-    - '.github/workflows/*jit*.yml'
+      # CI
+      - '.github/workflows/*jit*.yml'


### PR DESCRIPTION
* Skip labeling "jit" for backport PRs
    * The team isn't responsible for reviewing backports. Remove non-`master` branch PRs.
* Skip labeling "jit" for auto-merged PRs
    * Similarly to `.github/auto_request_review.yml`, I think it's best to ignore GitHub Actions workflows. Notifying dependabot updates is too noisy and they're auto-merged anyway.