### PR TITLE
Run more of the suite on Windows

### DIFF
--- a/spec/ruby/library/socket/addrinfo/unix_spec.rb
+++ b/spec/ruby/library/socket/addrinfo/unix_spec.rb
@@ -55,15 +55,13 @@ describe "Addrinfo#unix?" do
     end
   end
 
-  platform_is_not :windows do
-    describe "for a unix socket" do
-      before :each do
-        @addrinfo = Addrinfo.unix("/tmp/sock")
-      end
+  describe "for a unix socket" do
+    before :each do
+      @addrinfo = Addrinfo.unix("/tmp/sock")
+    end
 
-      it "returns true" do
-        @addrinfo.unix?.should == true
-      end
+    it "returns true" do
+      @addrinfo.unix?.should == true
     end
   end
 end

--- a/spec/ruby/library/socket/socket/pair_spec.rb
+++ b/spec/ruby/library/socket/socket/pair_spec.rb
@@ -2,140 +2,138 @@ require_relative '../spec_helper'
 require_relative '../fixtures/classes'
 
 describe "Socket.pair" do
-  platform_is_not :windows do
-    it "ensures the returned sockets are connected" do
-      s1, s2 = Socket.pair(Socket::AF_UNIX, 1, 0)
-      s1.puts("test")
-      s2.gets.should == "test\n"
+  it "ensures the returned sockets are connected" do
+    s1, s2 = Socket.pair(Socket::AF_UNIX, 1, 0)
+    s1.puts("test")
+    s2.gets.should == "test\n"
+    s1.close
+    s2.close
+  end
+
+  it "returns an array of two sockets" do
+    begin
+      s1, s2 = Socket.pair(:UNIX, :STREAM)
+
+      s1.should.instance_of?(Socket)
+      s2.should.instance_of?(Socket)
+    ensure
       s1.close
       s2.close
     end
+  end
 
-    it "returns an array of two sockets" do
-      begin
-        s1, s2 = Socket.pair(:UNIX, :STREAM)
+  describe 'using an Integer as the 1st and 2nd argument' do
+    it 'returns two Socket objects' do
+      s1, s2 = Socket.pair(Socket::AF_UNIX, Socket::SOCK_STREAM)
 
-        s1.should.instance_of?(Socket)
-        s2.should.instance_of?(Socket)
-      ensure
-        s1.close
-        s2.close
-      end
+      s1.should.instance_of?(Socket)
+      s2.should.instance_of?(Socket)
+      s1.close
+      s2.close
     end
+  end
 
-    describe 'using an Integer as the 1st and 2nd argument' do
-      it 'returns two Socket objects' do
-        s1, s2 = Socket.pair(Socket::AF_UNIX, Socket::SOCK_STREAM)
+  describe 'using a Symbol as the 1st and 2nd argument' do
+    it 'returns two Socket objects' do
+      s1, s2 = Socket.pair(:UNIX, :STREAM)
 
-        s1.should.instance_of?(Socket)
-        s2.should.instance_of?(Socket)
-        s1.close
-        s2.close
-      end
-    end
-
-    describe 'using a Symbol as the 1st and 2nd argument' do
-      it 'returns two Socket objects' do
-        s1, s2 = Socket.pair(:UNIX, :STREAM)
-
-        s1.should.instance_of?(Socket)
-        s2.should.instance_of?(Socket)
-        s1.close
-        s2.close
-      end
-
-      it 'raises SocketError for an unknown address family' do
-        -> { Socket.pair(:CATS, :STREAM) }.should.raise(SocketError)
-      end
-
-      it 'raises SocketError for an unknown socket type' do
-        -> { Socket.pair(:UNIX, :CATS) }.should.raise(SocketError)
-      end
-    end
-
-    describe 'using a String as the 1st and 2nd argument' do
-      it 'returns two Socket objects' do
-        s1, s2 = Socket.pair('UNIX', 'STREAM')
-
-        s1.should.instance_of?(Socket)
-        s2.should.instance_of?(Socket)
-        s1.close
-        s2.close
-      end
-
-      it 'raises SocketError for an unknown address family' do
-        -> { Socket.pair('CATS', 'STREAM') }.should.raise(SocketError)
-      end
-
-      it 'raises SocketError for an unknown socket type' do
-        -> { Socket.pair('UNIX', 'CATS') }.should.raise(SocketError)
-      end
-    end
-
-    describe 'using an object that responds to #to_str as the 1st and 2nd argument' do
-      it 'returns two Socket objects' do
-        family = mock(:family)
-        type   = mock(:type)
-
-        family.stub!(:to_str).and_return('UNIX')
-        type.stub!(:to_str).and_return('STREAM')
-
-        s1, s2 = Socket.pair(family, type)
-
-        s1.should.instance_of?(Socket)
-        s2.should.instance_of?(Socket)
-        s1.close
-        s2.close
-      end
-
-      it 'raises TypeError when #to_str does not return a String' do
-        family = mock(:family)
-        type   = mock(:type)
-
-        family.stub!(:to_str).and_return(Socket::AF_UNIX)
-        type.stub!(:to_str).and_return(Socket::SOCK_STREAM)
-
-        -> { Socket.pair(family, type) }.should.raise(TypeError)
-      end
-
-      it 'raises SocketError for an unknown address family' do
-        family = mock(:family)
-        type   = mock(:type)
-
-        family.stub!(:to_str).and_return('CATS')
-        type.stub!(:to_str).and_return('STREAM')
-
-        -> { Socket.pair(family, type) }.should.raise(SocketError)
-      end
-
-      it 'raises SocketError for an unknown socket type' do
-        family = mock(:family)
-        type   = mock(:type)
-
-        family.stub!(:to_str).and_return('UNIX')
-        type.stub!(:to_str).and_return('CATS')
-
-        -> { Socket.pair(family, type) }.should.raise(SocketError)
-      end
-    end
-
-    it 'accepts a custom protocol as an Integer as the 3rd argument' do
-      s1, s2 = Socket.pair(:UNIX, :STREAM, Socket::IPPROTO_IP)
       s1.should.instance_of?(Socket)
       s2.should.instance_of?(Socket)
       s1.close
       s2.close
     end
 
-    it 'connects the returned Socket objects' do
-      s1, s2 = Socket.pair(:UNIX, :STREAM)
-      begin
-        s1.write('hello')
-        s2.recv(5).should == 'hello'
-      ensure
-        s1.close
-        s2.close
-      end
+    it 'raises SocketError for an unknown address family' do
+      -> { Socket.pair(:CATS, :STREAM) }.should.raise(SocketError)
+    end
+
+    it 'raises SocketError for an unknown socket type' do
+      -> { Socket.pair(:UNIX, :CATS) }.should.raise(SocketError)
+    end
+  end
+
+  describe 'using a String as the 1st and 2nd argument' do
+    it 'returns two Socket objects' do
+      s1, s2 = Socket.pair('UNIX', 'STREAM')
+
+      s1.should.instance_of?(Socket)
+      s2.should.instance_of?(Socket)
+      s1.close
+      s2.close
+    end
+
+    it 'raises SocketError for an unknown address family' do
+      -> { Socket.pair('CATS', 'STREAM') }.should.raise(SocketError)
+    end
+
+    it 'raises SocketError for an unknown socket type' do
+      -> { Socket.pair('UNIX', 'CATS') }.should.raise(SocketError)
+    end
+  end
+
+  describe 'using an object that responds to #to_str as the 1st and 2nd argument' do
+    it 'returns two Socket objects' do
+      family = mock(:family)
+      type   = mock(:type)
+
+      family.stub!(:to_str).and_return('UNIX')
+      type.stub!(:to_str).and_return('STREAM')
+
+      s1, s2 = Socket.pair(family, type)
+
+      s1.should.instance_of?(Socket)
+      s2.should.instance_of?(Socket)
+      s1.close
+      s2.close
+    end
+
+    it 'raises TypeError when #to_str does not return a String' do
+      family = mock(:family)
+      type   = mock(:type)
+
+      family.stub!(:to_str).and_return(Socket::AF_UNIX)
+      type.stub!(:to_str).and_return(Socket::SOCK_STREAM)
+
+      -> { Socket.pair(family, type) }.should.raise(TypeError)
+    end
+
+    it 'raises SocketError for an unknown address family' do
+      family = mock(:family)
+      type   = mock(:type)
+
+      family.stub!(:to_str).and_return('CATS')
+      type.stub!(:to_str).and_return('STREAM')
+
+      -> { Socket.pair(family, type) }.should.raise(SocketError)
+    end
+
+    it 'raises SocketError for an unknown socket type' do
+      family = mock(:family)
+      type   = mock(:type)
+
+      family.stub!(:to_str).and_return('UNIX')
+      type.stub!(:to_str).and_return('CATS')
+
+      -> { Socket.pair(family, type) }.should.raise(SocketError)
+    end
+  end
+
+  it 'accepts a custom protocol as an Integer as the 3rd argument' do
+    s1, s2 = Socket.pair(:UNIX, :STREAM, Socket::IPPROTO_IP)
+    s1.should.instance_of?(Socket)
+    s2.should.instance_of?(Socket)
+    s1.close
+    s2.close
+  end
+
+  it 'connects the returned Socket objects' do
+    s1, s2 = Socket.pair(:UNIX, :STREAM)
+    begin
+      s1.write('hello')
+      s2.recv(5).should == 'hello'
+    ensure
+      s1.close
+      s2.close
     end
   end
 end

--- a/spec/ruby/library/socket/socket/socket_spec.rb
+++ b/spec/ruby/library/socket/socket/socket_spec.rb
@@ -20,19 +20,15 @@ describe "The socket class hierarchy" do
     UDPSocket.superclass.should == IPSocket
   end
 
-  platform_is_not :windows do
-    it "has a UNIXSocket in parallel to Socket" do
-      Socket.ancestors.include?(UNIXSocket).should == false
-      UNIXSocket.ancestors.include?(Socket).should == false
-      UNIXSocket.superclass.should == BasicSocket
-    end
+  it "has a UNIXSocket in parallel to Socket" do
+    Socket.ancestors.include?(UNIXSocket).should == false
+    UNIXSocket.ancestors.include?(Socket).should == false
+    UNIXSocket.superclass.should == BasicSocket
   end
 end
 
-platform_is_not :windows do
-  describe "Server class hierarchy" do
-    it "contains UNIXServer" do
-      UNIXServer.superclass.should == UNIXSocket
-    end
+describe "Server class hierarchy" do
+  it "contains UNIXServer" do
+    UNIXServer.superclass.should == UNIXSocket
   end
 end

--- a/spec/ruby/security/cve_2018_8779_spec.rb
+++ b/spec/ruby/security/cve_2018_8779_spec.rb
@@ -3,28 +3,26 @@ require_relative '../spec_helper'
 require 'socket'
 require 'tempfile'
 
-platform_is_not :windows do
-  describe "CVE-2018-8779 is resisted by" do
-    before :each do
-      tmpfile = Tempfile.new("s")
-      @path = tmpfile.path
-      tmpfile.close(true)
-    end
+describe "CVE-2018-8779 is resisted by" do
+  before :each do
+    tmpfile = Tempfile.new("s")
+    @path = tmpfile.path
+    tmpfile.close(true)
+  end
 
-    after :each do
-      File.unlink @path if @path && File.socket?(@path)
-    end
+  after :each do
+    File.unlink @path if @path && File.socket?(@path)
+  end
 
-    it "UNIXServer.open by raising an exception when there is a NUL byte" do
-      -> {
-        UNIXServer.open(@path+"\0")
-      }.should.raise(ArgumentError, /(path name|string) contains null byte/)
-    end
+  it "UNIXServer.open by raising an exception when there is a NUL byte" do
+    -> {
+      UNIXServer.open(@path+"\0")
+    }.should.raise(ArgumentError, /(path name|string) contains null byte/)
+  end
 
-    it "UNIXSocket.open by raising an exception when there is a NUL byte" do
-      -> {
-        UNIXSocket.open(@path+"\0")
-      }.should.raise(ArgumentError, /(path name|string) contains null byte/)
-    end
+  it "UNIXSocket.open by raising an exception when there is a NUL byte" do
+    -> {
+      UNIXSocket.open(@path+"\0")
+    }.should.raise(ArgumentError, /(path name|string) contains null byte/)
   end
 end

--- a/test/fiber/test_io.rb
+++ b/test/fiber/test_io.rb
@@ -67,7 +67,7 @@ class TestFiberIO < Test::Unit::TestCase
 
   def test_epipe_on_read
     omit unless defined?(UNIXSocket)
-    omit "nonblock=true isn't properly supported on Windows" if RUBY_PLATFORM =~ /mswin|mingw/
+    omit "a closed peer does not make the next write fail on Windows" if RUBY_PLATFORM =~ /mswin|mingw/
 
     i, o = UNIXSocket.pair
 

--- a/test/ruby/test_box.rb
+++ b/test/ruby/test_box.rb
@@ -1306,8 +1306,7 @@ class TestBox < Test::Unit::TestCase
   end
 
   def test_loading_extension_libs_in_main_box_2
-    pend if /mswin|mingw/ =~ RUBY_PLATFORM # timeout on windows environments
-    assert_separately([ENV_ENABLE_BOX], __FILE__, __LINE__, "#{<<~"begin;"}\n#{<<~'end;'}", ignore_stderr: true)
+    assert_separately([ENV_ENABLE_BOX], __FILE__, __LINE__, "#{<<~"begin;"}\n#{<<~'end;'}", ignore_stderr: true, timeout: 60)
     begin;
       require "zlib"
       require "open3"

--- a/test/ruby/test_io.rb
+++ b/test/ruby/test_io.rb
@@ -1076,10 +1076,6 @@ class TestIO < Test::Unit::TestCase
   end if defined? UNIXSocket
 
   def test_copy_stream_socket4
-    if RUBY_PLATFORM =~ /mingw|mswin/
-      omit "pread(2) is not implemented."
-    end
-
     with_bigsrc {|bigsrc, bigcontent|
       File.open(bigsrc) {|f|
         assert_equal(0, f.pos)
@@ -1099,10 +1095,6 @@ class TestIO < Test::Unit::TestCase
   end
 
   def test_copy_stream_socket5
-    if RUBY_PLATFORM =~ /mingw|mswin/
-      omit "pread(2) is not implemented."
-    end
-
     with_bigsrc {|bigsrc, bigcontent|
       File.open(bigsrc) {|f|
         assert_equal(bigcontent[0,100], f.read(100))
@@ -1123,10 +1115,6 @@ class TestIO < Test::Unit::TestCase
   end
 
   def test_copy_stream_socket6
-    if RUBY_PLATFORM =~ /mingw|mswin/
-      omit "pread(2) is not implemented."
-    end
-
     mkcdtmpdir {
       megacontent = "abc" * 1234567
       File.open("megasrc", "w") {|f| f << megacontent }
@@ -1150,9 +1138,7 @@ class TestIO < Test::Unit::TestCase
   end
 
   def test_copy_stream_socket7
-    if RUBY_PLATFORM =~ /mingw|mswin/
-      omit "pread(2) is not implemented."
-    end
+    omit "fork is not supported" unless Process.respond_to?(:fork)
 
     GC.start
     mkcdtmpdir {

--- a/test/ruby/test_ractor.rb
+++ b/test/ruby/test_ractor.rb
@@ -899,7 +899,6 @@ class TestRactor < Test::Unit::TestCase
   end
 
   def test_io_priority_wait_on_mn_thread
-    omit 'POLLPRI/MSG_OOB semantics differ on windows' if RUBY_PLATFORM =~ /mswin|mingw/
     # A timeout-less IO#wait(IO::PRIORITY) on an M:N thread must take the
     # blocking path: the M:N scheduler has no event for POLLPRI and used to
     # register nothing yet park the thread forever.

--- a/test/ruby/test_thread.rb
+++ b/test/ruby/test_thread.rb
@@ -1232,7 +1232,7 @@ q.pop
     assert_operator(size_default, :>=, size_0, "0 size")
     size_large = invoke_rec script, vm_stack_size, 1024 * 1024 * 10
     assert_operator(size_default, :<=, size_large, "large size")
-  end unless /mswin|mingw/ =~ RUBY_PLATFORM
+  end
 
   def test_blocking_mutex_unlocked_on_fork
     bug8433 = '[ruby-core:55102] [Bug #8433]'

--- a/test/ruby/test_thread.rb
+++ b/test/ruby/test_thread.rb
@@ -848,10 +848,6 @@ class TestThread < Test::Unit::TestCase
   end
 
   def test_handle_interrupt_masks_sigint
-    if /mswin|mingw/ =~ RUBY_PLATFORM
-      omit "SIGINT handling differs on Windows"
-    end
-
     assert_in_out_err([], <<-INPUT, %w(outer false), [])
       waiting = Thread::Queue.new
       release = Thread::Queue.new


### PR DESCRIPTION
Seven tests and four spec files were skipped on Windows for reasons that no longer hold, so `nmake check` there covered less than it could. Nothing here touches runtime code: the diff is `test/` and `spec/` only, and I ran each one to confirm it passes rather than trusting the comment.

The `IO.copy_stream` socket tests were waiting on `pread(2)`, which `rb_w32_pread()` has provided for a while; the one that really needs `fork()` now says so. `test_loading_extension_libs_in_main_box_2` was hiding a shutdown crash in `require "openssl"` under `RUBY_BOX=1` that is fixed, and it gets the 60 second timeout `box_1` already needed. The AF_UNIX specs need nothing Windows has lacked since Windows 10.

`test_epipe_on_read` stays off, but with the real reason: a closed peer does not make the next write fail.

Verified with `nmake check TESTOPTS=-j16` on `x64-mswin64_140`.

Generated with [Claude Code](https://claude.com/claude-code)
