### PR TITLE
[Bug #22209] IO#set_encoding ignores conversion options when the encoding is not a String

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -55,6 +55,12 @@ Note: We're only listing outstanding class updates.
       binary representation of a non-negative integer (its population count).
       [[Feature #20163]]
 
+* IO
+
+    * `IO#set_encoding` now honors conversion options like `newline:` also
+      when the encoding is given as an `Encoding` object or `nil`, not only
+      as a String. [[Bug #22209]]
+
 * IO::Buffer
 
     * `read`, `write`, `pread`, and `pwrite` now perform one IO operation using
@@ -422,6 +428,7 @@ A lot of work has gone into making Ractors more stable, performant, and usable. 
 ## JIT
 
 [Bug #18947]: https://bugs.ruby-lang.org/issues/18947
+[Bug #22209]: https://bugs.ruby-lang.org/issues/22209
 [Feature #8948]: https://bugs.ruby-lang.org/issues/8948
 [Feature #9779]: https://bugs.ruby-lang.org/issues/9779
 [Feature #15330]: https://bugs.ruby-lang.org/issues/15330

--- a/io.c
+++ b/io.c
@@ -11806,7 +11806,7 @@ io_encoding_set(rb_io_t *fptr, VALUE v1, VALUE v2, VALUE opt)
             /* Set to default encodings */
             rb_io_ext_int_to_encs(NULL, NULL, &enc, &enc2, 0);
             SET_UNIVERSAL_NEWLINE_DECORATOR_IF_ENC2(enc2, ecflags);
-            ecopts = Qnil;
+            ecflags = rb_econv_prepare_options(opt, &ecopts, ecflags);
         }
         else {
             tmp = rb_check_string_type(v1);
@@ -11818,7 +11818,7 @@ io_encoding_set(rb_io_t *fptr, VALUE v1, VALUE v2, VALUE opt)
             else {
                 rb_io_ext_int_to_encs(find_encoding(v1), NULL, &enc, &enc2, 0);
                 SET_UNIVERSAL_NEWLINE_DECORATOR_IF_ENC2(enc2, ecflags);
-                ecopts = Qnil;
+                ecflags = rb_econv_prepare_options(opt, &ecopts, ecflags);
             }
         }
     }

--- a/test/ruby/test_io_m17n.rb
+++ b/test/ruby/test_io_m17n.rb
@@ -51,8 +51,8 @@ class TestIO_M17N < Test::Unit::TestCase
     raise re if re
   end
 
-  def with_pipe(*args)
-    r, w = IO.pipe(*args)
+  def with_pipe(*args, **opts)
+    r, w = IO.pipe(*args, **opts)
     begin
       yield r, w
     ensure
@@ -1052,6 +1052,64 @@ EOT
         assert_equal("a\nb\n", f.read, bug22209)
       }
     }
+  end
+
+  def test_pipe_conversion_options_enc
+    bug22209 = '[Bug #22209]'
+    with_pipe(Encoding::UTF_8, newline: :universal) {|r, w|
+      w.write("a\r\nb\r\n")
+      w.close
+      assert_equal("a\nb\n", r.read, bug22209)
+    }
+  end
+
+  def test_pipe_conversion_options_nil
+    bug22209 = '[Bug #22209]'
+    with_pipe(newline: :universal) {|r, w|
+      w.write("a\r\nb\r\n")
+      w.close
+      assert_equal("a\nb\n", r.read, bug22209)
+    }
+  end
+
+  def test_cr_decorator_on_stdout_encoding_arg
+    bug22209 = '[Bug #22209]'
+    with_pipe do |in_r, in_w|
+      with_pipe do |out_r, out_w|
+        pid = Process.spawn({}, EnvUtil.rubybin, in: in_r, out: out_w)
+        in_r.close
+        out_w.close
+        in_w.write <<-EOS
+          STDOUT.set_encoding(Encoding::UTF_8, newline: :cr)
+          STDOUT.puts "abc"
+          STDOUT.flush
+        EOS
+        in_w.close
+        Process.wait pid
+        assert_equal("abc\r", out_r.binmode.read, bug22209)
+        out_r.close
+      end
+    end
+  end
+
+  def test_cr_decorator_on_stdout_nil_arg
+    bug22209 = '[Bug #22209]'
+    with_pipe do |in_r, in_w|
+      with_pipe do |out_r, out_w|
+        pid = Process.spawn({}, EnvUtil.rubybin, in: in_r, out: out_w)
+        in_r.close
+        out_w.close
+        in_w.write <<-EOS
+          STDOUT.set_encoding(nil, newline: :cr)
+          STDOUT.puts "abc"
+          STDOUT.flush
+        EOS
+        in_w.close
+        Process.wait pid
+        assert_equal("abc\r", out_r.binmode.read, bug22209)
+        out_r.close
+      end
+    end
   end
 
   def test_set_encoding_invalid

--- a/test/ruby/test_io_m17n.rb
+++ b/test/ruby/test_io_m17n.rb
@@ -1032,6 +1032,28 @@ EOT
          end)
   end
 
+  def test_set_encoding_enc_newline_option
+    bug22209 = '[Bug #22209]'
+    with_tmpdir {
+      generate_file("t.crlf", "a\r\nb\r\n")
+      open("t.crlf", "r") {|f|
+        f.set_encoding(Encoding::UTF_8, newline: :universal)
+        assert_equal("a\nb\n", f.read, bug22209)
+      }
+    }
+  end
+
+  def test_set_encoding_nil_newline_option
+    bug22209 = '[Bug #22209]'
+    with_tmpdir {
+      generate_file("t.crlf", "a\r\nb\r\n")
+      open("t.crlf", "r") {|f|
+        f.set_encoding(nil, newline: :universal)
+        assert_equal("a\nb\n", f.read, bug22209)
+      }
+    }
+  end
+
   def test_set_encoding_invalid
     pipe(proc do |w|
            w << "\x80"


### PR DESCRIPTION
`IO#set_encoding` honors its keyword arguments such as `newline:` only when the external encoding is given as an ascii-compatible String:

    f.set_encoding("utf-8", newline: :universal)         # CRLF -> LF
    f.set_encoding(Encoding::UTF_8, newline: :universal) # option silently ignored

In `io_encoding_set()` the options are parsed by `rb_econv_prepare_options()`, but that call exists only in the String branch (and in the two-argument form). The branch taken for an `Encoding` object, and the one that resets to the default encodings when `nil` is passed, just set `ecopts` to Qnil and drop the whole option hash.

This makes the remaining branches parse the options the same way, so the single-argument form behaves consistently no matter how the encoding is specified. `IO.pipe`, which funnels its encoding arguments through the same function, is fixed alike.

The tests fail without the io.c change and pass with it. The file and `IO.pipe` cases check reading with `newline: :universal`; the STDOUT subprocess cases check the write direction with `newline: :cr`, which is observable on every platform since the output pipe is read in binary mode, following the neighboring `test_cr_decorator_on_stdout` tests. Locally `test/ruby/test_io_m17n.rb` and `test/ruby/test_io.rb` pass in full (431 tests, 0 failures).