### PR TITLE
Fix the SYNTAX_SUGGEST_DEBUG spec on Windows

### DIFF
--- a/spec/syntax_suggest/integration/ruby_command_line_spec.rb
+++ b/spec/syntax_suggest/integration/ruby_command_line_spec.rb
@@ -208,7 +208,7 @@ module SyntaxSuggest
             puts "haha"
         EOM
 
-        out = `SYNTAX_SUGGEST_DEBUG=1 #{ruby} -I#{lib_dir} -rsyntax_suggest -r#{monkeypatch} #{script} 2>&1`
+        out = IO.popen({"SYNTAX_SUGGEST_DEBUG" => "1"}, "#{ruby} -I#{lib_dir} -rsyntax_suggest -r#{monkeypatch} #{script} 2>&1", &:read)
 
         expect($?.success?).to be_falsey
         expect(out).to include("boom from monkeypatch")


### PR DESCRIPTION
The spec added in 43b07929b0c fails on mswin because `cmd.exe` does not understand `SYNTAX_SUGGEST_DEBUG=1 ruby ...` and tries to run `SYNTAX_SUGGEST_DEBUG` as a command. I pass the variable through the env hash of `IO.popen` instead.

https://github.com/ruby/ruby/actions/runs/34515928495/job/103002536286

Generated with [Claude Code](https://claude.com/claude-code)
