### PR TITLE
Remove the workqueue

### DIFF
--- a/thread.c
+++ b/thread.c
@@ -2861,7 +2861,7 @@ rb_threadptr_execute_interrupts(rb_thread_t *th, int blocking_timing)
         }
 
         if (postponed_job_interrupt) {
-            rb_postponed_job_flush(th->vm);
+            rb_postponed_job_flush();
         }
 
         if (trap_interrupt) {
@@ -5947,7 +5947,6 @@ Init_Thread_Mutex(void)
 {
     rb_thread_t *th = GET_THREAD();
 
-    rb_native_mutex_initialize(&th->vm->workqueue_lock);
     rb_native_mutex_initialize(&th->vm->once_lock);
     rb_native_cond_initialize(&th->vm->once_cond);
     rb_native_mutex_initialize(&th->interrupt_lock);

--- a/vm.c
+++ b/vm.c
@@ -3596,7 +3596,6 @@ ruby_vm_destruct(rb_vm_t *vm)
             }
             rb_objspace_free(objspace);
         }
-        rb_native_mutex_destroy(&vm->workqueue_lock);
         rb_native_mutex_destroy(&vm->once_lock);
         rb_native_cond_destroy(&vm->once_cond);
         /* after freeing objspace, you *can't* use ruby_xfree() */
@@ -3614,7 +3613,6 @@ ruby_vm_destruct(rb_vm_t *vm)
     return 0;
 }
 
-size_t rb_vm_memsize_workqueue(struct ccan_list_head *workqueue); // vm_trace.c
 
 // Used for VM memsize reporting. Returns the size of the at_exit list by
 // looping through the linked list and adding up the size of the structs.
@@ -3669,7 +3667,6 @@ vm_memsize(const void *ptr)
     return (
         sizeof(rb_vm_t) +
         rb_vm_memsize_postponed_job_queue() +
-        rb_vm_memsize_workqueue(&vm->workqueue) +
         vm_memsize_at_exit_list(vm->at_exit) +
         (rb_st_memsize(&vm->ci_table) - sizeof(struct st_table)) +
         vm_memsize_builtin_function_table(vm->builtin_function_table) +

--- a/vm_core.h
+++ b/vm_core.h
@@ -778,9 +778,6 @@ typedef struct rb_vm_struct {
 
     int src_encoding_index;
 
-    /* workqueue (thread-safe, NOT async-signal-safe) */
-    struct ccan_list_head workqueue; /* <=> rb_workqueue_job.jnode */
-    rb_nativethread_lock_t workqueue_lock;
 
     /* `once` completion event (see vm_once_dispatch) */
     rb_nativethread_lock_t once_lock;
@@ -2093,7 +2090,6 @@ void rb_thread_wakeup_timer_thread(int);
 static inline void
 rb_vm_living_threads_init(rb_vm_t *vm)
 {
-    ccan_list_head_init(&vm->workqueue);
     ccan_list_head_init(&vm->ractor.set);
     ccan_list_head_init(&vm->ractor.terminated_set);
 }
@@ -2495,7 +2491,7 @@ int rb_thread_check_trap_pending(void);
 #define RUBY_EVENT_COVERAGE_LINE                0x010000
 #define RUBY_EVENT_COVERAGE_BRANCH              0x020000
 
-void rb_postponed_job_flush(rb_vm_t *vm);
+void rb_postponed_job_flush(void);
 void rb_postponed_job_trigger_for_ractor(unsigned int h, VALUE running_ractor);
 
 // ractor.c

--- a/vm_trace.c
+++ b/vm_trace.c
@@ -1794,61 +1794,11 @@ Init_vm_trace(void)
 }
 
 /*
- * Ruby actually has two separate mechanisms for enqueueing work from contexts
- * where it is not safe to run Ruby code, to run later on when it is safe. One
- * is async-signal-safe but more limited, and accessed through the
- * `rb_postponed_job_preregister` and `rb_postponed_job_trigger` functions. The
- * other is more flexible but cannot be used in signal handlers, and is accessed
- * through the `rb_workqueue_register` function.
- *
- * The postponed job functions form part of Ruby's extension API, but the
- * workqueue functions are for internal use only.
+ * Work enqueued from a context where it is not safe to run Ruby code, to run
+ * later on when it is safe.  Registering is async-signal-safe, and is part of
+ * Ruby's extension API: rb_postponed_job_preregister and
+ * rb_postponed_job_trigger.
  */
-
-struct rb_workqueue_job {
-    struct ccan_list_node jnode; /* <=> vm->workqueue */
-    rb_postponed_job_func_t func;
-    void *data;
-};
-
-// Used for VM memsize reporting. Returns the size of a list of rb_workqueue_job
-// structs. Defined here because the struct definition lives here as well.
-size_t
-rb_vm_memsize_workqueue(struct ccan_list_head *workqueue)
-{
-    struct rb_workqueue_job *work = 0;
-    size_t size = 0;
-
-    ccan_list_for_each(workqueue, work, jnode) {
-        size += sizeof(struct rb_workqueue_job);
-    }
-
-    return size;
-}
-
-/*
- * thread-safe and called from non-Ruby thread
- * returns FALSE on failure (ENOMEM), TRUE otherwise
- */
-int
-rb_workqueue_register(unsigned flags, rb_postponed_job_func_t func, void *data)
-{
-    struct rb_workqueue_job *wq_job = malloc(sizeof(*wq_job));
-    rb_vm_t *vm = GET_VM();
-
-    if (!wq_job) return FALSE;
-    wq_job->func = func;
-    wq_job->data = data;
-
-    rb_nativethread_lock_lock(&vm->workqueue_lock);
-    ccan_list_add_tail(&vm->workqueue, &wq_job->jnode);
-    rb_nativethread_lock_unlock(&vm->workqueue_lock);
-
-    // TODO: current implementation affects only main ractor
-    RUBY_VM_SET_POSTPONED_JOB_INTERRUPT(rb_vm_main_ractor_ec(vm));
-
-    return TRUE;
-}
 
 #define PJOB_TABLE_SIZE              (sizeof(rb_atomic_t) * CHAR_BIT)
 /* pre-registered jobs table, for async-safe jobs */
@@ -1971,20 +1921,13 @@ rb_postponed_job_trigger_for_ractor(unsigned int h, VALUE running_ractor)
 }
 
 void
-rb_postponed_job_flush(rb_vm_t *vm)
+rb_postponed_job_flush(void)
 {
     rb_postponed_job_queues_t *pjq = &postponed_job_queue;
     rb_execution_context_t *ec = GET_EC();
     const rb_atomic_t block_mask = POSTPONED_JOB_INTERRUPT_MASK | TRAP_INTERRUPT_MASK;
     volatile rb_atomic_t saved_mask = ec->interrupt_mask & block_mask;
     VALUE volatile saved_errno = ec->errinfo;
-    struct ccan_list_head tmp;
-
-    ccan_list_head_init(&tmp);
-
-    rb_nativethread_lock_lock(&vm->workqueue_lock);
-    ccan_list_append_list(&tmp, &vm->workqueue);
-    rb_nativethread_lock_unlock(&vm->workqueue_lock);
 
     volatile rb_atomic_t triggered_bits = RUBY_ATOMIC_EXCHANGE(pjq->triggered_bitset, 0);
 
@@ -2007,16 +1950,6 @@ rb_postponed_job_flush(rb_vm_t *vm)
                 void *data = RUBY_ATOMIC_PTR_LOAD(pjq->table[i].data);
                 (func)(data);
             }
-
-            /* execute workqueue jobs */
-            struct rb_workqueue_job *wq_job;
-            while ((wq_job = ccan_list_pop(&tmp, struct rb_workqueue_job, jnode))) {
-                rb_postponed_job_func_t func = wq_job->func;
-                void *data = wq_job->data;
-
-                free(wq_job);
-                (func)(data);
-            }
         }
         EC_POP_TAG();
     }
@@ -2024,17 +1957,8 @@ rb_postponed_job_flush(rb_vm_t *vm)
     ec->interrupt_mask &= ~(saved_mask ^ block_mask);
     ec->errinfo = saved_errno;
 
-    /* If we threw an exception, there might be leftover workqueue items; carry them over
-     * to a subsequent execution of flush */
-    if (!ccan_list_empty(&tmp)) {
-        rb_nativethread_lock_lock(&vm->workqueue_lock);
-        ccan_list_prepend_list(&vm->workqueue, &tmp);
-        rb_nativethread_lock_unlock(&vm->workqueue_lock);
-
-        RUBY_VM_SET_POSTPONED_JOB_INTERRUPT(GET_EC());
-    }
-    /* likewise with any remaining-to-be-executed bits of the preregistered postponed
-     * job table.  A merged bit can carry a Ractor-directed job that must not run on another
+    /* If we threw an exception, carry the bits that did not run yet over to a subsequent
+     * flush.  A merged bit can carry a Ractor-directed job that must not run on another
      * Ractor (rb_postponed_job_trigger_for_ractor), so re-post it to this Ractor's own mask
      * rather than to the global bitset. */
     if (triggered_bits) {


### PR DESCRIPTION
eb38fb670b added it as a thread-safe counterpart to postponed_job, for MJIT to enqueue work from its own thread [Bug #15316].  MJIT and RJIT are gone and nothing enqueues anything any more: rb_workqueue_register() has no caller, no declaration in any header, and hidden visibility, so an extension cannot reach it either.  What is left is rb_postponed_job_flush() taking workqueue_lock on every call to steal a list that is always empty.

rb_postponed_job_flush() no longer needs the VM: the preregistered job table it drains is a file-static.  Drop the argument.