### PR TITLE
Require envutil into the box by its path

### DIFF
--- a/test/ruby/test_box.rb
+++ b/test/ruby/test_box.rb
@@ -533,7 +533,9 @@ class TestBox < Test::Unit::TestCase
   def test_add_constants_in_box
     setup_box
 
-    @box.require('envutil')
+    # A new box copies the master box's $LOAD_PATH, so the tool/lib entry that
+    # tool/test/init.rb adds to the main box at boot is not visible here.
+    @box.require(File.expand_path("../../tool/lib/envutil", __dir__))
 
     String.const_set(:STR_CONST0, 999)
     assert_equal 999, String::STR_CONST0

--- a/test/ruby/test_box.rb
+++ b/test/ruby/test_box.rb
@@ -611,6 +611,8 @@ class TestBox < Test::Unit::TestCase
     assert_raise(NameError) { String::STR_CONST2 }
     assert_raise(NameError) { String::STR_CONST3 }
     assert_raise(NameError) { Integer::INT_CONST1 }
+  ensure
+    String.__send__(:remove_const, :STR_CONST0) if String.const_defined?(:STR_CONST0, false)
   end
 
   def test_global_variables


### PR DESCRIPTION
`RUBY_BOX=1 make test-all TESTS="ruby/test_box.rb"` fails with `LoadError: cannot load such file -- envutil` in `TestBox#test_add_constants_in_box`. It only appears through the test harness. A standalone `ruby` run passes.

`envutil.rb` lives in `tool/lib`, which joins `$LOAD_PATH` only through the runtime `unshift` in `tool/test/init.rb`. That entry lands in the main box, while a new box copies the master box's `$LOAD_PATH` (`box.c:181`), so it never reaches the box. A standalone run passes `tool/lib` with `-I`, which is processed before the main box diverges from master, so every box inherits it there.

Requiring `envutil` by absolute path bypasses `$LOAD_PATH` entirely. Per-box `$LOAD_PATH` is intended Box behavior, so this fixes the test rather than the runtime.

Generated with [Claude Code](https://claude.com/claude-code)
