### PR TITLE
ZJIT: Add line number mappings in Comment

### DIFF
--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -8900,6 +8900,11 @@ fn add_iseq_to_hir(
             state.pc = pc;
             let exit_state = state.clone();
 
+            let add_line_numbers = get_option!(dump_hir_map);
+            if add_line_numbers {
+                hir_comment!(fun, block, "{}", iseq_get_location(iseq, insn_idx));
+            }
+
             // Strip any ZJIT profiling instrumentation so we read the ISEQ's original opcodes,
             // leaving trace variants intact for the handling below.
             // try_into() call below is unfortunate. Maybe pick i32 instead of usize for opcodes.

--- a/zjit/src/options.rs
+++ b/zjit/src/options.rs
@@ -114,6 +114,9 @@ pub struct Options {
     /// Dump High-level IR in Iongraph JSON format after optimization to /tmp/zjit-iongraph-{$PID}
     pub dump_hir_iongraph: bool,
 
+    /// Add line number mappings to HIR.
+    pub dump_hir_map: bool,
+
     /// Dump low-level IR
     pub dump_lir: Option<HashSet<DumpLIR>>,
 
@@ -209,6 +212,7 @@ impl Default for Options {
             dump_hir_file: None,
             dump_hir_graphviz: None,
             dump_hir_iongraph: false,
+            dump_hir_map: false,
             dump_lir: None,
             dump_disasm: None,
             trace_side_exits: None,
@@ -565,6 +569,8 @@ fn parse_option(str_ptr: *const std::os::raw::c_char) -> Option<()> {
         ("dump-hir-init", "") => options.dump_hir_init = Some(DumpHIR::WithoutSnapshot),
         ("dump-hir-init", "all") => options.dump_hir_init = Some(DumpHIR::All),
         ("dump-hir-init", "debug") => options.dump_hir_init = Some(DumpHIR::Debug),
+
+        ("dump-hir-map", "") => options.dump_hir_map = true,
 
         ("dump-hir-graphviz", "") => options.dump_hir_graphviz = Some("/dev/stderr".into()),
         ("dump-hir-graphviz", _) => {


### PR DESCRIPTION
Add line number comments to HIR printouts if enabled. Trying this out. Might help for something like Compiler Explorer.