### PR TITLE
Run test_splat_long_array on RubyCI's openSUSE machine

### DIFF
--- a/test/ruby/test_method.rb
+++ b/test/ruby/test_method.rb
@@ -1465,10 +1465,6 @@ class TestMethod < Test::Unit::TestCase
   end
 
   def test_splat_long_array
-    if File.exist?('/etc/os-release') && File.read('/etc/os-release').include?('openSUSE Leap')
-      # For RubyCI's openSUSE machine http://rubyci.s3.amazonaws.com/opensuseleap/ruby-trunk/recent.html, which tends to die with NoMemoryError here.
-      omit 'do not exhaust memory on RubyCI openSUSE Leap machine'
-    end
     n = 10_000_000
     assert_equal n  , rest_parameter(*(1..n)).size, '[Feature #10440]'
   end


### PR DESCRIPTION
`test_splat_long_array` has been omitted on openSUSE Leap since 2018, when RubyCI's openSUSE machine died with `NoMemoryError` on the 10 million element splat. That machine is now openSUSE Leap 16.0 with 2 CPUs, 3857MB of RAM and no swap, and the guard still matches its `/etc/os-release`, so the test never runs there.

I measured it on that machine using the `master` build (`a4ad8e461a`) that `chkbuild` had just installed. Peak RSS grows linearly with `n`, reaching 172MB at 10,000,000, and `TestMethod#test_splat_long_array` passes in 0.42s under `test/runner.rb`. The whole `test/ruby/test_method.rb` file peaks at 180MB while the concurrent `chkbuild` `test-all` process sits at 360MB, so there is plenty of headroom.

Generated with [Claude Code](https://claude.com/claude-code)
