### PR TITLE
Reinitialize jit_cont_lock in a forked child

### DIFF
--- a/thread.c
+++ b/thread.c
@@ -5272,6 +5272,7 @@ rb_thread_atfork_internal(rb_thread_t *th, void (*atfork)(rb_thread_t *, const r
     rb_native_mutex_initialize(&th->interrupt_lock);
     rb_native_mutex_initialize(&vm->once_lock);
     rb_native_cond_initialize(&vm->once_cond);
+    rb_jit_cont_init(); // cont.c's jit_cont_lock, likewise
     rb_gc_zombie_objspaces_atfork();
     rb_gc_atfork_global_locks();
     rb_generic_fields_lock_atfork();


### PR DESCRIPTION
cont.c takes jit_cont_lock whenever an execution context is created or freed.  cont_free() does it from a Ractor reclaiming its own dead root fiber, outside the VM lock, so fork() can land there.  The child then inherits the lock held by a thread that no longer exists, and aborts in rb_jit_cont_finish():

    [BUG] pthread_mutex_destroy: Device or resource busy (EBUSY)

rb_thread_atfork_internal() already reinitializes the other locks another thread may have held at the fork; jit_cont_lock was missing.