### PR TITLE
Fix flaky TestHash#test_rehash by modelling the AR substitution hint

### DIFF
--- a/test/ruby/test_hash.rb
+++ b/test/ruby/test_hash.rb
@@ -617,7 +617,10 @@ class TestHash < Test::Unit::TestCase
   end
 
   def hash_hint hv
-    hv & 0xff
+    hint = hv & 0xff
+    # hash.c's ar_do_hash_hint() substitutes RHASH_AR_CLEARED_HINT (0x00)
+    # with RHASH_AR_SUBSTITUTION_HINT (0x01), so those two alias.
+    hint == 0 ? 1 : hint
   end
 
   def test_rehash


### PR DESCRIPTION
test_rehash mutates a key until its own `hash_hint` (the low byte of `Array#hash`) changes, then asserts the stale key no longer hits.

Since 127e903860 "hash.c: add a substition hint", `ar_do_hash_hint()` maps RHASH_AR_CLEARED_HINT (0x00) to RHASH_AR_SUBSTITUTION_HINT (0x01), so hash values ending in 0x00 and 0x01 share a hint. When the mutation loop happened to exit on such a pair, the test believed the hint had changed while the AR table's hint had not: `ar_find_entry_hint()` still matched and `ar_equal()` compared the key against itself, so the lookup returned 100 instead of nil.

That commit adjusted the affected specs but not test/ruby/test_hash.rb. Mirror the substitution in `hash_hint` so the loop keeps going until the hint really changes.

The hash seed is per process, so this depended on the run; measured over 2,000,000 independent starting hashes the old loop failed 63 times (1/31746), matching the predicted (2/256) * (1/255). Both TestHash and TestHash::TestSubHash fail together because they share a process and build the same strings.