### PR TITLE
coroutine/ppc64le: save the non-volatile FP and vector registers

### DIFF
--- a/coroutine/ppc64le/Context.S
+++ b/coroutine/ppc64le/Context.S
@@ -14,7 +14,7 @@ PREFIXED_SYMBOL(coroutine_transfer):
 	.localentry PREFIXED_SYMBOL(coroutine_transfer), .-PREFIXED_SYMBOL(coroutine_transfer)
 
 	# Make space on the stack for caller registers
-	addi 1,1,-160
+	addi 1,1,-496
 
 	# Save caller registers
 	std 14,0(1)
@@ -44,11 +44,103 @@ PREFIXED_SYMBOL(coroutine_transfer):
         mfcr 0
         std 0, 152(1)
 
+	# Save non-volatile FP registers f14-f31 (ELFv2 callee-saved). GCC keeps
+	# GPR values in them under pressure (mtvsrdd/mffprd spills).
+	stfd 14,160(1)
+	stfd 15,168(1)
+	stfd 16,176(1)
+	stfd 17,184(1)
+	stfd 18,192(1)
+	stfd 19,200(1)
+	stfd 20,208(1)
+	stfd 21,216(1)
+	stfd 22,224(1)
+	stfd 23,232(1)
+	stfd 24,240(1)
+	stfd 25,248(1)
+	stfd 26,256(1)
+	stfd 27,264(1)
+	stfd 28,272(1)
+	stfd 29,280(1)
+	stfd 30,288(1)
+	stfd 31,296(1)
+
+	# Save non-volatile vector registers v20-v31 (vs52-vs63). Offsets are
+	# multiples of 16 from a 16-byte aligned r1, as stvx/lvx require.
+	li 11,304
+	stvx 20,1,11
+	li 11,320
+	stvx 21,1,11
+	li 11,336
+	stvx 22,1,11
+	li 11,352
+	stvx 23,1,11
+	li 11,368
+	stvx 24,1,11
+	li 11,384
+	stvx 25,1,11
+	li 11,400
+	stvx 26,1,11
+	li 11,416
+	stvx 27,1,11
+	li 11,432
+	stvx 28,1,11
+	li 11,448
+	stvx 29,1,11
+	li 11,464
+	stvx 30,1,11
+	li 11,480
+	stvx 31,1,11
+
 	# Save stack pointer to first argument
 	std 1,0(3)
 
 	# Load stack pointer from second argument
 	ld 1,0(4)
+
+	# Restore non-volatile FP and vector registers
+	lfd 14,160(1)
+	lfd 15,168(1)
+	lfd 16,176(1)
+	lfd 17,184(1)
+	lfd 18,192(1)
+	lfd 19,200(1)
+	lfd 20,208(1)
+	lfd 21,216(1)
+	lfd 22,224(1)
+	lfd 23,232(1)
+	lfd 24,240(1)
+	lfd 25,248(1)
+	lfd 26,256(1)
+	lfd 27,264(1)
+	lfd 28,272(1)
+	lfd 29,280(1)
+	lfd 30,288(1)
+	lfd 31,296(1)
+	li 11,304
+	lvx 20,1,11
+	li 11,320
+	lvx 21,1,11
+	li 11,336
+	lvx 22,1,11
+	li 11,352
+	lvx 23,1,11
+	li 11,368
+	lvx 24,1,11
+	li 11,384
+	lvx 25,1,11
+	li 11,400
+	lvx 26,1,11
+	li 11,416
+	lvx 27,1,11
+	li 11,432
+	lvx 28,1,11
+	li 11,448
+	lvx 29,1,11
+	li 11,464
+	lvx 30,1,11
+	li 11,480
+	lvx 31,1,11
 
 	# Restore caller registers
 	ld 14,0(1)
@@ -81,7 +173,7 @@ PREFIXED_SYMBOL(coroutine_transfer):
         mtcrf 56,0
 
 	# Pop stack frame
-	addi 1,1,160
+	addi 1,1,496
 
 	# Jump to return address
 	blr

--- a/coroutine/ppc64le/Context.h
+++ b/coroutine/ppc64le/Context.h
@@ -13,6 +13,8 @@
 enum {
   COROUTINE_REGISTERS =
   20  /* 18 general purpose registers (r14-r31), 1 special register (cr) and 1 return address */
+  + 18 /* non-volatile FP registers f14-f31 */
+  + 24 /* non-volatile vector registers v20-v31, 16 bytes each */
   + 4  /* space for fiber_entry() to store the link register */
 };
 


### PR DESCRIPTION
The ELFv2 ABI makes f14-f31 and v20-v31 callee-saved (OpenPOWER 64-bit ELF V2 ABI, 2.2.1 Register Roles), but coroutine_transfer saved only r14-r31, LR and CR.  A coroutine resuming from a transfer therefore sees whatever the other side left in those registers, and GCC does keep GPR data there: it vectorizes "store the same pointer twice" as mtvsrdd vs63 / stxvx, and spills GPRs to VSX under register pressure.

This never bit while nothing on either side of a transfer held a live value there.  ce6f200972 reshaped nt_start, and GCC 13 now keeps a pointer in v31 for the whole shared-nt loop, the transfer target of every M:N park.  From then on rubyci ppc64le was red on every run: non-main Ractor threads resumed with a stale VALUE where the VM expected a block handler (rb_block_given_p() true without a block, "the block passed to ... may be ignored" warnings, SEGV in invoke_block_from_c_bh at 0x71/0x75 with the same address on every run).  x86_64 has no callee-saved FP registers and the aarch64 Context.S already saves d8-d15, which is why only ppc64le failed.

  https://rubyci.s3.amazonaws.com/ppc64le/ruby-master/recent.html
  https://rubyci.s3.amazonaws.com/ppc64le/ruby-master/log/20260911T003005Z.fail.html.gz

Save f14-f31 with stfd/lfd and v20-v31 with stvx/lvx (VMX only, no VSX requirement); the frame grows from 160 to 496 bytes and COROUTINE_REGISTERS from 24 to 66 words.  The LR slot stays at index 18, so coroutine_initialize is otherwise unchanged.  Fibers use the same transfer and are covered too.  glibc's setjmp/longjmp on ppc64 already save and restore this set, so the EC tags and
RB_VM_SAVE_MACHINE_CONTEXT were not affected.

Verified on POWER9 (Ubuntu 24.04, gcc 13.3.0, 64K pages, the rubyci configure) at fef20ce27c: without this patch
TestSetTraceFunc#test_tp_ractor_local_untargeted dies at 0x75 and TestEnv#test_delete_in_ractor at 0x71 as on rubyci, and TestTmpdir#test_ractor / TestEnv#test_fetch_in_ractor fail on the same warnings; with it all of them pass and bootstraptest/test_ractor.rb passes.