### PR TITLE
Keep the box of a local environment copied for an isolated Proc

### DIFF
--- a/test/ruby/test_box.rb
+++ b/test/ruby/test_box.rb
@@ -1012,6 +1012,16 @@ class TestBox < Test::Unit::TestCase
     end;
   end
 
+  def test_shareable_proc_made_in_a_module_body
+    assert_separately([ENV_ENABLE_BOX], __FILE__, __LINE__, "#{<<~"begin;"}\n#{<<~'end;'}", ignore_stderr: true)
+    begin;
+      module ShareableProcHolder
+        PROC = Ractor.make_shareable(->(s) { s.upcase })
+      end
+      assert_equal "HI", ShareableProcHolder::PROC.call("hi")
+    end;
+  end
+
   def test_boxes_have_different_rubygems
     # assert_separately w/ ENV_ENABLE_BOX and --enable=gems causes timeouts on CI @ Windows
     assert_in_out_err([ENV_ENABLE_BOX, "--enable=gems"], "#{<<-"begin;"}\n#{<<-'end;'}") do |output, error|

--- a/vm.c
+++ b/vm.c
@@ -1545,6 +1545,10 @@ env_copy(const VALUE *src_ep, VALUE read_only_variables)
         RB_OBJ_WRITTEN(copied_env, Qundef, new_prev_env);
         VM_ENV_FLAGS_UNSET(ep, VM_ENV_FLAG_LOCAL);
     }
+    else if (VM_ENV_BOXED_P(src_ep)) {
+        /* the specval holds a box here, see VM_CF_BLOCK_HANDLER */
+        ep[VM_ENV_DATA_INDEX_SPECVAL] = src_ep[VM_ENV_DATA_INDEX_SPECVAL];
+    }
     else {
         ep[VM_ENV_DATA_INDEX_SPECVAL] = VM_BLOCK_HANDLER_NONE;
     }


### PR DESCRIPTION
With `RUBY_BOX=1`, a lambda that is made shareable inside a module or class body segfaults as soon as it is called:

```ruby
module M
  P = Ractor.make_shareable(->(s) { s.upcase })
end
M::P.call("hi")  # [BUG] Segmentation fault at 0x0000000000000000
```

`env_copy` clears the SPECVAL of a local environment to `VM_BLOCK_HANDLER_NONE`, but a `VM_FRAME_MAGIC_CLASS` or `VM_FRAME_MAGIC_TOP` frame keeps its box there instead, as `VM_CF_BLOCK_HANDLER` already documents. The flags are copied from the source environment, so the copy stayed marked as boxed while its box became `NULL`, and the next method dispatch dereferenced it while looking up a classext. I keep the SPECVAL as it is for those frames.

Under `RUBY_BOX=1` on macOS/arm64 this removes three failures from `test_proc.rb`, `test_ractor.rb` and `test_refinement.rb` and introduces none: `test_refined_shareable_proc_across_ractors`, `test_refined_shareable_refined_proc_first_called_in_ractor` and `test_shareable_proc_define_method_super_method_missing`. Without `RUBY_BOX` the same files stay at 0 failures, and `btest-ruby` is unchanged in both modes.

Generated with [Claude Code](https://claude.com/claude-code)
