### PR TITLE
Preserve the blocking timeout across EC_EXEC_TAG

### DIFF
--- a/thread.c
+++ b/thread.c
@@ -4972,10 +4972,11 @@ COMPILER_WARNING_POP
         break;
       case io_wait_unhandled:
         EC_PUSH_TAG(ec);
+        struct timeval *volatile blocking_timeout = timeout;
         if ((state = EC_EXEC_TAG()) == TAG_NONE) {
             rb_hrtime_t *to, rel, end = 0;
             RUBY_VM_CHECK_INTS_BLOCKING(ec);
-            timeout_prepare(&to, &rel, &end, timeout);
+            timeout_prepare(&to, &rel, &end, blocking_timeout);
             do {
                 nfds = numberof(fds);
                 result = wait_for_single_fd_blocking_region(th, fds, nfds, to, &lerrno);


### PR DESCRIPTION
Save `timeout` in a volatile pointer before `EC_EXEC_TAG` to avoid GCC 15.3.0's `-Wclobbered` warning on aarch64-linux.

```
../src/thread.c: In function ‘thread_io_wait’:
../src/thread.c:4915:87: warning: argument ‘timeout’ might be clobbered by ‘longjmp’ or ‘vfork’ [-Wclobbered]
 4915 | thread_io_wait(rb_thread_t *th, struct rb_io *io, int fd, int events, struct timeval *timeout)
      |                                                                       ~~~~~~~~~~~~~~~~^~~~~~~
```