### PR TITLE
gc: let a new Ractor's objspace inherit GC.measure_total_time

### DIFF
--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -12609,7 +12609,6 @@ rb_gc_impl_objspace_init(void *objspace_ptr)
 
     gc_config_full_mark_set(TRUE);
 
-    objspace->flags.measure_gc = true;
     malloc_limit = gc_params.malloc_limit_min;
     objspace->shareable_objects_limit = SHAREABLE_OBJECTS_LIMIT_MIN;
 #ifdef MALLOC_COUNTERS_NEED_LOCK
@@ -12648,6 +12647,10 @@ rb_gc_impl_objspace_init(void *objspace_ptr)
 #endif
         gc_params.heap_init_bytes = GC_HEAP_INIT_BYTES;
     }
+    // GC.measure_total_time= sets the caller's objspace only; a new Ractor's follows
+    // its creator's, which is the objspace running this init (main starts it on).
+    objspace->flags.measure_gc = global_objspace->main_objspace == objspace ? true
+                                 : ((rb_objspace_t *)rb_gc_get_objspace())->flags.measure_gc;
 
     rb_darray_make_without_gc(&objspace->heap_pages.sorted, 0);
     rb_darray_make_without_gc(&objspace->weak_references, 0);


### PR DESCRIPTION
GC.measure_total_time= writes the flag of the calling Ractor's objspace, and every new objspace started with the flag on, so turning the timing off never reached the Ractors created afterwards: each of them kept paying two clock reads per GC phase, and GC.stat :time in a Ractor did not follow the setting.

Start a Ractor's objspace with its creator's current value, the way ractor_create already carries over verbose and debug.  The creating Ractor's thread is the one running this init, so the value is read without touching another Ractor's objspace.