### PR TITLE
ZJIT: model array reads on a virtual heap

### DIFF
--- a/zjit.rb
+++ b/zjit.rb
@@ -159,6 +159,7 @@ class << RubyVM::ZJIT
       :compile_hir_strength_reduce_time_ns,
       :compile_hir_inline_methods_time_ns,
       :compile_hir_remove_trivial_block_params_time_ns,
+      :compile_hir_optimize_load_aaron_time_ns,
       :compile_hir_optimize_load_store_time_ns,
       :compile_hir_canonicalize_time_ns,
       :compile_hir_fold_constants_time_ns,

--- a/zjit.rb
+++ b/zjit.rb
@@ -140,6 +140,9 @@ class << RubyVM::ZJIT
       :caller_splat_optimized,
     ], buf:, stats:, right_align: true, base: :send_count)
     print_counters([
+      :elided_array_aref_count,
+      :elided_array_length_count,
+
       :dynamic_setivar_count,
       :dynamic_getivar_count,
       :dynamic_definedivar_count,

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -6450,7 +6450,8 @@ impl Function {
             let mut compile_time_heap: HashMap<InsnId, usize>  = HashMap::new();
             let old_insns = std::mem::take(&mut self.blocks[block].insns);
             let mut new_insns = Vec::with_capacity(old_insns.len());
-            for insn_id in old_insns {
+            'block: for insn_id in old_insns {
+
                 let replacement_insn: InsnId = match self.resolve(insn_id).insn(self) {
                     Insn::NewArray { elements, .. } => {
                         compile_time_heap.insert(self.find_id(insn_id), elements.len());
@@ -6470,33 +6471,37 @@ impl Function {
                             insn_id
                         }
                     },
-                    Insn::ArrayAref { array, index } => {
-                        if let Some(size) = compile_time_heap.get(&self.chase_insn(*array)) {
-                            let size = *size;
-                            let array = *array;
+                    Insn::ArrayAref { array, index } => 'array_aref: {
+                        // Do we have a size?
+                        let Some(size) = compile_time_heap.get(&self.chase_insn(*array)) else {
+                            break 'array_aref insn_id;
+                        };
 
-                            if let Some(index_const) = self.type_of(*index).cint64_value() {
-                                if index_const >= 0 && index_const < size as i64 {
-                                    let array_id = self.chase_insn(array);
-                                    if let Insn::NewArray { elements, .. } = &self.insns[array_id] {
-                                        let new_insn_id = elements[index_const as usize];
-                                        self.make_equal_to(insn_id, new_insn_id);
-                                        if get_option!(stats) {
-                                            self.new_insn(Insn::IncrCounter(Counter::elided_array_aref_count))
-                                        } else {
-                                            continue;
-                                        }
-                                    } else {
-                                        insn_id
-                                    }
-                                } else {
-                                    insn_id
-                                }
-                            } else {
-                                insn_id
-                            }
+                        // Can we get an index for the aref?
+                        let Some(index_const) = self.type_of(*index).cint64_value() else {
+                            break 'array_aref insn_id;
+                        };
+
+                        let size = *size;
+                        let array = *array;
+
+                        // Is it in bounds?
+                        if !(index_const >= 0 && index_const < size as i64) {
+                            break 'array_aref insn_id;
+                        };
+
+                        let array_id = self.chase_insn(array);
+                        let Insn::NewArray { elements, .. } = &self.insns[array_id] else {
+                            break 'array_aref insn_id;
+                        };
+
+                        let new_insn_id = elements[index_const as usize];
+                        self.make_equal_to(insn_id, new_insn_id);
+
+                        if get_option!(stats) {
+                            self.new_insn(Insn::IncrCounter(Counter::elided_array_aref_count))
                         } else {
-                            insn_id
+                            continue 'block
                         }
                     },
                     insn => {

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -6445,6 +6445,74 @@ impl Function {
     }
 
 
+    fn optimize_load_aaron(&mut self) {
+        for block in self.reverse_post_order() {
+            let mut compile_time_heap: HashMap<InsnId, usize>  = HashMap::new();
+            let old_insns = std::mem::take(&mut self.blocks[block].insns);
+            let mut new_insns = Vec::with_capacity(old_insns.len());
+            for insn_id in old_insns {
+                let replacement_insn: InsnId = match self.resolve(insn_id).insn(self) {
+                    Insn::NewArray { elements, .. } => {
+                        compile_time_heap.insert(self.find_id(insn_id), elements.len());
+                        insn_id
+                    },
+                    Insn::ArrayLength { array, .. } => {
+                        if let Some(size) = compile_time_heap.get(&self.chase_insn(*array)) {
+                            let new_insn_id = self.new_insn(Insn::Const { val: Const::CInt64(*size as i64) });
+                            self.insn_types[new_insn_id] = self.infer_type(new_insn_id);
+                            if get_option!(stats) {
+                                let counter_id = self.new_insn(Insn::IncrCounter(Counter::elided_array_length_count));
+                                new_insns.push(counter_id);
+                            }
+                            self.make_equal_to(insn_id, new_insn_id);
+                            new_insn_id
+                        } else {
+                            insn_id
+                        }
+                    },
+                    Insn::ArrayAref { array, index } => {
+                        if let Some(size) = compile_time_heap.get(&self.chase_insn(*array)) {
+                            let size = *size;
+                            let array = *array;
+
+                            if let Some(index_const) = self.type_of(*index).cint64_value() {
+                                if index_const >= 0 && index_const < size as i64 {
+                                    let array_id = self.chase_insn(array);
+                                    if let Insn::NewArray { elements, .. } = &self.insns[array_id] {
+                                        let new_insn_id = elements[index_const as usize];
+                                        self.make_equal_to(insn_id, new_insn_id);
+                                        if get_option!(stats) {
+                                            self.new_insn(Insn::IncrCounter(Counter::elided_array_aref_count))
+                                        } else {
+                                            continue;
+                                        }
+                                    } else {
+                                        insn_id
+                                    }
+                                } else {
+                                    insn_id
+                                }
+                            } else {
+                                insn_id
+                            }
+                        } else {
+                            insn_id
+                        }
+                    },
+                    insn => {
+                        if insn.effects_of().includes(Effect::write(abstract_heaps::Memory)) {
+                            compile_time_heap.clear();
+                        }
+                        insn_id
+                    }
+                };
+
+                new_insns.push(replacement_insn);
+            }
+            self.blocks[block].insns = new_insns;
+        }
+    }
+
     fn optimize_load_store(&mut self) {
         for block in self.reverse_post_order() {
             let mut compile_time_heap: HashMap<(InsnId, i32), InsnId>  = HashMap::new();
@@ -7429,6 +7497,7 @@ impl Function {
             // End strength reduction bucket
             (inline_methods) => { Counter::compile_hir_inline_methods_time_ns };
             (remove_trivial_block_params) => { Counter::compile_hir_remove_trivial_block_params_time_ns };
+            (optimize_load_aaron) => { Counter::compile_hir_optimize_load_store_time_ns };
             (optimize_load_store) => { Counter::compile_hir_optimize_load_store_time_ns };
             (canonicalize) => { Counter::compile_hir_canonicalize_time_ns };
             (fold_constants) => { Counter::compile_hir_fold_constants_time_ns };
@@ -7483,6 +7552,7 @@ impl Function {
             run_pass!(remove_trivial_block_params);
             run_pass!(optimize_load_store);
             run_pass!(canonicalize);
+            run_pass!(optimize_load_aaron);
             run_pass!(fold_constants);
             run_pass!(clean_cfg);
             run_pass!(remove_redundant_patch_points);

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -2799,6 +2799,44 @@ impl CompilePolicy {
     }
 }
 
+enum VirtualArray {
+    Insns(Vec<InsnId>),
+    FrozenSource(VALUE),
+}
+
+enum VirtualElement {
+    Insn(InsnId),
+    Value(VALUE),
+}
+
+// VirtualArray modeling Array access in optimize-load-aaron
+impl VirtualArray {
+    fn len(&self) -> usize {
+        match self {
+            VirtualArray::Insns(elements) => elements.len(),
+            VirtualArray::FrozenSource(obj) => unsafe { rb_jit_array_len(*obj) as usize },
+        }
+    }
+
+    fn at(&self, index: i64) -> Option<VirtualElement> {
+        if index as usize >= self.len() { return None; }
+        match self {
+            VirtualArray::Insns(elements) => Some(VirtualElement::Insn(elements[index as usize])),
+            VirtualArray::FrozenSource(obj) => {
+                Some(VirtualElement::Value(unsafe { rb_ary_entry(*obj, index as i64) }))
+            }
+        }
+    }
+
+    fn set(&mut self, index: i64, val: InsnId) -> bool {
+        let VirtualArray::Insns(elements) = self else { return false };
+        match elements.get_mut(index as usize) {
+            Some(slot) => { *slot = val; true }
+            None => false,
+        }
+    }
+}
+
 /// A wrapper around [`InsnId`] that indicates the instruction's operands have been resolved.
 #[derive(Debug, Clone, Copy)]
 pub struct ResolvedInsnId(pub InsnId);
@@ -6444,69 +6482,75 @@ impl Function {
         }
     }
 
-
     fn optimize_load_aaron(&mut self) {
         for block in self.reverse_post_order() {
-            let mut compile_time_heap: HashMap<InsnId, usize>  = HashMap::new();
+            let mut virtual_heap: HashMap<InsnId, VirtualArray> = HashMap::new();
             let old_insns = std::mem::take(&mut self.blocks[block].insns);
             let mut new_insns = Vec::with_capacity(old_insns.len());
             'block: for insn_id in old_insns {
-
                 let replacement_insn: InsnId = match self.resolve(insn_id).insn(self) {
                     Insn::NewArray { elements, .. } => {
-                        compile_time_heap.insert(self.find_id(insn_id), elements.len());
+                        let elements = elements.clone();
+                        virtual_heap.insert(self.find_id(insn_id), VirtualArray::Insns(elements));
                         insn_id
                     },
-                    Insn::ArrayLength { array, .. } => {
-                        if let Some(size) = compile_time_heap.get(&self.chase_insn(*array)) {
-                            let new_insn_id = self.new_insn(Insn::Const { val: Const::CInt64(*size as i64) });
-                            self.insn_types[new_insn_id] = self.infer_type(new_insn_id);
-                            if get_option!(stats) {
-                                let counter_id = self.new_insn(Insn::IncrCounter(Counter::elided_array_length_count));
-                                new_insns.push(counter_id);
+                    &Insn::ArrayDup { val, .. } => {
+                        if let Some(obj) = self.type_of(val).ruby_object() {
+                            if obj.is_frozen() {
+                                virtual_heap.insert(self.find_id(insn_id), VirtualArray::FrozenSource(obj));
                             }
-                            self.make_equal_to(insn_id, new_insn_id);
-                            new_insn_id
+                        }
+                        insn_id
+                    },
+                    &Insn::ArrayLength { array } => {
+                        if let Some(array) = virtual_heap.get(&self.chase_insn(array)) {
+                            let len = array.len() as i64;
+                            let const_id = self.new_insn(Insn::Const { val: Const::CInt64(len) });
+                            self.insn_types[const_id] = self.infer_type(const_id);
+                            if get_option!(stats) {
+                                new_insns.push(self.new_insn(Insn::IncrCounter(Counter::elided_array_length_count)));
+                            }
+                            self.make_equal_to(insn_id, const_id);
+                            const_id
                         } else {
                             insn_id
                         }
                     },
-                    Insn::ArrayAref { array, index } => 'array_aref: {
-                        // Do we have a size?
-                        let Some(size) = compile_time_heap.get(&self.chase_insn(*array)) else {
-                            break 'array_aref insn_id;
-                        };
-
-                        // Can we get an index for the aref?
-                        let Some(index_const) = self.type_of(*index).cint64_value() else {
-                            break 'array_aref insn_id;
-                        };
-
-                        let size = *size;
-                        let array = *array;
-
-                        // Is it in bounds?
-                        if !(index_const >= 0 && index_const < size as i64) {
-                            break 'array_aref insn_id;
-                        };
-
+                    &Insn::ArrayAref { array, index } => {
                         let array_id = self.chase_insn(array);
-                        let Insn::NewArray { elements, .. } = &self.insns[array_id] else {
-                            break 'array_aref insn_id;
-                        };
-
-                        let new_insn_id = elements[index_const as usize];
-                        self.make_equal_to(insn_id, new_insn_id);
-
-                        if get_option!(stats) {
-                            self.new_insn(Insn::IncrCounter(Counter::elided_array_aref_count))
-                        } else {
-                            continue 'block
+                        let index = self.type_of(index).cint64_value();
+                        let mut element = None;
+                        if let Some(index) = index {
+                            if let Some(array) = virtual_heap.get(&array_id) {
+                                element = array.at(index);
+                            }
+                        }
+                        match element {
+                            Some(element) => {
+                                let element_id = match element {
+                                    VirtualElement::Insn(element_id) => element_id,
+                                    VirtualElement::Value(val) => {
+                                        let const_id = self.new_insn(Insn::Const { val: Const::Value(val) });
+                                        self.insn_types[const_id] = self.infer_type(const_id);
+                                        new_insns.push(const_id);
+                                        const_id
+                                    }
+                                };
+                                self.make_equal_to(insn_id, element_id);
+                                if !get_option!(stats) { continue 'block }
+                                self.new_insn(Insn::IncrCounter(Counter::elided_array_aref_count))
+                            }
+                            None => {
+                                // FIXME: Do we need to clear the virtual heap?
+                                // The effect is currently "any"
+                                virtual_heap.clear();
+                                insn_id
+                            }
                         }
                     },
                     insn => {
                         if insn.effects_of().includes(Effect::write(abstract_heaps::Memory)) {
-                            compile_time_heap.clear();
+                            virtual_heap.clear();
                         }
                         insn_id
                     }

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -4758,8 +4758,8 @@ mod hir_opt_tests {
           PushInlineFrame :foo, v24 (0x1038), num_args=1
           PatchPoint NoSingletonClass(Array@0x1058)
           PatchPoint MethodRedefined(Array@0x1058, length@0x1060, cme:0x1068)
-          v49:CInt64 = ArrayLength v25
-          v50:Fixnum = BoxFixnum v49
+          v51:CInt64[3] = Const CInt64(3)
+          v50:Fixnum = BoxFixnum v51
           CheckInterrupts
           PopInlineFrame
           Return v50
@@ -4798,8 +4798,8 @@ mod hir_opt_tests {
           PushInlineFrame :foo, v32 (0x1038), num_args=1
           PatchPoint NoSingletonClass(Array@0x1058)
           PatchPoint MethodRedefined(Array@0x1058, length@0x1060, cme:0x1068)
-          v57:CInt64 = ArrayLength v33
-          v58:Fixnum = BoxFixnum v57
+          v59:CInt64[7] = Const CInt64(7)
+          v58:Fixnum = BoxFixnum v59
           CheckInterrupts
           PopInlineFrame
           Return v58
@@ -4834,8 +4834,8 @@ mod hir_opt_tests {
           PushInlineFrame :foo, v24 (0x1038), num_args=1
           PatchPoint NoSingletonClass(Array@0x1058)
           PatchPoint MethodRedefined(Array@0x1058, length@0x1060, cme:0x1068)
-          v55:CInt64 = ArrayLength v25
-          v56:Fixnum = BoxFixnum v55
+          v57:CInt64[3] = Const CInt64(3)
+          v56:Fixnum = BoxFixnum v57
           v38:CPtr = GetEP 0
           v39:CInt64 = LoadField v38, :VM_ENV_DATA_INDEX_SPECVAL@0x1090
           v40:CInt64[-4] = Const CInt64(-4)
@@ -4927,8 +4927,8 @@ mod hir_opt_tests {
           PushInlineFrame :foo, v26 (0x1038), num_args=3
           PatchPoint NoSingletonClass(Array@0x1058)
           PatchPoint MethodRedefined(Array@0x1058, length@0x1060, cme:0x1068)
-          v61:CInt64 = ArrayLength v27
-          v62:Fixnum = BoxFixnum v61
+          v71:CInt64[2] = Const CInt64(2)
+          v62:Fixnum = BoxFixnum v71
           PatchPoint MethodRedefined(Integer@0x1090, +@0x1098, cme:0x10a0)
           v66:Fixnum = FixnumAdd v62, v11
           v70:Fixnum = FixnumAdd v66, v17
@@ -4967,8 +4967,8 @@ mod hir_opt_tests {
           PushInlineFrame :foo, v24 (0x1038), num_args=2
           PatchPoint NoSingletonClass(Array@0x1058)
           PatchPoint MethodRedefined(Array@0x1058, length@0x1060, cme:0x1068)
-          v56:CInt64 = ArrayLength v25
-          v57:Fixnum = BoxFixnum v56
+          v62:CInt64[2] = Const CInt64(2)
+          v57:Fixnum = BoxFixnum v62
           PatchPoint MethodRedefined(Integer@0x1090, +@0x1098, cme:0x10a0)
           v61:Fixnum = FixnumAdd v57, v15
           CheckInterrupts
@@ -5006,8 +5006,8 @@ mod hir_opt_tests {
           PushInlineFrame :foo, v22 (0x1038), num_args=2
           PatchPoint NoSingletonClass(Array@0x1058)
           PatchPoint MethodRedefined(Array@0x1058, length@0x1060, cme:0x1068)
-          v55:CInt64 = ArrayLength v23
-          v56:Fixnum = BoxFixnum v55
+          v61:CInt64[2] = Const CInt64(2)
+          v56:Fixnum = BoxFixnum v61
           PatchPoint MethodRedefined(Integer@0x1090, +@0x1098, cme:0x10a0)
           v60:Fixnum = FixnumAdd v56, v24
           CheckInterrupts
@@ -6635,8 +6635,8 @@ mod hir_opt_tests {
           v19:ArrayExact = NewArray v12, v13
           PatchPoint NoSingletonClass(Array@0x1008)
           PatchPoint MethodRedefined(Array@0x1008, length@0x1010, cme:0x1018)
-          v31:CInt64 = ArrayLength v19
-          v32:Fixnum = BoxFixnum v31
+          v33:CInt64[2] = Const CInt64(2)
+          v32:Fixnum = BoxFixnum v33
           CheckInterrupts
           Return v32
         ");
@@ -6666,8 +6666,8 @@ mod hir_opt_tests {
           v19:ArrayExact = NewArray v12, v13
           PatchPoint NoSingletonClass(Array@0x1008)
           PatchPoint MethodRedefined(Array@0x1008, size@0x1010, cme:0x1018)
-          v31:CInt64 = ArrayLength v19
-          v32:Fixnum = BoxFixnum v31
+          v33:CInt64[2] = Const CInt64(2)
+          v32:Fixnum = BoxFixnum v33
           CheckInterrupts
           Return v32
         ");
@@ -12197,10 +12197,8 @@ mod hir_opt_tests {
           v19:Fixnum[0] = Const Value(0)
           PatchPoint NoSingletonClass(Array@0x1008)
           PatchPoint MethodRedefined(Array@0x1008, []@0x1010, cme:0x1018)
-          v39:CInt64[0] = Const CInt64(0)
-          v32:CInt64 = ArrayLength v14
-          v33:CInt64[0] = GuardLess v39, v32
-          v37:BasicObject = ArrayAref v14, v33
+          v40:CInt64[0] = Const CInt64(0)
+          v37:BasicObject = ArrayAref v14, v40
           CheckInterrupts
           Return v37
         ");
@@ -15027,8 +15025,8 @@ mod hir_opt_tests {
           PushInlineFrame :foo, v29 (0x1040), num_args=1
           PatchPoint NoSingletonClass(Array@0x1060)
           PatchPoint MethodRedefined(Array@0x1060, length@0x1068, cme:0x1070)
-          v68:CInt64 = ArrayLength v44
-          v69:Fixnum = BoxFixnum v68
+          v70:CInt64[7] = Const CInt64(7)
+          v69:Fixnum = BoxFixnum v70
           CheckInterrupts
           PopInlineFrame
           Return v69
@@ -15163,8 +15161,8 @@ mod hir_opt_tests {
           PushInlineFrame :foo, v31 (0x1040), num_args=1
           PatchPoint NoSingletonClass(Array@0x1060)
           PatchPoint MethodRedefined(Array@0x1060, length@0x1068, cme:0x1070)
-          v68:CInt64 = ArrayLength v38
-          v69:Fixnum = BoxFixnum v68
+          v70:CInt64[3] = Const CInt64(3)
+          v69:Fixnum = BoxFixnum v70
           v51:CPtr = GetEP 0
           v52:CInt64 = LoadField v51, :VM_ENV_DATA_INDEX_SPECVAL@0x1098
           v53:CInt64[-4] = Const CInt64(-4)

--- a/zjit/src/stats.rs
+++ b/zjit/src/stats.rs
@@ -473,6 +473,9 @@ make_counters! {
     load_field_count,
     store_field_count,
 
+    elided_array_aref_count,
+    elided_array_length_count,
+
     invokeblock_handler_monomorphic_iseq,
     invokeblock_handler_monomorphic_ifunc,
     invokeblock_handler_monomorphic_other,

--- a/zjit/src/stats.rs
+++ b/zjit/src/stats.rs
@@ -173,6 +173,7 @@ make_counters! {
         compile_hir_strength_reduce_time_ns,
         compile_hir_inline_methods_time_ns,
         compile_hir_remove_trivial_block_params_time_ns,
+        compile_hir_optimize_load_aaron_time_ns,
         compile_hir_optimize_load_store_time_ns,
         compile_hir_canonicalize_time_ns,
         compile_hir_fold_constants_time_ns,


### PR DESCRIPTION
This PR models array access on a virtual heap.

The point of this optimization pass is to eliminate array length guards and to
propagate variables to their uses rather than go through the array.  Basically
eliminate the memory access.

For example:

```ruby
def foo
  [1, 2]
end

def bar
  a, b = foo
  a + b
end
```

Today, the HIR looks like this:

```
Optimized HIR:
fn block in <main>@test.rb:11:
bb1():
  EntryPoint interpreter
  v1:BasicObject = LoadSelf
  Jump bb3(v1)
bb2():
  EntryPoint JIT(0)
  v4:BasicObject = LoadArg :self@0
  Jump bb3(v4)
bb3(v6:BasicObject):
  PatchPoint MethodRedefined(Object@0x108f60f00, bar@0xa451, cme:0x1090267a0)
  v18:ObjectSubclass[class_exact*:Object@VALUE(0x108f60f00)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x108f60f00)] recompile
  v52:NilClass = Const Value(nil)
  v53:NilClass = Const Value(nil)
  PushInlineFrame :bar, v18 (0x108f75500), num_args=0
  PatchPoint MethodRedefined(Object@0x108f60f00, foo@0xa441, cme:0x109026778)
  PushInlineFrame :foo, v18 (0x108f754e0), num_args=0
  v71:ArrayExact[VALUE(0x109026638)] = Const Value(VALUE(0x109026638))
  v72:ArrayExact = ArrayDup v71
  CheckInterrupts
  PopInlineFrame
  v31:CInt64 = ArrayLength v72
  v32:CInt64[2] = Const CInt64(2)
  v33:CInt64 = GuardGreaterEq v31, v32
  v34:CInt64[1] = Const CInt64(1)
  v35:BasicObject = ArrayAref v72, v34
  v36:CInt64[0] = Const CInt64(0)
  v37:BasicObject = ArrayAref v72, v36
  PatchPoint NoEPEscape(bar)
  PatchPoint MethodRedefined(Integer@0x108f644c0, +@0x2b, cme:0x108f5c270)
  v63:Fixnum = GuardType v37, Fixnum recompile
  v64:Fixnum = GuardType v35, Fixnum
  v65:Fixnum = FixnumAdd v63, v64
  CheckInterrupts
  PopInlineFrame
  Return v65
```

After this branch, the HIR looks like this:

```
Optimized HIR:
fn block in <main>@test.rb:11:
bb1():
  EntryPoint interpreter
  v1:BasicObject = LoadSelf
  Jump bb3(v1)
bb2():
  EntryPoint JIT(0)
  v4:BasicObject = LoadArg :self@0
  Jump bb3(v4)
bb3(v6:BasicObject):
  PatchPoint MethodRedefined(Object@0x106840ec0, bar@0xa481, cme:0x106906800)
  v18:ObjectSubclass[class_exact*:Object@VALUE(0x106840ec0)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x106840ec0)] recompile
  v52:NilClass = Const Value(nil)
  v53:NilClass = Const Value(nil)
  PushInlineFrame :bar, v18 (0x106855500), num_args=0
  PatchPoint MethodRedefined(Object@0x106840ec0, foo@0xa471, cme:0x1069067d8)
  PushInlineFrame :foo, v18 (0x1068554e0), num_args=0
  v71:ArrayExact[VALUE(0x106906698)] = Const Value(VALUE(0x106906698))
  v72:ArrayExact = ArrayDup v71
  CheckInterrupts
  PopInlineFrame
  v82:Fixnum[2] = Const Value(2)
  v83:Fixnum[1] = Const Value(1)
  PatchPoint NoEPEscape(bar)
  PatchPoint MethodRedefined(Integer@0x106844480, +@0x2b, cme:0x10683c280)
  v84:Fixnum[3] = Const Value(3)
  PopInlineFrame
  Return v84
```

I don't know where this optimization pass should live, or what we should call
it, so I'm just calling it the "load aaron" pass.  Please help me with a better
name or location and I will change this.

Counter stats for the headline benchmarks:

| benchmark | `elided_array_aref_count` | `elided_array_length_count` |
|---|--:|--:|
| hexapdf | 162,772 | 81,386 |
| lobsters | 6,633 | 8,687 |
| shipit | 5,514 | 31,524 |
| rubocop | 4,668 | 2,178 |
| railsbench | 1,640 | 328 |
| erubi-rails | 856 | 214 |
| liquid-c | 80 | 16 |
| liquid-compile | 80 | 16 |
| liquid-il | 80 | 16 |
| liquid-render | 80 | 16 |
| activerecord | 0 | 1 |
| chunky-png | 0 | 0 |
| mail | 0 | 0 |
| psych-load | 0 | 0 |
| ruby-lsp | 0 | 0 |
| sequel | 0 | 0 |
| **total** | **182,403** | **124,382** |