### PR TITLE
Fix the peephole optimizer to avoid duplicated line events

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -1265,6 +1265,21 @@ ELEM_SWAP(LINK_ELEMENT *first, LINK_ELEMENT *second)
 
     second->prev = first->prev;
     first->prev = second;
+
+    if (IS_INSN(first) && IS_INSN(second)) {
+        INSN *first_insn = (INSN*)first;
+        INSN *second_insn = (INSN*)second;
+
+        // [Bug #22299] If both instructions are on the same line and the first one carries
+        // a line event we need to swap the event as well.
+        if (first_insn->insn_info.line_no == second_insn->insn_info.line_no) {
+            rb_event_flag_t mask = (RUBY_EVENT_LINE | RUBY_EVENT_COVERAGE_LINE);
+            rb_event_flag_t first_events = first_insn->insn_info.events & mask;
+            rb_event_flag_t second_events = second_insn->insn_info.events & mask;
+            first_insn->insn_info.events = (first_insn->insn_info.events & ~mask) | second_events;
+            second_insn->insn_info.events = (second_insn->insn_info.events & ~mask) | first_events;
+        }
+    }
 }
 
 static LINK_ELEMENT *

--- a/test/prism/newline_test.rb
+++ b/test/prism/newline_test.rb
@@ -24,7 +24,6 @@ module Prism
       ruby/parser_test.rb
       ruby/ripper_test.rb
       ruby/ruby_parser_test.rb
-      ruby/parameters_signature_test.rb
     ]
 
     base = __dir__


### PR DESCRIPTION
[[Bug #22299]](https://bugs.ruby-lang.org/issues/22299)

Followup: https://github.com/ruby/ruby/pull/18538