### PR TITLE
Remove obsolete s390x skip guards from core tests

### DIFF
--- a/test/ruby/test_array.rb
+++ b/test/ruby/test_array.rb
@@ -1821,7 +1821,6 @@ class TestArray < Test::Unit::TestCase
   end
 
   def test_slice_gc_compact_stress
-    omit "compaction doesn't work well on s390x" if RUBY_PLATFORM =~ /s390x/ # https://github.com/ruby/ruby/pull/5077
     EnvUtil.under_gc_compact_stress { assert_equal([1, 2, 3, 4, 5], (0..10).to_a[1, 5]) }
     EnvUtil.under_gc_compact_stress do
       a = [0, 1, 2, 3, 4, 5]

--- a/test/ruby/test_enumerator.rb
+++ b/test/ruby/test_enumerator.rb
@@ -128,7 +128,6 @@ class TestEnumerator < Test::Unit::TestCase
   end
 
   def test_with_index_under_gc_compact_stress
-    omit "compaction doesn't work well on s390x" if RUBY_PLATFORM =~ /s390x/ # https://github.com/ruby/ruby/pull/5077
     EnvUtil.under_gc_compact_stress do
       assert_equal([[1, 0], [2, 1], [3, 2]], @obj.to_enum(:foo, 1, 2, 3).with_index.to_a)
       assert_equal([[1, 5], [2, 6], [3, 7]], @obj.to_enum(:foo, 1, 2, 3).with_index(5).to_a)
@@ -864,7 +863,6 @@ class TestEnumerator < Test::Unit::TestCase
   end
 
   def test_lazy_chain_under_gc_compact_stress
-    omit "compaction doesn't work well on s390x" if RUBY_PLATFORM =~ /s390x/ # https://github.com/ruby/ruby/pull/5077
     EnvUtil.under_gc_compact_stress do
       ea = (10..).lazy.select(&:even?).take(10)
       ed = (20..).lazy.select(&:odd?)

--- a/test/ruby/test_eval.rb
+++ b/test/ruby/test_eval.rb
@@ -639,7 +639,6 @@ class TestEval < Test::Unit::TestCase
 
   def test_outer_local_variable_under_gc_compact_stress
     omit "compaction is not supported on this platform" unless GC.respond_to?(:compact)
-    omit "compaction is not supported on s390x" if /s390x/ =~ RUBY_PLATFORM
 
     assert_separately([], <<~RUBY)
       o = Object.new

--- a/test/ruby/test_exception.rb
+++ b/test/ruby/test_exception.rb
@@ -1478,8 +1478,6 @@ $stderr = $stdout; raise "\x82\xa0"') do |outs, errs, status|
   end
 
   def test_detailed_message_under_gc_compact_stress
-    omit "compaction doesn't work well on s390x" if RUBY_PLATFORM =~ /s390x/ # https://github.com/ruby/ruby/pull/5077
-
     # The first error display lazily requires did_you_mean and friends; inside the
     # block that library load costs one full mark+compact per allocation, enough to
     # trip the parallel runner's no-response timeout.  Load it here instead.

--- a/test/ruby/test_gc_compact.rb
+++ b/test/ruby/test_gc_compact.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 require 'test/unit'
 
-if RUBY_PLATFORM =~ /s390x/
-  warn "Currently, it is known that the compaction does not work well on s390x; contribution is welcome https://github.com/ruby/ruby/pull/5077"
-  return
-end
-
 class TestGCCompact < Test::Unit::TestCase
   module CompactionSupportInspector
     def supports_compact?

--- a/test/ruby/test_method.rb
+++ b/test/ruby/test_method.rb
@@ -492,7 +492,6 @@ class TestMethod < Test::Unit::TestCase
   end
 
   def test_clone_under_gc_compact_stress
-    omit "compaction doesn't work well on s390x" if RUBY_PLATFORM =~ /s390x/ # https://github.com/ruby/ruby/pull/5077
     EnvUtil.under_gc_compact_stress do
       o = Object.new
       def o.foo; :foo; end

--- a/test/ruby/test_regexp.rb
+++ b/test/ruby/test_regexp.rb
@@ -73,7 +73,6 @@ class TestRegexp < Test::Unit::TestCase
   end
 
   def test_to_s_under_gc_compact_stress
-    omit "compaction doesn't work well on s390x" if RUBY_PLATFORM =~ /s390x/ # https://github.com/ruby/ruby/pull/5077
     EnvUtil.under_gc_compact_stress do
       str = "abcd\u3042"
       [:UTF_16BE, :UTF_16LE, :UTF_32BE, :UTF_32LE].each do |es|
@@ -471,7 +470,6 @@ class TestRegexp < Test::Unit::TestCase
   end
 
   def test_inspect_under_gc_compact_stress
-    omit "compaction doesn't work well on s390x" if RUBY_PLATFORM =~ /s390x/ # https://github.com/ruby/ruby/pull/5077
     EnvUtil.under_gc_compact_stress do
       assert_equal('/(?-mix:\\/)|/', Regexp.union(/\//, "").inspect)
     end
@@ -904,7 +902,6 @@ class TestRegexp < Test::Unit::TestCase
   end
 
   def test_match_under_gc_compact_stress
-    omit "compaction doesn't work well on s390x" if RUBY_PLATFORM =~ /s390x/ # https://github.com/ruby/ruby/pull/5077
     EnvUtil.under_gc_compact_stress do
       m = /(?<foo>.)(?<n>[^aeiou])?(?<bar>.+)/.match("hoge\u3042")
       assert_equal("h", m.match(:foo))

--- a/test/ruby/test_regexp.rb
+++ b/test/ruby/test_regexp.rb
@@ -2139,7 +2139,6 @@ class TestRegexp < Test::Unit::TestCase
   end
 
   def test_timeout_longer_than_global
-    omit "timeout test is too unstable on s390x" if RUBY_PLATFORM =~ /s390x/
     per_instance_redos_test(0.01, 0.5, 0.5)
   end
 

--- a/test/ruby/test_string.rb
+++ b/test/ruby/test_string.rb
@@ -926,7 +926,6 @@ CODE
   end
 
   def test_undump_gc_compact_stress
-    omit "compaction doesn't work well on s390x" if RUBY_PLATFORM =~ /s390x/ # https://github.com/ruby/ruby/pull/5077
     a = S("Test") << 1 << 2 << 3 << 9 << 13 << 10
     EnvUtil.under_gc_compact_stress do
       assert_equal(a, S('"Test\\x01\\x02\\x03\\t\\r\\n"').undump)
@@ -1451,7 +1450,6 @@ CODE
   end
 
   def test_gsub_gc_compact_stress
-    omit "compaction doesn't work well on s390x" if RUBY_PLATFORM =~ /s390x/ # https://github.com/ruby/ruby/pull/5077
     EnvUtil.under_gc_compact_stress { assert_equal(S("h<e>ll<o>"), S("hello").gsub(/([aeiou])/, S('<\1>'))) }
   end
 
@@ -1499,7 +1497,6 @@ CODE
   end
 
   def test_gsub_bang_gc_compact_stress
-    omit "compaction doesn't work well on s390x" if RUBY_PLATFORM =~ /s390x/ # https://github.com/ruby/ruby/pull/5077
     EnvUtil.under_gc_compact_stress do
       a = S("hello")
       a.gsub!(/([aeiou])/, S('<\1>'))
@@ -1870,7 +1867,6 @@ CODE
   end
 
   def test_scan_gc_compact_stress
-    omit "compaction doesn't work well on s390x" if RUBY_PLATFORM =~ /s390x/ # https://github.com/ruby/ruby/pull/5077
     EnvUtil.under_gc_compact_stress { assert_equal([["1a"], ["2b"], ["3c"]], S("1a2b3c").scan(/(\d.)/)) }
   end
 
@@ -2418,7 +2414,6 @@ CODE
   end
 
   def test_sub_gc_compact_stress
-    omit "compaction doesn't work well on s390x" if RUBY_PLATFORM =~ /s390x/ # https://github.com/ruby/ruby/pull/5077
     EnvUtil.under_gc_compact_stress do
       m = /&(?<foo>.*?);/.match(S("aaa &amp; yyy"))
       assert_equal("amp", m["foo"])

--- a/test/ruby/test_symbol.rb
+++ b/test/ruby/test_symbol.rb
@@ -122,8 +122,6 @@ class TestSymbol < Test::Unit::TestCase
   end
 
   def test_inspect_under_gc_compact_stress
-    omit "compaction doesn't work well on s390x" if RUBY_PLATFORM =~ /s390x/ # https://github.com/ruby/ruby/pull/5077
-
     EnvUtil.under_gc_compact_stress do
       assert_inspect_evaled(':testing')
     end

--- a/test/ruby/test_transcode.rb
+++ b/test/ruby/test_transcode.rb
@@ -2398,7 +2398,6 @@ class TestTranscode < Test::Unit::TestCase
   end
 
   def test_ractor_lazy_load_encoding_random
-    omit 'unstable on s390x' if RUBY_PLATFORM =~ /s390x/
     assert_ractor("#{<<~"begin;"}\n#{<<~'end;'}", timeout: 30)
     begin;
       rs = []

--- a/test/ruby/test_variable.rb
+++ b/test/ruby/test_variable.rb
@@ -521,7 +521,6 @@ class TestVariable < Test::Unit::TestCase
   end
 
   def test_exivar_resize_with_compaction_stress
-    omit "compaction doesn't work well on s390x" if RUBY_PLATFORM =~ /s390x/ # https://github.com/ruby/ruby/pull/5077
     objs = 10_000.times.map do
       ExIvar.new
     end

--- a/test/ruby/test_weakkeymap.rb
+++ b/test/ruby/test_weakkeymap.rb
@@ -138,7 +138,6 @@ class TestWeakKeyMap < Test::Unit::TestCase
   end
 
   def test_gc_compact_stress
-    omit "compaction doesn't work well on s390x" if RUBY_PLATFORM =~ /s390x/ # https://github.com/ruby/ruby/pull/5077
     EnvUtil.under_gc_compact_stress { ObjectSpace::WeakKeyMap.new }
   end
 

--- a/test/ruby/test_weakmap.rb
+++ b/test/ruby/test_weakmap.rb
@@ -257,7 +257,6 @@ class TestWeakMap < Test::Unit::TestCase
   end
 
   def test_gc_compact_stress
-    omit "compaction doesn't work well on s390x" if RUBY_PLATFORM =~ /s390x/ # https://github.com/ruby/ruby/pull/5077
     EnvUtil.under_gc_compact_stress { ObjectSpace::WeakMap.new }
   end
 

--- a/tool/lib/envutil.rb
+++ b/tool/lib/envutil.rb
@@ -365,8 +365,6 @@ module EnvUtil
   module_function :under_gc_stress
 
   def under_gc_compact_stress(val = :empty, &block)
-    raise "compaction doesn't work well on s390x. Omit the test in the caller." if RUBY_PLATFORM =~ /s390x/ # https://github.com/ruby/ruby/pull/5077
-
     if GC.respond_to?(:auto_compact)
       auto_compact = GC.auto_compact
       GC.auto_compact = val


### PR DESCRIPTION
GC compaction has been skipped on s390x since 2021 because the tests randomly stalled past the 1800s output timeout. `test_timeout_longer_than_global` and `test_ractor_lazy_load_encoding_random` were skipped later for instability. None of these still reproduces.

I verified on `s390x.rubyci.org`, building master with `make -j1` and stripping every s390x guard under `test/` and `tool/`. The compaction tests pass individually, inside a full serial `test-all` matching chkbuild, and across a 100 run soak under CPU saturation, with `GC.compact` and `GC.verify_compaction_references` both correct. `test_timeout_longer_than_global` passed 70 of 70 and `test_ractor_lazy_load_encoding_random` 40 of 40, including runs under saturation.

One guard stays. `test_timeout_shorter_than_global` still reproduces its original failure, but only under CPU oversubscription, so the sensitivity is scheduling delay rather than s390x.

Generated with [Claude Code](https://claude.com/claude-code)
