### PR TITLE
Keep FL_FINALIZE on the shell an object leaves behind when it is moved

### DIFF
--- a/ractor.c
+++ b/ractor.c
@@ -2537,7 +2537,11 @@ move_neutralize_source(VALUE obj)
         break;
     }
 
-    VALUE flags = T_OBJECT | FL_FREEZE | (RBASIC(obj)->flags & FL_PROMOTED);
+    /* Keep FL_FINALIZE: the finalizer table entry stays keyed on this slot, and a
+     * shell without the flag makes the two disagree (rb_gc_impl_shutdown_call_finalizer_i
+     * asserts on it).  The finalizer runs when the shell dies, in the Ractor that
+     * defined it; the rebuilt object gets fresh flags and does not inherit it. */
+    VALUE flags = T_OBJECT | FL_FREEZE | (RBASIC(obj)->flags & (FL_PROMOTED | FL_FINALIZE));
     /* Read the slot size before the header is rewritten. */
     size_t slot_size = rb_gc_obj_slot_size(obj);
     RBASIC_SET_CLASS_RAW(obj, rb_cRactorMovedObject);

--- a/test/ruby/test_ractor.rb
+++ b/test/ruby/test_ractor.rb
@@ -908,4 +908,26 @@ class TestRactor < Test::Unit::TestCase
     RUBY
   end
 
+
+  def test_move_object_with_finalizer
+    # The moved-from shell keeps its finalizer table entry, so it has to keep
+    # FL_FINALIZE with it; the two disagreeing failed an assertion at shutdown.
+    assert_normal_exit(<<~'RUBY', '[Bug #21368]')
+      Warning[:experimental] = false
+      r = Ractor.new { Ractor.receive }
+      1000.times do
+        o = Object.new
+        ObjectSpace.define_finalizer(o, proc { |id| })
+        r.send(o, move: true)
+      end
+    RUBY
+
+    assert_in_out_err(%w[-W0], <<~'RUBY', %w[sent finalized], [], '[Bug #21368]')
+      r = Ractor.new { Ractor.receive }
+      o = Object.new
+      ObjectSpace.define_finalizer(o, proc { |id| $stdout.puts "finalized" })
+      r.send(o, move: true)
+      $stdout.puts "sent"
+    RUBY
+  end
 end


### PR DESCRIPTION
move_neutralize_source() rewrites the source's flags to T_OBJECT | FL_FREEZE | (flags & FL_PROMOTED), which drops FL_FINALIZE while the finalizer table entry keyed on that slot stays.  The two then disagree, and a RUBY_DEBUG build aborts at shutdown:

    gc/default/default.c:4044: Assertion Failed:
    rb_gc_impl_shutdown_call_finalizer_i:RB_FL_TEST(obj, FL_FINALIZE)

    r = Ractor.new { Ractor.receive }
    o = Object.new
    ObjectSpace.define_finalizer(o, proc { |id| })
    r.send(o, move: true)

Carry FL_FINALIZE over to the shell.  The finalizer then runs when the shell is collected, in the Ractor that defined it; the object rebuilt on the other side gets fresh flags and does not inherit it, so it still runs exactly once.

[Bug #21368]