### PR TITLE
ZJIT: s/side_exit_size/side_exit_size_bytes/ for consistency

### DIFF
--- a/zjit.rb
+++ b/zjit.rb
@@ -87,7 +87,7 @@ class << RubyVM::ZJIT
       stats[:guard_shape_exit_ratio] = stats[:exit_guard_shape_failure].to_f / stats[:guard_shape_count] * 100
     end
     if stats[:code_region_bytes]&.nonzero?
-      stats[:side_exit_size_ratio] = stats[:side_exit_size].to_f / stats[:code_region_bytes] * 100
+      stats[:side_exit_size_ratio] = stats[:side_exit_size_bytes].to_f / stats[:code_region_bytes] * 100
     end
     if stats[:compile_time_ns]&.nonzero?
       stats[:compile_side_exit_time_ratio] = stats[:compile_side_exit_time_ns].to_f / stats[:compile_time_ns] * 100
@@ -184,7 +184,7 @@ class << RubyVM::ZJIT
 
       :throw_count,
 
-      :side_exit_size,
+      :side_exit_size_bytes,
       :side_exit_size_ratio,
       :jit_frame_heap_bytes,
       :jit_frame_region_bytes,

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -3244,7 +3244,7 @@ impl Assembler
             self.pos_marker(move |start_pos, cb| {
                 let end_pos = cb.get_write_ptr();
                 let size = end_pos.as_offset() - start_pos.as_offset();
-                crate::stats::incr_counter_by(crate::stats::Counter::side_exit_size, size as u64);
+                crate::stats::incr_counter_by(crate::stats::Counter::side_exit_size_bytes, size as u64);
             });
         }
 

--- a/zjit/src/stats.rs
+++ b/zjit/src/stats.rs
@@ -165,7 +165,7 @@ make_counters! {
         invalidation_time_ns,
 
         compiled_side_exit_count,
-        side_exit_size,
+        side_exit_size_bytes,
         compile_side_exit_time_ns,
 
         compile_hir_time_ns,


### PR DESCRIPTION
Other code size metrics such as `code_region_bytes` use the `_bytes`
suffix and `side_exit_size` was the odd one out.
