### PR TITLE
Remove functions nothing calls

### DIFF
--- a/bignum.c
+++ b/bignum.c
@@ -6371,11 +6371,6 @@ rb_big_fdiv_double(VALUE x, VALUE y)
     return NUM2DBL(v);
 }
 
-VALUE
-rb_big_fdiv(VALUE x, VALUE y)
-{
-    return DBL2NUM(rb_big_fdiv_double(x, y));
-}
 
 VALUE
 rb_big_pow(VALUE x, VALUE y)

--- a/io.c
+++ b/io.c
@@ -7428,11 +7428,6 @@ rb_io_synchronized(rb_io_t *fptr)
     fptr->mode |= FMODE_SYNC;
 }
 
-void
-rb_io_unbuffered(rb_io_t *fptr)
-{
-    rb_io_synchronized(fptr);
-}
 
 int
 rb_pipe(int *pipes)

--- a/ractor.c
+++ b/ractor.c
@@ -1452,11 +1452,6 @@ rb_ractor_stderr_set(VALUE err)
     }
 }
 
-rb_hook_list_t *
-rb_ractor_hooks(rb_ractor_t *cr)
-{
-    return &cr->pub.hooks;
-}
 
 st_table *
 rb_ractor_targeted_hooks(rb_ractor_t *cr)

--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -1226,21 +1226,6 @@ static int timer_thread_set_timeout(rb_vm_t *vm);
 
 #include "thread_sched_mn.c"
 
-
-void
-rb_assert_sig(void)
-{
-    sigset_t oldmask;
-    pthread_sigmask(0, NULL, &oldmask);
-    if (sigismember(&oldmask, SIGVTALRM)) {
-        rb_bug("!!!");
-    }
-    else {
-        RUBY_DEBUG_LOG("ok");
-    }
-}
-
-
 /* only use signal-safe system calls here */
 static void
 signal_communication_pipe(int fd)

--- a/variable.c
+++ b/variable.c
@@ -2790,15 +2790,6 @@ get_autoload_data(VALUE autoload_const_value, struct autoload_const **autoload_c
     return autoload_data;
 }
 
-void
-rb_autoload(VALUE module, ID name, const char *feature)
-{
-    if (!feature || !*feature) {
-        rb_raise(rb_eArgError, "empty feature name");
-    }
-
-    rb_autoload_str(module, name, rb_fstring_cstr(feature));
-}
 
 static void const_set(VALUE klass, ID id, VALUE val);
 static void const_added(VALUE klass, ID const_name);

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -6656,11 +6656,6 @@ rb_vm_opt_newarray_pack_buffer(rb_execution_context_t *ec, rb_num_t array_len, c
     return vm_opt_newarray_pack_buffer(ec, array_len, ptr, fmt, buffer);
 }
 
-VALUE
-rb_vm_opt_newarray_pack(rb_execution_context_t *ec, rb_num_t array_len, const VALUE *ptr, VALUE fmt)
-{
-    return vm_opt_newarray_pack_buffer(ec, array_len, ptr, fmt, Qundef);
-}
 
 #undef id_cmp
 


### PR DESCRIPTION
None of these has a caller, a declaration in any header, or a place in libruby's dynamic symbol table, so an extension cannot reach them either.

* rb_vm_opt_newarray_pack: left over from cb9510f539, which moved the instruction to the _buffer form.
* rb_autoload: a wrapper around rb_autoload_str, deprecated and dropped from intern.h in Ruby 2.3 [Feature #11664].
* rb_big_fdiv: a wrapper around rb_big_fdiv_double, unused since Bignum stopped defining #fdiv.
* rb_io_unbuffered: a wrapper around rb_io_synchronized, which is what it was renamed to before 1.8.0.
* rb_ractor_hooks: an accessor for cr->pub.hooks; only its sibling rb_ractor_targeted_hooks is used.
* rb_assert_sig: a leftover debugging aid.