### PR TITLE
Give a box's top self the top-level definition methods

### DIFF
--- a/box.c
+++ b/box.c
@@ -175,7 +175,9 @@ box_entry_initialize(rb_box_t *box)
     box->box_object = 0;
     box->box_id = 0;
 
-    box->top_self = rb_obj_alloc(rb_cObject);
+    // Clone the master top self so that the box gets the top-level singleton
+    // methods (include, using, public, private, ...) defined during setup.
+    box->top_self = rb_obj_clone(master->top_self);
     rb_define_singleton_method(box->top_self, "to_s", box_main_to_s, 0);
     rb_define_alias(rb_singleton_class(box->top_self), "inspect", "to_s");
     box->load_path = rb_ary_dup(master->load_path);

--- a/box.c
+++ b/box.c
@@ -1033,6 +1033,10 @@ rb_initialize_mandatory_boxes(void)
     vm->root_box = root_box = rb_get_box_t(root_box_value);
     vm->main_box = main_box = rb_get_box_t(main_box_value);
 
+    // `main` stays one object for the process as it is without boxes, so
+    // that extending it is visible to a load that wraps it.
+    root_box->top_self = main_box->top_self = master_box->top_self;
+
     // create the writable classext of ::Object explicitly to finalize the set of visible top-level constants
     RCLASS_EXT_WRITABLE_IN_BOX(rb_cObject, root_box);
     RCLASS_EXT_WRITABLE_IN_BOX(rb_cObject, main_box);

--- a/test/ruby/box/top_level_methods.rb
+++ b/test/ruby/box/top_level_methods.rb
@@ -1,0 +1,17 @@
+def top_level_private; end
+private :top_level_private
+
+def top_level_public; end
+public :top_level_public
+
+module TopLevelInclude; end
+include TopLevelInclude
+
+define_method(:top_level_defined) { :ok }
+
+ruby2_keywords def top_level_ruby2_keywords(*args); args; end
+
+module TopLevelRefinement
+  refine(String) { def top_level_refined; end }
+end
+using TopLevelRefinement

--- a/test/ruby/test_box.rb
+++ b/test/ruby/test_box.rb
@@ -1071,6 +1071,16 @@ class TestBox < Test::Unit::TestCase
     end
   end
 
+  def test_top_level_definition_methods_in_a_box
+    assert_separately([ENV_ENABLE_BOX], __FILE__, __LINE__, "#{<<~"begin;"}\n#{<<~'end;'}", ignore_stderr: true)
+    begin;
+      path = File.join(ENV["TEST_DIR"], "box", "top_level_methods.rb")
+
+      assert Ruby::Box.new.load(path)
+      assert load(path, true)
+    end;
+  end
+
   def test_require_list_loaded_only_in_main_box
     Tempfile.create(["req_a", ".rb"]) do |t1|
       Tempfile.create(["req_b", ".rb"]) do |t2|


### PR DESCRIPTION
Under `RUBY_BOX=1`, loading a file that calls `private`, `public`, `include`, `using`, `define_method` or `ruby2_keywords` at the top level raises `NoMethodError`. Both `Ruby::Box#load` and `load(path, true)` are affected, which fails `TestRequire#test_private_in_wrapped_load`, `TestRequire#test_public_in_wrapped_load` and five specs under `spec/ruby/core/main` and `spec/ruby/core/kernel/load_spec.rb`.

Those six methods land on the singleton class of the master box's top self during setup, before `rb_initialize_mandatory_boxes` runs. Each box then allocated a bare `Object` as its own top self, so none of them carried the methods. I clone the master top self instead.

The root and main boxes now share that object rather than cloning it, so `main` stays one object for the process as it is without boxes. Otherwise a module extended into `main` was missing from the wrapper of a wrapped load, and the four `main.require` examples in `spec/ruby/core/kernel/autoload_spec.rb` and `spec/ruby/core/module/autoload_spec.rb` could not see the mock they install on `TOPLEVEL_BINDING.eval("self")`.

Generated with [Claude Code](https://claude.com/claude-code)
