### PR TITLE
Match the current name of a box-local extension copy

### DIFF
--- a/test/-ext-/test_abi.rb
+++ b/test/-ext-/test_abi.rb
@@ -10,7 +10,7 @@ class TestABI < Test::Unit::TestCase
       err = assert_raise(LoadError) { require "-test-/abi" }
       assert_match(/incompatible ABI version/, err.message)
       if Ruby::Box.enabled?
-        assert_match(/[0-9]+_[0-9]+_abi[.]/, err.message)
+        assert_match(%r{/_ruby_box_[^/]+/\d+_\d+_abi\.}, err.message)
       else
         assert_include err.message, "/-test-/abi."
       end
@@ -32,7 +32,7 @@ class TestABI < Test::Unit::TestCase
       err = assert_raise(LoadError) { require "-test-/abi" }
       assert_match(/incompatible ABI version/, err.message)
       if Ruby::Box.enabled?
-        assert_match(/[0-9]+_[0-9]+_abi[.]/, err.message)
+        assert_match(%r{/_ruby_box_[^/]+/\d+_\d+_abi\.}, err.message)
       else
         assert_include err.message, "/-test-/abi."
       end

--- a/test/-ext-/test_abi.rb
+++ b/test/-ext-/test_abi.rb
@@ -6,7 +6,7 @@ class TestABI < Test::Unit::TestCase
   def test_require_lib_with_incorrect_abi_on_dev_ruby
     omit "ABI is not checked" unless abi_checking_supported?
 
-    assert_separately [], <<~RUBY
+    assert_separately [], <<~'RUBY'
       err = assert_raise(LoadError) { require "-test-/abi" }
       assert_match(/incompatible ABI version/, err.message)
       if Ruby::Box.enabled?
@@ -20,7 +20,7 @@ class TestABI < Test::Unit::TestCase
   def test_disable_abi_check_using_environment_variable
     omit "ABI is not checked" unless abi_checking_supported?
 
-    assert_separately [{ "RUBY_ABI_CHECK" => "0" }], <<~RUBY
+    assert_separately [{ "RUBY_ABI_CHECK" => "0" }], <<~'RUBY'
       assert_nothing_raised { require "-test-/abi" }
     RUBY
   end
@@ -28,7 +28,7 @@ class TestABI < Test::Unit::TestCase
   def test_enable_abi_check_using_environment_variable
     omit "ABI is not checked" unless abi_checking_supported?
 
-    assert_separately [{ "RUBY_ABI_CHECK" => "1" }], <<~RUBY
+    assert_separately [{ "RUBY_ABI_CHECK" => "1" }], <<~'RUBY'
       err = assert_raise(LoadError) { require "-test-/abi" }
       assert_match(/incompatible ABI version/, err.message)
       if Ruby::Box.enabled?
@@ -42,7 +42,7 @@ class TestABI < Test::Unit::TestCase
   def test_require_lib_with_incorrect_abi_on_release_ruby
     omit "ABI is enforced" if abi_checking_supported?
 
-    assert_separately [], <<~RUBY
+    assert_separately [], <<~'RUBY'
       assert_nothing_raised { require "-test-/abi" }
     RUBY
   end

--- a/test/-ext-/test_abi.rb
+++ b/test/-ext-/test_abi.rb
@@ -10,7 +10,7 @@ class TestABI < Test::Unit::TestCase
       err = assert_raise(LoadError) { require "-test-/abi" }
       assert_match(/incompatible ABI version/, err.message)
       if Ruby::Box.enabled?
-        assert_include err.message, "_-test-+abi."
+        assert_match(/[0-9]+_[0-9]+_abi[.]/, err.message)
       else
         assert_include err.message, "/-test-/abi."
       end
@@ -32,7 +32,7 @@ class TestABI < Test::Unit::TestCase
       err = assert_raise(LoadError) { require "-test-/abi" }
       assert_match(/incompatible ABI version/, err.message)
       if Ruby::Box.enabled?
-        assert_include err.message, "_-test-+abi."
+        assert_match(/[0-9]+_[0-9]+_abi[.]/, err.message)
       else
         assert_include err.message, "/-test-/abi."
       end


### PR DESCRIPTION
Under `RUBY_BOX=1`, `TestABI#test_require_lib_with_incorrect_abi_on_dev_ruby` and `TestABI#test_enable_abi_check_using_environment_variable` fail. Since #18536 a box copies an extension into a per-process directory as `<box id>_<serial>_<basename>`, so the `LoadError` names `.../_ruby_box_p10894_f10d7c08b18abad7/3_3_abi.bundle`. The assertions still expected `_-test-+abi.`, the flattened source path the copy used to be named after.

The new name is intended, so I updated the test rather than the runtime. The assertion matches the `_ruby_box_` directory as well as the file name, so an unrelated component of `TMPDIR` no longer satisfies it and the per-process isolation stays under test. These `assert_separately` sources are non-interpolating heredocs now, which is what lets the pattern use ordinary `\d` and `\.`.

`make test-all TESTS="../test/-ext-/test_abi.rb"` passes without `RUBY_BOX`. Under `RUBY_BOX=1` the ABI assertions now pass, and the file goes green once the separate fix for the experimental warning that `assert_separately` children print is in.

One thing this does not address is that the message names the temporary copy rather than the path that was required. That is worth discussing, but not here.

Generated with [Claude Code](https://claude.com/claude-code)
