### PR TITLE
Avoid TestClass in TestBox#test_eval_with_classes

### DIFF
--- a/test/ruby/test_box.rb
+++ b/test/ruby/test_box.rb
@@ -884,14 +884,14 @@ class TestBox < Test::Unit::TestCase
     setup_box
 
     # Define a class in the box via eval
-    @box.eval("class TestClass; def hello; 'from box'; end; end")
+    @box.eval("class BoxEvalTestClass; def hello; 'from box'; end; end")
 
     # Class should be accessible in the box
-    instance = @box::TestClass.new
+    instance = @box::BoxEvalTestClass.new
     assert_equal "from box", instance.hello
 
     # Class should not be visible in main box
-    assert_raise(NameError) { TestClass }
+    assert_raise(NameError) { BoxEvalTestClass }
   end
 
   def test_eval_isolation


### PR DESCRIPTION
`TestBox#test_eval_with_classes` fails with `NameError expected but nothing was raised` whenever it shares a `test-all` process with `test/ruby/test_class.rb`. The box test defines `TestClass` inside its box and asserts the name is invisible from the main box, but `test/ruby/test_class.rb` defines a top-level `TestClass`, so the assertion resolves that one and nothing raises.

Box isolation itself is fine. `RUBY_BOX=1 ruby -e 'b = Ruby::Box.new; b.eval("class Foo; end"); p defined?(Foo)'` still prints `nil`. Only the name the test picked is wrong, so I renamed it to `BoxEvalTestClass`, which appears nowhere else in the tree. `TestClass` in `test/ruby/test_class.rb` is a legitimate test case name and stays as it is.

Reproduce with `RUBY_BOX=1 make test-all TESTS="ruby/test_class.rb ruby/test_box.rb"`. It goes from 11 failures to 10 here, and the one that disappears is exactly this test.

Generated with [Claude Code](https://claude.com/claude-code)
