### PR TITLE
Cover the whole `Const op= value` expression in the constant read node in parse.y

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -14826,19 +14826,25 @@ new_op_assign(struct parser_params *p, NODE *lhs, ID op, NODE *rhs, struct lex_c
     if (lhs) {
         ID vid = get_nd_vid(p, lhs);
         YYLTYPE lhs_loc = lhs->nd_loc;
+        /* A constant read can raise NameError. Prism has no separate read node
+         * for `Const op= value` and reports the whole expression, so give the
+         * NODE_CONST the location of the whole operator assignment as well,
+         * for consistent Thread::Backtrace::Location#source_range between both
+         * parsers. */
+        const YYLTYPE *read_loc = nd_type_p(lhs, NODE_CDECL) ? loc : &lhs_loc;
         if (op == tOROP) {
             set_nd_value(p, lhs, rhs);
             nd_set_loc(lhs, loc);
-            asgn = NEW_OP_ASGN_OR(gettable(p, vid, &lhs_loc), lhs, loc);
+            asgn = NEW_OP_ASGN_OR(gettable(p, vid, read_loc), lhs, loc);
         }
         else if (op == tANDOP) {
             set_nd_value(p, lhs, rhs);
             nd_set_loc(lhs, loc);
-            asgn = NEW_OP_ASGN_AND(gettable(p, vid, &lhs_loc), lhs, loc);
+            asgn = NEW_OP_ASGN_AND(gettable(p, vid, read_loc), lhs, loc);
         }
         else {
             asgn = lhs;
-            rhs = NEW_CALL(gettable(p, vid, &lhs_loc), op, NEW_LIST(rhs, &rhs->nd_loc), loc);
+            rhs = NEW_CALL(gettable(p, vid, read_loc), op, NEW_LIST(rhs, &rhs->nd_loc), loc);
             set_nd_value(p, asgn, rhs);
             nd_set_loc(asgn, loc);
         }

--- a/spec/ruby/core/thread/backtrace/location/source_range_spec.rb
+++ b/spec/ruby/core/thread/backtrace/location/source_range_spec.rb
@@ -376,9 +376,6 @@ ruby_version_is "4.1" do
       RUBY
     }.each_pair do |description, (source, prism_class, frame)|
       it "returns the precise range for #{description}" do
-        # Currently fails with parse.y, needs to be fixed
-        skip "parse.y" if description == "top-level constant operator assignments" && !syntax_tree_returns_prism_node
-
         capture_backtrace_location_source_range(source, prism_class, frame: frame || 0)
       end
     end


### PR DESCRIPTION
For `Const += value`, `parse.y` builds a `NODE_CDECL` whose value is an `OPCALL` on a `NODE_CONST` read node, and that read node only spanned the constant name. The `NameError` for an undefined constant is raised by that read, so `Thread::Backtrace::Location#source_range` reported only the constant name. Prism has no separate read node and reports the whole `ConstantOperatorWriteNode`, and the same holds for `ConstantAndWriteNode` (see https://bugs.ruby-lang.org/issues/22235).

Give the NODE_CONST read node the location of the whole operator assignment (`+=`, `&&=` and `||=`) so both parsers report the same range. Other variable reads keep their own location as `error_highlight` locates the operator from the end of the receiver node.