### PR TITLE
Skip test_autoload_fork on OpenBSD RubyCI

### DIFF
--- a/test/ruby/test_autoload.rb
+++ b/test/ruby/test_autoload.rb
@@ -420,7 +420,7 @@ p Foo::Bar
         end
       }
     end
-  end if Process.respond_to?(:fork)
+  end if Process.respond_to?(:fork) && ENV["RUBYCI_OPENBSD"] != "1"
 
   def test_autoload_same_file
     Dir.mktmpdir('autoload') do |tmpdir|


### PR DESCRIPTION
This test is flaky on OpenBSD RubyCI, probably due to the fact that the OpenBSD RubyCI machine is a software emulated virtual machine running on another virtual machine. The test runs fine on OpenBSD in general, and seems to pass the majority of time on OpenBSD RubyCI, but when it fails it stops the test-all run due to `timeout: output interval exceeds 1800.0 seconds`.