### PR TITLE
[Bug #22302] Emit a line event for a method's implicit nil return in parse.y

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -14095,8 +14095,12 @@ reduce_nodes(struct parser_params *p, NODE **body)
     while (node) {
         int newline = (int)nd_fl_newline(node);
         switch (nd_type(node)) {
-          end:
           case NODE_NIL:
+            // Keep an explicit nil in a method's tail (value) position when it
+            // is on its own line, so it still emits a :line event and records
+            // line coverage for that line. [Bug #22302]
+            if (newline) return;
+          end:
             *body = 0;
             return;
           case NODE_BEGIN:

--- a/test/coverage/test_coverage.rb
+++ b/test/coverage/test_coverage.rb
@@ -489,6 +489,26 @@ def test_branch_coverage_for_eval_repeated
     end;
   end
 
+  def test_line_coverage_for_implicit_nil_return
+    result = {
+      :lines => [1, 1, nil, nil, 1, 1, 1, nil, nil, nil, 1, 1]
+    }
+    assert_coverage(<<~"end;", { lines: true }, result) # Bug #22302
+      def a
+        nil
+      end
+
+      def b(x)
+        if x
+          nil
+        end
+      end
+
+      a
+      b(true)
+    end;
+  end
+
   def test_branch_coverage_for_if_statement
     result = {
       :branches => {


### PR DESCRIPTION
reduce_nodes eliminated a bare `nil` in a method's tail (value) position down to an empty method body, so parse.y emitted no :line event and recorded no line coverage for that line, even though it is executed:

    def m
      nil    # <- no :line event, no coverage under parse.y
    end

The Prism compiler keeps the explicit nil and correctly emits the event. Keep the nil in reduce_nodes when it carries a newline flag (i.e. it is on its own line) so it still produces a line event, while the implicit nil of an empty body (no newline flag) is still dropped. This makes parse.y match Prism for TracePoint :line events and line coverage.