### PR TITLE
Do not measure with a per-thread CPU clock under the M:N scheduler

### DIFF
--- a/process.c
+++ b/process.c
@@ -8124,6 +8124,13 @@ ruby_real_ms_time(void)
  *  +:CLOCK_MONOTONIC+, +:CLOCK_PROCESS_CPUTIME_ID+,
  *  and +:CLOCK_THREAD_CPUTIME_ID+ are optional.
  *
+ *  +:CLOCK_THREAD_CPUTIME_ID+ measures the native thread that reads it, not
+ *  the Ruby thread.  Under the M:N thread scheduler (see +RUBY_MN_THREADS+) a
+ *  Ruby thread can move between native threads, so two reads taken from one
+ *  Ruby thread may come from different native threads, and the later read can
+ *  be smaller than the earlier one.  To measure elapsed time there, use
+ *  +:CLOCK_PROCESS_CPUTIME_ID+ or +:CLOCK_MONOTONIC+.
+ *
  *  Certain emulations are used when the given +clock_id+
  *  is not supported directly:
  *

--- a/tool/lib/core_assertions.rb
+++ b/tool/lib/core_assertions.rb
@@ -876,10 +876,15 @@ eom
       end
       alias all_assertions_foreach assert_all_assertions_foreach
 
-      %w[
+      clocks = %w[
         CLOCK_THREAD_CPUTIME_ID CLOCK_PROCESS_CPUTIME_ID
         CLOCK_MONOTONIC
-      ].find do |c|
+      ]
+      # CLOCK_THREAD_CPUTIME_ID is per native thread, and an M:N thread moves
+      # between native threads, so it can go backwards and yield a negative
+      # elapsed time.  Measure process CPU time there instead.
+      clocks.shift if RUBY_DESCRIPTION.include?("+MN")
+      clocks.find do |c|
         if Process.const_defined?(c)
           [c.to_sym, Process.const_get(c)].find do |clk|
             begin


### PR DESCRIPTION
assert_linear_performance() prefers CLOCK_THREAD_CPUTIME_ID when it is available. That clock belongs to the native thread that reads it, and an M:N thread moves between native threads, so the two reads around one measurement can come from different native threads and the elapsed time comes out negative:

Expected 0 to be <= -2.2150775009999997.

This shows up as flaky failures in the linearity/timeout tests when the M:N scheduler runs the main thread.

Reproduced with RUBY_MN_THREADS=2, 1500 fork/waitpid pairs per run: the Ruby thread changed native thread 1, 9 and 10 times over three runs, and the clock went backwards 1, 5 and 6 times, by as much as 0.38s. The default, =1 and =-1 never moved the main thread and never went backwards. CLOCK_PROCESS_CPUTIME_ID stayed monotonic across 15 such migrations.

Prefer process CPU time when the M:N scheduler is on. This only changes which clock the assertion uses; it does not relax the assertion.

The second commit notes the caveat on Process.clock_gettime, since it applies to any code reading that clock, not just this assertion.