### PR TITLE
Skip classes already freed while freeing a box

### DIFF
--- a/box.c
+++ b/box.c
@@ -285,6 +285,12 @@ free_classext_for_box(st_data_t key, st_data_t _value, st_data_t box_arg)
     VALUE obj = (VALUE)key;
     const rb_box_t *box = (const rb_box_t *)box_arg;
 
+    if (RB_TYPE_P(obj, T_NONE)) {
+        /* RUBY_FREE_AT_EXIT can free a class before the box that refers to
+         * it, and freeing a class already freed its classext for this box. */
+        return ST_CONTINUE;
+    }
+
     if (RB_TYPE_P(obj, T_CLASS) || RB_TYPE_P(obj, T_MODULE)) {
         ext = rb_class_unlink_classext(obj, box);
         rb_class_classext_free(obj, ext, false);

--- a/test/ruby/test_box.rb
+++ b/test/ruby/test_box.rb
@@ -1028,6 +1028,10 @@ class TestBox < Test::Unit::TestCase
     end
   end
 
+  def test_free_at_exit_in_a_box
+    assert_ruby_status([ENV_ENABLE_BOX.merge("RUBY_FREE_AT_EXIT" => "1"), "-e;"], timeout: 30)
+  end
+
   def test_bundler_setup_not_loaded_while_decorator_gems_are_autoloaded
     with_bundler_setup_log do |env|
       # assert_separately w/ ENV_ENABLE_BOX and --enable=gems causes timeouts on CI @ Windows


### PR DESCRIPTION
`RUBY_FREE_AT_EXIT=1 RUBY_BOX=1 ruby -e 'p :ok'` prints `:ok` and then spins at 100% CPU forever instead of exiting. Without `RUBY_BOX` the same command exits normally. This is what makes `TestRubyOptions#test_free_at_exit_env_var` fail under `RUBY_BOX=1`.

`RUBY_FREE_AT_EXIT` frees objects in an arbitrary order, so a class a box refers to can go before the box, and freeing a class already frees its classext for every box. `free_classext_for_box` then reaches `rb_bug` with a `T_NONE`. Ordinary GC never sees that order because marking a box keeps those classes alive, so skipping the freed ones leaks nothing.

The spin is a separate, box-independent problem: a `[BUG]` during exit crashes in `rb_source_location_cstr`, and the `SIGSEGV` handler calls it again, so the report loops instead of aborting. Not addressed here.

Generated with [Claude Code](https://claude.com/claude-code)
