### PR TITLE
ZJIT: Add validation pass for reducibility

### DIFF
--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -2648,6 +2648,9 @@ pub enum ValidationError {
     DuplicateInstruction(BlockId, InsnId),
     /// The offending instruction, its operand, expected type string, actual type string
     MismatchedOperandType(InsnId, InsnId, String, String),
+    // There is an irreducible loop indicated by the backedge from the first block to the second
+    // block.
+    IrreducibleLoopEdge(BlockId, BlockId),
     MiscValidationError(InsnId, String),
 }
 
@@ -7587,6 +7590,31 @@ impl Function {
         Ok(())
     }
 
+    /// Check that we have a reducible control-flow graph. Some optimizations and assumptions
+    /// assume reducibility (TODO: which?).
+    ///
+    /// A CFG is irreducible if it contains a back-edge `B->H` to a loop header `H` where `B` is
+    /// not dominated by `H`.
+    fn validate_reducible(&self) -> Result<(), ValidationError> {
+        let rpo = self.reverse_post_order();
+        let mut rpo_index = vec![0; self.blocks.len()];
+        for (idx, &block) in rpo.iter().enumerate() {
+            rpo_index[block] = idx;
+        }
+        let dominators = Dominators::new(self);
+        for block in rpo {
+            for target in self.successors(block) {
+                if rpo_index[target] <= rpo_index[block] {
+                    // This is a back-edge. Check that the target dominates the source.
+                    if !dominators.is_dominated_by(block, target) {
+                        return Err(ValidationError::IrreducibleLoopEdge(block, target));
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
     // This performs a dataflow def-analysis over the entire CFG to detect any
     // possibly undefined instruction operands.
     fn validate_definite_assignment(&self) -> Result<(), ValidationError> {
@@ -8044,6 +8072,7 @@ impl Function {
     /// Run all validation passes we have.
     pub fn validate(&self) -> Result<(), ValidationError> {
         self.validate_block_terminators_and_jumps()?;
+        self.validate_reducible()?;
         self.validate_definite_assignment()?;
         self.validate_insn_uniqueness()?;
         self.validate_types()?;

--- a/zjit/src/stats.rs
+++ b/zjit/src/stats.rs
@@ -372,6 +372,7 @@ make_counters! {
     compile_error_validation_duplicate_instruction,
     compile_error_validation_type_check_failure,
     compile_error_validation_misc_validation_error,
+    compile_error_validation_cfg_not_reducible,
 
     // unhandled_hir_insn_: Unhandled HIR instructions
     unhandled_hir_insn_invokebuiltin,
@@ -580,6 +581,7 @@ pub fn exit_counter_for_compile_error(compile_error: &CompileError) -> Counter {
                 OperandNotDefined(_, _, _)    => compile_error_validation_operand_not_defined,
                 DuplicateInstruction(_, _)    => compile_error_validation_duplicate_instruction,
                 MismatchedOperandType(..)     => compile_error_validation_type_check_failure,
+                IrreducibleLoopEdge(..)       => compile_error_validation_cfg_not_reducible,
                 MiscValidationError(..)       => compile_error_validation_misc_validation_error,
             },
         }


### PR DESCRIPTION
Based on [ART's](https://android.googlesource.com/platform/art/+/refs/heads/main/compiler/optimizing/nodes.cc#999):

```c++
bool HLoopInformation::HasBackEdgeNotDominatedByHeader() const {
  for (HBasicBlock* back_edge : GetBackEdges()) {
    DCHECK(back_edge->GetDominator() != nullptr);
    if (!header_->Dominates(back_edge)) {
      return true;
    }
  }
  return false;
}
```