### PR TITLE
Free messages addressed to a port that died before delivery

### DIFF
--- a/ractor_sync.c
+++ b/ractor_sync.c
@@ -687,11 +687,33 @@ ractor_reap_dead_ports_i(st_data_t port_id, st_data_t val, st_data_t dat)
     }
 }
 
+/* A message is only moved from recv_queue to its port queue when the owner receives or
+ * closes, so one addressed to a port that died first is left here, out of the sweep
+ * above.  Its port is gone from the table by now: drop it. */
+static void
+ractor_reap_undeliverable_messages(rb_ractor_t *r)
+{
+    struct ractor_queue *recv_q = r->sync.recv_queue;
+    if (recv_q == NULL) return;
+
+    struct ractor_basket *b, *nxt;
+    ccan_list_for_each_safe(&recv_q->set, b, nxt, node) {
+        if (!st_lookup(r->sync.ports, b->port_id, NULL)) {
+            ccan_list_del_init(&b->node);
+            ractor_basket_free(b);
+        }
+    }
+}
+
 void
 rb_ractor_reap_dead_ports(rb_ractor_t *r)
 {
+    /* No sync lock here: the caller's gate is what keeps foreign senders out. */
+    VM_ASSERT(rb_gc_single_objspace_p() || rb_gc_during_global_gc_p());
+
     if (r->sync.ports) {
         st_foreach(r->sync.ports, ractor_reap_dead_ports_i, 0);
+        ractor_reap_undeliverable_messages(r);
     }
 }
 

--- a/test/ruby/test_ractor.rb
+++ b/test/ruby/test_ractor.rb
@@ -984,4 +984,22 @@ class TestRactor < Test::Unit::TestCase
       assert_equal true, Ractor.new { own = Object.new; own.singleton_class.attached_object.equal?(own) }.value
     RUBY
   end
+
+  def test_port_undelivered_message_does_not_leak
+    omit 'not fixed for mmtk: it never calls rb_ractor_finish_marking, where the reap runs' unless GC.config[:implementation] == 'default'
+    # A message is only moved out of the receiving Ractor's incoming queue when it
+    # receives or closes.  One addressed to a port that became unreachable first used to
+    # stay there for the life of the process, off-heap and invisible to ObjectSpace.
+    assert_no_memory_leak([], <<~'PREP', <<~'CODE', '[Bug #22122]', rss: true)
+      def t
+        port = Ractor::Port.new
+        5.times { port << ("z" * (4 << 20)) }
+      end
+      # A few large payloads rather than many small ones, and a baseline taken at the
+      # high-water mark: small-allocation RSS creep alone reached 2.5x on macOS.
+      5.times { t; GC.start }
+    PREP
+      30.times { t; GC.start }
+    CODE
+  end
 end


### PR DESCRIPTION
A message sent to a Ractor::Port is enqueued on the receiving Ractor's recv_queue, and only moved to that port's own queue when the Ractor receives or closes.  rb_ractor_reap_dead_ports() sweeps the port queues held in sync.ports, so a message whose port became unreachable before any delivery happened was never reaped: it stayed on recv_queue, off-heap and invisible to ObjectSpace, for the life of the process.

    200.times { p = Ractor::Port.new; 1000.times { p << ("z" * 4000) } }

grew without bound (RSS 858 -> 1692 -> 2523 MB over three such passes), and needs no Ractor at all to hit.  Closing the port, or any receive on the same Ractor, moved the messages to the port queue and hid the leak.

Sweep recv_queue in the reap as well, dropping the baskets whose port is no longer in the table.  The reap only runs with the world stopped or in a single objspace, so walking the queue there needs no extra synchronization.

[Bug #22122]