### PR TITLE
string.c: Fix `String#tr` edge cases and improve coverage

### DIFF
--- a/spec/ruby/core/string/tr_spec.rb
+++ b/spec/ruby/core/string/tr_spec.rb
@@ -32,6 +32,11 @@ describe "String#tr" do
     "hello".tr("a-z", "A-H.").should == "HE..."
   end
 
+  it "raises an ArgumentError when the receiver has broken encoding" do
+    -> { "\xFF".tr("€", "b") }.should.raise(ArgumentError)
+    -> { "\xFF".tr("", "") }.should.raise(ArgumentError)
+  end
+
   it "raises an ArgumentError when given wrong number of arguments" do
     -> { "hello".tr }.should.raise(ArgumentError)
     ruby_version_is ""..."4.1" do
@@ -141,6 +146,10 @@ describe "String#tr" do
         "h€llø".tr("€" => "e", "ø" => "o").should == "hello"
       end
 
+      it "returns a copy of self if the translation hash is empty" do
+        "hello".tr({}).should == "hello"
+      end
+
       it "returns a string in the combined encoding" do
         str = "hello".encode(Encoding::US_ASCII).tr("e" => "é")
         str.should == "héllo"
@@ -158,6 +167,11 @@ describe "String#tr" do
           "€".encode(Encoding::UTF_16LE) => "e".encode(Encoding::UTF_16LE),
           "ø".encode(Encoding::UTF_16LE) => "o".encode(Encoding::UTF_16LE),
         ).should == "hello".encode(Encoding::UTF_16LE)
+      end
+
+      it "raises ArgumentError the string encoding is broken" do
+        -> { "\xFF".tr("€" => "b") }.should.raise(ArgumentError)
+        -> { "\xFF".tr({}) }.should.raise(ArgumentError)
       end
 
       it "raises ArgumentError if a key is more than one codepoint" do
@@ -231,7 +245,18 @@ describe "String#tr!" do
       end
 
       it "returns nil if the string wasn't modified" do
-        "hello".tr!("€" => "", "Ø" => "").should == nil
+        s = "hello"
+        s.tr!({}).should == nil
+        s.should == "hello"
+
+        s = "hello"
+        s.tr!("€" => "", "Ø" => "").should == nil
+        s.should == "hello"
+      end
+
+      it "raises ArgumentError the string encoding is broken" do
+        -> { "\xFF".tr!("€" => "b") }.should.raise(ArgumentError)
+        -> { "\xFF".tr!({}) }.should.raise(ArgumentError)
       end
 
       it "raises ArgumentError if a key is more than one codepoint" do

--- a/string.c
+++ b/string.c
@@ -9362,7 +9362,7 @@ tr_trans_pairs_search_sse2(struct tr_trans_pairs_search *search)
                 matches[i] = _mm_cmpeq_epi8(bytes, masks[i]);
             }
 
-            for (i = i; i < search->needles_count; i++) {
+            for (i = 1; i < search->needles_count; i++) {
                 matches[0] = _mm_or_si128(matches[0], matches[i]);
             }
 
@@ -9427,7 +9427,7 @@ tr_trans_pairs_search_neon(struct tr_trans_pairs_search *search)
                     matches[i] = vceqq_u8(bytes, masks[i]);
                 }
 
-                for (i = i; i < search->needles_count; i++) {
+                for (i = 1; i < search->needles_count; i++) {
                     matches[0] = vorrq_u8(matches[0], matches[i]);
                 }
 
@@ -9457,6 +9457,7 @@ tr_trans_pairs(VALUE str, VALUE pairs_val)
 {
     Check_Type(pairs_val, T_HASH);
     size_t pairs_count = RHASH_SIZE(pairs_val);
+    mustnot_broken(str);
     rb_str_modify(str);
 
     if (RSTRING_LEN(str) == 0 || !RSTRING_PTR(str) || pairs_count == 0) return Qnil;
@@ -9486,6 +9487,7 @@ tr_trans_pairs(VALUE str, VALUE pairs_val)
     bool modify = false;
 
     if (RB_LIKELY(rb_str_encindex_fastpath(rb_enc_to_index(e1)))) {
+
         struct tr_trans_pairs_search search = {
             .s = sstart,
             .send = sstart + str_len,
@@ -9609,6 +9611,10 @@ tr_trans_pairs(VALUE str, VALUE pairs_val)
         }
     }
 
+    if (!modify) {
+        return Qnil;
+    }
+
     if (!STR_EMBED_P(str)) {
         SIZED_FREE_N(STR_HEAP_PTR(str), STR_HEAP_SIZE(str));
     }
@@ -9621,13 +9627,10 @@ tr_trans_pairs(VALUE str, VALUE pairs_val)
 
     RB_GC_GUARD(hash);
 
-    if (modify) {
-        if (cr != ENC_CODERANGE_BROKEN)
-            ENC_CODERANGE_SET(str, cr);
-        rb_enc_associate(str, e1);
-        return str;
-    }
-    return Qnil;
+    if (cr != ENC_CODERANGE_BROKEN)
+        ENC_CODERANGE_SET(str, cr);
+    rb_enc_associate(str, e1);
+    return str;
 }
 
 /*
@@ -9661,9 +9664,24 @@ rb_str_tr_bang(int argc, VALUE *argv, VALUE str)
 /*
  *  call-seq:
  *    tr(selector, replacements) -> new_string
+ *    tr(pairs) -> new_string
  *
- *  Returns a copy of +self+ with each character specified by string +selector+
- *  translated to the corresponding character in string +replacements+.
+ *  Accepts either a +selector+ and a +replacements+ string,
+ *  or a single +pairs+ Hash.
+ *
+ *  When a +pairs+ Hash is provided the keys, returns a copy of +self+ with
+ *  the keys of the hash replaced by the values.
+ *
+ *  - They keys must be strings containing a single codepoints.
+ *  - The values can be of any length.
+ *
+ *  Example:
+ *
+ *    'hello'.tr('e' => 'er', 'l' => '', 'o' => 'o !') #=> "hero !"
+ *
+ *  When +selector+ and +replacements+are provided, returns a copy of +self+
+ *  with each character specified by string +selector+ translated to the
+ *  corresponding character in string +replacements+.
  *  The correspondence is _positional_:
  *
  *  - Each occurrence of the first character specified by +selector+
@@ -9704,7 +9722,9 @@ rb_str_tr(int argc, VALUE *argv, VALUE str)
 
     if (argc == 1) {
         VALUE pairs = argv[0];
-        return tr_trans_pairs(str, pairs);
+        VALUE result = tr_trans_pairs(str, pairs);
+        if (NIL_P(result)) result = str;
+        return str;
     }
 
     VALUE src = argv[0], repl = argv[1];

--- a/test/ruby/test_string.rb
+++ b/test/ruby/test_string.rb
@@ -2687,6 +2687,8 @@ CODE
     assert_equal S(("A"*16 + "x" + "B"*3)), S(("A"*16  + "<" + "B"*3)).tr({"<"=>"x"})
     assert_equal S(("x"+"A"*16 + "B"*3)), S(("<"+"A"*16 + "B"*3)).tr({"<"=>"x"})
     assert_equal S(("."*15 + "<" * 17)), S(("."*15  + "x"*17)).tr({"x"=>"<"})
+
+    assert_equal(S("01@3456789abcdefgHij"), S("0123456789abcdefghij").tr("h" => "H", "2" => "@"))
   end
 
   def test_tr!


### PR DESCRIPTION
[[Feature #22238]](https://bugs.ruby-lang.org/issues/22238)

```ruby
"hello".tr("x" => "y")   #=> nil (should be "hello")
"hello".tr({})           #=> nil (should be "hello")

s = +"hello"
s.tr!("x" => "y")        #=> nil
s                        #=> "" (the receiver is emptied)

"0123456789abcdefghij".tr("h" => "H", "2" => "@")
```