### PR TITLE
[Bug #22293] Make String#unicode_normalize work in non-main Ractors

### DIFF
--- a/lib/unicode_normalize/normalize.rb
+++ b/lib/unicode_normalize/normalize.rb
@@ -25,18 +25,30 @@ module UnicodeNormalize  # :nodoc:
   ## Constant for max hash capacity to avoid DoS attack
   MAX_HASH_LENGTH = 18000 # enough for all test cases, otherwise tests get slow
 
-  ## Regular Expressions and Hash Constants
+  ## Regular Expressions and Memoization Caches
   REGEXP_D = Regexp.compile(REGEXP_D_STRING, Regexp::EXTENDED)
   REGEXP_C = Regexp.compile(REGEXP_C_STRING, Regexp::EXTENDED)
   REGEXP_K = Regexp.compile(REGEXP_K_STRING, Regexp::EXTENDED)
-  NF_HASH_D = Hash.new do |hash, key|
-                         hash.shift if hash.length>MAX_HASH_LENGTH # prevent DoS attack
-                         hash[key] = nfd_one(key)
-                       end
-  NF_HASH_C = Hash.new do |hash, key|
-                         hash.shift if hash.length>MAX_HASH_LENGTH # prevent DoS attack
-                         hash[key] = nfc_one(key)
-                       end
+
+  # Memoized per-pattern results, kept per Ractor: a shareable Hash could not be
+  # written to, and recomputing an entry always gives the same string.
+  def self.nf_hash_d
+    Ractor.store_if_absent(:__unicode_normalize_nf_hash_d__) do
+      Hash.new do |hash, key|
+        hash.shift if hash.length>MAX_HASH_LENGTH # prevent DoS attack
+        hash[key] = nfd_one(key)
+      end
+    end
+  end
+
+  def self.nf_hash_c
+    Ractor.store_if_absent(:__unicode_normalize_nf_hash_c__) do
+      Hash.new do |hash, key|
+        hash.shift if hash.length>MAX_HASH_LENGTH # prevent DoS attack
+        hash[key] = nfc_one(key)
+      end
+    end
+  end
 
   ## Constants For Hangul
   # for details such as the meaning of the identifiers below, please see
@@ -53,7 +65,7 @@ module UnicodeNormalize  # :nodoc:
 
   # Unicode-based encodings (except UTF-8)
   UNICODE_ENCODINGS = [Encoding::UTF_16BE, Encoding::UTF_16LE, Encoding::UTF_32BE, Encoding::UTF_32LE,
-                       Encoding::GB18030, Encoding::UCS_2BE, Encoding::UCS_4BE]
+                       Encoding::GB18030, Encoding::UCS_2BE, Encoding::UCS_4BE].freeze
 
   ## Hangul Algorithm
   def self.hangul_decomp_one(target)
@@ -135,13 +147,13 @@ module UnicodeNormalize  # :nodoc:
     when Encoding::UTF_8
       case form
       when :nfc then
-        string.gsub REGEXP_C, NF_HASH_C
+        string.gsub REGEXP_C, nf_hash_c
       when :nfd then
-        string.gsub REGEXP_D, NF_HASH_D
+        string.gsub REGEXP_D, nf_hash_d
       when :nfkc then
-        string.gsub(REGEXP_K, KOMPATIBLE_TABLE).gsub(REGEXP_C, NF_HASH_C)
+        string.gsub(REGEXP_K, KOMPATIBLE_TABLE).gsub(REGEXP_C, nf_hash_c)
       when :nfkd then
-        string.gsub(REGEXP_K, KOMPATIBLE_TABLE).gsub(REGEXP_D, NF_HASH_D)
+        string.gsub(REGEXP_K, KOMPATIBLE_TABLE).gsub(REGEXP_D, nf_hash_d)
       else
         raise ArgumentError, "Invalid normalization form #{form}."
       end
@@ -160,13 +172,17 @@ module UnicodeNormalize  # :nodoc:
     when Encoding::UTF_8
       case form
       when :nfc then
+        hash = nil # a string without a match never needs the cache
         string.scan REGEXP_C do |match|
-          return false  if NF_HASH_C[match] != match
+          hash ||= nf_hash_c
+          return false  if hash[match] != match
         end
         true
       when :nfd then
+        hash = nil
         string.scan REGEXP_D do |match|
-          return false  if NF_HASH_D[match] != match
+          hash ||= nf_hash_d
+          return false  if hash[match] != match
         end
         true
       when :nfkc then

--- a/test/test_unicode_normalize.rb
+++ b/test/test_unicode_normalize.rb
@@ -219,6 +219,22 @@ class TestUnicodeNormalize
     assert_equal "\u{16121 16121 16121 16121 16121 1611E}", "\u{1611E 16121 16121 16121 16121 16121}".unicode_normalize
   end
 
+  def test_ractor
+    assert_ractor(<<~'RUBY')
+      src = "D\u0307\u0323"
+      r = Ractor.new(src) do |s|
+        # call twice per form: the first fills the memoization cache, the second hits it
+        [%i[nfc nfd nfkc nfkd].map {|form| 2.times.map {s.unicode_normalize(form)}},
+         %i[nfc nfd nfkc nfkd].map {|form| s.unicode_normalized?(form)},
+         s.encode('UTF-16BE').unicode_normalize(:nfc)]
+      end.value
+      assert_equal([["\u1E0C\u0307"] * 2, ["D\u0323\u0307"] * 2,
+                    ["\u1E0C\u0307"] * 2, ["D\u0323\u0307"] * 2], r[0])
+      assert_equal([false] * 4, r[1])
+      assert_equal("\u1E0C\u0307".encode('UTF-16BE'), r[2])
+    RUBY
+  end
+
   def test_canonical_ordering
     a = "\u03B1\u0313\u0300\u0345"
     a_unordered1 = "\u03B1\u0345\u0313\u0300"


### PR DESCRIPTION
UnicodeNormalize.normalize and .normalized? read two constants that are not shareable, so any call from a non-main Ractor raised Ractor::IsolationError:

* NF_HASH_C / NF_HASH_D, the memoization caches. They cannot be made shareable because a shareable Hash cannot be written to. Keep them per Ractor instead: normalization is deterministic, so recomputing an entry in another Ractor always gives the same string, and the cache is only a cache. The DoS bound of MAX_HASH_LENGTH now applies per Ractor.

* UNICODE_ENCODINGS, which is splatted in a `when` clause on the path for UTF-16, UTF-32, GB18030 and UCS-2/4BE. Freeze it.

The other constants are already shareable on master: tables.rb is frozen_string_literal with frozen tables, and Regexp instances are frozen since cb03bf43eb.

Keeping the caches keeps main Ractor performance: dropping them instead costs 2.7x to 11x on real text, and asking the main Ractor for an entry costs 19.4us per round trip against 3.8us to just compute it. The per Ractor lookup adds about 60ns per call; normalized? fetches its cache lazily so a string without a match does not pay it.