### PR TITLE
ZJIT: Compile exception handlers

### DIFF
--- a/jit.c
+++ b/jit.c
@@ -652,6 +652,9 @@ rb_iseq_reset_jit_func(const rb_iseq_t *iseq)
     RUBY_ASSERT_ALWAYS(IMEMO_TYPE_P(iseq, imemo_iseq));
     ISEQ_BODY(iseq)->jit_entry = NULL;
     ISEQ_BODY(iseq)->jit_exception = NULL;
+#if USE_ZJIT
+    ISEQ_BODY(iseq)->zjit_exception_pc = NULL;
+#endif
     // Enable re-compiling this ISEQ. Event when it's invalidated for TracePoint,
     // we'd like to re-compile ISEQs that haven't been converted to trace_* insns.
     ISEQ_BODY(iseq)->jit_entry_calls = 0;

--- a/test/ruby/test_zjit_cli.rb
+++ b/test/ruby/test_zjit_cli.rb
@@ -174,6 +174,31 @@ class TestZJITCLI < Test::Unit::TestCase
     assert_equal "[1, 3, 4]", out
   end
 
+  def test_exception_handlers
+    assert_compiles '[[0, 1, 2, 3], [:ensure, :ensure, :ensure], 0]', <<~RUBY, call_threshold: 2, stats: true
+      def rescued_value(hash)
+        hash.fetch(:missing)
+      rescue KeyError
+        hash[:answer]
+      end
+
+      def ensure_value(log)
+        raise "boom"
+      ensure
+        log << :ensure
+      end
+      values = 4.times.map { |value| rescued_value(answer: value) }
+      log = []
+      3.times do
+        begin
+          ensure_value(log)
+        rescue RuntimeError
+        end
+      end
+      [values, log, RubyVM::ZJIT.stats(:exit_exception_handler)]
+    RUBY
+  end
+
   def test_send_exit_with_uninitialized_locals
     assert_runs 'nil', %q{
       def entry(init)

--- a/vm.c
+++ b/vm.c
@@ -618,41 +618,69 @@ jit_compile_exception(rb_execution_context_t *ec)
     struct rb_iseq_constant_body *body = ISEQ_BODY(iseq);
 
 #if USE_ZJIT
-    // rb_zjit_compiling_p is false until ZJIT is enabled, so no
-    // rb_zjit_enabled_p check is needed here.
-    if (body->jit_exception == NULL && rb_zjit_compiling_p) {
-        body->jit_exception_calls++;
+    if (rb_zjit_enabled_p) {
+        const VALUE *pc = CFP_PC(ec->cfp);
 
-        // At profile-threshold, rewrite some of the YARV instructions
-        // to zjit_* instructions to profile these instructions.
-        if (body->jit_exception_calls == rb_zjit_profile_threshold) {
-            rb_zjit_profile_enable(iseq);
+        // Count calls until the first exception entry reaches the compile threshold.
+        if (rb_zjit_compiling_p && body->jit_exception_calls < rb_zjit_call_threshold) {
+            body->jit_exception_calls++;
+
+            // At profile-threshold, rewrite some of the YARV instructions
+            // to zjit_* instructions to profile these instructions.
+            if (body->jit_exception_calls == rb_zjit_profile_threshold) {
+                rb_zjit_profile_enable(iseq);
+            }
         }
 
-        // At call-threshold, compile the ISEQ with ZJIT.
-        if (body->jit_exception_calls == rb_zjit_call_threshold) {
+        // Compile or select an entry for the current handler PC.
+        if (rb_zjit_compiling_p &&
+            body->jit_exception_calls >= rb_zjit_call_threshold &&
+            body->zjit_exception_pc != pc) {
             rb_zjit_compile_iseq(iseq, ec, true);
         }
+
+        return body->zjit_exception_pc == pc ? body->jit_exception : NULL;
     }
 #endif
 
 #if USE_YJIT
     // Increment the ISEQ's call counter and trigger JIT compilation if not compiled.
-    // Like the ZJIT branch above, no rb_yjit_enabled_p check is needed here.
     if (body->jit_exception == NULL && rb_yjit_compiling_p) {
         body->jit_exception_calls++;
         if (body->jit_exception_calls == rb_yjit_call_threshold) {
             rb_yjit_compile_iseq(iseq, ec, true);
         }
     }
-#endif
     return body->jit_exception;
+#else
+    return NULL;
+#endif
 }
 
 // Execute JIT code compiled by jit_compile_exception()
 static inline VALUE
 jit_exec_exception(rb_execution_context_t *ec)
 {
+#if USE_ZJIT
+    if (rb_zjit_enabled_p) {
+        void *zjit_entry = rb_zjit_entry;
+        if (zjit_entry) {
+            rb_jit_func_t func = jit_compile_exception(ec);
+            if (func) {
+                // The JIT pops the handler frame on leave. Save its FINISH flag first.
+                bool finish = VM_FRAME_FINISHED_P(ec->cfp);
+                VALUE result = ((rb_zjit_func_t)zjit_entry)(ec, ec->cfp, func);
+                if (!UNDEF_P(result) && !finish) {
+                    *ec->cfp->sp++ = result;
+                    return Qundef;
+                }
+                return result;
+            }
+        }
+        return Qundef;
+    }
+#endif
+
     rb_jit_func_t func = jit_compile_exception(ec);
     if (func) {
         // Call the JIT code

--- a/vm_core.h
+++ b/vm_core.h
@@ -577,6 +577,11 @@ struct rb_iseq_constant_body {
     rb_jit_func_t jit_entry;
     // Function pointer for JIT code on jit_exec_exception()
     rb_jit_func_t jit_exception;
+#if USE_ZJIT
+    // PC handled by jit_exception. ZJIT compiles separate entries for each handler PC.
+    const VALUE *zjit_exception_pc;
+#endif
+
     void *jit_payload;
 #endif
 

--- a/zjit.c
+++ b/zjit.c
@@ -140,7 +140,10 @@ rb_zjit_compile_iseq(const rb_iseq_t *iseq, rb_execution_context_t *ec, bool jit
         uintptr_t code_ptr = (uintptr_t)rb_zjit_iseq_gen_entry_point(iseq, ec, jit_exception);
 
         if (jit_exception) {
-            ISEQ_BODY(iseq)->jit_exception = (rb_jit_func_t)code_ptr;
+            if (code_ptr != 0) {
+                ISEQ_BODY(iseq)->jit_exception = (rb_jit_func_t)code_ptr;
+                ISEQ_BODY(iseq)->zjit_exception_pc = CFP_PC(ec->cfp);
+            }
         }
         else {
             ISEQ_BODY(iseq)->jit_entry = (rb_jit_func_t)code_ptr;

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -629,16 +629,16 @@ pub struct SideExit {
     /// `stack` and `locals` above.
     pub stack_map: Option<StackMap>,
     /// If set, the side exit will profile the current instruction and invalidate
-    /// the compiled ISEQ for recompilation.
+    /// the compiled version for recompilation.
     pub recompile: Option<SideExitRecompile>,
 }
 
 /// Metadata for the recompile callback on side exit.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct SideExitRecompile {
-    /// The compiled unit whose version must be invalidated to force a recompile. For inlined
-    /// methods, this will be the outer function it was inlined into.
-    pub compiled_iseq: Opnd,
+    /// The compiled version that must be invalidated. For inlined methods, this
+    /// version belongs to the outer function.
+    pub compiled_version: Opnd,
     /// The exiting frame's ISEQ, which owns the profile entry for `insn_idx`. For
     /// an exit out of inlined code this is the inlined callee, not the compiled unit.
     pub frame_iseq: Opnd,
@@ -3170,7 +3170,7 @@ impl Assembler
                 use crate::codegen::exit_recompile;
                 asm_comment!(asm, "profile and maybe recompile");
                 asm_ccall!(asm, exit_recompile,
-                    recompile.compiled_iseq,
+                    recompile.compiled_version,
                     recompile.frame_iseq,
                     recompile.insn_idx.into()
                 );

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -16,14 +16,14 @@ use crate::invariants::{
     track_root_box_assumption, track_no_newobj_hook_assumption
 };
 use crate::gc::append_gc_offsets;
-use crate::payload::{IseqCodePtrs, IseqStatus, IseqVersion, IseqVersionRef, JITFrame, get_or_create_iseq_payload};
+use crate::payload::{ExceptionEntry, IseqCodePtrs, IseqStatus, IseqVersion, IseqVersionRef, JITFrame, get_or_create_iseq_payload};
 use crate::profile::reset_profiles_remaining;
 use crate::state::{rb_zjit_compiling_p, ZJITState};
 use crate::stats::{CompileError, exit_counter_for_compile_error, exit_counter_for_unhandled_hir_insn, incr_counter, incr_counter_by, send_fallback_counter, send_fallback_counter_for_method_type, send_fallback_counter_for_super_method_type, send_fallback_counter_ptr_for_opcode, send_fallback_counter_for_optimized_method_type};
 use crate::stats::{counter_ptr, with_time_stat, trace_compile_phase, Counter, Counter::{compile_time_ns, exit_compile_error}};
 use crate::{asm::CodeBlock, cruby::*, options::debug, virtualmem::CodePtr};
 use crate::backend::lir::{self, Assembler, CArgLocation, C_ARG_OPNDS, C_RET_OPND, CFP, EC, NATIVE_BASE_PTR, NATIVE_STACK_PTR, Opnd, SP, SideExit, SideExitRecompile, SideExitTarget, StackMap, StackMapEntry, Target, asm_ccall, asm_comment};
-use crate::hir::{self, iseq_to_hir, BlockId, Invariant, RangeType, SideExitReason::{self, *}, SpecialBackrefSymbol, SpecialObjectType};
+use crate::hir::{self, iseq_to_hir, iseq_to_hir_exception, BlockId, Invariant, RangeType, SideExitReason::{self, *}, SpecialBackrefSymbol, SpecialObjectType};
 use crate::hir::{BlockHandler, CCallVariadicData, CCallWithFrameData, Const, FieldName, FrameState, Function, Insn, InsnId, Recompile, SendDirectData, SendFallbackReason, qualified_method_name};
 use crate::hir_type::{types, Type};
 use crate::options::{get_option, InlineDepth, PerfMap, DEFAULT_MAX_VERSIONS};
@@ -173,9 +173,12 @@ define_split_jumps! {
 /// triggers before the HIR is built so the `self`-producing instructions can be
 /// typed precisely. Must be called while holding the VM lock (it writes the payload).
 fn update_self_is_heap_object(iseq: IseqPtr, cfp: CfpPtr) {
-    let cme = unsafe { rb_vm_frame_method_entry(cfp) };
-    let self_is_heap_object = !cme.is_null()
-        && iseq_self_is_heap_object(iseq, unsafe { (*cme).owner });
+    let self_is_heap_object = if unsafe { get_iseq_body_type(iseq) } == ISEQ_TYPE_METHOD {
+        let cme = unsafe { rb_vm_frame_method_entry(cfp) };
+        !cme.is_null() && iseq_self_is_heap_object(iseq, unsafe { (*cme).owner })
+    } else {
+        false
+    };
     get_or_create_iseq_payload(iseq).self_is_heap_object = self_is_heap_object;
 }
 
@@ -189,16 +192,24 @@ pub extern "C" fn rb_zjit_iseq_gen_entry_point(iseq: IseqPtr, ec: EcPtr, jit_exc
         incr_counter!(skipped_native_stack_full);
         return std::ptr::null();
     }
+    // Exception entries can resume frames whose environments escaped to the heap.
+    // ZJIT entry code requires an on-stack environment.
+    if jit_exception && unsafe { cfp_env_has_escaped(get_ec_cfp(ec)) } {
+        incr_counter!(skipped_exceptional_entry_escaped_env);
+        return std::ptr::null();
+    }
+
 
     // Take a lock to avoid writing to ISEQ in parallel with Ractors.
     // with_vm_lock() does nothing if the program doesn't use Ractors.
     with_vm_lock(src_loc!(), || {
-        // The current frame is this ISEQ's method frame, so its method entry tells
-        // us the owning class and thus whether `self` is always a heap object.
-        update_self_is_heap_object(iseq, unsafe { get_ec_cfp(ec) });
+        if !jit_exception {
+            // A normal entry uses the current method frame to refine the type of `self`.
+            update_self_is_heap_object(iseq, unsafe { get_ec_cfp(ec) });
+        }
 
         let cb = ZJITState::get_code_block();
-        let mut code_ptr = with_time_stat(compile_time_ns, || gen_iseq_entry_point(cb, iseq, jit_exception));
+        let mut code_ptr = with_time_stat(compile_time_ns, || gen_iseq_entry_point(cb, iseq, ec, jit_exception));
 
         // If this compile ran out of executable memory, stop compiling so
         // that the interpreter stops incrementing ISEQ call counters. It is
@@ -210,8 +221,7 @@ pub extern "C" fn rb_zjit_iseq_gen_entry_point(iseq: IseqPtr, ec: EcPtr, jit_exc
 
         if let Err(err) = &code_ptr {
             // Assert that the ISEQ compiles if RubyVM::ZJIT.assert_compiles is enabled.
-            // We assert only `jit_exception: false` cases until we support exception handlers.
-            if ZJITState::assert_compiles_enabled() && !jit_exception {
+            if ZJITState::assert_compiles_enabled() {
                 let iseq_location = iseq_get_location(iseq, 0);
                 panic!("Failed to compile: {iseq_location}: {err:?}");
             }
@@ -230,17 +240,22 @@ pub extern "C" fn rb_zjit_iseq_gen_entry_point(iseq: IseqPtr, ec: EcPtr, jit_exc
     })
 }
 
-/// Compile an entry point for a given ISEQ
-fn gen_iseq_entry_point(cb: &mut CodeBlock, iseq: IseqPtr, jit_exception: bool) -> Result<CodePtr, CompileError> {
-    // We don't support exception handlers yet
+/// Compile an entry point for a given ISEQ.
+fn gen_iseq_entry_point(cb: &mut CodeBlock, iseq: IseqPtr, ec: EcPtr, jit_exception: bool) -> Result<CodePtr, CompileError> {
     if jit_exception {
-        return gen_exception_handler_counter(cb);
+        let cfp = unsafe { get_ec_cfp(ec) };
+        let pc = unsafe { get_cfp_pc(cfp) };
+        let insn_idx = iseq_pc_to_insn_idx(iseq, pc)
+            .ok_or(CompileError::ParseError(hir::ParseError::MalformedIseq(0)))?;
+        let stack_size = unsafe { get_cfp_sp(cfp).offset_from(rb_vm_base_ptr(cfp)) };
+        let stack_size = u8::try_from(stack_size).map_err(|_| CompileError::IseqStackTooLarge)?;
+        return gen_exception_iseq_entry_point(cb, iseq, insn_idx, stack_size);
     }
 
     let iseq_name = iseq_get_location(iseq, 0);
     trace_compile_phase(&iseq_name, || {
         // Compile ISEQ into High-level IR
-        let function = crate::stats::with_time_stat(Counter::compile_hir_time_ns, || compile_iseq(iseq).inspect_err(|_| {
+        let function = crate::stats::with_time_stat(Counter::compile_hir_time_ns, || compile_iseq(iseq, None).inspect_err(|_| {
             incr_counter!(failed_iseq_count);
         }))?;
 
@@ -253,6 +268,58 @@ fn gen_iseq_entry_point(cb: &mut CodeBlock, iseq: IseqPtr, jit_exception: bool) 
     })
 }
 
+/// Compile or reuse an entry for one exception-handler PC.
+fn gen_exception_iseq_entry_point(
+    cb: &mut CodeBlock,
+    iseq: IseqPtr,
+    insn_idx: u16,
+    stack_size: u8,
+) -> Result<CodePtr, CompileError> {
+    if let Some(entry) = get_or_create_iseq_payload(iseq)
+        .exception_entries
+        .iter()
+        .rev()
+        .find(|entry| entry.insn_idx == insn_idx)
+    {
+        match &unsafe { entry.version.as_ref() }.status {
+            IseqStatus::Compiled(code_ptrs) => return Ok(code_ptrs.start_ptr),
+            IseqStatus::CantCompile(err) => return Err(err.clone()),
+            IseqStatus::NotCompiled | IseqStatus::Invalidated => {}
+        }
+    }
+
+    let entry_version_count = get_or_create_iseq_payload(iseq).exception_entries.iter()
+        .filter(|entry| entry.insn_idx == insn_idx).count();
+    if entry_version_count >= max_iseq_versions() {
+        return Err(CompileError::IseqVersionLimitReached);
+    }
+
+    let mut version = IseqVersion::new(iseq);
+    let code_ptrs = (|| {
+        let function = crate::stats::with_time_stat(Counter::compile_hir_time_ns, || {
+            compile_iseq(iseq, Some((insn_idx, stack_size)))
+        })?;
+        if entry_version_count + 1 < max_iseq_versions() {
+            reset_profiles_remaining(iseq);
+        }
+        gen_iseq_body(cb, iseq, version, Some(&function))
+    })();
+    let result = match &code_ptrs {
+        Ok(code_ptrs) => {
+            unsafe { version.as_mut() }.status = IseqStatus::Compiled(code_ptrs.clone());
+            incr_counter!(compiled_iseq_count);
+            Ok(code_ptrs.start_ptr)
+        }
+        Err(err) => {
+            unsafe { version.as_mut() }.status = IseqStatus::CantCompile(err.clone());
+            incr_counter!(failed_iseq_count);
+            Err(err.clone())
+        }
+    };
+    get_or_create_iseq_payload(iseq).exception_entries.push(ExceptionEntry { insn_idx, version });
+    result
+}
+
 /// Invalidate an ISEQ version and allow it to be recompiled on the next call.
 /// Both PatchPoint invalidation and exit-profiling recompilation go through this
 /// function, serving as the central point for all invalidation/recompile decisions.
@@ -261,10 +328,8 @@ fn gen_iseq_entry_point(cb: &mut CodeBlock, iseq: IseqPtr, jit_exception: bool) 
 /// handles all compile lifecycle events (interpreter profiles, JIT profiles, invalidation,
 /// GC) so that all compile/recompile tuning decisions live in one place.
 pub fn invalidate_iseq_version(cb: &mut CodeBlock, iseq: IseqPtr, version: &mut IseqVersionRef) {
-    let payload = get_or_create_iseq_payload(iseq);
-    if !unsafe { version.as_ref() }.is_invalidated()
-        && payload.versions.len() < max_iseq_versions()
-    {
+    let version_count = get_or_create_iseq_payload(iseq).version_count_for(*version);
+    if !unsafe { version.as_ref() }.is_invalidated() && version_count < max_iseq_versions() {
         unsafe { version.as_mut() }.status = IseqStatus::Invalidated;
         unsafe { rb_iseq_reset_jit_func(iseq) };
 
@@ -408,7 +473,7 @@ fn gen_iseq_body(cb: &mut CodeBlock, iseq: IseqPtr, mut version: IseqVersionRef,
     // Convert ISEQ into optimized High-level IR if not given
     let function = match function {
         Some(function) => function,
-        None => &crate::stats::with_time_stat(Counter::compile_hir_time_ns, || compile_iseq(iseq))?,
+        None => &crate::stats::with_time_stat(Counter::compile_hir_time_ns, || compile_iseq(iseq, None))?,
     };
 
     // Compile the High-level IR
@@ -715,6 +780,7 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
         Insn::InvokeBuiltin { bf, leaf, args, state, .. } => gen_invokebuiltin(jit, asm, function, &function.frame_state(*state), unsafe { &**bf }, *leaf, opnds!(args)),
         Insn::InvokeBlockIseqDirect { iseq, captured, args, state } => gen_invoke_block_iseq_direct(cb, jit, asm, function, *iseq, opnd!(captured), opnds!(args), &function.frame_state(*state)),
         &Insn::EntryPoint { jit_entry_idx } => no_output!(gen_entry_point(jit, asm, jit_entry_idx)),
+        &Insn::ExceptionEntryPoint { insn_idx, stack_size } => no_output!(gen_exception_entry_point(jit, asm, insn_idx, stack_size)),
         Insn::Return { val } => no_output!(gen_return(asm, opnd!(val))),
         Insn::FixnumAdd { left, right, state } => gen_fixnum_add(jit, asm, function, opnd!(left), opnd!(right), &function.frame_state(*state)),
         Insn::FixnumSub { left, right, state } => gen_fixnum_sub(jit, asm, function, opnd!(left), opnd!(right), &function.frame_state(*state)),
@@ -2753,12 +2819,27 @@ fn gen_entry_point(jit: &mut JITState, asm: &mut Assembler, jit_entry_idx: Optio
             jit_entry.borrow_mut().start_addr.set(Some(code_ptr));
         });
     }
+    gen_frame_entry_point(jit, asm, entry_pc(jit.iseq(), jit_entry_idx));
+}
+
+/// Compile a frame setup for entry from jit_exec_exception().
+fn gen_exception_entry_point(jit: &mut JITState, asm: &mut Assembler, insn_idx: u16, stack_size: u8) {
+    let pc = unsafe { rb_iseq_pc_at_idx(jit.iseq(), insn_idx.into()) };
+    gen_frame_entry_point(jit, asm, pc);
+
+    // ZJIT keeps SP at the bottom of the operand stack while it tracks values in FrameState.
+    if stack_size > 0 {
+        asm.sub_into(SP, (u32::from(stack_size) * SIZEOF_VALUE as u32).into());
+    }
+}
+
+fn gen_frame_entry_point(jit: &JITState, asm: &mut Assembler, pc: *const VALUE) {
     asm.frame_setup(&[]);
 
     // Publish a valid entry JITFrame before setting cfp->jit_return. The entry point is
     // always the top-level frame (depth 0). Inlined frames get their own deeper
     // slots in gen_push_inline_frame().
-    let jit_frame = JITFrame::new_iseq(entry_pc(jit.iseq(), jit_entry_idx), jit.iseq(), 0);
+    let jit_frame = JITFrame::new_iseq(pc, jit.iseq(), 0);
     asm.mov(Opnd::mem(64, NATIVE_BASE_PTR, -SIZEOF_VALUE_I32), Opnd::const_ptr(jit_frame));
     asm.mov(Opnd::mem(64, CFP, RUBY_OFFSET_CFP_JIT_RETURN), NATIVE_BASE_PTR);
 
@@ -3631,8 +3712,8 @@ fn gen_stack_overflow_check(jit: &mut JITState, asm: &mut Assembler, function: &
     asm.jbe(jit, side_exit(jit, function, state, StackOverflow));
 }
 
-/// Convert ISEQ into High-level IR
-fn compile_iseq(iseq: IseqPtr) -> Result<Function, CompileError> {
+/// Convert an ISEQ into High-level IR.
+fn compile_iseq(iseq: IseqPtr, exception_entry: Option<(u16, u8)>) -> Result<Function, CompileError> {
     // Convert ZJIT instructions back to bare instructions
     unsafe { crate::cruby::rb_zjit_profile_disable(iseq) };
 
@@ -3644,9 +3725,12 @@ fn compile_iseq(iseq: IseqPtr) -> Result<Function, CompileError> {
         return Err(CompileError::IseqStackTooLarge);
     }
 
-    let function = trace_compile_phase("build_hir", ||
-        crate::stats::with_time_stat(Counter::compile_hir_build_time_ns, || iseq_to_hir(iseq))
-    );
+    let function = trace_compile_phase("build_hir", || {
+        crate::stats::with_time_stat(Counter::compile_hir_build_time_ns, || match exception_entry {
+            Some((insn_idx, stack_size)) => iseq_to_hir_exception(iseq, insn_idx, stack_size),
+            None => iseq_to_hir(iseq),
+        })
+    });
     let mut function = match function {
         Ok(function) => function,
         Err(err) => {
@@ -3659,7 +3743,7 @@ fn compile_iseq(iseq: IseqPtr) -> Result<Function, CompileError> {
     }
     function.dump_hir();
     let non_final_version = get_or_create_iseq_payload(iseq).versions.len() + 1 < max_iseq_versions();
-    if non_final_version {
+    if exception_entry.is_none() && non_final_version {
         reset_profiles_remaining(iseq);
     }
     Ok(function)
@@ -3675,7 +3759,7 @@ fn side_exit(jit: &JITState, function: &Function, state: &FrameState, reason: Si
 fn side_exit_with_recompile(jit: &JITState, function: &Function, state: &FrameState, reason: SideExitReason, recompile: Option<Recompile>) -> Target {
     let mut exit = build_side_exit(jit, function, state);
     exit.recompile = recompile.map(|_| SideExitRecompile {
-        compiled_iseq: Opnd::Value(VALUE::from(jit.iseq())),
+        compiled_version: Opnd::const_ptr(jit.version.as_ptr()),
         frame_iseq: Opnd::Value(VALUE::from(state.iseq)),
         insn_idx: state.insn_idx() as u32,
     });
@@ -3739,53 +3823,37 @@ c_callable! {
     /// Called from JIT side-exit code to profile operands and trigger recompilation.
     /// Once enough profiles are gathered, invalidates the compiled unit for recompilation.
     ///
-    /// `compiled_iseq_raw` is the ISEQ that was actually compiled. For an exit out
-    /// of inlined code, the inliner folds the callee's body into the outer ISEQ, so
-    /// the outer ISEQ's version holds the failing guard and must be invalidated to
-    /// force a recompile. For non-inlined code, it is the same as the frame ISEQ.
+    /// `compiled_version_raw` identifies the version that contains the exit. For an
+    /// inlined method, this is the outer function's version.
     ///
-    /// `frame_iseq_raw` and `insn_idx` identify the instruction this exit came from,
-    /// whose re-profiling gates the recompile. Both are baked in at compile time,
-    /// where the exit already knows them, rather than read back out of the control
-    /// frame: the control frame describes the exiting frame only because the exit
-    /// wrote its ISEQ and PC there moments earlier, and an exit path that does not
-    /// write them would silently gate the recompile on an unrelated instruction.
-    pub(crate) fn exit_recompile(compiled_iseq_raw: VALUE, frame_iseq_raw: VALUE, insn_idx: u32) {
-        // Fast check before taking the VM lock: skip if the compiled unit is already
-        // invalidated or at the version limit. This avoids expensive lock acquisition
-        // on every shape guard exit after the recompile has already been triggered.
-        // The check is on the compiled unit because that is the version we invalidate.
+    /// `frame_iseq_raw` and `insn_idx` identify the instruction this exit came from.
+    /// The profile for that instruction controls the recompile.
+    pub(crate) fn exit_recompile(compiled_version_raw: *mut IseqVersion, frame_iseq_raw: VALUE, insn_idx: u32) {
+        let Some(compiled_version) = IseqVersionRef::new(compiled_version_raw) else {
+            return;
+        };
+        let compiled_iseq = unsafe { compiled_version.as_ref() }.iseq;
+        let compiled_version_addr = compiled_version_raw.addr();
+
+        // Skip the VM lock after this version was invalidated or reached its limit.
         {
-            let compiled_iseq: IseqPtr = compiled_iseq_raw.as_iseq();
-            let payload = get_or_create_iseq_payload(compiled_iseq);
-            let already_done = payload.versions.last()
-                .map_or(false, |v| unsafe { v.as_ref() }.is_invalidated())
-                || payload.versions.len() >= max_iseq_versions();
-            if already_done {
+            let version_count = get_or_create_iseq_payload(compiled_iseq).version_count_for(compiled_version);
+            if unsafe { compiled_version.as_ref() }.is_invalidated() || version_count >= max_iseq_versions() {
                 return;
             }
         }
 
         with_vm_lock(src_loc!(), || {
-            let compiled_iseq: IseqPtr = compiled_iseq_raw.as_iseq();
-
+            let mut compiled_version = IseqVersionRef::new(compiled_version_addr as *mut IseqVersion).expect("compiled version pointer should not be null");
             let should_recompile = with_time_stat(Counter::profile_time_ns, || {
                 get_or_create_iseq_payload(frame_iseq_raw.as_iseq())
                     .profile.done_profiling_at(insn_idx as YarvInsnIdx)
             });
 
-            // Once we have enough profiles, invalidate the compiled unit so it
-            // recompiles and reads the freshly recorded profile. We invalidate
-            // `compiled_iseq` rather than `frame_iseq` because an inlined callee has no
-            // compiled code of its own; the outer function it was folded into is what
-            // actually got compiled.
             if should_recompile {
-                let payload = get_or_create_iseq_payload(compiled_iseq);
-                if let Some(version) = payload.versions.last_mut() {
-                    let cb = ZJITState::get_code_block();
-                    invalidate_iseq_version(cb, compiled_iseq, version);
-                    cb.mark_all_executable();
-                }
+                let cb = ZJITState::get_code_block();
+                invalidate_iseq_version(cb, compiled_iseq, &mut compiled_version);
+                cb.mark_all_executable();
             }
         });
     }
@@ -4282,19 +4350,6 @@ fn gen_compile_error_counter(cb: &mut CodeBlock, compile_error: &CompileError) -
     asm.new_block_without_id("compile_error_counter");
     gen_incr_counter(&mut asm, exit_compile_error);
     gen_incr_counter(&mut asm, exit_counter_for_compile_error(compile_error));
-    asm.cret(Qundef.into());
-
-    asm.compile(cb).map(|(code_ptr, gc_offsets)| {
-        assert_eq!(0, gc_offsets.len());
-        code_ptr
-    })
-}
-
-/// Generate a JIT entry that just increments exit_exception_handler and exits
-fn gen_exception_handler_counter(cb: &mut CodeBlock) -> Result<CodePtr, CompileError> {
-    let mut asm = Assembler::new();
-    asm.new_block_without_id("exception_handler_counter");
-    gen_incr_counter(&mut asm, Counter::exit_exception_handler);
     asm.cret(Qundef.into());
 
     asm.compile(cb).map(|(code_ptr, gc_offsets)| {

--- a/zjit/src/codegen_tests.rs
+++ b/zjit/src/codegen_tests.rs
@@ -6748,8 +6748,6 @@ fn test_checkmatch_when_splat_array() {
 
 #[test]
 fn test_checkmatch_rescue() {
-    // Rescue behavior is tested functionally here. It still side-exits because
-    // JIT exception handling is not supported yet.
     eval(r#"
         def test
           begin

--- a/zjit/src/cruby.rs
+++ b/zjit/src/cruby.rs
@@ -180,6 +180,7 @@ pub use rb_get_ec_cfp as get_ec_cfp;
 pub use rb_get_cfp_iseq as get_cfp_iseq;
 pub use rb_get_cfp_pc as get_cfp_pc;
 pub use rb_get_cfp_sp as get_cfp_sp;
+pub use rb_get_cfp_ep as get_cfp_ep;
 pub use rb_get_cfp_ep_level as get_cfp_ep_level;
 pub use rb_get_cme_def_type as get_cme_def_type;
 pub use rb_get_cme_def_body_attr_id as get_cme_def_body_attr_id;
@@ -206,6 +207,12 @@ pub use rb_vm_ci_flag as vm_ci_flag;
 pub use rb_METHOD_ENTRY_VISI as METHOD_ENTRY_VISI;
 pub use rb_RCLASS_ORIGIN as RCLASS_ORIGIN;
 pub use rb_jit_fix_mod_fix as rb_fix_mod_fix;
+/// Check whether a control frame has an escaped environment.
+pub unsafe fn cfp_env_has_escaped(cfp: CfpPtr) -> bool {
+    let ep = unsafe { get_cfp_ep(cfp) };
+    (unsafe { ep.offset(VM_ENV_DATA_INDEX_FLAGS as isize).read().0 } & VM_ENV_FLAG_ESCAPED.to_usize()) != 0
+}
+
 
 /// A YARV instruction opcode (`ruby_vminsn_type`), stored as a `u16` since there are only
 /// `VM_INSTRUCTION_SIZE` (~259) instructions. Keeps enums that embed an opcode (e.g.

--- a/zjit/src/gc.rs
+++ b/zjit/src/gc.rs
@@ -53,7 +53,7 @@ pub extern "C" fn rb_zjit_iseq_free(iseq: IseqPtr) {
 
     // TODO(Shopify/ruby#682): Free `IseqPayload`
     let payload = get_or_create_iseq_payload(iseq);
-    for version in payload.versions.iter_mut() {
+    for mut version in payload.all_versions() {
         unsafe { version.as_mut() }.iseq = null();
     }
 
@@ -107,7 +107,7 @@ fn iseq_mark(payload: &IseqPayload) {
 
     // Mark objects baked in JIT code
     let cb = ZJITState::get_code_block();
-    for version in payload.versions.iter() {
+    for version in payload.all_versions() {
         for &offset in unsafe { version.as_ref() }.gc_offsets.iter() {
             let value_ptr: *const u8 = offset.raw_ptr(cb);
             // Creating an unaligned pointer is well defined unlike in C.
@@ -131,7 +131,7 @@ fn iseq_update_references(payload: &mut IseqPayload) {
         }
     });
 
-    for &version in payload.versions.iter() {
+    for version in payload.all_versions() {
         iseq_version_update_references(version);
     }
 }

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -922,6 +922,7 @@ pub enum FieldName {
     thread_ptr,
     len,
     SelfParam,
+    Stack(u16),
     Id(ID),
 }
 
@@ -932,6 +933,7 @@ impl std::fmt::Display for FieldName {
             Id(id) if id_is_empty(*id) => f.write_str("<empty>"),
             Id(id) => f.write_str(&id.contents_lossy()),
             SelfParam => f.write_str("self"),
+            Stack(index) => write!(f, "stack[{index}]"),
             _ => write!(f, "{self:?}"),
         }
     }
@@ -1267,6 +1269,8 @@ pub enum Insn {
 
     /// Set up frame. Remember the address as the JIT entry for the insn_idx in `jit_entry_insns()[jit_entry_idx]`.
     EntryPoint { jit_entry_idx: Option<usize> },
+    /// Set up a frame entered from jit_exec_exception() at the given instruction.
+    ExceptionEntryPoint { insn_idx: u16, stack_size: u8 },
     /// Control flow instructions
     Return { val: InsnId },
     /// Non-local control flow. See the throw YARV instruction
@@ -1361,6 +1365,7 @@ macro_rules! for_each_operand_impl {
             | Insn::LoadArg { .. }
             | Insn::Entries { .. }
             | Insn::EntryPoint { .. }
+            | Insn::ExceptionEntryPoint { .. }
             | Insn::LoadPC
             | Insn::LoadSP
             | Insn::LoadEC
@@ -1689,7 +1694,7 @@ impl Insn {
             Insn::Comment { .. }
             | Insn::Jump(_)
             | Insn::Entries { .. }
-            | Insn::CondBranch { .. } | Insn::EntryPoint { .. } | Insn::Return { .. }
+            | Insn::CondBranch { .. } | Insn::EntryPoint { .. } | Insn::ExceptionEntryPoint { .. } | Insn::Return { .. }
             | Insn::PatchPoint { .. } | Insn::SetIvar { .. } | Insn::SetClassVar { .. } | Insn::ArrayExtend { .. }
             | Insn::ArrayPush { .. } | Insn::SideExit { .. } | Insn::SetGlobal { .. }
             | Insn::SetLocal { .. } | Insn::Throw { .. } | Insn::IncrCounter(_) | Insn::IncrCounterPtr { .. }
@@ -1888,6 +1893,7 @@ impl Insn {
             ),
             Insn::InvokeBuiltin { .. } => effects::Any,
             Insn::EntryPoint { .. } => effects::Any,
+            Insn::ExceptionEntryPoint { .. } => effects::Any,
             Insn::Return { .. } => effects::Any,
             Insn::Throw { .. } => effects::Any,
             Insn::FixnumAdd { .. } => effects::Empty,
@@ -2281,6 +2287,7 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
             }
             &Insn::EntryPoint { jit_entry_idx: Some(idx) } => write!(f, "EntryPoint JIT({idx})"),
             &Insn::EntryPoint { jit_entry_idx: None } => write!(f, "EntryPoint interpreter"),
+            &Insn::ExceptionEntryPoint { insn_idx, stack_size } => write!(f, "EntryPoint exception({insn_idx}, stack_size={stack_size})"),
             Insn::Return { val } => { write!(f, "Return {val}") }
             Insn::FixnumAdd  { left, right, .. } => { write!(f, "FixnumAdd {left}, {right}") },
             Insn::FixnumSub  { left, right, .. } => { write!(f, "FixnumSub {left}, {right}") },
@@ -2774,6 +2781,8 @@ struct CompilePolicy {
     /// side-exit, and instead use fallback paths (e.g. C calls) on mismatch.
     /// Set when this is the final version of an ISEQ after recompilation.
     no_side_exits: bool,
+    /// Whether this entry can create another version after a profiling side exit.
+    allow_recompile: bool,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -2784,18 +2793,23 @@ struct SetIvarSpec {
 }
 
 impl CompilePolicy {
-    fn new(iseq: *const rb_iseq_t) -> Self {
-        // When a previous version was invalidated and we've reached the version
-        // limit, avoid speculative optimizations that may side-exit.
-        let no_side_exits = if iseq.is_null() {
-            false
+    fn from_versions(versions: impl Iterator<Item = crate::payload::IseqVersionRef>) -> Self {
+        let (version_count, has_invalidated_version) = versions.fold((0, false), |(count, invalidated), version| {
+            (count + 1, invalidated || unsafe { version.as_ref() }.is_invalidated())
+        });
+        let allow_recompile = version_count + 1 < max_iseq_versions();
+        Self {
+            no_side_exits: has_invalidated_version && !allow_recompile,
+            allow_recompile,
+        }
+    }
+
+    fn new(iseq: IseqPtr) -> Self {
+        if iseq.is_null() {
+            Self { no_side_exits: false, allow_recompile: true }
         } else {
-            let payload = get_or_create_iseq_payload(iseq);
-            payload.versions.iter().any(
-                |v| unsafe { v.as_ref() }.is_invalidated()
-            ) && payload.versions.len() + 1 >= max_iseq_versions()
-        };
-        Self { no_side_exits }
+            Self::from_versions(get_or_create_iseq_payload(iseq).versions.iter().copied())
+        }
     }
 }
 
@@ -3588,7 +3602,7 @@ impl Function {
         match &self.insns[insn] {
             Insn::Param => unimplemented!("params should not be present in block.insns"),
             Insn::LoadArg { val_type, .. } => *val_type,
-            Insn::SetGlobal { .. } | Insn::Jump(_) | Insn::Entries { .. } | Insn::EntryPoint { .. }
+            Insn::SetGlobal { .. } | Insn::Jump(_) | Insn::Entries { .. } | Insn::EntryPoint { .. } | Insn::ExceptionEntryPoint { .. }
             | Insn::Comment { .. }
             | Insn::CondBranch { .. } | Insn::Return { .. } | Insn::Throw { .. }
             | Insn::PatchPoint { .. } | Insn::SetIvar { .. } | Insn::SetClassVar { .. } | Insn::ArrayExtend { .. }
@@ -6258,8 +6272,7 @@ impl Function {
         // On the final version, recompilation is not possible, so converting sends to
         // SideExits would just add overhead (the exit fires every time without benefit).
         // Keep them as Send fallbacks so the interpreter handles them directly.
-        let payload = get_or_create_iseq_payload(self.iseq);
-        if payload.versions.len() + 1 >= crate::codegen::max_iseq_versions() {
+        if !self.policy.allow_recompile {
             return;
         }
         for block in self.reverse_post_order() {
@@ -7714,6 +7727,7 @@ impl Function {
             | Insn::Jump { .. }
             | Insn::Entries { .. }
             | Insn::EntryPoint { .. }
+            | Insn::ExceptionEntryPoint { .. }
             | Insn::PatchPoint { .. }
             | Insn::SideExit { .. }
             | Insn::IncrCounter { .. }
@@ -8695,6 +8709,10 @@ pub const SELF_PARAM_IDX: usize = 0;
 #[derive(Clone, Copy)]
 enum AddIseqMode {
     Standalone,
+    Exception {
+        insn_idx: u16,
+        stack_size: u8,
+    },
     Inlined {
         return_block: BlockId,
         /// The caller's post-send `Snapshot`. Allows side-exits to restore the outer frame.
@@ -8724,8 +8742,17 @@ struct AddIseqResult {
     profiles: ProfileOracle,
 }
 
-/// Compile ISEQ into High-level IR
-pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
+/// Compile an ISEQ into High-level IR for a normal interpreter entry.
+pub fn iseq_to_hir(iseq: IseqPtr) -> Result<Function, ParseError> {
+    iseq_to_hir_with_mode(iseq, AddIseqMode::Standalone)
+}
+
+/// Compile an ISEQ into High-level IR for an exception entry.
+pub fn iseq_to_hir_exception(iseq: IseqPtr, insn_idx: u16, stack_size: u8) -> Result<Function, ParseError> {
+    iseq_to_hir_with_mode(iseq, AddIseqMode::Exception { insn_idx, stack_size })
+}
+
+fn iseq_to_hir_with_mode(iseq: IseqPtr, mode: AddIseqMode) -> Result<Function, ParseError> {
     if !ZJITState::can_compile_iseq(iseq) {
         return Err(ParseError::NotAllowed);
     }
@@ -8733,8 +8760,15 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
     let mut fun = Function::new(iseq);
     fun.was_invalidated_for_singleton_class_creation = payload.was_invalidated_for_singleton_class_creation;
     fun.self_is_heap_object = payload.self_is_heap_object;
+    if let AddIseqMode::Exception { insn_idx, .. } = mode {
+        fun.policy = CompilePolicy::from_versions(
+            payload.exception_entries.iter()
+                .filter(|entry| entry.insn_idx == insn_idx)
+                .map(|entry| entry.version),
+        );
+    }
 
-    let result = add_iseq_to_hir(&mut fun, iseq, AddIseqMode::Standalone)?;
+    let result = add_iseq_to_hir(&mut fun, iseq, mode)?;
     fun.profiles = Some(result.profiles);
 
     if let Err(err) = crate::stats::trace_compile_phase("validate", || fun.validate()) {
@@ -8777,7 +8811,7 @@ fn add_iseq_to_hir(
     fn new_frame_state(mode: AddIseqMode, iseq: IseqPtr) -> FrameState {
         match mode {
             AddIseqMode::Inlined { caller, depth, .. } => FrameState::inlined(iseq, caller, depth),
-            AddIseqMode::Standalone => FrameState::new(iseq),
+            AddIseqMode::Standalone | AddIseqMode::Exception { .. } => FrameState::new(iseq),
         }
     }
 
@@ -8790,14 +8824,20 @@ fn add_iseq_to_hir(
     // Those entries are known to be unreachable so slicing them off here avoids
     // translating prologue blocks that would only be discarded later, rather
     // than emitting them and relying on a downstream pass to prune the dead CFG.
-    let jit_entry_start = match mode {
-        AddIseqMode::Standalone => 0,
-        AddIseqMode::Inlined { jit_entry_idx, .. } => jit_entry_idx,
+    let jit_entry_insns = match mode {
+        AddIseqMode::Exception { insn_idx, .. } => vec![u32::from(insn_idx)],
+        AddIseqMode::Standalone | AddIseqMode::Inlined { .. } => {
+            let jit_entry_start = match mode {
+                AddIseqMode::Standalone => 0,
+                AddIseqMode::Inlined { jit_entry_idx, .. } => jit_entry_idx,
+                AddIseqMode::Exception { .. } => unreachable!(),
+            };
+            unsafe { iseq.params() }.opt_table_slice()
+                .get(jit_entry_start..)
+                .expect("JIT entry index must be within the callee opt table")
+                .iter().copied().map(VALUE::as_u32).collect()
+        }
     };
-    let jit_entry_insns = unsafe { iseq.params() }.opt_table_slice()
-        .get(jit_entry_start..)
-        .expect("JIT entry index must be within the callee opt table")
-        .iter().copied().map(VALUE::as_u32).collect::<Vec<_>>();
     let BytecodeInfo { jump_targets } = compute_bytecode_info(iseq, &jit_entry_insns);
 
     let compile_jit_entries = matches!(mode, AddIseqMode::Standalone) && iseq_supports_jit_entry(iseq);
@@ -8832,25 +8872,32 @@ fn add_iseq_to_hir(
     // optionals, reached from this one by fallthrough rather than targeted directly.
     // Standalone compilation has no single body entry block, so it produces none.
     let body_entry_block = match mode {
-        AddIseqMode::Standalone => None,
+        AddIseqMode::Standalone | AddIseqMode::Exception { .. } => None,
         AddIseqMode::Inlined { .. } => Some(insn_idx_to_block[&jit_entry_insns[0]]),
     };
 
-    if matches!(mode, AddIseqMode::Standalone) {
-        // Compile an entry_block for the interpreter
-        compile_entry_block(fun, jit_entry_insns.as_slice(), &insn_idx_to_block);
+    let exception_entry_state = match mode {
+        AddIseqMode::Standalone => {
+            // Compile an entry_block for the interpreter
+            compile_entry_block(fun, jit_entry_insns.as_slice(), &insn_idx_to_block);
 
-        if compile_jit_entries {
-            // Compile all JIT-to-JIT entry blocks
-            for (jit_entry_idx, insn_idx) in jit_entry_insns.iter().enumerate() {
-                let target_block = insn_idx_to_block.get(insn_idx)
-                    .copied()
-                    .expect("we make a block for each jump target and \
-                             each entry in the ISEQ opt_table is a jump target");
-                compile_jit_entry_block(fun, jit_entry_idx, target_block);
+            if compile_jit_entries {
+                // Compile all JIT-to-JIT entry blocks
+                for (jit_entry_idx, insn_idx) in jit_entry_insns.iter().enumerate() {
+                    let target_block = insn_idx_to_block.get(insn_idx)
+                        .copied()
+                        .expect("we make a block for each jump target and each entry in the ISEQ opt_table is a jump target");
+                    compile_jit_entry_block(fun, jit_entry_idx, target_block);
+                }
             }
+            None
         }
-    }
+        AddIseqMode::Exception { insn_idx, stack_size } => {
+            let target_block = insn_idx_to_block[&u32::from(insn_idx)];
+            Some(compile_exception_entry_block(fun, insn_idx, stack_size, target_block))
+        }
+        AddIseqMode::Inlined { .. } => None,
+    };
 
     // Check if the EP is escaped for the ISEQ from the beginning. We give up
     // optimizing locals in that case because they're shared with other frames.
@@ -8863,8 +8910,13 @@ fn add_iseq_to_hir(
     // Iteratively fill out basic blocks using a queue.
     // TODO(max): Basic block arguments at edges
     let mut queue = VecDeque::new();
-    for &insn_idx in jit_entry_insns.iter() {
-        queue.push_back((new_frame_state(mode, iseq), insn_idx_to_block[&insn_idx], /*insn_idx=*/insn_idx, /*local_inval=*/false));
+    if let Some(entry_state) = exception_entry_state {
+        let insn_idx = u32::try_from(entry_state.insn_idx()).unwrap();
+        queue.push_back((entry_state, insn_idx_to_block[&insn_idx], insn_idx, false));
+    } else {
+        for &insn_idx in jit_entry_insns.iter() {
+            queue.push_back((new_frame_state(mode, iseq), insn_idx_to_block[&insn_idx], insn_idx, false));
+        }
     }
 
     // Keep compiling blocks until the queue becomes empty
@@ -10043,7 +10095,7 @@ fn add_iseq_to_hir(
                     fun.push_insn(block, Insn::CheckInterrupts { state: exit_id });
                     let val = state.stack_pop()?;
                     match mode {
-                        AddIseqMode::Standalone => fun.push_insn(block, Insn::Return { val }),
+                        AddIseqMode::Standalone | AddIseqMode::Exception { .. } => fun.push_insn(block, Insn::Return { val }),
                         AddIseqMode::Inlined { return_block, .. } => { fun.push_insn(block, Insn::Jump(BranchEdge { target: return_block, args: vec![val] })) }
                     };
                     break;  // Don't enqueue the next block as a successor
@@ -10767,7 +10819,7 @@ fn add_iseq_to_hir(
         }
     }
 
-    if matches!(mode, AddIseqMode::Standalone) {
+    if matches!(mode, AddIseqMode::Standalone | AddIseqMode::Exception { .. }) {
         // Populate the entries superblock with an Entries instruction targeting all entry blocks
         fun.seal_entries();
 
@@ -10877,6 +10929,54 @@ fn compile_entry_state(fun: &mut Function) -> (InsnId, FrameState) {
         }
     }
     (self_param, entry_state)
+}
+
+/// Compile an entry that restores the interpreter state at an exception handler PC.
+fn compile_exception_entry_block(
+    fun: &mut Function,
+    insn_idx: u16,
+    stack_size: u8,
+    target_block: BlockId,
+) -> FrameState {
+    let entry_block = fun.entry_block;
+    fun.push_insn(entry_block, Insn::ExceptionEntryPoint { insn_idx, stack_size });
+
+    let iseq = fun.iseq;
+    let self_param = fun.load_self(entry_block);
+    let mut entry_state = FrameState::new(iseq);
+    entry_state.insn_idx = insn_idx.into();
+    entry_state.pc = unsafe { rb_iseq_pc_at_idx(iseq, insn_idx.into()) };
+
+    // Exception entries resume an existing frame. Load every local from its EP.
+    let ep = fun.get_ep(entry_block, 0);
+    for local_idx in 0..num_locals(iseq) {
+        let ep_offset = local_idx_to_ep_offset(iseq, local_idx);
+        let ep_offset = u32::try_from(ep_offset)
+            .unwrap_or_else(|_| panic!("Could not convert ep_offset {ep_offset} to u32"));
+        let local = fun.get_local_from_ep(entry_block, iseq, ep, ep_offset, 0, types::BasicObject);
+        entry_state.locals.push(local);
+    }
+
+    // The exception entry point moves SP to the bottom of the operand stack.
+    if stack_size > 0 {
+        let sp = fun.load_sp(entry_block);
+        for stack_idx in 0..u16::from(stack_size) {
+            let val = fun.load_field(
+                entry_block,
+                sp,
+                FieldName::Stack(stack_idx),
+                SIZEOF_VALUE_I32 * i32::from(stack_idx),
+                types::BasicObject,
+            );
+            entry_state.stack_push(val);
+        }
+    }
+
+    if get_option!(stats) {
+        fun.count_iseq_calls(entry_block);
+    }
+    fun.push_insn(entry_block, Insn::Jump(BranchEdge { target: target_block, args: entry_state.as_args(self_param) }));
+    entry_state
 }
 
 /// Compile a jit_entry_block

--- a/zjit/src/invariants.rs
+++ b/zjit/src/invariants.rs
@@ -456,7 +456,7 @@ pub extern "C" fn rb_zjit_tracing_invalidate_all() {
         for_each_iseq(|iseq| {
             let payload = get_or_create_iseq_payload(iseq);
 
-            if let Some(version) = payload.versions.last_mut() {
+            for mut version in payload.all_versions() {
                 unsafe { version.as_mut() }.status = IseqStatus::Invalidated;
             }
             unsafe { rb_iseq_reset_jit_func(iseq) };

--- a/zjit/src/payload.rs
+++ b/zjit/src/payload.rs
@@ -14,6 +14,8 @@ pub struct IseqPayload {
     pub profile: IseqProfile,
     /// JIT code versions. Different versions should have different assumptions.
     pub versions: Vec<IseqVersionRef>,
+    /// JIT code versions entered from jit_exec_exception(), keyed by instruction index.
+    pub exception_entries: Vec<ExceptionEntry>,
     /// Whether a previous compilation of this ISEQ was invalidated due to
     /// singleton class creation (violation of [`crate::hir::Invariant::NoSingletonClass`]).
     pub was_invalidated_for_singleton_class_creation: bool,
@@ -27,13 +29,36 @@ pub struct IseqPayload {
     pub self_is_heap_object: bool,
 }
 
+/// A compiled exception entry for one bytecode instruction.
+#[derive(Debug)]
+pub struct ExceptionEntry {
+    pub insn_idx: u16,
+    pub version: IseqVersionRef,
+}
+
 impl IseqPayload {
     fn new() -> Self {
         Self {
             profile: IseqProfile::new(),
             versions: vec![],
+            exception_entries: vec![],
             was_invalidated_for_singleton_class_creation: false,
             self_is_heap_object: false,
+        }
+    }
+
+    /// Iterate over normal and exception-entry versions.
+    pub fn all_versions(&self) -> impl Iterator<Item = IseqVersionRef> + '_ {
+        self.versions.iter().copied()
+            .chain(self.exception_entries.iter().map(|entry| entry.version))
+    }
+
+    /// Return the version count for the entry represented by `version`.
+    pub fn version_count_for(&self, version: IseqVersionRef) -> usize {
+        match self.exception_entries.iter().find(|entry| entry.version == version) {
+            Some(exception_entry) => self.exception_entries.iter()
+                .filter(|entry| entry.insn_idx == exception_entry.insn_idx).count(),
+            None => self.versions.len(),
         }
     }
 
@@ -91,7 +116,7 @@ impl IseqVersion {
 /// Set of CodePtrs for an ISEQ
 #[derive(Clone, Debug, PartialEq)]
 pub struct IseqCodePtrs {
-    /// Entry for the interpreter
+    /// Entry for the interpreter.
     pub start_ptr: CodePtr,
     /// Entries for JIT-to-JIT calls
     pub jit_entry_ptrs: Vec<CodePtr>,

--- a/zjit/src/stats.rs
+++ b/zjit/src/stats.rs
@@ -158,6 +158,7 @@ make_counters! {
         failed_iseq_count,
         jit_frame_heap_bytes,
         skipped_native_stack_full,
+        skipped_exceptional_entry_escaped_env,
 
         compile_time_ns,
         profile_time_ns,


### PR DESCRIPTION
## Summary

This change lets ZJIT compile code that starts at an exception-handler entry.

ZJIT now:

- Compiles from the active handler PC instead of emitting an `exit_exception_handler` stub.
- Restores the existing frame locals and operand stack at the handler entry.
- Caches separate code versions for each handler PC.
- Includes these versions in invalidation, garbage collection, and recompilation logic.
- Returns non-FINISH handler results through the caller stack before interpreter execution continues.
- Uses the interpreter when the handler frame has an escaped environment.

## ISEQ entry selection

Before this change, every compiled exception entry returned to the interpreter through a counter stub.

```mermaid
flowchart LR
    EXCEPTION["Exception handler"] --> STUB["Counter stub"]
    STUB --> VM["Interpreter"]
```

ZJIT now selects or compiles code for the current handler PC.

```mermaid
flowchart LR
    PC["Current handler PC"] --> MATCH{"Cached entry?"}
    MATCH -->|Yes| RUN["Run ZJIT code"]
    MATCH -->|No| COMPILE["Compile and cache"]
    COMPILE --> RUN
```

The ISEQ keeps the active entry in its C fields and all versions in its Rust payload.

```mermaid
flowchart LR
    ISEQ["ISEQ"] --> ACTIVE["Active PC and jit_exception"]
    ISEQ --> PAYLOAD["ISEQ payload"]
    PAYLOAD --> ENTRIES["Handler PC → IseqVersion"]
    ENTRIES --> ACTIVE
```

## How exception handlers enter HIR

Ruby creates the `rescue` or `ensure` frame before `jit_exec_exception()` runs.
This change replaces the code that runs after that point.

Before this change, ZJIT generated no handler HIR:

```mermaid
flowchart LR
    FRAME["Handler frame"] --> STUB["Counter stub"]
    STUB --> QUNDEF["Return Qundef"]
    QUNDEF --> VM["Interpret handler"]
```

This change adds an entry from the existing frame into normal handler HIR:

```mermaid
flowchart LR
    FRAME["Handler frame and PC"] --> SELECT["Select or compile entry"]
    SELECT --> ENTRY["ExceptionEntryPoint"]
    ENTRY --> HIR["Run handler HIR"]
```

The new entry is visible in an annotated `--zjit-dump-hir=all` excerpt:

```text
fn rescue in handled:
bb1():
  EntryPoint exception(0, stack_size=0)  # Enter the existing frame at handler PC 0
  v2:CPtr = GetEP 0                     # Read its environment
  v3:BasicObject = LoadField v2, :$!    # Read its current exception
  ...
  v20:Fixnum[42] = Const Value(42)
  Return v20                            # Continue through normal handler HIR
```

`ExceptionEntryPoint` also normalizes `SP` and loads the existing locals and operand stack.

A non-FINISH handler must return its value through the caller frame:

```mermaid
flowchart LR
    RESULT["Handler result"] --> FINISH{"FINISH frame?"}
    FINISH -->|Yes| RETURN["Return result"]
    FINISH -->|No| PUSH["Push result to caller"]
    PUSH --> QUNDEF["Return Qundef"]
```

This path lets `vm_exec_core()` continue with the caller.
An escaped environment continues through the interpreter.

Fixes Shopify/ruby#966.

## Liquid benchmark impact

I ran `liquid-render` with ZJIT on Apple arm64.
The timing run used five warm-up iterations and at least 20 measured iterations.

| Metric | `master` | This change | Difference |
| --- | ---: | ---: | ---: |
| Average time | 118 ms | 112 ms | -5.1% |
| `exit_exception_handler` | 44,544 | 0 | -100% |
| Total side exits | 62,464 | 17,921 | -71.3% |

The exit counters came from a separate run with one warm-up iteration and one measured iteration.
The timing result is a short local sample.

## Verification

- `make zjit-check` passed with 1,968 Rust tests and 24 ZJIT CLI tests.
- The new CLI test covers `rescue`, `ensure`, handler return values, and exception exits.
- Smoke checks passed for GC compaction, TracePoint invalidation, and method redefinition.
