### PR TITLE
Deprecate RHASH_TBL

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,7 @@ Note: We're only listing outstanding class updates.
       interrupts, including interrupts masked by `Thread.handle_interrupt`.
       As with the existing skip path, `errno` is `0` because the function was
       never called.
+    * `RHASH_TBL` is deprecated.  [[Feature #22232]]
 
 * Array
 
@@ -461,6 +462,7 @@ A lot of work has gone into making Ractors more stable, performant, and usable. 
 [Feature #22185]: https://bugs.ruby-lang.org/issues/22185
 [Feature #22205]: https://bugs.ruby-lang.org/issues/22205
 [Feature #22226]: https://bugs.ruby-lang.org/issues/22226
+[Feature #22232]: https://bugs.ruby-lang.org/issues/22232
 [Feature #22238]: https://bugs.ruby-lang.org/issues/22238
 [Feature #22297]: https://bugs.ruby-lang.org/issues/22297
 [PR #17201]: https://github.com/ruby/ruby/pull/17201

--- a/ext/-test-/st/update/update.c
+++ b/ext/-test-/st/update/update.c
@@ -19,7 +19,8 @@ update_func(st_data_t *key, st_data_t *value, st_data_t arg, int existing)
 static VALUE
 test_st_update(VALUE self, VALUE key)
 {
-    if (st_update(RHASH_TBL(self), (st_data_t)key, update_func, 0))
+    // rb_hash_tbl is private API to bypass deprecation warnings.
+    if (st_update(rb_hash_tbl(self), (st_data_t)key, update_func, 0))
         return Qtrue;
     else
         return Qfalse;
@@ -31,4 +32,3 @@ Init_update(void)
     VALUE st = rb_define_class_under(rb_define_module("Bug"), "StTable", rb_cHash);
     rb_define_method(st, "st_update", test_st_update, 1);
 }
-

--- a/hash.c
+++ b/hash.c
@@ -759,7 +759,7 @@ ar_each_key(ar_table *ar, int max, enum ar_each_key_type type, st_data_t *dst_ke
 }
 
 static st_table *
-ar_force_convert_table(VALUE hash, const char *file, int line)
+ar_force_convert_table(VALUE hash)
 {
     if (RHASH_ST_TABLE_P(hash)) {
         return RHASH_ST_TABLE(hash);
@@ -1792,16 +1792,16 @@ rb_hash_modify_check(VALUE hash)
 }
 
 struct st_table *
-rb_hash_tbl_raw(VALUE hash, const char *file, int line)
+rb_hash_tbl_raw(VALUE hash)
 {
-    return ar_force_convert_table(hash, file, line);
+    return ar_force_convert_table(hash);
 }
 
 struct st_table *
-rb_hash_tbl(VALUE hash, const char *file, int line)
+rb_hash_tbl(VALUE hash)
 {
     OBJ_WB_UNPROTECT(hash);
-    return rb_hash_tbl_raw(hash, file, line);
+    return rb_hash_tbl_raw(hash);
 }
 
 static void
@@ -1852,7 +1852,7 @@ rb_hash_stlike_update(VALUE hash, st_data_t key, st_update_callback_func *func, 
     if (RHASH_AR_TABLE_P(hash)) {
         int result = ar_update(hash, key, func, arg);
         if (result == -1) {
-            ar_force_convert_table(hash, __FILE__, __LINE__);
+            ar_force_convert_table(hash);
         }
         else {
             return result;

--- a/include/ruby/internal/abi.h
+++ b/include/ruby/internal/abi.h
@@ -24,7 +24,7 @@
  * In released versions of Ruby, this number is not defined since teeny
  * versions of Ruby should guarantee ABI compatibility.
  */
-#define RUBY_ABI_VERSION 4
+#define RUBY_ABI_VERSION 5
 
 /* Windows does not support weak symbols so ruby_abi_version will not exist
  * in the shared library. */

--- a/include/ruby/internal/core/rhash.h
+++ b/include/ruby/internal/core/rhash.h
@@ -34,18 +34,6 @@
 #endif
 
 /**
- * Retrieves the internal table.
- *
- * @param[in]  h  An instance of RHash.
- * @pre        `h` must be of ::RUBY_T_HASH.
- * @return     A struct st_table which has the contents of this hash.
- * @note       Nowadays as Ruby  evolved over ages, RHash  has multiple backend
- *             storage  engines.   `h`'s backend  is  not  guaranteed to  be  a
- *             st_table.  This function creates one when necessary.
- */
-#define RHASH_TBL(h)                rb_hash_tbl(h, __FILE__, __LINE__)
-
-/**
  * @private
  *
  * @deprecated  This macro once was a thing in the old days, but makes no sense
@@ -115,7 +103,26 @@ size_t rb_hash_size_num(VALUE hash);
  * @pre        `hash` must be of ::RUBY_T_HASH.
  * @return     Table that has the contents of the hash.
  */
-struct st_table *rb_hash_tbl(VALUE hash, const char *file, int line);
+struct st_table *rb_hash_tbl(VALUE hash);
+
+RBIMPL_ATTR_DEPRECATED(("other `rb_hash_*` APIs"))
+/**
+ * Retrieves the internal table.
+ *
+ * @param[in]  h  An instance of RHash.
+ * @pre        `h` must be of ::RUBY_T_HASH.
+ * @return     A struct st_table which has the contents of this hash.
+ * @note       Nowadays as Ruby  evolved over ages, RHash  has multiple backend
+ *             storage  engines.   `h`'s backend  is  not  guaranteed to  be  a
+ *             st_table.  This function creates one when necessary.
+ * @deprecated This imposes that RHash can backed by a `struct st_table` which is limiting
+ *             runtime optimizations.
+ */
+static inline st_table *
+RHASH_TBL(VALUE h)
+{
+    return rb_hash_tbl(h);
+}
 
 /**
  * This is the  implementation detail of #RHASH_SET_IFNONE.   People don't call

--- a/include/ruby/st.h
+++ b/include/ruby/st.h
@@ -187,8 +187,6 @@ CONSTFUNC(st_index_t rb_st_hash_end(st_index_t h));
 CONSTFUNC(st_index_t rb_st_hash_start(st_index_t h));
 #define st_hash_start(h) ((st_index_t)(h))
 
-void rb_hash_bulk_insert_into_st_table(long, const VALUE *, VALUE);
-
 RUBY_SYMBOL_EXPORT_END
 
 #if defined(__cplusplus)

--- a/internal/hash.h
+++ b/internal/hash.h
@@ -121,8 +121,7 @@ VALUE rb_hash_keys(VALUE hash);
 VALUE rb_hash_has_key(VALUE hash, VALUE key);
 VALUE rb_hash_compare_by_id_p(VALUE hash);
 
-st_table *rb_hash_tbl_raw(VALUE hash, const char *file, int line);
-#define RHASH_TBL_RAW(h) rb_hash_tbl_raw(h, __FILE__, __LINE__)
+st_table *rb_hash_tbl_raw(VALUE hash);
 
 VALUE rb_hash_compare_by_id(VALUE hash);
 

--- a/internal/st.h
+++ b/internal/st.h
@@ -23,4 +23,7 @@ int rb_st_insert_no_rebuild(st_table *tab, st_data_t key, st_data_t value);
 typedef int st_foreach_with_hash_callback_func(st_data_t, st_data_t, st_data_t, st_data_t);
 int rb_st_foreach_with_hash(st_table *, st_foreach_with_hash_callback_func *, st_data_t);
 #define st_foreach_with_hash rb_st_foreach_with_hash
+
+void rb_hash_bulk_insert_into_st_table(long, const VALUE *, VALUE);
+
 #endif

--- a/st.c
+++ b/st.c
@@ -2451,7 +2451,7 @@ rb_hash_bulk_insert_into_st_table(long argc, const VALUE *argv, VALUE hash)
     st_index_t n, size = argc / 2;
     st_table *tab = RHASH_ST_TABLE(hash);
 
-    tab = RHASH_TBL_RAW(hash);
+    tab = rb_hash_tbl_raw(hash);
     n = tab->entries_bound + size;
     st_expand_table(tab, n);
     if (UNLIKELY(tab->num_entries))


### PR DESCRIPTION
[[Feature #22232]](https://bugs.ruby-lang.org/issues/22232)

Guaranteeing that any hash can be converted into an st_table is limiting the evolution of RHash.

None of the public usages of `RHASH_TBL` were justified, they all had equivalent `rb_hash_*` public APIs to perform the same thing more efficiently without disabling write barriers nor coercing the hash into an st_table.