### PR TITLE
gc: time a collection on the collecting thread, not the whole process

### DIFF
--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -8586,10 +8586,32 @@ gc_enter_count(enum gc_enter_event event)
 
 static bool current_process_time(struct timespec *ts);
 
+/* A gc phase must be timed on the collecting thread's own cpu.  A local gc runs
+ * while the other ractors keep going, and process cpu time counts their work as
+ * gc: with eight busy ractors the same ten collections were reported as 131ms
+ * instead of 3ms, more than the wall clock they ran in.  The kernel also answers
+ * this one without walking every thread in the process. */
+static bool
+current_thread_time(struct timespec *ts)
+{
+#if defined(HAVE_CLOCK_GETTIME) && defined(CLOCK_THREAD_CPUTIME_ID)
+    {
+        static int try_clock_gettime = 1;
+        if (try_clock_gettime && clock_gettime(CLOCK_THREAD_CPUTIME_ID, ts) == 0) {
+            return true;
+        }
+        else {
+            try_clock_gettime = 0;
+        }
+    }
+#endif
+    return current_process_time(ts);
+}
+
 static void
 gc_clock_start(struct timespec *ts)
 {
-    if (!current_process_time(ts)) {
+    if (!current_thread_time(ts)) {
         ts->tv_sec = 0;
         ts->tv_nsec = 0;
     }
@@ -8601,7 +8623,7 @@ gc_clock_end(struct timespec *ts)
     struct timespec end_time;
 
     if ((ts->tv_sec > 0 || ts->tv_nsec > 0) &&
-            current_process_time(&end_time) &&
+            current_thread_time(&end_time) &&
             end_time.tv_sec >= ts->tv_sec) {
         return (unsigned long long)(end_time.tv_sec - ts->tv_sec) * (1000 * 1000 * 1000) +
                     (end_time.tv_nsec - ts->tv_nsec);


### PR DESCRIPTION
gc_clock_start/end read CLOCK_PROCESS_CPUTIME_ID, which is the sum of every thread's cpu time. A local GC runs while the other Ractors keep going, so their work is counted as collection: the same ten collections of the same objects in one Ractor are reported as 3ms alone and 146ms with eight unrelated busy Ractors -- 96% of the wall clock that Ractor ran in, and in another run more than the wall clock.

Read the collecting thread's own cpu instead. A local GC runs to its end on one thread, and a global one stops the others, so this is what the number was always meant to be. With the fix the same measurement reads 3 / 4 / 6 / 18ms, the remaining growth being collections that genuinely cost more on a busy machine.

The read also gets cheaper. GC.measure_total_time is on by default, so every program pays for four of these reads per collection, and neither cpu clock is served by the vDSO: both are real syscalls. Reading CLOCK_PROCESS_CPUTIME_ID makes the kernel walk every thread in the process, so it costs 477ns with one thread and 3.6us with 256, while CLOCK_THREAD_CPUTIME_ID is 454ns whatever the count (idle Ryzen 9 8945HS; the threads were asleep, they only have to exist, not run).