### PR TITLE
gc: only clear try_clock_gettime when the clock actually failed

### DIFF
--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -8597,11 +8597,13 @@ current_thread_time(struct timespec *ts)
 #if defined(HAVE_CLOCK_GETTIME) && defined(CLOCK_THREAD_CPUTIME_ID)
     {
         static int try_clock_gettime = 1;
-        if (try_clock_gettime && clock_gettime(CLOCK_THREAD_CPUTIME_ID, ts) == 0) {
-            return true;
-        }
-        else {
-            try_clock_gettime = 0;
+        if (try_clock_gettime) {
+            if (clock_gettime(CLOCK_THREAD_CPUTIME_ID, ts) == 0) {
+                return true;
+            }
+            else {
+                try_clock_gettime = 0;
+            }
         }
     }
 #endif
@@ -11292,11 +11294,13 @@ current_process_time(struct timespec *ts)
 #if defined(HAVE_CLOCK_GETTIME) && defined(CLOCK_PROCESS_CPUTIME_ID)
     {
         static int try_clock_gettime = 1;
-        if (try_clock_gettime && clock_gettime(CLOCK_PROCESS_CPUTIME_ID, ts) == 0) {
-            return true;
-        }
-        else {
-            try_clock_gettime = 0;
+        if (try_clock_gettime) {
+            if (clock_gettime(CLOCK_PROCESS_CPUTIME_ID, ts) == 0) {
+                return true;
+            }
+            else {
+                try_clock_gettime = 0;
+            }
         }
     }
 #endif


### PR DESCRIPTION
Once the flag had fallen to 0 the short-circuited condition still landed in the else, so every later call stored 0 again.  Guard the attempt so the store happens only on the call that saw clock_gettime fail.

current_process_time carries the same idiom and is what current_thread_time falls through to, so both are fixed together.

Pointed out by nobu in review of https://github.com/ruby/ruby/pull/18717