### PR TITLE
Mask object addresses in error_highlight message assertions

### DIFF
--- a/test/error_highlight/test_error_highlight.rb
+++ b/test/error_highlight/test_error_highlight.rb
@@ -40,6 +40,12 @@ class ErrorHighlightTest < Test::Unit::TestCase
     end
   end
 
+  # A moving GC can relocate the receiver between the expected message baking
+  # `#inspect` and the error being raised, so the two addresses need not agree.
+  def mask_addresses(msg)
+    msg.gsub(/0x\h+/, "0xXXXX")
+  end
+
   if Exception.method_defined?(:detailed_message)
     def assert_error_message(klass, expected_msg, &blk)
       omit unless klass < ErrorHighlight::CoreExt
@@ -55,13 +61,14 @@ class ErrorHighlightTest < Test::Unit::TestCase
           assert_kind_of(Array, spot[:script_lines])
         end
       end
-      assert_equal(preprocess(expected_msg).chomp, err.detailed_message(highlight: false).sub(/ \((?:NoMethod|Name)Error\)/, ""))
+      actual_msg = err.detailed_message(highlight: false).sub(/ \((?:NoMethod|Name)Error\)/, "")
+      assert_equal(mask_addresses(preprocess(expected_msg).chomp), mask_addresses(actual_msg))
     end
   else
     def assert_error_message(klass, expected_msg, &blk)
       omit unless klass < ErrorHighlight::CoreExt
       err = assert_raise(klass, &blk)
-      assert_equal(preprocess(expected_msg).chomp, err.message)
+      assert_equal(mask_addresses(preprocess(expected_msg).chomp), mask_addresses(err.message))
     end
   end
 


### PR DESCRIPTION
`ErrorHighlightTest` fails on the MMTk jobs with a diff that is only the receiver's address. It reproduces on master, and on macOS arm64 a rerun does not clear it.

The expected message evaluates `#inspect` while the heredoc is built, and the address is generated again when the error message is materialized inside the block. A moving GC that relocates the receiver between those two points makes them disagree. Masking `0x\h+` on both sides leaves the class name and the snippet under assertion.

This is not MMTk specific. `test_local_variable_get` fails the same way under the default GC when `GC.compact` runs in that window. Eight tests are affected, and forcing a GC into the window reproduces all of them under MMTk and none after this change.

Generated with [Claude Code](https://claude.com/claude-code)
