### PR TITLE
ppc/ppc64 coroutines: preserve nonvolatile CR fields

### DIFF
--- a/coroutine/ppc/Context.S
+++ b/coroutine/ppc/Context.S
@@ -19,7 +19,7 @@
 PREFIXED_SYMBOL(coroutine_transfer):
 	; Make space on the stack for caller registers
 	; (Should we rather use red zone? See libphobos example.)
-	subi r1,r1,80
+	subi r1,r1,84
 
 	; Get LR
 	mflr r0
@@ -46,8 +46,11 @@ PREFIXED_SYMBOL(coroutine_transfer):
 	stw r13,72(r1)
 
 	; Save return address
-	; Possibly should rather be saved into linkage area, see libphobos and IBM docs
 	stw r0,76(r1)
+
+	; Save caller CR register
+	mfcr r0
+	stw r0,80(r1)
 
 	; Save stack pointer to first argument
 	stw r1,0(r3)
@@ -82,8 +85,14 @@ PREFIXED_SYMBOL(coroutine_transfer):
 	; Set LR
 	mtlr r0
 
+	; Load CR register
+	lwz r0,80(r1)
+	; While it is feasible to deal with select fields of CR,
+	; it is easier and potentially faster to use the whole of it.
+	mtcr r0
+
 	; Pop stack frame
-	addi r1,r1,80
+	addi r1,r1,84
 
 	; Jump to return address
 	blr

--- a/coroutine/ppc/Context.S
+++ b/coroutine/ppc/Context.S
@@ -19,7 +19,7 @@
 PREFIXED_SYMBOL(coroutine_transfer):
 	; Make space on the stack for caller registers
 	; (Should we rather use red zone? See libphobos example.)
-	subi r1,r1,84
+	subi r1,r1,80
 
 	; Get LR
 	mflr r0
@@ -48,9 +48,9 @@ PREFIXED_SYMBOL(coroutine_transfer):
 	; Save return address
 	stw r0,76(r1)
 
-	; Save caller CR register
+	; Save nonvolatile CR fields in the caller linkage area
 	mfcr r0
-	stw r0,80(r1)
+	stw r0,84(r1)
 
 	; Save stack pointer to first argument
 	stw r1,0(r3)
@@ -85,14 +85,12 @@ PREFIXED_SYMBOL(coroutine_transfer):
 	; Set LR
 	mtlr r0
 
-	; Load CR register
-	lwz r0,80(r1)
-	; While it is feasible to deal with select fields of CR,
-	; it is easier and potentially faster to use the whole of it.
-	mtcr r0
+	; Restore nonvolatile CR2-CR4
+	lwz r0,84(r1)
+	mtcrf 56,r0
 
 	; Pop stack frame
-	addi r1,r1,84
+	addi r1,r1,80
 
 	; Jump to return address
 	blr

--- a/coroutine/ppc/Context.h
+++ b/coroutine/ppc/Context.h
@@ -13,7 +13,7 @@
 
 enum {
   COROUTINE_REGISTERS =
-  20  /* 19 general purpose registers (r13-r31) and 1 return address */
+  21  /* 19 general purpose registers (r13-r31), 1 special register (cr) and 1 return address */
   + 4  /* space for fiber_entry() to store the link register */
 };
 

--- a/coroutine/ppc/Context.h
+++ b/coroutine/ppc/Context.h
@@ -13,8 +13,8 @@
 
 enum {
   COROUTINE_REGISTERS =
-  21  /* 19 general purpose registers (r13-r31), 1 special register (cr) and 1 return address */
-  + 4  /* space for fiber_entry() to store the link register */
+  20  /* 19 general purpose registers (r13-r31) and 1 return address */
+  + 4  /* caller linkage area, including the condition register save slot */
 };
 
 struct coroutine_context

--- a/coroutine/ppc64/Context.S
+++ b/coroutine/ppc64/Context.S
@@ -18,7 +18,7 @@
 PREFIXED_SYMBOL(coroutine_transfer):
 	; Make space on the stack for caller registers
 	; (Should we rather use red zone? See libphobos example.)
-	subi r1,r1,160
+	subi r1,r1,168
 
 	; Get LR
 	mflr r0
@@ -45,8 +45,11 @@ PREFIXED_SYMBOL(coroutine_transfer):
 	std r13,144(r1)
 
 	; Save return address
-	; Possibly should rather be saved into linkage area, see libphobos and IBM docs
 	std r0,152(r1)
+
+	; Save caller CR register
+	mfcr r0
+	std r0,160(r1)
 
 	; Save stack pointer to first argument
 	std r1,0(r3)
@@ -81,8 +84,14 @@ PREFIXED_SYMBOL(coroutine_transfer):
 	; Set LR
 	mtlr r0
 
+	; Load CR register
+	ld r0,160(r1)
+	; While it is feasible to deal with select fields of CR,
+	; it is easier and potentially faster to use the whole of it.
+	mtcr r0
+
 	; Pop stack frame
-	addi r1,r1,160
+	addi r1,r1,168
 
 	; Jump to return address
 	blr

--- a/coroutine/ppc64/Context.S
+++ b/coroutine/ppc64/Context.S
@@ -18,7 +18,7 @@
 PREFIXED_SYMBOL(coroutine_transfer):
 	; Make space on the stack for caller registers
 	; (Should we rather use red zone? See libphobos example.)
-	subi r1,r1,168
+	subi r1,r1,160
 
 	; Get LR
 	mflr r0
@@ -47,9 +47,9 @@ PREFIXED_SYMBOL(coroutine_transfer):
 	; Save return address
 	std r0,152(r1)
 
-	; Save caller CR register
+	; Save nonvolatile CR fields in the caller linkage area
 	mfcr r0
-	std r0,160(r1)
+	std r0,168(r1)
 
 	; Save stack pointer to first argument
 	std r1,0(r3)
@@ -84,14 +84,12 @@ PREFIXED_SYMBOL(coroutine_transfer):
 	; Set LR
 	mtlr r0
 
-	; Load CR register
-	ld r0,160(r1)
-	; While it is feasible to deal with select fields of CR,
-	; it is easier and potentially faster to use the whole of it.
-	mtcr r0
+	; Restore nonvolatile CR2-CR4
+	ld r0,168(r1)
+	mtcrf 56,r0
 
 	; Pop stack frame
-	addi r1,r1,168
+	addi r1,r1,160
 
 	; Jump to return address
 	blr

--- a/coroutine/ppc64/Context.h
+++ b/coroutine/ppc64/Context.h
@@ -12,7 +12,7 @@
 
 enum {
   COROUTINE_REGISTERS =
-  20  /* 19 general purpose registers (r13-r31) and 1 return address */
+  21  /* 19 general purpose registers (r13-r31), 1 special register (cr) and 1 return address */
   + 4  /* space for fiber_entry() to store the link register */
 };
 

--- a/coroutine/ppc64/Context.h
+++ b/coroutine/ppc64/Context.h
@@ -12,8 +12,8 @@
 
 enum {
   COROUTINE_REGISTERS =
-  21  /* 19 general purpose registers (r13-r31), 1 special register (cr) and 1 return address */
-  + 4  /* space for fiber_entry() to store the link register */
+  20  /* 19 general purpose registers (r13-r31) and 1 return address */
+  + 4  /* caller linkage area, including the condition register save slot */
 };
 
 struct coroutine_context


### PR DESCRIPTION
Supersedes #13007 and is based on its latest head, preserving the original commits and authorship.

The Darwin PowerPC ABI requires CR2-CR4 to be preserved across calls. This keeps the original CR save/restore fix while addressing the review feedback:

- Save CR in the ABI caller linkage area at `84(r1)` on PPC and `168(r1)` on PPC64.
- Retain the existing 80-byte and 160-byte stack frames, preserving 16-byte stack alignment.
- Keep `COROUTINE_REGISTERS` unchanged because its existing `+ 4` allocation provides the linkage area for initialized contexts.
- Restore only nonvolatile CR2-CR4 using `mtcrf 56,r0`.

Testing:

- `git diff --check`
- Not assembled locally because the current Apple Clang toolchain no longer provides PowerPC targets. The original patch was tested on PPC Darwin as documented in #13007.