### PR TITLE
Change leaf-ness of the `intern` VM instruction

### DIFF
--- a/insns.def
+++ b/insns.def
@@ -438,6 +438,9 @@ intern
 ()
 (VALUE str)
 (VALUE sym)
+/* This instruction can raise EncodingError, thus can call
+ * EncodingError#initialize. */
+// attr bool leaf = false;
 {
     sym = rb_str_intern(str);
 }

--- a/spec/ruby/core/thread/backtrace/location/source_range_spec.rb
+++ b/spec/ruby/core/thread/backtrace/location/source_range_spec.rb
@@ -371,14 +371,13 @@ ruby_version_is "4.1" do
       end
       RUBY
 
-      # Aborts the test process on CRuby's CI with ZJIT
-      # "interpolated symbol" => [<<-RUBY, :InterpolatedSymbolNode],
-      # value = Object.new
-      # def value.to_s
-      #   (+"\\xFF").force_encoding(Encoding::UTF_8)
-      # end
-      # %I[$\#{value}$]
-      # RUBY
+      "interpolated symbol" => [<<-RUBY, :InterpolatedSymbolNode],
+      value = Object.new
+      def value.to_s
+      (+"\\xFF").force_encoding(Encoding::UTF_8)
+      end
+      %I[$\#{value}$]
+      RUBY
     }.each_pair do |description, (source, prism_class, frame)|
       it "returns the precise range for #{description}" do
         capture_backtrace_location_source_range(source, prism_class, frame: frame || 0)

--- a/spec/ruby/language/symbol_spec.rb
+++ b/spec/ruby/language/symbol_spec.rb
@@ -96,7 +96,6 @@ describe "A Symbol literal" do
     %I{a b #{"c"}}.should == [:a, :b, :c]
   end
 
-  quarantine! do # Aborts the test process on CRuby's CI
   it "raises an EncodingError when an interpolated symbol has invalid bytes" do
     -> {
       :"#{(+"\xFF").force_encoding(Encoding::UTF_8)}"
@@ -105,7 +104,6 @@ describe "A Symbol literal" do
     -> {
       %I[#{(+"\xFF").force_encoding(Encoding::UTF_8)}]
     }.should.raise(EncodingError, 'invalid symbol in encoding UTF-8 :"\xFF"')
-  end
   end
 
   ruby_bug "#20280", ""..."3.4" do

--- a/test/ruby/test_insns_leaf.rb
+++ b/test/ruby/test_insns_leaf.rb
@@ -43,4 +43,19 @@ class TestInsnsLeaf < Test::Unit::TestCase
     assert Namespace.test?(Id.new(1)), "IDS should include 1"
     assert !Namespace.test?(Id.new(5)), "IDS should not include 5"
   end
+
+  def test_intern_is_not_leaf
+    assert_separately([], <<~'RUBY')
+      class EncodingError
+        def initialize(...)
+          $encoding_error_initialize_called = true
+          super
+        end
+      end
+
+      invalid_utf8 = (+"\xFF").force_encoding(Encoding::UTF_8)
+      assert_raise(EncodingError) { :"#{invalid_utf8}" }
+      assert $encoding_error_initialize_called
+    RUBY
+  end
 end

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -10254,8 +10254,8 @@ fn gen_intern(
     jit: &mut JITState,
     asm: &mut Assembler,
 ) -> Option<CodegenStatus> {
-    // Save the PC and SP because we might allocate
-    jit_prepare_call_with_gc(jit, asm);
+    // rb_str_intern can allocate and raise EncodingError.
+    jit_prepare_non_leaf_call(jit, asm);
 
     let str = asm.stack_opnd(0);
     let sym = asm.ccall(rb_str_intern as *const u8, vec![str]);

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -684,7 +684,7 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
         Insn::StringAppend { recv, other, state } => gen_string_append(jit, asm, function, opnd!(recv), opnd!(other), &function.frame_state(*state)),
         Insn::StringAppendCodepoint { recv, other, state } => gen_string_append_codepoint(jit, asm, function, opnd!(recv), opnd!(other), &function.frame_state(*state)),
         Insn::StringEqual { left, right } => gen_string_equal(asm, opnd!(left), opnd!(right)),
-        Insn::StringIntern { val, state } => gen_intern(asm, opnd!(val), &function.frame_state(*state)),
+        Insn::StringIntern { val, state } => gen_intern(jit, asm, function, opnd!(val), &function.frame_state(*state)),
         Insn::ToRegexp { opt, values, state } => gen_toregexp(jit, asm, function, *opt, opnds!(values), &function.frame_state(*state)),
         Insn::Param => unreachable!("block.insns should not have Insn::Param"),
         Insn::LoadArg { .. } => return Ok(()), // compiled in the LoadArg pre-pass above
@@ -1267,8 +1267,9 @@ fn gen_getglobal(jit: &mut JITState, asm: &mut Assembler, function: &Function, i
 }
 
 /// Intern a string
-fn gen_intern(asm: &mut Assembler, val: Opnd, state: &FrameState) -> Opnd {
-    gen_prepare_leaf_call_with_gc(asm, state);
+fn gen_intern(jit: &JITState, asm: &mut Assembler, function: &Function, val: Opnd, state: &FrameState) -> Opnd {
+    // rb_str_intern can allocate and raise EncodingError.
+    gen_prepare_non_leaf_call(jit, asm, function, state);
 
     asm_ccall!(asm, rb_str_intern, val)
 }


### PR DESCRIPTION
`rb_str_intern` can raise `EncodingError` and call its initializer. This call can push a Ruby frame.

Mark the VM, YJIT, and ZJIT paths as non-leaf.

Fixes https://github.com/Shopify/ruby/issues/1044.