### PR TITLE
Use `_addcarry_u64` intrinsic for size overflow on MSVC x64

### DIFF
--- a/include/ruby/internal/memory.h
+++ b/include/ruby/internal/memory.h
@@ -42,6 +42,7 @@
 # include <intrin.h>
 # if defined(_M_AMD64)
 # pragma intrinsic(_umul128)
+# pragma intrinsic(_addcarry_u64)
 # endif
 # if defined(_M_ARM64)
 # pragma intrinsic(__umulh)
@@ -663,6 +664,12 @@ rbimpl_size_add_overflow(size_t x, size_t y)
     RB_GNUC_EXTENSION DSIZE_T dz = dx + dy;
     ret.overflowed = dz > SIZE_MAX;
     ret.result = (size_t)dz;
+
+#elif defined(_MSC_VER) && defined(_M_AMD64)
+    unsigned __int64 dz = 0;
+    unsigned char carry = _addcarry_u64(0, x, y, &dz);
+    ret.overflowed = RBIMPL_CAST((bool)carry);
+    ret.result = RBIMPL_CAST((size_t)dz);
 
 #else
     ret.result = x + y;


### PR DESCRIPTION
`size_t` is `unsigned __int64` on Microsoft 64-bit targets, so `_addcarry_u64` directly implements `rbimpl_size_add_overflow` on MSVC x64 without narrowing.

The multiplication helper already uses `_umul128` under the same `_M_AMD64` guard. Add the corresponding `_addcarry_u64` path for addition, while preserving the existing preference order: C23 checked arithmetic, compiler builtins, and widened integer arithmetic are used first.

References:

* Microsoft documents that `size_t` is `unsigned __int64` on 64-bit platforms: https://learn.microsoft.com/en-us/cpp/c-language/largest-array-size?view=msvc-170
* Microsoft STL wraps the intrinsic as `_AddCarry64`: https://github.com/microsoft/STL/blob/main/stl/inc/__msvc_int128.hpp
* WABT uses `_addcarry_u64` for checked `uint64_t` addition after its builtin path: https://github.com/WebAssembly/wabt/blob/main/test/wasm2c/tail-calls.txt

---

AI assistance was used to research the external precedents and draft this patch and pull request.