### PR TITLE
[Bug #22301] Check IO Buffer is writeable before writing

### DIFF
--- a/io_buffer.c
+++ b/io_buffer.c
@@ -1158,6 +1158,8 @@ io_buffer_validate_for_writing(struct rb_io_buffer *buffer)
 static struct rb_io_buffer *
 get_io_buffer_for_writing(VALUE self)
 {
+    rb_check_frozen(self);
+
     struct rb_io_buffer *buffer = get_io_buffer(self);
     io_buffer_validate_for_writing(buffer);
     return buffer;
@@ -3302,7 +3304,7 @@ io_buffer_set_string(int argc, VALUE *argv, VALUE self)
 {
     rb_check_arity(argc, 1, 4);
 
-    struct rb_io_buffer *buffer = get_io_buffer(self);
+    struct rb_io_buffer *buffer = get_io_buffer_for_writing(self);
 
     VALUE string = rb_str_to_str(argv[0]);
 
@@ -3317,7 +3319,7 @@ io_buffer_set_string(int argc, VALUE *argv, VALUE self)
 void
 rb_io_buffer_clear(VALUE self, uint8_t value, size_t offset, size_t length)
 {
-    struct rb_io_buffer *buffer = get_io_buffer(self);
+    struct rb_io_buffer *buffer = get_io_buffer_for_writing(self);
 
     void *base;
     size_t size;
@@ -3472,10 +3474,10 @@ io_buffer_read_internal(void *_argument)
 VALUE
 rb_io_buffer_read(VALUE self, VALUE io, size_t offset, size_t length)
 {
+    struct rb_io_buffer *buffer = get_io_buffer_for_writing(self);
+
     io = rb_io_get_io(io);
 
-    struct rb_io_buffer *buffer = get_io_buffer(self);
-    io_buffer_validate_for_writing(buffer);
     io_buffer_validate_range(buffer, offset, length);
 
     if (length == 0) return SIZET2NUM(0);
@@ -3563,10 +3565,10 @@ io_buffer_pread_internal(void *_argument)
 VALUE
 rb_io_buffer_pread(VALUE self, VALUE io, rb_off_t from, size_t offset, size_t length)
 {
+    struct rb_io_buffer *buffer = get_io_buffer_for_writing(self);
+
     io = rb_io_get_io(io);
 
-    struct rb_io_buffer *buffer = get_io_buffer(self);
-    io_buffer_validate_for_writing(buffer);
     io_buffer_validate_range(buffer, offset, length);
 
     if (length == 0) return SIZET2NUM(0);
@@ -4032,7 +4034,7 @@ memory_and_inplace(unsigned char * restrict base, size_t size, unsigned char * r
 static VALUE
 io_buffer_and_inplace(VALUE self, VALUE mask)
 {
-    struct rb_io_buffer *buffer = get_io_buffer(self);
+    struct rb_io_buffer *buffer = get_io_buffer_for_writing(self);
 
     struct rb_io_buffer *mask_buffer = get_io_buffer(mask);
 
@@ -4080,7 +4082,7 @@ memory_or_inplace(unsigned char * restrict base, size_t size, unsigned char * re
 static VALUE
 io_buffer_or_inplace(VALUE self, VALUE mask)
 {
-    struct rb_io_buffer *buffer = get_io_buffer(self);
+    struct rb_io_buffer *buffer = get_io_buffer_for_writing(self);
 
     struct rb_io_buffer *mask_buffer = get_io_buffer(mask);
 
@@ -4128,7 +4130,7 @@ memory_xor_inplace(unsigned char * restrict base, size_t size, unsigned char * r
 static VALUE
 io_buffer_xor_inplace(VALUE self, VALUE mask)
 {
-    struct rb_io_buffer *buffer = get_io_buffer(self);
+    struct rb_io_buffer *buffer = get_io_buffer_for_writing(self);
 
     struct rb_io_buffer *mask_buffer = get_io_buffer(mask);
 
@@ -4176,7 +4178,7 @@ memory_not_inplace(unsigned char * restrict base, size_t size)
 static VALUE
 io_buffer_not_inplace(VALUE self)
 {
-    struct rb_io_buffer *buffer = get_io_buffer(self);
+    struct rb_io_buffer *buffer = get_io_buffer_for_writing(self);
 
     void *base;
     size_t size;

--- a/test/ruby/test_io_buffer.rb
+++ b/test/ruby/test_io_buffer.rb
@@ -838,6 +838,30 @@ class TestIOBuffer < Test::Unit::TestCase
     assert_equal string, buffer.get_string
   end
 
+  def test_write_frozen
+    buffer = IO::Buffer.new(8)
+    buffer.freeze
+
+    mask = IO::Buffer.new(8)
+
+    assert_raise(FrozenError) {buffer.set_string("x")}
+    assert_raise(FrozenError) {buffer.copy(IO::Buffer.new(8))}
+    assert_raise(FrozenError) {buffer.clear}
+    assert_raise(FrozenError) {buffer.set_value(:U8, 0, 1)}
+    assert_raise(FrozenError) {buffer.set_values([:U8], 0, [1])}
+    assert_raise(FrozenError) {buffer.and!(mask)}
+    assert_raise(FrozenError) {buffer.or!(mask)}
+    assert_raise(FrozenError) {buffer.xor!(mask)}
+    assert_raise(FrozenError) {buffer.not!}
+
+    File.open(__FILE__) do |file|
+      assert_raise(FrozenError) {buffer.read(file)}
+      assert_raise(FrozenError) {buffer.pread(file, 0)}
+    end
+
+    assert_equal "\0" * 8, buffer.get_string
+  end
+
   def test_counted_locking
     buffer = IO::Buffer.new(128)
 


### PR DESCRIPTION
Add a frozen check to `get_io_buffer_for_writing` and use that where we need to write to a buffer.

We also switch to use it in `read` and `pread` functions - they were manually calling `get_io_buffer` and `io_buffer_validate_for_writing` anyway, which is what `get_io_buffer_for_writing` does.