### PR TITLE
Implement the thread event hook API on Windows

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -321,6 +321,10 @@ Ruby 4.0 bundled RubyGems and Bundler version 4. see the following links for det
 
 ## C API updates
 
+* `rb_internal_thread_add_event_hook` now works on Windows.  It used to be a
+  no-op there, so a profiler built on the thread event hooks recorded nothing.
+  [[Feature #18339]]
+
 ### Embedded TypedData
 
 * The `RUBY_TYPED_EMBEDDABLE` flag is now public and documented and can be used by C extensions.
@@ -440,6 +444,7 @@ A lot of work has gone into making Ractors more stable, performant, and usable. 
 [Feature #8948]: https://bugs.ruby-lang.org/issues/8948
 [Feature #9779]: https://bugs.ruby-lang.org/issues/9779
 [Feature #15330]: https://bugs.ruby-lang.org/issues/15330
+[Feature #18339]: https://bugs.ruby-lang.org/issues/18339
 [Feature #20163]: https://bugs.ruby-lang.org/issues/20163
 [Feature #21390]: https://bugs.ruby-lang.org/issues/21390
 [Feature #21768]: https://bugs.ruby-lang.org/issues/21768

--- a/include/ruby/thread.h
+++ b/include/ruby/thread.h
@@ -280,7 +280,7 @@ typedef struct rb_internal_thread_event_hook rb_internal_thread_event_hook_t;
  * @param[in]  events  A set of events that `func` should run.
  * @param[in]  data    Passed as-is to `func`.
  * @return     An opaque pointer to the hook, to unregister it later.
- * @note       This functionality is a noop on Windows and WebAssembly.
+ * @note       This functionality is not provided on WASI.
  * @note       The callback will be called without the GVL held, except for the
  *             RESUMED event.
  * @note       Callbacks are not guaranteed to be executed on the native threads
@@ -296,11 +296,11 @@ rb_internal_thread_event_hook_t *rb_internal_thread_add_event_hook(
 /**
  * Unregister the passed hook.
  *
- * @param[in]  hook.  The hook to unregister.
+ * @param[in]  hook   The hook to unregister.
  * @return     Whether the hook was found and unregistered.
- * @note       This functionality is a noop on Windows and WebAssembly.
+ * @note       This functionality is not provided on WASI.
  * @warning    This function MUST not be called from a thread event callback.
-*/
+ */
 bool rb_internal_thread_remove_event_hook(
         rb_internal_thread_event_hook_t * hook);
 

--- a/internal/thread.h
+++ b/internal/thread.h
@@ -55,7 +55,7 @@ void rb_ec_check_ints(struct rb_execution_context_struct *ec);
 
 void rb_thread_free_native_thread(void *th_ptr);
 
-bool rb_thread_event_hooks_registered_p(void); /* thread_pthread.c */
+bool rb_thread_event_hooks_registered_p(void); /* THREAD_IMPL_SRC */
 void rb_thread_free_body(void *th);            /* vm.c */
 
 RUBY_SYMBOL_EXPORT_BEGIN

--- a/test/-ext-/thread/test_instrumentation_api.rb
+++ b/test/-ext-/thread/test_instrumentation_api.rb
@@ -6,15 +6,12 @@ class TestThreadInstrumentation < Test::Unit::TestCase
   include ThreadInstrumentation::TestHelper
 
   def setup
-    pend("No windows support") if /mswin|mingw|bccwin/ =~ RUBY_PLATFORM
-
     require '-test-/thread/instrumentation'
 
     cleanup_threads
   end
 
   def teardown
-    return if /mswin|mingw|bccwin/ =~ RUBY_PLATFORM
     Bug::ThreadInstrumentation.unregister_callback
     cleanup_threads
   end
@@ -225,7 +222,7 @@ class TestThreadInstrumentation < Test::Unit::TestCase
   end
 
   def test_thread_instrumentation_fork_safe
-    skip "No fork()" unless Process.respond_to?(:fork)
+    omit "No fork()" unless Process.respond_to?(:fork)
 
     thread_statuses = full_timeline = nil
     IO.popen("-") do |read_pipe|

--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -1517,7 +1517,7 @@ rb_thread_acquire_fork_lock(void)
     }
 }
 
-// thread internal event hooks (only for pthread)
+// thread internal event hooks
 
 struct rb_internal_thread_event_hook {
     rb_internal_thread_event_callback callback;

--- a/thread_win32.c
+++ b/thread_win32.c
@@ -329,13 +329,16 @@ native_cond_timedwait(rb_nativethread_cond_t *cond, rb_nativethread_lock_t *mute
 
     if (*abs <= now) return ETIMEDOUT;
 
-    rb_hrtime_t rel = *abs - now;
-    unsigned long msec = (unsigned long)(rel / RB_HRTIME_PER_MSEC);
+    // unsigned long is 32 bits here, and INFINITE would never time out.
+    rb_hrtime_t ms = roomof(*abs - now, RB_HRTIME_PER_MSEC);
+    unsigned long msec = ms < INFINITE ? (unsigned long)ms : INFINITE - 1;
+    int r = native_cond_timedwait_ms(cond, mutex, msec);
 
-    // do not busy loop on a sub-millisecond deadline
-    if (msec == 0) msec = 1;
+    // The wait runs on another clock than rb_hrtime_now() and can end early.
+    // Report that as spurious, the way pthread_cond_timedwait would.
+    if (r == ETIMEDOUT && rb_hrtime_now() < *abs) return 0;
 
-    return native_cond_timedwait_ms(cond, mutex, msec);
+    return r;
 }
 
 void

--- a/thread_win32.c
+++ b/thread_win32.c
@@ -38,8 +38,10 @@
 
 #include COROUTINE_H
 
-// Thread event hooks are not implemented on this platform.
-#define RB_INTERNAL_THREAD_HOOK(event, th) ((void)0)
+static rb_internal_thread_event_hook_t *rb_internal_thread_event_hooks = NULL;
+static void rb_thread_execute_hooks(rb_event_flag_t event, rb_thread_t *th);
+
+#define RB_INTERNAL_THREAD_HOOK(event, th) if (UNLIKELY(rb_internal_thread_event_hooks)) { rb_thread_execute_hooks(event, th); }
 
 // No fork(), so this never advances; it only keeps TIMER_THREAD_CREATED_P()
 // spelled the same way on both platforms.
@@ -56,24 +58,95 @@ static void native_thread_destroy(struct rb_native_thread *nt);
 static void timer_thread_wakeup_force(void);
 static void ubf_select(void *ptr); // thread_sched.c
 
+// thread internal event hooks
+//
+// A hook fires on every GVL transition, so the list is read far more often
+// than it is written.  An SRW lock, the Win32 counterpart of the pthread
+// rwlock the POSIX side uses, keeps those reads from serialising each other.
+
+struct rb_internal_thread_event_hook {
+    rb_internal_thread_event_callback callback;
+    rb_event_flag_t event;
+    void *user_data;
+
+    struct rb_internal_thread_event_hook *next;
+};
+
+static SRWLOCK rb_internal_thread_event_hooks_rw_lock = SRWLOCK_INIT;
+
 rb_internal_thread_event_hook_t *
 rb_internal_thread_add_event_hook(rb_internal_thread_event_callback callback, rb_event_flag_t internal_event, void *user_data)
 {
-    // not implemented
-    return NULL;
+    rb_internal_thread_event_hook_t *hook = ALLOC_N(rb_internal_thread_event_hook_t, 1);
+    hook->callback = callback;
+    hook->user_data = user_data;
+    hook->event = internal_event;
+
+    AcquireSRWLockExclusive(&rb_internal_thread_event_hooks_rw_lock);
+    hook->next = rb_internal_thread_event_hooks;
+    ATOMIC_PTR_EXCHANGE(rb_internal_thread_event_hooks, hook);
+    ReleaseSRWLockExclusive(&rb_internal_thread_event_hooks_rw_lock);
+
+    return hook;
 }
 
 bool
 rb_internal_thread_remove_event_hook(rb_internal_thread_event_hook_t * hook)
 {
-    // not implemented
-    return false;
+    bool success = false;
+
+    AcquireSRWLockExclusive(&rb_internal_thread_event_hooks_rw_lock);
+
+    if (rb_internal_thread_event_hooks == hook) {
+        ATOMIC_PTR_EXCHANGE(rb_internal_thread_event_hooks, hook->next);
+        success = true;
+    }
+    else {
+        for (rb_internal_thread_event_hook_t *h = rb_internal_thread_event_hooks; h; h = h->next) {
+            if (h->next == hook) {
+                h->next = hook->next;
+                success = true;
+                break;
+            }
+        }
+    }
+
+    ReleaseSRWLockExclusive(&rb_internal_thread_event_hooks_rw_lock);
+
+    if (success) {
+        SIZED_FREE(hook);
+    }
+    return success;
 }
 
+// See the pthread implementation for what the GC asks this and why the lock
+// makes the answer good enough.
 bool
 rb_thread_event_hooks_registered_p(void)
 {
-    return false; // hooks are not implemented on this platform
+    AcquireSRWLockShared(&rb_internal_thread_event_hooks_rw_lock);
+    const bool registered = (rb_internal_thread_event_hooks != NULL);
+    ReleaseSRWLockShared(&rb_internal_thread_event_hooks_rw_lock);
+    return registered;
+}
+
+static void
+rb_thread_execute_hooks(rb_event_flag_t event, rb_thread_t *th)
+{
+    if (th->self == 0) return;
+
+    AcquireSRWLockShared(&rb_internal_thread_event_hooks_rw_lock);
+
+    for (rb_internal_thread_event_hook_t *h = rb_internal_thread_event_hooks; h; h = h->next) {
+        if (h->event & event) {
+            rb_internal_thread_event_data_t event_data = {
+                .thread = th->self,
+            };
+            (*h->callback)(event, &event_data, h->user_data);
+        }
+    }
+
+    ReleaseSRWLockShared(&rb_internal_thread_event_hooks_rw_lock);
 }
 
 RBIMPL_ATTR_NORETURN()


### PR DESCRIPTION
`rb_internal_thread_add_event_hook` has always been a no-op on Windows, so a GVL profiler records nothing there and `test/-ext-/thread/test_instrumentation_api.rb` was pended on the platform.

The hook call sites already live in the shared `thread_sched.c`, so `thread_win32.c` was only missing the hook list and a lock for it. I use an `SRWLOCK` where the POSIX side uses a `pthread_rwlock_t`, because a hook fires on every GVL transition and readers must not serialise each other.

Enabling the test exposed a Win32 condvar issue. The wait runs on a different clock from `rb_hrtime_now()` and can end before the deadline, and `native_cond_timedwait` reported that as a timeout, which sent the scheduler round for an extra GVL release and re-acquire. It now reports a spurious wakeup the way `pthread_cond_timedwait` does, so the test file runs on Windows without a platform guard.

Generated with [Claude Code](https://claude.com/claude-code)
