### PR TITLE
Strip the Ruby::Box experimental warning from harness-captured output

### DIFF
--- a/spec/default.mspec
+++ b/spec/default.mspec
@@ -69,6 +69,38 @@ class MSpecScript
   prepend JobServer
 end
 
+if ENV["RUBY_BOX"] == "1"
+  # Ruby::Box prints this at startup of every child process when RUBY_BOX=1
+  # is inherited from the environment.
+  module MSpecScript::StripBoxExperimentalWarning
+    WARNING = /^.*: warning: Ruby::Box is experimental, and the behavior may change in the future!\nSee https:\/\/docs\.ruby-lang\.org\/\S+ for known issues, etc\.\n/
+
+    # At load time this would resolve RUBY_EXE before mspec exports the flags.
+    def setup_env
+      super
+      require "mspec/helpers/ruby_exe"
+      Object.class_eval do
+        # Not a prepend, which the Module ancestor specs would see.
+        alias_method :ruby_exe_with_box_warning, :ruby_exe
+        private :ruby_exe_with_box_warning
+
+        private def ruby_exe(code = :not_given, opts = {})
+          output = ruby_exe_with_box_warning(code, opts)
+          if code != :not_given and !opts[:env]&.any? {|k,| k.to_s == "RUBY_BOX"}
+            # on the bytes, since the output is not always valid in its encoding
+            output = output.b.gsub(WARNING, "").force_encoding(output.encoding)
+          end
+          output
+        end
+      end
+    end
+  end
+
+  class MSpecScript
+    prepend StripBoxExperimentalWarning
+  end
+end
+
 require 'mspec/runner/formatters/dotted'
 
 class DottedFormatter

--- a/tool/lib/envutil.rb
+++ b/tool/lib/envutil.rb
@@ -43,6 +43,16 @@ module EnvUtil
 
   RUBYLIB = ENV["RUBYLIB"]
 
+  # Ruby::Box prints this at startup of every child process when RUBY_BOX=1
+  # is inherited from the environment.
+  BOX_EXPERIMENTAL_WARNING = /^.*: warning: Ruby::Box is experimental, and the behavior may change in the future!\nSee https:\/\/docs\.ruby-lang\.org\/\S+ for known issues, etc\.\n/
+
+  def strip_box_warning(str)
+    # on the bytes, since captured output is not always valid in its encoding
+    str.b.gsub(BOX_EXPERIMENTAL_WARNING, "").force_encoding(str.encoding) if str
+  end
+  module_function :strip_box_warning
+
   class << self
     attr_accessor :timeout_scale
     attr_reader :original_internal_encoding, :original_external_encoding,
@@ -266,6 +276,10 @@ module EnvUtil
       out_p.close if capture_stdout
       err_p.close if capture_stderr && capture_stderr != :merge_to_stdout
       status ||= Process.wait2(pid)[1]
+      if ENV["RUBY_BOX"] == "1" and !child_env.key?("RUBY_BOX")
+        stdout = strip_box_warning(stdout) if capture_stderr == :merge_to_stdout
+        stderr = strip_box_warning(stderr)
+      end
       stdout = stdout_filter.call(stdout) if stdout_filter
       stderr = stderr_filter.call(stderr) if stderr_filter
       if timeout_error


### PR DESCRIPTION
With `RUBY_BOX=1` in the environment, every child ruby that `EnvUtil.invoke_ruby` and mspec's `ruby_exe` spawn prints the two-line experimental warning into the captured output, so assertions on stderr and on merged output fail.

#18698 suppressed that warning with `-W:no-experimental` and covers most of it, including the `-w` that `assert_separately` injects. What it cannot cover is a test whose own subject is the warning flags or `RUBYOPT` itself. `test/ruby/test_rubyoptions.rb` sets `ENV['RUBYOPT']` and asserts the resulting stderr verbatim, and `test/ruby/test_require.rb` clears `RUBYOPT` for the child on purpose. On current master those files plus `test/ruby/test_method.rb` go from 19 failures to 5 over 220 tests with this change, with nothing newly broken and no remaining failure carrying the warning.

This strips the two lines from the captured output instead, and only when the environment supplied `RUBY_BOX=1` and the test did not pass it to the child itself, so `test/ruby/test_box.rb` still asserts on the warning. Nothing changes without `RUBY_BOX=1`, and `make test-all` and `make test-spec` are unaffected.

The alternatives are updating each affected test to expect the warning, which lands squarely on the files whose subject is warning-free output, or suppressing the startup warning in `box.c` when box mode came from the environment, which hides an experimental notice from anyone who exports `RUBY_BOX` outside the test suite.

Generated with [Claude Code](https://claude.com/claude-code)
