### PR TITLE
[Bug #22301] Respect frozen `IO::Buffer` state when writing

### DIFF
--- a/io_buffer.c
+++ b/io_buffer.c
@@ -1159,6 +1159,7 @@ static struct rb_io_buffer *
 get_io_buffer_for_writing(VALUE self)
 {
     struct rb_io_buffer *buffer = get_io_buffer(self);
+    rb_check_frozen(self);
     io_buffer_validate_for_writing(buffer);
     return buffer;
 }
@@ -1180,7 +1181,7 @@ io_buffer_get_bytes_for_writing(struct rb_io_buffer *buffer, void **base, size_t
 void
 rb_io_buffer_get_bytes_for_writing(VALUE self, void **base, size_t *size)
 {
-    struct rb_io_buffer *buffer = get_io_buffer(self);
+    struct rb_io_buffer *buffer = get_io_buffer_for_writing(self);
 
     io_buffer_get_bytes_for_writing(buffer, base, size);
 }
@@ -3302,7 +3303,7 @@ io_buffer_set_string(int argc, VALUE *argv, VALUE self)
 {
     rb_check_arity(argc, 1, 4);
 
-    struct rb_io_buffer *buffer = get_io_buffer(self);
+    struct rb_io_buffer *buffer = get_io_buffer_for_writing(self);
 
     VALUE string = rb_str_to_str(argv[0]);
 
@@ -3317,7 +3318,7 @@ io_buffer_set_string(int argc, VALUE *argv, VALUE self)
 void
 rb_io_buffer_clear(VALUE self, uint8_t value, size_t offset, size_t length)
 {
-    struct rb_io_buffer *buffer = get_io_buffer(self);
+    struct rb_io_buffer *buffer = get_io_buffer_for_writing(self);
 
     void *base;
     size_t size;
@@ -3474,8 +3475,7 @@ rb_io_buffer_read(VALUE self, VALUE io, size_t offset, size_t length)
 {
     io = rb_io_get_io(io);
 
-    struct rb_io_buffer *buffer = get_io_buffer(self);
-    io_buffer_validate_for_writing(buffer);
+    struct rb_io_buffer *buffer = get_io_buffer_for_writing(self);
     io_buffer_validate_range(buffer, offset, length);
 
     if (length == 0) return SIZET2NUM(0);
@@ -3565,8 +3565,7 @@ rb_io_buffer_pread(VALUE self, VALUE io, rb_off_t from, size_t offset, size_t le
 {
     io = rb_io_get_io(io);
 
-    struct rb_io_buffer *buffer = get_io_buffer(self);
-    io_buffer_validate_for_writing(buffer);
+    struct rb_io_buffer *buffer = get_io_buffer_for_writing(self);
     io_buffer_validate_range(buffer, offset, length);
 
     if (length == 0) return SIZET2NUM(0);
@@ -4032,7 +4031,7 @@ memory_and_inplace(unsigned char * restrict base, size_t size, unsigned char * r
 static VALUE
 io_buffer_and_inplace(VALUE self, VALUE mask)
 {
-    struct rb_io_buffer *buffer = get_io_buffer(self);
+    struct rb_io_buffer *buffer = get_io_buffer_for_writing(self);
 
     struct rb_io_buffer *mask_buffer = get_io_buffer(mask);
 
@@ -4080,7 +4079,7 @@ memory_or_inplace(unsigned char * restrict base, size_t size, unsigned char * re
 static VALUE
 io_buffer_or_inplace(VALUE self, VALUE mask)
 {
-    struct rb_io_buffer *buffer = get_io_buffer(self);
+    struct rb_io_buffer *buffer = get_io_buffer_for_writing(self);
 
     struct rb_io_buffer *mask_buffer = get_io_buffer(mask);
 
@@ -4128,7 +4127,7 @@ memory_xor_inplace(unsigned char * restrict base, size_t size, unsigned char * r
 static VALUE
 io_buffer_xor_inplace(VALUE self, VALUE mask)
 {
-    struct rb_io_buffer *buffer = get_io_buffer(self);
+    struct rb_io_buffer *buffer = get_io_buffer_for_writing(self);
 
     struct rb_io_buffer *mask_buffer = get_io_buffer(mask);
 
@@ -4176,7 +4175,7 @@ memory_not_inplace(unsigned char * restrict base, size_t size)
 static VALUE
 io_buffer_not_inplace(VALUE self)
 {
-    struct rb_io_buffer *buffer = get_io_buffer(self);
+    struct rb_io_buffer *buffer = get_io_buffer_for_writing(self);
 
     void *base;
     size_t size;

--- a/spec/ruby/core/io/buffer/and_spec.rb
+++ b/spec/ruby/core/io/buffer/and_spec.rb
@@ -59,4 +59,15 @@ describe "IO::Buffer#and!" do
       end
     end
   end
+
+  ruby_version_is "4.1" do
+    it "raises FrozenError without modifying a frozen buffer" do
+      buffer = IO::Buffer.new(4)
+      buffer.set_string("test")
+      buffer.freeze
+
+      -> { buffer.and!(IO::Buffer.new(4)) }.should.raise(FrozenError)
+      buffer.get_string.should == "test"
+    end
+  end
 end

--- a/spec/ruby/core/io/buffer/clear_spec.rb
+++ b/spec/ruby/core/io/buffer/clear_spec.rb
@@ -1,0 +1,14 @@
+require_relative '../../../spec_helper'
+
+describe "IO::Buffer#clear" do
+  ruby_version_is "4.1" do
+    it "raises FrozenError without modifying a frozen buffer" do
+      buffer = IO::Buffer.new(4)
+      buffer.set_string("test")
+      buffer.freeze
+
+      -> { buffer.clear }.should.raise(FrozenError)
+      buffer.get_string.should == "test"
+    end
+  end
+end

--- a/spec/ruby/core/io/buffer/copy_spec.rb
+++ b/spec/ruby/core/io/buffer/copy_spec.rb
@@ -1,0 +1,17 @@
+require_relative '../../../spec_helper'
+
+describe "IO::Buffer#copy" do
+  ruby_version_is "4.1" do
+    it "raises FrozenError without modifying a frozen buffer" do
+      buffer = IO::Buffer.new(4)
+      buffer.set_string("test")
+      buffer.freeze
+
+      IO::Buffer.for("fail") do |source|
+        -> { buffer.copy(source, 0) }.should.raise(FrozenError)
+      end
+
+      buffer.get_string.should == "test"
+    end
+  end
+end

--- a/spec/ruby/core/io/buffer/not_spec.rb
+++ b/spec/ruby/core/io/buffer/not_spec.rb
@@ -34,4 +34,15 @@ describe "IO::Buffer#not!" do
       result.should.external?
     end
   end
+
+  ruby_version_is "4.1" do
+    it "raises FrozenError without modifying a frozen buffer" do
+      buffer = IO::Buffer.new(4)
+      buffer.set_string("test")
+      buffer.freeze
+
+      -> { buffer.not! }.should.raise(FrozenError)
+      buffer.get_string.should == "test"
+    end
+  end
 end

--- a/spec/ruby/core/io/buffer/or_spec.rb
+++ b/spec/ruby/core/io/buffer/or_spec.rb
@@ -59,4 +59,15 @@ describe "IO::Buffer#or!" do
       end
     end
   end
+
+  ruby_version_is "4.1" do
+    it "raises FrozenError without modifying a frozen buffer" do
+      buffer = IO::Buffer.new(4)
+      buffer.set_string("test")
+      buffer.freeze
+
+      -> { buffer.or!(IO::Buffer.new(4)) }.should.raise(FrozenError)
+      buffer.get_string.should == "test"
+    end
+  end
 end

--- a/spec/ruby/core/io/buffer/pread_spec.rb
+++ b/spec/ruby/core/io/buffer/pread_spec.rb
@@ -1,0 +1,24 @@
+require_relative '../../../spec_helper'
+
+describe "IO::Buffer#pread" do
+  ruby_version_is "4.1" do
+    it "raises FrozenError without modifying a frozen buffer" do
+      file_name = tmp("io_buffer_pread")
+      File.write(file_name, "data")
+
+      begin
+        buffer = IO::Buffer.new(4)
+        buffer.set_string("test")
+        buffer.freeze
+
+        File.open(file_name, "rb") do |file|
+          -> { buffer.pread(file, 0, 4) }.should.raise(FrozenError)
+        end
+
+        buffer.get_string.should == "test"
+      ensure
+        rm_r file_name
+      end
+    end
+  end
+end

--- a/spec/ruby/core/io/buffer/read_spec.rb
+++ b/spec/ruby/core/io/buffer/read_spec.rb
@@ -1,0 +1,24 @@
+require_relative '../../../spec_helper'
+
+describe "IO::Buffer#read" do
+  ruby_version_is "4.1" do
+    it "raises FrozenError without modifying a frozen buffer" do
+      file_name = tmp("io_buffer_read")
+      File.write(file_name, "data")
+
+      begin
+        buffer = IO::Buffer.new(4)
+        buffer.set_string("test")
+        buffer.freeze
+
+        File.open(file_name, "rb") do |file|
+          -> { buffer.read(file, 4) }.should.raise(FrozenError)
+        end
+
+        buffer.get_string.should == "test"
+      ensure
+        rm_r file_name
+      end
+    end
+  end
+end

--- a/spec/ruby/core/io/buffer/set_string_spec.rb
+++ b/spec/ruby/core/io/buffer/set_string_spec.rb
@@ -1,0 +1,45 @@
+require_relative '../../../spec_helper'
+
+describe "IO::Buffer#set_string" do
+  ruby_version_is "4.1" do
+    it "raises FrozenError without modifying a frozen buffer" do
+      buffer = IO::Buffer.new(4)
+      buffer.set_string("test")
+      buffer.freeze
+
+      -> { buffer.set_string("fail") }.should.raise(FrozenError)
+      buffer.get_string.should == "test"
+    end
+
+    it "raises FrozenError without modifying the source of a frozen buffer" do
+      string = +"test"
+
+      IO::Buffer.for(string) do |buffer|
+        buffer.freeze
+
+        -> { buffer.set_string("fail") }.should.raise(FrozenError)
+      end
+
+      string.should == "test"
+    end
+
+    it "raises FrozenError on a clone of a frozen buffer" do
+      buffer = IO::Buffer.new(4)
+      buffer.set_string("test")
+
+      clone = buffer.freeze.clone
+
+      -> { clone.set_string("fail") }.should.raise(FrozenError)
+      clone.get_string.should == "test"
+    end
+
+    it "raises FrozenError rather than IO::Buffer::AccessError when also read-only" do
+      buffer = IO::Buffer.for("test".freeze)
+
+      -> { buffer.set_string("fail") }.should.raise(IO::Buffer::AccessError)
+
+      buffer.freeze
+      -> { buffer.set_string("fail") }.should.raise(FrozenError)
+    end
+  end
+end

--- a/spec/ruby/core/io/buffer/set_value_spec.rb
+++ b/spec/ruby/core/io/buffer/set_value_spec.rb
@@ -1,0 +1,14 @@
+require_relative '../../../spec_helper'
+
+describe "IO::Buffer#set_value" do
+  ruby_version_is "4.1" do
+    it "raises FrozenError without modifying a frozen buffer" do
+      buffer = IO::Buffer.new(4)
+      buffer.set_string("test")
+      buffer.freeze
+
+      -> { buffer.set_value(:U8, 0, 0) }.should.raise(FrozenError)
+      buffer.get_string.should == "test"
+    end
+  end
+end

--- a/spec/ruby/core/io/buffer/set_values_spec.rb
+++ b/spec/ruby/core/io/buffer/set_values_spec.rb
@@ -1,0 +1,14 @@
+require_relative '../../../spec_helper'
+
+describe "IO::Buffer#set_values" do
+  ruby_version_is "4.1" do
+    it "raises FrozenError without modifying a frozen buffer" do
+      buffer = IO::Buffer.new(4)
+      buffer.set_string("test")
+      buffer.freeze
+
+      -> { buffer.set_values([:U8], 0, [0]) }.should.raise(FrozenError)
+      buffer.get_string.should == "test"
+    end
+  end
+end

--- a/spec/ruby/core/io/buffer/xor_spec.rb
+++ b/spec/ruby/core/io/buffer/xor_spec.rb
@@ -59,4 +59,15 @@ describe "IO::Buffer#xor!" do
       end
     end
   end
+
+  ruby_version_is "4.1" do
+    it "raises FrozenError without modifying a frozen buffer" do
+      buffer = IO::Buffer.new(4)
+      buffer.set_string("test")
+      buffer.freeze
+
+      -> { buffer.xor!(IO::Buffer.new(4)) }.should.raise(FrozenError)
+      buffer.get_string.should == "test"
+    end
+  end
 end

--- a/test/ruby/test_io_buffer.rb
+++ b/test/ruby/test_io_buffer.rb
@@ -679,6 +679,69 @@ class TestIOBuffer < Test::Unit::TestCase
     assert_equal string, buffer.get_string
   end
 
+  def test_write_frozen
+    buffer = IO::Buffer.new(4)
+    buffer.set_string("test")
+    buffer.freeze
+
+    assert_raise(FrozenError) {buffer.set_string("fail")}
+    assert_raise(FrozenError) {buffer.set_value(:U8, 0, 0)}
+    assert_raise(FrozenError) {buffer.set_values([:U8], 0, [0])}
+    assert_raise(FrozenError) {buffer.copy(IO::Buffer.for("fail"), 0)}
+    assert_raise(FrozenError) {buffer.clear}
+    assert_raise(FrozenError) {buffer.and!(IO::Buffer.new(4))}
+    assert_raise(FrozenError) {buffer.or!(IO::Buffer.new(4))}
+    assert_raise(FrozenError) {buffer.xor!(IO::Buffer.new(4))}
+    assert_raise(FrozenError) {buffer.not!}
+
+    assert_equal "test", buffer.get_string
+  end
+
+  def test_write_frozen_read
+    buffer = IO::Buffer.new(4)
+    buffer.set_string("test")
+    buffer.freeze
+
+    File.open(__FILE__) do |file|
+      assert_raise(FrozenError) {buffer.read(file, 4)}
+      assert_raise(FrozenError) {buffer.pread(file, 0, 4)}
+    end
+
+    assert_equal "test", buffer.get_string
+  end
+
+  def test_write_frozen_external
+    string = +"Hello World"
+
+    IO::Buffer.for(string) do |buffer|
+      buffer.freeze
+
+      assert_raise(FrozenError) {buffer.set_string("Goodbye")}
+    end
+
+    assert_equal "Hello World", string
+  end
+
+  def test_write_frozen_clone
+    buffer = IO::Buffer.new(4)
+    buffer.set_string("test")
+
+    clone = buffer.freeze.clone
+    assert_predicate clone, :frozen?
+
+    assert_raise(FrozenError) {clone.set_string("fail")}
+    assert_equal "test", clone.get_string
+  end
+
+  def test_write_frozen_readonly
+    buffer = IO::Buffer.for("Hello World".freeze)
+
+    assert_raise(IO::Buffer::AccessError) {buffer.set_string("Goodbye")}
+
+    buffer.freeze
+    assert_raise(FrozenError) {buffer.set_string("Goodbye")}
+  end
+
   def test_compare_same_size
     buffer1 = IO::Buffer.new(1)
     assert_equal buffer1, buffer1


### PR DESCRIPTION
## Summary

- Raise `FrozenError` when writing to the contents of a frozen `IO::Buffer`.
- Check the receiver in `get_io_buffer_for_writing`, leaving `io_buffer_validate_for_writing` unchanged.
- A frozen buffer that is also read-only now raises `FrozenError` rather than `IO::Buffer::AccessError`.

[Bug #22301]