### PR TITLE
Do not write back a frozen $LOADED_FEATURES while rebuilding its index

### DIFF
--- a/load.c
+++ b/load.c
@@ -394,8 +394,11 @@ get_loaded_features_index(const rb_box_t *box)
                 rb_ary_store(features, i, as_str);
             features_index_add(box, as_str, INT2FIX(i));
         }
-        /* The user modified $LOADED_FEATURES, so we should restore the changes. */
-        if (!rb_ary_shared_with_p(features, box->loaded_features)) {
+        /* The user modified $LOADED_FEATURES, so we should restore the changes.
+         * A frozen array is never shared, so this check always fires for one.
+         * Let rb_provide_feature() report the freeze instead. */
+        if (!OBJ_FROZEN(box->loaded_features) &&
+            !rb_ary_shared_with_p(features, box->loaded_features)) {
             rb_ary_replace(box->loaded_features, features);
         }
         reset_loaded_features_snapshot(box);

--- a/test/ruby/test_box.rb
+++ b/test/ruby/test_box.rb
@@ -652,6 +652,16 @@ class TestBox < Test::Unit::TestCase
     end
   end
 
+  def test_frozen_loaded_features_in_box
+    assert_separately([ENV_ENABLE_BOX], __FILE__, __LINE__, "#{<<~"begin;"}\n#{<<~'end;'}", ignore_stderr: true)
+    begin;
+      box = Ruby::Box.new
+      assert_raise_with_message(RuntimeError, /\$LOADED_FEATURES is frozen; cannot append feature/) do
+        box.eval('$LOADED_FEATURES.freeze; require "erb"')
+      end
+    end;
+  end
+
   def test_match_variables_are_not_cached_in_box
     assert_separately([ENV_ENABLE_BOX], __FILE__, __LINE__, "#{<<~"begin;"}\n#{<<~'end;'}", ignore_stderr: true)
     begin;

--- a/test/ruby/test_require.rb
+++ b/test/ruby/test_require.rb
@@ -537,6 +537,11 @@ class TestRequire < Test::Unit::TestCase
                       bug3756)
   end
 
+  def test_frozen_loaded_features_while_rebuilding_index
+    assert_in_out_err(['-e', '$LOADED_FEATURES << "dummy.rb"; $LOADED_FEATURES.freeze; require "erb"'], "",
+                      [], /\$LOADED_FEATURES is frozen; cannot append feature \(RuntimeError\)$/)
+  end
+
   def test_race_exception
     bug5754 = '[ruby-core:41618]'
     path = nil


### PR DESCRIPTION
`require` raises `FrozenError: can't modify frozen Array` instead of the `RuntimeError` that `rb_provide_feature()` reports, whenever `$LOADED_FEATURES` was modified before it was frozen. Under `RUBY_BOX=1` every box hits this without any modification, because a box starts with an empty feature index snapshot and rebuilds the index on its first `require`. The behaviour goes back to the introduction of the feature index in Ruby 2.0.

`get_loaded_features_index()` rebuilds the index into a copy made by `rb_ary_resurrect()` and writes that copy back with `rb_ary_replace()` when it is no longer shared with `$LOADED_FEATURES`. `ary_make_shared()` returns a frozen array unchanged rather than converting it into a shared root, so the sharing check always reports a modification for a frozen `$LOADED_FEATURES` and the write-back raises. Skipping it when the array is frozen is safe, because the index is keyed by string content rather than by the interned objects the rebuild would have stored.

```console
$ ruby -e '$LOADED_FEATURES << "dummy.rb"; $LOADED_FEATURES.freeze; require "erb"'
-e:1:in 'Kernel#require': can't modify frozen Array: [...] (FrozenError)
```

Generated with [Claude Code](https://claude.com/claude-code)
