### PR TITLE
Do not report an interrupted M:N io wait as a timeout

### DIFF
--- a/test/ruby/test_process.rb
+++ b/test/ruby/test_process.rb
@@ -1795,7 +1795,7 @@ class TestProcess < Test::Unit::TestCase
       end
       assert_send [sig_r, :wait_readable, 5], 'self-pipe not readable'
     end
-    assert_equal [true], signal_received, "[ruby-core:19744]"
+    assert_equal [true], signal_received.uniq, "[ruby-core:19744]"
   rescue NotImplementedError, ArgumentError
   ensure
     begin

--- a/thread.c
+++ b/thread.c
@@ -4895,7 +4895,25 @@ COMPILER_WARNING_POP
     // A zero timeout is a plain probe; ppoll answers it without parking.
     bool mn_wait = timeout == NULL || timeout->tv_sec != 0 || timeout->tv_usec != 0;
 
-    switch (mn_wait ? thread_io_wait_events(th, fd, events, timeout, false) : io_wait_unhandled) {
+    enum io_wait_result mn_result = io_wait_unhandled;
+    struct timeval tv_rest;
+    if (mn_wait) {
+        rb_hrtime_t started = timeout ? rb_hrtime_now() : 0;
+        mn_result = thread_io_wait_events(th, fd, events, timeout, false);
+
+        // The M:N wait may hand an interrupted wait back to the blocking path
+        // below.  Charge what it already waited against the timeout, so the
+        // deadline is the one the caller asked for.
+        if (mn_result == io_wait_unhandled && timeout) {
+            rb_hrtime_t total = rb_timeval2hrtime(timeout);
+            rb_hrtime_t spent = rb_hrtime_sub(rb_hrtime_now(), started);
+            rb_hrtime_t rest = spent < total ? total - spent : 0;
+            rb_hrtime2timeval(&tv_rest, &rest);
+            timeout = &tv_rest;
+        }
+    }
+
+    switch (mn_result) {
       case io_wait_ready:
         fds[0].revents = events;
         errno = 0;

--- a/thread_sched_mn.c
+++ b/thread_sched_mn.c
@@ -609,6 +609,9 @@ thread_sched_wait_events(struct rb_thread_sched *sched, rb_thread_t *th, int fd,
     if (reg == timer_thread_unavailable) return thread_sched_wait_unavailable;
     // A ready fd never registered, so it never timed out either.
     if (reg == timer_thread_already_ready) return thread_sched_wait_event;
+    // No event fired and we are interrupted: that is an interrupt, not a
+    // timeout.  Hand the wait back so the caller runs it and re-polls the fd.
+    if (timedout && RUBY_VM_INTERRUPTED(th->ec)) return thread_sched_wait_unavailable;
     return timedout ? thread_sched_wait_timeout : thread_sched_wait_event;
 }
 


### PR DESCRIPTION
IO#wait_readable returns nil under RUBY_MN_THREADS=2 when a signal interrupts the wait, even though the fd has become readable.

```ruby
r, w = IO.pipe
Signal.trap(:USR1) { }
Thread.new { sleep 0.03; Process.kill(:USR1, Process.pid); sleep 0.03; w.write('?') }
p r.wait_readable(3)   # => nil with RUBY_MN_THREADS=2, the IO otherwise
```

200/200 nil with =2; 200/200 truthy with the default, =1 and =-1. Only =2 puts the main thread on the M:N io path.

thread_sched_wait_events() decided "timed out" from waiting_reason.data.result == 0, which only says no event fired, a thread woken by an interrupt lands there too. rb_thread_io_wait() then left revents at 0.

The fix hands an interrupted wait back to the caller's blocking path, and charges the time the M:N wait already spent against the timeout, so a genuine timeout still returns nil at the requested deadline (measured: 300?301 ms for a 0.30 s wait, with and without interrupting signals; unfixed =2 stretched it to 401 ms). make test-all is clean with =2 and with the default.