### PR TITLE
Run the crash report and Ractor tests on macOS again

### DIFF
--- a/test/-ext-/bug_reporter/test_bug_reporter.rb
+++ b/test/-ext-/bug_reporter/test_bug_reporter.rb
@@ -6,7 +6,6 @@ require_relative '../../lib/parser_support'
 
 class TestBugReporter < Test::Unit::TestCase
   def test_bug_reporter_add
-    omit if macos? && ENV["CI"] # we're getting timeouts even after 100s in CI
     description = RUBY_DESCRIPTION
     description = description.sub(/\+PRISM /, '') unless ParserSupport.prism_enabled_in_subprocess?
     expected_stderr = [
@@ -26,7 +25,8 @@ class TestBugReporter < Test::Unit::TestCase
     args.push("--zjit") if JITSupport.zjit_enabled?
     args.unshift({"RUBY_ON_BUG" => nil, "RUBY_CRASH_REPORT" => nil})
     stdin = "#{no_core}register_sample_bug_reporter(12345); Bug.segv"
-    assert_in_out_err(args, stdin, [], expected_stderr, encoding: "ASCII-8BIT")
+    # Writing the report is slow, see TestRubyOptions#assert_segv.
+    assert_in_out_err(args, stdin, [], expected_stderr, encoding: "ASCII-8BIT", timeout: 60)
   ensure
     FileUtils.rm_rf(tmpdir) if tmpdir
   end

--- a/test/ruby/test_ractor.rb
+++ b/test/ruby/test_ractor.rb
@@ -356,7 +356,7 @@ class TestRactor < Test::Unit::TestCase
 
   # [Bug #21398]
   def test_port_receive_dnt_with_port_send
-    omit 'unstable on windows and macos-14' if RUBY_PLATFORM =~ /mswin|mingw|darwin/
+    omit 'unstable on windows' if RUBY_PLATFORM =~ /mswin|mingw/
     assert_ractor(<<~'RUBY', timeout: 90)
       THREADS = 10
       JOBS_PER_THREAD = 50

--- a/test/ruby/test_rubyoptions.rb
+++ b/test/ruby/test_rubyoptions.rb
@@ -844,8 +844,12 @@ class TestRubyOptions < Test::Unit::TestCase
     KILL_SELF = "Bug.segv"
   end
 
-  def assert_segv(args, message=nil, list: SEGVTest::ExpectedStderrList, **opt, &block)
-    omit if macos? && ENV["CI"] # we're getting timeouts even after 100s in CI, not sure why.
+  # Turning the C level backtrace into file:line pairs walks the whole of the
+  # binary's debug info, and that is nearly all of what a crash costs: 0.8s of
+  # CPU with the dSYM in place against 0.01s without it, on an idle arm64 macOS
+  # host.  The default subprocess budget of 10 seconds is meant for a child
+  # that does none of that work.
+  def assert_segv(args, message=nil, list: SEGVTest::ExpectedStderrList, timeout: 60, **opt, &block)
     # We want YJIT to be enabled in the subprocess if it's enabled for us
     # so that the Ruby description matches.
     env = Hash === args.first ? args.shift : {}
@@ -867,7 +871,7 @@ class TestRubyOptions < Test::Unit::TestCase
     end
 
     assert_in_out_err(args, test_stdin, *tests, encoding: "ASCII-8BIT",
-                      **SEGVTest::ExecOptions, **opt, &block)
+                      timeout: timeout, **SEGVTest::ExecOptions, **opt, &block)
   end
 
   def test_segv_test

--- a/tool/lib/test/unit.rb
+++ b/tool/lib/test/unit.rb
@@ -1840,7 +1840,12 @@ module Test
               "Failure:\n#{klass}##{meth} [#{location e}]:\n#{e.message}\n"
             when Timeout::Error
               @errors += 1
-              "Timeout:\n#{klass}##{meth}\n"
+              # A worker that stopped responding is reported with a bare
+              # Timeout::Error and has nothing to say.  One raised inside the
+              # test says what expired and carries the output of the
+              # subprocess that hung, which is all there is to go on.
+              detail = e.message == e.class.name ? "" : "#{e.message}\n"
+              "Timeout:\n#{klass}##{meth}\n#{detail}"
             else
               @errors += 1
               bt = Test::filter_backtrace(e.backtrace).join "\n    "


### PR DESCRIPTION
The crash report tests in `test_rubyoptions.rb` and `test_bug_reporter.rb` were omitted on macOS CI for timing out. Symbolizing the C level backtrace is nearly all of what a crash costs, 0.8s of CPU with the dSYM against 0.01s without it on an idle arm64 Mac, so they now get 60 seconds instead of the default 10. I could not reproduce the CI timeout locally, so `tool/lib/test/unit.rb` now keeps the message of a `Timeout::Error` raised in a test, which carries the child's output.

`test_port_receive_dnt_with_port_send` was omitted on macOS when its timeout was 30 seconds. It takes about a second now.

Generated with [Claude Code](https://claude.com/claude-code)
