### PR TITLE
Load prelude per box under Ruby::Box

### DIFF
--- a/box.c
+++ b/box.c
@@ -429,6 +429,7 @@ box_initialize(VALUE box_value)
     rb_ivar_set(box_value, id_box_entry, entry);
 
     if (ruby_box_init_done) {
+        rb_load_prelude((VALUE)box);
         if (box_gem_flags->gem) {
             rb_vm_call_cfunc_in_box(Qnil, rb_define_gem_modules, (VALUE)box_gem_flags, Qnil,
                                     rb_str_new_cstr("before_prelude.user.dummy"), (const rb_box_t *)box);

--- a/builtin.c
+++ b/builtin.c
@@ -119,7 +119,12 @@ rb_load_gem_prelude(VALUE box)
 void
 rb_load_prelude(VALUE box)
 {
-    load_with_builtin_functions("prelude", NULL, (const rb_box_t *)box);
+    // A non-NULL table is what makes ibf_load_iseq complete the method iseqs
+    // eagerly, which rb_method_definition_set relies on under USE_LAZY_LOAD.
+    static const struct rb_builtin_function prelude_table[] = {
+        RB_BUILTIN_FUNCTION(-1, NULL, NULL, 0),
+    };
+    load_with_builtin_functions("prelude", prelude_table, (const rb_box_t *)box);
 }
 
 #endif

--- a/builtin.c
+++ b/builtin.c
@@ -116,6 +116,12 @@ rb_load_gem_prelude(VALUE box)
     load_with_builtin_functions("gem_prelude", NULL, (const rb_box_t *)box);
 }
 
+void
+rb_load_prelude(VALUE box)
+{
+    load_with_builtin_functions("prelude", NULL, (const rb_box_t *)box);
+}
+
 #endif
 
 void
@@ -133,6 +139,16 @@ Init_builtin(void)
 void
 Init_builtin_features(void)
 {
+    /*
+     * Load prelude per box (user boxes load it in Ruby::Box#initialize), so
+     * that the methods defined there belong to each box and `require` in
+     * their bodies loads features into the box of the caller.
+     */
+    rb_load_prelude((VALUE)rb_root_box());
+
+    if (rb_box_available()) {
+        rb_load_prelude((VALUE)rb_main_box());
+    }
 
 #ifdef BUILTIN_BINARY_SIZE
 

--- a/builtin.h
+++ b/builtin.h
@@ -23,6 +23,7 @@ struct rb_builtin_function {
 void rb_load_with_builtin_functions(const char *feature_name, const struct rb_builtin_function *table);
 VALUE rb_define_gem_modules(VALUE, VALUE);
 void rb_load_gem_prelude(VALUE box);
+void rb_load_prelude(VALUE box);
 
 #ifndef rb_execution_context_t
 typedef struct rb_execution_context_struct rb_execution_context_t;

--- a/inits.c
+++ b/inits.c
@@ -11,9 +11,6 @@
 
 #include "internal/inits.h"
 #include "ruby.h"
-#include "builtin.h"
-static void Init_builtin_prelude(void);
-#include "prelude.rbinc"
 
 #define CALL(n) {void Init_##n(void); Init_##n();}
 
@@ -112,6 +109,6 @@ rb_call_builtin_inits(void)
     BUILTIN(nilclass);
     BUILTIN(marshal);
     BUILTIN(jit_undef);
-    Init_builtin_prelude();
+    // prelude is loaded per box in Init_builtin_features
 }
 #undef CALL

--- a/mini_builtin.c
+++ b/mini_builtin.c
@@ -116,3 +116,10 @@ rb_load_gem_prelude(VALUE _)
 {
     // do nothing - miniruby doesn't support loading RubyGems.
 }
+
+void
+rb_load_prelude(VALUE box)
+{
+    const rb_iseq_t *iseq = builtin_iseq_load("prelude", NULL);
+    rb_iseq_eval(iseq, (const rb_box_t *)box);
+}

--- a/miniinit.c
+++ b/miniinit.c
@@ -97,6 +97,12 @@ Init_builtin(void)
 void
 Init_builtin_features(void)
 {
+    rb_load_prelude((VALUE)rb_root_box());
+
+    if (rb_box_available()) {
+        rb_load_prelude((VALUE)rb_main_box());
+    }
+
     // register for ruby
     builtin_iseq_load("gem_prelude", NULL);
 }

--- a/test/ruby/test_box.rb
+++ b/test/ruby/test_box.rb
@@ -988,6 +988,49 @@ class TestBox < Test::Unit::TestCase
     end
   end
 
+  def test_prelude_method_require_loads_feature_into_calling_box
+    # `Kernel#pp` in <internal:prelude> requires 'pp' and calls the real pp.
+    # The require must load the feature into the box of the caller, not into
+    # the master box where it is invisible from every other box.
+    assert_in_out_err([ENV_ENABLE_BOX], "#{<<-"begin;"}\n#{<<-'end;'}") do |output, error|
+      begin;
+        root = Ruby::Box.root
+        root.eval("pp 42")
+        puts root.eval("defined?(PP)").inspect
+        puts root.eval("method(:pp).source_location.first")
+        puts root.eval("$LOADED_FEATURES").grep(%r{/pp\.rb\z}).size
+        puts defined?(PP).inspect
+        pp :main
+        puts defined?(PP).inspect
+        puts method(:pp).source_location.first
+      end;
+      assert_equal "42", output[0]
+      assert_equal '"constant"', output[1], "PP must be defined in the root box"
+      assert_match(%r{/pp\.rb\z}, output[2], "lib/pp.rb must redefine pp in the root box")
+      assert_equal "1", output[3], "pp.rb must be in the root box's $LOADED_FEATURES"
+      assert_equal "nil", output[4], "PP must not leak into the main box"
+      assert_equal ":main", output[5]
+      assert_equal '"constant"', output[6], "PP must be defined in the main box"
+      assert_match(%r{/pp\.rb\z}, output[7], "lib/pp.rb must redefine pp in the main box")
+    end
+  end
+
+  def test_prelude_method_require_loads_feature_into_user_box
+    assert_in_out_err([ENV_ENABLE_BOX], "#{<<-"begin;"}\n#{<<-'end;'}") do |output, error|
+      begin;
+        box = Ruby::Box.new
+        box.eval("pp :user")
+        puts box.eval("defined?(PP)").inspect
+        puts box.eval("method(:pp).source_location.first")
+        puts defined?(PP).inspect
+      end;
+      assert_equal ":user", output[0]
+      assert_equal '"constant"', output[1], "PP must be defined in the user box"
+      assert_match(%r{/pp\.rb\z}, output[2], "lib/pp.rb must redefine pp in the user box")
+      assert_equal "nil", output[3], "PP must not leak into the main box"
+    end
+  end
+
   def test_calling_root_box_methods_does_not_change_user_boxes_newly_created
     assert_separately([ENV_ENABLE_BOX], __FILE__, __LINE__, "#{<<~"begin;"}\n#{<<~'end;'}", ignore_stderr: true, timeout: 60)
     begin;


### PR DESCRIPTION
With `RUBY_BOX=1`, calling `pp` printed correctly but left no trace in the calling box. Neither `PP` nor the `pp.rb` entry in `$LOADED_FEATURES` showed up there, and `binding.irb` failed with `uninitialized constant Binding::Gem` while rescuing `cannot load such file -- irb`.

```
$ RUBY_BOX=1 ./ruby -e 'Ruby::Box.root.eval("pp 42"); p Ruby::Box.root.eval("defined?(PP)")'
42
nil
```

`prelude.rb` was evaluated once in `rb_call_builtin_inits`, before the root and main boxes exist, so `Kernel#pp` and `Binding#irb` belonged to the master box. A `require` resolves its loading box from the box of the method it runs in, so the feature landed in the master box instead of the calling box. Only boxes created afterwards see it, because they start from the master box.

This loads prelude into each box the way `gem_prelude` already is, in `Init_builtin_features` for the root and main boxes and in `Ruby::Box#initialize` for user boxes.

Generated with [Claude Code](https://claude.com/claude-code)
