### PR TITLE
Pass -W:no-experimental down to the ruby processes tests spawn

### DIFF
--- a/spec/default.mspec
+++ b/spec/default.mspec
@@ -3,8 +3,11 @@ $VERBOSE = false
 if (opt = ENV["RUBYOPT"]) and (opt = opt.dup).sub!(/(?:\A|\s)-w(?=\z|\s)/, '')
   ENV["RUBYOPT"] = opt
 end
-# The specs assert the output of the ruby processes they spawn verbatim.
-ENV["RUBYOPT"] = (["-W:no-experimental"] | ENV["RUBYOPT"].to_s.split).join(" ")
+# The specs assert the output of the ruby processes they spawn verbatim.  See
+# tool/test/init.rb for why the switch goes where it does.
+rubyopt = ENV["RUBYOPT"].to_s.split - ["-W:no-experimental"]
+rubyopt.insert(rubyopt.index("-") || rubyopt.size, "-W:no-experimental")
+ENV["RUBYOPT"] = rubyopt.join(" ")
 
 # Enable constant leak checks by ruby/mspec
 ENV["CHECK_CONSTANT_LEAKS"] ||= "true"

--- a/spec/default.mspec
+++ b/spec/default.mspec
@@ -3,6 +3,8 @@ $VERBOSE = false
 if (opt = ENV["RUBYOPT"]) and (opt = opt.dup).sub!(/(?:\A|\s)-w(?=\z|\s)/, '')
   ENV["RUBYOPT"] = opt
 end
+# The specs assert the output of the ruby processes they spawn verbatim.
+ENV["RUBYOPT"] = (["-W:no-experimental"] | ENV["RUBYOPT"].to_s.split).join(" ")
 
 # Enable constant leak checks by ruby/mspec
 ENV["CHECK_CONSTANT_LEAKS"] ||= "true"

--- a/spec/ruby/core/warning/element_reference_spec.rb
+++ b/spec/ruby/core/warning/element_reference_spec.rb
@@ -5,9 +5,11 @@ describe "Warning.[]" do
     # If any warning options were set on the Ruby that will be executed, then
     # it's possible this test will fail. In this case we will skip this test.
     skip if ruby_exe.any? { |opt| opt.start_with?("-W") }
+    # RUBYOPT can carry -W too, and the defaults are what this example is about.
+    no_rubyopt = { "RUBYOPT" => nil }
 
-    ruby_exe('p [Warning[:deprecated], Warning[:experimental]]').chomp.should == "[false, true]"
-    ruby_exe('p [Warning[:deprecated], Warning[:experimental]]', options: "-w").chomp.should == "[true, true]"
+    ruby_exe('p [Warning[:deprecated], Warning[:experimental]]', env: no_rubyopt).chomp.should == "[false, true]"
+    ruby_exe('p [Warning[:deprecated], Warning[:experimental]]', options: "-w", env: no_rubyopt).chomp.should == "[true, true]"
   end
 
   it "returns default values for :performance category" do

--- a/test/ruby/test_argf.rb
+++ b/test/ruby/test_argf.rb
@@ -1131,7 +1131,9 @@ class TestArgf < Test::Unit::TestCase
   def test_puts
     t = make_tempfile("argf-#{__method__}", 'bar')
     err = "#{@tmpdir}/errout"
-    ruby('-pi-', '-W2', '-e', "print ARGF.puts('foo')", t.path, {err: err}) do |f|
+    # -W:no-experimental because -W2 turns the category back on, and Ruby::Box
+    # warns at startup when it is enabled.
+    ruby('-pi-', '-W2', '-W:no-experimental', '-e', "print ARGF.puts('foo')", t.path, {err: err}) do |f|
     end
     assert_equal("foo\nbar\n", File.read(t.path))
     assert_empty File.read(err)

--- a/test/ruby/test_box.rb
+++ b/test/ruby/test_box.rb
@@ -942,7 +942,7 @@ class TestBox < Test::Unit::TestCase
   # Tests which run always (w/o RUBY_BOX=1 globally)
 
   def test_prelude_gems_and_loaded_features
-    assert_in_out_err([ENV_ENABLE_BOX, "--enable=gems"], "#{<<-"begin;"}\n#{<<-'end;'}") do |output, error|
+    assert_in_out_err([ENV_ENABLE_BOX, "--enable=gems", "-W:experimental"], "#{<<-"begin;"}\n#{<<-'end;'}") do |output, error|
       begin;
         puts ["before:", $LOADED_FEATURES.select{ it.end_with?("/bundled_gems.rb") }&.first].join
         puts ["before:", $LOADED_FEATURES.select{ it.end_with?("/error_highlight.rb") }&.first].join
@@ -966,7 +966,7 @@ class TestBox < Test::Unit::TestCase
   end
 
   def test_prelude_gems_and_loaded_features_with_disable_gems
-    assert_in_out_err([ENV_ENABLE_BOX, "--disable=gems"], "#{<<-"begin;"}\n#{<<-'end;'}") do |output, error|
+    assert_in_out_err([ENV_ENABLE_BOX, "--disable=gems", "-W:experimental"], "#{<<-"begin;"}\n#{<<-'end;'}") do |output, error|
       begin;
         puts ["before:", $LOADED_FEATURES.select{ it.end_with?("/bundled_gems.rb") }&.first].join
         puts ["before:", $LOADED_FEATURES.select{ it.end_with?("/error_highlight.rb") }&.first].join

--- a/test/ruby/test_process.rb
+++ b/test/ruby/test_process.rb
@@ -2587,7 +2587,7 @@ EOS
       bin = "#{EnvUtil.rubybin}"
       args = Array.new(256) {"x"}
       GC.stress = true
-      system(bin, "--disable=gems", "-w", "-e", "puts ARGV", *args)
+      system(bin, "--disable=gems", "-w", "-W:no-experimental", "-e", "puts ARGV", *args)
     end;
   end
 

--- a/tool/lib/core_assertions.rb
+++ b/tool/lib/core_assertions.rb
@@ -362,7 +362,10 @@ BEGIN {
 #{line -= __LINE__; src}
 eom
         args = args.dup
-        args.insert((Hash === args.first ? 1 : 0), "-w", "--disable=gems", *$:.map {|l| "-I#{l}"})
+        # -W:no-experimental after the -w, which would otherwise turn the category
+        # back on.  The option itself needs 2.7 or later.
+        warn_opts = RUBY_VERSION >= "2.7." ? ["-w", "-W:no-experimental"] : ["-w"]
+        args.insert((Hash === args.first ? 1 : 0), *warn_opts, "--disable=gems", *$:.map {|l| "-I#{l}"})
         args << "--debug" if RUBY_ENGINE == 'jruby' # warning: tracing (e.g. set_trace_func) will not capture all events without --debug flag
         # power_assert 3 requires ruby 3.1 or later
         args << "-W:no-experimental" if ("2.7."..."3.1.").cover?(RUBY_VERSION)

--- a/tool/test/init.rb
+++ b/tool/test/init.rb
@@ -14,9 +14,12 @@ ENV.delete("RUBY_CODESIGN")
 
 Warning[:experimental] = false
 # The tests assert the output of the ruby processes they spawn verbatim, so the
-# children need this too.  It has to precede the bare "-" that common.mk puts in
-# RUBYOPT, which ends the option scan.
-ENV["RUBYOPT"] = (["-W:no-experimental"] | ENV["RUBYOPT"].to_s.split).join(" ")
+# children need this too.  The last -W wins, so the switch has to come after
+# whatever RUBYOPT already carries, but before the bare "-" that common.mk puts
+# there, which ends the option scan.
+rubyopt = ENV["RUBYOPT"].to_s.split - ["-W:no-experimental"]
+rubyopt.insert(rubyopt.index("-") || rubyopt.size, "-W:no-experimental")
+ENV["RUBYOPT"] = rubyopt.join(" ")
 
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 

--- a/tool/test/init.rb
+++ b/tool/test/init.rb
@@ -13,6 +13,10 @@ ENV["GEM_SKIP"] = "".freeze
 ENV.delete("RUBY_CODESIGN")
 
 Warning[:experimental] = false
+# The tests assert the output of the ruby processes they spawn verbatim, so the
+# children need this too.  It has to precede the bare "-" that common.mk puts in
+# RUBYOPT, which ends the option scan.
+ENV["RUBYOPT"] = (["-W:no-experimental"] | ENV["RUBYOPT"].to_s.split).join(" ")
 
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 


### PR DESCRIPTION
With `RUBY_BOX=1` in the environment, `make check` fails in every test that spawns `ruby` with `Open3`, `IO.popen` or `PTY` and asserts the captured output verbatim. The child inherits `RUBY_BOX` and prints the two `Ruby::Box` experimental warning lines. `ruby/test_process.rb` fares worse. `test_popen_exit` reads the child's stdout as a pid, gets `0` out of the warning text, and `Process.kill(:TERM, 0)` takes down the whole `test-all` process group.

`tool/test/init.rb` already sets `Warning[:experimental] = false` for its own process. I pass the same setting to the children through `RUBYOPT`, there and in `spec/default.mspec`. It has to come after whatever `RUBYOPT` already carries, since the last `-W` wins, and before the bare `-` that `common.mk` puts there, which ends the option scan. A command-line `-w` beats `RUBYOPT` the same way, so `assert_separately` and the tests that raise their own warning level now say what they need explicitly.

`tool/lib/core_assertions.rb` is copied verbatim into ruby/test-unit-ruby-core, so the new switch is guarded at 2.7, where `-W:` arrived. On 2.7 through 3.0 it duplicates the guarded one two lines below, and I am happy to collapse them if you prefer. The `spec/ruby` change needs a separate forward-port to ruby/spec. Tests that clear or overwrite `RUBYOPT` themselves still let the warning through, `ruby/test_rubyoptions.rb` worst of all, and #18712 strips the lines from the captured output to cover those. `test_verbose_nil_silences_warnings_in_box` in #18579 asserts the warning and will need `-W:experimental` once both land.
