### PR TITLE
Remove an fd from the M:N poller when its last waiter leaves

### DIFF
--- a/test/ruby/test_thread.rb
+++ b/test/ruby/test_thread.rb
@@ -1687,6 +1687,26 @@ q.pop
     end;
   end
 
+  def test_mn_threads_killed_io_waiter_does_not_spin
+    assert_separately([{'RUBY_MN_THREADS' => '1'}], "#{<<~"begin;"}\n#{<<~'end;'}", timeout: 30)
+    begin;
+      r, w = IO.pipe
+      th = Thread.new { r.read(1) }
+      sleep 0.1 # let th park in the M:N poller
+      th.kill
+      th.join
+      w.close # r hangs up while the poller still holds a registration for it
+
+      t0 = Process.clock_gettime(Process::CLOCK_PROCESS_CPUTIME_ID)
+      sleep 0.3
+      cpu = Process.clock_gettime(Process::CLOCK_PROCESS_CPUTIME_ID) - t0
+      # A spinning timer thread never reaches its timeout branch, which under
+      # RUBY_MN_THREADS=2 is the only thing that can serve the exiting Ractor.
+      assert_operator cpu, :<, 0.15, "timer thread spins on an fd nobody waits on"
+      r.close
+    end;
+  end
+
   # [Bug #21926]
   def test_thread_join_during_finalizers
     assert_separately([], "#{<<~"begin;"}\n#{<<~'end;'}", timeout: 60)

--- a/thread_sched_mn.c
+++ b/thread_sched_mn.c
@@ -1281,23 +1281,26 @@ fd_waiters_arm(int fd, struct rb_fd_waiters *e, uint32_t want, bool consumed)
     }
 #elif HAVE_SYS_EPOLL_H
     if (want == 0) {
-        // A delivered oneshot event has already disarmed the fd; otherwise
-        // disarm by MOD to no events.  Either way the registration stays, so
-        // the next wait is one MOD instead of DEL + ADD.
+        // A delivered oneshot event has already disarmed the fd; otherwise DEL
+        // it.  MOD to no events would not do: EPOLLHUP and EPOLLERR are
+        // reported whatever the mask asks for, and without EPOLLONESHOT they
+        // are reported level-triggered, so a registration left behind by a
+        // waiter that gave up (kill, interrupt, timeout) spins the timer
+        // thread once the fd hangs up -- and a spinning timer thread never
+        // reaches its timeout branch, the only place that mints an snt.
         if (!consumed && e->registered) {
-            struct epoll_event off = { .events = 0, .data = { .u64 = 0 } };
-            if (epoll_ctl(timer_th.event_fd, EPOLL_CTL_MOD, fd, &off) == -1) {
+            if (epoll_ctl(timer_th.event_fd, EPOLL_CTL_DEL, fd, NULL) == -1) {
                 switch (errno) {
                   case EBADF:
                   case ENOENT:
                     // the fd is already closed or gone from the set
-                    e->registered = false;
                     break;
                   default:
                     perror("epoll_ctl");
                     rb_bug("fd_waiters_arm/epoll_ctl disarm failed (fd:%d errno:%d)", fd, errno);
                 }
             }
+            e->registered = false;
         }
         // Anything epoll_wait already queued for the old arming is stale now.
         e->generation++;


### PR DESCRIPTION
The disarm path MOD'd the registration to no events instead of deleting it, to save a syscall on the next wait.  But epoll reports EPOLLHUP and EPOLLERR whatever the mask asks for, and a mask of 0 carries no EPOLLONESHOT, so those are reported level-triggered.  A waiter that gave up without an event -- Thread#kill, an interrupt, a timeout -- therefore left a registration that fires forever once the fd hangs up, and epoll_wait returned it on every round.

The timer thread then never took its timeout branch, which is the only place that mints a shared NT or signals the global ready queue.  Under RUBY_MN_THREADS=2 the main thread goes dedicated while it waits in rb_ractor_terminate_all, so snt_cnt reaches 0, a ractor sits on the grq with nothing to run it, and the process never exits.  Repro: kill a thread blocked on a pipe read, close the write end, then use a Ractor -- 4/6 to 8/20 runs hang, with the timer thread at 100% CPU.

Under RUBY_MN_THREADS=1 the same spin burns a core silently.