### PR TITLE
coroutine: normalize assembly indentation

### DIFF
--- a/coroutine/amd64/Context.S
+++ b/coroutine/amd64/Context.S
@@ -17,8 +17,8 @@
 PREFIXED_SYMBOL(coroutine_transfer):
 
 #if defined(__CET__) && (__CET__ & 0x01) != 0
-        /* IBT landing pad */
-        endbr64
+	/* IBT landing pad */
+	endbr64
 #endif
 
 	# Make space on the stack for 6 registers:

--- a/coroutine/arm64/Context.S
+++ b/coroutine/arm64/Context.S
@@ -141,20 +141,20 @@ PREFIXED_SYMBOL(coroutine_transfer):
 #    define PAC_FLAG 0
 #  endif
 
-  # The note section format is described by Note Section in Chapter 5
-  # of "System V Application Binary Interface, Edition 4.1".
-  .pushsection .note.gnu.property, "a"
-  .p2align 3
-  .long 0x4        /* Name size ("GNU\0") */
-  .long 0x10       /* Descriptor size */
-  .long 0x5        /* Type: NT_GNU_PROPERTY_TYPE_0 */
-  .asciz "GNU"     /* Name */
-  # Begin descriptor
-  .long 0xc0000000 /* Property type: GNU_PROPERTY_AARCH64_FEATURE_1_AND */
-  .long 0x4        /* Property size */
-  .long (BTI_FLAG|PAC_FLAG)
-  .long 0x0        /* 8-byte alignment padding */
-  # End descriptor
-  .popsection
+	# The note section format is described by Note Section in Chapter 5
+	# of "System V Application Binary Interface, Edition 4.1".
+	.pushsection .note.gnu.property, "a"
+	.p2align 3
+	.long 0x4        /* Name size ("GNU\0") */
+	.long 0x10       /* Descriptor size */
+	.long 0x5        /* Type: NT_GNU_PROPERTY_TYPE_0 */
+	.asciz "GNU"     /* Name */
+	# Begin descriptor
+	.long 0xc0000000 /* Property type: GNU_PROPERTY_AARCH64_FEATURE_1_AND */
+	.long 0x4        /* Property size */
+	.long (BTI_FLAG|PAC_FLAG)
+	.long 0x0        /* 8-byte alignment padding */
+	# End descriptor
+	.popsection
 #endif
 #endif


### PR DESCRIPTION
Normalize leading indentation in the AMD64 CET block and ARM64 GNU property-note block to match the tab indentation used by the surrounding assembly.

This is a whitespace-only change; the generated objects are unchanged.

Verification:
- git diff --check
- Cross-assembled AMD64 with CET enabled
- Cross-assembled ARM64 with BTI and PAC enabled
- Confirmed before/after object files are byte-for-byte identical