### PR TITLE
Lower number of threads in a ractor in a bootstrap test

### DIFF
--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -1534,10 +1534,10 @@ assert_equal '[nil, "b", "a"]', %q{
 }
 
 assert_equal '1', %q{
-  N = 1_000
+  N = 100
   Ractor.new{
     a = []
-    1_000.times.map{|i|
+    100.times.map{|i|
       Thread.new(i){|i|
         Thread.pass if i < N
         a << Ractor.store_if_absent(:i){ i }


### PR DESCRIPTION
OpenBSD CI now runs inside a qemu virtual machine inside a Ubuntu virtual machine, without hardware virtualization support. It is limited to 2.5GB of RAM and only 2 vCPUs. There is a bootstrap test that fails on it due to resource issues.

```
bootstraptest.test_ractor.rb_1536_1361.rb:8:in 'Thread#initialize':
can't create Thread: Cannot allocate memory (ThreadError)
```

Fix this by using 100 threads instead of 1000.

This change is made for all platforms. If it should only be made on OpenBSD, let me know and I'll update this.