### PR TITLE
string.c: Fix multibyte replace in String#tr fast path

### DIFF
--- a/string.c
+++ b/string.c
@@ -9542,8 +9542,8 @@ tr_trans_pairs(VALUE str, VALUE pairs_val)
                 tr_buffer_append(&buffer, checkpoint, search.s - checkpoint);
             }
             tr_buffer_append_str(&buffer, repl);
-            search.s += clen;
-            checkpoint = search.s;
+            checkpoint = search.s + clen;
+            search.s++;
 
             if (cr == ENC_CODERANGE_7BIT && rb_enc_str_coderange(repl) != ENC_CODERANGE_7BIT) {
                 cr = ENC_CODERANGE_VALID;

--- a/test/ruby/test_string.rb
+++ b/test/ruby/test_string.rb
@@ -2689,6 +2689,7 @@ CODE
     assert_equal S(("."*15 + "<" * 17)), S(("."*15  + "x"*17)).tr({"x"=>"<"})
 
     assert_equal(S("01@3456789abcdefgHij"), S("0123456789abcdefghij").tr("h" => "H", "2" => "@"))
+    assert_equal(S("UL" * 16 ), S("\u2028<" * 16).tr("\u2028" => "U", "<" => "L"))
   end
 
   def test_tr!


### PR DESCRIPTION
`tr_trans_pairs_search` expect the pointer to be incremented by one only. Therefore, when matching a multibyte character, `search.s` must be incremented by 1, and not `clen`.