### PR TITLE
mkmf: Remove dead icc warnflags workaround

### DIFF
--- a/lib/mkmf.rb
+++ b/lib/mkmf.rb
@@ -2763,9 +2763,6 @@ site-install-rb: install-rb
     if $warnflags = CONFIG['warnflags'] and CONFIG['GCC'] == 'yes'
       # turn warnings into errors only for bundled extensions.
       config['warnflags'] = $warnflags.gsub(/(?:\A|\s)-W\Kerror[-=](?!implicit-function-declaration)/, '')
-      if /icc\z/ =~ config['CC']
-        config['warnflags'].gsub!(/(\A|\s)-W(?:division-by-zero|deprecated-declarations)/, '\1')
-      end
       RbConfig.expand(rbconfig['warnflags'] = config['warnflags'].dup)
       config.each do |key, val|
         RbConfig.expand(rbconfig[key] = val.dup) if /warnflags/ =~ val


### PR DESCRIPTION
`init_mkmf` strips `-Wdivision-by-zero` and `-Wdeprecated-declarations` from the extension `warnflags` when `RbConfig::CONFIG['CC']` matches `/icc\z/`. The workaround came from 9bed6e8e8ef (2016), where the classic `icc` rejected the plain `-W` spellings.

The branch no longer fires. On `icc.rubyci.org` the configured `CC` is `icx -std=gnu99 -std=gnu11` because `AC_PROG_CC` appends `-std=gnu11`, so the anchored pattern never matches. I confirmed that by running an `extconf.rb` there against the CI compiler.

It is also no longer needed. `icx` 2026.1.1 accepts both flags and emits the warnings they name, and a bundled extension compiles cleanly with both on the command line. The classic `icc` no longer ships in oneAPI. So I am removing the branch rather than widening the pattern to `icx`. The `icc` handling in `configure.ac` is a separate question and I am leaving it alone here.

Generated with [Claude Code](https://claude.com/claude-code)
