### PR TITLE
Fix memory leak of TracePoint in Ractor

### DIFF
--- a/vm_trace.c
+++ b/vm_trace.c
@@ -92,6 +92,9 @@ static void clean_hooks(rb_hook_list_t *list);
 void
 rb_hook_list_free(rb_hook_list_t *hooks)
 {
+    for (rb_event_hook_t *hook = hooks->hooks; hook; hook = hook->next) {
+        hook->hook_flags |= RUBY_EVENT_HOOK_FLAG_DELETED;
+    }
     hooks->need_clean = true;
 
     if (hooks->running == 0) {


### PR DESCRIPTION
TracePoints that are enabled but never disabled in a Ractor leak memory. For example, the following script leaks memory:

```ruby
10.times do
  1_000.times do
    Ractor.new {
      200.times { TracePoint.new(:call) { }.enable }
    }.value
    GC.start
  end

  puts `ps -o rss= -p #{$$}`
end
```

Before:

    32180
    47868
    63492
    79116
    94744
    110368
    125992
    141616
    157244
    172868

After:

    16428
    16492
    16492
    16492
    16492
    16492
    16492
    16492
    16492
    16492