### PR TITLE
Let only the first thread write a bug report

### DIFF
--- a/error.c
+++ b/error.c
@@ -1042,9 +1042,41 @@ bug_report_end(FILE *out, rb_pid_t pid)
     finish_report(out, pid);
 }
 
+/* Only the first thread to get here writes a report.  A second one -- another Ractor
+ * failing the same assertion, say -- would interleave into it and leave both
+ * unreadable [Bug #21146], so it waits for the writer to abort the process instead.
+ * The writer is let through again, for the crash-while-reporting path. */
+static const rb_execution_context_t *bug_reporter_ec;
+static rb_atomic_t bug_reporter_claimed;
+
+static bool
+bug_report_claim(void)
+{
+    const rb_execution_context_t *ec = rb_current_execution_context(false);
+
+    if (RUBY_ATOMIC_CAS(bug_reporter_claimed, 0, 1) == 0) {
+        bug_reporter_ec = ec;
+        return true;
+    }
+    if (ec != NULL && ec == bug_reporter_ec) {
+        return true;
+    }
+
+    /* Bounded, so a writer that hangs ends as a crash and not as a hang. */
+    for (int i = 0; i < 100; i++) {
+#ifdef _WIN32
+        Sleep(100);
+#else
+        struct timespec ts = { 0, 100 * 1000 * 1000 };
+        nanosleep(&ts, NULL);
+#endif
+    }
+    return false;
+}
+
 #define report_bug(file, line, fmt, ctx) do { \
     rb_pid_t pid = -1; \
-    FILE *out = bug_report_file(file, line, &pid); \
+    FILE *out = bug_report_claim() ? bug_report_file(file, line, &pid) : NULL; \
     if (out) { \
         bug_report_begin(out, fmt); \
         rb_vm_bugreport(ctx, out); \
@@ -1054,7 +1086,7 @@ bug_report_end(FILE *out, rb_pid_t pid)
 
 #define report_bug_valist(file, line, fmt, ctx, args) do { \
     rb_pid_t pid = -1; \
-    FILE *out = bug_report_file(file, line, &pid); \
+    FILE *out = bug_report_claim() ? bug_report_file(file, line, &pid) : NULL; \
     if (out) { \
         bug_report_begin_valist(out, fmt, args); \
         rb_vm_bugreport(ctx, out); \
@@ -1207,7 +1239,7 @@ rb_assert_failure_detail(const char *file, int line, const char *name, const cha
                          const char *fmt, ...)
 {
     rb_pid_t pid = -1;
-    FILE *out = bug_report_file(file, line, &pid);
+    FILE *out = bug_report_claim() ? bug_report_file(file, line, &pid) : NULL;
     if (out) {
         fputs("Assertion Failed: ", out);
         if (name) fprintf(out, "%s:", name);


### PR DESCRIPTION
When two Ractors fail an assertion at nearly the same time both write into the same stream, and the first report -- the interesting one -- is cut short by the second:

    rs = 100.times.map { Ractor.new { sleep rand(1..3); Ractor.fail_assert } }

produced a 25-line report ending in "Crashed while printing bug report", every time.

Take a claim before writing.  The first thread through writes its report and aborts the process; a later one waits for that instead of writing its own.  The claiming thread is let through again, so the existing crash-while-reporting path still works.  The wait is bounded, so a writer that hangs still ends the process as a crash rather than a hang.

rb_assert_failure_detail() writes a report without going through report_bug(), so it needs the same claim.

The example above now produces one complete report.

[Bug #21146]