### PR TITLE
Convert the fast fallback test delay with NUM2LONG

### DIFF
--- a/ext/socket/ipsocket.c
+++ b/ext/socket/ipsocket.c
@@ -713,7 +713,7 @@ init_fast_fallback_inetsock_internal(VALUE v)
                 VALUE test_delay_setting = rb_hash_aref(test_mode_settings, ID2SYM(rb_intern("delay")));
                 if (!NIL_P(test_delay_setting)) {
                     VALUE rb_test_delay_ms = rb_hash_aref(test_delay_setting, ID2SYM(rb_intern(family_sym)));
-                    long test_delay_ms = NIL_P(rb_test_delay_ms) ? 0 : rb_test_delay_ms;
+                    long test_delay_ms = NIL_P(rb_test_delay_ms) ? 0 : NUM2LONG(rb_test_delay_ms);
                     arg->getaddrinfo_entries[i]->test_sleep_ms = test_delay_ms;
                 }
 


### PR DESCRIPTION
`TCPSocket.new` with `test_mode_settings: { delay: { ipv4: n } }` sleeps for 2n+1 milliseconds instead of n, because the delay is stored as a raw `VALUE` without `NUM2LONG`. The `error` setting right below already converts with `NUM2INT`.

On x86_64-linux, a delay of 500 took 1002 ms before this change and 501 ms after. The tests in `test/socket/test_tcp.rb` pass unchanged with the halved delays. `test_initialize_v6_hostname_resolved_in_resolution_delay` now sleeps 25 ms as its comment says, instead of 51 ms, which exceeded the 50 ms resolution delay.

Generated with [Claude Code](https://claude.com/claude-code)
