### PR TITLE
[Bug #21918] Scope Fiber scheduler interrupts to blocking IO operations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -41,8 +41,9 @@ Note: We're only listing outstanding class updates.
 
 * Fiber::Scheduler
 
-    * The `fiber_interrupt` hook is now required. Schedulers which do not
-      implement it can no longer be installed with `Fiber.set_scheduler`.
+    * The `blocking_operation_interrupt` hook is added for operation-scoped
+      interruption. A scheduler must implement either this hook or the legacy
+      `fiber_interrupt` hook.
 
 * Hash
 

--- a/doc/language/fiber.md
+++ b/doc/language/fiber.md
@@ -234,7 +234,9 @@ non-blocking*, the operation will invoke the scheduler.
 
 Closing an IO interrupts all blocking operations on that IO. When a thread calls `IO#close`, it first attempts to interrupt any threads or fibers that are blocked on that IO. The closing thread waits until all blocked threads and fibers have been properly interrupted and removed from the IO's blocking list. Each interrupted thread or fiber receives an `IOError` and is cleanly removed from the blocking operation. Only after all blocking operations have been interrupted and cleaned up will the actual file descriptor be closed, ensuring proper resource cleanup and preventing potential race conditions.
 
-For fibers managed by a scheduler, the interruption process involves calling `rb_fiber_scheduler_fiber_interrupt` on the scheduler. The corresponding `Fiber::Scheduler#fiber_interrupt` hook is required. This allows the scheduler to handle the interruption in a way that's appropriate for its event loop implementation. The scheduler can then notify the fiber, which will receive an `IOError` and be removed from the blocking operation. This mechanism ensures that fiber-based concurrency works correctly with IO operations, even when those operations are interrupted by `IO#close`.
+For fibers managed by a scheduler, the interruption process preferably uses the `Fiber::Scheduler#blocking_operation_interrupt` hook. It receives an opaque operation and the exception associated with the interruption. The scheduler should enqueue the operation on its owning thread and call `operation.interrupt` there. If the operation completes before the queued interruption is processed, `operation.active?` returns false and `operation.interrupt` has no effect. This prevents a delayed exception from escaping the operation which caused it and interrupting a later operation on the same fiber.
+
+Schedulers which do not implement `blocking_operation_interrupt` use the legacy `Fiber::Scheduler#fiber_interrupt` hook instead. A scheduler must implement one of these hooks.
 
 ```mermaid
 sequenceDiagram
@@ -266,18 +268,18 @@ sequenceDiagram
     ThreadB->>IO: thread_io_close_notify_all
     Note over ThreadB: rb_mutex_sleep
 
-    IO->>Scheduler: rb_fiber_scheduler_fiber_interrupt(Fiber1)
-    Scheduler->>Fiber1: fiber_interrupt with IOError
+    IO->>Scheduler: blocking_operation_interrupt(Operation1, IOError)
+    Scheduler->>Fiber1: Operation1.interrupt
     activate Fiber1
-    Note over IO: fiber_interrupt causes removal from blocking list
+    Note over IO: operation interruption causes removal from blocking list
     Fiber1->>IO: rb_io_blocking_operation_exit()
     IO-->>ThreadB: Wakeup thread
     deactivate Fiber1
 
-    IO->>Scheduler: rb_fiber_scheduler_fiber_interrupt(Fiber2)
-    Scheduler->>Fiber2: fiber_interrupt with IOError
+    IO->>Scheduler: blocking_operation_interrupt(Operation2, IOError)
+    Scheduler->>Fiber2: Operation2.interrupt
     activate Fiber2
-    Note over IO: fiber_interrupt causes removal from blocking list
+    Note over IO: operation interruption causes removal from blocking list
     Fiber2->>IO: rb_io_blocking_operation_exit()
     IO-->>ThreadB: Wakeup thread
     deactivate Fiber2

--- a/include/ruby/fiber/scheduler.h
+++ b/include/ruby/fiber/scheduler.h
@@ -25,7 +25,8 @@ RBIMPL_SYMBOL_EXPORT_BEGIN()
 
 // Version 3: Adds support for `fiber_interrupt`.
 // Version 4: IO hooks use single-transfer `(offset, length)` semantics.
-#define RUBY_FIBER_SCHEDULER_VERSION 4
+// Version 5: Adds support for operation-scoped interruption.
+#define RUBY_FIBER_SCHEDULER_VERSION 5
 
 struct timeval;
 struct rb_thread_struct;
@@ -473,6 +474,21 @@ int rb_fiber_scheduler_blocking_operation_cancel(rb_fiber_scheduler_blocking_ope
  * @return     otherwise         What `scheduler.blocking_operation_wait` returns.
  */
 VALUE rb_fiber_scheduler_blocking_operation_wait(VALUE scheduler, void* (*function)(void *), void *data, rb_unblock_function_t *unblock_function, void *data2, int flags, struct rb_fiber_scheduler_blocking_operation_state *state);
+
+/**
+ * Interrupt a specific blocking operation with an exception.
+ *
+ * The operation is an opaque object which responds to `active?` and
+ * `interrupt`. This hook may be invoked by a different thread. The scheduler
+ * should enqueue the operation and invoke `operation.interrupt` on the
+ * scheduler's owning thread.
+ *
+ * @param[in]  scheduler  Target scheduler.
+ * @param[in]  operation  The opaque operation to interrupt.
+ * @param[in]  exception  The exception associated with the interruption.
+ * @return     What `scheduler.blocking_operation_interrupt` returns.
+ */
+VALUE rb_fiber_scheduler_blocking_operation_interrupt(VALUE scheduler, VALUE operation, VALUE exception);
 
 /**
  * Interrupt a fiber by raising an exception. You can construct an exception using `rb_make_exception`.

--- a/internal/io.h
+++ b/internal/io.h
@@ -27,6 +27,9 @@ struct rb_io_blocking_operation {
 
     // The execution context of the blocking operation.
     struct rb_execution_context_struct *ec;
+
+    // An opaque scheduler operation, created if the operation is interrupted.
+    VALUE scheduler_operation;
 };
 
 /** Ruby's IO, metadata and buffers. */

--- a/internal/scheduler.h
+++ b/internal/scheduler.h
@@ -1,0 +1,16 @@
+#ifndef INTERNAL_SCHEDULER_H                            /*-*-C-*-vi:se ft=cpp:*/
+#define INTERNAL_SCHEDULER_H
+/**
+ * @author     Ruby developers <ruby-core@ruby-lang.org>
+ * @copyright  This file is a part of the Ruby language project.
+ * @brief      Internal interfaces for the Fiber scheduler.
+ */
+
+#include "ruby/ruby.h"
+
+VALUE rb_fiber_scheduler_io_operation_new(VALUE fiber, VALUE exception);
+VALUE rb_fiber_scheduler_io_operation_exception(VALUE operation);
+void rb_fiber_scheduler_io_operation_invalidate(VALUE operation);
+bool rb_fiber_scheduler_supports_blocking_operation_interrupt(VALUE scheduler);
+
+#endif /* INTERNAL_SCHEDULER_H */

--- a/scheduler.c
+++ b/scheduler.c
@@ -17,6 +17,7 @@
 #include "ruby/thread.h"
 
 // For `ruby_thread_has_gvl_p`:
+#include "internal/scheduler.h"
 #include "internal/thread.h"
 
 // For atomic operations:
@@ -45,12 +46,117 @@ static ID id_io_close;
 static ID id_address_resolve;
 
 static ID id_blocking_operation_wait;
+static ID id_blocking_operation_interrupt;
 static ID id_fiber_interrupt;
 
 static ID id_fiber_schedule;
 
 // Our custom blocking operation class
 static VALUE rb_cFiberSchedulerBlockingOperation;
+static VALUE rb_cFiberSchedulerIOOperation;
+
+struct rb_fiber_scheduler_io_operation {
+    VALUE fiber;
+    VALUE exception;
+    bool active;
+};
+
+static void
+io_operation_mark(void *ptr)
+{
+    struct rb_fiber_scheduler_io_operation *operation = ptr;
+
+    rb_gc_mark(operation->fiber);
+    rb_gc_mark(operation->exception);
+}
+
+static size_t
+io_operation_memsize(const void *ptr)
+{
+    return sizeof(struct rb_fiber_scheduler_io_operation);
+}
+
+static const rb_data_type_t io_operation_data_type = {
+    "Fiber::Scheduler::IOOperation",
+    {
+        io_operation_mark,
+        RUBY_DEFAULT_FREE,
+        io_operation_memsize,
+    },
+    0, 0, RUBY_TYPED_FREE_IMMEDIATELY
+};
+
+static struct rb_fiber_scheduler_io_operation *
+get_io_operation(VALUE self)
+{
+    struct rb_fiber_scheduler_io_operation *operation;
+    TypedData_Get_Struct(self, struct rb_fiber_scheduler_io_operation, &io_operation_data_type, operation);
+    return operation;
+}
+
+static VALUE
+io_operation_active_p(VALUE self)
+{
+    return RBOOL(get_io_operation(self)->active);
+}
+
+/*
+ * Raise the pending exception in the fiber if this operation is still active.
+ * This method is intended to be invoked on the scheduler's owning thread.
+ */
+static VALUE
+io_operation_interrupt(VALUE self)
+{
+    struct rb_fiber_scheduler_io_operation *operation = get_io_operation(self);
+
+    if (!operation->active) {
+        return Qfalse;
+    }
+
+    VALUE exception = operation->exception;
+    return rb_fiber_raise(operation->fiber, 1, &exception);
+}
+
+VALUE
+rb_fiber_scheduler_io_operation_new(VALUE fiber, VALUE exception)
+{
+    struct rb_fiber_scheduler_io_operation *operation;
+    VALUE self = TypedData_Make_Struct(rb_cFiberSchedulerIOOperation, struct rb_fiber_scheduler_io_operation, &io_operation_data_type, operation);
+
+    operation->fiber = fiber;
+    operation->exception = exception;
+    operation->active = true;
+
+    return self;
+}
+
+VALUE
+rb_fiber_scheduler_io_operation_exception(VALUE self)
+{
+    struct rb_fiber_scheduler_io_operation *operation = get_io_operation(self);
+
+    if (operation->active) {
+        return operation->exception;
+    }
+
+    return Qnil;
+}
+
+void
+rb_fiber_scheduler_io_operation_invalidate(VALUE self)
+{
+    struct rb_fiber_scheduler_io_operation *operation = get_io_operation(self);
+
+    operation->active = false;
+    operation->fiber = Qnil;
+    operation->exception = Qnil;
+}
+
+bool
+rb_fiber_scheduler_supports_blocking_operation_interrupt(VALUE scheduler)
+{
+    return rb_respond_to(scheduler, id_blocking_operation_interrupt);
+}
 
 /*
  * Custom blocking operation structure for blocking operations
@@ -289,12 +395,14 @@ rb_fiber_scheduler_blocking_operation_new(void *(*function)(void *), void *data,
  *  * #address_resolve
  *  * #block and #unblock
  *  * #blocking_operation_wait
+ *  * #blocking_operation_interrupt
  *  * #fiber_interrupt
  *  * #yield
  *  * (the list is expanded as Ruby developers make more methods having non-blocking calls)
  *
- *  The #block, #unblock, #kernel_sleep, #io_wait, and #fiber_interrupt hooks are mandatory.
- *  Other hooks are optional unless specified otherwise.
+ *  The #block, #unblock, #kernel_sleep, and #io_wait hooks are mandatory. Schedulers must also
+ *  implement either #blocking_operation_interrupt or #fiber_interrupt. Other hooks are optional
+ *  unless specified otherwise.
  *
  *  It is also strongly recommended that the scheduler implements the #fiber method, which is
  *  delegated to by Fiber.schedule.
@@ -331,6 +439,7 @@ Init_Fiber_Scheduler(void)
     id_address_resolve = rb_intern_const("address_resolve");
 
     id_blocking_operation_wait = rb_intern_const("blocking_operation_wait");
+    id_blocking_operation_interrupt = rb_intern_const("blocking_operation_interrupt");
     id_fiber_interrupt = rb_intern_const("fiber_interrupt");
 
     id_fiber_schedule = rb_intern_const("fiber");
@@ -343,6 +452,14 @@ Init_Fiber_Scheduler(void)
 
     // Register the anonymous class as a GC root so it doesn't get collected
     rb_gc_register_mark_object(rb_cFiberSchedulerBlockingOperation);
+
+    // Define an anonymous IO operation class. Instances are passed to
+    // blocking_operation_interrupt and cannot be instantiated directly.
+    rb_cFiberSchedulerIOOperation = rb_class_new(rb_cObject);
+    rb_undef_alloc_func(rb_cFiberSchedulerIOOperation);
+    rb_define_method(rb_cFiberSchedulerIOOperation, "active?", io_operation_active_p, 0);
+    rb_define_method(rb_cFiberSchedulerIOOperation, "interrupt", io_operation_interrupt, 0);
+    rb_gc_register_mark_object(rb_cFiberSchedulerIOOperation);
 
 #if 0 /* for RDoc */
     rb_cFiberScheduler = rb_define_class_under(rb_cFiber, "Scheduler", rb_cObject);
@@ -361,6 +478,7 @@ Init_Fiber_Scheduler(void)
     rb_define_method(rb_cFiberScheduler, "unblock", rb_fiber_scheduler_unblock, 2);
     rb_define_method(rb_cFiberScheduler, "fiber", rb_fiber_scheduler_fiber, -2);
     rb_define_method(rb_cFiberScheduler, "blocking_operation_wait", rb_fiber_scheduler_blocking_operation_wait, -2);
+    rb_define_method(rb_cFiberScheduler, "blocking_operation_interrupt", rb_fiber_scheduler_blocking_operation_interrupt, 2);
     rb_define_method(rb_cFiberScheduler, "yield", rb_fiber_scheduler_yield, 0);
     rb_define_method(rb_cFiberScheduler, "fiber_interrupt", rb_fiber_scheduler_fiber_interrupt, 2);
     rb_define_method(rb_cFiberScheduler, "io_close", rb_fiber_scheduler_io_close, 1);
@@ -397,8 +515,8 @@ verify_interface(VALUE scheduler)
         rb_raise(rb_eArgError, "Scheduler must implement #io_wait");
     }
 
-    if (!rb_respond_to(scheduler, id_fiber_interrupt)) {
-        rb_raise(rb_eArgError, "Scheduler must implement #fiber_interrupt");
+    if (!rb_respond_to(scheduler, id_blocking_operation_interrupt) && !rb_respond_to(scheduler, id_fiber_interrupt)) {
+        rb_raise(rb_eArgError, "Scheduler must implement #blocking_operation_interrupt or #fiber_interrupt");
     }
 }
 
@@ -1152,25 +1270,13 @@ VALUE rb_fiber_scheduler_blocking_operation_wait(VALUE scheduler, void* (*functi
     return result;
 }
 
-/*
- * Document-method: Fiber::Scheduler#fiber_interrupt
- * call-seq: fiber_interrupt(fiber, exception)
- *
- * Invoked by Ruby's core methods to notify the scheduler that the blocked fiber should be interrupted
- * with an exception. For example, IO#close uses this method to interrupt fibers that are performing
- * blocking IO operations.
- *
- */
-VALUE rb_fiber_scheduler_fiber_interrupt(VALUE scheduler, VALUE fiber, VALUE exception)
+static VALUE
+fiber_scheduler_interrupt(VALUE scheduler, ID method, int argc, const VALUE *arguments)
 {
-    VALUE arguments[] = {
-        fiber, exception
-    };
-
     VALUE result;
     enum ruby_tag_type state;
 
-    // We must prevent interrupts while invoking the fiber_interrupt method, because otherwise fibers can be left permanently blocked if an interrupt occurs during the execution of user code. See also `rb_fiber_scheduler_unblock`.
+    // We must prevent interrupts while invoking the scheduler, because otherwise fibers can be left permanently blocked if an interrupt occurs during the execution of user code. See also `rb_fiber_scheduler_unblock`.
     rb_execution_context_t * volatile ec = GET_EC();
     volatile int saved_interrupt_mask = ec->interrupt_mask;
     ec->interrupt_mask |= PENDING_INTERRUPT_MASK;
@@ -1178,7 +1284,7 @@ VALUE rb_fiber_scheduler_fiber_interrupt(VALUE scheduler, VALUE fiber, VALUE exc
     rb_control_frame_t *volatile cfp = ec->cfp;
     EC_PUSH_TAG(ec);
     if ((state = EC_EXEC_TAG()) == TAG_NONE) {
-        result = rb_funcallv(scheduler, id_fiber_interrupt, 2, arguments);
+        result = rb_funcallv(scheduler, method, argc, arguments);
     }
     else {
         rb_vm_rewind_cfp(ec, cfp);
@@ -1194,6 +1300,51 @@ VALUE rb_fiber_scheduler_fiber_interrupt(VALUE scheduler, VALUE fiber, VALUE exc
     RUBY_VM_CHECK_INTS(ec);
 
     return result;
+}
+
+/*
+ * Document-method: Fiber::Scheduler#blocking_operation_interrupt
+ * call-seq: blocking_operation_interrupt(operation, exception)
+ *
+ * Invoked by IO#close to interrupt a specific blocking operation. The opaque
+ * +operation+ responds to #active? and #interrupt. Because this hook may be
+ * invoked from another thread, the scheduler should enqueue +operation+ on its
+ * owning thread and invoke #interrupt there. If the operation completed before
+ * the queued interruption runs, #active? returns false and #interrupt has no
+ * effect.
+ *
+ * This hook is preferred over #fiber_interrupt because the interruption cannot
+ * escape the operation which caused it.
+ */
+VALUE
+rb_fiber_scheduler_blocking_operation_interrupt(VALUE scheduler, VALUE operation, VALUE exception)
+{
+    VALUE arguments[] = {
+        operation, exception
+    };
+
+    return fiber_scheduler_interrupt(scheduler, id_blocking_operation_interrupt, 2, arguments);
+}
+
+/*
+ * Document-method: Fiber::Scheduler#fiber_interrupt
+ * call-seq: fiber_interrupt(fiber, exception)
+ *
+ * Invoked by Ruby's core methods to notify the scheduler that the blocked fiber should be interrupted
+ * with an exception. For example, IO#close uses this method to interrupt fibers that are performing
+ * blocking IO operations.
+ *
+ * This hook is retained for compatibility. New schedulers should implement
+ * #blocking_operation_interrupt instead.
+ */
+VALUE
+rb_fiber_scheduler_fiber_interrupt(VALUE scheduler, VALUE fiber, VALUE exception)
+{
+    VALUE arguments[] = {
+        fiber, exception
+    };
+
+    return fiber_scheduler_interrupt(scheduler, id_fiber_interrupt, 2, arguments);
 }
 
 /*

--- a/spec/ruby/core/fiber/set_scheduler_spec.rb
+++ b/spec/ruby/core/fiber/set_scheduler_spec.rb
@@ -5,18 +5,38 @@ require "fiber"
 describe "Fiber.scheduler" do
   it "validates the scheduler for required methods" do
     required_methods = [:block, :unblock, :kernel_sleep, :io_wait]
-    ruby_version_is "4.1" do
-      required_methods << :fiber_interrupt
-    end
 
     required_methods.each do |missing_method|
       scheduler = Object.new
       required_methods.difference([missing_method]).each do |method|
         scheduler.define_singleton_method(method) {}
       end
+      scheduler.define_singleton_method(:fiber_interrupt) {}
       -> {
         Fiber.set_scheduler(scheduler)
       }.should.raise(ArgumentError, /Scheduler must implement ##{missing_method}/)
+    end
+
+    ruby_version_is "4.1" do
+      scheduler = Object.new
+      required_methods.each do |method|
+        scheduler.define_singleton_method(method) {}
+      end
+      -> {
+        Fiber.set_scheduler(scheduler)
+      }.should.raise(ArgumentError, /Scheduler must implement #blocking_operation_interrupt or #fiber_interrupt/)
+    end
+  end
+
+  ruby_version_is "4.1" do
+    it "accepts blocking_operation_interrupt instead of fiber_interrupt" do
+      scheduler = Object.new
+      [:block, :unblock, :kernel_sleep, :io_wait, :blocking_operation_interrupt].each do |method|
+        scheduler.define_singleton_method(method) {}
+      end
+
+      Fiber.set_scheduler(scheduler)
+      Fiber.scheduler.should == scheduler
     end
   end
 

--- a/test/fiber/scheduler.rb
+++ b/test/fiber/scheduler.rb
@@ -337,6 +337,29 @@ class Scheduler
     io.write_nonblock('.')
   end
 
+  class BlockingOperationInterrupt
+    def initialize(operation)
+      @operation = operation
+    end
+
+    def alive?
+      @operation.active?
+    end
+
+    def transfer
+      @operation.interrupt
+    end
+  end
+
+  def blocking_operation_interrupt(operation, _exception)
+    @lock.synchronize do
+      @ready << BlockingOperationInterrupt.new(operation)
+    end
+
+    io = @urgent.last
+    io.write_nonblock('.')
+  end
+
   # This hook is invoked by `Fiber.schedule`. Strictly speaking, you should use
   # it to create scheduled fibers, but it is not required in practice;
   # `Fiber.new` is usually sufficient.

--- a/test/fiber/test_io_close.rb
+++ b/test/fiber/test_io_close.rb
@@ -1,8 +1,13 @@
 # frozen_string_literal: true
 require 'test/unit'
+require 'io/wait'
 require_relative 'scheduler'
 
 class TestFiberIOClose < Test::Unit::TestCase
+  class LegacyScheduler < Scheduler
+    undef_method :blocking_operation_interrupt
+  end
+
   def with_socket_pair(&block)
     omit "UNIXSocket is not defined!" unless defined?(UNIXSocket)
 
@@ -19,28 +24,70 @@ class TestFiberIOClose < Test::Unit::TestCase
   def test_io_close_across_fibers
     # omit "Interrupting a io_wait read is not supported!" if RUBY_PLATFORM =~ /mswin|mingw/
 
-    with_socket_pair do |i, o|
-      error = nil
+    [Scheduler, LegacyScheduler].each do |scheduler_class|
+      with_socket_pair do |i, o|
+        error = nil
 
-      thread = Thread.new do
-        scheduler = Scheduler.new
-        Fiber.set_scheduler scheduler
+        thread = Thread.new do
+          scheduler = scheduler_class.new
+          Fiber.set_scheduler scheduler
 
-        Fiber.schedule do
-          i.read
-        rescue => error
-          # Ignore.
+          Fiber.schedule do
+            i.read
+          rescue => error
+            # Ignore.
+          end
+
+          Fiber.schedule do
+            i.close
+          end
         end
 
-        Fiber.schedule do
-          i.close
+        thread.join
+
+        assert_instance_of IOError, error
+        assert_match(/closed/, error.message)
+      end
+    end
+  end
+
+  def test_io_close_interrupt_does_not_escape_blocking_operation
+    with_socket_pair do |source, source_peer|
+      with_socket_pair do |unrelated, unrelated_peer|
+        errors = []
+
+        thread = Thread.new do
+          scheduler = Scheduler.new
+          Fiber.set_scheduler scheduler
+
+          5.times do
+            Fiber.schedule do
+              begin
+                source.wait_readable(0.01)
+                source.close
+              rescue => error
+                errors << [:source, error]
+              end
+
+              begin
+                unrelated.wait_readable(0.01)
+              rescue => error
+                errors << [:unrelated, error]
+              end
+            end
+          end
+        end
+
+        thread.join
+
+        assert_equal 4, errors.size
+        assert_equal [:source], errors.map(&:first).uniq
+        errors.each do |location, error|
+          assert_equal :source, location
+          assert_instance_of IOError, error
+          assert_match(/closed/, error.message)
         end
       end
-
-      thread.join
-
-      assert_instance_of IOError, error
-      assert_match(/closed/, error.message)
     end
   end
 

--- a/test/fiber/test_scheduler.rb
+++ b/test/fiber/test_scheduler.rb
@@ -106,7 +106,7 @@ class TestFiberScheduler < Test::Unit::TestCase
     thread.join
   end
 
-  def test_fiber_interrupt_is_required
+  def test_interruption_hook_is_required
     scheduler = Object.new
 
     [:block, :unblock, :io_wait, :kernel_sleep].each do |method|
@@ -117,7 +117,21 @@ class TestFiberScheduler < Test::Unit::TestCase
       Fiber.set_scheduler scheduler
     end
 
-    assert_equal "Scheduler must implement #fiber_interrupt", error.message
+    assert_equal "Scheduler must implement #blocking_operation_interrupt or #fiber_interrupt", error.message
+  end
+
+  def test_blocking_operation_interrupt_can_replace_fiber_interrupt
+    scheduler = Object.new
+
+    [:block, :unblock, :io_wait, :kernel_sleep, :blocking_operation_interrupt].each do |method|
+      scheduler.define_singleton_method(method) {}
+    end
+
+    thread = Thread.new do
+      Fiber.set_scheduler scheduler
+    end
+
+    thread.join
   end
 
   def test_current_scheduler

--- a/thread.c
+++ b/thread.c
@@ -87,6 +87,7 @@
 #include "internal/object.h"
 #include "internal/proc.h"
 #include "ruby/fiber/scheduler.h"
+#include "internal/scheduler.h"
 #include "internal/signal.h"
 #include "internal/thread.h"
 #include "internal/time.h"
@@ -2023,6 +2024,10 @@ rb_io_blocking_operation_exit(struct rb_io *io, struct rb_io_blocking_operation 
     // Indicate that the blocking operation is no longer active:
     blocking_operation->ec = NULL;
 
+    if (!NIL_P(blocking_operation->scheduler_operation)) {
+        rb_fiber_scheduler_io_operation_invalidate(blocking_operation->scheduler_operation);
+    }
+
     if (RB_TEST(wakeup_mutex)) {
         struct io_blocking_operation_arguments arguments = {
             .io = io,
@@ -2047,6 +2052,30 @@ rb_thread_io_blocking_operation_ensure(VALUE _argument)
     return Qnil;
 }
 
+struct thread_io_blocking_operation_arguments {
+    VALUE (*function)(VALUE);
+    VALUE argument;
+    struct rb_io_blocking_operation *blocking_operation;
+};
+
+static VALUE
+rb_thread_io_blocking_operation_body(VALUE _arguments)
+{
+    struct thread_io_blocking_operation_arguments *arguments = (void *)_arguments;
+    VALUE result = arguments->function(arguments->argument);
+    VALUE operation = arguments->blocking_operation->scheduler_operation;
+
+    if (!NIL_P(operation)) {
+        VALUE exception = rb_fiber_scheduler_io_operation_exception(operation);
+
+        if (!NIL_P(exception)) {
+            rb_exc_raise(exception);
+        }
+    }
+
+    return result;
+}
+
 /*
  * Executes a function that performs a blocking IO operation, while properly tracking
  * the operation in the IO's blocking_operations list. This ensures proper cleanup
@@ -2069,6 +2098,7 @@ rb_thread_io_blocking_operation(VALUE self, VALUE(*function)(VALUE), VALUE argum
     rb_execution_context_t *ec = GET_EC();
     struct rb_io_blocking_operation blocking_operation = {
         .ec = ec,
+        .scheduler_operation = Qnil,
     };
     rb_io_blocking_operation_enter(io, &blocking_operation);
 
@@ -2077,7 +2107,13 @@ rb_thread_io_blocking_operation(VALUE self, VALUE(*function)(VALUE), VALUE argum
         .blocking_operation = &blocking_operation
     };
 
-    return rb_ensure(function, argument, rb_thread_io_blocking_operation_ensure, (VALUE)&io_blocking_operation_arguments);
+    struct thread_io_blocking_operation_arguments arguments = {
+        .function = function,
+        .argument = argument,
+        .blocking_operation = &blocking_operation,
+    };
+
+    return rb_ensure(rb_thread_io_blocking_operation_body, (VALUE)&arguments, rb_thread_io_blocking_operation_ensure, (VALUE)&io_blocking_operation_arguments);
 }
 
 static bool
@@ -2187,6 +2223,7 @@ rb_thread_io_blocking_call(struct rb_io* io, rb_blocking_function_t *func, void 
 
     struct rb_io_blocking_operation blocking_operation = {
         .ec = ec,
+        .scheduler_operation = Qnil,
     };
     rb_io_blocking_operation_enter(io, &blocking_operation);
 
@@ -3061,7 +3098,8 @@ rb_ec_reset_raised(rb_execution_context_t *ec)
  * - Set up wakeup_mutex for synchronization
  * - Iterate through all blocking operations in io->blocking_operations
  * - For each blocked fiber with a scheduler:
- *   - Notify via rb_fiber_scheduler_fiber_interrupt
+ *   - Notify via rb_fiber_scheduler_blocking_operation_interrupt, or
+ *     rb_fiber_scheduler_fiber_interrupt for compatibility
  * - For each blocked thread without a scheduler:
  *   - Enqueue IOError via rb_threadptr_pending_interrupt_enque
  *   - Wake via rb_threadptr_interrupt
@@ -3086,7 +3124,22 @@ thread_io_close_notify_all(VALUE _io)
             rb_thread_t *thread = ec->thread_ptr;
 
             if (thread->scheduler != Qnil) {
-                rb_fiber_scheduler_fiber_interrupt(thread->scheduler, rb_fiberptr_self(ec->fiber_ptr), error);
+                VALUE fiber = rb_fiberptr_self(ec->fiber_ptr);
+
+                if (rb_fiber_scheduler_supports_blocking_operation_interrupt(thread->scheduler)) {
+                    VALUE operation = blocking_operation->scheduler_operation;
+
+                    if (NIL_P(operation)) {
+                        operation = rb_fiber_scheduler_io_operation_new(fiber, error);
+                        blocking_operation->scheduler_operation = operation;
+                    }
+
+                    rb_fiber_scheduler_blocking_operation_interrupt(thread->scheduler, operation, error);
+                    RB_GC_GUARD(operation);
+                }
+                else {
+                    rb_fiber_scheduler_fiber_interrupt(thread->scheduler, fiber, error);
+                }
             }
             else {
                 // If the thread is not the current thread, we need to enqueue an error:
@@ -4884,6 +4937,7 @@ thread_io_wait(rb_thread_t *th, struct rb_io *io, int fd, int events, struct tim
 
     if (io) {
         blocking_operation.ec = ec;
+        blocking_operation.scheduler_operation = Qnil;
 COMPILER_WARNING_PUSH
 #if RBIMPL_COMPILER_SINCE(GCC, 12, 0, 0)
 COMPILER_WARNING_IGNORED(-Wdangling-pointer)
@@ -5054,12 +5108,14 @@ thread_io_wait(rb_thread_t *th, struct rb_io *io, int fd, int events, struct tim
     if (io) {
         args.io = io;
         blocking_operation.ec = th->ec;
+        blocking_operation.scheduler_operation = Qnil;
         rb_io_blocking_operation_enter(io, &blocking_operation);
         args.blocking_operation = &blocking_operation;
     }
     else {
         args.io = NULL;
         blocking_operation.ec = NULL;
+        blocking_operation.scheduler_operation = Qnil;
         args.blocking_operation = NULL;
     }
 


### PR DESCRIPTION
Fixes https://bugs.ruby-lang.org/issues/21918

`IO#close` currently notifies a scheduler with `fiber_interrupt(fiber, exception)`. If that notification is processed after the Fiber has already resumed, the exception can escape the operation that caused it and be raised during an unrelated later operation.

This adds `blocking_operation_interrupt(operation, exception)`. The opaque operation responds to `active?` and `interrupt`, allowing the scheduler to enqueue it on its owning thread. CRuby records the pending exception before invoking the scheduler, raises it before the original operation can return normally, and invalidates the operation during cleanup. Delayed callbacks therefore become no-ops.

Schedulers that only implement `fiber_interrupt` continue to use the legacy behavior.

The scheduler API version is bumped to 5, and the example scheduler, documentation, interface specs, compatibility coverage, and a regression test are updated.

Tests:

- Full `test/fiber` suite: 103 tests, 447 assertions
- `test_io_close.rb` repeated 50 times: 200 tests, 1500 assertions
- Scheduler interface specs: 6 examples, 10 expectations
- Clean arm64 macOS build