### PR TITLE
[Bug #11142] Fix "" escape inside quoted command line arguments

### DIFF
--- a/test/ruby/test_rubyoptions.rb
+++ b/test/ruby/test_rubyoptions.rb
@@ -1130,9 +1130,9 @@ class TestRubyOptions < Test::Unit::TestCase
     def test_command_line_quote_pair
       bug11142 = '[Bug #11142]'
       ruby = EnvUtil.rubybin
-      cmd = %["#{ruby}" -e "puts ARGV" "foo""bar" "foo"" bar" "foo""bar""baz" a""b "a\\"b" "" "a"""" b" """" c 'a''b']
+      cmd = %["#{ruby}" -e "puts ARGV" "foo""bar" "foo"" bar" "foo""bar""baz" a""b "a\\"b" "" "a"""" b" """" c 'a''b' "a"" b c]
       out = IO.popen(cmd, &:read).lines(chomp: true)
-      assert_equal(['foo"bar', 'foo" bar', 'foo"bar"baz', 'ab', 'a"b', '', 'a"" b', '"', 'c', 'ab'],
+      assert_equal(['foo"bar', 'foo" bar', 'foo"bar"baz', 'ab', 'a"b', '', 'a"" b', '"', 'c', 'ab', 'a" b c'],
                    out, bug11142)
     end
   when /cygwin/

--- a/test/ruby/test_rubyoptions.rb
+++ b/test/ruby/test_rubyoptions.rb
@@ -1130,9 +1130,9 @@ class TestRubyOptions < Test::Unit::TestCase
     def test_command_line_quote_pair
       bug11142 = '[Bug #11142]'
       ruby = EnvUtil.rubybin
-      cmd = %["#{ruby}" -e "puts ARGV" "foo""bar" "foo"" bar" "foo""bar""baz" a""b "a\\"b" "" "a"""" b" """" c]
+      cmd = %["#{ruby}" -e "puts ARGV" "foo""bar" "foo"" bar" "foo""bar""baz" a""b "a\\"b" "" "a"""" b" """" c 'a''b']
       out = IO.popen(cmd, &:read).lines(chomp: true)
-      assert_equal(['foo"bar', 'foo" bar', 'foo"bar"baz', 'ab', 'a"b', '', 'a"" b', '"', 'c'],
+      assert_equal(['foo"bar', 'foo" bar', 'foo"bar"baz', 'ab', 'a"b', '', 'a"" b', '"', 'c', 'ab'],
                    out, bug11142)
     end
   when /cygwin/

--- a/test/ruby/test_rubyoptions.rb
+++ b/test/ruby/test_rubyoptions.rb
@@ -1132,6 +1132,7 @@ class TestRubyOptions < Test::Unit::TestCase
       ruby = EnvUtil.rubybin
       cmd = %["#{ruby}" -e "puts ARGV" "foo""bar" "foo"" bar" "foo""bar""baz" a""b "a\\"b" "" "a"""" b" """" c 'a''b' "a"" b c]
       out = IO.popen(cmd, &:read).lines(chomp: true)
+      assert_predicate($?, :success?, bug11142)
       assert_equal(['foo"bar', 'foo" bar', 'foo"bar"baz', 'ab', 'a"b', '', 'a"" b', '"', 'c', 'ab', 'a" b c'],
                    out, bug11142)
     end

--- a/test/ruby/test_rubyoptions.rb
+++ b/test/ruby/test_rubyoptions.rb
@@ -1135,7 +1135,6 @@ class TestRubyOptions < Test::Unit::TestCase
       assert_equal(['foo"bar', 'foo" bar', 'foo"bar"baz', 'ab', 'a"b', '', 'a"" b', '"', 'c'],
                    out, bug11142)
     end
-
   when /cygwin/
     def test_command_line_non_ascii
       assert_separately([{"LC_ALL"=>"ja_JP.SJIS"}, "-", "\u{3042}".encode("SJIS")], <<-"end;")

--- a/test/ruby/test_rubyoptions.rb
+++ b/test/ruby/test_rubyoptions.rb
@@ -1126,6 +1126,16 @@ class TestRubyOptions < Test::Unit::TestCase
         assert_e_script_encoding(s, %W[-E#{locale.name}])
       end
     end
+
+    def test_command_line_quote_pair
+      bug11142 = '[Bug #11142]'
+      ruby = EnvUtil.rubybin
+      cmd = %["#{ruby}" -e "puts ARGV" "foo""bar" "foo"" bar" "foo""bar""baz" a""b "a\\"b" "" "a"""" b" """" c]
+      out = IO.popen(cmd, &:read).lines(chomp: true)
+      assert_equal(['foo"bar', 'foo" bar', 'foo"bar"baz', 'ab', 'a"b', '', 'a"" b', '"', 'c'],
+                   out, bug11142)
+    end
+
   when /cygwin/
     def test_command_line_non_ascii
       assert_separately([{"LC_ALL"=>"ja_JP.SJIS"}, "-", "\u{3042}".encode("SJIS")], <<-"end;")

--- a/win32/win32.c
+++ b/win32/win32.c
@@ -1812,8 +1812,9 @@ w32_cmdvector(const WCHAR *cmd, char ***vec, UINT cp, rb_encoding *enc)
                 // the string, but not necessarily with the element.
                 // If we're not already in a string, start one.
                 // A pair of double quotes inside a double-quoted string
-                // is an escaped double quote, and does not terminate
-                // the string.
+                // is an escaped double quote, and does not terminate the
+                // string, following MSVCRT/UCRT parse_cmdline rather
+                // than shell32's CommandLineToArgvW. See [Bug #11142]
                 //
 
                 if (!(slashes & 1)) {

--- a/win32/win32.c
+++ b/win32/win32.c
@@ -1813,7 +1813,7 @@ w32_cmdvector(const WCHAR *cmd, char ***vec, UINT cp, rb_encoding *enc)
                 // If we're not already in a string, start one.
                 // A pair of double quotes inside a double-quoted string
                 // is an escaped double quote, and does not terminate the
-                // string, following MSVCRT/UCRT parse_cmdline rather
+                // string, following UCRT parse_cmdline rather
                 // than shell32's CommandLineToArgvW. See [Bug #11142]
                 //
 

--- a/win32/win32.c
+++ b/win32/win32.c
@@ -1811,6 +1811,9 @@ w32_cmdvector(const WCHAR *cmd, char ***vec, UINT cp, rb_encoding *enc)
                 // terminating close-quote. If it is, we're finished with
                 // the string, but not necessarily with the element.
                 // If we're not already in a string, start one.
+                // A pair of double quotes inside a double-quoted string
+                // is an escaped double quote, and does not terminate
+                // the string.
                 //
 
                 if (!(slashes & 1)) {
@@ -1819,7 +1822,8 @@ w32_cmdvector(const WCHAR *cmd, char ***vec, UINT cp, rb_encoding *enc)
                     else if (quote == *ptr) {
                         if (quote == L'"' && quote == ptr[1])
                             ptr++;
-                        quote = L'\0';
+                        else
+                            quote = L'\0';
                     }
                 }
                 escape++;
@@ -1873,7 +1877,8 @@ w32_cmdvector(const WCHAR *cmd, char ***vec, UINT cp, rb_encoding *enc)
                         if (quote) {
                             if (quote == L'"' && quote == *p)
                                 p++;
-                            quote = L'\0';
+                            else
+                                quote = L'\0';
                         }
                         else
                             quote = c;


### PR DESCRIPTION
`w32_cmdvector` treated a pair of double quotes inside a quoted string as a literal quote and closed the string at the same time, so `ruby -e "puts ARGV" "foo"" bar"` arrived as two arguments `foo"` and `bar` rather than one argument `foo" bar`. Keeping the quote state open follows the rule the modern CRT implements, where `2n` quotes inside a quoted string produce `n` literal quotes and `2n+1` quotes also toggle the state. I verified the whole family of quote cases against a CRT `argv` dump on Windows 11, and the fixed parser agrees with it everywhere. Backslash escapes are unchanged, and globbing is unaffected because wildcard suppression keys on single quotes.

The old behavior did match `CommandLineToArgvW`, which still implements the older rule, so a script relying on `"a"" b"` splitting into two arguments changes behavior.

https://bugs.ruby-lang.org/issues/11142
