### PR TITLE
Fix unused warning for mn_threads_enabled_p

### DIFF
--- a/thread_sched.c
+++ b/thread_sched.c
@@ -109,13 +109,6 @@ static void timer_thread_wakeup_force(void);
 // 1 = the main Ractor's threads too; 2 = the main thread as well.
 static int mn_threads_mode = 0;
 
-// Only consulted from USE_MN_THREADS code; the platform gate is not defined yet here.
-static bool
-mn_threads_enabled_p(void)
-{
-    return mn_threads_mode >= 0;
-}
-
 static void nt_snts_join(rb_vm_t *vm, struct rb_native_thread *nt);
 static void nt_snts_leave(rb_vm_t *vm, struct rb_native_thread *nt);
 static bool nt_shared_loop(struct rb_native_thread *nt);

--- a/thread_sched_mn.c
+++ b/thread_sched_mn.c
@@ -919,6 +919,11 @@ nt_free_stack(void *mstack)
     rb_native_mutex_unlock(&nt_machine_stack_lock);
 }
 
+static bool
+mn_threads_enabled_p(void)
+{
+    return mn_threads_mode >= 0;
+}
 
 static int
 native_thread_check_and_create_shared(rb_vm_t *vm)


### PR DESCRIPTION
Fixes the following warning:

    thread_sched.c:114:1: warning: unused function 'mn_threads_enabled_p' [-Wunused-function]
      114 | mn_threads_enabled_p(void)
          | ^~~~~~~~~~~~~~~~~~~~