### PR TITLE
Allow super in a module method to work if method was called by refinement method super

### DIFF
--- a/test/ruby/test_refinement.rb
+++ b/test/ruby/test_refinement.rb
@@ -1035,9 +1035,8 @@ class TestRefinement < Test::Unit::TestCase
     RUBY
   end
 
-  def test_prohibit_super_in_refined_module_method
+  def test_super_in_refined_module_method
     assert_separately([], <<-"end;")
-      bug22071 = '[ruby-core:125511] [Bug #22071]'
       class BasicObject
         def a; "B" end
       end
@@ -1066,9 +1065,431 @@ class TestRefinement < Test::Unit::TestCase
       end
       using R
 
-      msg = "super in a method in a module that has been refined and that is called via super" +
-        " from a refinement method is not supported."
-      assert_raise(NoMethodError, msg, bug22071) { B.new.a }
+      assert_equal("RFGAB", B.new.a)
+    end;
+  end
+
+  def test_super_in_refined_prepended_module_method
+    assert_separately([], <<-"end;")
+      module M
+        def m = [:M, *super]
+      end
+
+      class C
+        prepend M
+        def m = :C
+      end
+
+      module R
+        refine M do
+          def m = [:R, *super]
+        end
+      end
+      using R
+
+      assert_equal([:R, :M, :C], C.new.m)
+    end;
+  end
+
+  def test_super_in_refined_prepended_module_method_called_by_other_method_same_object
+    assert_separately([], <<-"end;")
+      module M
+        def m = [:M, *super]
+      end
+
+      module N
+        include M
+      end
+
+      class C
+        def m = :C
+      end
+
+      class SC < C
+        include N
+        prepend M
+        def m = [:SC, *super]
+      end
+
+      module R
+        refine M do
+          def m = [:R, *super]
+        end
+      end
+      using R
+
+      module N
+        def n
+          m
+        end
+      end
+
+      assert_equal([:R, :M, :SC, :M, :C], SC.new.n)
+    end;
+  end
+
+  def test_super_in_refined_prepended_module_method_with_aliases
+    assert_separately([], <<-"end;")
+      module M
+        def m = [:Mm, *super]
+        def n = [:Mn, *super]
+        def o = [:Mo, *super]
+      end
+
+      module R
+        refine M do
+          def m = [:Rm, *super]
+          def n = [:Rn, *super]
+          def o = [:Ro, *super]
+        end
+      end
+      using R
+
+      module N
+        include M
+        def n = m
+      end
+
+      class C
+        prepend M
+        def m = :C
+      end
+
+      class SC < C
+        include N
+        prepend M
+        alias n m
+      end
+
+      class SSC < SC
+        prepend M
+        def n = [:SSC, *super]
+      end
+
+      class SSSC < SSC
+        prepend M
+        alias o n
+      end
+
+      class SSSSC < SSSC
+        prepend M
+        def o = [:SSSSC, *super]
+      end
+
+      assert_equal([:Ro, :Mo, :SSSSC, :Ro, :Mo, :Mn, :Mn, :SSC, :Rn, :Mn, :Mm, :Mm, :C], SSSSC.new.o)
+    end;
+  end
+
+  def test_super_in_refined_prepended_module_method_called_by_other_object
+    assert_separately([], <<-"end;")
+      module M
+        def m = [:M, *super]
+      end
+
+      class C
+        prepend M
+        def m = :C
+      end
+
+      module R
+        refine M do
+          def m = [:R, *super]
+        end
+      end
+      using R
+
+      o = Object.new
+      def o.m = C.new.m
+      assert_equal([:R, :M, :C], o.m)
+    end;
+  end
+
+  def test_super_in_refined_prepended_module_method_refined_multiple_times
+    assert_separately([], <<-"end;")
+      module M
+        def m = [:M, *super]
+      end
+
+      class C
+        prepend M
+        def m = :C
+      end
+
+      module R1
+        refine M do
+          def m = [:R1, *super]
+        end
+      end
+      using R1
+
+      module R2
+        refine M do
+          def m = [:R2, *super]
+        end
+      end
+      using R2
+
+      assert_equal([:R2, :R1, :M, :C], C.new.m)
+    end;
+  end
+
+  def test_super_in_refined_module_method_prepended_multiple_times
+    assert_separately([], <<-"end;")
+      module M
+        def m = [:M, *super]
+      end
+
+      module R
+        refine M do
+          def m = [:R, *super]
+        end
+      end
+      using R
+
+      class C
+        prepend M
+        def m = :C
+      end
+
+      class SC < C
+        prepend M
+        def m = [:SC, *super]
+      end
+
+      assert_equal([:R, :M, :SC, :R, :M, :C], SC.new.m)
+    end;
+  end
+
+  def test_super_in_refined_module_method_with_multiple_refined_modules
+    assert_separately([], <<-"end;")
+      module M
+        def m = [:M, *super]
+      end
+
+      module N
+        def m = [:N, *super]
+      end
+
+      module R
+        refine M do
+          def m = [:RM, *super]
+        end
+
+        refine N do
+          def m = [:RN, *super]
+        end
+      end
+      using R
+
+      class C
+        prepend M
+        prepend N
+        def m = :C
+      end
+
+      class SC < C
+        prepend N
+        prepend M
+        def m = [:SC, *super]
+      end
+
+      assert_equal([:RM, :M, :N, :SC, :RN, :N, :M, :C], SC.new.m)
+    end;
+  end
+
+  def test_super_in_refined_module_method_with_super_method_after_refinement
+    assert_separately([], <<-"end;")
+      module M
+      end
+
+      module R
+        refine M do
+          def m = [:R, *super]
+        end
+      end
+      using R
+
+      module M
+        def m = [:M, *super]
+      end
+
+      class C
+        prepend M
+        def m = :C
+      end
+
+      class SC < C
+        prepend M
+        def m = [:SC, *super]
+      end
+
+      assert_equal([:R, :M, :SC, :R, :M, :C], SC.new.m)
+    end;
+  end
+
+  def test_super_in_refined_module_method_with_multiple_refined_modules_with_super_method_after_refinement
+    assert_separately([], <<-"end;")
+      module M
+      end
+
+      module N
+      end
+
+      module R
+        refine M do
+          def m = [:RM, *super]
+        end
+
+        refine N do
+          def m = [:RN, *super]
+        end
+      end
+      using R
+
+      module M
+        def m = [:M, *super]
+      end
+
+      module N
+        def m = [:N, *super]
+      end
+
+      class C
+        prepend M
+        prepend N
+        def m = :C
+      end
+
+      class SC < C
+        prepend N
+        prepend M
+        def m = [:SC, *super]
+      end
+
+      assert_equal([:RM, :M, :RN, :N, :SC, :RN, :N, :RM, :M, :C], SC.new.m)
+    end;
+  end
+
+  def test_super_in_refined_module_method_in_nested_block
+    assert_separately([], <<-"end;")
+      module M
+        def m = ->{Array.new(1){[:M, *super]}.flatten}.call
+      end
+
+      module R
+        refine M do
+          def m = ->{Array.new(1){[:R, *super]}.flatten}.call
+        end
+      end
+      using R
+
+      class C
+        prepend M
+        def m = :C
+      end
+
+      class SC < C
+        prepend M
+        def m = [:SC, *super]
+      end
+
+      assert_equal([:R, :M, :SC, :R, :M, :C], SC.new.m)
+    end;
+  end
+
+  def test_super_in_refined_module_method_combined_cases
+    assert_separately([], <<-"end;")
+      module M
+        define_method(:m){->{Array.new(1){[:M, *super()]}.flatten}.call}
+      end
+
+      module N
+        def m = ->{Array.new(1){[:N, *super]}.flatten}.call
+      end
+
+      module P
+        def m = ->{Array.new(1){[:P, *super]}.flatten}.call
+      end
+
+      module R1
+        refine M do
+          def m = ->{Array.new(1){[:R1M, *super]}.flatten}.call
+        end
+
+        refine N do
+          define_method(:m){->{Array.new(1){[:R1N, *super()]}.flatten}.call}
+        end
+
+        refine P do
+          def m = ->{Array.new(1){[:R1P, *super]}.flatten}.call
+        end
+      end
+      using R1
+
+      module R2
+        refine M do
+          define_method(:m){->{Array.new(1){[:R2M, *super()]}.flatten}.call}
+        end
+
+        refine N do
+          def m = ->{Array.new(1){[:R2N, *super]}.flatten}.call
+        end
+
+        refine P do
+          define_method(:m){->{Array.new(1){[:R2P, *super()]}.flatten}.call}
+        end
+      end
+      using R2
+
+      class C
+        prepend M
+        prepend N
+        def m = :C
+      end
+
+      class SC < C
+        include P
+        def m = ->{Array.new(1){[:SC, *super]}.flatten}.call
+      end
+
+      class SSC < SC
+        prepend N
+        prepend M
+        def m = ->{Array.new(1){[:SSC, *super]}.flatten}.call
+      end
+
+      o = Object.new
+      def o.m = SSC.new.m
+      assert_equal([:R2M, :R1M, :M, :N, :SSC, :SC, :R2P, :R1P, :P, :N, :M, :C], o.m)
+    end;
+  end
+
+  def test_super_in_refined_module_bmethod_with_no_super_method
+    assert_separately([], <<-"end;")
+      called = []
+      M = Module.new do
+        define_method(:m) do
+          called << :M
+          super()
+        end
+      end
+
+      class C
+        prepend M
+      end
+
+      R = Module.new do
+        refine M do
+          define_method(:m) do
+            called << :R
+            super()
+          end
+        end
+      end
+      using R
+
+      assert_raise(NoMethodError) { C.new.m }
+      assert_equal([:R, :M], called)
     end;
   end
 

--- a/test/ruby/test_refinement.rb
+++ b/test/ruby/test_refinement.rb
@@ -1038,20 +1038,32 @@ class TestRefinement < Test::Unit::TestCase
   def test_super_in_refined_module_method
     assert_separately([], <<-"end;")
       class BasicObject
-        def a; "B" end
+        def a
+          raise 'defined?(super) true, should be false' if defined?(super)
+          "B"
+        end
       end
 
       module G
-        def a; "G" + super end
+        def a
+          raise 'defined?(super) false, should be true' unless defined?(super)
+          "G" + super
+        end
       end
 
       module F
         include G
-        def a; "F" + super end
+        def a
+          raise 'defined?(super) false, should be true' unless defined?(super)
+          "F" + super
+        end
       end
 
       class A
-        def a; "A" + super end
+        def a
+          raise 'defined?(super) false, should be true' unless defined?(super)
+          "A" + super
+        end
       end
 
       class B < A
@@ -1060,7 +1072,10 @@ class TestRefinement < Test::Unit::TestCase
 
       module R
        refine F do
-         def a; "R"+super end
+         def a
+          raise 'defined?(super) false, should be true' unless defined?(super)
+           "R"+super
+         end
        end
       end
       using R
@@ -1072,17 +1087,26 @@ class TestRefinement < Test::Unit::TestCase
   def test_super_in_refined_prepended_module_method
     assert_separately([], <<-"end;")
       module M
-        def m = [:M, *super]
+        def m
+          raise 'defined?(super) false, should be true' unless defined?(super)
+          [:M, *super]
+        end
       end
 
       class C
         prepend M
-        def m = :C
+        def m
+          raise 'defined?(super) true, should be false' if defined?(super)
+          :C
+        end
       end
 
       module R
         refine M do
-          def m = [:R, *super]
+          def m
+            raise 'defined?(super) false, should be true' unless defined?(super)
+            [:R, *super]
+          end
         end
       end
       using R
@@ -1094,7 +1118,10 @@ class TestRefinement < Test::Unit::TestCase
   def test_super_in_refined_prepended_module_method_called_by_other_method_same_object
     assert_separately([], <<-"end;")
       module M
-        def m = [:M, *super]
+        def m
+          raise 'defined?(super) false, should be true' unless defined?(super)
+          [:M, *super]
+        end
       end
 
       module N
@@ -1102,18 +1129,27 @@ class TestRefinement < Test::Unit::TestCase
       end
 
       class C
-        def m = :C
+        def m
+          raise 'defined?(super) true, should be false' if defined?(super)
+          :C
+        end
       end
 
       class SC < C
         include N
         prepend M
-        def m = [:SC, *super]
+        def m
+          raise 'defined?(super) false, should be true' unless defined?(super)
+          [:SC, *super]
+        end
       end
 
       module R
         refine M do
-          def m = [:R, *super]
+          def m
+            raise 'defined?(super) false, should be true' unless defined?(super)
+            [:R, *super]
+          end
         end
       end
       using R
@@ -1131,16 +1167,34 @@ class TestRefinement < Test::Unit::TestCase
   def test_super_in_refined_prepended_module_method_with_aliases
     assert_separately([], <<-"end;")
       module M
-        def m = [:Mm, *super]
-        def n = [:Mn, *super]
-        def o = [:Mo, *super]
+        def m
+          raise 'defined?(super) false, should be true' unless defined?(super)
+          [:Mm, *super]
+        end
+        def n
+          raise 'defined?(super) false, should be true' unless defined?(super)
+          [:Mn, *super]
+        end
+        def o
+          raise 'defined?(super) false, should be true' unless defined?(super)
+          [:Mo, *super]
+        end
       end
 
       module R
         refine M do
-          def m = [:Rm, *super]
-          def n = [:Rn, *super]
-          def o = [:Ro, *super]
+          def m
+            raise 'defined?(super) false, should be true' unless defined?(super)
+            [:Rm, *super]
+          end
+          def n
+            raise 'defined?(super) false, should be true' unless defined?(super)
+            [:Rn, *super]
+          end
+          def o
+            raise 'defined?(super) false, should be true' unless defined?(super)
+            [:Ro, *super]
+          end
         end
       end
       using R
@@ -1152,7 +1206,10 @@ class TestRefinement < Test::Unit::TestCase
 
       class C
         prepend M
-        def m = :C
+        def m
+          raise 'defined?(super) true, should be false' if defined?(super)
+          :C
+        end
       end
 
       class SC < C
@@ -1163,7 +1220,10 @@ class TestRefinement < Test::Unit::TestCase
 
       class SSC < SC
         prepend M
-        def n = [:SSC, *super]
+        def n
+          raise 'defined?(super) false, should be true' unless defined?(super)
+          [:SSC, *super]
+        end
       end
 
       class SSSC < SSC
@@ -1173,7 +1233,10 @@ class TestRefinement < Test::Unit::TestCase
 
       class SSSSC < SSSC
         prepend M
-        def o = [:SSSSC, *super]
+        def o
+          raise 'defined?(super) false, should be true' unless defined?(super)
+          [:SSSSC, *super]
+        end
       end
 
       assert_equal([:Ro, :Mo, :SSSSC, :Ro, :Mo, :Mn, :Mn, :SSC, :Rn, :Mn, :Mm, :Mm, :C], SSSSC.new.o)
@@ -1183,17 +1246,26 @@ class TestRefinement < Test::Unit::TestCase
   def test_super_in_refined_prepended_module_method_called_by_other_object
     assert_separately([], <<-"end;")
       module M
-        def m = [:M, *super]
+        def m
+          raise 'defined?(super) false, should be true' unless defined?(super)
+          [:M, *super]
+        end
       end
 
       class C
         prepend M
-        def m = :C
+        def m
+          raise 'defined?(super) true, should be false' if defined?(super)
+          :C
+        end
       end
 
       module R
         refine M do
-          def m = [:R, *super]
+          def m
+            raise 'defined?(super) false, should be true' unless defined?(super)
+            [:R, *super]
+          end
         end
       end
       using R
@@ -1207,24 +1279,36 @@ class TestRefinement < Test::Unit::TestCase
   def test_super_in_refined_prepended_module_method_refined_multiple_times
     assert_separately([], <<-"end;")
       module M
-        def m = [:M, *super]
+        def m
+          raise 'defined?(super) false, should be true' unless defined?(super)
+          [:M, *super]
+        end
       end
 
       class C
         prepend M
-        def m = :C
+        def m
+          raise 'defined?(super) true, should be false' if defined?(super)
+          :C
+        end
       end
 
       module R1
         refine M do
-          def m = [:R1, *super]
+          def m
+            raise 'defined?(super) false, should be true' unless defined?(super)
+            [:R1, *super]
+          end
         end
       end
       using R1
 
       module R2
         refine M do
-          def m = [:R2, *super]
+          def m
+            raise 'defined?(super) false, should be true' unless defined?(super)
+            [:R2, *super]
+          end
         end
       end
       using R2
@@ -1236,24 +1320,36 @@ class TestRefinement < Test::Unit::TestCase
   def test_super_in_refined_module_method_prepended_multiple_times
     assert_separately([], <<-"end;")
       module M
-        def m = [:M, *super]
+        def m
+          raise 'defined?(super) false, should be true' unless defined?(super)
+          [:M, *super]
+        end
       end
 
       module R
         refine M do
-          def m = [:R, *super]
+          def m
+            raise 'defined?(super) false, should be true' unless defined?(super)
+            [:R, *super]
+          end
         end
       end
       using R
 
       class C
         prepend M
-        def m = :C
+        def m
+          raise 'defined?(super) true, should be false' if defined?(super)
+          :C
+        end
       end
 
       class SC < C
         prepend M
-        def m = [:SC, *super]
+        def m
+          raise 'defined?(super) false, should be true' unless defined?(super)
+          [:SC, *super]
+        end
       end
 
       assert_equal([:R, :M, :SC, :R, :M, :C], SC.new.m)
@@ -1263,20 +1359,32 @@ class TestRefinement < Test::Unit::TestCase
   def test_super_in_refined_module_method_with_multiple_refined_modules
     assert_separately([], <<-"end;")
       module M
-        def m = [:M, *super]
+        def m
+          raise 'defined?(super) false, should be true' unless defined?(super)
+          [:M, *super]
+        end
       end
 
       module N
-        def m = [:N, *super]
+        def m
+          raise 'defined?(super) false, should be true' unless defined?(super)
+          [:N, *super]
+        end
       end
 
       module R
         refine M do
-          def m = [:RM, *super]
+          def m
+            raise 'defined?(super) false, should be true' unless defined?(super)
+            [:RM, *super]
+          end
         end
 
         refine N do
-          def m = [:RN, *super]
+          def m
+            raise 'defined?(super) false, should be true' unless defined?(super)
+            [:RN, *super]
+          end
         end
       end
       using R
@@ -1284,13 +1392,19 @@ class TestRefinement < Test::Unit::TestCase
       class C
         prepend M
         prepend N
-        def m = :C
+        def m
+          raise 'defined?(super) true, should be false' if defined?(super)
+          :C
+        end
       end
 
       class SC < C
         prepend N
         prepend M
-        def m = [:SC, *super]
+        def m
+          raise 'defined?(super) false, should be true' unless defined?(super)
+          [:SC, *super]
+        end
       end
 
       assert_equal([:RM, :M, :N, :SC, :RN, :N, :M, :C], SC.new.m)
@@ -1304,23 +1418,35 @@ class TestRefinement < Test::Unit::TestCase
 
       module R
         refine M do
-          def m = [:R, *super]
+          def m
+            raise 'defined?(super) false, should be true' unless defined?(super)
+            [:R, *super]
+          end
         end
       end
       using R
 
       module M
-        def m = [:M, *super]
+        def m
+          raise 'defined?(super) false, should be true' unless defined?(super)
+          [:M, *super]
+        end
       end
 
       class C
         prepend M
-        def m = :C
+        def m
+          raise 'defined?(super) true, should be false' if defined?(super)
+          :C
+        end
       end
 
       class SC < C
         prepend M
-        def m = [:SC, *super]
+        def m
+          raise 'defined?(super) false, should be true' unless defined?(super)
+          [:SC, *super]
+        end
       end
 
       assert_equal([:R, :M, :SC, :R, :M, :C], SC.new.m)
@@ -1337,33 +1463,51 @@ class TestRefinement < Test::Unit::TestCase
 
       module R
         refine M do
-          def m = [:RM, *super]
+          def m
+            raise 'defined?(super) false, should be true' unless defined?(super)
+            [:RM, *super]
+          end
         end
 
         refine N do
-          def m = [:RN, *super]
+          def m
+            raise 'defined?(super) false, should be true' unless defined?(super)
+            [:RN, *super]
+          end
         end
       end
       using R
 
       module M
-        def m = [:M, *super]
+        def m
+          raise 'defined?(super) false, should be true' unless defined?(super)
+          [:M, *super]
+        end
       end
 
       module N
-        def m = [:N, *super]
+        def m
+          raise 'defined?(super) false, should be true' unless defined?(super)
+          [:N, *super]
+        end
       end
 
       class C
         prepend M
         prepend N
-        def m = :C
+        def m
+          raise 'defined?(super) true, should be false' if defined?(super)
+          :C
+        end
       end
 
       class SC < C
         prepend N
         prepend M
-        def m = [:SC, *super]
+        def m
+          raise 'defined?(super) false, should be true' unless defined?(super)
+          [:SC, *super]
+        end
       end
 
       assert_equal([:RM, :M, :RN, :N, :SC, :RN, :N, :RM, :M, :C], SC.new.m)
@@ -1373,24 +1517,36 @@ class TestRefinement < Test::Unit::TestCase
   def test_super_in_refined_module_method_in_nested_block
     assert_separately([], <<-"end;")
       module M
-        def m = ->{Array.new(1){[:M, *super]}.flatten}.call
+        def m
+          raise 'defined?(super) false, should be true' unless defined?(super)
+          ->{Array.new(1){[:M, *super]}.flatten}.call
+        end
       end
 
       module R
         refine M do
-          def m = ->{Array.new(1){[:R, *super]}.flatten}.call
+          def m
+            raise 'defined?(super) false, should be true' unless defined?(super)
+            ->{Array.new(1){[:R, *super]}.flatten}.call
+          end
         end
       end
       using R
 
       class C
         prepend M
-        def m = :C
+        def m
+          raise 'defined?(super) true, should be false' if defined?(super)
+          :C
+        end
       end
 
       class SC < C
         prepend M
-        def m = [:SC, *super]
+        def m
+          raise 'defined?(super) false, should be true' unless defined?(super)
+          [:SC, *super]
+        end
       end
 
       assert_equal([:R, :M, :SC, :R, :M, :C], SC.new.m)
@@ -1400,43 +1556,70 @@ class TestRefinement < Test::Unit::TestCase
   def test_super_in_refined_module_method_combined_cases
     assert_separately([], <<-"end;")
       module M
-        define_method(:m){->{Array.new(1){[:M, *super()]}.flatten}.call}
+        define_method(:m) do
+          raise 'defined?(super) false, should be true' unless defined?(super)
+          ->{Array.new(1){[:M, *super()]}.flatten}.call
+        end
       end
 
       module N
-        def m = ->{Array.new(1){[:N, *super]}.flatten}.call
+        def m
+          raise 'defined?(super) false, should be true' unless defined?(super)
+          ->{Array.new(1){[:N, *super]}.flatten}.call
+        end
       end
 
       module P
-        def m = ->{Array.new(1){[:P, *super]}.flatten}.call
+        def m
+          raise 'defined?(super) false, should be true' unless defined?(super)
+          ->{Array.new(1){[:P, *super]}.flatten}.call
+        end
       end
 
       module R1
         refine M do
-          def m = ->{Array.new(1){[:R1M, *super]}.flatten}.call
+          def m
+            raise 'defined?(super) false, should be true' unless defined?(super)
+            ->{Array.new(1){[:R1M, *super]}.flatten}.call
+          end
         end
 
         refine N do
-          define_method(:m){->{Array.new(1){[:R1N, *super()]}.flatten}.call}
+          define_method(:m) do
+            raise 'defined?(super) false, should be true' unless defined?(super)
+            ->{Array.new(1){[:R1N, *super()]}.flatten}.call
+          end
         end
 
         refine P do
-          def m = ->{Array.new(1){[:R1P, *super]}.flatten}.call
+          def m
+            raise 'defined?(super) false, should be true' unless defined?(super)
+            ->{Array.new(1){[:R1P, *super]}.flatten}.call
+          end
         end
       end
       using R1
 
       module R2
         refine M do
-          define_method(:m){->{Array.new(1){[:R2M, *super()]}.flatten}.call}
+          define_method(:m) do
+            raise 'defined?(super) false, should be true' unless defined?(super)
+            ->{Array.new(1){[:R2M, *super()]}.flatten}.call
+          end
         end
 
         refine N do
-          def m = ->{Array.new(1){[:R2N, *super]}.flatten}.call
+          def m
+            raise 'defined?(super) false, should be true' unless defined?(super)
+            ->{Array.new(1){[:R2N, *super]}.flatten}.call
+          end
         end
 
         refine P do
-          define_method(:m){->{Array.new(1){[:R2P, *super()]}.flatten}.call}
+          define_method(:m) do
+            raise 'defined?(super) false, should be true' unless defined?(super)
+            ->{Array.new(1){[:R2P, *super()]}.flatten}.call
+          end
         end
       end
       using R2
@@ -1444,18 +1627,27 @@ class TestRefinement < Test::Unit::TestCase
       class C
         prepend M
         prepend N
-        def m = :C
+        def m
+          raise 'defined?(super) true, should be false' if defined?(super)
+          :C
+        end
       end
 
       class SC < C
         include P
-        def m = ->{Array.new(1){[:SC, *super]}.flatten}.call
+        def m
+          raise 'defined?(super) false, should be true' unless defined?(super)
+          ->{Array.new(1){[:SC, *super]}.flatten}.call
+        end
       end
 
       class SSC < SC
         prepend N
         prepend M
-        def m = ->{Array.new(1){[:SSC, *super]}.flatten}.call
+        def m
+          raise 'defined?(super) false, should be true' unless defined?(super)
+          ->{Array.new(1){[:SSC, *super]}.flatten}.call
+        end
       end
 
       o = Object.new
@@ -1470,6 +1662,7 @@ class TestRefinement < Test::Unit::TestCase
       M = Module.new do
         define_method(:m) do
           called << :M
+          raise 'defined?(super) true, should be false' if defined?(super)
           super()
         end
       end
@@ -1482,6 +1675,7 @@ class TestRefinement < Test::Unit::TestCase
         refine M do
           define_method(:m) do
             called << :R
+            raise 'defined?(super) false, should be true' unless defined?(super)
             super()
           end
         end

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -4601,7 +4601,7 @@ current_method_entry(const rb_execution_context_t *ec, rb_control_frame_t *cfp)
 {
     rb_control_frame_t *top_cfp = cfp;
 
-    if (CFP_ISEQ(cfp) && ISEQ_BODY(CFP_ISEQ(cfp))->type == ISEQ_TYPE_BLOCK) {
+    if (CFP_ISEQ(cfp) && !VM_FRAME_BMETHOD_P(cfp) && ISEQ_BODY(CFP_ISEQ(cfp))->type == ISEQ_TYPE_BLOCK) {
         const rb_iseq_t *local_iseq = ISEQ_BODY(CFP_ISEQ(cfp))->local_iseq;
 
         do {
@@ -4610,7 +4610,7 @@ current_method_entry(const rb_execution_context_t *ec, rb_control_frame_t *cfp)
                 /* TODO: orphan block */
                 return top_cfp;
             }
-        } while (CFP_ISEQ(cfp) != local_iseq);
+        } while (CFP_ISEQ(cfp) != local_iseq && !VM_FRAME_BMETHOD_P(cfp));
     }
     return cfp;
 }
@@ -5102,6 +5102,70 @@ vm_search_normal_superclass(VALUE klass)
     return RCLASS_SUPER(klass);
 }
 
+static const rb_control_frame_t *
+vm_previous_cfp_from_current_method_entry(const rb_execution_context_t *ec, const rb_control_frame_t *cfp)
+{
+    return RUBY_VM_PREVIOUS_CONTROL_FRAME(current_method_entry(ec, (rb_control_frame_t *)cfp));
+}
+
+static inline bool
+vm_refined_module_iclass_p(VALUE defined_class)
+{
+    return RB_TYPE_P(defined_class, T_ICLASS) &&
+        !RICLASS_FOR_REFINEMENT_P(defined_class) &&
+        RCLASS_INCLUDER(defined_class) == 0;
+}
+
+static VALUE
+vm_superclass_after_module(VALUE klass, VALUE module)
+{
+    for (; klass; klass = RCLASS_SUPER(klass)) {
+        if (RB_TYPE_P(klass, T_ICLASS) && RBASIC(klass)->klass == module) {
+            return RCLASS_SUPER(klass);
+        }
+    }
+    return 0;
+}
+
+// Find the correct ancestor for super in a module method when that method
+// was called via a refinement method. In this case, we cannot tell from the
+// module information what the superclass would be. However, we know the
+// current method entry is the module method, and the previous method entry
+// is the refinement.  The method before that may be another module method
+// for a refinement super call, so keep walking up the call stack a couple
+// methods at a time until we come to a method that isn't a module method
+// called from a refinement method.
+static VALUE
+vm_find_next_ancestor_after_refined_module(const rb_control_frame_t *cfp, VALUE recv, VALUE module, ID mid)
+{
+    const rb_execution_context_t *ec = GET_EC();
+    VALUE klass = 0;
+
+    while (klass == 0) {
+        const rb_control_frame_t *refinement_cfp = vm_previous_cfp_from_current_method_entry(ec, cfp);
+        if (RUBY_VM_CONTROL_FRAME_STACK_OVERFLOW_P(ec, refinement_cfp)) break;
+        const rb_control_frame_t *caller_cfp = vm_previous_cfp_from_current_method_entry(ec, refinement_cfp);
+        if (RUBY_VM_CONTROL_FRAME_STACK_OVERFLOW_P(ec, caller_cfp)) break;
+
+        const rb_callable_method_entry_t *caller_me = rb_vm_frame_method_entry(caller_cfp);
+        if (!caller_me || caller_cfp->self != recv || caller_me->def->original_id != mid) break;
+
+        if (vm_refined_module_iclass_p(caller_me->defined_class) ||
+                RICLASS_FOR_REFINEMENT_P(caller_me->defined_class)) {
+            cfp = caller_cfp;
+        }
+        else {
+            klass = vm_search_normal_superclass(caller_me->defined_class);
+        }
+    }
+
+    if (klass) {
+        VALUE found = vm_superclass_after_module(klass, module);
+        if (found) return found;
+    }
+    return vm_superclass_after_module(CLASS_OF(recv), module);
+}
+
 NORETURN(static void vm_super_outside(void));
 
 static void
@@ -5169,17 +5233,15 @@ vm_search_super_method(const rb_control_frame_t *reg_cfp, struct rb_call_data *c
 
     VALUE klass = vm_search_normal_superclass(me->defined_class);
 
+    if (klass == rb_cBasicObject && vm_refined_module_iclass_p(me->defined_class)) {
+        klass = vm_find_next_ancestor_after_refined_module(reg_cfp, recv,
+            RBASIC(me->defined_class)->klass, me->def->original_id);
+    }
+
     if (!klass) {
         /* bound instance method of module */
         cc = vm_cc_new(Qundef, NULL, vm_call_method_missing, cc_type_super);
         RB_OBJ_WRITE(iseq, &cd->cc, cc);
-    }
-    else if (klass == rb_cBasicObject &&
-             RB_TYPE_P(me->defined_class, T_ICLASS) &&
-             RCLASS_INCLUDER(me->defined_class) == 0) {
-        rb_raise(rb_eNoMethodError,
-                 "super in a method in a module that has been refined and that is called via super"
-                 " from a refinement method is not supported.");
     }
     else {
         cc = vm_search_method_fastpath(reg_cfp, cd, klass);

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -5166,6 +5166,18 @@ vm_find_next_ancestor_after_refined_module(const rb_control_frame_t *cfp, VALUE 
     return vm_superclass_after_module(CLASS_OF(recv), module);
 }
 
+static VALUE
+vm_search_super_class(const rb_control_frame_t *cfp, const rb_callable_method_entry_t *me, VALUE recv)
+{
+    VALUE klass = vm_search_normal_superclass(me->defined_class);
+
+    if (klass == rb_cBasicObject && vm_refined_module_iclass_p(me->defined_class)) {
+        klass = vm_find_next_ancestor_after_refined_module(cfp, recv, RBASIC(me->defined_class)->klass,
+                                                            me->def->original_id);
+    }
+    return klass;
+}
+
 NORETURN(static void vm_super_outside(void));
 
 static void
@@ -5231,12 +5243,7 @@ vm_search_super_method(const rb_control_frame_t *reg_cfp, struct rb_call_data *c
 
     const struct rb_callcache *cc;
 
-    VALUE klass = vm_search_normal_superclass(me->defined_class);
-
-    if (klass == rb_cBasicObject && vm_refined_module_iclass_p(me->defined_class)) {
-        klass = vm_find_next_ancestor_after_refined_module(reg_cfp, recv,
-            RBASIC(me->defined_class)->klass, me->def->original_id);
-    }
+    VALUE klass = vm_search_super_class(reg_cfp, me, recv);
 
     if (!klass) {
         /* bound instance method of module */
@@ -5834,7 +5841,7 @@ vm_defined(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, rb_num_t op_
             const rb_callable_method_entry_t *me = rb_vm_frame_method_entry(GET_CFP());
 
             if (me) {
-                VALUE klass = vm_search_normal_superclass(me->defined_class);
+                VALUE klass = vm_search_super_class(GET_CFP(), me, GET_SELF());
                 if (!klass) return false;
 
                 ID id = me->def->original_id;


### PR DESCRIPTION
Ruby started allowing refinements of modules in 2.4. However, there was one limitation, which is that while the refinement method could call `super` to call the module method, the module method could not call `super`, because it did not have enough information to determine the appropriate ancestor. This limitation was known at the time and was accepted when module refinements were accepted in #12534.

As discussed in #22071, `super` wasn't actually prohibited in the module method, it just used the incorrect method lookup, looking for a super method in `BasicObject`. After discussion in #22071, I fixed this to use an explicit exception for this case, so an error was was raised for it.

While that addressed the incorrect super method lookup issue, it was an unsatisfying conclusion. I kept thinking about ways to actually fix the issue. My initial idea was to use a separate `T_ICLASS` for the module being refined in every class ancestry chain where it could be called via refinement `super`. However, that approach would result in a large amount of complexity, as well as potentially significant additional memory.

This uses an alternative approach which relies on the fact that when we call `super` in the module method, we know that the current method is a module method, and that the previous method in the call stack is a refinement method. We can walk up the call stack to find the refinement method, look at the previous method calling that to determine the class to use for the super lookup. Note that the previous method may use a different receiver/method, in which case we start with the receiver's class. There are cases where we need to do this multiple times, if there are multiple refinements or multiple modules being refined that have already called super to reach this point.  I'm not sure this alternative approach works in all cases, but I have gotten it to work every case I've tried:

* Module and refinement appears multiple times in the ancestor chain
* `super` calls both directly in method as well as in nested blocks in method
* Both refinement method and module method are bmethods
* Refinement refines multiple modules and both modules are involved in the same super call chain
* Multiple refinements of the same module method
* Use of ZSUPER aliases in the super call chain
* The `super` call in the module method is not found, and `NoMethodError` is raised correctly

We want the behavior of module refinement `super` to be consistent, so in addition to fixing `super` itself, we also need to fix `defined?(super)` as well as `Method#super_method` and `UnboundMethod#super_method`. `defined?(super)` is fixed by sharing the lookup that `super` now uses. However, `Method#super_method` and `UnboundMethod#super_method` require a different approach. Thankfully, `struct METHOD` already has a member named `iclass` that is used to implement `#super_method`. So we just need to make adjustments to the setting of the `iclass` member for `#super_method` to work.

I'm requesting reviews from multiple people for the following reasons:

* @shugo: to confirm the module refinement behavior with this change is correct/desired, and whether there are any cases missed
* @ko1: to determine that the call frame walking for `super` and `defined?(super)` is an allowable/supportable approach
* @nobu: to determine whether the changes to `struct METHOD` `iclass` handling used for `#super_method` will cause any problems
* @ruby/jit team: to determine whether this will cause any problems for YJIT/ZJIT