### PR TITLE
Bypass the broken autoconf wrapper on Cygwin

### DIFF
--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -58,7 +58,8 @@ jobs:
 
       - name: configure
         run: |
-          ./autogen.sh
+          # The autoreconf wrapper in autoconf-20260320-1 has a shell syntax error
+          AUTORECONF=autoreconf-2.73 ./autogen.sh
           ./configure --disable-install-doc
         shell: C:\cygwin\bin\bash.EXE --noprofile --norc -e -o igncr -o pipefail {0}
 


### PR DESCRIPTION
The Cygwin job on master has failed before `configure` since 1a64fc0205. Cygwin updated the `autoconf` package from 15-3 to 20260320-1, and its new `/usr/bin/autoreconf` wrapper aborts on every call with `syntax error near unexpected token 'then'` because it uses `elsif` in a shell loop. The Gentoo script it is based on does not have this bug, so it comes from the Cygwin packaging.

This sets `AUTORECONF=autoreconf-2.73` so `autogen.sh` runs the versioned binary from `autoconf2.7` directly. That binary calls `autoconf-2.73` and `autom4te-2.73` by absolute path, so nothing goes through the wrapper. The line can go away once Cygwin ships a fixed wrapper.

Generated with [Claude Code](https://claude.com/claude-code)
